### PR TITLE
fix: enrichment status honesty -- per-step tracking + self-healing

### DIFF
--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -1189,7 +1189,7 @@ pub async fn list_memories_cmd(
             entity_id: None,
             quality: None,
             is_recap: info.source_id.starts_with("recap_"),
-            enrichment_status: String::from("enriched"),
+            enrichment_status: String::from("raw"),
             supersede_mode: String::from("hide"),
             structured_fields: None,
             retrieval_cue: None,

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -4740,7 +4740,7 @@ impl MemoryDB {
         }
         let conn = self.conn.lock().await;
         conn.execute(
-            "UPDATE memories SET embedding = vector32(?1), enrichment_status = 'enriched', needs_reembed = 0 WHERE id = ?2",
+            "UPDATE memories SET embedding = vector32(?1), enrichment_status = 'legacy', needs_reembed = 0 WHERE id = ?2",
             libsql::params![Self::vec_to_sql(&embeddings[0]), chunk_id],
         )
         .await
@@ -6839,6 +6839,13 @@ impl MemoryDB {
         )
         .await
         .map_err(|e| OriginError::VectorDb(format!("delete_by_source_id: {}", e)))?;
+        // Clean up orphaned enrichment_steps (no FK cascade)
+        conn.execute(
+            "DELETE FROM enrichment_steps WHERE source_id = ?1",
+            libsql::params![source_id.to_string()],
+        )
+        .await
+        .ok();
         Ok(())
     }
 
@@ -20011,14 +20018,14 @@ pub(crate) mod tests {
         let conn = db.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT enrichment_status FROM memories WHERE id = 're1'",
+                "SELECT needs_reembed FROM memories WHERE id = 're1'",
                 (),
             )
             .await
             .unwrap();
         let row = rows.next().await.unwrap().unwrap();
-        let status: String = row.get(0).unwrap();
-        assert_eq!(status, "enriched");
+        let needs_reembed: i64 = row.get(0).unwrap();
+        assert_eq!(needs_reembed, 0, "needs_reembed should be cleared after re-embedding");
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -554,6 +554,17 @@ pub struct PendingRevision {
     pub source_agent: Option<String>,
 }
 
+/// A memory chunk that needs its embedding refreshed.
+#[derive(Debug, Clone)]
+pub struct PendingReembed {
+    /// The `id` primary key of the chunk row (passed to `reembed_memory`).
+    pub chunk_id: String,
+    /// The `source_id` of the parent memory (used for look-ups and assertions).
+    pub source_id: String,
+    /// The text to embed (source_text when available, otherwise content).
+    pub embed_text: String,
+}
+
 /// An activity row from the consolidated activities table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActivityRow {
@@ -2072,7 +2083,8 @@ impl MemoryDB {
 
         // Migration 19: Flatten existing structured_fields into content, mark for re-embedding
         // Reads each memory with structured_fields, flattens to pipe-delimited string,
-        // moves original prose to source_text, and marks reembed_pending.
+        // moves original prose to source_text, and marks enrichment_status = 'reembed_pending'
+        // (migration 42 backfills this into needs_reembed later).
         if version < 19 {
             let conn = self.conn.lock().await;
             // Fetch all memories with structured_fields that haven't been flattened yet
@@ -4670,7 +4682,7 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT id, content, source_text, structured_fields FROM memories
-                 WHERE enrichment_status = 'reembed_pending' AND source = 'memory'
+                 WHERE needs_reembed = 1 AND source = 'memory'
                  ORDER BY last_modified DESC LIMIT ?1",
                 libsql::params![limit as i64],
             )
@@ -4689,6 +4701,37 @@ impl MemoryDB {
         Ok(results)
     }
 
+    /// Get memories that need re-embedding, keyed by source_id (needs_reembed = 1).
+    pub async fn get_pending_reembeds(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<PendingReembed>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT id, source_id, content, source_text FROM memories
+                 WHERE needs_reembed = 1 AND source = 'memory'
+                 ORDER BY last_modified DESC LIMIT ?1",
+                libsql::params![limit as i64],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_pending_reembeds: {}", e)))?;
+        let mut results = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            let chunk_id: String = row.get(0).unwrap_or_default();
+            let source_id: String = row.get(1).unwrap_or_default();
+            let content: String = row.get(2).unwrap_or_default();
+            let source_text: Option<String> = row.get::<Option<String>>(3).unwrap_or(None);
+            let embed_text = source_text.unwrap_or_else(|| content.clone());
+            results.push(PendingReembed {
+                chunk_id,
+                source_id,
+                embed_text,
+            });
+        }
+        Ok(results)
+    }
+
     /// Re-embed a single memory with fresh embedding from its current content.
     pub async fn reembed_memory(&self, chunk_id: &str, content: &str) -> Result<(), OriginError> {
         let embeddings = self.generate_embeddings(&[content.to_string()])?;
@@ -4697,7 +4740,7 @@ impl MemoryDB {
         }
         let conn = self.conn.lock().await;
         conn.execute(
-            "UPDATE memories SET embedding = vector32(?1), enrichment_status = 'enriched' WHERE id = ?2",
+            "UPDATE memories SET embedding = vector32(?1), enrichment_status = 'enriched', needs_reembed = 0 WHERE id = ?2",
             libsql::params![Self::vec_to_sql(&embeddings[0]), chunk_id],
         )
         .await
@@ -11879,7 +11922,7 @@ impl MemoryDB {
     ) -> Result<(), OriginError> {
         let conn = self.conn.lock().await;
         conn.execute(
-            "UPDATE memories SET structured_fields = ?1, enrichment_status = 'reembed_pending' \
+            "UPDATE memories SET structured_fields = ?1, needs_reembed = 1 \
              WHERE source_id = ?2 AND chunk_index = 0",
             libsql::params![structured_fields_json, source_id],
         )
@@ -11931,10 +11974,7 @@ impl MemoryDB {
                 "UPDATE memories SET
                     structured_fields = COALESCE(?1, structured_fields),
                     retrieval_cue = COALESCE(?2, retrieval_cue),
-                    enrichment_status = CASE
-                        WHEN ?1 IS NOT NULL THEN 'reembed_pending'
-                        ELSE enrichment_status
-                    END
+                    needs_reembed = CASE WHEN ?1 IS NOT NULL THEN 1 ELSE needs_reembed END
                  WHERE source_id = ?3 AND chunk_index = 0",
                 libsql::params![structured_fields, retrieval_cue, source_id],
             )
@@ -19490,8 +19530,8 @@ pub(crate) mod tests {
     ///     preserve the caller-supplied original, `Some` replaces.
     ///   * `structured_fields` / `retrieval_cue` only touch `chunk_index = 0`
     ///     (those fields live on the lead chunk only).
-    ///   * `enrichment_status` flips to `reembed_pending` iff structured
-    ///     fields were provided (so the re-embed pass picks it up).
+    ///   * `needs_reembed` flips to `1` iff structured fields were provided
+    ///     (so the re-embed pass picks it up).
     #[tokio::test]
     async fn test_apply_enrichment_writes_classification_and_extraction() {
         let (db, _dir) = test_db().await;
@@ -19525,7 +19565,7 @@ pub(crate) mod tests {
         let mut rows = conn
             .query(
                 "SELECT memory_type, domain, quality, supersede_mode,
-                        structured_fields, retrieval_cue, enrichment_status
+                        structured_fields, retrieval_cue, needs_reembed
                  FROM memories WHERE source_id = 'mem_apply' AND chunk_index = 0",
                 (),
             )
@@ -19538,7 +19578,7 @@ pub(crate) mod tests {
         let supersede_mode: String = row.get(3).unwrap();
         let sf: Option<String> = row.get(4).unwrap();
         let cue: Option<String> = row.get(5).unwrap();
-        let status: String = row.get(6).unwrap();
+        let needs_reembed: i64 = row.get(6).unwrap();
 
         assert_eq!(memory_type, "preference");
         assert_eq!(
@@ -19552,8 +19592,8 @@ pub(crate) mod tests {
         assert!(sf.unwrap().contains("dark mode"));
         assert_eq!(cue.as_deref(), Some("What editor theme does Alice use?"));
         assert_eq!(
-            status, "reembed_pending",
-            "structured_fields update must flip status so re-embed picks it up"
+            needs_reembed, 1,
+            "structured_fields update must set needs_reembed = 1 so re-embed picks it up"
         );
     }
 
@@ -19896,12 +19936,12 @@ pub(crate) mod tests {
     async fn test_get_reembed_candidates() {
         let (db, _dir) = test_db().await;
         let conn = db.conn.lock().await;
-        // Insert a memory with source_text and reembed_pending status
+        // Insert a memory with source_text and needs_reembed = 1
         conn.execute(
             "INSERT INTO memories (id, content, source, source_id, title, chunk_index, last_modified,
-             chunk_type, word_count, source_text, enrichment_status, structured_fields)
+             chunk_type, word_count, source_text, needs_reembed, structured_fields)
              VALUES ('rc1', 'preference: dark mode', 'memory', 'mem_rc1', 'test', 0, 0,
-             'text', 1, 'I prefer dark mode', 'reembed_pending', '{\"preference\":\"dark mode\"}')",
+             'text', 1, 'I prefer dark mode', 1, '{\"preference\":\"dark mode\"}')",
             (),
         ).await.unwrap();
         // Insert a normal enriched memory (should NOT be returned)
@@ -19922,12 +19962,12 @@ pub(crate) mod tests {
     async fn test_reembed_memory() {
         let (db, _dir) = test_db().await;
         let conn = db.conn.lock().await;
-        // Insert a reembed_pending memory
+        // Insert a memory that needs re-embedding (needs_reembed = 1)
         conn.execute(
             "INSERT INTO memories (id, content, source, source_id, title, chunk_index, last_modified,
-             chunk_type, word_count, enrichment_status, structured_fields)
+             chunk_type, word_count, needs_reembed, structured_fields)
              VALUES ('re1', 'preference: dark mode', 'memory', 'mem_re1', 'test', 0, 0,
-             'text', 1, 'reembed_pending', '{\"preference\":\"dark mode\"}')",
+             'text', 1, 1, '{\"preference\":\"dark mode\"}')",
             (),
         ).await.unwrap();
         drop(conn);
@@ -19947,6 +19987,30 @@ pub(crate) mod tests {
         let row = rows.next().await.unwrap().unwrap();
         let status: String = row.get(0).unwrap();
         assert_eq!(status, "enriched");
+    }
+
+    #[tokio::test]
+    async fn test_needs_reembed_replaces_reembed_pending() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_reembed_test", "dark mode preference", "preference", "tools", "test");
+        db.upsert_documents(vec![doc]).await.unwrap();
+
+        // Memory starts with needs_reembed = 0
+        let pending = db.get_pending_reembeds(10).await.unwrap();
+        assert!(!pending.iter().any(|r| r.source_id == "mem_reembed_test"));
+
+        // Mark needs_reembed = 1 (simulating a structured_fields update)
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE memories SET needs_reembed = 1 WHERE source_id = 'mem_reembed_test'",
+                (),
+            ).await.unwrap();
+        }
+
+        // Should now appear in pending reembeds
+        let pending = db.get_pending_reembeds(10).await.unwrap();
+        assert!(pending.iter().any(|r| r.source_id == "mem_reembed_test"));
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -3951,14 +3951,14 @@ impl MemoryDB {
             }
         }
 
-        // Migration 42: enrichment_steps table + needs_reembed column + summary view
+        // Migration 43: enrichment_steps table + needs_reembed column + summary view
         {
             let version: i64 = {
                 let conn = self.conn.lock().await;
                 let mut rows = conn
                     .query("PRAGMA user_version", ())
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("read version for m42: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("read version for m43: {e}")))?;
                 if let Some(row) = rows
                     .next()
                     .await
@@ -3970,7 +3970,7 @@ impl MemoryDB {
                 }
             };
 
-            if version < 42 {
+            if version < 43 {
                 let conn = self.conn.lock().await;
 
                 // Create enrichment_steps table if not exists (idempotent)
@@ -3981,7 +3981,7 @@ impl MemoryDB {
                             (),
                         )
                         .await
-                        .map_err(|e| OriginError::VectorDb(format!("m42 table check: {e}")))?;
+                        .map_err(|e| OriginError::VectorDb(format!("m43 table check: {e}")))?;
                     if let Some(row) = rows
                         .next()
                         .await
@@ -3996,7 +3996,7 @@ impl MemoryDB {
 
                 conn.execute("BEGIN", ())
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 begin: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 begin: {e}")))?;
 
                 if !table_exists {
                     conn.execute(
@@ -4012,14 +4012,14 @@ impl MemoryDB {
                         (),
                     )
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 create table: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 create table: {e}")))?;
 
                     conn.execute(
                         "CREATE INDEX IF NOT EXISTS idx_enrichment_steps_failed ON enrichment_steps(status) WHERE status = 'failed'",
                         (),
                     )
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 create index: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 create index: {e}")))?;
                 }
 
                 // Add needs_reembed column if missing
@@ -4027,7 +4027,7 @@ impl MemoryDB {
                     let mut rows = conn
                         .query("PRAGMA table_info(memories)", ())
                         .await
-                        .map_err(|e| OriginError::VectorDb(format!("m42 pragma: {e}")))?;
+                        .map_err(|e| OriginError::VectorDb(format!("m43 pragma: {e}")))?;
                     let mut found = false;
                     while let Ok(Some(row)) = rows.next().await {
                         let col_name: String = row.get(1).unwrap_or_default();
@@ -4045,7 +4045,7 @@ impl MemoryDB {
                         (),
                     )
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 add column: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 add column: {e}")))?;
 
                     // Backfill: mark existing reembed_pending memories
                     conn.execute(
@@ -4053,7 +4053,7 @@ impl MemoryDB {
                         (),
                     )
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 backfill: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 backfill: {e}")))?;
                 }
 
                 // Create summary view
@@ -4073,17 +4073,17 @@ impl MemoryDB {
                     (),
                 )
                 .await
-                .map_err(|e| OriginError::VectorDb(format!("m42 create view: {e}")))?;
+                .map_err(|e| OriginError::VectorDb(format!("m43 create view: {e}")))?;
 
                 conn.execute("COMMIT", ())
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 commit: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 commit: {e}")))?;
 
-                conn.execute("PRAGMA user_version = 42", ())
+                conn.execute("PRAGMA user_version = 43", ())
                     .await
-                    .map_err(|e| OriginError::VectorDb(format!("m42 bump: {e}")))?;
+                    .map_err(|e| OriginError::VectorDb(format!("m43 bump: {e}")))?;
 
-                log::info!("[migration] Migration 42 applied: enrichment_steps table, needs_reembed column, memory_enrichment_summary view");
+                log::info!("[migration] Migration 43 applied: enrichment_steps table, needs_reembed column, memory_enrichment_summary view");
             }
         }
 
@@ -23262,7 +23262,7 @@ pub(crate) mod tests {
         );
     }
 
-    // ==================== Migration 42: enrichment_steps ====================
+    // ==================== Migration 43: enrichment_steps ====================
 
     #[tokio::test]
     async fn test_record_and_get_enrichment_steps() {

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -8665,6 +8665,39 @@ impl MemoryDB {
         Ok(rows_affected)
     }
 
+    /// Return memories with at least one `failed` enrichment step that hasn't
+    /// exceeded `max_attempts`, ordered oldest-first. Returns (source_id, step_name, content).
+    pub async fn get_failed_enrichment_memories(
+        &self,
+        max_attempts: usize,
+        limit: usize,
+    ) -> Result<Vec<(String, String, String)>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT es.source_id, es.step_name, m.content
+                 FROM enrichment_steps es
+                 JOIN (SELECT source_id, content FROM memories WHERE chunk_index = 0 AND source = 'memory') m
+                    ON m.source_id = es.source_id
+                 WHERE es.status = 'failed' AND es.attempts < ?1
+                 ORDER BY es.updated_at ASC LIMIT ?2",
+                libsql::params![max_attempts as i64, limit as i64],
+            )
+            .await
+            .map_err(|e| {
+                OriginError::VectorDb(format!("get_failed_enrichment_memories: {e}"))
+            })?;
+        let mut results = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            results.push((
+                row.get::<String>(0).unwrap_or_default(),
+                row.get::<String>(1).unwrap_or_default(),
+                row.get::<String>(2).unwrap_or_default(),
+            ));
+        }
+        Ok(results)
+    }
+
     pub async fn confirm_entity(
         &self,
         entity_id: &str,
@@ -10262,6 +10295,26 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| OriginError::VectorDb(format!("get_memory_type: {}", e)))?;
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            Ok(row.get::<Option<String>>(0).unwrap_or(None))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn get_memory_domain(&self, source_id: &str) -> Result<Option<String>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT domain FROM memories WHERE source_id = ?1 AND source = 'memory' LIMIT 1",
+                libsql::params![source_id.to_string()],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_memory_domain: {}", e)))?;
         if let Some(row) = rows
             .next()
             .await

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -3939,6 +3939,142 @@ impl MemoryDB {
             }
         }
 
+        // Migration 42: enrichment_steps table + needs_reembed column + summary view
+        {
+            let version: i64 = {
+                let conn = self.conn.lock().await;
+                let mut rows = conn
+                    .query("PRAGMA user_version", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("read version for m42: {e}")))?;
+                if let Some(row) = rows
+                    .next()
+                    .await
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?
+                {
+                    row.get(0).unwrap_or(0)
+                } else {
+                    0
+                }
+            };
+
+            if version < 42 {
+                let conn = self.conn.lock().await;
+
+                // Create enrichment_steps table if not exists (idempotent)
+                let table_exists: bool = {
+                    let mut rows = conn
+                        .query(
+                            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='enrichment_steps'",
+                            (),
+                        )
+                        .await
+                        .map_err(|e| OriginError::VectorDb(format!("m42 table check: {e}")))?;
+                    if let Some(row) = rows
+                        .next()
+                        .await
+                        .map_err(|e| OriginError::VectorDb(e.to_string()))?
+                    {
+                        let count: i64 = row.get(0).unwrap_or(0);
+                        count > 0
+                    } else {
+                        false
+                    }
+                };
+
+                conn.execute("BEGIN", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 begin: {e}")))?;
+
+                if !table_exists {
+                    conn.execute(
+                        "CREATE TABLE enrichment_steps (
+                            source_id TEXT NOT NULL,
+                            step_name TEXT NOT NULL,
+                            status TEXT NOT NULL,
+                            error TEXT,
+                            attempts INTEGER NOT NULL DEFAULT 1,
+                            updated_at INTEGER NOT NULL,
+                            PRIMARY KEY (source_id, step_name)
+                        )",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 create table: {e}")))?;
+
+                    conn.execute(
+                        "CREATE INDEX idx_enrichment_steps_failed ON enrichment_steps(status) WHERE status = 'failed'",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 create index: {e}")))?;
+                }
+
+                // Add needs_reembed column if missing
+                let col_exists: bool = {
+                    let mut rows = conn
+                        .query("PRAGMA table_info(memories)", ())
+                        .await
+                        .map_err(|e| OriginError::VectorDb(format!("m42 pragma: {e}")))?;
+                    let mut found = false;
+                    while let Ok(Some(row)) = rows.next().await {
+                        let col_name: String = row.get(1).unwrap_or_default();
+                        if col_name == "needs_reembed" {
+                            found = true;
+                            break;
+                        }
+                    }
+                    found
+                };
+
+                if !col_exists {
+                    conn.execute(
+                        "ALTER TABLE memories ADD COLUMN needs_reembed INTEGER NOT NULL DEFAULT 0",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 add column: {e}")))?;
+
+                    // Backfill: mark existing reembed_pending memories
+                    conn.execute(
+                        "UPDATE memories SET needs_reembed = 1 WHERE enrichment_status = 'reembed_pending'",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 backfill: {e}")))?;
+                }
+
+                // Create summary view
+                conn.execute(
+                    "CREATE VIEW IF NOT EXISTS memory_enrichment_summary AS
+                     SELECT
+                         m.source_id,
+                         CASE
+                             WHEN COUNT(s.step_name) = 0 THEN 'raw'
+                             WHEN SUM(CASE WHEN s.status IN ('failed','abandoned') THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                             WHEN SUM(CASE WHEN s.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                             ELSE 'enrichment_partial'
+                         END AS summary
+                     FROM (SELECT DISTINCT source_id FROM memories) m
+                     LEFT JOIN enrichment_steps s ON s.source_id = m.source_id
+                     GROUP BY m.source_id",
+                    (),
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("m42 create view: {e}")))?;
+
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 commit: {e}")))?;
+
+                conn.execute("PRAGMA user_version = 42", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m42 bump: {e}")))?;
+
+                log::info!("[migration] Migration 42 applied: enrichment_steps table, needs_reembed column, memory_enrichment_summary view");
+            }
+        }
+
         Ok(())
     }
 
@@ -8384,6 +8520,103 @@ impl MemoryDB {
         .await
         .map_err(|e| OriginError::VectorDb(format!("mark_enriched: {}", e)))?;
         Ok(())
+    }
+
+    /// Record (or upsert) a single enrichment step outcome for a memory.
+    /// If a row for (source_id, step_name) already exists, increments attempts and updates status/error.
+    pub async fn record_enrichment_step(
+        &self,
+        source_id: &str,
+        step_name: &str,
+        status: &str,
+        error: Option<&str>,
+    ) -> Result<(), OriginError> {
+        let now = chrono::Utc::now().timestamp();
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "INSERT INTO enrichment_steps (source_id, step_name, status, error, attempts, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 1, ?5)
+             ON CONFLICT(source_id, step_name) DO UPDATE SET
+                status = ?3, error = ?4, attempts = enrichment_steps.attempts + 1, updated_at = ?5",
+            libsql::params![source_id, step_name, status, error, now],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("record_enrichment_step: {e}")))?;
+        Ok(())
+    }
+
+    /// Return all enrichment step records for a memory, ordered by insertion.
+    pub async fn get_enrichment_steps(
+        &self,
+        source_id: &str,
+    ) -> Result<Vec<origin_types::EnrichmentStepStatus>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT step_name, status, error, attempts FROM enrichment_steps WHERE source_id = ?1 ORDER BY rowid",
+                libsql::params![source_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_enrichment_steps: {e}")))?;
+        let mut steps = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            steps.push(origin_types::EnrichmentStepStatus {
+                step: row.get::<String>(0).unwrap_or_default(),
+                status: row.get::<String>(1).unwrap_or_default(),
+                error: row.get::<Option<String>>(2).ok().flatten(),
+                attempts: row.get::<u32>(3).unwrap_or(0),
+            });
+        }
+        Ok(steps)
+    }
+
+    /// Derive a summary string from the enrichment_steps for a memory.
+    /// Returns: "raw" (no steps), "enriched" (all ok/skipped), "enrichment_failed" (all failed/abandoned),
+    /// or "enrichment_partial" (mixed).
+    pub async fn get_enrichment_summary(&self, source_id: &str) -> Result<String, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) as total,
+                        SUM(CASE WHEN status = 'failed' OR status = 'abandoned' THEN 1 ELSE 0 END) as failed_count,
+                        SUM(CASE WHEN status IN ('ok','skipped') THEN 1 ELSE 0 END) as ok_count
+                 FROM enrichment_steps WHERE source_id = ?1",
+                libsql::params![source_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_enrichment_summary: {e}")))?;
+        if let Ok(Some(row)) = rows.next().await {
+            let total: i64 = row.get(0).unwrap_or(0);
+            let failed: i64 = row.get(1).unwrap_or(0);
+            let ok: i64 = row.get(2).unwrap_or(0);
+            Ok(if total == 0 {
+                "raw".to_string()
+            } else if failed == 0 {
+                "enriched".to_string()
+            } else if ok == 0 {
+                "enrichment_failed".to_string()
+            } else {
+                "enrichment_partial".to_string()
+            })
+        } else {
+            Ok("raw".to_string())
+        }
+    }
+
+    /// Reset any "abandoned" steps for a memory back to "failed" with attempts = 0.
+    /// Returns the number of rows updated.
+    pub async fn reset_abandoned_steps(&self, source_id: &str) -> Result<u64, OriginError> {
+        let now = chrono::Utc::now().timestamp();
+        let conn = self.conn.lock().await;
+        let rows_affected = conn
+            .execute(
+                "UPDATE enrichment_steps SET status = 'failed', attempts = 0, updated_at = ?1
+                 WHERE source_id = ?2 AND status = 'abandoned'",
+                libsql::params![now, source_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("reset_abandoned_steps: {e}")))?;
+        Ok(rows_affected)
     }
 
     pub async fn confirm_entity(
@@ -22921,5 +23154,89 @@ pub(crate) mod tests {
             matched.is_empty(),
             "empty candidate set should yield empty result"
         );
+    }
+
+    // ==================== Migration 42: enrichment_steps ====================
+
+    #[tokio::test]
+    async fn test_record_and_get_enrichment_steps() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_step_test", "Rust is great", "fact", "tech", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.record_enrichment_step("mem_step_test", "dedup", "ok", None).await.unwrap();
+        db.record_enrichment_step("mem_step_test", "entity_link", "failed", Some("timeout")).await.unwrap();
+        db.record_enrichment_step("mem_step_test", "title_enrich", "skipped", None).await.unwrap();
+        let steps = db.get_enrichment_steps("mem_step_test").await.unwrap();
+        assert_eq!(steps.len(), 3);
+        let dedup = steps.iter().find(|s| s.step == "dedup").unwrap();
+        assert_eq!(dedup.status, "ok");
+        assert!(dedup.error.is_none());
+        assert_eq!(dedup.attempts, 1);
+        let entity = steps.iter().find(|s| s.step == "entity_link").unwrap();
+        assert_eq!(entity.status, "failed");
+        assert_eq!(entity.error.as_deref(), Some("timeout"));
+        let title = steps.iter().find(|s| s.step == "title_enrich").unwrap();
+        assert_eq!(title.status, "skipped");
+    }
+
+    #[tokio::test]
+    async fn test_record_enrichment_step_upserts_on_retry() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_upsert_step", "test content", "fact", "tech", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.record_enrichment_step("mem_upsert_step", "entity_extract", "failed", Some("LLM down")).await.unwrap();
+        let steps = db.get_enrichment_steps("mem_upsert_step").await.unwrap();
+        assert_eq!(steps[0].attempts, 1);
+        db.record_enrichment_step("mem_upsert_step", "entity_extract", "failed", Some("still down")).await.unwrap();
+        let steps = db.get_enrichment_steps("mem_upsert_step").await.unwrap();
+        assert_eq!(steps[0].attempts, 2);
+        assert_eq!(steps[0].error.as_deref(), Some("still down"));
+        db.record_enrichment_step("mem_upsert_step", "entity_extract", "ok", None).await.unwrap();
+        let steps = db.get_enrichment_steps("mem_upsert_step").await.unwrap();
+        assert_eq!(steps[0].status, "ok");
+        assert!(steps[0].error.is_none());
+        assert_eq!(steps[0].attempts, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_enrichment_summary() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_summary_test", "test", "fact", "tech", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        let summary = db.get_enrichment_summary("mem_summary_test").await.unwrap();
+        assert_eq!(summary, "raw");
+        db.record_enrichment_step("mem_summary_test", "dedup", "ok", None).await.unwrap();
+        db.record_enrichment_step("mem_summary_test", "entity_link", "skipped", None).await.unwrap();
+        let summary = db.get_enrichment_summary("mem_summary_test").await.unwrap();
+        assert_eq!(summary, "enriched");
+        db.record_enrichment_step("mem_summary_test", "title_enrich", "failed", Some("err")).await.unwrap();
+        let summary = db.get_enrichment_summary("mem_summary_test").await.unwrap();
+        assert_eq!(summary, "enrichment_partial");
+    }
+
+    #[tokio::test]
+    async fn test_get_enrichment_summary_all_failed() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_all_fail", "test", "fact", "tech", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.record_enrichment_step("mem_all_fail", "dedup", "failed", Some("err1")).await.unwrap();
+        db.record_enrichment_step("mem_all_fail", "entity_link", "failed", Some("err2")).await.unwrap();
+        let summary = db.get_enrichment_summary("mem_all_fail").await.unwrap();
+        assert_eq!(summary, "enrichment_failed");
+    }
+
+    #[tokio::test]
+    async fn test_reset_abandoned_steps() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_abandon_test", "test", "fact", "tech", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.record_enrichment_step("mem_abandon_test", "entity_extract", "abandoned", Some("gave up")).await.unwrap();
+        db.record_enrichment_step("mem_abandon_test", "dedup", "ok", None).await.unwrap();
+        let reset = db.reset_abandoned_steps("mem_abandon_test").await.unwrap();
+        assert_eq!(reset, 1);
+        let steps = db.get_enrichment_steps("mem_abandon_test").await.unwrap();
+        let extract = steps.iter().find(|s| s.step == "entity_extract").unwrap();
+        assert_eq!(extract.status, "failed");
+        assert_eq!(extract.attempts, 0);
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -2084,7 +2084,7 @@ impl MemoryDB {
         // Migration 19: Flatten existing structured_fields into content, mark for re-embedding
         // Reads each memory with structured_fields, flattens to pipe-delimited string,
         // moves original prose to source_text, and marks enrichment_status = 'reembed_pending'
-        // (migration 42 backfills this into needs_reembed later).
+        // (migration 43 backfills this into needs_reembed later).
         if version < 19 {
             let conn = self.conn.lock().await;
             // Fetch all memories with structured_fields that haven't been flattened yet
@@ -5106,6 +5106,10 @@ impl MemoryDB {
             pending_revision: bool,
             word_count: i64,
             entity_id: Option<String>,
+            // Retired column: kept in struct for compatibility with RawDocument
+            // but ignored on INSERT (always written as "legacy"). Status is now
+            // derived from the enrichment_steps table.
+            #[allow(dead_code)]
             enrichment_status: String,
             quality: Option<String>,
             is_recap: bool,
@@ -14308,6 +14312,8 @@ impl MemoryDB {
             confirmed: i64,
             stability: String,
             entity_id: Option<String>,
+            // Retired: see MemoryRow.enrichment_status above.
+            #[allow(dead_code)]
             enrichment_status: String,
             quality: Option<String>,
             is_recap: i64,

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -4000,7 +4000,7 @@ impl MemoryDB {
 
                 if !table_exists {
                     conn.execute(
-                        "CREATE TABLE enrichment_steps (
+                        "CREATE TABLE IF NOT EXISTS enrichment_steps (
                             source_id TEXT NOT NULL,
                             step_name TEXT NOT NULL,
                             status TEXT NOT NULL,
@@ -4015,7 +4015,7 @@ impl MemoryDB {
                     .map_err(|e| OriginError::VectorDb(format!("m42 create table: {e}")))?;
 
                     conn.execute(
-                        "CREATE INDEX idx_enrichment_steps_failed ON enrichment_steps(status) WHERE status = 'failed'",
+                        "CREATE INDEX IF NOT EXISTS idx_enrichment_steps_failed ON enrichment_steps(status) WHERE status = 'failed'",
                         (),
                     )
                     .await
@@ -8532,37 +8532,15 @@ impl MemoryDB {
         Ok(results)
     }
 
-    /// Get enrichment status for a chunk (for testing and diagnostics).
+    /// Get enrichment status for a memory, derived from per-step outcomes.
+    /// Delegates to `get_enrichment_summary` so callers get a live view of
+    /// what actually ran rather than a stale flag.
     pub async fn get_enrichment_status(
         &self,
         source_id: &str,
     ) -> Result<Option<String>, OriginError> {
-        let conn = self.conn.lock().await;
-        let mut rows = conn
-            .query(
-                "SELECT enrichment_status FROM memories WHERE source_id = ?1 LIMIT 1",
-                libsql::params![source_id],
-            )
-            .await
-            .map_err(|e| OriginError::VectorDb(format!("get_enrichment_status: {}", e)))?;
-        if let Ok(Some(row)) = rows.next().await {
-            let status: String = row.get(0).unwrap();
-            Ok(Some(status))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// Mark a chunk as enriched (post-ingest pipeline complete).
-    pub async fn mark_enriched(&self, source_id: &str) -> Result<(), OriginError> {
-        let conn = self.conn.lock().await;
-        conn.execute(
-            "UPDATE memories SET enrichment_status = 'enriched' WHERE source_id = ?1",
-            libsql::params![source_id],
-        )
-        .await
-        .map_err(|e| OriginError::VectorDb(format!("mark_enriched: {}", e)))?;
-        Ok(())
+        let summary = self.get_enrichment_summary(source_id).await?;
+        Ok(Some(summary))
     }
 
     /// Record (or upsert) a single enrichment step outcome for a memory.
@@ -19595,53 +19573,6 @@ pub(crate) mod tests {
             needs_reembed, 1,
             "structured_fields update must set needs_reembed = 1 so re-embed picks it up"
         );
-    }
-
-    // ==================== mark_enriched ====================
-
-    #[tokio::test]
-    async fn test_mark_enriched() {
-        let (db, _dir) = test_db().await;
-        let doc = make_memory_doc("mem_enrich", "Some fact", "fact", "work", "claude");
-        db.upsert_documents(vec![doc]).await.unwrap();
-
-        // Initially "raw" (default from RawDocument)
-        let row = db
-            .conn
-            .lock()
-            .await
-            .query(
-                "SELECT enrichment_status FROM memories WHERE source_id = 'mem_enrich' LIMIT 1",
-                (),
-            )
-            .await
-            .unwrap()
-            .next()
-            .await
-            .unwrap()
-            .unwrap();
-        let status: String = row.get(0).unwrap();
-        assert_eq!(status, "raw");
-
-        // Mark enriched
-        db.mark_enriched("mem_enrich").await.unwrap();
-
-        let row = db
-            .conn
-            .lock()
-            .await
-            .query(
-                "SELECT enrichment_status FROM memories WHERE source_id = 'mem_enrich' LIMIT 1",
-                (),
-            )
-            .await
-            .unwrap()
-            .next()
-            .await
-            .unwrap()
-            .unwrap();
-        let status: String = row.get(0).unwrap();
-        assert_eq!(status, "enriched");
     }
 
     // ==================== Space CRUD ====================

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -5347,7 +5347,7 @@ impl MemoryDB {
                     pending_revision_val,
                     row.word_count,
                     entity_id_val,
-                    row.enrichment_status,
+                    "legacy", // column retired; status derived from enrichment_steps
                     quality_val,
                     is_recap_val,
                     row.supersede_mode,
@@ -7223,7 +7223,12 @@ impl MemoryDB {
                     MAX(entity_id) as entity_id,
                     MAX(quality) as quality,
                     MAX(is_recap) as is_recap,
-                    MAX(enrichment_status) as enrichment_status,
+                    (SELECT CASE
+                        WHEN COUNT(es.source_id) = 0 THEN 'raw'
+                        WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                        WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                        ELSE 'enrichment_partial'
+                    END FROM enrichment_steps es WHERE es.source_id = memories.source_id) AS enrichment_status,
                     MAX(supersede_mode) as supersede_mode,
                     MAX(structured_fields) as structured_fields,
                     MAX(retrieval_cue) as retrieval_cue,
@@ -7325,7 +7330,12 @@ impl MemoryDB {
                     MAX(entity_id) as entity_id,
                     MAX(quality) as quality,
                     MAX(is_recap) as is_recap,
-                    MAX(enrichment_status) as enrichment_status,
+                    (SELECT CASE
+                        WHEN COUNT(es.source_id) = 0 THEN 'raw'
+                        WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                        WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                        ELSE 'enrichment_partial'
+                    END FROM enrichment_steps es WHERE es.source_id = memories.source_id) AS enrichment_status,
                     MAX(supersede_mode) as supersede_mode,
                     MAX(structured_fields) as structured_fields,
                     MAX(retrieval_cue) as retrieval_cue,
@@ -7411,7 +7421,12 @@ impl MemoryDB {
                 MAX(entity_id) as entity_id,
                 MAX(quality) as quality,
                 MAX(is_recap) as is_recap,
-                MAX(enrichment_status) as enrichment_status,
+                (SELECT CASE
+                    WHEN COUNT(es.source_id) = 0 THEN 'raw'
+                    WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                    WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                    ELSE 'enrichment_partial'
+                END FROM enrichment_steps es WHERE es.source_id = memories.source_id) AS enrichment_status,
                 MAX(supersede_mode) as supersede_mode,
                 MAX(structured_fields) as structured_fields,
                 MAX(retrieval_cue) as retrieval_cue,
@@ -7510,7 +7525,12 @@ impl MemoryDB {
                     MAX(entity_id) as entity_id,
                     MAX(quality) as quality,
                     MAX(is_recap) as is_recap,
-                    MAX(enrichment_status) as enrichment_status,
+                    (SELECT CASE
+                        WHEN COUNT(es.source_id) = 0 THEN 'raw'
+                        WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                        WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                        ELSE 'enrichment_partial'
+                    END FROM enrichment_steps es WHERE es.source_id = memories.source_id) AS enrichment_status,
                     MAX(supersede_mode) as supersede_mode,
                     MAX(structured_fields) as structured_fields,
                     MAX(retrieval_cue) as retrieval_cue,
@@ -7608,7 +7628,12 @@ impl MemoryDB {
                     MAX(entity_id) as entity_id,
                     MAX(quality) as quality,
                     MAX(is_recap) as is_recap,
-                    MAX(enrichment_status) as enrichment_status,
+                    (SELECT CASE
+                        WHEN COUNT(es.source_id) = 0 THEN 'raw'
+                        WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                        WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                        ELSE 'enrichment_partial'
+                    END FROM enrichment_steps es WHERE es.source_id = memories.source_id) AS enrichment_status,
                     MAX(supersede_mode) as supersede_mode,
                     MAX(structured_fields) as structured_fields,
                     MAX(retrieval_cue) as retrieval_cue,
@@ -9031,7 +9056,7 @@ impl MemoryDB {
         // Enrichment pending count
         let mut ep_rows = conn
             .query(
-                "SELECT COUNT(DISTINCT source_id) FROM memories WHERE source = 'memory' AND enrichment_status = 'raw'",
+                "SELECT COUNT(DISTINCT source_id) FROM memories WHERE source = 'memory' AND source_id NOT IN (SELECT DISTINCT source_id FROM enrichment_steps)",
                 libsql::params![],
             )
             .await
@@ -10331,7 +10356,12 @@ impl MemoryDB {
                     c.source_agent, c.confidence, c.confirmed, c.stability,
                     c.pinned, c.supersedes, c.last_modified,
                     c.entity_id, c.quality, COALESCE(c.is_recap, 0) as is_recap,
-                    c.enrichment_status, c.supersede_mode, c.structured_fields,
+                    (SELECT CASE
+                        WHEN COUNT(es.source_id) = 0 THEN 'raw'
+                        WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched'
+                        WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed'
+                        ELSE 'enrichment_partial'
+                    END FROM enrichment_steps es WHERE es.source_id = c.source_id) AS enrichment_status, c.supersede_mode, c.structured_fields,
                     c.retrieval_cue, c.access_count, c.source_text
              FROM memories c
              WHERE c.source = 'memory'
@@ -12529,7 +12559,14 @@ impl MemoryDB {
             let mut rows = conn
                 .query(
                     "SELECT source_id, title, summary, content, \
-                            created_at, last_modified, enrichment_status, entity_id \
+                            created_at, last_modified, \
+                            (SELECT CASE \
+                                WHEN COUNT(es.source_id) = 0 THEN 'raw' \
+                                WHEN SUM(CASE WHEN es.status = 'failed' OR es.status = 'abandoned' THEN 1 ELSE 0 END) = 0 THEN 'enriched' \
+                                WHEN SUM(CASE WHEN es.status IN ('ok','skipped') THEN 1 ELSE 0 END) = 0 THEN 'enrichment_failed' \
+                                ELSE 'enrichment_partial' \
+                            END FROM enrichment_steps es WHERE es.source_id = memories.source_id) AS enrichment_status, \
+                            entity_id \
                      FROM memories \
                      WHERE source = 'memory' AND chunk_index = 0 \
                        AND (supersede_mode IS NULL OR supersede_mode != 'archive') \
@@ -12876,9 +12913,9 @@ impl MemoryDB {
     pub async fn pipeline_status(&self) -> Result<serde_json::Value, OriginError> {
         let conn = self.conn.lock().await;
 
-        // Enrichment status breakdown
+        // Enrichment status breakdown — derived from enrichment_steps table
         let mut rows = conn.query(
-            "SELECT enrichment_status, COUNT(*) FROM memories WHERE source = 'memory' GROUP BY enrichment_status",
+            "SELECT status, COUNT(*) FROM enrichment_steps GROUP BY status",
             (),
         ).await.map_err(|e| OriginError::VectorDb(format!("pipeline_status enrichment: {e}")))?;
         let mut enrichment = serde_json::Map::new();
@@ -12886,6 +12923,17 @@ impl MemoryDB {
             let status: String = row.get(0).unwrap_or_default();
             let count: i64 = row.get(1).unwrap_or(0);
             enrichment.insert(status, serde_json::Value::Number(count.into()));
+        }
+        // Count memories with no enrichment steps at all (raw)
+        let mut raw_rows = conn.query(
+            "SELECT COUNT(DISTINCT source_id) FROM memories WHERE source = 'memory' AND source_id NOT IN (SELECT DISTINCT source_id FROM enrichment_steps)",
+            (),
+        ).await.map_err(|e| OriginError::VectorDb(format!("pipeline_status raw count: {e}")))?;
+        if let Ok(Some(row)) = raw_rows.next().await {
+            let raw_count: i64 = row.get(0).unwrap_or(0);
+            if raw_count > 0 {
+                enrichment.insert("raw".to_string(), serde_json::Value::Number(raw_count.into()));
+            }
         }
 
         // Entity linking
@@ -14365,7 +14413,7 @@ impl MemoryDB {
                     saved.stability,
                     new_word_count,
                     saved.entity_id,
-                    saved.enrichment_status,
+                    "legacy", // column retired; status derived from enrichment_steps
                     saved.quality,
                     saved.is_recap,
                     saved.structured_fields,
@@ -21409,7 +21457,7 @@ pub(crate) mod tests {
 
         // created_at = 100_000 s (well before since_s = 400_000 s).
         // last_modified = 500_000 s (after since, and 400_000 s after created_at → >> 60 s grace).
-        // enrichment_status = 'enriched'.
+        // enrichment_status derived as 'enriched' from enrichment_steps.
         // since_ms = 400_000_000 ms  →  since_s = 400_000 s.
         insert_memory_at(
             &db,
@@ -21421,6 +21469,9 @@ pub(crate) mod tests {
             "enriched",
         )
         .await;
+        // Record enrichment steps so the derived status is 'enriched'
+        db.record_enrichment_step("mem_ref", "dedup", "ok", None).await.unwrap();
+        db.record_enrichment_step("mem_ref", "entity_link", "ok", None).await.unwrap();
 
         let items = db
             .list_recent_memories(10, Some(400_000_000))
@@ -23233,5 +23284,29 @@ pub(crate) mod tests {
         let extract = steps.iter().find(|s| s.step == "entity_extract").unwrap();
         assert_eq!(extract.status, "failed");
         assert_eq!(extract.attempts, 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_memories_derives_enrichment_status_from_steps() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory_doc("mem_list_enrich", "Rust ownership model", "fact", "tech", "test");
+        db.upsert_documents(vec![doc]).await.unwrap();
+
+        // Before any steps are recorded, status should be "raw"
+        let items = db.list_memories(None, None, None, None, 10).await.unwrap();
+        let item = items.iter().find(|i| i.source_id == "mem_list_enrich").unwrap();
+        assert_eq!(item.enrichment_status, "raw", "no steps => raw");
+
+        // Record one ok step and one failed step => partial
+        db.record_enrichment_step("mem_list_enrich", "dedup", "ok", None).await.unwrap();
+        db.record_enrichment_step("mem_list_enrich", "entity_link", "failed", Some("no entities")).await.unwrap();
+
+        let items = db.list_memories(None, None, None, None, 10).await.unwrap();
+        let item = items.iter().find(|i| i.source_id == "mem_list_enrich").unwrap();
+        assert_eq!(item.enrichment_status, "enrichment_partial", "mix of ok and failed => partial");
+
+        // Also verify get_memory_detail derives from steps
+        let detail = db.get_memory_detail("mem_list_enrich").await.unwrap().unwrap();
+        assert_eq!(detail.enrichment_status, "enrichment_partial", "detail also derives from steps");
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -12978,10 +12978,13 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
 
         // Enrichment status breakdown — derived from enrichment_steps table
-        let mut rows = conn.query(
-            "SELECT status, COUNT(*) FROM enrichment_steps GROUP BY status",
-            (),
-        ).await.map_err(|e| OriginError::VectorDb(format!("pipeline_status enrichment: {e}")))?;
+        let mut rows = conn
+            .query(
+                "SELECT status, COUNT(*) FROM enrichment_steps GROUP BY status",
+                (),
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("pipeline_status enrichment: {e}")))?;
         let mut enrichment = serde_json::Map::new();
         while let Ok(Some(row)) = rows.next().await {
             let status: String = row.get(0).unwrap_or_default();
@@ -12996,7 +12999,10 @@ impl MemoryDB {
         if let Ok(Some(row)) = raw_rows.next().await {
             let raw_count: i64 = row.get(0).unwrap_or(0);
             if raw_count > 0 {
-                enrichment.insert("raw".to_string(), serde_json::Value::Number(raw_count.into()));
+                enrichment.insert(
+                    "raw".to_string(),
+                    serde_json::Value::Number(raw_count.into()),
+                );
             }
         }
 
@@ -20023,21 +20029,27 @@ pub(crate) mod tests {
 
         let conn = db.conn.lock().await;
         let mut rows = conn
-            .query(
-                "SELECT needs_reembed FROM memories WHERE id = 're1'",
-                (),
-            )
+            .query("SELECT needs_reembed FROM memories WHERE id = 're1'", ())
             .await
             .unwrap();
         let row = rows.next().await.unwrap().unwrap();
         let needs_reembed: i64 = row.get(0).unwrap();
-        assert_eq!(needs_reembed, 0, "needs_reembed should be cleared after re-embedding");
+        assert_eq!(
+            needs_reembed, 0,
+            "needs_reembed should be cleared after re-embedding"
+        );
     }
 
     #[tokio::test]
     async fn test_needs_reembed_replaces_reembed_pending() {
         let (db, _dir) = test_db().await;
-        let doc = make_memory_doc("mem_reembed_test", "dark mode preference", "preference", "tools", "test");
+        let doc = make_memory_doc(
+            "mem_reembed_test",
+            "dark mode preference",
+            "preference",
+            "tools",
+            "test",
+        );
         db.upsert_documents(vec![doc]).await.unwrap();
 
         // Memory starts with needs_reembed = 0
@@ -20050,7 +20062,9 @@ pub(crate) mod tests {
             conn.execute(
                 "UPDATE memories SET needs_reembed = 1 WHERE source_id = 'mem_reembed_test'",
                 (),
-            ).await.unwrap();
+            )
+            .await
+            .unwrap();
         }
 
         // Should now appear in pending reembeds
@@ -21536,8 +21550,12 @@ pub(crate) mod tests {
         )
         .await;
         // Record enrichment steps so the derived status is 'enriched'
-        db.record_enrichment_step("mem_ref", "dedup", "ok", None).await.unwrap();
-        db.record_enrichment_step("mem_ref", "entity_link", "ok", None).await.unwrap();
+        db.record_enrichment_step("mem_ref", "dedup", "ok", None)
+            .await
+            .unwrap();
+        db.record_enrichment_step("mem_ref", "entity_link", "ok", None)
+            .await
+            .unwrap();
 
         let items = db
             .list_recent_memories(10, Some(400_000_000))
@@ -23275,9 +23293,15 @@ pub(crate) mod tests {
         let (db, _dir) = test_db().await;
         let doc = make_memory_doc("mem_step_test", "Rust is great", "fact", "tech", "agent");
         db.upsert_documents(vec![doc]).await.unwrap();
-        db.record_enrichment_step("mem_step_test", "dedup", "ok", None).await.unwrap();
-        db.record_enrichment_step("mem_step_test", "entity_link", "failed", Some("timeout")).await.unwrap();
-        db.record_enrichment_step("mem_step_test", "title_enrich", "skipped", None).await.unwrap();
+        db.record_enrichment_step("mem_step_test", "dedup", "ok", None)
+            .await
+            .unwrap();
+        db.record_enrichment_step("mem_step_test", "entity_link", "failed", Some("timeout"))
+            .await
+            .unwrap();
+        db.record_enrichment_step("mem_step_test", "title_enrich", "skipped", None)
+            .await
+            .unwrap();
         let steps = db.get_enrichment_steps("mem_step_test").await.unwrap();
         assert_eq!(steps.len(), 3);
         let dedup = steps.iter().find(|s| s.step == "dedup").unwrap();
@@ -23296,14 +23320,30 @@ pub(crate) mod tests {
         let (db, _dir) = test_db().await;
         let doc = make_memory_doc("mem_upsert_step", "test content", "fact", "tech", "agent");
         db.upsert_documents(vec![doc]).await.unwrap();
-        db.record_enrichment_step("mem_upsert_step", "entity_extract", "failed", Some("LLM down")).await.unwrap();
+        db.record_enrichment_step(
+            "mem_upsert_step",
+            "entity_extract",
+            "failed",
+            Some("LLM down"),
+        )
+        .await
+        .unwrap();
         let steps = db.get_enrichment_steps("mem_upsert_step").await.unwrap();
         assert_eq!(steps[0].attempts, 1);
-        db.record_enrichment_step("mem_upsert_step", "entity_extract", "failed", Some("still down")).await.unwrap();
+        db.record_enrichment_step(
+            "mem_upsert_step",
+            "entity_extract",
+            "failed",
+            Some("still down"),
+        )
+        .await
+        .unwrap();
         let steps = db.get_enrichment_steps("mem_upsert_step").await.unwrap();
         assert_eq!(steps[0].attempts, 2);
         assert_eq!(steps[0].error.as_deref(), Some("still down"));
-        db.record_enrichment_step("mem_upsert_step", "entity_extract", "ok", None).await.unwrap();
+        db.record_enrichment_step("mem_upsert_step", "entity_extract", "ok", None)
+            .await
+            .unwrap();
         let steps = db.get_enrichment_steps("mem_upsert_step").await.unwrap();
         assert_eq!(steps[0].status, "ok");
         assert!(steps[0].error.is_none());
@@ -23317,11 +23357,17 @@ pub(crate) mod tests {
         db.upsert_documents(vec![doc]).await.unwrap();
         let summary = db.get_enrichment_summary("mem_summary_test").await.unwrap();
         assert_eq!(summary, "raw");
-        db.record_enrichment_step("mem_summary_test", "dedup", "ok", None).await.unwrap();
-        db.record_enrichment_step("mem_summary_test", "entity_link", "skipped", None).await.unwrap();
+        db.record_enrichment_step("mem_summary_test", "dedup", "ok", None)
+            .await
+            .unwrap();
+        db.record_enrichment_step("mem_summary_test", "entity_link", "skipped", None)
+            .await
+            .unwrap();
         let summary = db.get_enrichment_summary("mem_summary_test").await.unwrap();
         assert_eq!(summary, "enriched");
-        db.record_enrichment_step("mem_summary_test", "title_enrich", "failed", Some("err")).await.unwrap();
+        db.record_enrichment_step("mem_summary_test", "title_enrich", "failed", Some("err"))
+            .await
+            .unwrap();
         let summary = db.get_enrichment_summary("mem_summary_test").await.unwrap();
         assert_eq!(summary, "enrichment_partial");
     }
@@ -23331,8 +23377,12 @@ pub(crate) mod tests {
         let (db, _dir) = test_db().await;
         let doc = make_memory_doc("mem_all_fail", "test", "fact", "tech", "agent");
         db.upsert_documents(vec![doc]).await.unwrap();
-        db.record_enrichment_step("mem_all_fail", "dedup", "failed", Some("err1")).await.unwrap();
-        db.record_enrichment_step("mem_all_fail", "entity_link", "failed", Some("err2")).await.unwrap();
+        db.record_enrichment_step("mem_all_fail", "dedup", "failed", Some("err1"))
+            .await
+            .unwrap();
+        db.record_enrichment_step("mem_all_fail", "entity_link", "failed", Some("err2"))
+            .await
+            .unwrap();
         let summary = db.get_enrichment_summary("mem_all_fail").await.unwrap();
         assert_eq!(summary, "enrichment_failed");
     }
@@ -23342,8 +23392,17 @@ pub(crate) mod tests {
         let (db, _dir) = test_db().await;
         let doc = make_memory_doc("mem_abandon_test", "test", "fact", "tech", "agent");
         db.upsert_documents(vec![doc]).await.unwrap();
-        db.record_enrichment_step("mem_abandon_test", "entity_extract", "abandoned", Some("gave up")).await.unwrap();
-        db.record_enrichment_step("mem_abandon_test", "dedup", "ok", None).await.unwrap();
+        db.record_enrichment_step(
+            "mem_abandon_test",
+            "entity_extract",
+            "abandoned",
+            Some("gave up"),
+        )
+        .await
+        .unwrap();
+        db.record_enrichment_step("mem_abandon_test", "dedup", "ok", None)
+            .await
+            .unwrap();
         let reset = db.reset_abandoned_steps("mem_abandon_test").await.unwrap();
         assert_eq!(reset, 1);
         let steps = db.get_enrichment_steps("mem_abandon_test").await.unwrap();
@@ -23355,24 +23414,55 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_list_memories_derives_enrichment_status_from_steps() {
         let (db, _dir) = test_db().await;
-        let doc = make_memory_doc("mem_list_enrich", "Rust ownership model", "fact", "tech", "test");
+        let doc = make_memory_doc(
+            "mem_list_enrich",
+            "Rust ownership model",
+            "fact",
+            "tech",
+            "test",
+        );
         db.upsert_documents(vec![doc]).await.unwrap();
 
         // Before any steps are recorded, status should be "raw"
         let items = db.list_memories(None, None, None, None, 10).await.unwrap();
-        let item = items.iter().find(|i| i.source_id == "mem_list_enrich").unwrap();
+        let item = items
+            .iter()
+            .find(|i| i.source_id == "mem_list_enrich")
+            .unwrap();
         assert_eq!(item.enrichment_status, "raw", "no steps => raw");
 
         // Record one ok step and one failed step => partial
-        db.record_enrichment_step("mem_list_enrich", "dedup", "ok", None).await.unwrap();
-        db.record_enrichment_step("mem_list_enrich", "entity_link", "failed", Some("no entities")).await.unwrap();
+        db.record_enrichment_step("mem_list_enrich", "dedup", "ok", None)
+            .await
+            .unwrap();
+        db.record_enrichment_step(
+            "mem_list_enrich",
+            "entity_link",
+            "failed",
+            Some("no entities"),
+        )
+        .await
+        .unwrap();
 
         let items = db.list_memories(None, None, None, None, 10).await.unwrap();
-        let item = items.iter().find(|i| i.source_id == "mem_list_enrich").unwrap();
-        assert_eq!(item.enrichment_status, "enrichment_partial", "mix of ok and failed => partial");
+        let item = items
+            .iter()
+            .find(|i| i.source_id == "mem_list_enrich")
+            .unwrap();
+        assert_eq!(
+            item.enrichment_status, "enrichment_partial",
+            "mix of ok and failed => partial"
+        );
 
         // Also verify get_memory_detail derives from steps
-        let detail = db.get_memory_detail("mem_list_enrich").await.unwrap().unwrap();
-        assert_eq!(detail.enrichment_status, "enrichment_partial", "detail also derives from steps");
+        let detail = db
+            .get_memory_detail("mem_list_enrich")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            detail.enrichment_status, "enrichment_partial",
+            "detail also derives from steps"
+        );
     }
 }

--- a/crates/origin-core/src/post_ingest.rs
+++ b/crates/origin-core/src/post_ingest.rs
@@ -972,4 +972,42 @@ mod tests {
         assert_eq!(claude_ids, vec!["mem_iso_claude"]);
         assert_eq!(cursor_ids, vec!["mem_iso_cursor"]);
     }
+
+    #[tokio::test]
+    async fn test_enrichment_honesty_end_to_end() {
+        let (db, _dir) = test_db().await;
+
+        // Store memory A -- full enrichment (no LLM, so LLM steps get skipped)
+        let doc_a = make_doc("mem_honest_a", "The Eiffel Tower is in Paris");
+        db.upsert_documents(vec![doc_a]).await.unwrap();
+        run_post_ingest_enrichment(
+            &db, "mem_honest_a", "The Eiffel Tower is in Paris",
+            None, Some("fact"), None, None, None,
+            &crate::prompts::PromptRegistry::default(),
+            &crate::tuning::RefineryConfig::default(),
+            &crate::tuning::DistillationConfig::default(),
+            None,
+        ).await.unwrap();
+
+        // Summary should be enriched (all non-LLM steps ok, LLM steps skipped)
+        let summary_a = db.get_enrichment_summary("mem_honest_a").await.unwrap();
+        assert_eq!(summary_a, "enriched");
+
+        // list_memories should show enriched
+        let items = db.list_memories(None, None, None, None, 10).await.unwrap();
+        let item_a = items.iter().find(|i| i.source_id == "mem_honest_a").unwrap();
+        assert_eq!(item_a.enrichment_status, "enriched");
+
+        // Store memory B -- no enrichment run yet
+        let doc_b = make_doc("mem_honest_b", "Tokyo is the capital of Japan");
+        db.upsert_documents(vec![doc_b]).await.unwrap();
+
+        // Should be raw (no steps recorded)
+        let summary_b = db.get_enrichment_summary("mem_honest_b").await.unwrap();
+        assert_eq!(summary_b, "raw");
+
+        let items = db.list_memories(None, None, None, None, 10).await.unwrap();
+        let item_b = items.iter().find(|i| i.source_id == "mem_honest_b").unwrap();
+        assert_eq!(item_b.enrichment_status, "raw");
+    }
 }

--- a/crates/origin-core/src/post_ingest.rs
+++ b/crates/origin-core/src/post_ingest.rs
@@ -49,14 +49,20 @@ pub async fn run_post_ingest_enrichment(
                 "[post_ingest] dedup safety net fired for {source_id}: {n} duplicate candidate(s) queued. \
                  This suggests a gap in topic matching or novelty gate."
             );
-            db.record_enrichment_step(source_id, "dedup", "ok", None).await.ok();
+            db.record_enrichment_step(source_id, "dedup", "ok", None)
+                .await
+                .ok();
         }
         Ok(_) => {
-            db.record_enrichment_step(source_id, "dedup", "ok", None).await.ok();
+            db.record_enrichment_step(source_id, "dedup", "ok", None)
+                .await
+                .ok();
         }
         Err(e) => {
             log::warn!("[post_ingest] dedup check failed: {e}");
-            db.record_enrichment_step(source_id, "dedup", "failed", Some(&e.to_string())).await.ok();
+            db.record_enrichment_step(source_id, "dedup", "failed", Some(&e.to_string()))
+                .await
+                .ok();
         }
     }
 
@@ -64,18 +70,26 @@ pub async fn run_post_ingest_enrichment(
     if entity_id.is_none() {
         match auto_link_entity(db, source_id, content, tuning).await {
             Ok(true) => {
-                db.record_enrichment_step(source_id, "entity_link", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "entity_link", "ok", None)
+                    .await
+                    .ok();
             }
             Ok(false) => {
-                db.record_enrichment_step(source_id, "entity_link", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "entity_link", "ok", None)
+                    .await
+                    .ok();
             }
             Err(e) => {
                 log::warn!("[post_ingest] entity linking failed: {e}");
-                db.record_enrichment_step(source_id, "entity_link", "failed", Some(&e.to_string())).await.ok();
+                db.record_enrichment_step(source_id, "entity_link", "failed", Some(&e.to_string()))
+                    .await
+                    .ok();
             }
         }
     } else {
-        db.record_enrichment_step(source_id, "entity_link", "skipped", None).await.ok();
+        db.record_enrichment_step(source_id, "entity_link", "skipped", None)
+            .await
+            .ok();
     }
 
     // 2b. Store-time entity extraction with time-windowed batching
@@ -131,14 +145,25 @@ pub async fn run_post_ingest_enrichment(
                             "[post_ingest] batch extraction linked {} memories to entity",
                             batch.len()
                         );
-                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None)
+                            .await
+                            .ok();
                     }
                     Ok(None) => {
-                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None)
+                            .await
+                            .ok();
                     }
                     Err(e) => {
                         log::warn!("[post_ingest] batch entity extraction failed: {e}");
-                        db.record_enrichment_step(source_id, "entity_extract", "failed", Some(&e.to_string())).await.ok();
+                        db.record_enrichment_step(
+                            source_id,
+                            "entity_extract",
+                            "failed",
+                            Some(&e.to_string()),
+                        )
+                        .await
+                        .ok();
                     }
                 }
             } else {
@@ -151,22 +176,37 @@ pub async fn run_post_ingest_enrichment(
                     Ok(Some(eid)) => {
                         let eid_prefix: String = eid.chars().take(12).collect();
                         log::info!("[post_ingest] {source_id}: extracted entity {eid_prefix}");
-                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None)
+                            .await
+                            .ok();
                     }
                     Ok(None) => {
-                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None)
+                            .await
+                            .ok();
                     }
                     Err(e) => {
                         log::warn!("[post_ingest] store-time entity extraction failed: {e}");
-                        db.record_enrichment_step(source_id, "entity_extract", "failed", Some(&e.to_string())).await.ok();
+                        db.record_enrichment_step(
+                            source_id,
+                            "entity_extract",
+                            "failed",
+                            Some(&e.to_string()),
+                        )
+                        .await
+                        .ok();
                     }
                 }
             }
         } else {
-            db.record_enrichment_step(source_id, "entity_extract", "skipped", None).await.ok();
+            db.record_enrichment_step(source_id, "entity_extract", "skipped", None)
+                .await
+                .ok();
         }
     } else {
-        db.record_enrichment_step(source_id, "entity_extract", "skipped", None).await.ok();
+        db.record_enrichment_step(source_id, "entity_extract", "skipped", None)
+            .await
+            .ok();
     }
 
     // 3. Semantic contradiction check (type+domain pre-filter)
@@ -174,43 +214,76 @@ pub async fn run_post_ingest_enrichment(
         match check_contradiction(db, source_id, mt, domain, structured_fields, content).await {
             Ok(n) if n > 0 => {
                 log::info!("[post_ingest] {source_id}: {n} contradiction candidate(s) queued");
-                db.record_enrichment_step(source_id, "contradiction", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "contradiction", "ok", None)
+                    .await
+                    .ok();
             }
             Ok(_) => {
-                db.record_enrichment_step(source_id, "contradiction", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "contradiction", "ok", None)
+                    .await
+                    .ok();
             }
             Err(e) => {
                 log::warn!("[post_ingest] contradiction check failed: {e}");
-                db.record_enrichment_step(source_id, "contradiction", "failed", Some(&e.to_string())).await.ok();
+                db.record_enrichment_step(
+                    source_id,
+                    "contradiction",
+                    "failed",
+                    Some(&e.to_string()),
+                )
+                .await
+                .ok();
             }
         }
     } else {
-        db.record_enrichment_step(source_id, "contradiction", "skipped", None).await.ok();
+        db.record_enrichment_step(source_id, "contradiction", "skipped", None)
+            .await
+            .ok();
     }
 
     // 3b. Concept contradiction check — flag related concepts for re-distill if new memory contradicts
     match check_concept_contradiction(db, source_id, content).await {
         Ok(n) if n > 0 => {
             log::info!("[post_ingest] {source_id}: flagged {n} concept(s) for re-distill");
-            db.record_enrichment_step(source_id, "concept_contradiction", "ok", None).await.ok();
+            db.record_enrichment_step(source_id, "concept_contradiction", "ok", None)
+                .await
+                .ok();
         }
         Ok(_) => {
-            db.record_enrichment_step(source_id, "concept_contradiction", "ok", None).await.ok();
+            db.record_enrichment_step(source_id, "concept_contradiction", "ok", None)
+                .await
+                .ok();
         }
         Err(e) => {
             log::warn!("[post_ingest] concept contradiction check failed: {e}");
-            db.record_enrichment_step(source_id, "concept_contradiction", "failed", Some(&e.to_string())).await.ok();
+            db.record_enrichment_step(
+                source_id,
+                "concept_contradiction",
+                "failed",
+                Some(&e.to_string()),
+            )
+            .await
+            .ok();
         }
     }
 
     // 4. Entity creation suggestion (stub — full extraction runs in refinery steep)
     match suggest_entity_creation(db, content).await {
         Ok(()) => {
-            db.record_enrichment_step(source_id, "entity_suggestion", "ok", None).await.ok();
+            db.record_enrichment_step(source_id, "entity_suggestion", "ok", None)
+                .await
+                .ok();
         }
         Err(e) => {
             log::warn!("[post_ingest] entity suggestion failed: {e}");
-            db.record_enrichment_step(source_id, "entity_suggestion", "failed", Some(&e.to_string())).await.ok();
+            db.record_enrichment_step(
+                source_id,
+                "entity_suggestion",
+                "failed",
+                Some(&e.to_string()),
+            )
+            .await
+            .ok();
         }
     }
 
@@ -219,18 +292,31 @@ pub async fn run_post_ingest_enrichment(
         match enrich_title(db, source_id, content, llm_ref).await {
             Ok(true) => {
                 log::info!("[post_ingest] {source_id}: title enriched");
-                db.record_enrichment_step(source_id, "title_enrich", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "title_enrich", "ok", None)
+                    .await
+                    .ok();
             }
             Ok(false) => {
-                db.record_enrichment_step(source_id, "title_enrich", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "title_enrich", "ok", None)
+                    .await
+                    .ok();
             }
             Err(e) => {
                 log::warn!("[post_ingest] title enrichment failed: {e}");
-                db.record_enrichment_step(source_id, "title_enrich", "failed", Some(&e.to_string())).await.ok();
+                db.record_enrichment_step(
+                    source_id,
+                    "title_enrich",
+                    "failed",
+                    Some(&e.to_string()),
+                )
+                .await
+                .ok();
             }
         }
     } else {
-        db.record_enrichment_step(source_id, "title_enrich", "skipped", None).await.ok();
+        db.record_enrichment_step(source_id, "title_enrich", "skipped", None)
+            .await
+            .ok();
     }
 
     // 6. Recap trigger — REMOVED. Recaps are now generated by the event-driven
@@ -252,7 +338,9 @@ pub async fn run_post_ingest_enrichment(
     {
         Ok(true) => {
             log::info!("[post_ingest] {source_id}: updated matching concept");
-            db.record_enrichment_step(source_id, "concept_growth", "ok", None).await.ok();
+            db.record_enrichment_step(source_id, "concept_growth", "ok", None)
+                .await
+                .ok();
             if let Some(kp) = knowledge_path {
                 write_grown_concept(db, source_id, kp).await;
             }
@@ -260,14 +348,20 @@ pub async fn run_post_ingest_enrichment(
         Ok(false) => {
             // grow_concept returns false when LLM is unavailable — treat as skipped
             if llm.map(|l| l.is_available()).unwrap_or(false) {
-                db.record_enrichment_step(source_id, "concept_growth", "ok", None).await.ok();
+                db.record_enrichment_step(source_id, "concept_growth", "ok", None)
+                    .await
+                    .ok();
             } else {
-                db.record_enrichment_step(source_id, "concept_growth", "skipped", None).await.ok();
+                db.record_enrichment_step(source_id, "concept_growth", "skipped", None)
+                    .await
+                    .ok();
             }
         }
         Err(e) => {
             log::warn!("[post_ingest] concept growth failed: {e}");
-            db.record_enrichment_step(source_id, "concept_growth", "failed", Some(&e.to_string())).await.ok();
+            db.record_enrichment_step(source_id, "concept_growth", "failed", Some(&e.to_string()))
+                .await
+                .ok();
         }
     }
 
@@ -474,7 +568,10 @@ pub(crate) async fn check_concept_contradiction(
 }
 
 /// Stub for entity creation suggestion. Full implementation in Task 5 (refinery).
-pub(crate) async fn suggest_entity_creation(_db: &MemoryDB, _content: &str) -> Result<(), OriginError> {
+pub(crate) async fn suggest_entity_creation(
+    _db: &MemoryDB,
+    _content: &str,
+) -> Result<(), OriginError> {
     // TODO: Detect entity-like proper nouns in content and queue
     // 'suggest_entity' refinement action if no matching entity exists.
     Ok(())
@@ -740,13 +837,21 @@ mod tests {
         db.upsert_documents(vec![doc]).await.unwrap();
 
         run_post_ingest_enrichment(
-            &db, "mem_step_record", "The capital of France is Paris",
-            None, Some("fact"), None, None, None,
+            &db,
+            "mem_step_record",
+            "The capital of France is Paris",
+            None,
+            Some("fact"),
+            None,
+            None,
+            None,
             &crate::prompts::PromptRegistry::default(),
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::DistillationConfig::default(),
             None,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         let steps = db.get_enrichment_steps("mem_step_record").await.unwrap();
         assert!(!steps.is_empty(), "should have recorded enrichment steps");
@@ -981,13 +1086,21 @@ mod tests {
         let doc_a = make_doc("mem_honest_a", "The Eiffel Tower is in Paris");
         db.upsert_documents(vec![doc_a]).await.unwrap();
         run_post_ingest_enrichment(
-            &db, "mem_honest_a", "The Eiffel Tower is in Paris",
-            None, Some("fact"), None, None, None,
+            &db,
+            "mem_honest_a",
+            "The Eiffel Tower is in Paris",
+            None,
+            Some("fact"),
+            None,
+            None,
+            None,
             &crate::prompts::PromptRegistry::default(),
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::DistillationConfig::default(),
             None,
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         // Summary should be enriched (all non-LLM steps ok, LLM steps skipped)
         let summary_a = db.get_enrichment_summary("mem_honest_a").await.unwrap();
@@ -995,7 +1108,10 @@ mod tests {
 
         // list_memories should show enriched
         let items = db.list_memories(None, None, None, None, 10).await.unwrap();
-        let item_a = items.iter().find(|i| i.source_id == "mem_honest_a").unwrap();
+        let item_a = items
+            .iter()
+            .find(|i| i.source_id == "mem_honest_a")
+            .unwrap();
         assert_eq!(item_a.enrichment_status, "enriched");
 
         // Store memory B -- no enrichment run yet
@@ -1007,7 +1123,10 @@ mod tests {
         assert_eq!(summary_b, "raw");
 
         let items = db.list_memories(None, None, None, None, 10).await.unwrap();
-        let item_b = items.iter().find(|i| i.source_id == "mem_honest_b").unwrap();
+        let item_b = items
+            .iter()
+            .find(|i| i.source_id == "mem_honest_b")
+            .unwrap();
         assert_eq!(item_b.enrichment_status, "raw");
     }
 }

--- a/crates/origin-core/src/post_ingest.rs
+++ b/crates/origin-core/src/post_ingest.rs
@@ -14,7 +14,7 @@
 //! 5. Title enrichment (LLM short title if current looks truncated)
 //! 6. (Removed — recaps now handled by event-driven scheduler)
 //! 7. Concept growth (update matching concept with new memory)
-//! 8. Mark enrichment_status = 'enriched'
+//! 8. (Removed -- enrichment status derived from per-step outcomes in enrichment_steps table)
 
 use crate::db::MemoryDB;
 use crate::error::OriginError;
@@ -48,19 +48,34 @@ pub async fn run_post_ingest_enrichment(
             log::warn!(
                 "[post_ingest] dedup safety net fired for {source_id}: {n} duplicate candidate(s) queued. \
                  This suggests a gap in topic matching or novelty gate."
-            )
+            );
+            db.record_enrichment_step(source_id, "dedup", "ok", None).await.ok();
         }
-        Ok(_) => {}
-        Err(e) => log::warn!("[post_ingest] dedup check failed: {e}"),
+        Ok(_) => {
+            db.record_enrichment_step(source_id, "dedup", "ok", None).await.ok();
+        }
+        Err(e) => {
+            log::warn!("[post_ingest] dedup check failed: {e}");
+            db.record_enrichment_step(source_id, "dedup", "failed", Some(&e.to_string())).await.ok();
+        }
     }
 
     // 2. Entity auto-linking (only if not already linked)
     if entity_id.is_none() {
         match auto_link_entity(db, source_id, content, tuning).await {
-            Ok(true) => {} // already logged inside auto_link_entity
-            Ok(false) => {}
-            Err(e) => log::warn!("[post_ingest] entity linking failed: {e}"),
+            Ok(true) => {
+                db.record_enrichment_step(source_id, "entity_link", "ok", None).await.ok();
+            }
+            Ok(false) => {
+                db.record_enrichment_step(source_id, "entity_link", "ok", None).await.ok();
+            }
+            Err(e) => {
+                log::warn!("[post_ingest] entity linking failed: {e}");
+                db.record_enrichment_step(source_id, "entity_link", "failed", Some(&e.to_string())).await.ok();
+            }
         }
+    } else {
+        db.record_enrichment_step(source_id, "entity_link", "skipped", None).await.ok();
     }
 
     // 2b. Store-time entity extraction with time-windowed batching
@@ -116,9 +131,15 @@ pub async fn run_post_ingest_enrichment(
                             "[post_ingest] batch extraction linked {} memories to entity",
                             batch.len()
                         );
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
                     }
-                    Ok(None) => {}
-                    Err(e) => log::warn!("[post_ingest] batch entity extraction failed: {e}"),
+                    Ok(None) => {
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
+                    }
+                    Err(e) => {
+                        log::warn!("[post_ingest] batch entity extraction failed: {e}");
+                        db.record_enrichment_step(source_id, "entity_extract", "failed", Some(&e.to_string())).await.ok();
+                    }
                 }
             } else {
                 // Single memory extraction (no batch or source_agent unknown)
@@ -130,46 +151,86 @@ pub async fn run_post_ingest_enrichment(
                     Ok(Some(eid)) => {
                         let eid_prefix: String = eid.chars().take(12).collect();
                         log::info!("[post_ingest] {source_id}: extracted entity {eid_prefix}");
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
                     }
-                    Ok(None) => {}
-                    Err(e) => log::warn!("[post_ingest] store-time entity extraction failed: {e}"),
+                    Ok(None) => {
+                        db.record_enrichment_step(source_id, "entity_extract", "ok", None).await.ok();
+                    }
+                    Err(e) => {
+                        log::warn!("[post_ingest] store-time entity extraction failed: {e}");
+                        db.record_enrichment_step(source_id, "entity_extract", "failed", Some(&e.to_string())).await.ok();
+                    }
                 }
             }
+        } else {
+            db.record_enrichment_step(source_id, "entity_extract", "skipped", None).await.ok();
         }
+    } else {
+        db.record_enrichment_step(source_id, "entity_extract", "skipped", None).await.ok();
     }
 
     // 3. Semantic contradiction check (type+domain pre-filter)
     if let Some(mt) = memory_type {
         match check_contradiction(db, source_id, mt, domain, structured_fields, content).await {
             Ok(n) if n > 0 => {
-                log::info!("[post_ingest] {source_id}: {n} contradiction candidate(s) queued")
+                log::info!("[post_ingest] {source_id}: {n} contradiction candidate(s) queued");
+                db.record_enrichment_step(source_id, "contradiction", "ok", None).await.ok();
             }
-            Ok(_) => {}
-            Err(e) => log::warn!("[post_ingest] contradiction check failed: {e}"),
+            Ok(_) => {
+                db.record_enrichment_step(source_id, "contradiction", "ok", None).await.ok();
+            }
+            Err(e) => {
+                log::warn!("[post_ingest] contradiction check failed: {e}");
+                db.record_enrichment_step(source_id, "contradiction", "failed", Some(&e.to_string())).await.ok();
+            }
         }
+    } else {
+        db.record_enrichment_step(source_id, "contradiction", "skipped", None).await.ok();
     }
 
     // 3b. Concept contradiction check — flag related concepts for re-distill if new memory contradicts
     match check_concept_contradiction(db, source_id, content).await {
         Ok(n) if n > 0 => {
-            log::info!("[post_ingest] {source_id}: flagged {n} concept(s) for re-distill")
+            log::info!("[post_ingest] {source_id}: flagged {n} concept(s) for re-distill");
+            db.record_enrichment_step(source_id, "concept_contradiction", "ok", None).await.ok();
         }
-        Ok(_) => {}
-        Err(e) => log::warn!("[post_ingest] concept contradiction check failed: {e}"),
+        Ok(_) => {
+            db.record_enrichment_step(source_id, "concept_contradiction", "ok", None).await.ok();
+        }
+        Err(e) => {
+            log::warn!("[post_ingest] concept contradiction check failed: {e}");
+            db.record_enrichment_step(source_id, "concept_contradiction", "failed", Some(&e.to_string())).await.ok();
+        }
     }
 
     // 4. Entity creation suggestion (stub — full extraction runs in refinery steep)
-    if let Err(e) = suggest_entity_creation(db, content).await {
-        log::warn!("[post_ingest] entity suggestion failed: {e}");
+    match suggest_entity_creation(db, content).await {
+        Ok(()) => {
+            db.record_enrichment_step(source_id, "entity_suggestion", "ok", None).await.ok();
+        }
+        Err(e) => {
+            log::warn!("[post_ingest] entity suggestion failed: {e}");
+            db.record_enrichment_step(source_id, "entity_suggestion", "failed", Some(&e.to_string())).await.ok();
+        }
     }
 
     // 5. Title enrichment — generate short topic title if current title is a truncation
     if let Some(llm_ref) = llm {
         match enrich_title(db, source_id, content, llm_ref).await {
-            Ok(true) => log::info!("[post_ingest] {source_id}: title enriched"),
-            Ok(false) => {}
-            Err(e) => log::warn!("[post_ingest] title enrichment failed: {e}"),
+            Ok(true) => {
+                log::info!("[post_ingest] {source_id}: title enriched");
+                db.record_enrichment_step(source_id, "title_enrich", "ok", None).await.ok();
+            }
+            Ok(false) => {
+                db.record_enrichment_step(source_id, "title_enrich", "ok", None).await.ok();
+            }
+            Err(e) => {
+                log::warn!("[post_ingest] title enrichment failed: {e}");
+                db.record_enrichment_step(source_id, "title_enrich", "failed", Some(&e.to_string())).await.ok();
+            }
         }
+    } else {
+        db.record_enrichment_step(source_id, "title_enrich", "skipped", None).await.ok();
     }
 
     // 6. Recap trigger — REMOVED. Recaps are now generated by the event-driven
@@ -191,12 +252,23 @@ pub async fn run_post_ingest_enrichment(
     {
         Ok(true) => {
             log::info!("[post_ingest] {source_id}: updated matching concept");
+            db.record_enrichment_step(source_id, "concept_growth", "ok", None).await.ok();
             if let Some(kp) = knowledge_path {
                 write_grown_concept(db, source_id, kp).await;
             }
         }
-        Ok(false) => {}
-        Err(e) => log::warn!("[post_ingest] concept growth failed: {e}"),
+        Ok(false) => {
+            // grow_concept returns false when LLM is unavailable — treat as skipped
+            if llm.map(|l| l.is_available()).unwrap_or(false) {
+                db.record_enrichment_step(source_id, "concept_growth", "ok", None).await.ok();
+            } else {
+                db.record_enrichment_step(source_id, "concept_growth", "skipped", None).await.ok();
+            }
+        }
+        Err(e) => {
+            log::warn!("[post_ingest] concept growth failed: {e}");
+            db.record_enrichment_step(source_id, "concept_growth", "failed", Some(&e.to_string())).await.ok();
+        }
     }
 
     // 7b. KG quality verification — check entity self-retrieval after all linking/extraction
@@ -217,16 +289,11 @@ pub async fn run_post_ingest_enrichment(
         }
     }
 
-    // 8. Mark enriched (even on partial failure above)
-    if let Err(e) = db.mark_enriched(source_id).await {
-        log::warn!("[post_ingest] mark_enriched failed: {e}");
-    }
-
     Ok(())
 }
 
 /// Check for semantic contradictions against existing same-type memories.
-pub async fn check_contradiction(
+pub(crate) async fn check_contradiction(
     db: &MemoryDB,
     source_id: &str,
     memory_type: &str,
@@ -274,7 +341,7 @@ pub async fn check_contradiction(
 
 /// Check for near-duplicates via vector similarity (cosine > 0.92).
 /// Queues `dedup_merge` refinement proposals for matches.
-async fn check_dedup(
+pub(crate) async fn check_dedup(
     db: &MemoryDB,
     source_id: &str,
     content: &str,
@@ -312,7 +379,7 @@ async fn check_dedup(
 
 /// Auto-link memory to an existing entity via vector search.
 /// Links to the best matching entity with distance < 0.15 (cosine similarity > 0.85).
-async fn auto_link_entity(
+pub(crate) async fn auto_link_entity(
     db: &MemoryDB,
     source_id: &str,
     content: &str,
@@ -340,7 +407,7 @@ async fn auto_link_entity(
 /// Uses FTS5 search to find related concepts, then checks for negation signals
 /// with topic overlap. Flags contradicting concepts for re-distill by adding the
 /// new memory to their source list.
-async fn check_concept_contradiction(
+pub(crate) async fn check_concept_contradiction(
     db: &MemoryDB,
     source_id: &str,
     content: &str,
@@ -407,14 +474,14 @@ async fn check_concept_contradiction(
 }
 
 /// Stub for entity creation suggestion. Full implementation in Task 5 (refinery).
-async fn suggest_entity_creation(_db: &MemoryDB, _content: &str) -> Result<(), OriginError> {
+pub(crate) async fn suggest_entity_creation(_db: &MemoryDB, _content: &str) -> Result<(), OriginError> {
     // TODO: Detect entity-like proper nouns in content and queue
     // 'suggest_entity' refinement action if no matching entity exists.
     Ok(())
 }
 
 /// Generate a short topic title if the current title looks like a content truncation.
-async fn enrich_title(
+pub(crate) async fn enrich_title(
     db: &MemoryDB,
     source_id: &str,
     content: &str,
@@ -447,7 +514,7 @@ async fn enrich_title(
 }
 
 /// Check if new memory matches an existing concept; if so, update it.
-async fn grow_concept(
+pub(crate) async fn grow_concept(
     db: &MemoryDB,
     source_id: &str,
     content: &str,
@@ -661,9 +728,48 @@ mod tests {
         .await
         .unwrap();
 
-        // Verify enrichment_status was updated
-        let status = db.get_enrichment_status("mem_enrich_test").await.unwrap();
-        assert_eq!(status, Some("enriched".to_string()));
+        // Verify enrichment_summary is derived from per-step outcomes
+        let summary = db.get_enrichment_summary("mem_enrich_test").await.unwrap();
+        assert_eq!(summary, "enriched");
+    }
+
+    #[tokio::test]
+    async fn test_enrichment_records_per_step_outcomes() {
+        let (db, _dir) = test_db().await;
+        let doc = make_doc("mem_step_record", "The capital of France is Paris");
+        db.upsert_documents(vec![doc]).await.unwrap();
+
+        run_post_ingest_enrichment(
+            &db, "mem_step_record", "The capital of France is Paris",
+            None, Some("fact"), None, None, None,
+            &crate::prompts::PromptRegistry::default(),
+            &crate::tuning::RefineryConfig::default(),
+            &crate::tuning::DistillationConfig::default(),
+            None,
+        ).await.unwrap();
+
+        let steps = db.get_enrichment_steps("mem_step_record").await.unwrap();
+        assert!(!steps.is_empty(), "should have recorded enrichment steps");
+
+        // dedup should be ok (no duplicates)
+        let dedup = steps.iter().find(|s| s.step == "dedup").unwrap();
+        assert_eq!(dedup.status, "ok");
+
+        // entity_extract should be skipped (no LLM)
+        let extract = steps.iter().find(|s| s.step == "entity_extract").unwrap();
+        assert_eq!(extract.status, "skipped");
+
+        // title_enrich should be skipped (no LLM)
+        let title = steps.iter().find(|s| s.step == "title_enrich").unwrap();
+        assert_eq!(title.status, "skipped");
+
+        // concept_growth should be skipped (no LLM)
+        let growth = steps.iter().find(|s| s.step == "concept_growth").unwrap();
+        assert_eq!(growth.status, "skipped");
+
+        // Summary should be enriched (no failures)
+        let summary = db.get_enrichment_summary("mem_step_record").await.unwrap();
+        assert_eq!(summary, "enriched");
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/refinery.rs
+++ b/crates/origin-core/src/refinery.rs
@@ -3057,28 +3057,26 @@ pub(crate) async fn retry_failed_enrichment(
             }
             Err(e) => {
                 log::warn!("[refinery] retry of '{step_name}' for {source_id} failed: {e}");
-                db.record_enrichment_step(
-                    source_id,
-                    step_name,
-                    "failed",
-                    Some(&e.to_string()),
-                )
-                .await
-                .ok();
-                // Check if we hit max retries
-                if let Ok(steps) = db.get_enrichment_steps(source_id).await {
-                    if let Some(step) = steps.iter().find(|s| s.step == *step_name) {
-                        if step.attempts as usize >= tuning.max_enrichment_retries {
-                            db.record_enrichment_step(
-                                source_id,
-                                step_name,
-                                "abandoned",
-                                Some(&e.to_string()),
-                            )
-                            .await
-                            .ok();
-                        }
-                    }
+                // Check current attempts BEFORE recording, so we can decide
+                // whether to mark failed (retryable) or abandoned (final).
+                let current_attempts = db
+                    .get_enrichment_steps(source_id)
+                    .await
+                    .ok()
+                    .and_then(|steps| steps.iter().find(|s| s.step == *step_name).map(|s| s.attempts))
+                    .unwrap_or(0);
+                // record_enrichment_step increments attempts via UPSERT, so
+                // after this call attempts = current_attempts + 1.
+                let status = if (current_attempts + 1) as usize >= tuning.max_enrichment_retries {
+                    "abandoned"
+                } else {
+                    "failed"
+                };
+                db.record_enrichment_step(source_id, step_name, status, Some(&e.to_string()))
+                    .await
+                    .ok();
+                if status == "abandoned" {
+                    log::info!("[refinery] step '{step_name}' for {source_id} abandoned after {} attempts", current_attempts + 1);
                 }
                 retried += 1;
             }

--- a/crates/origin-core/src/refinery.rs
+++ b/crates/origin-core/src/refinery.rs
@@ -3011,11 +3011,9 @@ pub(crate) async fn retry_failed_enrichment(
             "dedup" => crate::post_ingest::check_dedup(db, source_id, content, tuning)
                 .await
                 .map(|_| ()),
-            "entity_link" => {
-                crate::post_ingest::auto_link_entity(db, source_id, content, tuning)
-                    .await
-                    .map(|_| ())
-            }
+            "entity_link" => crate::post_ingest::auto_link_entity(db, source_id, content, tuning)
+                .await
+                .map(|_| ()),
             "contradiction" => {
                 let mt = db.get_memory_type(source_id).await.unwrap_or(None);
                 let domain = db.get_memory_domain(source_id).await.unwrap_or(None);
@@ -3039,9 +3037,7 @@ pub(crate) async fn retry_failed_enrichment(
                     .await
                     .map(|_| ())
             }
-            "entity_suggestion" => {
-                crate::post_ingest::suggest_entity_creation(db, content).await
-            }
+            "entity_suggestion" => crate::post_ingest::suggest_entity_creation(db, content).await,
             // LLM-requiring steps can't be retried without LLM
             _ => {
                 log::info!("[refinery] step '{step_name}' requires LLM, skipping");
@@ -3063,7 +3059,12 @@ pub(crate) async fn retry_failed_enrichment(
                     .get_enrichment_steps(source_id)
                     .await
                     .ok()
-                    .and_then(|steps| steps.iter().find(|s| s.step == *step_name).map(|s| s.attempts))
+                    .and_then(|steps| {
+                        steps
+                            .iter()
+                            .find(|s| s.step == *step_name)
+                            .map(|s| s.attempts)
+                    })
                     .unwrap_or(0);
                 // record_enrichment_step increments attempts via UPSERT, so
                 // after this call attempts = current_attempts + 1.
@@ -3076,7 +3077,10 @@ pub(crate) async fn retry_failed_enrichment(
                     .await
                     .ok();
                 if status == "abandoned" {
-                    log::info!("[refinery] step '{step_name}' for {source_id} abandoned after {} attempts", current_attempts + 1);
+                    log::info!(
+                        "[refinery] step '{step_name}' for {source_id} abandoned after {} attempts",
+                        current_attempts + 1
+                    );
                 }
                 retried += 1;
             }

--- a/crates/origin-core/src/refinery.rs
+++ b/crates/origin-core/src/refinery.rs
@@ -28,6 +28,7 @@ pub const ALL_PHASES: &[&str] = &[
     "decision_backfill",
     "prune_rejections",
     "kg_rethink",
+    "retry_failed_enrichment",
 ];
 
 /// What triggered a refinery cycle. Different triggers run different subsets
@@ -57,7 +58,11 @@ impl TriggerKind {
             Self::BurstEnd => matches!(phase_name, "recaps" | "refinement_queue"),
             Self::Idle => matches!(
                 phase_name,
-                "community_detection" | "emergence" | "re-distill" | "decision_logs"
+                "community_detection"
+                    | "emergence"
+                    | "re-distill"
+                    | "decision_logs"
+                    | "retry_failed_enrichment"
             ),
             Self::Daily => matches!(
                 phase_name,
@@ -763,6 +768,22 @@ pub async fn run_periodic_steep_with_api(
             }
             phases.push(phase);
         }
+    }
+
+    // Phase 11: Retry failed enrichment — self-healing for non-LLM steps
+    if trigger.runs_phase("retry_failed_enrichment") {
+        let phase = run_phase("retry_failed_enrichment", || async {
+            let retried = retry_failed_enrichment(db_ref, tuning).await?;
+            log::info!("[refinery] retry_failed_enrichment: retried {retried} steps");
+            let (nudge, headline) = classify_backfill(retried);
+            Ok(PhaseOutput {
+                items_processed: retried,
+                nudge,
+                headline,
+            })
+        })
+        .await;
+        phases.push(phase);
     }
 
     let elapsed = steep_start.elapsed();
@@ -2966,6 +2987,106 @@ async fn apply_merge_by_tier(
     Ok(())
 }
 
+/// Retry enrichment steps that previously failed (status = "failed") but
+/// haven't exceeded `max_enrichment_retries`. Only non-LLM steps (dedup,
+/// entity_link, contradiction, concept_contradiction, entity_suggestion)
+/// can be retried here — LLM-requiring steps are skipped. On success the
+/// step is marked "ok"; on repeated failure and max retries reached the
+/// step is moved to "abandoned".
+pub(crate) async fn retry_failed_enrichment(
+    db: &MemoryDB,
+    tuning: &crate::tuning::RefineryConfig,
+) -> Result<usize, OriginError> {
+    let failed = db
+        .get_failed_enrichment_memories(tuning.max_enrichment_retries, 20)
+        .await?;
+    if failed.is_empty() {
+        return Ok(0);
+    }
+
+    let mut retried = 0usize;
+    for (source_id, step_name, content) in &failed {
+        log::info!("[refinery] retrying enrichment step '{step_name}' for {source_id}");
+        let result = match step_name.as_str() {
+            "dedup" => crate::post_ingest::check_dedup(db, source_id, content, tuning)
+                .await
+                .map(|_| ()),
+            "entity_link" => {
+                crate::post_ingest::auto_link_entity(db, source_id, content, tuning)
+                    .await
+                    .map(|_| ())
+            }
+            "contradiction" => {
+                let mt = db.get_memory_type(source_id).await.unwrap_or(None);
+                let domain = db.get_memory_domain(source_id).await.unwrap_or(None);
+                if let Some(mt) = &mt {
+                    crate::post_ingest::check_contradiction(
+                        db,
+                        source_id,
+                        mt,
+                        domain.as_deref(),
+                        None,
+                        content,
+                    )
+                    .await
+                    .map(|_| ())
+                } else {
+                    Ok(())
+                }
+            }
+            "concept_contradiction" => {
+                crate::post_ingest::check_concept_contradiction(db, source_id, content)
+                    .await
+                    .map(|_| ())
+            }
+            "entity_suggestion" => {
+                crate::post_ingest::suggest_entity_creation(db, content).await
+            }
+            // LLM-requiring steps can't be retried without LLM
+            _ => {
+                log::info!("[refinery] step '{step_name}' requires LLM, skipping");
+                continue;
+            }
+        };
+        match result {
+            Ok(()) => {
+                db.record_enrichment_step(source_id, step_name, "ok", None)
+                    .await
+                    .ok();
+                retried += 1;
+            }
+            Err(e) => {
+                log::warn!("[refinery] retry of '{step_name}' for {source_id} failed: {e}");
+                db.record_enrichment_step(
+                    source_id,
+                    step_name,
+                    "failed",
+                    Some(&e.to_string()),
+                )
+                .await
+                .ok();
+                // Check if we hit max retries
+                if let Ok(steps) = db.get_enrichment_steps(source_id).await {
+                    if let Some(step) = steps.iter().find(|s| s.step == *step_name) {
+                        if step.attempts as usize >= tuning.max_enrichment_retries {
+                            db.record_enrichment_step(
+                                source_id,
+                                step_name,
+                                "abandoned",
+                                Some(&e.to_string()),
+                            )
+                            .await
+                            .ok();
+                        }
+                    }
+                }
+                retried += 1;
+            }
+        }
+    }
+    Ok(retried)
+}
+
 /// Trigger a refinery steep on demand — used by the chat import flow to
 /// process freshly-ingested memories without waiting for the scheduled
 /// 30-minute tick.
@@ -3287,6 +3408,7 @@ mod tests {
             "emergence",
             "re-distill",
             "decision_logs",
+            "retry_failed_enrichment",
         ];
         for &exp in expected {
             assert!(
@@ -3402,9 +3524,9 @@ mod tests {
 
         let phase_names: Vec<&str> = result.phases.iter().map(|p| p.name.as_str()).collect();
 
-        // All 15 phases must run with Backstop (14 prior + kg_rethink added
-        // in the KG quality work). `kg_rethink` is rate-limited, so on a
-        // fresh DB (last_kg_rethink_ts=0) it runs on the first steep.
+        // All 16 phases must run with Backstop. `kg_rethink` is
+        // rate-limited, so on a fresh DB (last_kg_rethink_ts=0) it runs
+        // on the first steep.
         let expected: &[&str] = &[
             "decay",
             "promote",
@@ -3421,6 +3543,7 @@ mod tests {
             "decision_backfill",
             "prune_rejections",
             "kg_rethink",
+            "retry_failed_enrichment",
         ];
         for &exp in expected {
             assert!(
@@ -4458,5 +4581,51 @@ mod tests {
             strip_source_prefix("[has spaces] content"),
             "[has spaces] content"
         );
+    }
+
+    // ── retry_failed_enrichment tests (Task 8) ─────────────────────────
+
+    #[tokio::test]
+    async fn test_retry_failed_enrichment_phase() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory(
+            "mem_retry_test",
+            "Python uses indentation for blocks",
+            "fact",
+            "tech",
+        );
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.record_enrichment_step("mem_retry_test", "dedup", "failed", Some("transient error"))
+            .await
+            .unwrap();
+        db.record_enrichment_step("mem_retry_test", "entity_link", "ok", None)
+            .await
+            .unwrap();
+        let tuning = crate::tuning::RefineryConfig::default();
+        let count = retry_failed_enrichment(&db, &tuning).await.unwrap();
+        assert!(count > 0, "should have retried at least one memory");
+        let steps = db.get_enrichment_steps("mem_retry_test").await.unwrap();
+        let dedup = steps.iter().find(|s| s.step == "dedup").unwrap();
+        assert_eq!(dedup.status, "ok", "retry should have fixed the dedup step");
+    }
+
+    #[tokio::test]
+    async fn test_retry_skips_abandoned_steps() {
+        let (db, _dir) = test_db().await;
+        let doc = make_memory("mem_abandon_skip", "test content", "fact", "tech");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.record_enrichment_step(
+            "mem_abandon_skip",
+            "entity_extract",
+            "abandoned",
+            Some("gave up"),
+        )
+        .await
+        .unwrap();
+        let tuning = crate::tuning::RefineryConfig::default();
+        let count = retry_failed_enrichment(&db, &tuning).await.unwrap();
+        assert_eq!(count, 0, "should not retry abandoned steps");
+        let steps = db.get_enrichment_steps("mem_abandon_skip").await.unwrap();
+        assert_eq!(steps[0].status, "abandoned");
     }
 }

--- a/crates/origin-core/src/tuning.rs
+++ b/crates/origin-core/src/tuning.rs
@@ -280,6 +280,8 @@ pub struct RefineryConfig {
     pub kg_rethink_interval_hours: u64,
     #[serde(default = "d_5_usize")]
     pub entity_backfill_batch_size: usize,
+    #[serde(default = "d_3_usize")]
+    pub max_enrichment_retries: usize,
     #[serde(default)]
     pub topic_match: TopicMatchConfig,
 }
@@ -475,6 +477,7 @@ impl Default for RefineryConfig {
             batch_window_secs: d_30_i64(),
             kg_rethink_interval_hours: d_168_u64(),
             entity_backfill_batch_size: d_5_usize(),
+            max_enrichment_retries: d_3_usize(),
             topic_match: TopicMatchConfig::default(),
         }
     }

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1625,6 +1625,55 @@ pub async fn handle_dismiss_contradiction(
     Ok(StatusCode::OK)
 }
 
+// ===== Enrichment Status =====
+
+/// GET /api/memory/{source_id}/enrichment-status
+///
+/// Returns the enrichment step history and summary for a given memory.
+pub async fn handle_get_enrichment_status(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(source_id): Path<String>,
+) -> Result<Json<origin_types::EnrichmentStatusResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let steps = db
+        .get_enrichment_steps(&source_id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    let summary = db
+        .get_enrichment_summary(&source_id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    Ok(Json(origin_types::EnrichmentStatusResponse {
+        source_id,
+        summary,
+        steps,
+    }))
+}
+
+/// POST /api/memory/{source_id}/enrichment-status/retry
+///
+/// Resets any abandoned enrichment steps so they will be retried.
+/// Returns the number of steps reset. Idempotent: returns 0 if nothing was abandoned.
+pub async fn handle_retry_enrichment(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(source_id): Path<String>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let reset = db
+        .reset_abandoned_steps(&source_id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    Ok(Json(
+        serde_json::json!({ "source_id": source_id, "steps_reset": reset }),
+    ))
+}
+
 // ===== Entity Suggestions =====
 
 #[derive(Debug, Serialize)]

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -101,6 +101,15 @@ pub fn build_router(state: SharedState) -> Router {
             "/api/memory/reclassify/{source_id}",
             post(memory_routes::handle_reclassify_memory),
         )
+        // Enrichment status
+        .route(
+            "/api/memory/{source_id}/enrichment-status",
+            get(memory_routes::handle_get_enrichment_status),
+        )
+        .route(
+            "/api/memory/{source_id}/enrichment-status/retry",
+            post(memory_routes::handle_retry_enrichment),
+        )
         // Pending revisions
         .route(
             "/api/memory/revision/{id}/accept",

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -19,9 +19,10 @@ pub use entities::{
 };
 pub use memory::{
     ActivityBadge, ActivityKind, AgentActivityRow, AgentConnection, ConceptChange,
-    ConceptChangeKind, DomainInfo, HomeStats, IndexedFileInfo, MemoryItem, MemoryStats,
-    MemoryVersionItem, Profile, RecentActivityItem, RejectionRecord, RetrievalEvent, SearchResult,
-    SessionSnapshot, SnapshotCapture, SnapshotCaptureWithContent, Space, TopMemory, TypeBreakdown,
+    ConceptChangeKind, DomainInfo, EnrichmentStatusResponse, EnrichmentStepStatus, HomeStats,
+    IndexedFileInfo, MemoryItem, MemoryStats, MemoryVersionItem, Profile, RecentActivityItem,
+    RejectionRecord, RetrievalEvent, SearchResult, SessionSnapshot, SnapshotCapture,
+    SnapshotCaptureWithContent, Space, TopMemory, TypeBreakdown,
 };
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 

--- a/crates/origin-types/src/memory.rs
+++ b/crates/origin-types/src/memory.rs
@@ -101,6 +101,24 @@ fn default_version() -> i64 {
     1
 }
 
+/// Per-step enrichment outcome for diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnrichmentStepStatus {
+    pub step: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    pub attempts: u32,
+}
+
+/// Response for GET /api/memory/{id}/enrichment-status.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnrichmentStatusResponse {
+    pub source_id: String,
+    pub summary: String,
+    pub steps: Vec<EnrichmentStepStatus>,
+}
+
 /// A single item in a version chain.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryVersionItem {

--- a/crates/origin-types/src/sources.rs
+++ b/crates/origin-types/src/sources.rs
@@ -147,7 +147,8 @@ pub struct RawDocument {
     /// Whether this memory is a recap/summary of other memories
     #[serde(default)]
     pub is_recap: bool,
-    /// Enrichment pipeline status: "raw", "pending", "enriched", "failed"
+    /// Deprecated: enrichment status is now derived from the `enrichment_steps` table.
+    /// This field is ignored on INSERT. Kept for API compatibility with downstream consumers.
     #[serde(default = "default_enrichment_status")]
     pub enrichment_status: String,
     /// How superseded content is handled: "hide" (default) or "archive" (visible but muted)


### PR DESCRIPTION
## Summary

- **New `enrichment_steps` table** (migration 42): tracks per-step outcomes (ok/failed/skipped/abandoned) for the post-ingest enrichment pipeline, replacing the dishonest `enrichment_status` column that marked everything "enriched" regardless of failures
- **`needs_reembed` boolean column**: separates the re-embedding lifecycle from enrichment status (previously conflated in one column)
- **Self-healing retry phase**: `retry_failed_enrichment` runs on the Idle trigger (30min), retries non-LLM steps up to 3 times before marking them abandoned
- **Diagnostic API**: `GET /api/memory/{id}/enrichment-status` returns per-step breakdown; `POST .../retry` resets abandoned steps
- **All query paths migrated**: list/detail/search derive status from step table via scalar subquery; old column writes "legacy"

P0 pipeline audit finding. 11 files changed, +989/-150.

## Test plan

- [x] 910 origin-core tests pass (0 failures)
- [x] Workspace compiles clean
- [x] End-to-end test: store -> enrich -> list shows correct derived status
- [x] Raw memories (no enrichment) correctly show as "raw"
- [x] Partial failures correctly show as "enrichment_partial"
- [x] Retry phase fixes transient failures and abandons after max retries
- [x] Memory deletion cleans up orphaned enrichment_steps rows
- [x] needs_reembed replaces reembed_pending in all active code paths

Generated with [Claude Code](https://claude.com/claude-code)