### PR TITLE
fix(ci): use RELEASE_TOKEN for version-sync push in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,13 +23,20 @@ jobs:
           token: ${{ secrets.RELEASE_TOKEN }}
 
       # When a release PR is open, also bump Cargo.toml versions
-      # (release-please can't handle Cargo workspace manifests)
+      # (release-please can't handle Cargo workspace manifests).
+      #
+      # IMPORTANT: use the same RELEASE_TOKEN PAT that release-please-action
+      # used to create the PR. The subsequent `git push` of synced version
+      # files needs to fire a `pull_request synchronize` event so CI runs
+      # against the new HEAD — GITHUB_TOKEN-driven pushes never trigger
+      # downstream workflows (GitHub security policy), which would leave the
+      # PR head with empty `statusCheckRollup` and block branch protection.
       - name: Checkout (for Cargo version sync)
         if: steps.release.outputs.pr != ''
         uses: actions/checkout@v4
         with:
           ref: release-please--branches--main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Sync all version files to match release
         if: steps.release.outputs.pr != ''


### PR DESCRIPTION
## Summary
- Version-sync step in `release-please.yml` now uses `secrets.RELEASE_TOKEN` (PAT) instead of `secrets.GITHUB_TOKEN` for the checkout that drives the subsequent push.
- Without this, GitHub's recursion-prevention policy suppresses the `pull_request synchronize` event for the synced commit, leaving the release PR's head SHA with no associated check_suite. Branch protection then blocks merging without `--admin`.

## Why
v0.1.4 had to be merged via admin override because the release PR's `statusCheckRollup` was empty (the workflow_dispatch CI run we triggered registered the check on the commit but not on the PR-event-bound rollup). Verified via:
```
gh api /repos/.../commits/<sync-sha>/check-runs  ← had Test & Lint success
gh pr view 20 --json statusCheckRollup           ← empty []
```

## Test plan
- [ ] Merge this PR (regular path, no admin needed since this PR isn't a release PR).
- [ ] Land any subsequent fix:/feat: commit on main → release-please opens v0.1.6 PR.
- [ ] Confirm v0.1.6 PR's statusCheckRollup populates after sync push and merges naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)