### PR TITLE
feat: Tauri auto-updater + pnpm update-all + UX polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,8 @@ jobs:
           # APPLE_ID/PASSWORD/TEAM_ID must be omitted (not empty) or Tauri
           # attempts notarization and fails on "Team ID must be at least 3 characters".
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
       - name: Upload standalone origin-server binary
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4397,6 +4397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5041,6 +5047,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5220,6 +5238,7 @@ dependencies = [
  "tauri-plugin-mcp",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5264,7 +5283,7 @@ dependencies = [
  "tokio",
  "toml 0.8.2",
  "uuid",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -5334,6 +5353,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6382,15 +6415,20 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -6523,6 +6561,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6530,6 +6580,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -7424,6 +7501,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7701,6 +7789,39 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http 1.4.0",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -10107,6 +10228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xcap"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10387,6 +10518,18 @@ dependencies = [
  "memchr",
  "thiserror 2.0.18",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-global-shortcut = "2"
 tauri-plugin-clipboard-x = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -16,6 +16,7 @@ mod sensor;
 pub mod sources;
 pub mod state;
 mod trigger;
+mod updater;
 
 // ── Re-export origin-core modules ──
 // These re-exports let existing `crate::module::Type` paths work unchanged
@@ -795,6 +796,12 @@ pub fn run() {
                     });
                 }
             }
+
+            // Check for updates on startup; prompt user if one is available
+            let handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                crate::updater::check_and_prompt(handle).await;
+            });
 
             Ok(())
         })

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -123,6 +123,7 @@ pub fn run() {
 
     builder
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_clipboard_x::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_shell::init())

--- a/app/src/updater.rs
+++ b/app/src/updater.rs
@@ -4,6 +4,7 @@ use std::time::{Duration, SystemTime};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
 
 /// How long a "Later" dismissal of a given version suppresses re-prompts.
@@ -108,10 +109,36 @@ pub async fn check_and_prompt(app: AppHandle) {
         return;
     }
 
+    // The Tauri dialog disappears when the user clicks Install, but
+    // download_and_install can take 5-60s for a multi-MB bundle. Use system
+    // notifications to keep the user informed instead of leaving them staring
+    // at a vanished dialog wondering if the app is frozen.
+    let _ = app
+        .notification()
+        .builder()
+        .title("Origin")
+        .body(format!("Downloading update v{version}…"))
+        .show();
+
     if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
         log::error!("update install failed: {e}");
+        let _ = app
+            .notification()
+            .builder()
+            .title("Origin update failed")
+            .body(format!("{e}. The current version will keep running."))
+            .show();
         return;
     }
+
+    let _ = app
+        .notification()
+        .builder()
+        .title("Origin")
+        .body(format!("Update v{version} installed. Restarting…"))
+        .show();
+    // Brief pause so the notification has time to appear before the process exits.
+    tokio::time::sleep(Duration::from_millis(800)).await;
 
     app.restart();
 }

--- a/app/src/updater.rs
+++ b/app/src/updater.rs
@@ -1,10 +1,70 @@
-use tauri::AppHandle;
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_updater::UpdaterExt;
 
-/// Check for an update on startup. If one exists, prompt the user; on accept,
-/// download + install + relaunch. Failures are logged, never blocking.
+/// How long a "Later" dismissal of a given version suppresses re-prompts.
+const SUPPRESS_TTL: Duration = Duration::from_secs(24 * 3600);
+
+/// Delay before the first update check so the main app window has time to
+/// paint — otherwise the dialog can appear before the window, leaving the
+/// user unsure which app is asking.
+const STARTUP_DELAY: Duration = Duration::from_secs(3);
+
+#[derive(Serialize, Deserialize, Debug)]
+struct DismissedUpdate {
+    version: String,
+    dismissed_at_secs: u64,
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn dismissal_path(app: &AppHandle) -> Option<PathBuf> {
+    let dir = app.path().app_data_dir().ok()?;
+    std::fs::create_dir_all(&dir).ok()?;
+    Some(dir.join("updater-dismissed.json"))
+}
+
+fn was_recently_dismissed(app: &AppHandle, version: &str) -> bool {
+    let Some(path) = dismissal_path(app) else {
+        return false;
+    };
+    let Ok(bytes) = std::fs::read(&path) else {
+        return false;
+    };
+    let Ok(entry) = serde_json::from_slice::<DismissedUpdate>(&bytes) else {
+        return false;
+    };
+    entry.version == version
+        && now_secs().saturating_sub(entry.dismissed_at_secs) < SUPPRESS_TTL.as_secs()
+}
+
+fn record_dismissal(app: &AppHandle, version: &str) {
+    if let Some(path) = dismissal_path(app) {
+        let entry = DismissedUpdate {
+            version: version.to_string(),
+            dismissed_at_secs: now_secs(),
+        };
+        if let Ok(bytes) = serde_json::to_vec(&entry) {
+            let _ = std::fs::write(path, bytes);
+        }
+    }
+}
+
+/// Check for an update on startup. If one exists and the user hasn't dismissed
+/// it within the last 24 hours, prompt the user; on accept, download + install
+/// + relaunch. Failures are logged, never blocking.
 pub async fn check_and_prompt(app: AppHandle) {
+    tokio::time::sleep(STARTUP_DELAY).await;
+
     let updater = match app.updater() {
         Ok(u) => u,
         Err(e) => {
@@ -23,6 +83,13 @@ pub async fn check_and_prompt(app: AppHandle) {
     };
 
     let version = update.version.clone();
+
+    if was_recently_dismissed(&app, &version) {
+        log::info!("update v{version} suppressed (dismissed within 24h)");
+        return;
+    }
+
+    // OkCancelCustom: clicking the red X / pressing Esc returns false (Cancel).
     let accepted = app
         .dialog()
         .message(format!(
@@ -37,6 +104,7 @@ pub async fn check_and_prompt(app: AppHandle) {
         .blocking_show();
 
     if !accepted {
+        record_dismissal(&app, &version);
         return;
     }
 

--- a/app/src/updater.rs
+++ b/app/src/updater.rs
@@ -1,0 +1,49 @@
+use tauri::AppHandle;
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
+use tauri_plugin_updater::UpdaterExt;
+
+/// Check for an update on startup. If one exists, prompt the user; on accept,
+/// download + install + relaunch. Failures are logged, never blocking.
+pub async fn check_and_prompt(app: AppHandle) {
+    let updater = match app.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            log::warn!("updater unavailable: {e}");
+            return;
+        }
+    };
+
+    let update = match updater.check().await {
+        Ok(Some(u)) => u,
+        Ok(None) => return,
+        Err(e) => {
+            log::warn!("update check failed: {e}");
+            return;
+        }
+    };
+
+    let version = update.version.clone();
+    let accepted = app
+        .dialog()
+        .message(format!(
+            "Origin {version} is available. Download and install now?"
+        ))
+        .kind(MessageDialogKind::Info)
+        .title("Update available")
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Install".into(),
+            "Later".into(),
+        ))
+        .blocking_show();
+
+    if !accepted {
+        return;
+    }
+
+    if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
+        log::error!("update install failed: {e}");
+        return;
+    }
+
+    app.restart();
+}

--- a/app/tauri.conf.json
+++ b/app/tauri.conf.json
@@ -66,5 +66,14 @@
       "binaries/origin-mcp",
       "binaries/cloudflared"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "active": true,
+      "endpoints": [
+        "https://github.com/7xuanlu/origin/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQ0N0IzOEQ4REQyRDRDNkEKUldScVRDM2QyRGg3UkZlaUdFUHorb0RDcElzTmd6bHpOYjQzcW9LK29USzRNaE9WaFQ1WUQwV0kK"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@tauri-apps/plugin-global-shortcut": "^2.0.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-shell": "^2.0.0",
+    "@tauri-apps/plugin-updater": "^2.0.0",
     "d3-force": "^3.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "release:daemon": "cargo build --release -p origin-server",
     "release": "pnpm clean:release && TRIPLE=$(rustc -vV | grep host | awk '{print $2}') && pnpm release:daemon && cp target/release/origin-server app/binaries/origin-server-$TRIPLE && CXXFLAGS='-std=c++17' pnpm tauri build",
     "release:dmg": "rm -f target/release/bundle/macos/rw.*.dmg && mkdir -p target/release/bundle/dmg && node -e \"const v=require('./package.json').version; const f='target/release/bundle/dmg/Origin_'+v+'_aarch64.dmg'; require('fs').rmSync(f,{force:true}); const {execSync}=require('child_process'); execSync('hdiutil create -volname Origin -srcfolder target/release/bundle/macos -ov -format UDZO '+f,{stdio:'inherit'}); console.log('Created',f);\"",
+    "update-all": "bash scripts/update-all.sh",
     "clean:dev": "pkill -9 -f origin-server 2>/dev/null; pkill -9 -f 'target/debug/origin' 2>/dev/null; lsof -ti :7878 2>/dev/null | xargs kill -9 2>/dev/null; lsof -ti :1420 2>/dev/null | xargs kill -9 2>/dev/null; sleep 0.3; echo 'Dev processes cleaned'",
     "clean:release": "rm -f target/release/bundle/macos/rw.*.dmg; rm -rf target/release/bundle/dmg/Origin_*.dmg; echo 'Release artifacts cleaned'",
     "clean:all": "pnpm clean:dev && pnpm clean:release && echo 'All cleaned'",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@tauri-apps/plugin-shell':
         specifier: ^2.0.0
         version: 2.3.4
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.0.0
+        version: 2.10.1
       d3-force:
         specifier: ^3.0.0
         version: 3.0.0
@@ -697,6 +700,9 @@ packages:
 
   '@tauri-apps/plugin-shell@2.3.4':
     resolution: {integrity: sha512-ktsRWf8wHLD17aZEyqE8c5x98eNAuTizR1FSX475zQ4TxaiJnhwksLygQz+AGwckJL5bfEP13nWrlTNQJUpKpA==}
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2286,6 +2292,10 @@ snapshots:
       '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-shell@2.3.4':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Update Origin desktop app, daemon, and origin-mcp to latest main.
+# Idempotent: safe to run repeatedly.
+set -euo pipefail
+
+ORIGIN_DIR="${ORIGIN_DIR:-$HOME/Repos/origin}"
+ORIGIN_MCP_DIR="${ORIGIN_MCP_DIR:-$HOME/Repos/origin-mcp}"
+
+echo "==> Pulling origin..."
+git -C "$ORIGIN_DIR" pull --ff-only
+
+echo "==> Pulling origin-mcp..."
+git -C "$ORIGIN_MCP_DIR" pull --ff-only
+
+echo "==> Upgrading origin-mcp via brew..."
+brew upgrade 7xuanlu/tap/origin-mcp || echo "(already up to date)"
+
+echo "==> Building Origin .app..."
+cd "$ORIGIN_DIR"
+CXXFLAGS="-std=c++17" pnpm release
+
+echo "==> Replacing /Applications/Origin.app..."
+TS=$(date +%Y%m%d-%H%M%S)
+if [ -d /Applications/Origin.app ]; then
+  mv /Applications/Origin.app "/tmp/Origin.app.bak-$TS"
+fi
+cp -R "$ORIGIN_DIR/target/release/bundle/macos/Origin.app" /Applications/
+xattr -cr /Applications/Origin.app
+
+VERSION=$(/usr/bin/defaults read /Applications/Origin.app/Contents/Info.plist CFBundleShortVersionString)
+echo "==> Installed Origin v$VERSION (backup at /tmp/Origin.app.bak-$TS)"

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -3,6 +3,9 @@
 # Idempotent: safe to run repeatedly.
 set -euo pipefail
 
+TS=""
+trap 'if [ -n "$TS" ] && [ -d "/tmp/Origin.app.bak-$TS" ] && [ ! -d /Applications/Origin.app ]; then mv "/tmp/Origin.app.bak-$TS" /Applications/Origin.app; echo "==> Restored backup after failure"; fi' ERR
+
 ORIGIN_DIR="${ORIGIN_DIR:-$HOME/Repos/origin}"
 ORIGIN_MCP_DIR="${ORIGIN_MCP_DIR:-$HOME/Repos/origin-mcp}"
 
@@ -13,7 +16,7 @@ echo "==> Pulling origin-mcp..."
 git -C "$ORIGIN_MCP_DIR" pull --ff-only
 
 echo "==> Upgrading origin-mcp via brew..."
-brew upgrade 7xuanlu/tap/origin-mcp || echo "(already up to date)"
+brew upgrade 7xuanlu/tap/origin-mcp
 
 echo "==> Building Origin .app..."
 cd "$ORIGIN_DIR"
@@ -29,3 +32,8 @@ xattr -cr /Applications/Origin.app
 
 VERSION=$(/usr/bin/defaults read /Applications/Origin.app/Contents/Info.plist CFBundleShortVersionString)
 echo "==> Installed Origin v$VERSION (backup at /tmp/Origin.app.bak-$TS)"
+
+if lsof -ti :7878 >/dev/null 2>&1; then
+  echo "==> Note: a daemon is running on :7878. Restart it to pick up the new binary:"
+  echo "    lsof -ti :7878 | xargs kill -9 && open -a Origin"
+fi


### PR DESCRIPTION
## Summary

Wires up the Tauri auto-updater plugin so end users get an in-app prompt when a new release lands, plus a developer convenience script.

### Tauri auto-updater (Phase 5 of the auto-update plan)

- Adds `@tauri-apps/plugin-updater@^2.0.0` and `tauri-plugin-updater = "2"`
- Configures `plugins.updater` in `tauri.conf.json` (GitHub releases manifest URL + minisign pubkey)
- Registers the plugin in the Tauri builder chain (`app/src/lib.rs`)
- New `app/src/updater.rs`: on startup (after a 3s window-paint delay), checks for updates; if found and not dismissed in the last 24h, shows a dialog with "Install" / "Later". On Install: downloads (with progress notifications), then second notification + 800ms pause + `app.restart()`. On Later: persists `{version, dismissed_at}` so we don't re-nag for the same version within 24h
- `.github/workflows/release.yml` gets `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` env vars on the tauri-action step (secrets configured in repo)

### Developer convenience

- `pnpm update-all` script: pulls every Origin repo, upgrades brew origin-mcp, rebuilds .app, replaces `/Applications/Origin.app`. ERR trap to restore backup if cp fails. Prints daemon-restart hint if :7878 is in use

## Pre-merge gate (IMPORTANT)

The signed update flow has not been exercised end-to-end yet. Per adversarial review:

> Cut a v0.1.5-beta.1 first, install manually, bump to v0.1.5-beta.2, confirm the signed update flow works before promoting to stable.

After merge:
1. Cut `v0.1.5-beta.1` tag → wait for CI → `curl .../latest.json | jq .` → confirm `signature` field populated
2. Install the beta DMG manually → confirm app runs
3. Bump to `v0.1.5-beta.2` → confirm beta.1 → beta.2 update flow

## Test plan

- [x] cargo check -p origin clean
- [x] cargo fmt clean
- [ ] Manual: cut beta release per gate above before promoting stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)