### PR TITLE
fix(eval): EVAL_BASELINES_DIR env var for worktree-agnostic cache sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,16 @@ Earlier versions of `.githooks/pre-push` enforced a 90% `cargo llvm-cov` gate. T
 
 The current pre-push runs only clippy + non-instrumented tests. Coverage is L5 (informational on PR) or L7 (manual command on laptop).
 
+### Eval baselines cache
+
+The per-scenario DB cache (Phase 1 enrichment + Phase 3 answer cache + judge JSONLs) lives at `<baselines_dir>/`, where `baselines_dir` defaults to `app/eval/baselines/` per worktree. Override with `EVAL_BASELINES_DIR=<path>` to point at a shared, worktree-agnostic location:
+
+```bash
+export EVAL_BASELINES_DIR=$HOME/.cache/origin-eval
+```
+
+Path must be writable and local (network mounts not recommended). When set, also chains `EVAL_ENRICHMENT_CACHE_DIR` default to the same dir unless explicitly overridden. Migration: `bash scripts/migrate-eval-cache.sh <source-baselines>`.
+
 ## Releasing (release-please)
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please). The workflow runs on every push to `main`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7944,6 +7944,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
 dependencies = [
+ "futures",
  "parking_lot",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5239,6 +5239,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -7935,6 +7936,15 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -82,7 +82,7 @@ origin-types = { workspace = true }
 origin-core = { workspace = true }
 
 [dev-dependencies]
-temp-env = "0.3"
+temp-env = { version = "0.3", features = ["async_closure"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy", "closed-core-eval"))'] }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -82,6 +82,7 @@ origin-types = { workspace = true }
 origin-core = { workspace = true }
 
 [dev-dependencies]
+temp-env = "0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy", "closed-core-eval"))'] }

--- a/app/tests/eval_harness.rs
+++ b/app/tests/eval_harness.rs
@@ -4011,3 +4011,28 @@ fn percentile(sorted: &[f64], p: f64) -> f64 {
         sorted[lo] + (sorted[hi] - sorted[lo]) * (rank - lo as f64)
     }
 }
+
+#[test]
+fn eval_baselines_dir_override_env_var() {
+    use origin_lib::eval::shared::eval_baselines_dir_override;
+
+    // Unset → None.
+    temp_env::with_var("EVAL_BASELINES_DIR", None::<&str>, || {
+        assert_eq!(eval_baselines_dir_override(), None);
+    });
+
+    // Set → Some(PathBuf).
+    let tmp = tempfile::tempdir().unwrap();
+    let path_str = tmp.path().to_str().unwrap().to_string();
+    temp_env::with_var("EVAL_BASELINES_DIR", Some(&path_str), || {
+        assert_eq!(
+            eval_baselines_dir_override().as_deref(),
+            Some(tmp.path())
+        );
+    });
+
+    // Empty string → None.
+    temp_env::with_var("EVAL_BASELINES_DIR", Some(""), || {
+        assert_eq!(eval_baselines_dir_override(), None);
+    });
+}

--- a/app/tests/eval_harness.rs
+++ b/app/tests/eval_harness.rs
@@ -2773,6 +2773,46 @@ async fn smoke_per_scenario_locomo() {
     );
 }
 
+/// End-to-end smoke that verifies EVAL_BASELINES_DIR wires through to a real
+/// DB-open code path. Builds the scenario path via the helper + `scenario_db_dir`,
+/// opens a `MemoryDB` at that path, and asserts the DB file lands where expected.
+///
+/// Avoids `open_or_seed_scenario_db` to keep the test light: no enrichment,
+/// no embedder warmup beyond what `MemoryDB::new` does on its own.
+#[tokio::test]
+#[ignore]
+async fn smoke_eval_baselines_dir_e2e() {
+    use origin_core::db::MemoryDB;
+    use origin_core::events::NoopEmitter;
+    use origin_lib::eval::shared::{eval_baselines_dir_override, scenario_db_dir};
+    use std::sync::Arc;
+
+    let tmp = tempfile::tempdir().unwrap();
+    std::env::set_var("EVAL_BASELINES_DIR", tmp.path());
+
+    let baselines = eval_baselines_dir_override().expect("override should resolve");
+    assert_eq!(baselines, tmp.path());
+
+    let scope = scenario_db_dir(&baselines, "smoketest", "id-1");
+    std::fs::create_dir_all(&scope).unwrap();
+
+    let db = MemoryDB::new(&scope, Arc::new(NoopEmitter))
+        .await
+        .expect("MemoryDB should open at override path");
+
+    let count = db.list_memories(None, None, None, None, 1).await.map(|v| v.len()).unwrap_or(0);
+    assert_eq!(count, 0, "fresh DB should have 0 memories");
+
+    let expected_db_path = scope.join("origin_memory.db");
+    assert!(
+        expected_db_path.exists(),
+        "DB not at expected EVAL_BASELINES_DIR path: {}",
+        expected_db_path.display()
+    );
+
+    std::env::remove_var("EVAL_BASELINES_DIR");
+}
+
 /// Manual smoke for per-scenario enrichment using Claude CLI provider (D2).
 ///
 /// Validates that `EnrichmentMode::OnDevice(ClaudeCliProvider)` works end-to-end:

--- a/app/tests/eval_harness.rs
+++ b/app/tests/eval_harness.rs
@@ -2800,7 +2800,7 @@ async fn smoke_eval_baselines_dir_e2e() {
         .await
         .expect("MemoryDB should open at override path");
 
-    let count = db.list_memories(None, None, None, None, 1).await.map(|v| v.len()).unwrap_or(0);
+    let count = db.memory_count().await.unwrap_or(0);
     assert_eq!(count, 0, "fresh DB should have 0 memories");
 
     let expected_db_path = scope.join("origin_memory.db");

--- a/app/tests/eval_harness.rs
+++ b/app/tests/eval_harness.rs
@@ -2792,30 +2792,27 @@ async fn smoke_eval_baselines_dir_e2e() {
 
     // Use temp_env::async_with_vars for closure-scoped, panic-safe restore.
     // Avoids env-var leak if any assertion below panics.
-    temp_env::async_with_vars(
-        [("EVAL_BASELINES_DIR", Some(path_str.as_str()))],
-        async {
-            let baselines = eval_baselines_dir_override().expect("override should resolve");
-            assert_eq!(baselines, tmp.path());
+    temp_env::async_with_vars([("EVAL_BASELINES_DIR", Some(path_str.as_str()))], async {
+        let baselines = eval_baselines_dir_override().expect("override should resolve");
+        assert_eq!(baselines, tmp.path());
 
-            let scope = scenario_db_dir(&baselines, "smoketest", "id-1");
-            std::fs::create_dir_all(&scope).unwrap();
+        let scope = scenario_db_dir(&baselines, "smoketest", "id-1");
+        std::fs::create_dir_all(&scope).unwrap();
 
-            let db = MemoryDB::new(&scope, Arc::new(NoopEmitter))
-                .await
-                .expect("MemoryDB should open at override path");
+        let db = MemoryDB::new(&scope, Arc::new(NoopEmitter))
+            .await
+            .expect("MemoryDB should open at override path");
 
-            let count = db.memory_count().await.unwrap_or(0);
-            assert_eq!(count, 0, "fresh DB should have 0 memories");
+        let count = db.memory_count().await.unwrap_or(0);
+        assert_eq!(count, 0, "fresh DB should have 0 memories");
 
-            let expected_db_path = scope.join("origin_memory.db");
-            assert!(
-                expected_db_path.exists(),
-                "DB not at expected EVAL_BASELINES_DIR path: {}",
-                expected_db_path.display()
-            );
-        },
-    )
+        let expected_db_path = scope.join("origin_memory.db");
+        assert!(
+            expected_db_path.exists(),
+            "DB not at expected EVAL_BASELINES_DIR path: {}",
+            expected_db_path.display()
+        );
+    })
     .await;
 }
 
@@ -4085,10 +4082,7 @@ fn eval_baselines_dir_override_env_var() {
     let tmp = tempfile::tempdir().unwrap();
     let path_str = tmp.path().to_str().unwrap().to_string();
     temp_env::with_var("EVAL_BASELINES_DIR", Some(&path_str), || {
-        assert_eq!(
-            eval_baselines_dir_override().as_deref(),
-            Some(tmp.path())
-        );
+        assert_eq!(eval_baselines_dir_override().as_deref(), Some(tmp.path()));
     });
 
     // Empty string → None.

--- a/app/tests/eval_harness.rs
+++ b/app/tests/eval_harness.rs
@@ -2788,29 +2788,35 @@ async fn smoke_eval_baselines_dir_e2e() {
     use std::sync::Arc;
 
     let tmp = tempfile::tempdir().unwrap();
-    std::env::set_var("EVAL_BASELINES_DIR", tmp.path());
+    let path_str = tmp.path().to_str().unwrap().to_string();
 
-    let baselines = eval_baselines_dir_override().expect("override should resolve");
-    assert_eq!(baselines, tmp.path());
+    // Use temp_env::async_with_vars for closure-scoped, panic-safe restore.
+    // Avoids env-var leak if any assertion below panics.
+    temp_env::async_with_vars(
+        [("EVAL_BASELINES_DIR", Some(path_str.as_str()))],
+        async {
+            let baselines = eval_baselines_dir_override().expect("override should resolve");
+            assert_eq!(baselines, tmp.path());
 
-    let scope = scenario_db_dir(&baselines, "smoketest", "id-1");
-    std::fs::create_dir_all(&scope).unwrap();
+            let scope = scenario_db_dir(&baselines, "smoketest", "id-1");
+            std::fs::create_dir_all(&scope).unwrap();
 
-    let db = MemoryDB::new(&scope, Arc::new(NoopEmitter))
-        .await
-        .expect("MemoryDB should open at override path");
+            let db = MemoryDB::new(&scope, Arc::new(NoopEmitter))
+                .await
+                .expect("MemoryDB should open at override path");
 
-    let count = db.memory_count().await.unwrap_or(0);
-    assert_eq!(count, 0, "fresh DB should have 0 memories");
+            let count = db.memory_count().await.unwrap_or(0);
+            assert_eq!(count, 0, "fresh DB should have 0 memories");
 
-    let expected_db_path = scope.join("origin_memory.db");
-    assert!(
-        expected_db_path.exists(),
-        "DB not at expected EVAL_BASELINES_DIR path: {}",
-        expected_db_path.display()
-    );
-
-    std::env::remove_var("EVAL_BASELINES_DIR");
+            let expected_db_path = scope.join("origin_memory.db");
+            assert!(
+                expected_db_path.exists(),
+                "DB not at expected EVAL_BASELINES_DIR path: {}",
+                expected_db_path.display()
+            );
+        },
+    )
+    .await;
 }
 
 /// Manual smoke for per-scenario enrichment using Claude CLI provider (D2).

--- a/app/tests/eval_harness.rs
+++ b/app/tests/eval_harness.rs
@@ -1493,7 +1493,8 @@ async fn generate_e2e_context_tuples_locomo() {
     assert!(!tuples.is_empty(), "should generate at least some tuples");
 
     // Save for offline judging (try baselines dir, fallback to tmpdir)
-    let baselines_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines_dir = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     std::fs::create_dir_all(&baselines_dir).ok();
     let out_path = baselines_dir.join("e2e_context_tuples_locomo.json");
     save_judgment_tuples(&tuples, &out_path).expect("save tuples");
@@ -1528,7 +1529,8 @@ async fn generate_e2e_context_tuples_longmemeval() {
     eprintln!("Generated {} judgment tuples", tuples.len());
     assert!(!tuples.is_empty());
 
-    let baselines_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines_dir = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     std::fs::create_dir_all(&baselines_dir).ok();
     let out_path = baselines_dir.join("e2e_context_tuples_longmemeval.json");
     save_judgment_tuples(&tuples, &out_path).expect("save tuples");
@@ -1609,7 +1611,8 @@ async fn generate_e2e_context_tuples_locomo_api() {
     eprintln!("Generated {} judgment tuples (Haiku CLI)", tuples.len());
     assert!(!tuples.is_empty());
 
-    let baselines_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines_dir = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     std::fs::create_dir_all(&baselines_dir).ok();
     let out_path = baselines_dir.join("e2e_context_tuples_locomo_api.json");
     save_judgment_tuples(&tuples, &out_path).expect("save tuples");
@@ -1724,7 +1727,8 @@ async fn judge_e2e_batch() {
         aggregate_judgments, judge_with_batch_api, load_judgment_tuples,
     };
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     let tuples_path = baselines.join("e2e_context_tuples_locomo.json");
     if !tuples_path.exists() {
         eprintln!("SKIP: run generate_e2e_context_tuples_locomo first");
@@ -1793,7 +1797,8 @@ async fn generate_fullpipeline_locomo() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(10.0);
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     std::fs::create_dir_all(&baselines).ok();
     let output_path = baselines.join("fullpipeline_locomo_tuples.json");
 
@@ -1849,7 +1854,8 @@ async fn generate_fullpipeline_lme() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(10.0);
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     std::fs::create_dir_all(&baselines).ok();
     let output_path = baselines.join("fullpipeline_lme_tuples.json");
 
@@ -1916,7 +1922,8 @@ async fn enrich_fullpipeline_lme_only() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     std::fs::create_dir_all(&baselines).ok();
 
     eprintln!(
@@ -2037,7 +2044,8 @@ async fn smoke_enriched_db_reuse() {
     use origin_lib::memory_db::MemoryDB;
     use std::sync::Arc;
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
 
     let mut total_scenarios_checked = 0usize;
     let mut total_passed = 0usize;
@@ -2122,7 +2130,8 @@ async fn judge_fullpipeline_locomo() {
         aggregate_judgments, judge_with_batch_api, load_judgment_tuples,
     };
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     // EVAL_TUPLES_FILE override lets us judge alternate files (e.g. *_pregate.json)
     let default_path = baselines.join("fullpipeline_locomo_tuples.json");
     let tuples_path: std::path::PathBuf = std::env::var("EVAL_TUPLES_FILE")
@@ -2163,7 +2172,8 @@ async fn judge_fullpipeline_lme() {
         aggregate_judgments, judge_with_batch_api, load_judgment_tuples,
     };
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     let tuples_path = baselines.join("fullpipeline_lme_tuples.json");
     if !tuples_path.exists() {
         eprintln!("SKIP: run generate_fullpipeline_lme first");
@@ -3329,7 +3339,8 @@ async fn judge_fullpipeline_lme_cli() {
         aggregate_judgments, judge_with_claude_model_batched_persistent,
         judge_with_claude_model_persistent, load_judgment_tuples,
     };
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     let tuples_path = baselines.join("fullpipeline_lme_tuples.json");
     if !tuples_path.exists() {
         eprintln!("SKIP: run generate_fullpipeline_lme first");
@@ -3425,7 +3436,8 @@ async fn judge_fullpipeline_locomo_cli() {
         aggregate_judgments, judge_with_claude_model_batched_persistent,
         judge_with_claude_model_persistent, load_judgment_tuples,
     };
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     let tuples_path = baselines.join("fullpipeline_locomo_tuples.json");
     if !tuples_path.exists() {
         eprintln!("SKIP: run generate_fullpipeline_locomo first");
@@ -3551,7 +3563,8 @@ async fn probe_concept_scores() {
     use origin_lib::eval::shared::eval_shared_embedder;
     use std::sync::Arc;
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     let shared_embedder = eval_shared_embedder();
 
     // Sample questions from tuples
@@ -3692,7 +3705,8 @@ async fn probe_overlap_gate() {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    let baselines = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines");
+    let baselines = origin_lib::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("eval/baselines"));
     let shared_embedder = eval_shared_embedder();
     let min_overlap: usize = std::env::var("EVAL_MIN_OVERLAP")
         .ok()

--- a/crates/origin-core/src/eval/shared.rs
+++ b/crates/origin-core/src/eval/shared.rs
@@ -811,6 +811,30 @@ impl EnrichmentMode {
     }
 }
 
+/// Override for the eval baselines directory. When set, takes precedence over
+/// the per-test default (`{CARGO_MANIFEST_DIR}/eval/baselines`).
+///
+/// Use case: keep the per-scenario DB cache (and chained Phase 1 / Phase 3 / judge
+/// JSONL caches) outside any single worktree so it survives `git worktree remove`
+/// and parallel sessions can share it.
+///
+/// Recommended location: `~/.cache/origin-eval` (XDG-style).
+///
+/// Returns `None` if the variable is unset or empty (an empty string is treated
+/// as unset, since `PathBuf::from("")` resolves to cwd which is rarely intended).
+///
+/// # Example
+/// ```bash
+/// export EVAL_BASELINES_DIR=$HOME/.cache/origin-eval
+/// cargo test -p origin --test eval_harness generate_fullpipeline_locomo -- --ignored
+/// ```
+pub fn eval_baselines_dir_override() -> Option<std::path::PathBuf> {
+    std::env::var("EVAL_BASELINES_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(std::path::PathBuf::from)
+}
+
 /// Enrich a freshly-seeded eval DB: entity extraction + title enrichment + concept distillation.
 ///
 /// Caller must check `mem_count == enriched_count` before calling — this function unconditionally

--- a/crates/origin-core/src/eval/shared.rs
+++ b/crates/origin-core/src/eval/shared.rs
@@ -774,8 +774,11 @@ impl EnrichmentMode {
                     .and_then(|s| s.parse().ok())
                     .unwrap_or(5.0);
                 let cache_dir: PathBuf = std::env::var("EVAL_ENRICHMENT_CACHE_DIR")
+                    .ok()
+                    .filter(|s| !s.is_empty())
                     .map(PathBuf::from)
-                    .unwrap_or_else(|_| PathBuf::from("eval/baselines"));
+                    .or_else(eval_baselines_dir_override)
+                    .unwrap_or_else(|| PathBuf::from("eval/baselines"));
                 eprintln!(
                     "[enrichment] mode=cli model={} batch_entities={} batch_titles={} rotation={} retries={} cost_cap=${:.2} cache_dir={}",
                     model, batch_entities, batch_titles, rotation, retries, cli_cost_cap, cache_dir.display()

--- a/scripts/migrate-eval-cache.sh
+++ b/scripts/migrate-eval-cache.sh
@@ -39,6 +39,14 @@ if [[ -d "$DEST/fullpipeline" ]] && [[ $FORCE -eq 0 ]]; then
     exit 1
 fi
 
+# DEST sanity check: refuse destructive ops on dangerous paths.
+# Catches accidental EVAL_BASELINES_DIR=$HOME or =/ before --force rm -rf.
+if [[ -z "$DEST" ]] || [[ "$DEST" == "/" ]] || [[ "$DEST" == "$HOME" ]]; then
+    echo "ERROR: refusing to operate on dangerous DEST: '$DEST'"
+    echo "  EVAL_BASELINES_DIR must be a dedicated subdirectory, not / or \$HOME."
+    exit 1
+fi
+
 mkdir -p "$DEST"
 echo "Copying $SRC/fullpipeline -> $DEST/fullpipeline ..."
 [[ $FORCE -eq 1 ]] && rm -rf "$DEST/fullpipeline"

--- a/scripts/migrate-eval-cache.sh
+++ b/scripts/migrate-eval-cache.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Migrate eval per-scenario cache + sibling JSONL caches to a
+# worktree-agnostic shared location.
+#
+# Usage:
+#   bash scripts/migrate-eval-cache.sh <source-baselines-dir> [--force]
+#
+# Example (from any worktree):
+#   bash scripts/migrate-eval-cache.sh \
+#     ~/Repos/origin/.worktrees/eval-per-scenario/app/eval/baselines
+#
+# Defaults destination to ~/.cache/origin-eval. Override via EVAL_BASELINES_DIR.
+# By default refuses to run if destination already exists; use --force to
+# overwrite (after manual review of which copy is canonical).
+set -euo pipefail
+
+SRC="${1:?Usage: $0 <source-baselines-dir> [--force]}"
+FORCE=0
+[[ "${2:-}" == "--force" ]] && FORCE=1
+
+DEST="${EVAL_BASELINES_DIR:-$HOME/.cache/origin-eval}"
+
+if [[ ! -d "$SRC/fullpipeline" ]]; then
+    echo "ERROR: $SRC/fullpipeline not found"
+    exit 1
+fi
+
+# Idempotency safety: refuse to silently overwrite a populated destination.
+if [[ -d "$DEST/fullpipeline" ]] && [[ $FORCE -eq 0 ]]; then
+    src_mtime=$(stat -f "%m" "$SRC/fullpipeline")
+    dst_mtime=$(stat -f "%m" "$DEST/fullpipeline")
+    echo "ERROR: $DEST/fullpipeline already exists."
+    echo "  source mtime: $(date -r "$src_mtime")"
+    echo "  dest mtime:   $(date -r "$dst_mtime")"
+    if [[ "$src_mtime" -gt "$dst_mtime" ]]; then
+        echo "  Source is NEWER -- destination may be stale."
+    fi
+    echo "Re-run with --force to overwrite, after manual review of which copy is canonical."
+    exit 1
+fi
+
+mkdir -p "$DEST"
+echo "Copying $SRC/fullpipeline -> $DEST/fullpipeline ..."
+[[ $FORCE -eq 1 ]] && rm -rf "$DEST/fullpipeline"
+cp -R "$SRC/fullpipeline" "$DEST/fullpipeline"
+
+# Also migrate sibling JSONL caches (Phase 3 + judge response caches).
+for jsonl in "$SRC"/fullpipeline_*_phase3_answers_batch.jsonl "$SRC"/fullpipeline_*_judgments_batch.jsonl; do
+    [[ -f "$jsonl" ]] || continue
+    base=$(basename "$jsonl")
+    if [[ -f "$DEST/$base" ]] && [[ $FORCE -eq 0 ]]; then
+        echo "WARN: $DEST/$base already exists; skipping (use --force)"
+        continue
+    fi
+    cp "$jsonl" "$DEST/$base"
+    echo "Copied: $base"
+done
+
+# Verify per-scenario DB integrity (the 1.2 GB asset that matters most).
+src_count=$(find "$SRC/fullpipeline" -name "origin_memory.db" | wc -l | tr -d ' ')
+dst_count=$(find "$DEST/fullpipeline" -name "origin_memory.db" | wc -l | tr -d ' ')
+src_bytes=$(find "$SRC/fullpipeline" -type f -exec stat -f "%z" {} + | awk '{s+=$1} END {print s}')
+dst_bytes=$(find "$DEST/fullpipeline" -type f -exec stat -f "%z" {} + | awk '{s+=$1} END {print s}')
+
+echo ""
+echo "Source: $src_count DBs, $src_bytes bytes"
+echo "Dest:   $dst_count DBs, $dst_bytes bytes"
+
+if [[ "$src_count" != "$dst_count" ]] || [[ "$src_bytes" != "$dst_bytes" ]]; then
+    echo "ERROR: counts/bytes mismatch -- abort, do not delete source"
+    exit 1
+fi
+
+echo ""
+echo "OK. Set this in your shell:"
+echo "  export EVAL_BASELINES_DIR=$DEST"
+echo ""
+echo "Source preserved at $SRC. Remove manually only after confirming new path works."


### PR DESCRIPTION
## Summary

Adds `EVAL_BASELINES_DIR` env var so the eval per-scenario DB cache (1.2 GB) plus chained Phase 1 / Phase 3 / judge JSONL caches can live at a worktree-agnostic shared location. Replaces the hard-coded `CARGO_MANIFEST_DIR/eval/baselines` defaulting in 14 test sites.

This unblocks parallel eval sessions across worktrees: another in-flight session (temporal eval) can consume the same enriched cache without per-worktree symlinks or re-enrichment.

## Why

`git worktree remove` previously erased the 1.2 GB enriched cache (~hours of LLM enrichment). Per-scenario DBs are also not naturally shareable across worktrees.

## What changes

- New helper `eval_baselines_dir_override()` in `crates/origin-core/src/eval/shared.rs`.
- Chains `EVAL_ENRICHMENT_CACHE_DIR` default through `EVAL_BASELINES_DIR` so a single-env-var setup keeps enrichment JSONL alongside DBs.
- 14 hard-coded `let baselines = ...` sites in `app/tests/eval_harness.rs` use the helper. Inline `.join("eval/baselines/<file>.json")` sites left intentionally unchanged (separate artifacts, out of scope).
- New unit test (`eval_baselines_dir_override_env_var`) and end-to-end smoke (`smoke_eval_baselines_dir_e2e`). Smoke test uses `temp_env::async_with_vars` for panic-safe env restore.
- `temp-env` 0.3 (`async_closure` feature) added as dev-dep for race-free env mutation.
- `scripts/migrate-eval-cache.sh` with `--force` gate, mtime-based stale-warning, and DEST guard refusing destructive ops on `/` / `$HOME` / empty.
- CLAUDE.md note.

## Backward compatibility

- Env var unset → fallback to `CARGO_MANIFEST_DIR/eval/baselines` (existing behavior).
- Other worktrees without the env var continue to work as before.
- Production daemon does not read `eval/baselines`; setting env var globally has no production impact.

## Test plan

- [x] `cargo test -p origin-core --lib` passes (974 passed, 0 failed)
- [x] `cargo clippy -p origin-core --all-targets` clean
- [x] `cargo clippy -p origin --tests` clean
- [x] `eval_baselines_dir_override_env_var` (unit) passes
- [x] `smoke_eval_baselines_dir_e2e` (`--ignored`) passes
- [x] Migration script smoke-tested with idempotency check (refuses re-run without `--force`)

## Spec

`docs/superpowers/specs/2026-04-30-eval-baselines-dir-env-var-design.md` (gitignored, available locally on the author's working tree).

## Followups (post-merge)

- Inline `.join("eval/baselines/<file>.json")` sites: separate PR if/when normalization is needed.
- Migration script: add bidirectional staleness warning (currently warns only when source > dest mtime).
- Add unit test for the chain behavior in `EnrichmentMode::from_env` (covers EVAL_BASELINES_DIR fallback when EVAL_ENRICHMENT_CACHE_DIR is unset).
- Cleaning up the original 1.2 GB cache at `~/Repos/origin/.worktrees/eval-per-scenario/app/eval/baselines/fullpipeline/` (manual user decision after live cache verified across both sessions).
- Update CLAUDE.md `.fastembed_cache` symlink convention: target is `~/.fastembed_cache`, not `~/Repos/origin/.fastembed_cache`. Wrong target leaves new worktrees with broken symlinks → unit-test slowness from BGE model re-download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)