### PR TITLE
fix(updater): in-app toast overlay + Settings version footer

### DIFF
--- a/app/src/updater.rs
+++ b/app/src/updater.rs
@@ -1,18 +1,12 @@
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
-use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
-use tauri_plugin_notification::NotificationExt;
+use tauri::{AppHandle, Emitter, Listener, Manager};
 use tauri_plugin_updater::UpdaterExt;
 
-/// How long a "Later" dismissal of a given version suppresses re-prompts.
 const SUPPRESS_TTL: Duration = Duration::from_secs(24 * 3600);
-
-/// Delay before the first update check so the main app window has time to
-/// paint — otherwise the dialog can appear before the window, leaving the
-/// user unsure which app is asking.
 const STARTUP_DELAY: Duration = Duration::from_secs(3);
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -60,9 +54,40 @@ fn record_dismissal(app: &AppHandle, version: &str) {
     }
 }
 
+/// Emit `updater://available` to the main webview and wait for the user's
+/// choice via the `updater://action` event. The actual UI is rendered by
+/// `UpdaterDialog` inside the main window's React tree (see
+/// `src/components/UpdaterDialog.tsx`), so the dialog stays attached to the
+/// app window and travels with it.
+async fn prompt_via_overlay(app: &AppHandle, version: &str) -> bool {
+    let _ = app.emit(
+        "updater://available",
+        serde_json::json!({ "version": version }),
+    );
+
+    let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
+    let tx = Arc::new(Mutex::new(Some(tx)));
+
+    let tx_action = Arc::clone(&tx);
+    let action_id = app.listen("updater://action", move |event| {
+        let payload = event.payload();
+        let install = payload.contains("install");
+        if let Ok(mut g) = tx_action.lock() {
+            if let Some(sender) = g.take() {
+                let _ = sender.send(install);
+            }
+        }
+    });
+
+    let accepted = rx.await.unwrap_or(false);
+    app.unlisten(action_id);
+    accepted
+}
+
 /// Check for an update on startup. If one exists and the user hasn't dismissed
-/// it within the last 24 hours, prompt the user; on accept, download + install
-/// + relaunch. Failures are logged, never blocking.
+/// it within the last 24 hours, prompt via an in-app overlay; on accept,
+/// download + install + relaunch with progress events. Failures are logged
+/// and surfaced in the overlay, never blocking.
 pub async fn check_and_prompt(app: AppHandle) {
     tokio::time::sleep(STARTUP_DELAY).await;
 
@@ -90,55 +115,37 @@ pub async fn check_and_prompt(app: AppHandle) {
         return;
     }
 
-    // OkCancelCustom: clicking the red X / pressing Esc returns false (Cancel).
-    let accepted = app
-        .dialog()
-        .message(format!(
-            "Origin {version} is available. Download and install now?"
-        ))
-        .kind(MessageDialogKind::Info)
-        .title("Update available")
-        .buttons(MessageDialogButtons::OkCancelCustom(
-            "Install".into(),
-            "Later".into(),
-        ))
-        .blocking_show();
+    let accepted = prompt_via_overlay(&app, &version).await;
 
     if !accepted {
         record_dismissal(&app, &version);
         return;
     }
 
-    // The Tauri dialog disappears when the user clicks Install, but
-    // download_and_install can take 5-60s for a multi-MB bundle. Use system
-    // notifications to keep the user informed instead of leaving them staring
-    // at a vanished dialog wondering if the app is frozen.
-    let _ = app
-        .notification()
-        .builder()
-        .title("Origin")
-        .body(format!("Downloading update v{version}…"))
-        .show();
+    let app_chunk = app.clone();
+    let on_chunk = move |chunk_len: usize, total: Option<u64>| {
+        let _ = app_chunk.emit(
+            "updater://progress",
+            serde_json::json!({
+                "chunk": chunk_len,
+                "total": total,
+            }),
+        );
+    };
+    let app_done = app.clone();
+    let on_done = move || {
+        let _ = app_done.emit("updater://progress", serde_json::json!({ "done": true }));
+    };
 
-    if let Err(e) = update.download_and_install(|_, _| {}, || {}).await {
+    if let Err(e) = update.download_and_install(on_chunk, on_done).await {
         log::error!("update install failed: {e}");
-        let _ = app
-            .notification()
-            .builder()
-            .title("Origin update failed")
-            .body(format!("{e}. The current version will keep running."))
-            .show();
+        let _ = app.emit(
+            "updater://progress",
+            serde_json::json!({ "error": format!("{e}") }),
+        );
         return;
     }
 
-    let _ = app
-        .notification()
-        .builder()
-        .title("Origin")
-        .body(format!("Update v{version} installed. Restarting…"))
-        .show();
-    // Brief pause so the notification has time to appear before the process exits.
     tokio::time::sleep(Duration::from_millis(800)).await;
-
     app.restart();
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import IdentityDetail from "./components/memory/IdentityDetail";
 import Main from "./components/memory/Main";
 import SetupWizard from "./components/SetupWizard";
 import { MilestoneToaster } from "./components/onboarding/MilestoneToaster";
+import UpdaterDialog from "./components/UpdaterDialog";
 
 const MEMORY_WIDTH = 1280;
 const MEMORY_HEIGHT = 720;
@@ -258,6 +259,7 @@ export default function App() {
         />
       )}
       <MilestoneToaster />
+      <UpdaterDialog />
     </div>
   );
 }

--- a/src/components/UpdaterDialog.tsx
+++ b/src/components/UpdaterDialog.tsx
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { useEffect, useState } from "react";
+import { emit, listen } from "@tauri-apps/api/event";
+
+interface ProgressPayload {
+  chunk?: number;
+  total?: number | null;
+  done?: boolean;
+  error?: string;
+}
+
+/**
+ * In-app updater toast. Mirrors the MilestoneToaster visual language
+ * (eyebrow + heading + body + mem-shadow-toast + mem-fade-up animation),
+ * pinned to the main window's bottom-left so it travels with the window.
+ *
+ * Driven by Tauri events from `app/src/updater.rs`:
+ *   - `updater://available`  payload `{ version }` → show toast
+ *   - `updater://progress`   payload `{ chunk, total, error }`
+ * Sends back:
+ *   - `updater://action`     payload `"install"` | `"later"`
+ */
+export default function UpdaterDialog() {
+  const [visible, setVisible] = useState(false);
+  const [version, setVersion] = useState("");
+  const [installing, setInstalling] = useState(false);
+  const [downloaded, setDownloaded] = useState(0);
+  const [total, setTotal] = useState<number | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unlistenAvail = listen<{ version: string }>("updater://available", (e) => {
+      setVersion(e.payload.version);
+      setInstalling(false);
+      setDownloaded(0);
+      setTotal(null);
+      setErrorMsg(null);
+      setVisible(true);
+    });
+    const unlistenProg = listen<ProgressPayload>("updater://progress", (e) => {
+      const p = e.payload;
+      if (p.error) {
+        setErrorMsg(p.error);
+        return;
+      }
+      if (p.chunk) setDownloaded((prev) => prev + (p.chunk ?? 0));
+      if (p.total !== undefined && p.total !== null) setTotal(p.total);
+    });
+    return () => {
+      unlistenAvail.then((fn) => fn());
+      unlistenProg.then((fn) => fn());
+    };
+  }, []);
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    await emit("updater://action", "install");
+  };
+
+  const handleLater = async () => {
+    setVisible(false);
+    await emit("updater://action", "later");
+  };
+
+  if (!visible) return null;
+
+  const pct =
+    total && total > 0 ? Math.min(100, Math.round((downloaded / total) * 100)) : null;
+
+  const accent = "var(--mem-accent-indigo)";
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 24,
+        left: 24,
+        zIndex: 1000,
+        fontFamily: "var(--mem-font-body)",
+        color: "var(--mem-text)",
+        backgroundColor: "var(--mem-surface)",
+        border: "1px solid var(--mem-border)",
+        borderRadius: 10,
+        padding: "14px 18px",
+        boxShadow: "var(--mem-shadow-toast)",
+        animation: "mem-fade-up 400ms cubic-bezier(0.16, 1, 0.3, 1) both",
+        maxWidth: 360,
+        minWidth: 280,
+      }}
+    >
+      <div
+        style={{
+          fontFamily: "var(--mem-font-mono)",
+          fontSize: "10px",
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: accent,
+          marginBottom: 6,
+          opacity: 0.85,
+        }}
+      >
+        {errorMsg ? "Update failed" : installing ? "Updating" : "Update available"}
+      </div>
+
+      <div
+        style={{
+          fontFamily: "var(--mem-font-heading)",
+          fontSize: "15px",
+          fontWeight: 500,
+          lineHeight: 1.35,
+          color: "var(--mem-text)",
+          letterSpacing: "-0.005em",
+        }}
+      >
+        Origin v{version} is ready.
+      </div>
+
+      <div
+        style={{
+          marginTop: 6,
+          fontSize: "12.5px",
+          lineHeight: 1.5,
+          color: "var(--mem-text-secondary)",
+        }}
+      >
+        {errorMsg
+          ? errorMsg
+          : installing
+            ? pct !== null
+              ? `Downloading… ${pct}%`
+              : "Preparing…"
+            : "Install will quit, update, and relaunch."}
+      </div>
+
+      {installing && !errorMsg && (
+        <div
+          style={{
+            marginTop: 10,
+            height: 3,
+            background: "var(--mem-hover)",
+            borderRadius: 2,
+            overflow: "hidden",
+          }}
+        >
+          <div
+            style={{
+              height: "100%",
+              width: pct !== null ? `${pct}%` : "30%",
+              background: accent,
+              transition: "width 200ms linear",
+              animation: pct === null ? "updater-pulse 1.5s ease-in-out infinite" : "none",
+            }}
+          />
+        </div>
+      )}
+
+      {!installing && !errorMsg && (
+        <div style={{ display: "flex", gap: 6, justifyContent: "flex-end", marginTop: 12 }}>
+          <button
+            onClick={handleLater}
+            style={{
+              padding: "5px 12px",
+              borderRadius: 6,
+              border: "1px solid var(--mem-border)",
+              background: "transparent",
+              color: "var(--mem-text)",
+              fontSize: 12,
+              cursor: "pointer",
+              fontFamily: "var(--mem-font-body)",
+            }}
+          >
+            Later
+          </button>
+          <button
+            onClick={handleInstall}
+            style={{
+              padding: "5px 12px",
+              borderRadius: 6,
+              border: "none",
+              background: accent,
+              color: "white",
+              fontSize: 12,
+              fontWeight: 500,
+              cursor: "pointer",
+              fontFamily: "var(--mem-font-body)",
+            }}
+          >
+            Install
+          </button>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes updater-pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.4; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/memory/settings/SettingsSidebar.tsx
+++ b/src/components/memory/settings/SettingsSidebar.tsx
@@ -6,6 +6,9 @@
 // transition feels like "the sidebar switched modes" rather than "a
 // different layout loaded".
 
+import { useEffect, useState } from "react";
+import { getVersion } from "@tauri-apps/api/app";
+
 export type SettingsSection =
   | "capture"
   | "sources"
@@ -104,6 +107,10 @@ export default function SettingsSidebar({
   onSelect,
   onNavigateHome,
 }: SettingsSidebarProps) {
+  const [appVersion, setAppVersion] = useState<string>("");
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => setAppVersion(""));
+  }, []);
   return (
     <aside
       className="flex-shrink-0 flex flex-col transition-[width] duration-200 ease-out"
@@ -252,6 +259,21 @@ export default function SettingsSidebar({
               }}
             >
               Local-only. Your data never leaves this machine.
+              {appVersion && (
+                <>
+                  <span aria-hidden style={{ margin: "0 5px", opacity: 0.55 }}>·</span>
+                  <span
+                    style={{
+                      fontFamily: "var(--mem-font-mono)",
+                      fontSize: "9.5px",
+                      letterSpacing: "0.02em",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    v{appVersion}
+                  </span>
+                </>
+              )}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace the native macOS update dialog with a branded in-app toast pinned to the main window's bottom-left, mirroring `MilestoneToaster` style (eyebrow + heading + body, `mem-shadow-toast`, `mem-fade-up`). The toast is a fixed-position React overlay inside the main webview, so it travels with the window when moved.
- Rust side (`app/src/updater.rs`) emits `updater://available` and `updater://progress`; user choice returns via `updater://action`. No second Tauri window — overlay only.
- Inline app version next to the Settings sidebar privacy line (was an orphaned block beneath it).

## Test plan
- [x] Local-server smoke (Path B): old build (v0.1.5) → toast → Install → download → minisign verify → bundle replace → restart → new build (v0.99.0) hits manifest, version matches, no re-prompt loop
- [x] Toast follows main window when moved
- [x] Later button records 24h dismissal
- [x] Settings sidebar footer reads `🔒 Local-only … · v{version}` on one line
- [ ] Real GitHub release dry run (next release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)