### PR TITLE
ci: skip coverage for release PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,8 @@ jobs:
     name: Coverage report
     runs-on: macos-latest
     if: >-
-      !startsWith(github.event.head_commit.message, 'chore(main): release')
+      github.event_name != 'pull_request' ||
+      !startsWith(github.head_ref, 'release-please--branches--')
     # Informational: never blocks merges. Failing this job is a warning, not a
     # gate. Required-status-checks should NOT include this job.
     continue-on-error: true


### PR DESCRIPTION
## Summary
- make the coverage workflow's release-PR skip guard work on pull_request events
- skip release-please branches by head_ref instead of github.event.head_commit.message

## Verification
- git diff --check
- pre-push hook: cargo clippy --workspace --all-targets -- -D warnings; cargo test --workspace --lib --quiet