### PR TITLE
fix(updater): emit release updater metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,15 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      - name: Verify updater metadata
+        run: |
+          if ! gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' | grep -qx latest.json; then
+            echo "ERROR: latest.json was not uploaded. Check bundle.createUpdaterArtifacts and TAURI_SIGNING_PRIVATE_KEY."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload standalone origin-server binary
         run: |
           TAG="$RELEASE_TAG"

--- a/app/tauri.conf.json
+++ b/app/tauri.conf.json
@@ -49,6 +49,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "macOS": {
       "minimumSystemVersion": "11.0",
       "signingIdentity": "-",


### PR DESCRIPTION
## Summary
- enable Tauri v2 updater artifact generation with bundle.createUpdaterArtifacts
- fail the release workflow if tauri-action does not upload latest.json

## Root cause
The v0.2.0 release succeeded, but tauri-action logged: "Signature not found for the updater JSON. Skipping upload...". The release therefore has no latest.json for the configured updater endpoint.

## Verification
- node -e config assertion for bundle.createUpdaterArtifacts
- rg checks for release guard
- git diff --check
- pre-push hook: cargo clippy --workspace --all-targets -- -D warnings; cargo test --workspace --lib --quiet