### PR TITLE
chore: refresh Cargo.lock versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "origin"
-version = "0.1.4"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "origin-core"
-version = "0.1.4"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "origin-server"
-version = "0.1.4"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5319,7 +5319,7 @@ dependencies = [
 
 [[package]]
 name = "origin-types"
-version = "0.1.4"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
Refresh Cargo.lock after the v0.2.1 release so the locked workspace package versions match the manifests.

Validation:
- git diff --check
- cargo metadata --locked --format-version 1 --no-deps
- pre-push hook: clippy and library tests (96/96, 976/997 with 21 ignored, 17/17)