### PR TITLE
refactor: rename Tauri crate origin -> origin-app + typed TriggerSource (Phase 3 PR1)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,7 +19,7 @@ if [ "$HAS_RUST" = "yes" ]; then
     if echo "$STAGED_FILES" | grep -q '^crates/origin-types/'; then TOUCHED_CRATES="$TOUCHED_CRATES -p origin-types"; fi
     if echo "$STAGED_FILES" | grep -q '^crates/origin-core/'; then TOUCHED_CRATES="$TOUCHED_CRATES -p origin-core"; fi
     if echo "$STAGED_FILES" | grep -q '^crates/origin-server/'; then TOUCHED_CRATES="$TOUCHED_CRATES -p origin-server"; fi
-    if echo "$STAGED_FILES" | grep -q '^app/'; then TOUCHED_CRATES="$TOUCHED_CRATES -p origin"; fi
+    if echo "$STAGED_FILES" | grep -q '^app/'; then TOUCHED_CRATES="$TOUCHED_CRATES -p origin-app"; fi
 
     if [ -n "$TOUCHED_CRATES" ]; then
         echo "  Running Clippy on changed crates..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,11 +97,11 @@ jobs:
       # the hf-hub crate can't resolve manually seeded cache files.
       #
       # Run eval tests locally:
-      #   cargo test -p origin --test eval_harness
+      #   cargo test -p origin-app --test eval_harness
       #
       # The model downloads once into ~/.fastembed_cache and is reused.
       - name: Run app unit tests (eval harness runs locally)
-        run: cargo test -p origin --lib
+        run: cargo test -p origin-app --lib
 
       - name: Run frontend tests
         run: pnpm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ cargo test --workspace
 cargo check -p origin-types
 cargo check -p origin-core
 cargo check -p origin-server
-cargo check -p origin                  # the Tauri app
+cargo check -p origin-app              # the Tauri app
 
 # Run tests for a single crate
 cargo test -p origin-core
@@ -62,12 +62,12 @@ cargo test -p origin-core --lib locomo::tests
 cargo test -p origin-core --lib longmemeval::tests
 
 # Generate eval baselines (slow, needs Qwen 3.5-9B on Metal GPU):
-cargo test -p origin --test eval_harness save_locomo_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_locomo_reranked_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_locomo_expanded_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_longmemeval_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_longmemeval_reranked_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_longmemeval_expanded_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_locomo_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_locomo_reranked_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_locomo_expanded_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_longmemeval_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_longmemeval_reranked_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_longmemeval_expanded_baseline -- --ignored --nocapture
 # Baselines saved to app/eval/baselines/*.json (gitignored)
 ```
 
@@ -82,7 +82,7 @@ Origin runs across several layers. The split is driven by three questions: **(1)
 | **L1 dev loop** | rust-analyzer / IDE | Local | Every save | <1s | No |
 | **L2 pre-commit** | `cargo fmt --all`, clippy on staged crates, vitest if FE staged | Local | `git commit` | ~5s | Yes |
 | **L3 pre-push** | `cargo clippy --workspace --all-targets`, `cargo test --workspace`, `pnpm vitest run --bail 1` | Local | `git push` | ~60-90s | Yes |
-| **L4 CI on PR** | Same checks workspace-wide, plus `cargo test -p origin --lib`, `pnpm test` | GitHub (`ci.yml`) | Every PR | ~10min | Yes (required) |
+| **L4 CI on PR** | Same checks workspace-wide, plus `cargo test -p origin-app --lib`, `pnpm test` | GitHub (`ci.yml`) | Every PR | ~10min | Yes (required) |
 | **L5 coverage on PR** | `cargo llvm-cov` on origin-core + origin-server only; vitest --coverage | GitHub (`coverage.yml`) | Every PR | ~10min | **No (informational)** |
 | **L6 main canary** | Embedding-only eval (`cargo test -p origin-core --lib eval::token_efficiency -- --ignored`) | GitHub (`ci.yml`) | Push to `main` | ~10min | No (post-merge) |
 | **L7 manual local** | `bash scripts/coverage.sh` (HTML coverage), GPU eval suite (`cargo test -- --ignored`), Anthropic batch judge (`ANTHROPIC_API_KEY=... cargo test ...`) | Your laptop | On demand | minutes-hours | No |
@@ -189,7 +189,7 @@ The repo is a Cargo workspace with 4 crates:
 | `crates/origin-types` | Shared API boundary types (request/response, memory, entities). License: Apache-2.0 so `origin-mcp` (MIT) and other downstream consumers can use it without AGPL contamination. | serde only — no heavy deps |
 | `crates/origin-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, refinery, pages, export, eval. **Must have NO tauri or axum dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/origin-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `origin-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
-| `app/` (crate name `origin`) | Thin Tauri desktop client. Depends on `origin-types` + `reqwest` (HTTP) + a minimal bit of `origin-core` for sensor utilities. All data commands proxy to the daemon. | tauri, reqwest |
+| `app/` (crate name `origin-app`) | Thin Tauri desktop client. Depends on `origin-types` + `reqwest` (HTTP) + a minimal bit of `origin-core` for sensor utilities. All data commands proxy to the daemon. | tauri, reqwest |
 
 The daemon (`origin-server`) is the single source of truth. The Tauri app process can come and go; memory storage continues in the daemon. External tools (`origin-mcp`, curl, etc.) talk to the same daemon.
 
@@ -413,7 +413,7 @@ Thin client — only Tauri-specific code. Data commands proxy to the daemon.
 **Tauri app:**
 - **Never pipe Tauri binary output**: `./target/debug/origin 2>&1 | head -N` kills the process via SIGPIPE when head closes. Always redirect to file: `./target/debug/origin > /tmp/origin.log 2>&1 &`. This is the #1 reason the app appears to "exit silently".
 - **Use `pnpm tauri dev` for development**: It handles Vite startup, cargo watch, and the full dev lifecycle. Running `./target/debug/origin` directly skips sidecar management and process lifecycle.
-- **tauri.conf.json is compile-time**: Changes to `trafficLightPosition`, `visible`, `skipTaskbar`, window dimensions are baked into the binary. Requires `cargo build -p origin` and app restart (not HMR).
+- **tauri.conf.json is compile-time**: Changes to `trafficLightPosition`, `visible`, `skipTaskbar`, window dimensions are baked into the binary. Requires `cargo build -p origin-app` and app restart (not HMR).
 - **Vite required for dev binary**: `./target/debug/origin` loads the frontend from `devUrl` (localhost:1420). Without Vite running, the window shows a permanent white screen.
 - **Window visibility**: The main window config has `visible: false`. The app-ready event from React calls `show()` + `center()` after mount. This prevents the white flash and position jump on startup.
 
@@ -463,6 +463,6 @@ touch crates/origin-server/src/router.rs && pnpm dev:all
 - Log filter default is `warn` — add modules explicitly for `info` logs (e.g., `origin_core::db=info`, `origin_server=info`)
 - macOS-specific code uses CoreGraphics/AppKit FFI via `cocoa` and `objc` crates, only in the Tauri app (`app/src/sensor`, `app/src/trigger`)
 - All local data stored in `~/Library/Application Support/origin/` — MemoryDB, config, activities, tags
-- Crate names: `origin-types`, `origin-core`, `origin-server`, `origin` (the Tauri app). The legacy name `origin_lib` still appears as the library name of the `origin` crate in some log filters.
+- Crate names: `origin-types`, `origin-core`, `origin-server`, `origin-app` (the Tauri app). The legacy name `origin_lib` still appears as the library name of the `origin-app` crate in some log filters.
 - **Licenses**: `origin-types`, `origin-core`, and `origin-server` are **Apache-2.0** (permissive — lets downstream tools like `origin-mcp` consume them without AGPL contamination). The Tauri app (`origin` crate in `app/`) is **AGPL-3.0-only** (the shipped desktop product).
 - `origin-mcp` lives in a separate repo (`~/Repos/origin-mcp`), is MIT-licensed, and talks to the daemon via HTTP. It can depend on `origin-types` (Apache-2.0) without license issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,10 +411,10 @@ Thin client — only Tauri-specific code. Data commands proxy to the daemon.
 - **Worktree target directories are shared**: All worktrees share the same `target/` directory in the main repo. Building in one worktree overwrites binaries from another. After switching worktrees, always rebuild to ensure the binary matches the checked-out source.
 
 **Tauri app:**
-- **Never pipe Tauri binary output**: `./target/debug/origin 2>&1 | head -N` kills the process via SIGPIPE when head closes. Always redirect to file: `./target/debug/origin > /tmp/origin.log 2>&1 &`. This is the #1 reason the app appears to "exit silently".
-- **Use `pnpm tauri dev` for development**: It handles Vite startup, cargo watch, and the full dev lifecycle. Running `./target/debug/origin` directly skips sidecar management and process lifecycle.
+- **Never pipe Tauri binary output**: `./target/debug/origin-app 2>&1 | head -N` kills the process via SIGPIPE when head closes. Always redirect to file: `./target/debug/origin-app > /tmp/origin-app.log 2>&1 &`. This is the #1 reason the app appears to "exit silently".
+- **Use `pnpm tauri dev` for development**: It handles Vite startup, cargo watch, and the full dev lifecycle. Running `./target/debug/origin-app` directly skips sidecar management and process lifecycle.
 - **tauri.conf.json is compile-time**: Changes to `trafficLightPosition`, `visible`, `skipTaskbar`, window dimensions are baked into the binary. Requires `cargo build -p origin-app` and app restart (not HMR).
-- **Vite required for dev binary**: `./target/debug/origin` loads the frontend from `devUrl` (localhost:1420). Without Vite running, the window shows a permanent white screen.
+- **Vite required for dev binary**: `./target/debug/origin-app` loads the frontend from `devUrl` (localhost:1420). Without Vite running, the window shows a permanent white screen.
 - **Window visibility**: The main window config has `visible: false`. The app-ready event from React calls `show()` + `center()` after mount. This prevents the white flash and position jump on startup.
 
 **Cleanup scripts:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ cargo test --workspace
 cargo check -p origin-types
 cargo check -p origin-core
 cargo check -p origin-server
-cargo check -p origin                  # the Tauri app
+cargo check -p origin-app              # the Tauri app
 
 # Run tests for a single crate
 cargo test -p origin-core
@@ -62,12 +62,12 @@ cargo test -p origin-core --lib locomo::tests
 cargo test -p origin-core --lib longmemeval::tests
 
 # Generate eval baselines (slow, needs Qwen 3.5-9B on Metal GPU):
-cargo test -p origin --test eval_harness save_locomo_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_locomo_reranked_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_locomo_expanded_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_longmemeval_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_longmemeval_reranked_baseline -- --ignored --nocapture
-cargo test -p origin --test eval_harness save_longmemeval_expanded_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_locomo_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_locomo_reranked_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_locomo_expanded_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_longmemeval_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_longmemeval_reranked_baseline -- --ignored --nocapture
+cargo test -p origin-app --test eval_harness save_longmemeval_expanded_baseline -- --ignored --nocapture
 # Baselines saved to app/eval/baselines/*.json (gitignored)
 ```
 
@@ -82,7 +82,7 @@ Origin runs across several layers. The split is driven by three questions: **(1)
 | **L1 dev loop** | rust-analyzer / IDE | Local | Every save | <1s | No |
 | **L2 pre-commit** | `cargo fmt --all`, clippy on staged crates, vitest if FE staged | Local | `git commit` | ~5s | Yes |
 | **L3 pre-push** | `cargo clippy --workspace --all-targets`, `cargo test --workspace`, `pnpm vitest run --bail 1` | Local | `git push` | ~60-90s | Yes |
-| **L4 CI on PR** | Same checks workspace-wide, plus `cargo test -p origin --lib`, `pnpm test` | GitHub (`ci.yml`) | Every PR | ~10min | Yes (required) |
+| **L4 CI on PR** | Same checks workspace-wide, plus `cargo test -p origin-app --lib`, `pnpm test` | GitHub (`ci.yml`) | Every PR | ~10min | Yes (required) |
 | **L5 coverage on PR** | `cargo llvm-cov` on origin-core + origin-server only; vitest --coverage | GitHub (`coverage.yml`) | Every PR | ~10min | **No (informational)** |
 | **L6 main canary** | Embedding-only eval (`cargo test -p origin-core --lib eval::token_efficiency -- --ignored`) | GitHub (`ci.yml`) | Push to `main` | ~10min | No (post-merge) |
 | **L7 manual local** | `bash scripts/coverage.sh` (HTML coverage), GPU eval suite (`cargo test -- --ignored`), Anthropic batch judge (`ANTHROPIC_API_KEY=... cargo test ...`) | Your laptop | On demand | minutes-hours | No |
@@ -189,7 +189,7 @@ The repo is a Cargo workspace with 4 crates:
 | `crates/origin-types` | Shared API boundary types (request/response, memory, entities). License: Apache-2.0 so `origin-mcp` (MIT) and other downstream consumers can use it without AGPL contamination. | serde only — no heavy deps |
 | `crates/origin-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, refinery, pages, export, eval. **Must have NO tauri or axum dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/origin-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `origin-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
-| `app/` (crate name `origin`) | Thin Tauri desktop client. Depends on `origin-types` + `reqwest` (HTTP) + a minimal bit of `origin-core` for sensor utilities. All data commands proxy to the daemon. | tauri, reqwest |
+| `app/` (crate name `origin-app`) | Thin Tauri desktop client. Depends on `origin-types` + `reqwest` (HTTP) + a minimal bit of `origin-core` for sensor utilities. All data commands proxy to the daemon. | tauri, reqwest |
 
 The daemon (`origin-server`) is the single source of truth. The Tauri app process can come and go; memory storage continues in the daemon. External tools (`origin-mcp`, curl, etc.) talk to the same daemon.
 
@@ -409,7 +409,7 @@ Thin client — only Tauri-specific code. Data commands proxy to the daemon.
 **Tauri app:**
 - **Never pipe Tauri binary output**: `./target/debug/origin 2>&1 | head -N` kills the process via SIGPIPE when head closes. Always redirect to file: `./target/debug/origin > /tmp/origin.log 2>&1 &`. This is the #1 reason the app appears to "exit silently".
 - **Use `pnpm tauri dev` for development**: It handles Vite startup, cargo watch, and the full dev lifecycle. Running `./target/debug/origin` directly skips sidecar management and process lifecycle.
-- **tauri.conf.json is compile-time**: Changes to `trafficLightPosition`, `visible`, `skipTaskbar`, window dimensions are baked into the binary. Requires `cargo build -p origin` and app restart (not HMR).
+- **tauri.conf.json is compile-time**: Changes to `trafficLightPosition`, `visible`, `skipTaskbar`, window dimensions are baked into the binary. Requires `cargo build -p origin-app` and app restart (not HMR).
 - **Vite required for dev binary**: `./target/debug/origin` loads the frontend from `devUrl` (localhost:1420). Without Vite running, the window shows a permanent white screen.
 - **Window visibility**: The main window config has `visible: false`. The app-ready event from React calls `show()` + `center()` after mount. This prevents the white flash and position jump on startup.
 
@@ -459,6 +459,6 @@ touch crates/origin-server/src/router.rs && pnpm dev:all
 - Log filter default is `warn` — add modules explicitly for `info` logs (e.g., `origin_core::db=info`, `origin_server=info`)
 - macOS-specific code uses CoreGraphics/AppKit FFI via `cocoa` and `objc` crates, only in the Tauri app (`app/src/sensor`, `app/src/trigger`)
 - All local data stored in `~/Library/Application Support/origin/` — MemoryDB, config, activities, tags
-- Crate names: `origin-types`, `origin-core`, `origin-server`, `origin` (the Tauri app). The legacy name `origin_lib` still appears as the library name of the `origin` crate in some log filters.
+- Crate names: `origin-types`, `origin-core`, `origin-server`, `origin-app` (the Tauri app). The legacy name `origin_lib` still appears as the library name of the `origin-app` crate in some log filters.
 - **Licenses**: `origin-types`, `origin-core`, and `origin-server` are **Apache-2.0** (permissive — lets downstream tools like `origin-mcp` consume them without AGPL contamination). The Tauri app (`origin` crate in `app/`) is **AGPL-3.0-only** (the shipped desktop product).
 - `origin-mcp` lives in a separate repo (`~/Repos/origin-mcp`), is MIT-licensed, and talks to the daemon via HTTP. It can depend on `origin-types` (Apache-2.0) without license issues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -407,10 +407,10 @@ Thin client — only Tauri-specific code. Data commands proxy to the daemon.
 - **Worktree target directories are shared**: All worktrees share the same `target/` directory in the main repo. Building in one worktree overwrites binaries from another. After switching worktrees, always rebuild to ensure the binary matches the checked-out source.
 
 **Tauri app:**
-- **Never pipe Tauri binary output**: `./target/debug/origin 2>&1 | head -N` kills the process via SIGPIPE when head closes. Always redirect to file: `./target/debug/origin > /tmp/origin.log 2>&1 &`. This is the #1 reason the app appears to "exit silently".
-- **Use `pnpm tauri dev` for development**: It handles Vite startup, cargo watch, and the full dev lifecycle. Running `./target/debug/origin` directly skips sidecar management and process lifecycle.
+- **Never pipe Tauri binary output**: `./target/debug/origin-app 2>&1 | head -N` kills the process via SIGPIPE when head closes. Always redirect to file: `./target/debug/origin-app > /tmp/origin-app.log 2>&1 &`. This is the #1 reason the app appears to "exit silently".
+- **Use `pnpm tauri dev` for development**: It handles Vite startup, cargo watch, and the full dev lifecycle. Running `./target/debug/origin-app` directly skips sidecar management and process lifecycle.
 - **tauri.conf.json is compile-time**: Changes to `trafficLightPosition`, `visible`, `skipTaskbar`, window dimensions are baked into the binary. Requires `cargo build -p origin-app` and app restart (not HMR).
-- **Vite required for dev binary**: `./target/debug/origin` loads the frontend from `devUrl` (localhost:1420). Without Vite running, the window shows a permanent white screen.
+- **Vite required for dev binary**: `./target/debug/origin-app` loads the frontend from `devUrl` (localhost:1420). Without Vite running, the window shows a permanent white screen.
 - **Window visibility**: The main window config has `visible: false`. The app-ready event from React calls `show()` + `center()` after mount. This prevents the white flash and position jump on startup.
 
 **Cleanup scripts:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5203,7 +5203,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "origin"
+name = "origin-app"
 version = "0.3.0"
 dependencies = [
  "anyhow",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "origin"
+name = "origin-app"
 version = "0.3.0" # x-release-please-version
 edition = "2021"
 license = "AGPL-3.0-only"
-default-run = "origin"
+default-run = "origin-app"
 
 [lib]
 name = "origin_lib"

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -101,7 +101,11 @@ fn current_app_path() -> Result<PathBuf> {
 }
 
 fn is_stable_launch_agent_target(exe: &Path) -> bool {
-    if exe.file_name().and_then(|s| s.to_str()) != Some("origin") {
+    // Accept both legacy "origin" and renamed "origin-app" binary names.
+    // Tauri crate package was renamed origin -> origin-app in Phase 3 PR1, but
+    // existing user installs may still have the old binary path on disk.
+    let name = exe.file_name().and_then(|s| s.to_str());
+    if name != Some("origin-app") && name != Some("origin") {
         return false;
     }
 

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -462,6 +462,16 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    fn stable_launch_agent_target_allows_renamed_origin_app_binary() {
+        // After Phase 3 PR1 rename (origin -> origin-app), new installs ship
+        // with binary path `.../MacOS/origin-app`. The check must accept both.
+        assert!(is_stable_launch_agent_target(std::path::Path::new(
+            "/Applications/Origin.app/Contents/MacOS/origin-app"
+        )));
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn install_app_plist_rolls_back_file_when_launchctl_load_fails() {
         // H5: when `launchctl load` reports non-zero status, the plist file
         // must be removed so stale-plist detection on next startup does not

--- a/app/src/router/bundle.rs
+++ b/app/src/router/bundle.rs
@@ -7,6 +7,11 @@ use chrono::{DateTime, Utc};
 /// Source classification for a context bundle. Replaces the previous
 /// stringly-typed `trigger_type: String` field for compiler-checked match
 /// arms across the router pipeline.
+///
+/// `Context` has no producer in the current code path — it is the historical
+/// fallback string emitted by `extract_ingest_fields` for non-Thought bundles
+/// (currently only `Hotkey`). Kept as a variant to preserve the legacy HTTP
+/// `source = "context"` payload value for downstream consumers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TriggerSource {
     Hotkey,

--- a/app/src/router/bundle.rs
+++ b/app/src/router/bundle.rs
@@ -4,6 +4,33 @@ use crate::sensor::vision::{TextObservation, WindowOcrResult};
 use crate::trigger::types::TriggerEvent;
 use chrono::{DateTime, Utc};
 
+/// Source classification for a context bundle. Replaces the previous
+/// stringly-typed `trigger_type: String` field for compiler-checked match
+/// arms across the router pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerSource {
+    Hotkey,
+    Thought,
+    Context,
+}
+
+impl TriggerSource {
+    /// Stable string form for downstream HTTP payloads + log compatibility.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TriggerSource::Hotkey => "hotkey",
+            TriggerSource::Thought => "thought",
+            TriggerSource::Context => "context",
+        }
+    }
+}
+
+impl std::fmt::Display for TriggerSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// A window snapshot within a context bundle.
 #[derive(Debug, Clone)]
 pub struct WindowSnapshot {
@@ -19,7 +46,7 @@ pub struct WindowSnapshot {
 /// A complete context capture bundle, ready for consumption.
 #[derive(Debug, Clone)]
 pub struct ContextBundle {
-    pub trigger_type: String,
+    pub trigger_type: TriggerSource,
     pub timestamp: DateTime<Utc>,
     #[allow(dead_code)]
     pub intent: Option<IntentClassification>,
@@ -31,7 +58,7 @@ impl ContextBundle {
     /// Create a bundle from a QuickThought text (bypasses vision).
     pub fn from_text(text: String) -> Self {
         Self {
-            trigger_type: "thought".to_string(),
+            trigger_type: TriggerSource::Thought,
             timestamp: Utc::now(),
             intent: None,
             windows: vec![],
@@ -43,7 +70,7 @@ impl ContextBundle {
 /// Assemble a ContextBundle from OCR results (ambient — no intent).
 #[allow(dead_code)]
 pub fn assemble_bundle(ocr: Vec<WindowOcrResult>, event: &TriggerEvent) -> ContextBundle {
-    let trigger_type = trigger_type_str(event);
+    let trigger_type = trigger_source(event);
     let windows = ocr_to_snapshots(ocr);
 
     ContextBundle {
@@ -61,7 +88,7 @@ pub fn assemble_bundle_with_intent(
     event: &TriggerEvent,
     intent: IntentClassification,
 ) -> ContextBundle {
-    let trigger_type = trigger_type_str(event);
+    let trigger_type = trigger_source(event);
     let windows = ocr_to_snapshots(ocr);
 
     ContextBundle {
@@ -171,11 +198,11 @@ fn flush_nav_run(result: &mut Vec<String>, nav_run: &mut Vec<&str>) {
     nav_run.clear();
 }
 
-/// Convert a TriggerEvent to its string type label.
-fn trigger_type_str(event: &TriggerEvent) -> String {
+/// Convert a TriggerEvent to its TriggerSource classification.
+fn trigger_source(event: &TriggerEvent) -> TriggerSource {
     match event {
-        TriggerEvent::ManualHotkey => "hotkey".to_string(),
-        TriggerEvent::QuickThought { .. } => "thought".to_string(),
+        TriggerEvent::ManualHotkey => TriggerSource::Hotkey,
+        TriggerEvent::QuickThought { .. } => TriggerSource::Thought,
     }
 }
 

--- a/app/src/router/intent.rs
+++ b/app/src/router/intent.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 use crate::privacy::redact_pii;
-use crate::router::bundle::{assemble_bundle_with_intent, ContextBundle};
+use crate::router::bundle::{assemble_bundle_with_intent, ContextBundle, TriggerSource};
 use crate::router::keywords;
 use crate::sensor;
 use crate::state::AppState;
@@ -196,7 +196,7 @@ pub async fn run_context_consumer(
     let mut last_consumer: Option<(String, String, i64)> = None; // (source, text, timestamp)
 
     while let Some(bundle) = bundle_rx.recv().await {
-        let trigger_type = bundle.trigger_type.clone();
+        let trigger_type = bundle.trigger_type.to_string();
 
         // Build title and content from the bundle (same logic as bundle_to_raw_document)
         let (source, source_id, title, content, url, metadata) = extract_ingest_fields(&bundle);
@@ -332,8 +332,8 @@ fn extract_ingest_fields(
     Option<String>,
     std::collections::HashMap<String, String>,
 ) {
-    let source = match bundle.trigger_type.as_str() {
-        "thought" => "quick_thought",
+    let source = match bundle.trigger_type {
+        TriggerSource::Thought => "quick_thought",
         _ => "context",
     }
     .to_string();

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "origin",
+  "name": "origin-app",
   "private": true,
   "version": "0.3.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Renames the Tauri desktop crate from `origin` to `origin-app` to free up the `origin` package name for the upcoming `origin-cli` crate (Phase 3 PR2). Folds in a small typed `TriggerSource` enum cleanup deferred from Phase 2 PR2 (too small for standalone PR).

Pure mechanical refactor + one small enum addition. Zero behavioral change.

## Changes

### Tauri crate rename

- `app/Cargo.toml`: `name = "origin"` → `"origin-app"`, `default-run` updated.
- `package.json`: Node package `"name": "origin"` → `"origin-app"`.
- `.githooks/pre-commit`: clippy invocation updated to `-p origin-app`.
- `.github/workflows/ci.yml`: `cargo test -p origin --lib` → `-p origin-app`.
- `CLAUDE.md` + `AGENTS.md`: ~10 doc references updated.
- `app/src/lifecycle.rs::is_stable_launch_agent_target`: accepts both `"origin-app"` (new) and `"origin"` (legacy install path). New test covers the renamed path.
- 3 stale `target/debug/origin` doc paths in CLAUDE.md/AGENTS.md → `target/debug/origin-app` (Tauri binary specifically; `origin-server` paths intact).

**NOT renamed (intentional):**
- Library target name `origin_lib` (preserves ~10 import paths in `app/tests/eval_harness.rs`).
- `app/tauri.conf.json` `productName: "Origin"` and `identifier: "com.origin.desktop"` (user-visible).
- `release-please-config.json`, `.release-please-manifest.json`, `version.txt` (path-based release config).

### Typed TriggerSource enum (Phase 2 PR2 fold)

`ContextBundle.trigger_type: String` → `TriggerSource` enum with 3 variants (`Hotkey`, `Thought`, `Context`). Compiler-checked match arms across the router. Same `as_str()` strings preserve HTTP payload compatibility.

`Context` variant has no producer in current code path; kept to preserve the legacy fallback HTTP `source = "context"` value for non-Thought triggers.

## Why now

Phase 3 PR2 will introduce `crates/origin-cli/` with binary name `origin`. The Tauri crate's package name `origin` collides — rename clears the namespace. Aligns with Phase 5 plan (extract Tauri app to standalone `origin-app` repo).

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` passes (951 origin-core + 61 origin-app + 17 origin-server)
- [x] `pnpm test --run` passes (319 frontend tests, 1 skipped)
- [x] `cargo build -p origin-app` clean (rename verified)
- [x] Smoke test daemon: health, store, search, no panics, clean shutdown
- [x] New `is_stable_launch_agent_target` test covers renamed binary path
- [x] Adversarial review subagent completed; 1 important finding (test gap) + 1 nit (Context variant doc) addressed

## Stats

- 4 commits
- ~15 files modified (mostly doc + config refs + 1 enum + 1 test)