### PR TITLE
fix: origin-cli crate with subcommands (Phase 3 PR2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ cargo check -p origin-types
 cargo check -p origin-core
 cargo check -p origin-server
 cargo check -p origin-app              # the Tauri app
+cargo check -p origin                  # the CLI binary
+cargo build -p origin --release
+./target/release/origin --help
 
 # Run tests for a single crate
 cargo test -p origin-core
@@ -189,6 +192,7 @@ The repo is a Cargo workspace with 4 crates:
 | `crates/origin-types` | Shared API boundary types (request/response, memory, entities). License: Apache-2.0 so `origin-mcp` (MIT) and other downstream consumers can use it without AGPL contamination. | serde only — no heavy deps |
 | `crates/origin-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, refinery, pages, export, eval. **Must have NO tauri or axum dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/origin-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `origin-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
+| `crates/origin-cli` | CLI binary `origin` (Apache-2.0). Talks to daemon HTTP via `origin-types`. Subcommands: status/search/recall/store/list/agents. | reqwest, clap |
 | `app/` (crate name `origin-app`) | Thin Tauri desktop client. Depends on `origin-types` + `reqwest` (HTTP) + a minimal bit of `origin-core` for sensor utilities. All data commands proxy to the daemon. | tauri, reqwest |
 
 The daemon (`origin-server`) is the single source of truth. The Tauri app process can come and go; memory storage continues in the daemon. External tools (`origin-mcp`, curl, etc.) talk to the same daemon.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,9 @@ cargo check -p origin-types
 cargo check -p origin-core
 cargo check -p origin-server
 cargo check -p origin-app              # the Tauri app
+cargo check -p origin                  # the CLI binary
+cargo build -p origin --release
+./target/release/origin --help
 
 # Run tests for a single crate
 cargo test -p origin-core
@@ -189,6 +192,7 @@ The repo is a Cargo workspace with 4 crates:
 | `crates/origin-types` | Shared API boundary types (request/response, memory, entities). License: Apache-2.0 so `origin-mcp` (MIT) and other downstream consumers can use it without AGPL contamination. | serde only — no heavy deps |
 | `crates/origin-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, refinery, pages, export, eval. **Must have NO tauri or axum dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/origin-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `origin-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
+| `crates/origin-cli` | CLI binary `origin` (Apache-2.0). Talks to daemon HTTP via `origin-types`. Subcommands: status/search/recall/store/list/agents. | reqwest, clap |
 | `app/` (crate name `origin-app`) | Thin Tauri desktop client. Depends on `origin-types` + `reqwest` (HTTP) + a minimal bit of `origin-core` for sensor utilities. All data commands proxy to the daemon. | tauri, reqwest |
 
 The daemon (`origin-server`) is the single source of truth. The Tauri app process can come and go; memory storage continues in the daemon. External tools (`origin-mcp`, curl, etc.) talk to the same daemon.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,8 +2538,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2549,9 +2551,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3110,6 +3114,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4219,6 +4224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rust2"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5203,6 +5214,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "origin"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "origin-types",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "origin-app"
 version = "0.3.0"
 dependencies = [
@@ -6049,6 +6073,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6387,6 +6466,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6394,6 +6475,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -6403,6 +6485,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6582,6 +6665,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,6 +1660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,6 +2192,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4611,6 +4641,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5218,8 +5254,10 @@ name = "origin"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "origin-types",
+ "predicates",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5885,6 +5923,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6085,7 +6153,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6122,9 +6190,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8126,6 +8194,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "text-splitter"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9122,6 +9196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "app",
+    "crates/origin-cli",
     "crates/origin-types",
     "crates/origin-core",
     "crates/origin-server",

--- a/crates/origin-cli/Cargo.toml
+++ b/crates/origin-cli/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "origin"
-version = "0.3.0"
+version = "0.3.0" # x-release-please-version
 edition = "2021"
 license = "Apache-2.0"
-description = "Origin CLI — talk to the local Origin daemon from your terminal."
+description = "Origin CLI. Talk to the local Origin daemon from your terminal."
 default-run = "origin"
+publish = false
 
 [[bin]]
 name = "origin"

--- a/crates/origin-cli/Cargo.toml
+++ b/crates/origin-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "origin"
+version = "0.3.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Origin CLI — talk to the local Origin daemon from your terminal."
+default-run = "origin"
+
+[[bin]]
+name = "origin"
+path = "src/main.rs"
+
+[dependencies]
+origin-types = { path = "../origin-types" }
+clap = { version = "4", features = ["derive"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+anyhow = "1"

--- a/crates/origin-cli/Cargo.toml
+++ b/crates/origin-cli/Cargo.toml
@@ -18,3 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 anyhow = "1"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -4,22 +4,94 @@ Origin CLI — talk to the local Origin daemon from your terminal.
 
 License: Apache-2.0.
 
-## Usage
+## Install
 
 ```bash
-origin status                    # daemon health + version
-origin search "embedding model"  # full-text + vector search
-origin recall "what we agreed on" # working memory bundle for query
-origin store "remember this"     # store a memory
-origin list --limit 10           # recent memories
-origin agents list               # registered agents + trust levels
+cargo install --path crates/origin-cli
 ```
 
-Set `ORIGIN_HOST` to point at a remote daemon (default `http://127.0.0.1:7878`).
-
-## Build
+Or build from the workspace:
 
 ```bash
-cargo build -p origin
-./target/debug/origin --help
+cargo build -p origin --release
+./target/release/origin --help
 ```
+
+## Configuration
+
+Set `ORIGIN_HOST` to point at a remote daemon:
+
+```bash
+export ORIGIN_HOST=http://127.0.0.1:7878  # default
+```
+
+## Subcommands
+
+### `origin status`
+
+Show daemon health + version.
+
+```bash
+origin status
+origin status --format json
+```
+
+### `origin search <query>`
+
+Search memories (vector + FTS hybrid).
+
+```bash
+origin search "embedding model"
+origin search "rust" --limit 5
+origin search "rust" --format json | jq '.results[].score'
+```
+
+### `origin recall <query>`
+
+Get the working memory bundle for a query (pages + decisions + relevant memories + graph context).
+
+```bash
+origin recall "what we agreed on for the API"
+origin recall "memory layer" --format json
+```
+
+### `origin store [text] [--file <path>] [--type <type>]`
+
+Store a memory. Provide content positionally, via `--file`, or pipe via stdin.
+
+```bash
+origin store "remember this insight" --type fact
+origin store --file notes.md --type page
+echo "stdin pipe content" | origin store --type quick_thought
+```
+
+### `origin list [--limit N] [--type X]`
+
+List recent memories.
+
+```bash
+origin list
+origin list --limit 5
+origin list --type fact --format json
+```
+
+### `origin agents list/show/edit`
+
+Manage registered agents.
+
+```bash
+origin agents list
+origin agents show claude-code
+origin agents edit claude-code --trust trusted --enabled true
+```
+
+## Output formats
+
+- `--format auto` (default) — table on TTY, JSON when piped.
+- `--format json` — pretty-printed JSON.
+- `--format table` — human-readable table.
+- `--quiet` / `-q` — suppress success output (errors still go to stderr).
+
+## License
+
+Apache-2.0. See top-level LICENSE.

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -1,6 +1,6 @@
 # origin-cli
 
-Origin CLI — talk to the local Origin daemon from your terminal.
+Origin CLI. Talk to the local Origin daemon from your terminal.
 
 License: Apache-2.0.
 
@@ -87,10 +87,10 @@ origin agents edit claude-code --trust trusted --enabled true
 
 ## Output formats
 
-- `--format auto` (default) — table on TTY, JSON when piped.
-- `--format json` — pretty-printed JSON.
-- `--format table` — human-readable table.
-- `--quiet` / `-q` — suppress success output (errors still go to stderr).
+- `--format auto` (default): table on TTY, JSON when piped.
+- `--format json`: pretty-printed JSON.
+- `--format table`: human-readable table.
+- `--quiet` / `-q`: suppress success output (errors still go to stderr).
 
 ## License
 

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -1,0 +1,25 @@
+# origin-cli
+
+Origin CLI — talk to the local Origin daemon from your terminal.
+
+License: Apache-2.0.
+
+## Usage
+
+```bash
+origin status                    # daemon health + version
+origin search "embedding model"  # full-text + vector search
+origin recall "what we agreed on" # working memory bundle for query
+origin store "remember this"     # store a memory
+origin list --limit 10           # recent memories
+origin agents list               # registered agents + trust levels
+```
+
+Set `ORIGIN_HOST` to point at a remote daemon (default `http://127.0.0.1:7878`).
+
+## Build
+
+```bash
+cargo build -p origin
+./target/debug/origin --help
+```

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: Apache-2.0
+//! HTTP client for talking to the origin daemon.
+//!
+//! Mirrors the relevant slice of `app/src/api.rs::OriginClient` but uses
+//! `anyhow::Result` (this is a CLI binary, not a Tauri command surface),
+//! and reads `ORIGIN_HOST` (full URL) instead of `ORIGIN_PORT` so users can
+//! point the CLI at a remote daemon over a tunnel.
+//!
+//! The methods exposed here are the subset the CLI subcommands (Tasks 3-6)
+//! need: status, ping, search, context, store, list, agents.
+//!
+//! `dead_code` is allowed at the module level because the methods land here
+//! before their callers; Tasks 3-6 wire each subcommand to these methods.
+
+#![allow(dead_code)]
+
+use anyhow::{Context, Result};
+use origin_types::{
+    requests::{ListMemoriesRequest, SearchRequest, StoreMemoryRequest},
+    responses::{
+        AgentResponse, HealthResponse, KnowledgeContext, ListMemoriesResponse, SearchResponse,
+        StoreMemoryResponse,
+    },
+};
+
+const DEFAULT_HOST: &str = "http://127.0.0.1:7878";
+
+pub struct OriginClient {
+    base_url: String,
+    http: reqwest::Client,
+}
+
+impl OriginClient {
+    /// Create a client using `ORIGIN_HOST` env var, or default to `http://127.0.0.1:7878`.
+    pub fn from_env() -> Self {
+        let base_url = std::env::var("ORIGIN_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string());
+        // Strip trailing slash so URL joins are predictable.
+        let base_url = base_url.trim_end_matches('/').to_string();
+        Self {
+            base_url,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// GET /api/health — daemon liveness + version.
+    pub async fn health(&self) -> Result<HealthResponse> {
+        let url = format!("{}/api/health", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {} failed (is the daemon running?)", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json().await.context("parsing /api/health response")
+    }
+
+    /// GET /api/ping — liveness probe; returns `"pong"`.
+    pub async fn ping(&self) -> Result<String> {
+        let url = format!("{}/api/ping", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {} failed", url))?;
+        resp.text().await.context("reading /api/ping response")
+    }
+
+    /// POST /api/search — hybrid memory search.
+    pub async fn search(&self, query: String, limit: usize) -> Result<SearchResponse> {
+        let url = format!("{}/api/search", self.base_url);
+        let req = SearchRequest {
+            query,
+            limit,
+            source_filter: None,
+            domain: None,
+        };
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json().await.context("parsing /api/search response")
+    }
+
+    /// POST /api/chat-context — contextual knowledge bundle for a query.
+    ///
+    /// Note: `/api/context` (the older endpoint) takes `current_file` +
+    /// `cursor_prefix` and is hidden from the public API. The CLI uses
+    /// `/api/chat-context` which accepts a free-form query and returns
+    /// the same `KnowledgeContext` shape inside its response.
+    pub async fn context(&self, query: String) -> Result<KnowledgeContext> {
+        let url = format!("{}/api/chat-context", self.base_url);
+        let req = serde_json::json!({ "query": query });
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        let full: serde_json::Value = resp
+            .json()
+            .await
+            .context("parsing /api/chat-context response")?;
+        let knowledge = full
+            .get("knowledge")
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("/api/chat-context response missing `knowledge`"))?;
+        serde_json::from_value(knowledge).context("parsing knowledge subobject")
+    }
+
+    /// POST /api/memory/store — write a memory.
+    pub async fn store(
+        &self,
+        content: String,
+        memory_type: Option<String>,
+    ) -> Result<StoreMemoryResponse> {
+        let url = format!("{}/api/memory/store", self.base_url);
+        let req = StoreMemoryRequest {
+            content,
+            memory_type,
+            domain: None,
+            source_agent: None,
+            title: None,
+            confidence: None,
+            supersedes: None,
+            entity: None,
+            entity_id: None,
+            structured_fields: None,
+            retrieval_cue: None,
+        };
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json()
+            .await
+            .context("parsing /api/memory/store response")
+    }
+
+    /// POST /api/memory/list — list memories with optional filters.
+    pub async fn list(
+        &self,
+        limit: Option<usize>,
+        memory_type: Option<String>,
+    ) -> Result<ListMemoriesResponse> {
+        let url = format!("{}/api/memory/list", self.base_url);
+        let req = ListMemoriesRequest {
+            memory_type,
+            domain: None,
+            limit: limit.unwrap_or(100),
+        };
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("POST {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json()
+            .await
+            .context("parsing /api/memory/list response")
+    }
+
+    /// GET /api/agents — list registered agents.
+    pub async fn list_agents(&self) -> Result<Vec<AgentResponse>> {
+        let url = format!("{}/api/agents", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json().await.context("parsing /api/agents response")
+    }
+
+    /// GET /api/agents/{name} — fetch a single agent.
+    pub async fn get_agent(&self, name: &str) -> Result<AgentResponse> {
+        let url = format!("{}/api/agents/{}", self.base_url, name);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json()
+            .await
+            .context("parsing /api/agents/{name} response")
+    }
+}

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -6,13 +6,8 @@
 //! and reads `ORIGIN_HOST` (full URL) instead of `ORIGIN_PORT` so users can
 //! point the CLI at a remote daemon over a tunnel.
 //!
-//! The methods exposed here are the subset the CLI subcommands (Tasks 3-6)
-//! need: status, ping, search, context, store, list, agents.
-//!
-//! `dead_code` is allowed at the module level because the methods land here
-//! before their callers; Tasks 3-6 wire each subcommand to these methods.
-
-#![allow(dead_code)]
+//! The methods exposed here are the subset the CLI subcommands need:
+//! status, ping, search, context, store, list, agents.
 
 use anyhow::{Context, Result};
 use origin_types::{
@@ -59,18 +54,6 @@ impl OriginClient {
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
         resp.json().await.context("parsing /api/health response")
-    }
-
-    /// GET /api/ping — liveness probe; returns `"pong"`.
-    pub async fn ping(&self) -> Result<String> {
-        let url = format!("{}/api/ping", self.base_url);
-        let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed", url))?;
-        resp.text().await.context("reading /api/ping response")
     }
 
     /// POST /api/search — hybrid memory search.

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -16,7 +16,7 @@
 
 use anyhow::{Context, Result};
 use origin_types::{
-    requests::{ListMemoriesRequest, SearchRequest, StoreMemoryRequest},
+    requests::{ListMemoriesRequest, SearchRequest, StoreMemoryRequest, UpdateAgentRequest},
     responses::{
         AgentResponse, HealthResponse, KnowledgeContext, ListMemoriesResponse, SearchResponse,
         StoreMemoryResponse,
@@ -217,5 +217,23 @@ impl OriginClient {
         resp.json()
             .await
             .context("parsing /api/agents/{name} response")
+    }
+
+    /// PUT /api/agents/{name} — update an agent's metadata.
+    pub async fn update_agent(&self, name: &str, req: UpdateAgentRequest) -> Result<AgentResponse> {
+        let url = format!("{}/api/agents/{}", self.base_url, name);
+        let resp = self
+            .http
+            .put(&url)
+            .json(&req)
+            .send()
+            .await
+            .with_context(|| format!("PUT {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json()
+            .await
+            .context("parsing /api/agents/{name} update response")
     }
 }

--- a/crates/origin-cli/src/commands/agents.rs
+++ b/crates/origin-cli/src/commands/agents.rs
@@ -142,7 +142,7 @@ async fn edit(
 ) -> Result<()> {
     if trust.is_none() && enabled.is_none() && display_name.is_none() && description.is_none() {
         anyhow::bail!(
-            "No fields to update — provide at least --trust, --enabled, --display-name, or --description"
+            "No fields to update. Provide at least --trust, --enabled, --display-name, or --description."
         );
     }
     let req = UpdateAgentRequest {

--- a/crates/origin-cli/src/commands/agents.rs
+++ b/crates/origin-cli/src/commands/agents.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin agents list/show/edit` — manage registered agents.
+
+use anyhow::Result;
+use clap::Subcommand;
+use origin_types::requests::UpdateAgentRequest;
+
+use crate::client::OriginClient;
+use crate::output::{print_json, OutputFormat};
+
+#[derive(Subcommand)]
+pub enum AgentsCmd {
+    /// List all registered agents.
+    List,
+    /// Show a single agent's full details.
+    Show {
+        /// Agent name (e.g. "claude-code", "cursor").
+        name: String,
+    },
+    /// Update an agent's trust level, enabled state, or metadata.
+    Edit {
+        /// Agent name.
+        name: String,
+        /// New trust level (e.g. "trusted", "limited", "untrusted").
+        #[arg(long)]
+        trust: Option<String>,
+        /// Enable or disable the agent.
+        #[arg(long)]
+        enabled: Option<bool>,
+        /// New display name (use empty string "" to clear).
+        #[arg(long = "display-name")]
+        display_name: Option<String>,
+        /// New description.
+        #[arg(long)]
+        description: Option<String>,
+    },
+}
+
+pub async fn run(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    cmd: AgentsCmd,
+) -> Result<()> {
+    match cmd {
+        AgentsCmd::List => list(client, format, quiet).await,
+        AgentsCmd::Show { name } => show(client, format, quiet, &name).await,
+        AgentsCmd::Edit {
+            name,
+            trust,
+            enabled,
+            display_name,
+            description,
+        } => {
+            edit(
+                client,
+                format,
+                quiet,
+                &name,
+                trust,
+                enabled,
+                display_name,
+                description,
+            )
+            .await
+        }
+    }
+}
+
+async fn list(client: &OriginClient, format: OutputFormat, quiet: bool) -> Result<()> {
+    let agents = client.list_agents().await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&agents)?,
+        OutputFormat::Table => {
+            if agents.is_empty() {
+                println!("(no agents registered)");
+                return Ok(());
+            }
+            println!("{} agent(s)", agents.len());
+            for a in &agents {
+                let display = a.display_name.as_deref().unwrap_or(&a.name);
+                let status = if a.enabled { "enabled" } else { "disabled" };
+                println!(
+                    "  {:24} [{}] trust={} memories={}",
+                    display, status, a.trust_level, a.memory_count
+                );
+            }
+        }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}
+
+async fn show(client: &OriginClient, format: OutputFormat, quiet: bool, name: &str) -> Result<()> {
+    let agent = client.get_agent(name).await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&agent)?,
+        OutputFormat::Table => {
+            println!("Agent: {}", agent.name);
+            println!("  ID:            {}", agent.id);
+            println!(
+                "  Display:       {}",
+                agent.display_name.as_deref().unwrap_or("-")
+            );
+            println!("  Type:          {}", agent.agent_type);
+            println!(
+                "  Description:   {}",
+                agent.description.as_deref().unwrap_or("-")
+            );
+            println!("  Enabled:       {}", agent.enabled);
+            println!("  Trust:         {}", agent.trust_level);
+            println!("  Memory count:  {}", agent.memory_count);
+            println!(
+                "  Last seen:     {}",
+                agent
+                    .last_seen_at
+                    .map(|t| t.to_string())
+                    .unwrap_or_else(|| "-".to_string())
+            );
+        }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn edit(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    name: &str,
+    trust: Option<String>,
+    enabled: Option<bool>,
+    display_name: Option<String>,
+    description: Option<String>,
+) -> Result<()> {
+    if trust.is_none() && enabled.is_none() && display_name.is_none() && description.is_none() {
+        anyhow::bail!(
+            "No fields to update — provide at least --trust, --enabled, --display-name, or --description"
+        );
+    }
+    let req = UpdateAgentRequest {
+        agent_type: None,
+        description,
+        enabled,
+        trust_level: trust,
+        display_name,
+    };
+    let updated = client.update_agent(name, req).await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&updated)?,
+        OutputFormat::Table => {
+            println!("Updated agent {}", updated.name);
+            println!("  Trust:         {}", updated.trust_level);
+            println!("  Enabled:       {}", updated.enabled);
+        }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}

--- a/crates/origin-cli/src/commands/list.rs
+++ b/crates/origin-cli/src/commands/list.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin list [--limit N] [--type X]` — POST /api/memory/list.
+
+use anyhow::Result;
+use origin_types::responses::ListMemoriesResponse;
+
+use crate::client::OriginClient;
+use crate::output::{print_json, OutputFormat};
+
+pub async fn run(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    limit: usize,
+    memory_type: Option<String>,
+) -> Result<()> {
+    let resp = client.list(Some(limit), memory_type).await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&resp)?,
+        OutputFormat::Table => print_table(&resp),
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}
+
+fn print_table(resp: &ListMemoriesResponse) {
+    if resp.memories.is_empty() {
+        println!("(no memories)");
+        return;
+    }
+    println!(
+        "{} memor{}",
+        resp.memories.len(),
+        if resp.memories.len() == 1 { "y" } else { "ies" }
+    );
+    for m in &resp.memories {
+        let title: &str = if m.title.is_empty() {
+            "(no title)"
+        } else {
+            &m.title
+        };
+        let title_disp = if title.chars().count() > 60 {
+            format!("{}...", title.chars().take(57).collect::<String>())
+        } else {
+            title.to_string()
+        };
+        let mtype = m.memory_type.as_deref().unwrap_or("-");
+        println!("  {} [{}] {}", m.source_id, mtype, title_disp);
+    }
+}

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Subcommand implementations for the origin CLI.
 
+pub mod search;
 pub mod status;

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Subcommand implementations for the origin CLI.
+
+pub mod status;

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Subcommand implementations for the origin CLI.
 
+pub mod agents;
 pub mod list;
 pub mod recall;
 pub mod search;

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Subcommand implementations for the origin CLI.
 
+pub mod list;
+pub mod recall;
 pub mod search;
 pub mod status;
+pub mod store;

--- a/crates/origin-cli/src/commands/recall.rs
+++ b/crates/origin-cli/src/commands/recall.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin recall <query>` — POST /api/chat-context (knowledge bundle).
+
+use anyhow::Result;
+use origin_types::responses::KnowledgeContext;
+
+use crate::client::OriginClient;
+use crate::output::{print_json, OutputFormat};
+
+pub async fn run(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    query: String,
+) -> Result<()> {
+    let ctx = client.context(query).await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&ctx)?,
+        OutputFormat::Table => print_table(&ctx),
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}
+
+fn print_table(ctx: &KnowledgeContext) {
+    let pages = ctx.pages.len();
+    let decisions = ctx.decisions.len();
+    let memories = ctx.relevant_memories.len();
+    let graph = ctx.graph_context.len();
+    if pages == 0 && decisions == 0 && memories == 0 && graph == 0 {
+        println!("(empty knowledge bundle)");
+        return;
+    }
+    println!(
+        "Knowledge: {} page(s), {} decision(s), {} memor{}, {} graph fact(s)",
+        pages,
+        decisions,
+        memories,
+        if memories == 1 { "y" } else { "ies" },
+        graph,
+    );
+    if !ctx.relevant_memories.is_empty() {
+        println!("Top memories:");
+        for r in ctx.relevant_memories.iter().take(5) {
+            let title: &str = if r.title.is_empty() {
+                r.content.lines().next().unwrap_or("(no title)")
+            } else {
+                &r.title
+            };
+            let title_disp = if title.chars().count() > 60 {
+                format!("{}...", title.chars().take(57).collect::<String>())
+            } else {
+                title.to_string()
+            };
+            println!("  [{:.3}] {} ({})", r.score, title_disp, r.source_id);
+        }
+    }
+    if !ctx.pages.is_empty() {
+        println!("Pages:");
+        for p in ctx.pages.iter().take(5) {
+            let line = p.lines().next().unwrap_or("");
+            let disp = if line.chars().count() > 70 {
+                format!("{}...", line.chars().take(67).collect::<String>())
+            } else {
+                line.to_string()
+            };
+            println!("  {}", disp);
+        }
+    }
+}

--- a/crates/origin-cli/src/commands/search.rs
+++ b/crates/origin-cli/src/commands/search.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin search <query>` — POST /api/search.
+
+use anyhow::Result;
+use origin_types::responses::SearchResponse;
+
+use crate::client::OriginClient;
+use crate::output::{print_json, OutputFormat};
+
+pub async fn run(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    query: String,
+    limit: usize,
+) -> Result<()> {
+    let resp = client.search(query, limit).await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&resp)?,
+        OutputFormat::Table => print_table(&resp),
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}
+
+fn print_table(resp: &SearchResponse) {
+    if resp.results.is_empty() {
+        println!("(no results)");
+        return;
+    }
+    println!("{} result(s) in {:.0}ms", resp.results.len(), resp.took_ms);
+    for r in &resp.results {
+        // Use title if non-empty, otherwise fall back to first content line.
+        let title: &str = if r.title.is_empty() {
+            r.content.lines().next().unwrap_or("(no title)")
+        } else {
+            &r.title
+        };
+        // Truncate to 60 chars.
+        let title_disp = if title.chars().count() > 60 {
+            format!("{}...", title.chars().take(57).collect::<String>())
+        } else {
+            title.to_string()
+        };
+        println!("  [{:.3}] {} ({})", r.score, title_disp, r.source_id);
+    }
+}

--- a/crates/origin-cli/src/commands/status.rs
+++ b/crates/origin-cli/src/commands/status.rs
@@ -6,9 +6,11 @@ use anyhow::Result;
 use crate::client::OriginClient;
 use crate::output::{print_json, OutputFormat};
 
+/// `format` is the resolved output format (Auto already collapsed in main).
+/// `quiet` suppresses success output; errors still propagate via `?` to stderr.
+/// We still hit the daemon under `quiet` to surface connection failures via exit code.
 pub async fn run(client: &OriginClient, format: OutputFormat, quiet: bool) -> Result<()> {
     let health = client.health().await?;
-    let format = format.resolve();
     if quiet {
         return Ok(());
     }
@@ -16,7 +18,7 @@ pub async fn run(client: &OriginClient, format: OutputFormat, quiet: bool) -> Re
         OutputFormat::Json => {
             print_json(&health)?;
         }
-        OutputFormat::Table | OutputFormat::Auto => {
+        OutputFormat::Table => {
             println!("Origin daemon");
             println!("  Status:        {}", health.status);
             println!(
@@ -30,6 +32,7 @@ pub async fn run(client: &OriginClient, format: OutputFormat, quiet: bool) -> Re
             println!("  Version:       {}", health.version);
             println!("  Host:          {}", client.base_url());
         }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
     }
     Ok(())
 }

--- a/crates/origin-cli/src/commands/status.rs
+++ b/crates/origin-cli/src/commands/status.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin status` — show daemon health + version.
+
+use anyhow::Result;
+
+use crate::client::OriginClient;
+use crate::output::{print_json, OutputFormat};
+
+pub async fn run(client: &OriginClient, format: OutputFormat, quiet: bool) -> Result<()> {
+    let health = client.health().await?;
+    let format = format.resolve();
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => {
+            print_json(&health)?;
+        }
+        OutputFormat::Table | OutputFormat::Auto => {
+            println!("Origin daemon");
+            println!("  Status:        {}", health.status);
+            println!(
+                "  DB:            {}",
+                if health.db_initialized {
+                    "initialized"
+                } else {
+                    "uninitialized"
+                }
+            );
+            println!("  Version:       {}", health.version);
+            println!("  Host:          {}", client.base_url());
+        }
+    }
+    Ok(())
+}

--- a/crates/origin-cli/src/commands/store.rs
+++ b/crates/origin-cli/src/commands/store.rs
@@ -2,7 +2,7 @@
 //! `origin store [text] [--file <path>] [--type <type>]` — POST /api/memory/store.
 
 use anyhow::{Context, Result};
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::path::PathBuf;
 
 use crate::client::OriginClient;
@@ -22,6 +22,11 @@ pub async fn run(
             std::fs::read_to_string(&p).with_context(|| format!("reading {}", p.display()))?
         }
         (None, None) => {
+            // Reject interactive TTY stdin — would block indefinitely waiting for EOF.
+            // User must provide text, --file, or pipe content.
+            if std::io::stdin().is_terminal() {
+                anyhow::bail!("No input — provide text, --file <path>, or pipe content via stdin");
+            }
             let mut s = String::new();
             std::io::stdin()
                 .read_to_string(&mut s)

--- a/crates/origin-cli/src/commands/store.rs
+++ b/crates/origin-cli/src/commands/store.rs
@@ -25,7 +25,7 @@ pub async fn run(
             // Reject interactive TTY stdin — would block indefinitely waiting for EOF.
             // User must provide text, --file, or pipe content.
             if std::io::stdin().is_terminal() {
-                anyhow::bail!("No input — provide text, --file <path>, or pipe content via stdin");
+                anyhow::bail!("No input. Provide text, --file <path>, or pipe content via stdin.");
             }
             let mut s = String::new();
             std::io::stdin()
@@ -39,7 +39,7 @@ pub async fn run(
     };
     let content = content.trim().to_string();
     if content.is_empty() {
-        anyhow::bail!("Empty content — provide text, --file, or pipe content via stdin");
+        anyhow::bail!("Empty content. Provide text, --file, or pipe content via stdin.");
     }
     let resp = client.store(content, memory_type).await?;
     if quiet {

--- a/crates/origin-cli/src/commands/store.rs
+++ b/crates/origin-cli/src/commands/store.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin store [text] [--file <path>] [--type <type>]` — POST /api/memory/store.
+
+use anyhow::{Context, Result};
+use std::io::Read;
+use std::path::PathBuf;
+
+use crate::client::OriginClient;
+use crate::output::{print_json, OutputFormat};
+
+pub async fn run(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    text: Option<String>,
+    file: Option<PathBuf>,
+    memory_type: Option<String>,
+) -> Result<()> {
+    let content = match (text, file) {
+        (Some(t), None) => t,
+        (None, Some(p)) => {
+            std::fs::read_to_string(&p).with_context(|| format!("reading {}", p.display()))?
+        }
+        (None, None) => {
+            let mut s = String::new();
+            std::io::stdin()
+                .read_to_string(&mut s)
+                .context("reading stdin")?;
+            s
+        }
+        (Some(_), Some(_)) => {
+            anyhow::bail!("Provide either positional text or --file, not both");
+        }
+    };
+    let content = content.trim().to_string();
+    if content.is_empty() {
+        anyhow::bail!("Empty content — provide text, --file, or pipe content via stdin");
+    }
+    let resp = client.store(content, memory_type).await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => print_json(&resp)?,
+        OutputFormat::Table => {
+            println!(
+                "Stored memory {} ({} chunk(s))",
+                resp.source_id, resp.chunks_created
+            );
+        }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
+}

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -37,6 +37,31 @@ enum Commands {
         #[arg(short, long, default_value_t = 10)]
         limit: usize,
     },
+    /// Recall the working memory bundle for a query.
+    Recall {
+        /// Query to recall context for.
+        query: String,
+    },
+    /// Store a memory. Provide text positionally, or use --file, or pipe via stdin.
+    Store {
+        /// Content text. If omitted and --file unset, read from stdin.
+        text: Option<String>,
+        /// Read content from a file.
+        #[arg(short, long)]
+        file: Option<std::path::PathBuf>,
+        /// Memory type (e.g. fact, task, decision).
+        #[arg(short = 't', long = "type")]
+        memory_type: Option<String>,
+    },
+    /// List recent memories.
+    List {
+        /// Max results.
+        #[arg(short, long, default_value_t = 20)]
+        limit: usize,
+        /// Filter by memory type.
+        #[arg(short = 't', long = "type")]
+        memory_type: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -49,6 +74,17 @@ async fn main() -> anyhow::Result<()> {
         Commands::Status => commands::status::run(&client, format, cli.quiet).await?,
         Commands::Search { query, limit } => {
             commands::search::run(&client, format, cli.quiet, query, limit).await?
+        }
+        Commands::Recall { query } => {
+            commands::recall::run(&client, format, cli.quiet, query).await?
+        }
+        Commands::Store {
+            text,
+            file,
+            memory_type,
+        } => commands::store::run(&client, format, cli.quiet, text, file, memory_type).await?,
+        Commands::List { limit, memory_type } => {
+            commands::list::run(&client, format, cli.quiet, limit, memory_type).await?
         }
     }
     Ok(())

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -10,7 +10,7 @@ use output::OutputFormat;
 #[command(
     name = "origin",
     version,
-    about = "Origin CLI — talk to the local Origin daemon"
+    about = "Origin CLI. Talk to the local Origin daemon."
 )]
 struct Cli {
     #[command(subcommand)]

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    name = "origin",
+    version,
+    about = "Origin CLI — talk to the local Origin daemon"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+
+    /// Output format. Auto-detects JSON when piped, table on TTY.
+    #[arg(long, value_enum, default_value_t = OutputFormat::Auto, global = true)]
+    format: OutputFormat,
+
+    /// Suppress all non-error output. Useful for scripts.
+    #[arg(long, short, global = true)]
+    quiet: bool,
+}
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum OutputFormat {
+    Auto,
+    Json,
+    Table,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Show daemon health + version (stub — wired in later task).
+    Status,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Status => {
+            println!(
+                "origin-cli v0.3.0 — status subcommand stub (Task 3 wires the real implementation)"
+            );
+            Ok(())
+        }
+    }
+}

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+mod client;
+mod output;
+
 use clap::{Parser, Subcommand};
+use output::OutputFormat;
 
 #[derive(Parser)]
 #[command(
@@ -20,13 +24,6 @@ struct Cli {
     quiet: bool,
 }
 
-#[derive(clap::ValueEnum, Clone, Copy, Debug)]
-enum OutputFormat {
-    Auto,
-    Json,
-    Table,
-}
-
 #[derive(Subcommand)]
 enum Commands {
     /// Show daemon health + version (stub — wired in later task).
@@ -36,6 +33,7 @@ enum Commands {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+    let _format = cli.format.resolve();
     match cli.command {
         Commands::Status => {
             println!(

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -35,8 +35,10 @@ enum Commands {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     let client = client::OriginClient::from_env();
+    // Resolve Auto once based on stdout TTY state. Subcommands receive Json or Table only.
+    let format = cli.format.resolve();
     match cli.command {
-        Commands::Status => commands::status::run(&client, cli.format, cli.quiet).await?,
+        Commands::Status => commands::status::run(&client, format, cli.quiet).await?,
     }
     Ok(())
 }

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 mod client;
+mod commands;
 mod output;
 
 use clap::{Parser, Subcommand};
@@ -26,20 +27,16 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Show daemon health + version (stub — wired in later task).
+    /// Show daemon health + version.
     Status,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let _format = cli.format.resolve();
+    let client = client::OriginClient::from_env();
     match cli.command {
-        Commands::Status => {
-            println!(
-                "origin-cli v0.3.0 — status subcommand stub (Task 3 wires the real implementation)"
-            );
-            Ok(())
-        }
+        Commands::Status => commands::status::run(&client, cli.format, cli.quiet).await?,
     }
+    Ok(())
 }

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -62,6 +62,11 @@ enum Commands {
         #[arg(short = 't', long = "type")]
         memory_type: Option<String>,
     },
+    /// Manage registered agents (list / show / edit).
+    Agents {
+        #[command(subcommand)]
+        cmd: commands::agents::AgentsCmd,
+    },
 }
 
 #[tokio::main]
@@ -86,6 +91,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::List { limit, memory_type } => {
             commands::list::run(&client, format, cli.quiet, limit, memory_type).await?
         }
+        Commands::Agents { cmd } => commands::agents::run(&client, format, cli.quiet, cmd).await?,
     }
     Ok(())
 }

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -29,6 +29,14 @@ struct Cli {
 enum Commands {
     /// Show daemon health + version.
     Status,
+    /// Search memories by query (vector + FTS hybrid).
+    Search {
+        /// Search query.
+        query: String,
+        /// Max results (default 10).
+        #[arg(short, long, default_value_t = 10)]
+        limit: usize,
+    },
 }
 
 #[tokio::main]
@@ -39,6 +47,9 @@ async fn main() -> anyhow::Result<()> {
     let format = cli.format.resolve();
     match cli.command {
         Commands::Status => commands::status::run(&client, format, cli.quiet).await?,
+        Commands::Search { query, limit } => {
+            commands::search::run(&client, format, cli.quiet, query, limit).await?
+        }
     }
     Ok(())
 }

--- a/crates/origin-cli/src/output.rs
+++ b/crates/origin-cli/src/output.rs
@@ -2,15 +2,11 @@
 //! Output format helpers — JSON, table, quiet.
 //!
 //! `OutputFormat::Auto` resolves based on stdout TTY detection:
-//! - TTY (humans)  → `Table` (pretty)
-//! - Pipe (scripts) → `Json` (machine-readable)
+//! - TTY (humans)  -> `Table` (pretty)
+//! - Pipe (scripts) -> `Json` (machine-readable)
 //!
 //! Uses `std::io::IsTerminal` (stable since Rust 1.70) so we don't pull in
 //! the external `is-terminal` crate.
-//!
-//! `print_json` is allowed-dead-code because it's consumed by Tasks 3-6.
-
-#![allow(dead_code)]
 
 use anyhow::Result;
 use serde::Serialize;

--- a/crates/origin-cli/src/output.rs
+++ b/crates/origin-cli/src/output.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Output format helpers — JSON, table, quiet.
+//!
+//! `OutputFormat::Auto` resolves based on stdout TTY detection:
+//! - TTY (humans)  → `Table` (pretty)
+//! - Pipe (scripts) → `Json` (machine-readable)
+//!
+//! Uses `std::io::IsTerminal` (stable since Rust 1.70) so we don't pull in
+//! the external `is-terminal` crate.
+//!
+//! `print_json` is allowed-dead-code because it's consumed by Tasks 3-6.
+
+#![allow(dead_code)]
+
+use anyhow::Result;
+use serde::Serialize;
+use std::io::IsTerminal;
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputFormat {
+    /// Pick automatically based on stdout TTY: terminal → Table, pipe → Json.
+    Auto,
+    Json,
+    Table,
+}
+
+impl OutputFormat {
+    /// Resolve `Auto` to a concrete format based on whether stdout is a TTY.
+    /// `Json` and `Table` pass through unchanged.
+    pub fn resolve(self) -> OutputFormat {
+        match self {
+            OutputFormat::Auto => {
+                if std::io::stdout().is_terminal() {
+                    OutputFormat::Table
+                } else {
+                    OutputFormat::Json
+                }
+            }
+            other => other,
+        }
+    }
+}
+
+/// Print a value as pretty-printed JSON to stdout.
+pub fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    let s = serde_json::to_string_pretty(value)?;
+    println!("{}", s);
+    Ok(())
+}

--- a/crates/origin-cli/tests/cli_integration.rs
+++ b/crates/origin-cli/tests/cli_integration.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for the origin CLI. Offline (no daemon required).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+fn cli() -> Command {
+    Command::cargo_bin("origin").expect("origin binary built")
+}
+
+#[test]
+fn top_level_help() {
+    cli()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Origin CLI"));
+}
+
+#[test]
+fn version_flag() {
+    cli()
+        .arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("origin"));
+}
+
+#[test]
+fn each_subcommand_has_help() {
+    for sub in ["status", "search", "recall", "store", "list", "agents"] {
+        cli().args([sub, "--help"]).assert().success();
+    }
+}
+
+#[test]
+fn invalid_subcommand_fails() {
+    cli().arg("nonexistent-command").assert().failure();
+}
+
+#[test]
+fn store_text_and_file_conflict_bails() {
+    // text=Some, file=Some -> bail at runtime (mutual exclusion)
+    cli()
+        .args(["store", "some text", "--file", "/dev/null"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("either"));
+}
+
+#[test]
+fn agents_edit_no_flags_bails() {
+    cli()
+        .args(["agents", "edit", "dummy-agent-name"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("No fields to update"));
+}


### PR DESCRIPTION
Adds crates/origin-cli with subcommands: status, search, recall, store, list, agents. OutputFormat::{Auto,Json,Table} resolved before dispatch. Integration tests via assert_cmd. No breaking changes to daemon API. Apache-2.0.