### PR TITLE
fix: /api/llm/test endpoint + app proxy (Phase 5 PR3 — recreated)

### DIFF
--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -292,4 +292,15 @@ impl OriginClient {
         let path = format!("/api/pages/{}/sources", page_id);
         self.get_json(&path).await
     }
+
+    pub async fn test_llm(&self, endpoint: String, model: String) -> Result<String, String> {
+        let req = origin_types::requests::TestLlmRequest {
+            endpoint,
+            model,
+            prompt: None,
+        };
+        let resp: origin_types::requests::TestLlmResponse =
+            self.post_json("/api/llm/test", &req).await?;
+        Ok(resp.response)
+    }
 }

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -2826,21 +2826,16 @@ pub async fn set_external_llm(
 }
 
 #[tauri::command]
-pub async fn test_external_llm(endpoint: String, model: String) -> Result<String, String> {
-    use origin_core::llm_provider::{LlmProvider, LlmRequest};
-    let provider = origin_core::llm_provider::OpenAICompatibleProvider::new(endpoint, model);
-    let request = LlmRequest {
-        system_prompt: None,
-        user_prompt: "Say 'hello' and nothing else.".into(),
-        max_tokens: 10,
-        temperature: 0.0,
-        label: None,
-        timeout_secs: None,
+pub async fn test_external_llm(
+    state: tauri::State<'_, State>,
+    endpoint: String,
+    model: String,
+) -> Result<String, String> {
+    let client = {
+        let s = state.read().await;
+        s.client.clone()
     };
-    provider
-        .generate(request)
-        .await
-        .map_err(|e| format!("{}", e))
+    client.test_llm(endpoint, model).await
 }
 
 /// Proxy for `GET /api/on-device-model` — returns per-model cache/load state.

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -27,6 +27,7 @@ pub fn build_router(state: SharedState) -> Router {
         .route("/api/context", post(routes::handle_context))
         .route("/api/chat-context", post(routes::handle_chat_context))
         .route("/api/ping", get(routes::handle_ping))
+        .route("/api/llm/test", post(routes::handle_test_llm))
         .route("/api/shutdown", post(routes::handle_shutdown))
         .route("/api/debug/pipeline", get(routes::handle_pipeline_status))
         .route(

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -773,6 +773,31 @@ pub async fn handle_recent_pages(
     Ok(Json(items))
 }
 
+/// POST /api/llm/test — probe an OpenAI-compatible LLM endpoint with a 1-shot prompt.
+/// Validates a custom endpoint from the app settings UI before saving.
+pub async fn handle_test_llm(
+    Json(req): Json<origin_types::requests::TestLlmRequest>,
+) -> Result<Json<origin_types::requests::TestLlmResponse>, ServerError> {
+    use origin_core::llm_provider::{LlmProvider, LlmRequest, OpenAICompatibleProvider};
+
+    let provider = OpenAICompatibleProvider::new(req.endpoint, req.model);
+    let llm_req = LlmRequest {
+        system_prompt: None,
+        user_prompt: req
+            .prompt
+            .unwrap_or_else(|| "Say 'hello' and nothing else.".into()),
+        max_tokens: 10,
+        temperature: 0.0,
+        label: None,
+        timeout_secs: None,
+    };
+    let response = provider
+        .generate(llm_req)
+        .await
+        .map_err(|e| ServerError::Internal(format!("test_llm: {e}")))?;
+    Ok(Json(origin_types::requests::TestLlmResponse { response }))
+}
+
 /// POST /api/shutdown — exits the daemon process cleanly.
 /// Returns 200 OK, then exits 0 after a brief delay so the response is delivered.
 pub async fn handle_shutdown() -> &'static str {

--- a/crates/origin-types/src/requests.rs
+++ b/crates/origin-types/src/requests.rs
@@ -410,6 +410,24 @@ pub struct ExportPageRequest {
     pub vault_path: String,
 }
 
+// ===== LLM test =====
+
+/// `POST /api/llm/test` — probe an OpenAI-compatible LLM endpoint with a 1-shot prompt.
+/// Used by the app settings UI to validate a custom endpoint before saving.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestLlmRequest {
+    pub endpoint: String,
+    pub model: String,
+    /// Optional override prompt. Defaults to "Say 'hello' and nothing else." server-side.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TestLlmResponse {
+    pub response: String,
+}
+
 // ===== Default value functions =====
 
 fn default_limit() -> usize {


### PR DESCRIPTION
Phase 5 PR3 of 3. Recreated as fresh PR off current main after #55 + #59 squash-merges. Same content as the original #57.

## Summary
- New `POST /api/llm/test` endpoint on origin-server: tests an external LLM endpoint with a small prompt, returns its response.
- New `OriginClient::test_llm` HTTP wrapper.
- App's `test_external_llm` Tauri command now proxies through `OriginClient` (no direct origin-core LlmProvider dependency).

## Test plan
- [x] cargo check --workspace --all-targets clean
- [x] cargo clippy --workspace --all-targets -- -D warnings clean
- [x] cargo test --workspace --lib pass
- [x] Daemon smoke: /api/llm/test endpoint reachable, returns response

Replaces #57 (still open but pointing at orphaned base branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)