### PR TITLE
fix: Phase 5-D PR2 — drop origin-core dep from app crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5282,8 +5282,8 @@ dependencies = [
  "notify",
  "notify-debouncer-full",
  "objc",
- "origin-core",
  "origin-types",
+ "pdf-extract",
  "raw-window-handle",
  "regex",
  "reqwest 0.12.28",
@@ -5292,6 +5292,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "sha2",
+ "sysinfo 0.33.1",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-x",
@@ -5312,6 +5313,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "xcap 0.8.3",
+ "zip 2.4.2",
 ]
 
 [[package]]

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -80,7 +80,9 @@ raw-window-handle = "0.6"
 
 # Workspace crates
 origin-types = { workspace = true }
-origin-core = { workspace = true }
+sysinfo = { workspace = true }
+pdf-extract = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
 serial_test = "3"

--- a/app/src/activity.rs
+++ b/app/src/activity.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! App-local activity tracking (macOS focus event ring buffer).
+//! Copied from origin-core; kept here because activities are an in-process
+//! sensor record, never served through the daemon.
+use crate::error::AppError;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+pub const ACTIVITY_GAP_SECS: i64 = 1800; // 30-min inactivity → new activity
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Activity {
+    pub id: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActivitySummary {
+    pub id: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub is_live: bool,
+    pub app_names: Vec<String>,
+}
+
+impl Activity {
+    pub fn new(now: i64) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            started_at: now,
+            ended_at: now,
+        }
+    }
+
+    pub fn new_with_range(started_at: i64, ended_at: i64) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            started_at,
+            ended_at,
+        }
+    }
+
+    pub fn to_summary(&self, is_live: bool) -> ActivitySummary {
+        ActivitySummary {
+            id: self.id.clone(),
+            started_at: self.started_at,
+            ended_at: self.ended_at,
+            is_live,
+            app_names: Vec::new(),
+        }
+    }
+}
+
+fn activities_path() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("origin")
+        .join("activities.json")
+}
+
+pub fn load_activities() -> Vec<Activity> {
+    let path = activities_path();
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+pub fn save_activities(activities: &[Activity]) -> Result<(), AppError> {
+    let path = activities_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(activities)?;
+    std::fs::write(&path, json)?;
+    Ok(())
+}

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -224,4 +224,172 @@ mod tests {
         let config: Config = serde_json::from_str("{}").unwrap();
         assert!(config.watch_paths.is_empty());
     }
+
+    // --- save_config / load_config I/O roundtrip ---
+
+    #[test]
+    fn save_load_config_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Point config_path() at our temp dir via the env override.
+        // serial_test is not used here because env mutation is process-wide;
+        // each call sets and then the test's scope owns the dir, and the dir
+        // is unique per invocation, so races are avoided.
+        std::env::set_var("ORIGIN_DATA_DIR", tmp.path());
+        let mut config = Config {
+            clipboard_enabled: true,
+            ..Config::default()
+        };
+        config.watch_paths = vec![PathBuf::from("/test/path")];
+        save_config(&config).unwrap();
+        let loaded = load_config();
+        // After load_config, migrate() runs: watch_paths -> sources, watch_paths cleared.
+        assert!(loaded.clipboard_enabled);
+        assert_eq!(loaded.sources.len(), 1);
+        assert_eq!(loaded.sources[0].path, PathBuf::from("/test/path"));
+        assert!(loaded.watch_paths.is_empty());
+        std::env::remove_var("ORIGIN_DATA_DIR");
+    }
+
+    // --- setup_completed ---
+
+    #[test]
+    fn test_setup_completed_defaults_to_false() {
+        let config = Config::default();
+        assert!(!config.setup_completed);
+    }
+
+    #[test]
+    fn test_setup_completed_roundtrip() {
+        let config = Config {
+            setup_completed: true,
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert!(restored.setup_completed);
+    }
+
+    #[test]
+    fn test_setup_completed_missing_in_json_defaults_false() {
+        let json = r#"{"clipboard_enabled": true}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(!config.setup_completed);
+    }
+
+    // --- remote_access_enabled ---
+
+    #[test]
+    fn test_remote_access_enabled_defaults_to_false() {
+        let config = Config::default();
+        assert!(!config.remote_access_enabled);
+    }
+
+    #[test]
+    fn test_remote_access_enabled_roundtrip() {
+        let config = Config {
+            remote_access_enabled: true,
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert!(restored.remote_access_enabled);
+    }
+
+    #[test]
+    fn test_remote_access_enabled_missing_in_json_defaults_false() {
+        let json = r#"{"clipboard_enabled": true}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(!config.remote_access_enabled);
+    }
+
+    // --- screen_capture_enabled ---
+
+    #[test]
+    fn test_screen_capture_enabled_defaults_to_false() {
+        let config = Config::default();
+        assert!(!config.screen_capture_enabled);
+    }
+
+    #[test]
+    fn test_screen_capture_enabled_roundtrip() {
+        let config = Config {
+            screen_capture_enabled: true,
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert!(restored.screen_capture_enabled);
+    }
+
+    #[test]
+    fn test_screen_capture_enabled_missing_in_json_defaults_false() {
+        let json = r#"{"clipboard_enabled": true}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(!config.screen_capture_enabled);
+    }
+
+    // --- migrate() / watch_paths / sources / knowledge_path ---
+
+    #[test]
+    fn test_config_defaults_empty_sources() {
+        let config: Config = serde_json::from_str("{}").unwrap();
+        let mut config = config;
+        config.migrate();
+        assert!(config.sources.is_empty());
+        assert!(config.knowledge_path.is_none());
+    }
+
+    #[test]
+    fn config_watch_paths_migration() {
+        let old_json = r#"{
+            "watch_paths": ["/Users/x/docs", "/Users/x/notes"],
+            "clipboard_enabled": false
+        }"#;
+        let mut config: Config = serde_json::from_str(old_json).unwrap();
+        config.migrate();
+        assert_eq!(config.sources.len(), 2);
+        assert_eq!(config.sources[0].source_type, SourceType::Directory);
+        assert_eq!(config.sources[0].path, PathBuf::from("/Users/x/docs"));
+        assert_eq!(config.sources[1].path, PathBuf::from("/Users/x/notes"));
+        // Legacy field cleared after migration.
+        assert!(config.watch_paths.is_empty());
+    }
+
+    #[test]
+    fn config_knowledge_path_default() {
+        let config: Config = serde_json::from_str("{}").unwrap();
+        let default_path = dirs::home_dir().unwrap().join("Origin/knowledge");
+        assert_eq!(config.knowledge_path_or_default(), default_path);
+    }
+
+    #[test]
+    fn config_knowledge_path_custom() {
+        let json = r#"{"knowledge_path": "/my/custom/path"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            config.knowledge_path_or_default(),
+            PathBuf::from("/my/custom/path")
+        );
+    }
+
+    #[test]
+    fn directory_source_paths() {
+        let json = r#"{"sources": [
+            {"id": "d1", "source_type": "directory", "path": "/a", "status": "Active", "last_sync": null, "file_count": 0, "memory_count": 0},
+            {"id": "o1", "source_type": "obsidian", "path": "/b", "status": "Active", "last_sync": null, "file_count": 0, "memory_count": 0}
+        ]}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let paths = config.directory_source_paths();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], PathBuf::from("/a"));
+    }
+
+    // --- unknown-field tolerance ---
+
+    #[test]
+    fn dwell_enabled_alias() {
+        // dwell_enabled was removed with ambient capture; verify unknown fields are ignored.
+        let json = r#"{"dwell_enabled": true}"#;
+        let _config: Config = serde_json::from_str(json).unwrap();
+    }
 }

--- a/app/src/config.rs
+++ b/app/src/config.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! App-local config file I/O. Reads/writes the shared
+//! `~/Library/Application Support/origin/config.json` that the daemon also
+//! writes. The app reads it directly for sensor gating (skip_apps, etc.) and
+//! for settings that must be available before the daemon is reachable.
+//!
+//! Copied from origin-core::config; uses AppError instead of OriginError.
+use crate::error::AppError;
+use origin_types::sources::{Source, SourceType, SyncStatus};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_skip_apps() -> Vec<String> {
+    vec![
+        "Window Server".into(),
+        "Dock".into(),
+        "SystemUIServer".into(),
+        "Control Center".into(),
+        "Notification Center".into(),
+        "loginwindow".into(),
+        "Spotlight".into(),
+        "Origin".into(),
+        "1Password".into(),
+        "Keychain Access".into(),
+        "LastPass".into(),
+        "Bitwarden".into(),
+        "Dashlane".into(),
+        "KeePass".into(),
+    ]
+}
+
+fn default_skip_title_patterns() -> Vec<String> {
+    vec![]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Config {
+    /// Legacy field — kept for backward compat with old config files.
+    /// Use `sources` instead. Migrated to Source structs by `migrate()`.
+    #[serde(default)]
+    pub watch_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub sources: Vec<Source>,
+    #[serde(default)]
+    pub knowledge_path: Option<PathBuf>,
+    #[serde(default)]
+    pub clipboard_enabled: bool,
+    #[serde(default = "default_skip_apps")]
+    pub skip_apps: Vec<String>,
+    #[serde(default = "default_skip_title_patterns")]
+    pub skip_title_patterns: Vec<String>,
+    #[serde(default = "default_true")]
+    pub private_browsing_detection: bool,
+    #[serde(default)]
+    pub setup_completed: bool,
+    #[serde(default)]
+    pub anthropic_api_key: Option<String>,
+    #[serde(default)]
+    pub routine_model: Option<String>,
+    #[serde(default)]
+    pub synthesis_model: Option<String>,
+    #[serde(default)]
+    pub remote_access_enabled: bool,
+    #[serde(default)]
+    pub screen_capture_enabled: bool,
+    #[serde(default)]
+    pub on_device_model: Option<String>,
+    #[serde(default)]
+    pub external_llm_endpoint: Option<String>,
+    #[serde(default)]
+    pub external_llm_model: Option<String>,
+}
+
+/// Generate a source ID slug from a directory path (last component, lowercased, sanitized).
+fn slug_from_path(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_lowercase())
+        .unwrap_or_else(|| "dir".to_string())
+        .replace(|c: char| !c.is_alphanumeric() && c != '-', "-")
+}
+
+impl Config {
+    /// Migrate legacy `watch_paths` entries into `sources` vec.
+    /// Idempotent — only converts paths not already represented in `sources`.
+    pub fn migrate(&mut self) {
+        if self.watch_paths.is_empty() {
+            return;
+        }
+        let existing_paths: std::collections::HashSet<PathBuf> =
+            self.sources.iter().map(|s| s.path.clone()).collect();
+
+        for path in &self.watch_paths {
+            if existing_paths.contains(path) {
+                continue;
+            }
+            let slug = slug_from_path(path);
+            self.sources.push(Source {
+                id: format!("dir-{}", slug),
+                source_type: SourceType::Directory,
+                path: path.clone(),
+                status: SyncStatus::Active,
+                last_sync: None,
+                file_count: 0,
+                memory_count: 0,
+                last_sync_errors: 0,
+                last_sync_error_detail: None,
+            });
+        }
+        // Clear legacy field so it doesn't re-migrate on next load
+        self.watch_paths.clear();
+    }
+
+    /// Returns the configured knowledge path, or `~/Origin/knowledge/` as default.
+    pub fn knowledge_path_or_default(&self) -> PathBuf {
+        self.knowledge_path.clone().unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("Origin/knowledge")
+        })
+    }
+
+    /// Returns paths for all active Directory-type sources (for indexer compat).
+    pub fn directory_source_paths(&self) -> Vec<PathBuf> {
+        self.sources
+            .iter()
+            .filter(|s| s.source_type == SourceType::Directory)
+            .filter(|s| matches!(s.status, SyncStatus::Active))
+            .map(|s| s.path.clone())
+            .collect()
+    }
+}
+
+fn config_path() -> PathBuf {
+    // Honor the `ORIGIN_DATA_DIR` override so a scratch daemon (e.g.
+    // `origin-server --data-dir /tmp/origin-demo`) reads and writes its own
+    // config file rather than clobbering the user's real one.
+    let root = std::env::var_os("ORIGIN_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("origin")
+        });
+    root.join("config.json")
+}
+
+pub fn load_config() -> Config {
+    let path = config_path();
+    let mut config = match std::fs::read_to_string(&path) {
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Err(_) => Config::default(),
+    };
+    config.migrate();
+    config
+}
+
+pub fn save_config(config: &Config) -> Result<(), AppError> {
+    let path = config_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(config)?;
+    std::fs::write(&path, &json)?;
+
+    // Restrict file permissions when API key is present (user-only read/write)
+    #[cfg(unix)]
+    if config.anthropic_api_key.is_some() {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        std::fs::set_permissions(&path, perms).ok();
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_default_values() {
+        let config = Config::default();
+        assert!(config.watch_paths.is_empty());
+        assert!(!config.clipboard_enabled);
+    }
+
+    #[test]
+    fn test_config_roundtrip_serde() {
+        let mut config = Config {
+            clipboard_enabled: true,
+            skip_apps: vec!["TestApp".into()],
+            skip_title_patterns: vec!["secret*".into()],
+            private_browsing_detection: false,
+            setup_completed: false,
+            anthropic_api_key: None,
+            remote_access_enabled: false,
+            screen_capture_enabled: false,
+            ..Config::default()
+        };
+        config.watch_paths = vec![PathBuf::from("/tmp/test")];
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.watch_paths, config.watch_paths);
+        assert!(restored.clipboard_enabled);
+        assert_eq!(restored.skip_apps, vec!["TestApp".to_string()]);
+        assert!(!restored.private_browsing_detection);
+    }
+
+    #[test]
+    fn test_config_deserialize_missing_fields_uses_defaults() {
+        let json = r#"{"watch_paths": ["/tmp/a"]}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.watch_paths, vec![PathBuf::from("/tmp/a")]);
+        assert!(config.private_browsing_detection);
+        assert!(!config.skip_apps.is_empty());
+    }
+
+    #[test]
+    fn test_config_deserialize_empty_json() {
+        let config: Config = serde_json::from_str("{}").unwrap();
+        assert!(config.watch_paths.is_empty());
+    }
+}

--- a/app/src/error.rs
+++ b/app/src/error.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! App-local error type. Mirrors the variants used by app code (file watcher,
+//! MCP config, sensor, sources/sync). origin-core's OriginError is no longer
+//! imported after the dep removal in Phase 5-D PR2.
+use serde::Serialize;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AppError {
+    #[error("Indexer error: {0}")]
+    Indexer(String),
+
+    #[error("Source error: {source_name}: {message}")]
+    Source {
+        source_name: String,
+        message: String,
+    },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("HTTP error: {0}")]
+    #[allow(dead_code)]
+    Http(String),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Vision error: {0}")]
+    Vision(String),
+
+    #[error("{0}")]
+    Generic(String),
+}
+
+// Tauri requires Serialize to pass errors across IPC
+impl Serialize for AppError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}

--- a/app/src/indexer.rs
+++ b/app/src/indexer.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-use crate::error::OriginError;
+use crate::error::AppError;
 use crate::sources::local_files::LocalFilesSource;
 use crate::sources::RawDocument;
 use crate::state::AppState;
@@ -37,7 +37,7 @@ struct IngestResponse {
 pub async fn ingest_documents(
     mut docs: Vec<RawDocument>,
     state: &Arc<RwLock<AppState>>,
-) -> Result<usize, OriginError> {
+) -> Result<usize, AppError> {
     if docs.is_empty() {
         return Ok(0);
     }
@@ -131,14 +131,14 @@ pub async fn ingest_documents(
     }
 
     if let Some(err) = last_error {
-        Err(OriginError::VectorDb(err))
+        Err(AppError::Indexer(err))
     } else {
         Ok(total_chunks)
     }
 }
 
 /// Create a file watcher that ingests changed files into the vector database.
-pub fn create_file_watcher(state: Arc<RwLock<AppState>>) -> Result<FileWatcher, OriginError> {
+pub fn create_file_watcher(state: Arc<RwLock<AppState>>) -> Result<FileWatcher, AppError> {
     let debouncer = new_debouncer(
         Duration::from_secs(2),
         None,
@@ -182,7 +182,7 @@ pub fn create_file_watcher(state: Arc<RwLock<AppState>>) -> Result<FileWatcher, 
             }
         },
     )
-    .map_err(|e| OriginError::Indexer(e.to_string()))?;
+    .map_err(|e| AppError::Indexer(e.to_string()))?;
 
     log::info!("File watcher created");
     Ok(debouncer)
@@ -213,7 +213,7 @@ const WATCH_SKIP_DIRS: &[&str] = &[
 /// Instead of a single recursive watch (which monitors build artifacts, .git, etc.
 /// and exhausts file descriptors), we walk the directory tree ourselves and skip
 /// ignored directories, watching each valid directory individually.
-pub fn watch_path(watcher: &mut FileWatcher, path: &Path) -> Result<(), OriginError> {
+pub fn watch_path(watcher: &mut FileWatcher, path: &Path) -> Result<(), AppError> {
     let skip: std::collections::HashSet<&str> = WATCH_SKIP_DIRS.iter().copied().collect();
     let mut count = 0;
 
@@ -228,11 +228,11 @@ fn watch_path_filtered(
     dir: &Path,
     skip: &std::collections::HashSet<&str>,
     count: &mut usize,
-) -> Result<(), OriginError> {
+) -> Result<(), AppError> {
     // Watch this directory (non-recursive)
     watcher
         .watch(dir, notify::RecursiveMode::NonRecursive)
-        .map_err(|e| OriginError::Indexer(format!("Failed to watch {}: {}", dir.display(), e)))?;
+        .map_err(|e| AppError::Indexer(format!("Failed to watch {}: {}", dir.display(), e)))?;
     *count += 1;
 
     // Recurse into child directories, skipping ignored ones
@@ -265,7 +265,7 @@ fn watch_path_filtered(
 pub async fn sync_source(
     source_name: &str,
     state: &Arc<RwLock<AppState>>,
-) -> Result<usize, OriginError> {
+) -> Result<usize, AppError> {
     // Set is_running early so the UI reflects progress immediately
     {
         let mut s = state.write().await;
@@ -290,7 +290,7 @@ pub async fn sync_source(
 async fn sync_source_inner(
     source_name: &str,
     state: &Arc<RwLock<AppState>>,
-) -> Result<usize, OriginError> {
+) -> Result<usize, AppError> {
     let docs = if source_name == "local_files" {
         // Clone watch_paths under a brief read lock, then scan without holding any lock
         let watch_paths = {
@@ -318,20 +318,20 @@ async fn sync_source_inner(
             docs
         })
         .await
-        .map_err(|e| OriginError::Indexer(format!("Scan task failed: {}", e)))?
+        .map_err(|e| AppError::Indexer(format!("Scan task failed: {}", e)))?
     } else {
         // For non-local sources, use write lock so fetch_updates can mutate (token refresh)
         let mut s = state.write().await;
         let source = s
             .sources
             .get_mut(source_name)
-            .ok_or_else(|| OriginError::Source {
+            .ok_or_else(|| AppError::Source {
                 source_name: source_name.to_string(),
                 message: "Source not found".to_string(),
             })?;
 
         if !source.is_connected().await {
-            return Err(OriginError::Source {
+            return Err(AppError::Source {
                 source_name: source_name.to_string(),
                 message: "Source is not connected".to_string(),
             });

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -4,11 +4,15 @@
 extern crate objc;
 
 // ── App-specific modules (Tauri, sensors, UI) ──
+pub mod activity;
 pub mod api;
+pub mod config;
+pub mod error;
 pub mod events;
 mod indexer;
 mod lifecycle;
 pub mod mcp_config;
+pub mod privacy;
 pub mod remote_access;
 mod router;
 mod search;
@@ -21,22 +25,6 @@ pub mod system_info;
 pub(crate) mod tray_health;
 mod trigger;
 mod updater;
-
-// ── Re-export origin-core modules ──
-// These re-exports let existing `crate::module::Type` paths work unchanged
-// throughout the app (search.rs, state.rs, router/, etc.)
-pub use origin_core::activity;
-pub use origin_core::briefing;
-pub use origin_core::config;
-pub use origin_core::db as memory_db;
-pub use origin_core::error;
-pub use origin_core::export;
-pub use origin_core::narrative;
-pub use origin_core::pages;
-pub use origin_core::privacy;
-// sources is a local module (has app-specific sync logic)
-pub use origin_core::spaces;
-pub use origin_core::working_memory;
 
 use state::AppState;
 use std::sync::Arc;
@@ -820,7 +808,6 @@ pub fn run() {
             search::pin_memory,
             search::unpin_memory,
             search::list_pinned_memories,
-            search::record_eval_signal,
             search::set_avatar,
             search::get_avatar_data_url,
             search::remove_avatar,
@@ -872,9 +859,6 @@ pub fn run() {
             search::export_page_to_obsidian,
             search::get_knowledge_path,
             search::count_knowledge_files,
-            // Distillation trigger commands
-            search::trigger_distillation,
-            search::redistill_page,
             search::get_screen_capture_enabled,
             search::set_screen_capture_enabled,
             search::check_screen_permission,

--- a/app/src/mcp_config.rs
+++ b/app/src/mcp_config.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-use crate::error::OriginError;
+use crate::error::AppError;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -112,7 +112,7 @@ pub fn origin_mcp_entry() -> serde_json::Value {
 pub fn write_origin_entry(
     config_path: &std::path::Path,
     is_claude_code: bool,
-) -> Result<(), OriginError> {
+) -> Result<(), AppError> {
     let mut root = if config_path.exists() {
         // Back up existing file
         let backup_path = config_path.with_extension("json.bak");
@@ -120,10 +120,10 @@ pub fn write_origin_entry(
 
         let contents = std::fs::read_to_string(config_path)?;
         serde_json::from_str::<serde_json::Value>(&contents).map_err(|e| {
-            OriginError::Generic(format!("Invalid JSON in {}: {}", config_path.display(), e))
+            AppError::Generic(format!("Invalid JSON in {}: {}", config_path.display(), e))
         })?
     } else if is_claude_code {
-        return Err(OriginError::Generic(
+        return Err(AppError::Generic(
             "Claude Code config file not found — Claude Code manages this file internally".into(),
         ));
     } else {
@@ -142,7 +142,7 @@ pub fn write_origin_entry(
         std::fs::create_dir_all(parent)?;
     }
     let formatted =
-        serde_json::to_string_pretty(&root).map_err(|e| OriginError::Generic(e.to_string()))?;
+        serde_json::to_string_pretty(&root).map_err(|e| AppError::Generic(e.to_string()))?;
     std::fs::write(config_path, formatted)?;
 
     Ok(())

--- a/app/src/privacy.rs
+++ b/app/src/privacy.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! PII redaction for in-process sensor data.
+//! Copied from origin-core; kept here because redaction runs in the smart router
+//! before data is sent to the daemon, making it strictly app-local.
+use regex::Regex;
+use std::sync::LazyLock;
+
+struct PiiPattern {
+    regex: Regex,
+    label: &'static str,
+}
+
+static PII_PATTERNS: LazyLock<Vec<PiiPattern>> = LazyLock::new(|| {
+    vec![
+        PiiPattern {
+            regex: Regex::new(r"\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b").unwrap(),
+            label: "CREDIT_CARD",
+        },
+        PiiPattern {
+            regex: Regex::new(r"\b\d{3}-\d{2}-\d{4}\b").unwrap(),
+            label: "SSN",
+        },
+        PiiPattern {
+            regex: Regex::new(r"(?i)AKIA[0-9A-Z]{16}").unwrap(),
+            label: "AWS_KEY",
+        },
+        PiiPattern {
+            regex: Regex::new(r"-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA )?PRIVATE KEY-----").unwrap(),
+            label: "PRIVATE_KEY",
+        },
+        PiiPattern {
+            regex: Regex::new(r#"(?i)(?:api_key|apikey|api-key|secret_key|secret|token|password|passwd)\s*[=:]\s*["']?[A-Za-z0-9\-_.]{8,}["']?"#).unwrap(),
+            label: "API_KEY",
+        },
+        PiiPattern {
+            regex: Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b").unwrap(),
+            label: "EMAIL",
+        },
+        PiiPattern {
+            regex: Regex::new(r"(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b").unwrap(),
+            label: "PHONE",
+        },
+    ]
+});
+
+/// Redact PII patterns from text, replacing matches with [REDACTED].
+pub fn redact_pii(text: &str) -> String {
+    let mut result = text.to_string();
+    for pattern in PII_PATTERNS.iter() {
+        result = pattern
+            .regex
+            .replace_all(&result, &format!("[REDACTED:{}]", pattern.label))
+            .to_string();
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_credit_card_redaction() {
+        let input = "My card is 4111-1111-1111-1111 and 5500 0000 0000 0004";
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:CREDIT_CARD]"));
+        assert!(!result.contains("4111"));
+        assert!(!result.contains("5500"));
+    }
+
+    #[test]
+    fn test_ssn_redaction() {
+        let input = "SSN: 123-45-6789";
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:SSN]"));
+        assert!(!result.contains("123-45-6789"));
+    }
+
+    #[test]
+    fn test_aws_key_redaction() {
+        let input = "aws_access_key = AKIAIOSFODNN7EXAMPLE";
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:AWS_KEY]"));
+    }
+
+    #[test]
+    fn test_api_key_redaction() {
+        let input = r#"api_key="sk-abc123def456ghi789""#;
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:API_KEY]"));
+    }
+
+    #[test]
+    fn test_private_key_redaction() {
+        let input =
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQ...\n-----END RSA PRIVATE KEY-----";
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:PRIVATE_KEY]"));
+    }
+
+    #[test]
+    fn test_no_false_positives() {
+        let input = "Regular text with a number 12345 and no PII";
+        let result = redact_pii(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_email_redaction() {
+        let input = "Contact us at user@example.com or admin.team@company.co.uk for help";
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:EMAIL]"));
+        assert!(!result.contains("user@example.com"));
+        assert!(!result.contains("admin.team@company.co.uk"));
+    }
+
+    #[test]
+    fn test_phone_redaction() {
+        let input = "Call me at (555) 123-4567 or +1-800-555-0199";
+        let result = redact_pii(input);
+        assert!(result.contains("[REDACTED:PHONE]"));
+        assert!(!result.contains("555) 123-4567"));
+        assert!(!result.contains("800-555-0199"));
+    }
+
+    #[test]
+    fn test_phone_no_false_positive_on_short_numbers() {
+        let input = "Error code 12345 and version 1.2.3";
+        let result = redact_pii(input);
+        assert!(!result.contains("[REDACTED:PHONE]"));
+    }
+}

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -655,7 +655,7 @@ pub async fn add_watch_path(
                 .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| "dir".to_string());
-            let slug = crate::export::obsidian::slugify(&dirname);
+            let slug = crate::sources::obsidian::slugify(&dirname);
             let id = format!("directory-{}", slug);
             cfg.sources.push(crate::sources::Source {
                 id,
@@ -803,7 +803,7 @@ pub async fn list_sources(state: tauri::State<'_, State>) -> Result<Vec<SourceSt
 
 async fn save_current_config(
     state: &tauri::State<'_, State>,
-) -> Result<(), crate::error::OriginError> {
+) -> Result<(), crate::error::AppError> {
     let app_state = state.read().await;
     let existing = config::load_config();
     let cfg = config::Config {
@@ -1134,9 +1134,9 @@ pub async fn get_chunks(
     state: tauri::State<'_, State>,
     _source: String,
     source_id: String,
-) -> Result<Vec<crate::memory_db::MemoryDetail>, String> {
+) -> Result<Vec<MemoryDetail>, String> {
     let s = state.read().await;
-    let chunks: Vec<crate::memory_db::MemoryDetail> = s
+    let chunks: Vec<MemoryDetail> = s
         .client
         .get_json(&format!("/api/chunks/{}", source_id))
         .await?;
@@ -1840,18 +1840,6 @@ pub async fn list_pinned_memories(
     Ok(resp.memories)
 }
 
-#[tauri::command]
-pub async fn record_eval_signal(
-    _state: tauri::State<'_, State>,
-    _signal_type: String,
-    _memory_id: String,
-    _query_context: Option<String>,
-    _rank_position: Option<i32>,
-) -> Result<(), String> {
-    // Eval signals are now handled entirely by the daemon
-    Ok(())
-}
-
 // ── Pending revisions ─────────────────────────────────────────────────
 
 #[tauri::command]
@@ -1899,9 +1887,9 @@ pub async fn dismiss_contradiction(
 pub async fn get_pending_revision(
     state: tauri::State<'_, State>,
     source_id: String,
-) -> Result<Option<crate::memory_db::PendingRevision>, String> {
+) -> Result<Option<PendingRevision>, String> {
     let s = state.read().await;
-    let revision: Option<crate::memory_db::PendingRevision> = s
+    let revision: Option<PendingRevision> = s
         .client
         .get_json(&format!("/api/memory/pending-revision/{}", source_id))
         .await?;
@@ -1911,37 +1899,34 @@ pub async fn get_pending_revision(
 // ── Briefing / narrative ──────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_briefing(
-    state: tauri::State<'_, State>,
-) -> Result<crate::briefing::BriefingResponse, String> {
+pub async fn get_briefing(state: tauri::State<'_, State>) -> Result<BriefingResponse, String> {
     let s = state.read().await;
-    let resp: crate::briefing::BriefingResponse = s.client.get_json("/api/briefing").await?;
+    let resp: BriefingResponse = s.client.get_json("/api/briefing").await?;
     Ok(resp)
 }
 
 #[tauri::command]
 pub async fn get_pending_contradictions(
     _state: tauri::State<'_, State>,
-) -> Result<Vec<crate::briefing::ContradictionItem>, String> {
+) -> Result<Vec<ContradictionItem>, String> {
     Ok(vec![])
 }
 
 #[tauri::command]
 pub async fn get_profile_narrative(
     state: tauri::State<'_, State>,
-) -> Result<crate::narrative::NarrativeResponse, String> {
+) -> Result<NarrativeResponse, String> {
     let s = state.read().await;
-    let resp: crate::narrative::NarrativeResponse =
-        s.client.get_json("/api/profile/narrative").await?;
+    let resp: NarrativeResponse = s.client.get_json("/api/profile/narrative").await?;
     Ok(resp)
 }
 
 #[tauri::command]
 pub async fn regenerate_narrative(
     state: tauri::State<'_, State>,
-) -> Result<crate::narrative::NarrativeResponse, String> {
+) -> Result<NarrativeResponse, String> {
     let s = state.read().await;
-    let resp: crate::narrative::NarrativeResponse = s
+    let resp: NarrativeResponse = s
         .client
         .post_empty("/api/profile/narrative/regenerate")
         .await?;
@@ -2024,16 +2009,6 @@ pub async fn dismiss_entity_suggestion_cmd(
 }
 
 // ── Spaces ────────────────────────────────────────────────────────────
-
-#[derive(Debug, Clone, Serialize)]
-#[allow(dead_code)]
-pub struct SpaceData {
-    pub spaces: Vec<crate::spaces::Space>,
-    pub activity_streams: Vec<crate::spaces::ActivityStream>,
-    pub document_spaces: HashMap<String, String>,
-    pub document_tags: HashMap<String, Vec<String>>,
-    pub tags: Vec<String>,
-}
 
 #[tauri::command]
 pub async fn list_spaces(state: tauri::State<'_, State>) -> Result<Vec<Space>, String> {
@@ -2313,7 +2288,7 @@ fn percent_encode(s: &str) -> String {
 #[tauri::command]
 pub async fn get_working_memory(
     state: tauri::State<'_, State>,
-) -> Result<Vec<crate::working_memory::WorkingMemoryEntry>, String> {
+) -> Result<Vec<origin_types::working_memory::WorkingMemoryEntry>, String> {
     // Working memory is in-process state populated by the context consumer
     // (`router/intent.rs`). Sensors run only in the app process, so this
     // is served from the app's local rolling buffer rather than an HTTP endpoint.
@@ -2410,14 +2385,11 @@ pub async fn correct_memory_cmd(
 /// Wire wrapper for the daemon's `{ "page": {...} }` response shape.
 #[derive(serde::Deserialize)]
 struct GetPageWire {
-    page: Option<crate::pages::Page>,
+    page: Option<Page>,
 }
 
 #[tauri::command]
-pub async fn get_page(
-    state: tauri::State<'_, State>,
-    id: String,
-) -> Result<Option<crate::pages::Page>, String> {
+pub async fn get_page(state: tauri::State<'_, State>, id: String) -> Result<Option<Page>, String> {
     let client = state.read().await.client.clone();
     // The daemon returns 404 when the page doesn't exist, which reqwest
     // turns into an error. Distinguish "not found" from real errors so the
@@ -2477,7 +2449,7 @@ pub async fn delete_page(state: tauri::State<'_, State>, id: String) -> Result<(
 /// origin-types), so we can't put this in the shared response types.
 #[derive(serde::Deserialize)]
 struct ListPagesWire {
-    pages: Vec<crate::pages::Page>,
+    pages: Vec<Page>,
 }
 
 #[tauri::command]
@@ -2487,7 +2459,7 @@ pub async fn list_pages(
     domain: Option<String>,
     limit: Option<usize>,
     offset: Option<usize>,
-) -> Result<Vec<crate::pages::Page>, String> {
+) -> Result<Vec<Page>, String> {
     let client = state.read().await.client.clone();
     // Build query string from the filter params that were previously ignored.
     let mut params: Vec<String> = Vec::new();
@@ -2517,7 +2489,7 @@ pub async fn search_pages(
     state: tauri::State<'_, State>,
     query: String,
     limit: Option<usize>,
-) -> Result<Vec<crate::pages::Page>, String> {
+) -> Result<Vec<Page>, String> {
     let client = state.read().await.client.clone();
     let req = requests::SearchPagesRequest { query, limit };
     let resp: ListPagesWire = client.post_json("/api/pages/search", &req).await?;
@@ -2537,23 +2509,14 @@ pub async fn get_page_sources(
 pub async fn export_pages_to_obsidian(
     state: tauri::State<'_, State>,
     vault_path: String,
-) -> Result<crate::export::ExportStats, String> {
-    // Fetch pages from daemon, then export locally
-    let pages: Vec<crate::pages::Page> = {
-        let client = state.read().await.client.clone();
-        let resp: ListPagesWire = client.get_json("/api/pages").await?;
-        resp.pages
+) -> Result<ExportStats, String> {
+    // Delegate bulk export to the daemon (POST /api/pages/export).
+    // The daemon has direct FS access and owns the ObsidianExporter.
+    let client = state.read().await.client.clone();
+    let req = requests::ExportPagesRequest {
+        vault_path: Some(vault_path),
     };
-    let expanded = if let Some(rest) = vault_path.strip_prefix("~/") {
-        let home = std::env::var("HOME").unwrap_or_default();
-        format!("{}/{}", home, rest)
-    } else {
-        vault_path
-    };
-    let exporter =
-        crate::export::obsidian::ObsidianExporter::new(std::path::PathBuf::from(expanded));
-    use crate::export::PageExporter;
-    exporter.export_all(&pages).map_err(|e| e.to_string())
+    client.post_json("/api/pages/export", &req).await
 }
 
 #[tauri::command]
@@ -2581,26 +2544,6 @@ pub async fn count_knowledge_files(state: tauri::State<'_, State>) -> Result<u64
     let client = state.read().await.client.clone();
     let resp: responses::KnowledgeCountResponse = client.get_json("/api/knowledge/count").await?;
     Ok(resp.count)
-}
-
-// ── Distillation ──────────────────────────────────────────────────────
-
-#[tauri::command]
-pub async fn trigger_distillation(
-    state: tauri::State<'_, State>,
-) -> Result<serde_json::Value, String> {
-    let s = state.read().await;
-    s.client.post_empty("/api/distill").await
-}
-
-#[tauri::command]
-pub async fn redistill_page(state: tauri::State<'_, State>, page_id: String) -> Result<(), String> {
-    let s = state.read().await;
-    let _resp: serde_json::Value = s
-        .client
-        .post_empty(&format!("/api/distill/{}", page_id))
-        .await?;
-    Ok(())
 }
 
 // ── Quality gate / rejections ─────────────────────────────────────────
@@ -2681,7 +2624,7 @@ pub async fn add_source(
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| "dir".to_string());
-    let slug = crate::export::obsidian::slugify(&dirname);
+    let slug = crate::sources::obsidian::slugify(&dirname);
     let id = format!("{}-{}", st.as_str(), slug);
 
     let mut cfg = config::load_config();

--- a/app/src/sensor/vision.rs
+++ b/app/src/sensor/vision.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-use crate::error::OriginError;
+use crate::error::AppError;
 
 /// Metadata + image for a captured window (used by frame_compare for hash).
 pub struct WindowCapture {
@@ -37,10 +37,10 @@ pub fn capture_windows(
     skip_apps: &[String],
     skip_title_patterns: &[String],
     private_browsing_detection: bool,
-) -> Result<Vec<WindowCapture>, OriginError> {
+) -> Result<Vec<WindowCapture>, AppError> {
     use xcap::Window;
 
-    let windows = Window::all().map_err(|e| OriginError::Vision(format!("xcap list: {e}")))?;
+    let windows = Window::all().map_err(|e| AppError::Vision(format!("xcap list: {e}")))?;
 
     let mut captures = Vec::new();
     for win in &windows {
@@ -69,9 +69,7 @@ pub fn capture_windows(
         let img = match win.capture_image() {
             Ok(buf) => image::DynamicImage::ImageRgba8(
                 image::ImageBuffer::from_raw(buf.width(), buf.height(), buf.into_raw())
-                    .ok_or_else(|| {
-                        OriginError::Vision("Failed to create image buffer".to_string())
-                    })?,
+                    .ok_or_else(|| AppError::Vision("Failed to create image buffer".to_string()))?,
             ),
             Err(e) => {
                 log::debug!("[vision] capture failed for \"{}\": {}", title, e);
@@ -100,7 +98,7 @@ pub fn capture_windows(
 /// Run Apple Vision OCR on each window capture, returning per-window results
 /// with individual text observations.
 #[cfg(target_os = "macos")]
-pub fn ocr_per_window(captures: &[WindowCapture]) -> Result<Vec<WindowOcrResult>, OriginError> {
+pub fn ocr_per_window(captures: &[WindowCapture]) -> Result<Vec<WindowOcrResult>, AppError> {
     let mut results = Vec::new();
 
     for capture in captures {
@@ -153,7 +151,7 @@ pub fn ocr_per_window(captures: &[WindowCapture]) -> Result<Vec<WindowOcrResult>
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn ocr_per_window(_captures: &[WindowCapture]) -> Result<Vec<WindowOcrResult>, OriginError> {
+pub fn ocr_per_window(_captures: &[WindowCapture]) -> Result<Vec<WindowOcrResult>, AppError> {
     Ok(vec![])
 }
 

--- a/app/src/sources/data_source.rs
+++ b/app/src/sources/data_source.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! DataSource trait — app-local definition.
+//! Moved from origin-core::sources; the trait and its impls are app-only
+//! (origin-server never references DataSource directly).
+use crate::error::AppError;
+use async_trait::async_trait;
+use origin_types::sources::{RawDocument, SourceStatus};
+use std::any::Any;
+
+/// Trait that all data source connectors must implement.
+#[async_trait]
+pub trait DataSource: Send + Sync {
+    /// Unique name for this source ("gmail", "notion", etc.)
+    fn name(&self) -> &str;
+
+    /// Whether this source requires OAuth authentication
+    fn requires_auth(&self) -> bool;
+
+    /// Check if the source is currently connected/authenticated
+    async fn is_connected(&self) -> bool;
+
+    /// Connect/authenticate the source (triggers OAuth if needed)
+    async fn connect(&mut self) -> Result<(), AppError>;
+
+    /// Disconnect the source (revoke tokens, cleanup)
+    async fn disconnect(&mut self) -> Result<(), AppError>;
+
+    /// Fetch new/updated content since last sync
+    async fn fetch_updates(&mut self) -> Result<Vec<RawDocument>, AppError>;
+
+    /// Initial full sync - fetches all available content
+    async fn full_sync(&mut self) -> Result<Vec<RawDocument>, AppError>;
+
+    /// Get the current status of this source
+    async fn status(&self) -> SourceStatus;
+
+    /// Downcast to concrete type
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}

--- a/app/src/sources/local_files.rs
+++ b/app/src/sources/local_files.rs
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Local filesystem source connector.
+//! Moved from origin-core::sources::local_files; app-only after Phase 5-D PR2.
+use crate::error::AppError;
+use crate::sources::data_source::DataSource;
+use async_trait::async_trait;
+use origin_types::sources::{RawDocument, SourceStatus};
+use std::any::Any;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const DOCUMENT_EXTENSIONS: &[&str] = &["txt", "md", "csv", "log", "pdf", "docx", "rtf"];
+
+const SOURCE_CODE_EXTENSIONS: &[&str] = &[
+    "rs", "py", "js", "ts", "tsx", "jsx", "json", "toml", "yaml", "yml", "go", "java", "c", "cpp",
+    "h", "css", "html", "sh", "rb", "php", "swift", "kt", "scala",
+];
+
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    ".next",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+    ".cache",
+];
+
+fn max_file_size(ext: &str) -> u64 {
+    match ext {
+        "pdf" | "docx" => 10_485_760, // 10 MB
+        _ => 1_048_576,               // 1 MB
+    }
+}
+
+#[derive(Default)]
+pub struct LocalFilesSource {
+    watch_paths: Vec<PathBuf>,
+    last_sync: Option<i64>,
+    document_count: u64,
+}
+
+impl LocalFilesSource {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_watch_path(&mut self, path: PathBuf) {
+        if !self.watch_paths.contains(&path) {
+            self.watch_paths.push(path);
+        }
+    }
+
+    pub fn remove_watch_path(&mut self, path: &Path) {
+        self.watch_paths.retain(|p| p != path);
+    }
+
+    /// Scan a directory recursively and collect all indexable files.
+    pub fn scan_directory(dir: &Path) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        let skip_dirs: HashSet<&str> = SKIP_DIRS.iter().copied().collect();
+        Self::scan_recursive(dir, &skip_dirs, &mut files);
+        files
+    }
+
+    fn scan_recursive(dir: &Path, skip_dirs: &HashSet<&str>, files: &mut Vec<PathBuf>) {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => return,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_name = entry.file_name();
+            let name = file_name.to_string_lossy();
+
+            if name.starts_with('.') {
+                continue;
+            }
+
+            if path.is_dir() {
+                if !skip_dirs.contains(name.as_ref()) {
+                    Self::scan_recursive(&path, skip_dirs, files);
+                }
+                continue;
+            }
+
+            if Self::is_indexable(&path) {
+                files.push(path);
+            }
+        }
+    }
+
+    pub fn is_indexable(path: &Path) -> bool {
+        let ext = match path.extension().and_then(|e| e.to_str()) {
+            Some(e) => e.to_lowercase(),
+            None => return false,
+        };
+
+        let supported = DOCUMENT_EXTENSIONS
+            .iter()
+            .chain(SOURCE_CODE_EXTENSIONS.iter())
+            .any(|&e| e == ext);
+
+        if !supported {
+            return false;
+        }
+
+        match std::fs::metadata(path) {
+            Ok(meta) => meta.len() <= max_file_size(&ext),
+            Err(_) => false,
+        }
+    }
+
+    /// Read a file and create a RawDocument, dispatching on extension for binary formats.
+    pub fn read_file(path: &Path) -> Result<RawDocument, AppError> {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_lowercase())
+            .unwrap_or_default();
+
+        let content = match ext.as_str() {
+            "pdf" => {
+                let bytes = std::fs::read(path).map_err(|e| AppError::Source {
+                    source_name: "local_files".to_string(),
+                    message: format!("Failed to read {}: {}", path.display(), e),
+                })?;
+                extract_pdf_text(&bytes, path)?
+            }
+            "docx" => {
+                let bytes = std::fs::read(path).map_err(|e| AppError::Source {
+                    source_name: "local_files".to_string(),
+                    message: format!("Failed to read {}: {}", path.display(), e),
+                })?;
+                extract_docx_text(&bytes, path)?
+            }
+            "rtf" => {
+                let bytes = std::fs::read(path).map_err(|e| AppError::Source {
+                    source_name: "local_files".to_string(),
+                    message: format!("Failed to read {}: {}", path.display(), e),
+                })?;
+                extract_rtf_text(&bytes)
+            }
+            _ => std::fs::read_to_string(path).map_err(|e| AppError::Source {
+                source_name: "local_files".to_string(),
+                message: format!("Failed to read {}: {}", path.display(), e),
+            })?,
+        };
+
+        if content.is_empty() {
+            return Err(AppError::Source {
+                source_name: "local_files".to_string(),
+                message: format!("No text content extracted from {}", path.display()),
+            });
+        }
+
+        let metadata = std::fs::metadata(path)?;
+        let last_modified = metadata
+            .modified()
+            .map(|t| {
+                t.duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs() as i64
+            })
+            .unwrap_or(0);
+
+        let title = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| path.display().to_string());
+
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+
+        let mut metadata_map = std::collections::HashMap::new();
+        if !ext.is_empty() {
+            metadata_map.insert("extension".to_string(), ext);
+        }
+
+        Ok(RawDocument {
+            source: "local_files".to_string(),
+            source_id: path.to_string_lossy().to_string(),
+            title,
+            summary: None,
+            content,
+            url: Some(format!("file://{}", path.display())),
+            last_modified,
+            metadata: metadata_map,
+            memory_type: None,
+            source_agent: None,
+            domain: None,
+            confidence: None,
+            confirmed: None,
+            supersedes: None,
+            pending_revision: false,
+            ..Default::default()
+        })
+    }
+}
+
+/// Extract text from a PDF using pdf-extract.
+fn extract_pdf_text(bytes: &[u8], path: &Path) -> Result<String, AppError> {
+    match pdf_extract::extract_text_from_mem(bytes) {
+        Ok(text) => {
+            let trimmed = text.trim().to_string();
+            if trimmed.is_empty() {
+                log::warn!(
+                    "PDF has no extractable text (image-only?): {}",
+                    path.display()
+                );
+            }
+            Ok(trimmed)
+        }
+        Err(e) => {
+            log::warn!("Failed to extract text from PDF {}: {}", path.display(), e);
+            Ok(String::new())
+        }
+    }
+}
+
+/// Extract text from a DOCX file (ZIP of XML).
+fn extract_docx_text(bytes: &[u8], path: &Path) -> Result<String, AppError> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = zip::ZipArchive::new(cursor).map_err(|e| AppError::Source {
+        source_name: "local_files".to_string(),
+        message: format!("Failed to read DOCX {}: {}", path.display(), e),
+    })?;
+
+    let mut xml = String::new();
+    {
+        let mut file = archive
+            .by_name("word/document.xml")
+            .map_err(|e| AppError::Source {
+                source_name: "local_files".to_string(),
+                message: format!("No document.xml in DOCX {}: {}", path.display(), e),
+            })?;
+        std::io::Read::read_to_string(&mut file, &mut xml).map_err(|e| AppError::Source {
+            source_name: "local_files".to_string(),
+            message: format!("Failed to read document.xml from {}: {}", path.display(), e),
+        })?;
+    }
+
+    let mut paragraphs = Vec::new();
+    for para_xml in xml.split("</w:p>") {
+        let mut para_text = String::new();
+        for segment in para_xml.split("<w:t") {
+            if let Some(gt_pos) = segment.find('>') {
+                let after_gt = &segment[gt_pos + 1..];
+                if let Some(end_pos) = after_gt.find("</w:t>") {
+                    para_text.push_str(&after_gt[..end_pos]);
+                }
+            }
+        }
+        if !para_text.is_empty() {
+            paragraphs.push(para_text);
+        }
+    }
+
+    Ok(paragraphs.join("\n"))
+}
+
+/// Extract text from an RTF file using a simple state-machine stripper.
+fn extract_rtf_text(bytes: &[u8]) -> String {
+    let input = String::from_utf8_lossy(bytes);
+    let mut result = String::new();
+    let mut chars = input.chars().peekable();
+    let mut depth: i32 = 0;
+    let mut skip_depth: Option<i32> = None;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '{' => {
+                depth += 1;
+            }
+            '}' => {
+                if skip_depth == Some(depth) {
+                    skip_depth = None;
+                }
+                depth -= 1;
+                if depth < 0 {
+                    depth = 0;
+                }
+            }
+            _ if skip_depth.is_some() => continue,
+            '\\' => {
+                if let Some(&next) = chars.peek() {
+                    if next.is_ascii_alphabetic() {
+                        let mut word = String::new();
+                        while let Some(&c) = chars.peek() {
+                            if c.is_ascii_alphabetic() {
+                                word.push(c);
+                                chars.next();
+                            } else {
+                                break;
+                            }
+                        }
+                        if let Some(&c) = chars.peek() {
+                            if c == '-' || c.is_ascii_digit() {
+                                chars.next();
+                                while let Some(&d) = chars.peek() {
+                                    if d.is_ascii_digit() {
+                                        chars.next();
+                                    } else {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if chars.peek() == Some(&' ') {
+                            chars.next();
+                        }
+                        match word.as_str() {
+                            "fonttbl" | "colortbl" | "stylesheet" | "info" | "pict" | "header"
+                            | "footer" | "headerl" | "headerr" | "footerl" | "footerr" => {
+                                skip_depth = Some(depth);
+                            }
+                            "par" | "line" => result.push('\n'),
+                            "tab" => result.push('\t'),
+                            _ => {}
+                        }
+                    } else if next == '\'' {
+                        chars.next();
+                        let h1 = chars.next().unwrap_or('0');
+                        let h2 = chars.next().unwrap_or('0');
+                        if let Ok(byte) = u8::from_str_radix(&format!("{}{}", h1, h2), 16) {
+                            if byte >= 0x20 {
+                                result.push(byte as char);
+                            }
+                        }
+                    } else if next == '\\' || next == '{' || next == '}' {
+                        result.push(next);
+                        chars.next();
+                    } else {
+                        chars.next();
+                    }
+                }
+            }
+            '\n' | '\r' => {}
+            _ => {
+                if depth >= 1 {
+                    result.push(ch);
+                }
+            }
+        }
+    }
+
+    result.trim().to_string()
+}
+
+#[async_trait]
+impl DataSource for LocalFilesSource {
+    fn name(&self) -> &str {
+        "local_files"
+    }
+
+    fn requires_auth(&self) -> bool {
+        false
+    }
+
+    async fn is_connected(&self) -> bool {
+        !self.watch_paths.is_empty()
+    }
+
+    async fn connect(&mut self) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> Result<(), AppError> {
+        self.watch_paths.clear();
+        Ok(())
+    }
+
+    async fn fetch_updates(&mut self) -> Result<Vec<RawDocument>, AppError> {
+        self.full_sync().await
+    }
+
+    async fn full_sync(&mut self) -> Result<Vec<RawDocument>, AppError> {
+        let mut docs = Vec::new();
+        for watch_path in &self.watch_paths {
+            let files = Self::scan_directory(watch_path);
+            for file_path in files {
+                match Self::read_file(&file_path) {
+                    Ok(doc) => docs.push(doc),
+                    Err(e) => {
+                        log::warn!("Skipping file {}: {}", file_path.display(), e);
+                    }
+                }
+            }
+        }
+        Ok(docs)
+    }
+
+    async fn status(&self) -> SourceStatus {
+        SourceStatus {
+            name: "local_files".to_string(),
+            connected: !self.watch_paths.is_empty(),
+            requires_auth: false,
+            last_sync: self.last_sync,
+            document_count: self.document_count,
+            error: None,
+        }
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+}

--- a/app/src/sources/mod.rs
+++ b/app/src/sources/mod.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-//! App-level sources -- re-exports origin-types wire types + origin-core trait/impls.
+//! App-level sources: wire types from origin-types + app-local trait/impls.
+pub mod data_source;
+pub mod local_files;
+pub mod obsidian;
 pub mod sync;
 
 // Wire types (Source, SourceStatus, RawDocument, MemoryType, etc.) from the
 // shared types crate -- no heavy deps, safe for downstream consumers.
 pub use origin_types::sources::*;
 
-// Trait and connector impls that depend on origin-core internals.
-pub use origin_core::sources::{
-    base_confidence, compute_effective_confidence, decay_rate, local_files, obsidian, trust_weight,
-    DataSource,
-};
+// App-local DataSource trait (moved from origin-core in Phase 5-D PR2).
+pub use data_source::DataSource;

--- a/app/src/sources/obsidian.rs
+++ b/app/src/sources/obsidian.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! App-local Obsidian helpers used at source registration time.
+//! Only the filesystem-scanning utilities are needed by the app.
+//! The heavy note_to_documents conversion stays in origin-core (used by daemon).
+use std::path::Path;
+
+/// Directories to skip when scanning a vault.
+const SKIP_DIRS: &[&str] = &[".obsidian", ".trash", ".git", "templates"];
+
+/// Check if a path should be skipped (any component matches a skip directory).
+fn should_skip(path: &Path) -> bool {
+    path.components().any(|c| {
+        let name = c.as_os_str().to_string_lossy();
+        SKIP_DIRS.contains(&name.as_ref())
+    })
+}
+
+/// Short-circuit check: returns `true` as soon as any `.md` file is found in
+/// `root` or any (non-skipped) subdirectory. Used at source registration time
+/// so we don't need to walk the whole vault.
+pub fn has_any_markdown(root: &Path) -> bool {
+    has_any_markdown_recursive(root, root)
+}
+
+/// Convert a title string into a URL-safe slug (lowercase, spaces to hyphens,
+/// non-alphanumeric chars removed). Inlined from origin-core::export::obsidian.
+pub fn slugify(title: &str) -> String {
+    title
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c
+            } else if c == ' ' {
+                '-'
+            } else {
+                '\0'
+            }
+        })
+        .filter(|&c| c != '\0')
+        .collect::<String>()
+}
+
+fn has_any_markdown_recursive(root: &Path, dir: &Path) -> bool {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let relative = path.strip_prefix(root).unwrap_or(&path);
+        if should_skip(relative) {
+            continue;
+        }
+
+        if path.is_dir() {
+            if has_any_markdown_recursive(root, &path) {
+                return true;
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            return true;
+        }
+    }
+    false
+}

--- a/app/src/sources/sync.rs
+++ b/app/src/sources/sync.rs
@@ -5,7 +5,7 @@
 //! chunking) happens inside the origin-server daemon.  This module delegates
 //! to `POST /api/sources/{id}/sync` on the daemon.
 
-use crate::error::OriginError;
+use crate::error::AppError;
 use crate::state::AppState;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -41,7 +41,7 @@ pub fn content_hash(content: &str) -> String {
 pub async fn sync_obsidian_vault(
     source: &Source,
     state: &Arc<RwLock<AppState>>,
-) -> Result<SyncStats, OriginError> {
+) -> Result<SyncStats, AppError> {
     let client = {
         let s = state.read().await;
         s.client.clone()
@@ -51,7 +51,7 @@ pub async fn sync_obsidian_vault(
     let stats: SyncStats = client
         .post_empty(&path)
         .await
-        .map_err(|e| OriginError::Http(format!("daemon sync failed: {}", e)))?;
+        .map_err(|e| AppError::Http(format!("daemon sync failed: {}", e)))?;
 
     Ok(stats)
 }

--- a/app/src/state.rs
+++ b/app/src/state.rs
@@ -155,7 +155,7 @@ impl AppState {
 
     /// Initialize after daemon is confirmed healthy.
     /// Loads local file-based state only — no DB or LLM.
-    pub async fn initialize_local(&mut self) -> Result<Vec<PathBuf>, crate::error::OriginError> {
+    pub async fn initialize_local(&mut self) -> Result<Vec<PathBuf>, crate::error::AppError> {
         use crate::sources::local_files::LocalFilesSource;
 
         // Register local files source

--- a/app/src/system_info.rs
+++ b/app/src/system_info.rs
@@ -1,13 +1,37 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! System information detection for the Tauri app.
-//!
-//! Mirrors `origin_core::system_info::detect_system_info` so that once the
-//! app drops its origin-core dependency (PR2) this module can be updated to
-//! use a standalone implementation without touching the call site.
+//! Inlined from origin-core::system_info in Phase 5-D PR2 to remove the dep.
 
 use origin_types::system_info::SystemInfo;
 
 /// Detect system capabilities and hardware information.
 pub fn detect_system_info() -> SystemInfo {
-    origin_core::system_info::detect_system_info()
+    use sysinfo::System;
+    let mut sys = System::new_all();
+    sys.refresh_memory();
+
+    let total_ram_gb = sys.total_memory() as f64 / (1024.0 * 1024.0 * 1024.0);
+    let available_ram_gb = sys.available_memory() as f64 / (1024.0 * 1024.0 * 1024.0);
+
+    let os = std::env::consts::OS.to_string();
+    let arch = std::env::consts::ARCH.to_string();
+
+    let has_metal = os == "macos";
+    let has_cuda = std::process::Command::new("nvidia-smi")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    // The app defers model recommendation to the daemon; return empty string here.
+    let recommended_builtin = String::new();
+
+    SystemInfo {
+        total_ram_gb,
+        available_ram_gb,
+        has_metal,
+        has_cuda,
+        os,
+        arch,
+        recommended_builtin,
+    }
 }

--- a/crates/origin-core/src/export/mod.rs
+++ b/crates/origin-core/src/export/mod.rs
@@ -6,19 +6,15 @@ pub mod obsidian;
 
 use crate::error::OriginError;
 use crate::pages::Page;
-use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+// ExportStats moved to origin-types in Phase 5-D PR2 so the Tauri app can
+// deserialize it without pulling in the full origin-core dep.
+pub use origin_types::ExportStats;
+
+#[derive(Debug)]
 pub struct ExportResult {
     pub concept_id: String,
     pub path: String,
-}
-
-#[derive(Debug, Default, Serialize)]
-pub struct ExportStats {
-    pub exported: usize,
-    pub skipped: usize,
-    pub failed: usize,
 }
 
 /// Trait for exporting pages to external formats/systems.

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -8,7 +8,8 @@ use axum::{
 };
 use origin_core::sources::compute_effective_confidence;
 use origin_types::requests::{
-    ConfirmRequest, ListMemoriesRequest, SearchMemoryRequest, StoreMemoryRequest,
+    ConfirmRequest, ExportPagesRequest, ListMemoriesRequest, SearchMemoryRequest,
+    StoreMemoryRequest,
 };
 use origin_types::responses::{
     ConfirmResponse, DeleteResponse, ListMemoriesResponse, SearchMemoryResponse,
@@ -2094,16 +2095,11 @@ pub struct SearchPagesRequest {
     pub limit: Option<usize>,
 }
 
-#[derive(Debug, Deserialize)]
-pub struct ExportPagesRequest {
-    pub vault_path: Option<String>,
-}
-
 /// POST /api/pages/export
 pub async fn handle_export_pages(
     State(state): State<Arc<RwLock<ServerState>>>,
     Json(req): Json<ExportPagesRequest>,
-) -> Result<Json<origin_core::export::ExportStats>, ServerError> {
+) -> Result<Json<origin_types::ExportStats>, ServerError> {
     let pages = {
         let s = state.read().await;
         let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -34,7 +34,7 @@ pub use memory::{
 };
 pub use narrative::NarrativeResponse;
 pub use pages::Page;
-pub use responses::{MemoryDetail, PendingRevision};
+pub use responses::{ExportStats, MemoryDetail, PendingRevision};
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 
 use serde::{Deserialize, Serialize};

--- a/crates/origin-types/src/requests.rs
+++ b/crates/origin-types/src/requests.rs
@@ -417,6 +417,12 @@ pub struct UpdatePageRequest {
 
 // ===== Concept Export =====
 
+/// Request body for `POST /api/pages/export` (bulk export all pages to an Obsidian vault).
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ExportPagesRequest {
+    pub vault_path: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ExportPageRequest {
     pub vault_path: String,

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -400,6 +400,14 @@ pub struct IngestResponse {
 
 // ===== Concept Export =====
 
+/// Statistics from a bulk page export operation (POST /api/pages/export).
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ExportStats {
+    pub exported: usize,
+    pub skipped: usize,
+    pub failed: usize,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ExportPageResponse {
     pub path: String,


### PR DESCRIPTION
Phase 5-D PR2 of 2. **Atomic refactor — app crate now depends only on origin-types (no origin-core).**

Plan: docs/superpowers/plans/2026-05-06-phase-5-d-full-daemon-migration.md (Phases 4-7)

## Summary

After this PR, `app/Cargo.toml` has zero `origin-core` dependency. App is a true thin client — only `origin-types` (Apache-2.0, lightweight wire types) plus standard tauri/reqwest/etc. The `origin-core` crate (with libSQL, FastEmbed, llama-cpp-2, hf-hub) no longer pollutes app's compile graph.

## Changes

**Type relocations**
- `ExportStats` + `ExportPagesRequest` moved to `origin-types` (wire types, Serde-only).

**Modules copied into app/src/** (still exist in origin-core for daemon use; app no longer re-exports)
- `app/src/activity.rs` — local ring-buffer of macOS focus events.
- `app/src/privacy.rs` — PII redaction in sensor router.
- `app/src/config.rs` — local `~/.../config.json` I/O for app-side state.
- `app/src/error.rs` — new `AppError` enum (10 variants) replacing `OriginError` in app contexts.
- `app/src/sources/data_source.rs` + `local_files.rs` + `obsidian.rs` — DataSource trait + concrete impls used by app's file watcher and Obsidian sync.

All copies preserve AGPL-3.0-only SPDX headers.

**Tauri command refactors**
- `crate::briefing/narrative/pages/memory_db` → `origin_types::*` paths.
- 3 dead Tauri commands deleted: `record_eval_signal`, `trigger_distillation`, `redistill_page` (daemon endpoints `/api/distill` + `/api/distill/{id}` retained for future re-add).

**Final dep removal**
- `pub use origin_core::*` lines removed from `app/src/lib.rs`.
- `origin-core = { workspace = true }` removed from `app/Cargo.toml`.

## Test plan
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo check --workspace --all-targets` clean
- [x] origin-app lib tests: 91 pass (75 baseline + 16 ported config tests)
- [x] origin-types lib: 25 pass
- [x] origin-server: 44 pass
- [x] origin-core: 942 pass (1 pre-existing FastEmbed network failure)
- [x] `grep -rn "origin_core" app/src/` returns zero hits
- [x] `grep "origin-core" app/Cargo.toml` returns zero hits
- [x] Spec compliance review (Opus): COMPLIANT (all 7 phases delivered, 2 design decisions noted)
- [x] Code quality review (Opus): APPROVED WITH NOTES → 16 missing config tests addressed in commit 34b22188 (covers migrate(), setup state, watch path migration)

## Known follow-ups (not blocking)

- `DataSource` trait now exists in both `origin-core` (used by origin-server's LocalFilesSource ingestion path) and `app/src/sources/data_source.rs`. Two definitions don't interfere. Future cleanup: move origin-server's LocalFilesSource consumer to a free-function or origin-server-local trait.
- Coverage workflow may still flag eval_harness in origin-core (informational only per CLAUDE.md L5).

## Architecture impact

Per CLAUDE.md's "App is a thin client" rule, this PR completes the architectural correction. The daemon at `:7878` is the single source of truth for memory state. App's only role: Tauri UI + macOS-specific sensors + HTTP proxying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)