### PR TITLE
docs: note intentional DataSource trait dup with origin-app

### DIFF
--- a/crates/origin-core/src/sources/mod.rs
+++ b/crates/origin-core/src/sources/mod.rs
@@ -75,6 +75,13 @@ pub fn compute_effective_confidence(
 }
 
 /// Trait that all data source connectors must implement.
+///
+/// Intentionally duplicated in `origin-app/app/src/sources/data_source.rs`
+/// because origin-app has no origin-core dependency (Phase 5-D PR2). The
+/// two trait declarations are identical except for the error type
+/// (`OriginError` here, `AppError` in origin-app). The shared data shapes
+/// (`RawDocument`, `SourceStatus`) live in origin-types so connectors can
+/// move freely between crates.
 #[async_trait]
 pub trait DataSource: Send + Sync {
     /// Unique name for this source ("gmail", "notion", etc.)


### PR DESCRIPTION
## Summary

Add a doc comment explaining why the DataSource trait is duplicated between this repo and 7xuanlu/origin-app. The two declarations are identical except for the error type (OriginError vs AppError), and origin-app intentionally has no origin-core dep (Phase 5-D PR2). The note pairs with a matching comment landed in origin-app at https://github.com/7xuanlu/origin-app/commit/ea95453.

Trivial: 7-line doc-only change, no behavior.

## Test plan

- [x] cargo fmt --check --all -> ok (verified by pre-push hook)
- [x] cargo clippy --workspace --all-targets -- -D warnings -> ok (pre-push)
- [x] cargo test --workspace --lib -> ok (pre-push)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)