### PR TITLE
docs: update tagline to 'Where Personal AI Memory Compounds'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./docs/assets/social-preview.png" alt="Origin: Where AI memory compounds." width="100%">
+  <img src="./docs/assets/social-preview.png" alt="Origin: Where Personal AI Memory Compounds." width="100%">
 </p>
 
 [![CI](https://github.com/7xuanlu/origin/actions/workflows/ci.yml/badge.svg)](https://github.com/7xuanlu/origin/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary

One-line README hero alt-text update to the locked tagline.

Trivial doc change. Companion updates land directly on `main` of the sibling repos:
- `7xuanlu/origin-app` -> commit `cc2bc4a`
- `7xuanlu/origin-plugin` -> commit `41744de`

## Test plan

- [x] cargo fmt --check (pre-commit)
- [x] cargo clippy --workspace --all-targets -- -D warnings (pre-commit)
- [x] cargo test --workspace --lib (pre-push)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)