### PR TITLE
refactor: shared memory-type registry; purge legacy "goal" from prompts

### DIFF
--- a/crates/origin-core/src/classify.rs
+++ b/crates/origin-core/src/classify.rs
@@ -19,15 +19,9 @@ use llama_cpp_2::sampling::LlamaSampler;
 use std::num::NonZeroU32;
 use std::time::Instant;
 
-/// Valid memory types for classification (6 canonical types).
-const VALID_MEMORY_TYPES: &[&str] = &[
-    "identity",
-    "preference",
-    "decision",
-    "lesson",
-    "gotcha",
-    "fact",
-];
+/// Re-export the canonical set from `origin-types` so the daemon classifier,
+/// the eval harness, and the MCP tool schema all share the same vocabulary.
+use origin_types::VALID_MEMORY_TYPES;
 
 /// Result of classifying a single memory.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/origin-core/src/classify.rs
+++ b/crates/origin-core/src/classify.rs
@@ -16,12 +16,10 @@ use llama_cpp_2::llama_batch::LlamaBatch;
 use llama_cpp_2::model::AddBos;
 use llama_cpp_2::sampling::LlamaSampler;
 
+use origin_types::MemoryType;
+
 use std::num::NonZeroU32;
 use std::time::Instant;
-
-/// Re-export the canonical set from `origin-types` so the daemon classifier,
-/// the eval harness, and the MCP tool schema all share the same vocabulary.
-use origin_types::VALID_MEMORY_TYPES;
 
 /// Result of classifying a single memory.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -69,7 +67,7 @@ pub fn parse_classification_response(
                 .get("type")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_lowercase())
-                .filter(|s| VALID_MEMORY_TYPES.contains(&s.as_str()))
+                .filter(|s| MemoryType::all_values().contains(&s.as_str()))
                 .unwrap_or_else(|| "fact".to_string());
 
             let domain = entry
@@ -118,7 +116,7 @@ pub fn parse_profile_subtype(raw: &str) -> &'static str {
     }
 }
 
-/// Classify a "profile" alias into identity/preference/goal using the on-device engine.
+/// Classify a "profile" alias into identity / preference using the on-device engine.
 ///
 /// Runs synchronously on the engine's worker thread. Caller is responsible for
 /// running this inside `spawn_blocking` if invoking from an async context, since
@@ -552,14 +550,44 @@ mod tests {
 
     #[test]
     fn test_classify_prompt_contains_all_types() {
-        // Verify the classify prompt would include all valid types (6 canonical).
-        let all = origin_types::MemoryType::all_values();
-        let prompt_types = "identity, preference, decision, lesson, gotcha, fact";
-        for val in all {
+        // Drift guard: the compiled-in classify prompt must list every
+        // canonical type so the LLM never emits a value our parser rejects.
+        // Derive the haystack from the actual prompt const rather than a
+        // hand-typed string, otherwise the test rots in parallel with the
+        // prompt itself.
+        use crate::prompts::defaults::CLASSIFY_MEMORY_QUALITY;
+        for val in MemoryType::all_values() {
             assert!(
-                prompt_types.contains(val),
-                "prompt should include type '{}'",
-                val
+                CLASSIFY_MEMORY_QUALITY.contains(val),
+                "CLASSIFY_MEMORY_QUALITY prompt must include canonical type \"{val}\"",
+            );
+        }
+    }
+
+    #[test]
+    fn test_classify_prompts_omit_legacy_goal() {
+        // "goal" is folded to Identity by MemoryType::FromStr — it must not
+        // appear in any LLM-facing prompt or the model will keep emitting it.
+        use crate::prompts::defaults::{
+            BATCH_CLASSIFY, CLASSIFY_MEMORY, CLASSIFY_MEMORY_QUALITY,
+            CLASSIFY_MEMORY_QUALITY_STRICT, CLASSIFY_PROFILE_SUBTYPE,
+        };
+        for (label, prompt) in [
+            ("CLASSIFY_MEMORY", CLASSIFY_MEMORY),
+            ("CLASSIFY_MEMORY_QUALITY", CLASSIFY_MEMORY_QUALITY),
+            (
+                "CLASSIFY_MEMORY_QUALITY_STRICT",
+                CLASSIFY_MEMORY_QUALITY_STRICT,
+            ),
+            ("CLASSIFY_PROFILE_SUBTYPE", CLASSIFY_PROFILE_SUBTYPE),
+            ("BATCH_CLASSIFY", BATCH_CLASSIFY),
+        ] {
+            let has_goal = prompt
+                .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+                .any(|tok| tok == "goal");
+            assert!(
+                !has_goal,
+                "{label} prompt still advertises legacy \"goal\" token",
             );
         }
     }

--- a/crates/origin-core/src/eval/gen.rs
+++ b/crates/origin-core/src/eval/gen.rs
@@ -331,14 +331,7 @@ async fn grade_case(
     Ok(graded)
 }
 
-const VALID_MEMORY_TYPES: &[&str] = &[
-    "identity",
-    "preference",
-    "decision",
-    "lesson",
-    "gotcha",
-    "fact",
-];
+use origin_types::VALID_MEMORY_TYPES;
 
 /// Normalize invalid memory_type to the closest valid type.
 fn normalize_memory_type(raw: &str) -> String {

--- a/crates/origin-core/src/eval/gen.rs
+++ b/crates/origin-core/src/eval/gen.rs
@@ -331,12 +331,10 @@ async fn grade_case(
     Ok(graded)
 }
 
-use origin_types::VALID_MEMORY_TYPES;
-
 /// Normalize invalid memory_type to the closest valid type.
 fn normalize_memory_type(raw: &str) -> String {
     let lower = raw.to_lowercase();
-    if VALID_MEMORY_TYPES.contains(&lower.as_str()) {
+    if origin_types::MemoryType::all_values().contains(&lower.as_str()) {
         return lower;
     }
     // Map common LLM hallucinations to valid types

--- a/crates/origin-core/src/prompts/defaults.rs
+++ b/crates/origin-core/src/prompts/defaults.rs
@@ -33,13 +33,16 @@ quality must be one of: low, medium, high (how specific and actionable is this m
 
 // Used by llm_formatter in the app crate; referenced again once llm_formatter
 // moves into origin-core in a later phase.
+//
+// Profile memories split into 2 subtypes after the taxonomy refactor.
+// "goal" is folded to "identity" by MemoryType::FromStr (aspirations are
+// part of who the user is) and must not appear in this prompt.
 #[allow(dead_code)]
 pub(crate) const CLASSIFY_PROFILE_SUBTYPE: &str = "\
-Classify this profile memory into one of exactly 3 types. Respond with ONLY the type name.\n\n\
-identity — who the user is (role, background, expertise, values)\n\
-preference — how the user likes things done (tools, workflow, style)\n\
-goal — what the user is working toward (objectives, targets, deadlines)\n\n\
-Respond with one word: identity, preference, or goal";
+Classify this profile memory into one of exactly 2 types. Respond with ONLY the type name.\n\n\
+identity — who the user is (role, background, expertise, values, aspirations)\n\
+preference — how the user likes things done (tools, workflow, style)\n\n\
+Respond with one word: identity or preference";
 
 pub(crate) const CLASSIFY_SCREEN: &str = "\
 You classify screen capture text from a desktop application.\n\
@@ -95,7 +98,7 @@ Respond ONLY with JSON: {\"summary\": \"...\", \"tags\": [\"...\"]}";
 
 pub(crate) const BATCH_CLASSIFY: &str = "\
 Classify each memory. Return a JSON array.\n\
-For each: {\"i\": <number>, \"type\": \"<identity|preference|fact|decision|goal>\", \"domain\": \"<work|personal|health|finance|technology|travel|food>\", \"tags\": [\"<tag>\"]}";
+For each: {\"i\": <number>, \"type\": \"<identity|preference|decision|lesson|gotcha|fact>\", \"domain\": \"<work|personal|health|finance|technology|travel|food>\", \"tags\": [\"<tag>\"]}";
 
 pub(crate) const EXTRACT_KNOWLEDGE_GRAPH: &str = "\
 Extract entities and relations from these memories.\n\

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -2018,14 +2018,19 @@ mod tests {
         assert!(json["source_agent"].is_null());
     }
 
-    // ===== Memory type backward compat =====
+    // ===== Memory type pass-through =====
 
+    /// CaptureParams must pass every canonical memory_type through to the
+    /// daemon verbatim. The MCP layer is dumb wire — it doesn't validate or
+    /// rewrite the value; the daemon owns that. Drift test sourced from
+    /// `MemoryType::all_values()` so adding a variant extends coverage
+    /// automatically.
     #[test]
-    fn test_remember_passes_through_all_5_types() {
-        for t in &["identity", "preference", "fact", "decision", "goal"] {
+    fn test_capture_passes_through_all_canonical_types() {
+        for t in origin_types::MemoryType::all_values() {
             let params = CaptureParams {
                 content: "test".into(),
-                memory_type: Some(t.to_string()),
+                memory_type: Some((*t).to_string()),
                 domain: None,
                 entity: None,
                 confidence: None,
@@ -2035,6 +2040,24 @@ mod tests {
             };
             assert_eq!(params.memory_type.as_deref(), Some(*t));
         }
+    }
+
+    /// Legacy "goal" alias still flows through the wire untouched —
+    /// `MemoryType::FromStr` folds it to "identity" daemon-side. The MCP
+    /// layer must not pre-reject it (the daemon owns the fold decision).
+    #[test]
+    fn test_capture_passes_through_legacy_goal_alias() {
+        let params = CaptureParams {
+            content: "test".into(),
+            memory_type: Some("goal".into()),
+            domain: None,
+            entity: None,
+            confidence: None,
+            supersedes: None,
+            structured_fields: None,
+            retrieval_cue: None,
+        };
+        assert_eq!(params.memory_type.as_deref(), Some("goal"));
     }
 
     // ===== Structured fields in remember params =====
@@ -2232,9 +2255,9 @@ mod tests {
     #[test]
     fn instructions_list_every_canonical_memory_type() {
         let i = server_instructions();
-        for ty in origin_types::VALID_MEMORY_TYPES {
+        for ty in origin_types::MemoryType::all_values() {
             assert!(
-                i.contains(ty),
+                contains_word(&i, ty),
                 "with_instructions must list canonical memory type \"{ty}\" so MCP clients see the full vocabulary",
             );
         }
@@ -2243,13 +2266,25 @@ mod tests {
     #[test]
     fn instructions_omit_legacy_goal_type() {
         let i = server_instructions();
-        // "goal" is a legacy value; daemon classifier no longer emits it
-        // (folded via stability tier mapping). It must not appear in the
-        // type vocabulary advertised to MCP clients.
+        // "goal" (singular) is a legacy memory_type folded to Identity by
+        // MemoryType::FromStr. The plural English noun "goals" (life goals,
+        // profile.goals chat-context field) is a separate concern and must
+        // NOT trigger this test — tokenizing on word boundaries lets one
+        // through while still catching the legacy memory-type token.
         assert!(
-            !i.contains("/ goal /") && !i.contains("goal)"),
+            !contains_word(&i, "goal"),
             "with_instructions must not advertise legacy \"goal\" memory_type"
         );
+    }
+
+    /// Tokenize on non-alphanumeric boundaries and check whether `needle`
+    /// appears as a standalone token. Mirrors the helper used by the
+    /// origin-types drift tests so "goals" (plural noun) does not false-match
+    /// the legacy "goal" memory_type token.
+    fn contains_word(haystack: &str, needle: &str) -> bool {
+        haystack
+            .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .any(|tok| tok == needle)
     }
 
     #[test]
@@ -2661,7 +2696,7 @@ mod tests {
     fn capture_memory_type_schema_lists_every_canonical_type() {
         let params_schema = serde_json::to_string(&schemars::schema_for!(CaptureParams))
             .expect("CaptureParams schema serializes");
-        for ty in origin_types::VALID_MEMORY_TYPES {
+        for ty in origin_types::MemoryType::all_values() {
             assert!(
                 params_schema.contains(ty),
                 "CaptureParams.memory_type schema must list canonical type \"{ty}\", got: {params_schema}"
@@ -2673,7 +2708,7 @@ mod tests {
     fn recall_memory_type_schema_lists_every_canonical_type() {
         let params_schema = serde_json::to_string(&schemars::schema_for!(RecallParams))
             .expect("RecallParams schema serializes");
-        for ty in origin_types::VALID_MEMORY_TYPES {
+        for ty in origin_types::MemoryType::all_values() {
             assert!(
                 params_schema.contains(ty),
                 "RecallParams.memory_type schema must list canonical type \"{ty}\", got: {params_schema}"

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -86,9 +86,7 @@ pub struct CaptureParams {
         description = "The memory content. Write as a complete statement with context and reasoning, not shorthand. One idea per memory."
     )]
     pub content: String,
-    #[schemars(
-        description = "\"profile\" (about the user) or \"knowledge\" (about the world) — or precise: \"identity\", \"preference\", \"goal\", \"fact\", \"decision\" — auto-classified if omitted"
-    )]
+    #[schemars(description = origin_types::MEMORY_TYPE_CAPTURE_DESCRIPTION)]
     pub memory_type: Option<String>,
     #[schemars(
         description = "Topic scope (e.g. 'rust', 'work', 'health', 'origin'). Auto-detected if omitted."
@@ -127,9 +125,7 @@ pub struct RecallParams {
     )]
     #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
     pub limit: Option<usize>,
-    #[schemars(
-        description = "Filter by type. Two-level filter: \"profile\" (user-facing) or \"knowledge\" (world-facing), or precise: identity, preference, goal, fact, decision."
-    )]
+    #[schemars(description = origin_types::MEMORY_TYPE_FILTER_DESCRIPTION)]
     pub memory_type: Option<String>,
     #[schemars(description = "Filter by topic scope.")]
     pub domain: Option<String>,
@@ -1179,11 +1175,12 @@ impl ServerHandler for OriginMcpServer {
              - Declarative, not narrative: \"User prefers X because Y\" — not \"User said today they prefer X\". \
                Memories outlive the conversation that produced them.\n\n\
              MEMORY TYPES — omit and trust the backend.\n\n\
-             By default, do NOT set memory_type. The backend auto-classifies into identity / preference / goal / \
-             fact / decision with more context than you have. Agents that over-specify types tend to pick wrong.\n\n\
+             By default, do NOT set memory_type. The backend auto-classifies into identity / preference / \
+             decision / lesson / gotcha / fact with more context than you have. Agents that over-specify \
+             types tend to pick wrong.\n\n\
              Opt-in specification:\n\
-             - \"profile\"   — you're sure it's about the user (identity/preference/goal)\n\
-             - \"knowledge\" — you're sure it's about the world (fact/decision)\n\
+             - \"profile\"   — you're sure it's about the user (identity / preference)\n\
+             - \"knowledge\" — you're sure it's about the world (decision / lesson / gotcha / fact)\n\
              - Precise type — only if you're confident and the distinction matters.\n\n\
              EXCEPTION — decisions carry structured fields (alternatives considered, reversibility, domain) \
              that power the Decision Log view. Set memory_type=\"decision\" explicitly ONLY when the user \
@@ -2233,6 +2230,29 @@ mod tests {
     }
 
     #[test]
+    fn instructions_list_every_canonical_memory_type() {
+        let i = server_instructions();
+        for ty in origin_types::VALID_MEMORY_TYPES {
+            assert!(
+                i.contains(ty),
+                "with_instructions must list canonical memory type \"{ty}\" so MCP clients see the full vocabulary",
+            );
+        }
+    }
+
+    #[test]
+    fn instructions_omit_legacy_goal_type() {
+        let i = server_instructions();
+        // "goal" is a legacy value; daemon classifier no longer emits it
+        // (folded via stability tier mapping). It must not appear in the
+        // type vocabulary advertised to MCP clients.
+        assert!(
+            !i.contains("/ goal /") && !i.contains("goal)"),
+            "with_instructions must not advertise legacy \"goal\" memory_type"
+        );
+    }
+
+    #[test]
     fn instructions_carve_out_decisions_for_decision_log() {
         let i = server_instructions();
         assert!(
@@ -2633,6 +2653,30 @@ mod tests {
                 descriptions.contains_key(name),
                 "tool `{name}` must be registered, got: {:?}",
                 descriptions.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn capture_memory_type_schema_lists_every_canonical_type() {
+        let params_schema = serde_json::to_string(&schemars::schema_for!(CaptureParams))
+            .expect("CaptureParams schema serializes");
+        for ty in origin_types::VALID_MEMORY_TYPES {
+            assert!(
+                params_schema.contains(ty),
+                "CaptureParams.memory_type schema must list canonical type \"{ty}\", got: {params_schema}"
+            );
+        }
+    }
+
+    #[test]
+    fn recall_memory_type_schema_lists_every_canonical_type() {
+        let params_schema = serde_json::to_string(&schemars::schema_for!(RecallParams))
+            .expect("RecallParams schema serializes");
+        for ty in origin_types::VALID_MEMORY_TYPES {
+            assert!(
+                params_schema.contains(ty),
+                "RecallParams.memory_type schema must list canonical type \"{ty}\", got: {params_schema}"
             );
         }
     }

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod entities;
 pub mod events;
 pub mod import;
 pub mod memory;
+pub mod memory_type;
 pub mod narrative;
 pub mod onboarding;
 pub mod pages;
@@ -31,6 +32,9 @@ pub use memory::{
     MemoryStats, MemoryVersionItem, PageChange, PageChangeKind, Profile, RecentActivityItem,
     RejectionRecord, RetrievalEvent, SearchResult, SessionSnapshot, SnapshotCapture,
     SnapshotCaptureWithContent, Space, TopMemory, TypeBreakdown,
+};
+pub use memory_type::{
+    MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRIPTION, VALID_MEMORY_TYPES,
 };
 pub use narrative::NarrativeResponse;
 pub use pages::Page;

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -33,9 +33,7 @@ pub use memory::{
     RejectionRecord, RetrievalEvent, SearchResult, SessionSnapshot, SnapshotCapture,
     SnapshotCaptureWithContent, Space, TopMemory, TypeBreakdown,
 };
-pub use memory_type::{
-    MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRIPTION, VALID_MEMORY_TYPES,
-};
+pub use memory_type::{MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRIPTION};
 pub use narrative::NarrativeResponse;
 pub use pages::Page;
 pub use responses::{ExportStats, MemoryDetail, PendingRevision};

--- a/crates/origin-types/src/memory_type.rs
+++ b/crates/origin-types/src/memory_type.rs
@@ -1,27 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Canonical memory type registry. Single source of truth for the set of
-//! `memory_type` values the daemon accepts and emits.
+//! JSON Schema description strings for the `memory_type` parameter.
 //!
-//! Shared by:
-//! - `origin-core::classify` — classifier enforces this set when parsing LLM output
-//! - `origin-core::eval` — eval harness uses this set when generating synthetic data
-//! - `origin-mcp::tools` — MCP tool schema descriptions reference this set so
-//!   the JSON Schema advertised to clients matches what the daemon accepts
+//! The canonical type set is owned by [`crate::sources::MemoryType`] and
+//! returned by [`MemoryType::all_values`]. This module exposes the prose
+//! description strings that downstream tool schemas (MCP `capture`,
+//! MCP `recall`, future MCP/Tauri schemas) advertise to clients.
 //!
-//! When adding a type, update `VALID_MEMORY_TYPES` below. The drift test in
-//! this module asserts that every type appears in the schema descriptions.
-
-/// The canonical set of memory types accepted by the daemon classifier and
-/// storage layer. Legacy values (e.g. `"goal"`) are folded by callers via
-/// stability tier mapping but are NOT listed here.
-pub const VALID_MEMORY_TYPES: &[&str] = &[
-    "identity",
-    "preference",
-    "decision",
-    "lesson",
-    "gotcha",
-    "fact",
-];
+//! The drift tests below iterate over the canonical enum and assert each
+//! description string lists every variant. Adding a variant to
+//! [`crate::sources::MemoryType`] but forgetting to extend the description
+//! prose fails CI here — not silently in production.
 
 /// JSON Schema `description` for the `memory_type` parameter on memory-write
 /// tools (e.g. MCP `capture`). Lists the two-level filter values (profile /
@@ -43,10 +31,11 @@ pub const MEMORY_TYPE_FILTER_DESCRIPTION: &str =
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sources::MemoryType;
 
     #[test]
-    fn capture_description_lists_every_valid_type() {
-        for ty in VALID_MEMORY_TYPES {
+    fn capture_description_lists_every_canonical_type() {
+        for ty in MemoryType::all_values() {
             let needle = format!("\"{ty}\"");
             assert!(
                 MEMORY_TYPE_CAPTURE_DESCRIPTION.contains(&needle),
@@ -56,8 +45,8 @@ mod tests {
     }
 
     #[test]
-    fn filter_description_lists_every_valid_type() {
-        for ty in VALID_MEMORY_TYPES {
+    fn filter_description_lists_every_canonical_type() {
+        for ty in MemoryType::all_values() {
             let needle = format!("\"{ty}\"");
             assert!(
                 MEMORY_TYPE_FILTER_DESCRIPTION.contains(&needle),
@@ -66,11 +55,41 @@ mod tests {
         }
     }
 
+    /// "goal" is a legacy alias folded to Identity by `MemoryType::FromStr`.
+    /// It must NOT be advertised in any description surface, or clients will
+    /// believe they can store with `memory_type = "goal"` and get an
+    /// unexpected fold.
     #[test]
-    fn valid_set_has_no_legacy_goal() {
-        assert!(
-            !VALID_MEMORY_TYPES.contains(&"goal"),
-            "\"goal\" is a legacy value folded via stability tier mapping; it must not appear in VALID_MEMORY_TYPES"
-        );
+    fn descriptions_omit_legacy_goal() {
+        for desc in [
+            MEMORY_TYPE_CAPTURE_DESCRIPTION,
+            MEMORY_TYPE_FILTER_DESCRIPTION,
+        ] {
+            assert!(
+                !contains_word(desc, "goal"),
+                "description must not advertise legacy \"goal\": {desc}"
+            );
+        }
+    }
+
+    /// Word-boundary contains: returns true iff `needle` appears as a
+    /// standalone alphanumeric token (not a substring of a longer word).
+    /// Used by drift tests to ensure "goal" rejection doesn't false-match
+    /// on "goals" (plural English noun) elsewhere in prose.
+    pub(crate) fn contains_word(haystack: &str, needle: &str) -> bool {
+        haystack
+            .split(|c: char| !c.is_ascii_alphanumeric() && c != '_')
+            .any(|tok| tok == needle)
+    }
+
+    #[test]
+    fn contains_word_rejects_partial_matches() {
+        assert!(contains_word("goal", "goal"));
+        assert!(contains_word("/ goal /", "goal"));
+        assert!(contains_word("goal,", "goal"));
+        assert!(contains_word("(goal)", "goal"));
+        assert!(!contains_word("goals", "goal"));
+        assert!(!contains_word("their goals here", "goal"));
+        assert!(!contains_word("subgoal", "goal"));
     }
 }

--- a/crates/origin-types/src/memory_type.rs
+++ b/crates/origin-types/src/memory_type.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical memory type registry. Single source of truth for the set of
+//! `memory_type` values the daemon accepts and emits.
+//!
+//! Shared by:
+//! - `origin-core::classify` — classifier enforces this set when parsing LLM output
+//! - `origin-core::eval` — eval harness uses this set when generating synthetic data
+//! - `origin-mcp::tools` — MCP tool schema descriptions reference this set so
+//!   the JSON Schema advertised to clients matches what the daemon accepts
+//!
+//! When adding a type, update `VALID_MEMORY_TYPES` below. The drift test in
+//! this module asserts that every type appears in the schema descriptions.
+
+/// The canonical set of memory types accepted by the daemon classifier and
+/// storage layer. Legacy values (e.g. `"goal"`) are folded by callers via
+/// stability tier mapping but are NOT listed here.
+pub const VALID_MEMORY_TYPES: &[&str] = &[
+    "identity",
+    "preference",
+    "decision",
+    "lesson",
+    "gotcha",
+    "fact",
+];
+
+/// JSON Schema `description` for the `memory_type` parameter on memory-write
+/// tools (e.g. MCP `capture`). Lists the two-level filter values (profile /
+/// knowledge) and the precise types, plus the "auto-classified if omitted"
+/// hint that steers agents away from guessing.
+pub const MEMORY_TYPE_CAPTURE_DESCRIPTION: &str =
+    "\"profile\" (about the user) or \"knowledge\" (about the world) — or precise: \
+     \"identity\", \"preference\", \"decision\", \"lesson\", \"gotcha\", \"fact\" — \
+     auto-classified if omitted";
+
+/// JSON Schema `description` for the `memory_type` parameter on memory-read
+/// filter tools (e.g. MCP `recall`, `list_pending`). Same vocabulary as
+/// capture, framed as a filter.
+pub const MEMORY_TYPE_FILTER_DESCRIPTION: &str =
+    "Filter by type. Two-level filter: \"profile\" (user-facing) or \
+     \"knowledge\" (world-facing), or precise: \"identity\", \"preference\", \
+     \"decision\", \"lesson\", \"gotcha\", \"fact\".";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_description_lists_every_valid_type() {
+        for ty in VALID_MEMORY_TYPES {
+            let needle = format!("\"{ty}\"");
+            assert!(
+                MEMORY_TYPE_CAPTURE_DESCRIPTION.contains(&needle),
+                "MEMORY_TYPE_CAPTURE_DESCRIPTION missing \"{ty}\""
+            );
+        }
+    }
+
+    #[test]
+    fn filter_description_lists_every_valid_type() {
+        for ty in VALID_MEMORY_TYPES {
+            let needle = format!("\"{ty}\"");
+            assert!(
+                MEMORY_TYPE_FILTER_DESCRIPTION.contains(&needle),
+                "MEMORY_TYPE_FILTER_DESCRIPTION missing \"{ty}\""
+            );
+        }
+    }
+
+    #[test]
+    fn valid_set_has_no_legacy_goal() {
+        assert!(
+            !VALID_MEMORY_TYPES.contains(&"goal"),
+            "\"goal\" is a legacy value folded via stability tier mapping; it must not appear in VALID_MEMORY_TYPES"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Collapse the duplicated memory-type vocabulary into a single source of truth and close the largest drift surface — the LLM-facing classifier prompts that were still advertising the legacy `goal` type.

Before this branch, the canonical 6-type set (`identity`, `preference`, `decision`, `lesson`, `gotcha`, `fact`) appeared **four times** in this workspace and **diverged in three places**:

| Surface | Status before |
|---|---|
| `origin-types::sources::MemoryType` enum + `all_values()` | Correct |
| `origin-core::classify::VALID_MEMORY_TYPES` const | Correct (duplicated) |
| `origin-core::eval::gen::VALID_MEMORY_TYPES` const | Correct (duplicated) |
| `origin-mcp::tools` schema descriptions (capture + recall params) | **Stale** — advertised legacy `goal`, omitted `lesson` + `gotcha` |
| `origin-mcp::tools` server `with_instructions` block | **Stale** — same |
| `origin-core::prompts::defaults::CLASSIFY_PROFILE_SUBTYPE` | **Stale** — still asked the LLM for `goal` |
| `origin-core::prompts::defaults::BATCH_CLASSIFY` | **Stale** — same |

The prompt-side drift was the most impactful: the daemon was prompting its own classifier to emit `goal`, then the parser was silently folding `goal → identity`. The MCP schema was advertising a type set that didn't match what the daemon accepted.

## What this branch does

- Routes all consumers through the existing `MemoryType::all_values()` (no new "single source of truth" — the enum *is* the source).
- Adds two prose constants in `origin-types::memory_type` (`MEMORY_TYPE_CAPTURE_DESCRIPTION`, `MEMORY_TYPE_FILTER_DESCRIPTION`) that the MCP `capture` / `recall` schemas consume via `#[schemars(description = ...)]` — schemars 1 accepts const paths in attribute values, so the canonical string is baked into the emitted JSON Schema at compile time.
- Rewrites `CLASSIFY_PROFILE_SUBTYPE` to ask for 2 subtypes (identity / preference). Legacy `goal` fold preserved as a defensive arm in `parse_profile_subtype`.
- Rewrites `BATCH_CLASSIFY` to list all 6 canonical types.
- Fixes the `with_instructions` block to list all 6 (was 5 incl. legacy `goal`).

## Drift protection added

12 new or rewritten tests across the three crates. Highlights:
- Schema descriptions and `with_instructions` blocks each iterated against `MemoryType::all_values()`.
- All 5 classifier-facing prompt constants asserted to omit the `goal` token via word-boundary tokenization (so plural noun `goals` in unrelated prose does not false-match).
- `test_classify_prompt_contains_all_types` haystack now sourced from the prompt const itself rather than a hand-typed literal that would rot in parallel.
- `test_capture_passes_through_all_canonical_types` iterates the canonical set; legacy `goal` pass-through promoted to its own test (MCP wire must not pre-reject; daemon owns the fold).

## Why two commits, not amended

Per project convention (always create NEW commits rather than amending), the branch keeps the original implementation + the review-fixup as separate commits so the review trail stays legible. Squash-merge will fold them.

## Test plan
- [x] cargo test --workspace --lib — 944 / 107 / 29 pass (3 new tests, 0 removed, 0 ignored failures)
- [x] cargo clippy -p origin-types -p origin-core -p origin-mcp --all-targets — clean
- [x] Pre-commit hook (fmt + clippy on changed crates) — clean both commits
- [x] Pre-push hook (workspace clippy + lib tests) — clean
- [x] Adversarial code review (subagent, fresh-eye, framed adversarial not confirmatory) — 1 CRITICAL + 4 IMPORTANT findings raised before push; this PR is the version after those findings landed
- [ ] CI: Test & Lint required check
- [ ] CI: coverage informational

🤖 Generated with [Claude Code](https://claude.com/claude-code)