### PR TITLE
fix(pages): llm-wiki foundations — user_edited, cluster cap, refresh route, wikilink graph, fs watcher

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -4569,18 +4569,26 @@ impl MemoryDB {
             // pick up later when the target is recreated.
             if version < 47 {
                 let conn = self.conn.lock().await;
+                // `label_key` is the lowercased label used for cross-page
+                // dedup + the orphan-by-count signal. `label` keeps the
+                // first-seen casing for display. PRIMARY KEY is on
+                // (source, label_key) so a page that says `[[Origin]]`
+                // and another that says `[[origin]]` group together — the
+                // emergence signal "N pages reach for the same label"
+                // doesn't split on casing drift.
                 conn.execute_batch(
                     "CREATE TABLE IF NOT EXISTS page_links (\
                         source_page_id TEXT NOT NULL, \
                         target_page_id TEXT, \
+                        label_key TEXT NOT NULL, \
                         label TEXT NOT NULL, \
-                        PRIMARY KEY (source_page_id, label), \
+                        PRIMARY KEY (source_page_id, label_key), \
                         FOREIGN KEY (source_page_id) REFERENCES pages(id) ON DELETE CASCADE\
                      ); \
                      CREATE INDEX IF NOT EXISTS idx_page_links_target \
                        ON page_links(target_page_id) WHERE target_page_id IS NOT NULL; \
                      CREATE INDEX IF NOT EXISTS idx_page_links_orphan \
-                       ON page_links(label) WHERE target_page_id IS NULL;",
+                       ON page_links(label_key) WHERE target_page_id IS NULL;",
                 )
                 .await
                 .map_err(|e| OriginError::VectorDb(format!("m47 create: {e}")))?;
@@ -12461,12 +12469,19 @@ impl MemoryDB {
                                 continue;
                             }
                             if sub_group.len() > cap {
-                                log::info!(
+                                // warn! not info! — log filter default is
+                                // warn (per CLAUDE.md), so a silently
+                                // dropped cluster of legitimately related
+                                // memories actually surfaces in operator
+                                // logs instead of vanishing.
+                                log::warn!(
                                     "[distill] dropping {} sub-cluster after re-split: \
-                                 {} memories still > cap {}",
+                                 {} memories still > cap {} — raise \
+                                 max_{}_cluster_size if this is a genuine page",
                                     bucket_label,
                                     sub_group.len(),
                                     cap,
+                                    bucket_label,
                                 );
                                 continue;
                             }
@@ -14344,9 +14359,11 @@ impl MemoryDB {
         Ok(results)
     }
 
-    /// Update a page's content and source memory ids. Increments version, updates timestamps.
-    /// Dual-writes: updates the JSON `source_memory_ids` column (backward compat) AND
-    /// inserts any new links into the `page_sources` join table.
+    /// Update a page's content + source memory ids in a single atomic UPDATE
+    /// (content, version bump, timestamps, user_edited flag). Reconciles the
+    /// `page_sources` join table to match the new source set: rows no longer
+    /// in the list get DELETEd, surviving rows keep their existing
+    /// `link_reason` history via INSERT OR IGNORE.
     pub async fn update_page_content(
         &self,
         id: &str,
@@ -14354,30 +14371,110 @@ impl MemoryDB {
         source_memory_ids: &[&str],
         link_reason: &str,
     ) -> Result<(), OriginError> {
+        self.try_update_page_content(id, content, source_memory_ids, link_reason, false)
+            .await
+            .map(|_| ())
+    }
+
+    /// Refinery-flavoured variant of `update_page_content` that gates the
+    /// content swap on `stale_reason IS NOT NULL`. If a concurrent writer
+    /// (typically the agent's PUT) already cleared staleness, the UPDATE
+    /// affects zero rows and we yield instead of clobbering fresher content.
+    /// Returns `true` when the write landed, `false` when it was skipped.
+    /// Folds the CAS into the UPDATE itself — no TOCTOU gap between checking
+    /// `stale_reason` and writing.
+    pub async fn try_update_page_content_if_stale(
+        &self,
+        id: &str,
+        content: &str,
+        source_memory_ids: &[&str],
+        link_reason: &str,
+    ) -> Result<bool, OriginError> {
+        self.try_update_page_content(id, content, source_memory_ids, link_reason, true)
+            .await
+    }
+
+    async fn try_update_page_content(
+        &self,
+        id: &str,
+        content: &str,
+        source_memory_ids: &[&str],
+        link_reason: &str,
+        require_stale: bool,
+    ) -> Result<bool, OriginError> {
         let source_ids_json = serde_json::to_string(&source_memory_ids)
             .map_err(|e| OriginError::VectorDb(format!("serialize source_memory_ids: {e}")))?;
         let now = chrono::Utc::now().to_rfc3339();
         let now_ts = chrono::Utc::now().timestamp();
         let conn = self.conn.lock().await;
-        // Dual-write: update JSON column (backward compat) + increment version + timestamps
-        conn.execute(
-            "UPDATE pages SET content = ?1, source_memory_ids = ?2, version = version + 1, last_compiled = ?3, last_modified = ?3 WHERE id = ?4",
-            libsql::params![content, source_ids_json, now, id],
-        )
-        .await
-        .map_err(|e| OriginError::VectorDb(format!("update_page_content: {e}")))?;
-        // Flip user_edited so the refinery's auto-overwrite branch escalates to
-        // source_conflict instead of clobbering a hand-curated body. Only manual
-        // edits set the flag; re_distill / distill / concept_growth must not.
-        if link_reason == "manual_edit" {
+
+        // Single atomic UPDATE: content + version + timestamps + user_edited
+        // flag. Folding the manual_edit branch into SQL closes the TOCTOU gap
+        // where a concurrent reader could observe new content paired with the
+        // stale `user_edited = 0`. The CAS variant adds `AND stale_reason
+        // IS NOT NULL` so the refinery can guard against the agent's PUT
+        // landing mid-LLM.
+        let sql = if require_stale {
+            "UPDATE pages SET \
+               content = ?1, \
+               source_memory_ids = ?2, \
+               version = version + 1, \
+               last_compiled = ?3, \
+               last_modified = ?3, \
+               user_edited = CASE WHEN ?4 = 'manual_edit' THEN 1 ELSE user_edited END \
+             WHERE id = ?5 AND stale_reason IS NOT NULL"
+        } else {
+            "UPDATE pages SET \
+               content = ?1, \
+               source_memory_ids = ?2, \
+               version = version + 1, \
+               last_compiled = ?3, \
+               last_modified = ?3, \
+               user_edited = CASE WHEN ?4 = 'manual_edit' THEN 1 ELSE user_edited END \
+             WHERE id = ?5"
+        };
+        let affected = conn
+            .execute(
+                sql,
+                libsql::params![content, source_ids_json, now, link_reason, id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("update_page_content: {e}")))?;
+        if require_stale && affected == 0 {
+            return Ok(false);
+        }
+
+        // Reconcile join table: DELETE rows whose memory_source_id is no
+        // longer in the list, then INSERT OR IGNORE the survivors. Preserves
+        // existing `link_reason` on rows that survive — only brand-new rows
+        // pick up the current reason. Empty source list = wipe.
+        if source_memory_ids.is_empty() {
             conn.execute(
-                "UPDATE pages SET user_edited = 1 WHERE id = ?1",
+                "DELETE FROM page_sources WHERE page_id = ?1",
                 libsql::params![id],
             )
             .await
-            .map_err(|e| OriginError::VectorDb(format!("update_page_content user_edited: {e}")))?;
+            .map_err(|e| OriginError::VectorDb(format!("update_page_content prune: {e}")))?;
+        } else {
+            // Build the NOT IN clause via bind parameters — never string
+            // interpolation. Memory ids come from request bodies.
+            let placeholders: String = (0..source_memory_ids.len())
+                .map(|i| format!("?{}", i + 2))
+                .collect::<Vec<_>>()
+                .join(", ");
+            let delete_sql = format!(
+                "DELETE FROM page_sources WHERE page_id = ?1 AND memory_source_id NOT IN ({})",
+                placeholders
+            );
+            let mut bind: Vec<libsql::Value> = Vec::with_capacity(1 + source_memory_ids.len());
+            bind.push(libsql::Value::Text(id.to_string()));
+            for sid in source_memory_ids {
+                bind.push(libsql::Value::Text((*sid).to_string()));
+            }
+            conn.execute(&delete_sql, libsql::params_from_iter(bind))
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("update_page_content prune: {e}")))?;
         }
-        // Dual-write: insert any new source links into the join table (idempotent)
         for sid in source_memory_ids {
             let _ = conn
                 .execute(
@@ -14396,7 +14493,7 @@ impl MemoryDB {
         if let Err(e) = self.refresh_page_wikilinks(id, content).await {
             log::warn!("[page-links] refresh failed for {id}: {e}");
         }
-        Ok(())
+        Ok(true)
     }
 
     /// Extract wikilinks from `content`, resolve them against current page
@@ -14739,12 +14836,14 @@ impl MemoryDB {
             )
             .await?;
             for link in links {
+                let label_key = link.label.to_lowercase();
                 conn.execute(
-                    "INSERT INTO page_links (source_page_id, target_page_id, label) \
-                     VALUES (?1, ?2, ?3)",
+                    "INSERT INTO page_links (source_page_id, target_page_id, label_key, label) \
+                     VALUES (?1, ?2, ?3, ?4)",
                     libsql::params![
                         source_page_id,
                         link.target_page_id.clone(),
+                        label_key,
                         link.label.clone(),
                     ],
                 )
@@ -14777,7 +14876,7 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT target_page_id, label FROM page_links \
-                 WHERE source_page_id = ?1 ORDER BY label",
+                 WHERE source_page_id = ?1 ORDER BY label_key",
                 libsql::params![source_page_id],
             )
             .await
@@ -14798,7 +14897,8 @@ impl MemoryDB {
 
     /// Inbound links to a page — every active source whose body contains a
     /// `[[Title]]` reference that resolves here. Used by the page's "linked
-    /// from" view.
+    /// from" view. Tie-break on source_page_id keeps order stable across
+    /// same-second timestamps.
     pub async fn get_page_inbound_links(
         &self,
         target_page_id: &str,
@@ -14809,7 +14909,7 @@ impl MemoryDB {
                 "SELECT pl.source_page_id, pl.label FROM page_links pl \
                  INNER JOIN pages p ON p.id = pl.source_page_id \
                  WHERE pl.target_page_id = ?1 AND p.status = 'active' \
-                 ORDER BY p.last_modified DESC",
+                 ORDER BY p.last_modified DESC, pl.source_page_id ASC",
                 libsql::params![target_page_id],
             )
             .await
@@ -14828,9 +14928,11 @@ impl MemoryDB {
         Ok(out)
     }
 
-    /// Group every still-orphan label by count. The orphan-by-count feed is
-    /// the actual product win: a label that 3+ independent pages reach for
-    /// is a topic candidate emergence can synthesize a page from.
+    /// Group every still-orphan label by count, restricted to active source
+    /// pages (archived pages keep their `page_links` rows via cascade-on-
+    /// delete-only, but they shouldn't inflate the emergence signal once
+    /// the user has retired them). Returns up to 100 rows; callers needing
+    /// more should raise `min_count` and re-issue.
     pub async fn list_orphan_link_labels(
         &self,
         min_count: i64,
@@ -14838,12 +14940,14 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT label, COUNT(DISTINCT source_page_id) AS n \
-                 FROM page_links \
-                 WHERE target_page_id IS NULL \
-                 GROUP BY label \
+                "SELECT MIN(pl.label) AS display_label, \
+                        COUNT(DISTINCT pl.source_page_id) AS n \
+                 FROM page_links pl \
+                 INNER JOIN pages p ON p.id = pl.source_page_id \
+                 WHERE pl.target_page_id IS NULL AND p.status = 'active' \
+                 GROUP BY pl.label_key \
                  HAVING n >= ?1 \
-                 ORDER BY n DESC, label ASC \
+                 ORDER BY n DESC, display_label ASC \
                  LIMIT 100",
                 libsql::params![min_count],
             )
@@ -14865,39 +14969,44 @@ impl MemoryDB {
 
     /// Walk the orphan rows and re-resolve them against current page titles.
     /// Returns the number of rows that flipped from NULL to a real target —
-    /// the refinery uses this for the log line. Cheap: one indexed query +
-    /// one UPDATE per flipped row, no LLM.
+    /// the refinery uses this for the log line. Snapshots the label list
+    /// under a brief lock, then drops the connection before the per-label
+    /// lookups so other writers aren't starved while the resolver scans.
     pub async fn resolve_orphan_page_links(&self) -> Result<usize, OriginError> {
-        let conn = self.conn.lock().await;
-        let mut rows = conn
-            .query(
-                "SELECT DISTINCT label FROM page_links WHERE target_page_id IS NULL",
-                (),
-            )
-            .await
-            .map_err(|e| OriginError::VectorDb(format!("resolve_orphan_links list: {e}")))?;
-        let mut labels: Vec<String> = Vec::new();
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| OriginError::VectorDb(e.to_string()))?
-        {
-            labels.push(row.get::<String>(0).unwrap_or_default());
-        }
-        drop(rows);
+        let labels: Vec<String> = {
+            let conn = self.conn.lock().await;
+            let mut rows = conn
+                .query(
+                    "SELECT DISTINCT label_key FROM page_links WHERE target_page_id IS NULL",
+                    (),
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("resolve_orphan_links list: {e}")))?;
+            let mut labels: Vec<String> = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| OriginError::VectorDb(e.to_string()))?
+            {
+                labels.push(row.get::<String>(0).unwrap_or_default());
+            }
+            labels
+        };
 
         let mut resolved = 0usize;
-        for label in labels {
-            let trimmed = label.trim();
+        for label_key in labels {
+            let trimmed = label_key.trim();
             if trimmed.is_empty() {
                 continue;
             }
-            // Re-run the same case-insensitive lookup the resolver uses on
-            // write so behavior stays uniform.
+            // Look up + update under a fresh short-lived lock per label so
+            // other writers (page inserts, ingest) aren't blocked while we
+            // walk the full orphan set.
+            let conn = self.conn.lock().await;
             let mut hit = conn
                 .query(
                     "SELECT id FROM pages \
-                     WHERE LOWER(title) = LOWER(?1) AND status = 'active' \
+                     WHERE LOWER(title) = ?1 AND status = 'active' \
                      LIMIT 1",
                     libsql::params![trimmed],
                 )
@@ -14914,8 +15023,8 @@ impl MemoryDB {
                 drop(hit);
                 conn.execute(
                     "UPDATE page_links SET target_page_id = ?1 \
-                     WHERE label = ?2 AND target_page_id IS NULL",
-                    libsql::params![target, label],
+                     WHERE label_key = ?2 AND target_page_id IS NULL",
+                    libsql::params![target, label_key],
                 )
                 .await
                 .map_err(|e| OriginError::VectorDb(format!("resolve_orphan_links update: {e}")))?;
@@ -22024,6 +22133,21 @@ pub(crate) mod tests {
             after_refinery.user_edited,
             "user_edited must persist across subsequent non-manual writes"
         );
+
+        // A second manual_edit after a refinery write must keep the flag set
+        // (idempotent) — a regression that wrote `user_edited = 0` on the
+        // re_distill branch would pass the earlier asserts but fail here
+        // because the manual_edit doesn't UPSET an already-true flag.
+        db.update_page_content(
+            "page_manual",
+            "v4 hand-tweaked again",
+            &["m1"],
+            "manual_edit",
+        )
+        .await
+        .unwrap();
+        let after_second_manual = db.get_page("page_manual").await.unwrap().unwrap();
+        assert!(after_second_manual.user_edited);
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -14414,6 +14414,13 @@ impl MemoryDB {
         // stale `user_edited = 0`. The CAS variant adds `AND stale_reason
         // IS NOT NULL` so the refinery can guard against the agent's PUT
         // landing mid-LLM.
+        // The CAS variant also guards `user_edited = 0` so a fs_edit or
+        // manual_edit that landed mid-LLM (after the refinery loaded the
+        // row but before this UPDATE) takes priority. Without the
+        // user_edited check the refinery would clobber an in-flight
+        // human write since stale_reason stays set: the watcher
+        // deliberately doesn't clear staleness on apply (refinery
+        // escalates to source_conflict on the next sweep instead).
         let sql = if require_stale {
             "UPDATE pages SET \
                content = ?1, \
@@ -14422,7 +14429,9 @@ impl MemoryDB {
                last_compiled = ?3, \
                last_modified = ?3, \
                user_edited = CASE WHEN ?4 IN ('manual_edit', 'fs_edit') THEN 1 ELSE user_edited END \
-             WHERE id = ?5 AND stale_reason IS NOT NULL"
+             WHERE id = ?5 \
+               AND stale_reason IS NOT NULL \
+               AND COALESCE(user_edited, 0) = 0"
         } else {
             "UPDATE pages SET \
                content = ?1, \

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -14421,7 +14421,7 @@ impl MemoryDB {
                version = version + 1, \
                last_compiled = ?3, \
                last_modified = ?3, \
-               user_edited = CASE WHEN ?4 = 'manual_edit' THEN 1 ELSE user_edited END \
+               user_edited = CASE WHEN ?4 IN ('manual_edit', 'fs_edit') THEN 1 ELSE user_edited END \
              WHERE id = ?5 AND stale_reason IS NOT NULL"
         } else {
             "UPDATE pages SET \
@@ -14430,7 +14430,7 @@ impl MemoryDB {
                version = version + 1, \
                last_compiled = ?3, \
                last_modified = ?3, \
-               user_edited = CASE WHEN ?4 = 'manual_edit' THEN 1 ELSE user_edited END \
+               user_edited = CASE WHEN ?4 IN ('manual_edit', 'fs_edit') THEN 1 ELSE user_edited END \
              WHERE id = ?5"
         };
         let affected = conn

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -15122,19 +15122,44 @@ impl MemoryDB {
         Ok(())
     }
 
-    /// List active pages with the given stale_reason, up to `limit` rows.
+    /// List active pages with the given stale_reason, up to 10 rows.
     pub async fn list_stale_pages(
         &self,
         reason: &str,
     ) -> Result<Vec<crate::pages::Page>, OriginError> {
+        self.list_stale_pages_scoped(reason, None, None).await
+    }
+
+    /// Like `list_stale_pages` but restricts the result set by entity_id or
+    /// domain when either filter is supplied. Used by the `/api/distill`
+    /// route so a scoped pass (`/distill origin`) doesn't dump unrelated
+    /// stale pages on the user.
+    pub async fn list_stale_pages_scoped(
+        &self,
+        reason: &str,
+        entity_id_filter: Option<&str>,
+        domain_filter: Option<&str>,
+    ) -> Result<Vec<crate::pages::Page>, OriginError> {
         let conn = self.conn.lock().await;
+        let mut sql = String::from(
+            "SELECT id, title, summary, content, entity_id, domain, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0) \
+             FROM pages WHERE stale_reason = ?1 AND status = 'active'",
+        );
+        let mut bind: Vec<libsql::Value> = vec![libsql::Value::Text(reason.to_string())];
+        if let Some(eid) = entity_id_filter {
+            sql.push_str(" AND entity_id = ?");
+            bind.push(libsql::Value::Text(eid.to_string()));
+        }
+        if let Some(d) = domain_filter {
+            sql.push_str(" AND domain = ?");
+            bind.push(libsql::Value::Text(d.to_string()));
+        }
+        sql.push_str(" ORDER BY last_modified DESC LIMIT 10");
+
         let mut rows = conn
-            .query(
-                "SELECT id, title, summary, content, entity_id, domain, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0) FROM pages WHERE stale_reason = ?1 AND status = 'active' LIMIT 10",
-                libsql::params![reason],
-            )
+            .query(&sql, bind)
             .await
-            .map_err(|e| OriginError::VectorDb(format!("list_stale_pages: {e}")))?;
+            .map_err(|e| OriginError::VectorDb(format!("list_stale_pages_scoped: {e}")))?;
         let mut result = Vec::new();
         while let Some(row) = rows
             .next()
@@ -15187,6 +15212,53 @@ impl MemoryDB {
         .await
         .map_err(|e| OriginError::VectorDb(format!("clear_page_staleness: {e}")))?;
         Ok(())
+    }
+
+    /// Update only a page's summary (or clear it when `summary = None`).
+    /// Kept separate from `update_page_content` so callers can bump the body
+    /// without touching the one-line claim, and vice versa. Does NOT bump
+    /// `version` — that's `update_page_content`'s job since version tracks
+    /// the body, not the summary.
+    pub async fn update_page_summary(
+        &self,
+        page_id: &str,
+        summary: Option<&str>,
+    ) -> Result<(), OriginError> {
+        let conn = self.conn.lock().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        conn.execute(
+            "UPDATE pages SET summary = ?1, last_modified = ?2 WHERE id = ?3",
+            libsql::params![summary, now, page_id],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("update_page_summary: {e}")))?;
+        Ok(())
+    }
+
+    /// Read the current `stale_reason` for a page without loading the rest
+    /// of the row. Used by the refinery's CAS re-check before overwriting —
+    /// if another writer (the agent's PUT) cleared staleness during the LLM
+    /// call, refinery yields rather than clobbering the fresher content.
+    pub async fn get_page_stale_reason(
+        &self,
+        page_id: &str,
+    ) -> Result<Option<String>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT stale_reason FROM pages WHERE id = ?1",
+                libsql::params![page_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_page_stale_reason: {e}")))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            Some(row) => Ok(row.get::<Option<String>>(0).unwrap_or(None)),
+            None => Ok(None),
+        }
     }
 
     /// Update a memory's content in-place for topic-key upsert.
@@ -24412,6 +24484,146 @@ pub(crate) mod tests {
         assert!(
             stale.is_empty(),
             "archived pages should not appear in stale list"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_stale_pages_scoped_filters_by_entity_and_domain() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Three stale pages, one per scope axis.
+        db.insert_page(
+            "page_origin",
+            "Origin Page",
+            None,
+            "content",
+            Some("ent_origin"),
+            Some("origin"),
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page(
+            "page_other_entity",
+            "Other Entity",
+            None,
+            "content",
+            Some("ent_other"),
+            Some("origin"),
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page(
+            "page_other_domain",
+            "Other Domain",
+            None,
+            "content",
+            Some("ent_origin"),
+            Some("plugin"),
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        for id in ["page_origin", "page_other_entity", "page_other_domain"] {
+            db.set_page_stale(id, "source_updated").await.unwrap();
+        }
+
+        // No filter — all three.
+        let all = db
+            .list_stale_pages_scoped("source_updated", None, None)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 3);
+
+        // Entity filter — only ent_origin.
+        let by_entity = db
+            .list_stale_pages_scoped("source_updated", Some("ent_origin"), None)
+            .await
+            .unwrap();
+        let ids: Vec<&str> = by_entity.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"page_origin"));
+        assert!(ids.contains(&"page_other_domain"));
+
+        // Domain filter — only origin.
+        let by_domain = db
+            .list_stale_pages_scoped("source_updated", None, Some("origin"))
+            .await
+            .unwrap();
+        let ids: Vec<&str> = by_domain.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&"page_origin"));
+        assert!(ids.contains(&"page_other_entity"));
+
+        // Both filters — intersection.
+        let both = db
+            .list_stale_pages_scoped("source_updated", Some("ent_origin"), Some("origin"))
+            .await
+            .unwrap();
+        assert_eq!(both.len(), 1);
+        assert_eq!(both[0].id, "page_origin");
+    }
+
+    #[tokio::test]
+    async fn update_page_summary_writes_and_clears() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_sum",
+            "Title",
+            Some("old summary"),
+            "body",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        db.update_page_summary("page_sum", Some("new summary"))
+            .await
+            .unwrap();
+        let p = db.get_page("page_sum").await.unwrap().unwrap();
+        assert_eq!(p.summary.as_deref(), Some("new summary"));
+
+        db.update_page_summary("page_sum", None).await.unwrap();
+        let p = db.get_page("page_sum").await.unwrap().unwrap();
+        assert_eq!(p.summary, None);
+    }
+
+    #[tokio::test]
+    async fn get_page_stale_reason_reads_current_value() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page("page_cas", "Title", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+
+        assert_eq!(db.get_page_stale_reason("page_cas").await.unwrap(), None);
+
+        db.set_page_stale("page_cas", "source_updated")
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_page_stale_reason("page_cas").await.unwrap(),
+            Some("source_updated".to_string())
+        );
+
+        db.clear_page_staleness("page_cas").await.unwrap();
+        assert_eq!(db.get_page_stale_reason("page_cas").await.unwrap(), None);
+
+        // Unknown page → None (not an error). Refinery's CAS treats this
+        // the same as "already cleared" so we yield instead of panicking.
+        assert_eq!(
+            db.get_page_stale_reason("page_missing").await.unwrap(),
+            None
         );
     }
 

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -4555,6 +4555,40 @@ impl MemoryDB {
                     log::info!("[migration] Self-heal: recreated idx_pages_embedding");
                 }
             }
+
+            // Migration 47: page_links table — wikilink graph. Every `[[Label]]`
+            // in a page body resolves at write time against existing page
+            // titles; resolved links land here with `target_page_id` set,
+            // unresolved (orphan) links land with `target_page_id = NULL`.
+            // The orphan-by-label query feeds emergence as a topic-discovery
+            // signal once enough independent pages link to the same label.
+            //
+            // FK on source_page_id cascades so deleting a page wipes its
+            // outbound links; target_page_id deliberately has no FK so an
+            // archived/deleted target leaves orphan rows the resolver can
+            // pick up later when the target is recreated.
+            if version < 47 {
+                let conn = self.conn.lock().await;
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS page_links (\
+                        source_page_id TEXT NOT NULL, \
+                        target_page_id TEXT, \
+                        label TEXT NOT NULL, \
+                        PRIMARY KEY (source_page_id, label), \
+                        FOREIGN KEY (source_page_id) REFERENCES pages(id) ON DELETE CASCADE\
+                     ); \
+                     CREATE INDEX IF NOT EXISTS idx_page_links_target \
+                       ON page_links(target_page_id) WHERE target_page_id IS NOT NULL; \
+                     CREATE INDEX IF NOT EXISTS idx_page_links_orphan \
+                       ON page_links(label) WHERE target_page_id IS NULL;",
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("m47 create: {e}")))?;
+                conn.execute("PRAGMA user_version = 47", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m47 bump: {e}")))?;
+                log::info!("[migration] Migration 47 applied: page_links table for wikilink graph");
+            }
         }
 
         Ok(())
@@ -14165,6 +14199,14 @@ impl MemoryDB {
         conn.execute("COMMIT", ())
             .await
             .map_err(|e| OriginError::VectorDb(format!("insert_page commit: {e}")))?;
+        drop(conn);
+
+        // Wikilink graph refresh runs after the row + sources are committed
+        // so a failure here can't roll back the page itself. Same trade-off
+        // as update_page_content: link index is recoverable on the next save.
+        if let Err(e) = self.refresh_page_wikilinks(id, content).await {
+            log::warn!("[page-links] refresh failed for new page {id}: {e}");
+        }
         Ok(())
     }
 
@@ -14344,7 +14386,31 @@ impl MemoryDB {
                 )
                 .await;
         }
+        drop(conn);
+
+        // Refresh the wikilink graph for this page. Extraction is pure CPU;
+        // the resolver + replace use their own short-lived locks. Failures
+        // are logged but do not roll back the content write — a broken link
+        // index is recoverable on the next save and far less harmful than
+        // failing to persist the user-facing body.
+        if let Err(e) = self.refresh_page_wikilinks(id, content).await {
+            log::warn!("[page-links] refresh failed for {id}: {e}");
+        }
         Ok(())
+    }
+
+    /// Extract wikilinks from `content`, resolve them against current page
+    /// titles, and replace the page's row set in `page_links`. Idempotent.
+    /// Used by both `insert_page` and `update_page_content` so write paths
+    /// stay coherent without duplicating the orchestration.
+    pub async fn refresh_page_wikilinks(
+        &self,
+        page_id: &str,
+        content: &str,
+    ) -> Result<(), OriginError> {
+        let labels = crate::synthesis::wikilinks::extract_wikilinks(content);
+        let links = crate::synthesis::wikilinks::resolve_against_pages(self, &labels).await?;
+        self.replace_page_links(page_id, &links).await
     }
 
     /// Find a matching page for a new memory — by entity_id first, then embedding similarity.
@@ -14613,6 +14679,250 @@ impl MemoryDB {
             .await
             .map_err(|e| OriginError::VectorDb(format!("delete_page: {e}")))?;
         Ok(())
+    }
+
+    /// Find an active page id whose title matches `label` (case-insensitive,
+    /// trimmed). Used by the wikilink resolver. Returns None when no active
+    /// page matches; archived pages are deliberately ignored so a deleted-
+    /// then-recreated page resolves to the new id, not the dead one.
+    pub async fn find_active_page_id_by_title(
+        &self,
+        label: &str,
+    ) -> Result<Option<String>, OriginError> {
+        let trimmed = label.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT id FROM pages \
+                 WHERE LOWER(title) = LOWER(?1) AND status = 'active' \
+                 LIMIT 1",
+                libsql::params![trimmed],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("find_active_page_id_by_title: {e}")))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            Some(row) => Ok(Some(
+                row.get::<String>(0)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Replace the entire outbound-link set for a page in one BEGIN/COMMIT.
+    /// Called from `update_page_content` and `insert_page` after wikilink
+    /// extraction so the join table stays coherent with the body.
+    ///
+    /// `links` carries resolved + unresolved labels — unresolved rows go in
+    /// with `target_page_id = NULL` so the refinery's resolve phase can pick
+    /// them up later when the target page exists.
+    pub async fn replace_page_links(
+        &self,
+        source_page_id: &str,
+        links: &[crate::synthesis::wikilinks::Wikilink],
+    ) -> Result<(), OriginError> {
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("replace_page_links begin: {e}")))?;
+        let exec = async {
+            conn.execute(
+                "DELETE FROM page_links WHERE source_page_id = ?1",
+                libsql::params![source_page_id],
+            )
+            .await?;
+            for link in links {
+                conn.execute(
+                    "INSERT INTO page_links (source_page_id, target_page_id, label) \
+                     VALUES (?1, ?2, ?3)",
+                    libsql::params![
+                        source_page_id,
+                        link.target_page_id.clone(),
+                        link.label.clone(),
+                    ],
+                )
+                .await?;
+            }
+            Ok::<_, libsql::Error>(())
+        }
+        .await;
+        match exec {
+            Ok(()) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    OriginError::VectorDb(format!("replace_page_links commit: {e}"))
+                })?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(OriginError::VectorDb(format!("replace_page_links: {e}")))
+            }
+        }
+    }
+
+    /// Outbound links from a page. Used by `/api/pages/{id}/links` and the
+    /// `/read` preview's link-count line.
+    pub async fn get_page_outbound_links(
+        &self,
+        source_page_id: &str,
+    ) -> Result<Vec<crate::synthesis::wikilinks::Wikilink>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT target_page_id, label FROM page_links \
+                 WHERE source_page_id = ?1 ORDER BY label",
+                libsql::params![source_page_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_page_outbound_links: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            out.push(crate::synthesis::wikilinks::Wikilink {
+                target_page_id: row.get::<Option<String>>(0).unwrap_or(None),
+                label: row.get::<String>(1).unwrap_or_default(),
+            });
+        }
+        Ok(out)
+    }
+
+    /// Inbound links to a page — every active source whose body contains a
+    /// `[[Title]]` reference that resolves here. Used by the page's "linked
+    /// from" view.
+    pub async fn get_page_inbound_links(
+        &self,
+        target_page_id: &str,
+    ) -> Result<Vec<(String, String)>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT pl.source_page_id, pl.label FROM page_links pl \
+                 INNER JOIN pages p ON p.id = pl.source_page_id \
+                 WHERE pl.target_page_id = ?1 AND p.status = 'active' \
+                 ORDER BY p.last_modified DESC",
+                libsql::params![target_page_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_page_inbound_links: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            out.push((
+                row.get::<String>(0).unwrap_or_default(),
+                row.get::<String>(1).unwrap_or_default(),
+            ));
+        }
+        Ok(out)
+    }
+
+    /// Group every still-orphan label by count. The orphan-by-count feed is
+    /// the actual product win: a label that 3+ independent pages reach for
+    /// is a topic candidate emergence can synthesize a page from.
+    pub async fn list_orphan_link_labels(
+        &self,
+        min_count: i64,
+    ) -> Result<Vec<(String, i64)>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT label, COUNT(DISTINCT source_page_id) AS n \
+                 FROM page_links \
+                 WHERE target_page_id IS NULL \
+                 GROUP BY label \
+                 HAVING n >= ?1 \
+                 ORDER BY n DESC, label ASC \
+                 LIMIT 100",
+                libsql::params![min_count],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("list_orphan_link_labels: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            out.push((
+                row.get::<String>(0).unwrap_or_default(),
+                row.get::<i64>(1).unwrap_or(0),
+            ));
+        }
+        Ok(out)
+    }
+
+    /// Walk the orphan rows and re-resolve them against current page titles.
+    /// Returns the number of rows that flipped from NULL to a real target —
+    /// the refinery uses this for the log line. Cheap: one indexed query +
+    /// one UPDATE per flipped row, no LLM.
+    pub async fn resolve_orphan_page_links(&self) -> Result<usize, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT DISTINCT label FROM page_links WHERE target_page_id IS NULL",
+                (),
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("resolve_orphan_links list: {e}")))?;
+        let mut labels: Vec<String> = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            labels.push(row.get::<String>(0).unwrap_or_default());
+        }
+        drop(rows);
+
+        let mut resolved = 0usize;
+        for label in labels {
+            let trimmed = label.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            // Re-run the same case-insensitive lookup the resolver uses on
+            // write so behavior stays uniform.
+            let mut hit = conn
+                .query(
+                    "SELECT id FROM pages \
+                     WHERE LOWER(title) = LOWER(?1) AND status = 'active' \
+                     LIMIT 1",
+                    libsql::params![trimmed],
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("resolve_orphan_links lookup: {e}")))?;
+            if let Some(row) = hit
+                .next()
+                .await
+                .map_err(|e| OriginError::VectorDb(e.to_string()))?
+            {
+                let target: String = row
+                    .get(0)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?;
+                drop(hit);
+                conn.execute(
+                    "UPDATE page_links SET target_page_id = ?1 \
+                     WHERE label = ?2 AND target_page_id IS NULL",
+                    libsql::params![target, label],
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("resolve_orphan_links update: {e}")))?;
+                resolved += 1;
+            }
+        }
+        Ok(resolved)
     }
 
     /// Search pages via vector similarity + FTS5 with RRF fusion.
@@ -21761,6 +22071,251 @@ pub(crate) mod tests {
 
         // Deleting non-existent ID should not error
         db.delete_page("nonexistent").await.unwrap();
+    }
+
+    // ---- page_links / wikilink graph ----
+
+    #[tokio::test]
+    async fn page_links_resolve_against_existing_titles() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Two existing pages — wikilinks pointing at them should resolve.
+        db.insert_page(
+            "page_target",
+            "Rust Ownership",
+            None,
+            "body",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page("page_alpha", "Alpha", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+
+        // Source page links to both, plus an orphan label.
+        db.insert_page(
+            "page_src",
+            "Source",
+            None,
+            "see [[Rust Ownership]] and [[Alpha]] and [[Quantum Knitting]]",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let out = db.get_page_outbound_links("page_src").await.unwrap();
+        // Three labels, sorted alphabetically.
+        assert_eq!(out.len(), 3);
+        let by_label: std::collections::HashMap<_, _> = out
+            .into_iter()
+            .map(|l| (l.label, l.target_page_id))
+            .collect();
+        assert_eq!(
+            by_label.get("Rust Ownership"),
+            Some(&Some("page_target".to_string()))
+        );
+        assert_eq!(by_label.get("Alpha"), Some(&Some("page_alpha".to_string())));
+        // Orphan stays NULL until the target gets created.
+        assert_eq!(by_label.get("Quantum Knitting"), Some(&None));
+    }
+
+    #[tokio::test]
+    async fn page_links_inbound_excludes_archived() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Target first so source-page writes resolve immediately. (If the
+        // target were inserted last the sources would orphan; the refinery's
+        // resolve_orphan_page_links covers that case in a separate test.)
+        db.insert_page(
+            "page_target_in",
+            "Target",
+            None,
+            "body",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page(
+            "page_active_src",
+            "Active source",
+            None,
+            "body links to [[Target]]",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page(
+            "page_archived_src",
+            "Archived source",
+            None,
+            "body links to [[Target]]",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.archive_page("page_archived_src").await.unwrap();
+
+        let inbound = db.get_page_inbound_links("page_target_in").await.unwrap();
+        let src_ids: Vec<&str> = inbound.iter().map(|(s, _)| s.as_str()).collect();
+        assert!(src_ids.contains(&"page_active_src"));
+        // Archived source must not surface even though the row exists in
+        // page_links — the join filters on active status.
+        assert!(!src_ids.contains(&"page_archived_src"));
+    }
+
+    #[tokio::test]
+    async fn page_links_update_overwrites_old_links() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        db.insert_page(
+            "page_evolving",
+            "Evolving",
+            None,
+            "first version mentions [[Alpha]] and [[Beta]]",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let v1 = db.get_page_outbound_links("page_evolving").await.unwrap();
+        assert_eq!(v1.len(), 2);
+
+        // Rewrite — Alpha drops, Gamma appears, Beta stays.
+        db.update_page_content(
+            "page_evolving",
+            "second version mentions [[Gamma]] and [[Beta]]",
+            &[],
+            "manual_edit",
+        )
+        .await
+        .unwrap();
+
+        let v2 = db.get_page_outbound_links("page_evolving").await.unwrap();
+        let labels: std::collections::HashSet<&str> = v2.iter().map(|l| l.label.as_str()).collect();
+        assert!(labels.contains("Gamma"));
+        assert!(labels.contains("Beta"));
+        assert!(!labels.contains("Alpha"));
+        assert_eq!(v2.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn page_links_resolve_orphans_after_target_appears() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Source page first — link is initially orphaned.
+        db.insert_page(
+            "page_a",
+            "A",
+            None,
+            "see [[Topic Z]]",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page(
+            "page_b",
+            "B",
+            None,
+            "also [[Topic Z]]",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let labels = db.list_orphan_link_labels(2).await.unwrap();
+        assert_eq!(labels, vec![("Topic Z".to_string(), 2)]);
+
+        // Now the target page is created — refinery resolves orphans.
+        db.insert_page(
+            "page_z",
+            "Topic Z",
+            None,
+            "actual body",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let resolved = db.resolve_orphan_page_links().await.unwrap();
+        assert_eq!(resolved, 1, "one orphan label flipped to a real target");
+
+        let labels_after = db.list_orphan_link_labels(1).await.unwrap();
+        assert!(
+            labels_after.iter().all(|(l, _)| l != "Topic Z"),
+            "Topic Z should be off the orphan list after resolve"
+        );
+
+        // Confirm both source pages now point at the new target.
+        for src in ["page_a", "page_b"] {
+            let out = db.get_page_outbound_links(src).await.unwrap();
+            assert_eq!(out.len(), 1);
+            assert_eq!(out[0].target_page_id.as_deref(), Some("page_z"));
+        }
+    }
+
+    #[tokio::test]
+    async fn page_links_cascade_on_source_delete() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        db.insert_page("page_tgt", "Target", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+        db.insert_page(
+            "page_src_d",
+            "Source",
+            None,
+            "[[Target]] mention",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            db.get_page_inbound_links("page_tgt").await.unwrap().len(),
+            1
+        );
+        db.delete_page("page_src_d").await.unwrap();
+        // FK cascade wipes outbound rows when the source row is deleted.
+        assert_eq!(
+            db.get_page_inbound_links("page_tgt").await.unwrap().len(),
+            0
+        );
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -14778,6 +14778,32 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Return the titles of all active pages, ordered by most-recently-
+    /// modified, capped at `limit`. Used to seed the distill prompt with
+    /// the canonical label set so the LLM emits `[[Existing Title]]`
+    /// wikilinks that resolve immediately instead of inventing labels the
+    /// resolver has to leave as orphans.
+    pub async fn list_active_page_titles(&self, limit: usize) -> Result<Vec<String>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT title FROM pages WHERE status = 'active' \
+                 ORDER BY last_modified DESC LIMIT ?1",
+                libsql::params![limit as i64],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("list_active_page_titles: {e}")))?;
+        let mut out = Vec::with_capacity(limit);
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            out.push(row.get::<String>(0).unwrap_or_default());
+        }
+        Ok(out)
+    }
+
     /// Find an active page id whose title matches `label` (case-insensitive,
     /// trimmed). Used by the wikilink resolver. Returns None when no active
     /// page matches; archived pages are deliberately ignored so a deleted-
@@ -22198,6 +22224,32 @@ pub(crate) mod tests {
     }
 
     // ---- page_links / wikilink graph ----
+
+    #[tokio::test]
+    async fn list_active_page_titles_excludes_archived_and_honours_limit() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page("p1", "Alpha", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+        db.insert_page("p2", "Beta", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+        db.insert_page("p3", "Gamma", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+        db.archive_page("p3").await.unwrap();
+
+        let titles = db.list_active_page_titles(10).await.unwrap();
+        assert_eq!(titles.len(), 2);
+        assert!(titles.contains(&"Alpha".to_string()));
+        assert!(titles.contains(&"Beta".to_string()));
+        assert!(!titles.contains(&"Gamma".to_string()));
+
+        // Limit is respected.
+        let one = db.list_active_page_titles(1).await.unwrap();
+        assert_eq!(one.len(), 1);
+    }
 
     #[tokio::test]
     async fn page_links_resolve_against_existing_titles() {

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -14316,6 +14316,17 @@ impl MemoryDB {
         )
         .await
         .map_err(|e| OriginError::VectorDb(format!("update_page_content: {e}")))?;
+        // Flip user_edited so the refinery's auto-overwrite branch escalates to
+        // source_conflict instead of clobbering a hand-curated body. Only manual
+        // edits set the flag; re_distill / distill / concept_growth must not.
+        if link_reason == "manual_edit" {
+            conn.execute(
+                "UPDATE pages SET user_edited = 1 WHERE id = ?1",
+                libsql::params![id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("update_page_content user_edited: {e}")))?;
+        }
         // Dual-write: insert any new source links into the join table (idempotent)
         for sid in source_memory_ids {
             let _ = conn
@@ -21532,6 +21543,51 @@ pub(crate) mod tests {
         assert_eq!(c.content, "v2 content");
         assert_eq!(c.version, 2);
         assert_eq!(c.source_memory_ids, vec!["m1", "m2"]);
+        // concept_growth must NOT flip user_edited — refinery would then
+        // refuse to recompile every page it grew, defeating background
+        // distillation. Only manual edits set the flag.
+        assert!(!c.user_edited);
+    }
+
+    #[tokio::test]
+    async fn test_update_page_content_manual_edit_flips_user_edited() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_manual",
+            "Manual",
+            None,
+            "v1 content",
+            None,
+            None,
+            &["m1"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let before = db.get_page("page_manual").await.unwrap().unwrap();
+        assert!(!before.user_edited);
+
+        db.update_page_content("page_manual", "v2 hand-written", &["m1"], "manual_edit")
+            .await
+            .unwrap();
+        let after_manual = db.get_page("page_manual").await.unwrap().unwrap();
+        assert!(
+            after_manual.user_edited,
+            "manual_edit must flip user_edited so refinery escalates instead of overwriting"
+        );
+
+        // Subsequent re_distill / concept_growth must not unset the flag — it
+        // sticks until the page is replaced or archived.
+        db.update_page_content("page_manual", "v3 from refinery", &["m1"], "re_distill")
+            .await
+            .unwrap();
+        let after_refinery = db.get_page("page_manual").await.unwrap().unwrap();
+        assert!(
+            after_refinery.user_edited,
+            "user_edited must persist across subsequent non-manual writes"
+        );
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -12242,6 +12242,7 @@ impl MemoryDB {
         max_clusters: usize,
         token_limit: usize,
         max_unlinked_cluster_size: usize,
+        max_grouped_cluster_size: usize,
     ) -> Result<Vec<DistillationCluster>, OriginError> {
         self.find_distillation_clusters_scoped(
             similarity_threshold,
@@ -12249,6 +12250,7 @@ impl MemoryDB {
             max_clusters,
             token_limit,
             max_unlinked_cluster_size,
+            max_grouped_cluster_size,
             None,
             None,
         )
@@ -12268,6 +12270,7 @@ impl MemoryDB {
         max_clusters: usize,
         token_limit: usize,
         max_unlinked_cluster_size: usize,
+        max_grouped_cluster_size: usize,
         entity_id_filter: Option<&str>,
         domain_filter: Option<&str>,
     ) -> Result<Vec<DistillationCluster>, OriginError> {
@@ -12386,80 +12389,85 @@ impl MemoryDB {
 
         let mut clusters: Vec<DistillationCluster> = Vec::new();
 
-        // Sub-cluster within each community group by vector similarity
-        for indices in community_groups.values() {
-            let sub = cluster_by_similarity(&memories, indices, similarity_threshold);
-            for group in sub {
-                if group.len() >= min_size {
-                    let cluster = build_distillation_cluster(&memories, &group);
-                    let split = sub_cluster_by_tokens(&memories, cluster, token_limit);
-                    clusters.extend(split);
-                }
-            }
-        }
-
-        // Sub-cluster within each entity group by vector similarity (no community_id)
-        for indices in entity_groups.values() {
-            let sub = cluster_by_similarity(&memories, indices, similarity_threshold);
-            for group in sub {
-                if group.len() >= min_size {
-                    let cluster = build_distillation_cluster(&memories, &group);
-                    let split = sub_cluster_by_tokens(&memories, cluster, token_limit);
-                    clusters.extend(split);
-                }
-            }
-        }
-
-        // Cluster unlinked memories by vector similarity. Apply hard size cap
-        // to prevent runaway clusters of unlabeled memories (safety valve for
-        // the Mode B failure mode — see spec 2026-04-25). Oversized clusters
-        // are re-clustered once with a tighter threshold instead of dropped:
-        // a 200-memory pile usually contains coherent sub-topics that deserve
-        // their own pages, while truly noisy piles produce tighter groups
-        // that still exceed the cap and are then logged + skipped.
-        if unlinked.len() >= min_size {
-            let sub = cluster_by_similarity(&memories, &unlinked, similarity_threshold);
-            for group in sub {
-                if group.len() < min_size {
-                    continue;
-                }
-                if group.len() > max_unlinked_cluster_size {
-                    // Tighten by +0.05 (cosine similarity is logarithmic in
-                    // semantic distance — +0.1 from a default 0.85 jumps to
-                    // 0.95 which is near-duplicate territory and drops most
-                    // legitimate sub-topics at min_size). Cap at 0.92.
-                    let tighter = (similarity_threshold + 0.05).min(0.92);
-                    log::info!(
-                        "[distill] re-splitting oversized unlinked cluster: \
-                         {} memories at threshold {:.2} (cap = {})",
-                        group.len(),
-                        tighter,
-                        max_unlinked_cluster_size,
-                    );
-                    let resplit = cluster_by_similarity(&memories, &group, tighter);
-                    for sub_group in resplit {
-                        if sub_group.len() < min_size {
-                            continue;
-                        }
-                        if sub_group.len() > max_unlinked_cluster_size {
-                            log::info!(
-                                "[distill] dropping unlinked sub-cluster after re-split: \
-                                 {} memories still > cap {}",
-                                sub_group.len(),
-                                max_unlinked_cluster_size,
-                            );
-                            continue;
-                        }
-                        let cluster = build_distillation_cluster(&memories, &sub_group);
-                        let split = sub_cluster_by_tokens(&memories, cluster, token_limit);
-                        clusters.extend(split);
+        // Process a single bucket's similarity-clustered groups with a hard
+        // size cap. Groups that exceed the cap re-cluster once at a tighter
+        // threshold; sub-groups still over the cap are dropped with a log
+        // line. Used by all three buckets (community, entity, unlinked) so
+        // the same grab-bag mitigation applies uniformly — community 16's
+        // 99-memory "Origin" pile was the original failure mode but the
+        // entity-only bucket has the same risk (e.g. one entity that swept
+        // in unrelated sub-topics over time).
+        //
+        // Cosine similarity is logarithmic in semantic distance — +0.1 from
+        // 0.85 lands at 0.95 (near-duplicate), which drops most legitimate
+        // sub-topics at min_size. +0.05 with a cap of 0.92 is the sweet spot.
+        let process_bucket =
+            |bucket_label: &str,
+             indices: &[usize],
+             cap: usize,
+             clusters: &mut Vec<DistillationCluster>| {
+                let sub = cluster_by_similarity(&memories, indices, similarity_threshold);
+                for group in sub {
+                    if group.len() < min_size {
+                        continue;
                     }
-                    continue;
+                    if group.len() > cap {
+                        let tighter = (similarity_threshold + 0.05).min(0.92);
+                        log::info!(
+                            "[distill] re-splitting oversized {} cluster: \
+                         {} memories at threshold {:.2} (cap = {})",
+                            bucket_label,
+                            group.len(),
+                            tighter,
+                            cap,
+                        );
+                        let resplit = cluster_by_similarity(&memories, &group, tighter);
+                        for sub_group in resplit {
+                            if sub_group.len() < min_size {
+                                continue;
+                            }
+                            if sub_group.len() > cap {
+                                log::info!(
+                                    "[distill] dropping {} sub-cluster after re-split: \
+                                 {} memories still > cap {}",
+                                    bucket_label,
+                                    sub_group.len(),
+                                    cap,
+                                );
+                                continue;
+                            }
+                            let cluster = build_distillation_cluster(&memories, &sub_group);
+                            let split = sub_cluster_by_tokens(&memories, cluster, token_limit);
+                            clusters.extend(split);
+                        }
+                        continue;
+                    }
+                    let cluster = build_distillation_cluster(&memories, &group);
+                    let split = sub_cluster_by_tokens(&memories, cluster, token_limit);
+                    clusters.extend(split);
                 }
-                let cluster = build_distillation_cluster(&memories, &group);
-                let split = sub_cluster_by_tokens(&memories, cluster, token_limit);
-                clusters.extend(split);
-            }
+            };
+
+        for indices in community_groups.values() {
+            process_bucket(
+                "community",
+                indices,
+                max_grouped_cluster_size,
+                &mut clusters,
+            );
+        }
+
+        for indices in entity_groups.values() {
+            process_bucket("entity", indices, max_grouped_cluster_size, &mut clusters);
+        }
+
+        if unlinked.len() >= min_size {
+            process_bucket(
+                "unlinked",
+                &unlinked,
+                max_unlinked_cluster_size,
+                &mut clusters,
+            );
         }
 
         log::info!(
@@ -19891,7 +19899,7 @@ pub(crate) mod tests {
         }
 
         let clusters = db
-            .find_distillation_clusters(0.5, 2, 20, 3500, 50)
+            .find_distillation_clusters(0.5, 2, 20, 3500, 50, 50)
             .await
             .unwrap();
         // Should find at least 1 cluster (entity groups with 2+ members)
@@ -19941,7 +19949,7 @@ pub(crate) mod tests {
         }
 
         let clusters = db
-            .find_distillation_clusters(0.3, 2, 20, 3500, 50)
+            .find_distillation_clusters(0.3, 2, 20, 3500, 50, 50)
             .await
             .unwrap();
 
@@ -20001,7 +20009,7 @@ pub(crate) mod tests {
         }
 
         let clusters = db
-            .find_distillation_clusters(0.3, 2, 20, 3500, 5)
+            .find_distillation_clusters(0.3, 2, 20, 3500, 5, 50)
             .await
             .unwrap();
 
@@ -20046,7 +20054,7 @@ pub(crate) mod tests {
         // Run with cap = 30. The single 60-memory unlinked cluster should be
         // skipped entirely. No clusters > 30 should be returned.
         let clusters = db
-            .find_distillation_clusters(0.3, 2, 20, 3500, 30)
+            .find_distillation_clusters(0.3, 2, 20, 3500, 30, 50)
             .await
             .unwrap();
 
@@ -20056,6 +20064,52 @@ pub(crate) mod tests {
                 "cluster of {} memories exceeded cap of 30: {:?}",
                 cluster.source_ids.len(),
                 cluster.source_ids.first()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn find_distillation_clusters_caps_oversized_entity_group() {
+        // A single entity (think "Origin" community cid=16 in prod) sweeps in
+        // a long tail of unrelated memories over time. Greedy clustering at
+        // 0.73 returns one big blob; the agent's coherence check rejects it
+        // as a grab-bag and the user sees nothing. The grouped-cluster cap
+        // forces a re-split so coherent sub-topics still surface.
+        let (db, _dir) = test_db().await;
+
+        let now = chrono::Utc::now().timestamp_millis();
+        // 20 memories on the same entity, all with similar prose so they
+        // collapse into one greedy cluster at threshold 0.3 — well above the
+        // grouped cap of 6 used below.
+        for i in 0..20 {
+            let doc = RawDocument {
+                source: "memory".to_string(),
+                source_id: format!("mem_origin_{}", i),
+                content: format!("origin distillation pipeline note number {}", i),
+                title: format!("Note {}", i),
+                url: None,
+                last_modified: now + i as i64,
+                memory_type: None,
+                domain: Some("origin".to_string()),
+                entity_id: Some("ent_origin".to_string()),
+                ..Default::default()
+            };
+            db.upsert_documents(vec![doc]).await.unwrap();
+        }
+
+        // grouped cap = 6 → original blob must re-split or drop; no cluster
+        // returned can exceed 6 memories.
+        let clusters = db
+            .find_distillation_clusters(0.3, 2, 20, 3500, 50, 6)
+            .await
+            .unwrap();
+
+        for cluster in &clusters {
+            assert!(
+                cluster.source_ids.len() <= 6,
+                "entity-bucket cluster of {} memories exceeded grouped cap 6 — \
+                 oversized re-split not applied to entity_groups/community_groups",
+                cluster.source_ids.len(),
             );
         }
     }

--- a/crates/origin-core/src/eval/lifecycle.rs
+++ b/crates/origin-core/src/eval/lifecycle.rs
@@ -694,6 +694,7 @@ async fn run_lifecycle_phases(
                 distillation_cfg.max_clusters_per_steep,
                 3500,
                 distillation_cfg.max_unlinked_cluster_size,
+                distillation_cfg.max_grouped_cluster_size,
             )
             .await?;
         let pre_cluster_ids: Vec<Vec<String>> =

--- a/crates/origin-core/src/eval/pipeline.rs
+++ b/crates/origin-core/src/eval/pipeline.rs
@@ -534,6 +534,7 @@ pub async fn run_locomo_pipeline_eval(
                 tuning.max_clusters_per_steep,
                 llm.synthesis_token_limit(),
                 tuning.page_min_cluster_size,
+                tuning.max_grouped_cluster_size,
             )
             .await
             .unwrap_or_default();
@@ -840,6 +841,7 @@ pub async fn run_longmemeval_pipeline_eval(
                 tuning.max_clusters_per_steep,
                 llm.synthesis_token_limit(),
                 tuning.page_min_cluster_size,
+                tuning.max_grouped_cluster_size,
             )
             .await
             .unwrap_or_default();

--- a/crates/origin-core/src/eval/shared.rs
+++ b/crates/origin-core/src/eval/shared.rs
@@ -1756,6 +1756,7 @@ pub async fn run_concept_distillation_batch_api(
             tuning.max_clusters_per_steep,
             token_limit,
             tuning.max_unlinked_cluster_size,
+            tuning.max_grouped_cluster_size,
         )
         .await?;
 

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -106,6 +106,14 @@ impl KnowledgeWriter {
         candidate
     }
 
+    /// Resolve the filename currently recorded in `state.json` for a page,
+    /// or `None` if the page has no projection yet. Used by the PUT route's
+    /// rollback path so a failed DB update can restore the prior md bytes
+    /// instead of orphaning the file.
+    pub fn page_filename(&self, page_id: &str) -> Option<String> {
+        self.load_state().pages.get(page_id).map(|s| s.file.clone())
+    }
+
     pub fn remove_page(&self, page_id: &str) -> Result<(), OriginError> {
         let mut state = self.load_state();
 

--- a/crates/origin-core/src/refinery/mod.rs
+++ b/crates/origin-core/src/refinery/mod.rs
@@ -847,11 +847,31 @@ pub(crate) async fn re_distill_stale_pages(
                     .trim()
                     .to_string();
                 if !content.is_empty() {
-                    db.update_page_content(&page.id, &content, &source_id_refs, "re_distill")
-                        .await?;
-                    db.clear_page_staleness(&page.id).await?;
-                    recompiled += 1;
-                    log::info!("[re-distill-stale] refreshed page '{}'", page.title);
+                    // CAS-style re-check: if another writer (typically the
+                    // agent's PUT /api/pages/{id} during a `/distill` skill
+                    // pass) cleared staleness during our LLM call, yield.
+                    // Their content is fresher and we should not overwrite.
+                    // One extra SELECT per page is cheap; locks + TTL sweeps
+                    // would be overengineered for two writers that fight
+                    // maybe once a day.
+                    match db.get_page_stale_reason(&page.id).await? {
+                        Some(_) => {
+                            db.update_page_content(
+                                &page.id,
+                                &content,
+                                &source_id_refs,
+                                "re_distill",
+                            )
+                            .await?;
+                            db.clear_page_staleness(&page.id).await?;
+                            recompiled += 1;
+                            log::info!("[re-distill-stale] refreshed page '{}'", page.title);
+                        }
+                        None => log::info!(
+                            "[re-distill-stale] '{}' staleness already cleared, yielding",
+                            page.title
+                        ),
+                    }
                 }
             }
             Ok(_) => log::warn!("[re-distill-stale] empty LLM output for '{}'", page.title),

--- a/crates/origin-core/src/refinery/mod.rs
+++ b/crates/origin-core/src/refinery/mod.rs
@@ -859,30 +859,29 @@ pub(crate) async fn re_distill_stale_pages(
                     .trim()
                     .to_string();
                 if !content.is_empty() {
-                    // CAS-style re-check: if another writer (typically the
-                    // agent's PUT /api/pages/{id} during a `/distill` skill
-                    // pass) cleared staleness during our LLM call, yield.
-                    // Their content is fresher and we should not overwrite.
-                    // One extra SELECT per page is cheap; locks + TTL sweeps
-                    // would be overengineered for two writers that fight
-                    // maybe once a day.
-                    match db.get_page_stale_reason(&page.id).await? {
-                        Some(_) => {
-                            db.update_page_content(
-                                &page.id,
-                                &content,
-                                &source_id_refs,
-                                "re_distill",
-                            )
-                            .await?;
-                            db.clear_page_staleness(&page.id).await?;
-                            recompiled += 1;
-                            log::info!("[re-distill-stale] refreshed page '{}'", page.title);
-                        }
-                        None => log::info!(
+                    // Real CAS: the content swap + version bump are gated on
+                    // `stale_reason IS NOT NULL` in the UPDATE itself, so a
+                    // concurrent agent-side PUT that cleared staleness wins
+                    // the race without us having to coordinate. No TOCTOU
+                    // window between the check and the write — it's one
+                    // statement.
+                    let landed = db
+                        .try_update_page_content_if_stale(
+                            &page.id,
+                            &content,
+                            &source_id_refs,
+                            "re_distill",
+                        )
+                        .await?;
+                    if landed {
+                        db.clear_page_staleness(&page.id).await?;
+                        recompiled += 1;
+                        log::info!("[re-distill-stale] refreshed page '{}'", page.title);
+                    } else {
+                        log::info!(
                             "[re-distill-stale] '{}' staleness already cleared, yielding",
                             page.title
-                        ),
+                        );
                     }
                 }
             }

--- a/crates/origin-core/src/refinery/mod.rs
+++ b/crates/origin-core/src/refinery/mod.rs
@@ -468,6 +468,18 @@ pub async fn run_periodic_steep_with_api(
     if trigger.runs_phase(Phase::Emergence) {
         let phase = run_phase(Phase::Emergence, || async {
             let count = distill_pages(db_ref, compile_llm, prompts, distillation, kp_ref).await?;
+            // Re-resolve orphan wikilinks now that distill may have created
+            // new pages. Cheap: one SELECT DISTINCT + per-label UPDATE for
+            // hits; no LLM. Captures the case where page A linked to
+            // [[Topic Z]] before Topic Z existed, and emergence just minted
+            // a Topic Z page.
+            match db_ref.resolve_orphan_page_links().await {
+                Ok(n) if n > 0 => {
+                    log::info!("[emergence] resolved {n} orphan wikilink labels");
+                }
+                Ok(_) => {}
+                Err(e) => log::warn!("[emergence] orphan link resolve failed: {e}"),
+            }
             let (nudge, headline) = classify_emergence(count);
             Ok(PhaseOutput {
                 items_processed: count,

--- a/crates/origin-core/src/sources/mod.rs
+++ b/crates/origin-core/src/sources/mod.rs
@@ -10,6 +10,7 @@
 //! structs used by connectors.
 pub mod local_files;
 pub mod obsidian;
+pub mod page_watcher;
 
 use crate::error::OriginError;
 use async_trait::async_trait;

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -148,12 +148,17 @@ async fn sync_one_file(
     // bumped version without re-projecting (e.g. refinery write without
     // KnowledgeWriter call), the md is behind — we'd otherwise roll the
     // DB back to a stale body.
+    // Accept `origin_version: 3`, `origin_version: 3.0`, or
+    // `origin_version: "3"` — YAML parses each into a different serde_yaml
+    // shape and a hand-edited frontmatter shouldn't lock the user out of
+    // future fs_edits just because they retyped the field as a float.
     let md_version: i64 = fm
         .fields
         .get("origin_version")
         .and_then(|v| {
             v.as_i64()
-                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+                .or_else(|| v.as_f64().map(|f| f as i64))
+                .or_else(|| v.as_str().and_then(|s| s.trim().parse::<i64>().ok()))
         })
         .unwrap_or(0);
     if md_version < existing.version {

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Poll-based filesystem watcher for the page projection at
+//! `~/.origin/pages/*.md`.
+//!
+//! md is canonical. When the user opens a page in Obsidian / VS Code / etc.
+//! and saves a change, the daemon's DB row goes stale. This module walks the
+//! projection on a scheduler tick, compares each file against its DB
+//! counterpart, and applies the edit back through `update_page_content`
+//! with `link_reason = "fs_edit"`. That flips `user_edited` (same effect
+//! as a `manual_edit` write via POST /api/pages/{id}) so the refinery's
+//! re-distill escalation branch fires instead of clobbering the user's
+//! prose.
+//!
+//! Conflict direction: if the md's `origin_version` is less than the DB's,
+//! the daemon wrote last and the md on disk is stale (probably from a
+//! refinery cycle that hasn't re-projected yet). We skip rather than
+//! roll the DB back. The reverse (md ahead, DB behind) doesn't happen in
+//! practice — the daemon is the only writer that bumps the version
+//! column.
+//!
+//! v1 is poll-only, runs on the same cadence as the refinery scheduler
+//! tick. An event-driven `notify` watcher is a follow-up if 30-second
+//! latency proves too slow.
+
+use crate::db::MemoryDB;
+use crate::error::OriginError;
+use crate::export::knowledge::KnowledgeWriter;
+use crate::sources::obsidian;
+use std::path::{Path, PathBuf};
+
+/// Counts the watcher reports back to the scheduler tick. Useful for the
+/// daily-status feed once the UI surface lands; for now the daemon just
+/// logs `applied` so an operator can see edits flowing.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WatcherStats {
+    /// Total .md files inspected this pass.
+    pub scanned: usize,
+    /// Edits successfully written back to the DB.
+    pub applied: usize,
+    /// File had no `origin_id` in the frontmatter — most likely a user-
+    /// added md the daemon hasn't claimed. Skipped, not auto-promoted.
+    pub skipped_no_origin_id: usize,
+    /// Frontmatter named a page_id the DB doesn't know. Dangling md from
+    /// an archived/deleted page or a manually-pasted file.
+    pub skipped_unknown_page: usize,
+    /// md version stamp is behind the DB. Daemon wrote last; md will get
+    /// re-projected on the next daemon write, no need to reflect it back.
+    pub skipped_daemon_ahead: usize,
+    /// md body matches DB content. No-op.
+    pub skipped_unchanged: usize,
+    /// IO or parse failures — surfaced via `log::warn!` per file.
+    pub errors: usize,
+}
+
+/// Scan `knowledge_path` for page md files, reflect external edits back
+/// into the DB. Idempotent and safe to call on every scheduler tick.
+pub async fn sync_filesystem_edits(
+    db: &MemoryDB,
+    knowledge_path: &Path,
+) -> Result<WatcherStats, OriginError> {
+    let mut stats = WatcherStats::default();
+    if !knowledge_path.exists() {
+        return Ok(stats);
+    }
+    let entries = match std::fs::read_dir(knowledge_path) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!(
+                "[page-watcher] read_dir({}) failed: {e}",
+                knowledge_path.display()
+            );
+            return Ok(stats);
+        }
+    };
+    let knowledge_path_buf: PathBuf = knowledge_path.to_path_buf();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        // Pages live flat under knowledge_path. Subdirectories (e.g. the
+        // `.origin/` state dir) aren't recursed.
+        if !path.is_file() || ext != "md" {
+            continue;
+        }
+        stats.scanned += 1;
+        match sync_one_file(db, &path, &knowledge_path_buf).await {
+            Ok(Outcome::Applied { page_id }) => {
+                stats.applied += 1;
+                log::info!(
+                    "[page-watcher] applied fs_edit for {page_id} from {}",
+                    path.display()
+                );
+            }
+            Ok(Outcome::SkippedNoOriginId) => stats.skipped_no_origin_id += 1,
+            Ok(Outcome::SkippedUnknownPage { page_id }) => {
+                stats.skipped_unknown_page += 1;
+                log::debug!(
+                    "[page-watcher] {} references unknown page {page_id}",
+                    path.display()
+                );
+            }
+            Ok(Outcome::SkippedDaemonAhead { page_id }) => {
+                stats.skipped_daemon_ahead += 1;
+                log::debug!("[page-watcher] {page_id}: md trails DB version, skipping");
+            }
+            Ok(Outcome::Unchanged) => stats.skipped_unchanged += 1,
+            Err(e) => {
+                stats.errors += 1;
+                log::warn!("[page-watcher] {}: {e}", path.display());
+            }
+        }
+    }
+    Ok(stats)
+}
+
+enum Outcome {
+    Applied { page_id: String },
+    SkippedNoOriginId,
+    SkippedUnknownPage { page_id: String },
+    SkippedDaemonAhead { page_id: String },
+    Unchanged,
+}
+
+async fn sync_one_file(
+    db: &MemoryDB,
+    path: &Path,
+    knowledge_path: &Path,
+) -> Result<Outcome, OriginError> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| OriginError::VectorDb(format!("read {}: {e}", path.display())))?;
+    let (fm, body) = obsidian::extract_frontmatter(&raw);
+    let page_id = match fm.get_str("origin_id") {
+        Some(s) if !s.trim().is_empty() => s.trim().to_string(),
+        _ => return Ok(Outcome::SkippedNoOriginId),
+    };
+
+    let existing = match db.get_page(&page_id).await? {
+        Some(p) => p,
+        None => return Ok(Outcome::SkippedUnknownPage { page_id }),
+    };
+
+    // Skip when md is stale relative to DB. `origin_version` in the
+    // frontmatter is written by KnowledgeWriter::render_markdown and
+    // tracks the DB's version column at projection time. If the daemon
+    // bumped version without re-projecting (e.g. refinery write without
+    // KnowledgeWriter call), the md is behind — we'd otherwise roll the
+    // DB back to a stale body.
+    let md_version: i64 = fm
+        .fields
+        .get("origin_version")
+        .and_then(|v| {
+            v.as_i64()
+                .or_else(|| v.as_str().and_then(|s| s.parse::<i64>().ok()))
+        })
+        .unwrap_or(0);
+    if md_version < existing.version {
+        return Ok(Outcome::SkippedDaemonAhead { page_id });
+    }
+
+    // Trim trailing newlines on both sides — render_markdown emits a
+    // trailing `\n` and editors tend to add their own. Otherwise a no-op
+    // save would look like a real edit forever.
+    let body_norm = body.trim_end_matches('\n');
+    let db_norm = existing.content.trim_end_matches('\n');
+    if body_norm == db_norm {
+        return Ok(Outcome::Unchanged);
+    }
+
+    // Preserve existing source list — the user edited prose, not the
+    // memory provenance. Sources change only via /distill refresh or
+    // explicit POST.
+    let source_refs: Vec<&str> = existing
+        .source_memory_ids
+        .iter()
+        .map(String::as_str)
+        .collect();
+    db.update_page_content(&page_id, body_norm, &source_refs, "fs_edit")
+        .await?;
+
+    // Re-project the md so the frontmatter's `origin_version` catches up
+    // with the DB. Without this, the next watcher tick would see md
+    // version still trailing the freshly-bumped DB version and refuse to
+    // process subsequent user edits as `SkippedDaemonAhead`. Loads the
+    // updated row to render with the new version + timestamps.
+    if let Some(refreshed) = db.get_page(&page_id).await? {
+        let writer = KnowledgeWriter::new(knowledge_path.to_path_buf());
+        if let Err(e) = writer.write_page(&refreshed) {
+            log::warn!("[page-watcher] DB updated for {page_id} but md re-projection failed: {e}");
+        }
+    }
+    Ok(Outcome::Applied { page_id })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::MemoryDB;
+    use crate::events::NoopEmitter;
+    use crate::pages::Page;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    async fn fresh_db() -> (MemoryDB, TempDir) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("test.db");
+        let emitter: Arc<dyn crate::events::EventEmitter> = Arc::new(NoopEmitter);
+        let db = MemoryDB::new(&path, emitter).await.unwrap();
+        (db, dir)
+    }
+
+    fn write_page_md(dir: &std::path::Path, page: &Page, body_override: Option<&str>) {
+        let body = body_override.unwrap_or(&page.content);
+        let domain_line = match &page.domain {
+            Some(d) => format!("domain: {d}\n"),
+            None => String::new(),
+        };
+        let content = format!(
+            "---\ntitle: \"{}\"\n{}origin_id: {}\norigin_version: {}\ncreated: {}\nmodified: {}\n---\n\n{}\n",
+            page.title,
+            domain_line,
+            page.id,
+            page.version,
+            page.created_at.chars().take(10).collect::<String>(),
+            page.last_modified.chars().take(10).collect::<String>(),
+            body
+        );
+        std::fs::write(dir.join(format!("{}.md", slug(&page.title))), content).unwrap();
+    }
+
+    fn slug(s: &str) -> String {
+        s.to_lowercase()
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect()
+    }
+
+    fn sample_page(id: &str, title: &str, content: &str) -> Page {
+        let now = chrono::Utc::now().to_rfc3339();
+        Page {
+            id: id.to_string(),
+            title: title.to_string(),
+            summary: None,
+            content: content.to_string(),
+            entity_id: None,
+            domain: None,
+            source_memory_ids: vec!["mem_seed".to_string()],
+            version: 1,
+            status: "active".to_string(),
+            created_at: now.clone(),
+            last_compiled: now.clone(),
+            last_modified: now,
+            sources_updated_count: 0,
+            stale_reason: None,
+            user_edited: false,
+            relevance_score: 0.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn applies_user_edit_when_md_body_differs() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page("page_a", "Topic A", "original body line");
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            &page.id,
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        write_page_md(knowledge_dir.path(), &page, Some("user-edited body line"));
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(stats.applied, 1);
+
+        let p = db.get_page("page_a").await.unwrap().unwrap();
+        assert_eq!(p.content, "user-edited body line");
+        // fs_edit must flip user_edited so refinery escalates instead of
+        // overwriting on the next re-distill.
+        assert!(p.user_edited);
+    }
+
+    #[tokio::test]
+    async fn no_op_when_md_matches_db() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page("page_b", "Topic B", "matching content");
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            &page.id,
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+        write_page_md(knowledge_dir.path(), &page, None);
+
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(stats.applied, 0);
+        assert_eq!(stats.skipped_unchanged, 1);
+    }
+
+    #[tokio::test]
+    async fn skips_md_with_no_origin_id() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        // User dropped a plain md in the page dir with no origin_id.
+        std::fs::write(
+            knowledge_dir.path().join("freeform.md"),
+            "---\ntitle: \"Random\"\n---\n\njust a note",
+        )
+        .unwrap();
+
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(stats.applied, 0);
+        assert_eq!(stats.skipped_no_origin_id, 1);
+    }
+
+    #[tokio::test]
+    async fn skips_md_pointing_at_unknown_page_id() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let ghost = sample_page("page_ghost", "Ghost", "ghost body");
+        // DB never inserted page_ghost — md is dangling.
+        write_page_md(knowledge_dir.path(), &ghost, None);
+
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(stats.applied, 0);
+        assert_eq!(stats.skipped_unknown_page, 1);
+    }
+
+    #[tokio::test]
+    async fn skips_when_md_version_trails_db() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_c",
+            "Topic C",
+            None,
+            "daemon body v3",
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+        // Daemon bumped version to 3 via two updates without re-projecting md.
+        db.update_page_content("page_c", "daemon body v2", &["mem_seed"], "re_distill")
+            .await
+            .unwrap();
+        db.update_page_content("page_c", "daemon body v3", &["mem_seed"], "re_distill")
+            .await
+            .unwrap();
+
+        // md frontmatter stamps origin_version: 1 — the projection from
+        // the original insert. md body differs from DB.
+        let mut stale = sample_page("page_c", "Topic C", "old body from disk");
+        stale.version = 1;
+        write_page_md(knowledge_dir.path(), &stale, None);
+
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        // Daemon ahead — don't roll DB back to the disk's old body.
+        assert_eq!(stats.applied, 0);
+        assert_eq!(stats.skipped_daemon_ahead, 1);
+        let p = db.get_page("page_c").await.unwrap().unwrap();
+        assert_eq!(p.content, "daemon body v3");
+        assert!(!p.user_edited);
+    }
+
+    #[tokio::test]
+    async fn applies_consecutive_user_edits() {
+        // Regression: after apply, md must be re-projected so the frontmatter
+        // origin_version stays in sync with the DB. Otherwise the second
+        // edit lands as SkippedDaemonAhead.
+        //
+        // Seed the page via KnowledgeWriter so state.json + filename + DB
+        // all line up the way they would in production. Subsequent edits
+        // rewrite that same file in place.
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page("page_x", "Topic X", "original body");
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            &page.id,
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+        let writer = KnowledgeWriter::new(knowledge_dir.path().to_path_buf());
+        writer.write_page(&page).unwrap();
+        let md_path = knowledge_dir
+            .path()
+            .join(writer.page_filename(&page.id).expect("state has file"));
+
+        // Edit #1 — replace body.
+        let projected = std::fs::read_to_string(&md_path).unwrap();
+        let header_end = projected.find("\n---\n\n").expect("frontmatter present");
+        let head = &projected[..header_end + "\n---\n\n".len()];
+        std::fs::write(&md_path, format!("{head}edit one\n")).unwrap();
+        let s1 = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(s1.applied, 1, "edit one must apply; got {:?}", s1);
+
+        // Edit #2 — same path, new body. The watcher's re-projection
+        // bumped origin_version, so a fresh read picks up the new header.
+        let projected = std::fs::read_to_string(&md_path).unwrap();
+        let header_end = projected.find("\n---\n\n").expect("frontmatter present");
+        let head = &projected[..header_end + "\n---\n\n".len()];
+        std::fs::write(&md_path, format!("{head}edit two — second pass\n")).unwrap();
+        let s2 = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(s2.applied, 1, "edit two must apply; got {:?}", s2);
+        let p = db.get_page("page_x").await.unwrap().unwrap();
+        assert_eq!(p.content, "edit two — second pass");
+    }
+
+    #[tokio::test]
+    async fn nonexistent_knowledge_path_is_a_noop() {
+        let (db, _ddir) = fresh_db().await;
+        let missing = std::path::PathBuf::from("/tmp/origin-page-watcher-nonexistent");
+        let stats = sync_filesystem_edits(&db, &missing).await.unwrap();
+        assert_eq!(stats, WatcherStats::default());
+    }
+}

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -58,6 +58,30 @@ pub async fn resolve_distill_target(
     Ok(None)
 }
 
+/// Build the "existing page titles" hint prefix that gets prepended to
+/// every distill user prompt so the LLM emits exact-match `[[Title]]`
+/// wikilinks instead of inventing labels. Returns an empty string when
+/// the page set is empty or the DB call errors (best-effort — the worst
+/// case is the LLM invents a label that the orphan-by-count feed will
+/// surface later). Capped at 100 most-recent titles so the prompt stays
+/// bounded on large vaults.
+pub(crate) async fn build_existing_titles_hint(db: &MemoryDB) -> String {
+    let titles = db.list_active_page_titles(100).await.unwrap_or_default();
+    if titles.is_empty() {
+        return String::new();
+    }
+    let formatted = titles
+        .iter()
+        .map(|t| format!("[[{t}]]"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "Existing pages you may reference with exact-match wikilinks: {formatted}\n\
+         Use these labels verbatim when linking; only invent a new label \
+         when the topic isn't already covered.\n\n"
+    )
+}
+
 /// LLM cluster refinement: for entities with multiple clusters, ask the LLM to merge/split/rename.
 pub(crate) async fn refine_clusters_with_llm(
     llm: &Arc<dyn LlmProvider>,
@@ -365,26 +389,7 @@ pub(crate) async fn distill_one_cluster(
         })
         .collect::<Vec<_>>()
         .join("\n\n");
-    // Seed the prompt with existing page titles so the LLM emits
-    // `[[Existing Title]]` exactly instead of inventing labels (e.g.
-    // "Rust Borrow Checker" vs "Rust Borrow-Checker") that the resolver
-    // can't match. Cap at 100 most-recent titles to keep the prompt
-    // bounded; orphan-by-count surfaces any drift the cap misses.
-    let existing_titles = db.list_active_page_titles(100).await.unwrap_or_default();
-    let titles_hint = if existing_titles.is_empty() {
-        String::new()
-    } else {
-        let formatted = existing_titles
-            .iter()
-            .map(|t| format!("[[{t}]]"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!(
-            "Existing pages you may reference with exact-match wikilinks: {formatted}\n\
-             Use these labels verbatim when linking; only invent a new label \
-             when the topic isn't already covered.\n\n"
-        )
-    };
+    let titles_hint = build_existing_titles_hint(db).await;
     let user_prompt = format!("{titles_hint}Topic: {}\n\n{}", topic, memories_block);
 
     let response = llm
@@ -775,25 +780,7 @@ pub async fn distill_pages_scoped(
             })
             .collect::<Vec<_>>()
             .join("\n\n");
-        // Seed the prompt with existing page titles so the LLM emits exact-
-        // match `[[Existing Title]]` wikilinks. Identical to the parallel
-        // path in distill_one_cluster; centralized in a helper would risk
-        // breaking the test harness which exercises one path at a time.
-        let existing_titles = db.list_active_page_titles(100).await.unwrap_or_default();
-        let titles_hint = if existing_titles.is_empty() {
-            String::new()
-        } else {
-            let formatted = existing_titles
-                .iter()
-                .map(|t| format!("[[{t}]]"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!(
-                "Existing pages you may reference with exact-match wikilinks: {formatted}\n\
-                 Use these labels verbatim when linking; only invent a new label \
-                 when the topic isn't already covered.\n\n"
-            )
-        };
+        let titles_hint = build_existing_titles_hint(db).await;
         let user_prompt = format!("{titles_hint}Topic: {}\n\n{}", topic, memories_block);
 
         let response = llm
@@ -1036,7 +1023,8 @@ pub(crate) async fn recompile_single_page(
         })
         .collect::<Vec<_>>()
         .join("\n\n");
-    let user_prompt = format!("Topic: {}\n\n{}", page.title, memories_block);
+    let titles_hint = build_existing_titles_hint(db).await;
+    let user_prompt = format!("{titles_hint}Topic: {}\n\n{}", page.title, memories_block);
 
     let response = llm
         .generate(LlmRequest {

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -365,7 +365,27 @@ pub(crate) async fn distill_one_cluster(
         })
         .collect::<Vec<_>>()
         .join("\n\n");
-    let user_prompt = format!("Topic: {}\n\n{}", topic, memories_block);
+    // Seed the prompt with existing page titles so the LLM emits
+    // `[[Existing Title]]` exactly instead of inventing labels (e.g.
+    // "Rust Borrow Checker" vs "Rust Borrow-Checker") that the resolver
+    // can't match. Cap at 100 most-recent titles to keep the prompt
+    // bounded; orphan-by-count surfaces any drift the cap misses.
+    let existing_titles = db.list_active_page_titles(100).await.unwrap_or_default();
+    let titles_hint = if existing_titles.is_empty() {
+        String::new()
+    } else {
+        let formatted = existing_titles
+            .iter()
+            .map(|t| format!("[[{t}]]"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "Existing pages you may reference with exact-match wikilinks: {formatted}\n\
+             Use these labels verbatim when linking; only invent a new label \
+             when the topic isn't already covered.\n\n"
+        )
+    };
+    let user_prompt = format!("{titles_hint}Topic: {}\n\n{}", topic, memories_block);
 
     let response = llm
         .generate(LlmRequest {
@@ -755,7 +775,26 @@ pub async fn distill_pages_scoped(
             })
             .collect::<Vec<_>>()
             .join("\n\n");
-        let user_prompt = format!("Topic: {}\n\n{}", topic, memories_block);
+        // Seed the prompt with existing page titles so the LLM emits exact-
+        // match `[[Existing Title]]` wikilinks. Identical to the parallel
+        // path in distill_one_cluster; centralized in a helper would risk
+        // breaking the test harness which exercises one path at a time.
+        let existing_titles = db.list_active_page_titles(100).await.unwrap_or_default();
+        let titles_hint = if existing_titles.is_empty() {
+            String::new()
+        } else {
+            let formatted = existing_titles
+                .iter()
+                .map(|t| format!("[[{t}]]"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "Existing pages you may reference with exact-match wikilinks: {formatted}\n\
+                 Use these labels verbatim when linking; only invent a new label \
+                 when the topic isn't already covered.\n\n"
+            )
+        };
+        let user_prompt = format!("{titles_hint}Topic: {}\n\n{}", topic, memories_block);
 
         let response = llm
             .generate(LlmRequest {

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -577,6 +577,7 @@ pub async fn distill_pages_scoped(
                     tuning.max_clusters_per_steep,
                     16_000,
                     tuning.max_unlinked_cluster_size,
+                    tuning.max_grouped_cluster_size,
                     entity_id_filter.as_deref(),
                     domain_filter.as_deref(),
                 )
@@ -616,6 +617,7 @@ pub async fn distill_pages_scoped(
             tuning.max_clusters_per_steep,
             token_limit,
             tuning.max_unlinked_cluster_size,
+            tuning.max_grouped_cluster_size,
             entity_id_filter.as_deref(),
             domain_filter.as_deref(),
         )

--- a/crates/origin-core/src/synthesis/emergence.rs
+++ b/crates/origin-core/src/synthesis/emergence.rs
@@ -54,9 +54,31 @@ pub(crate) async fn assign_orphan_memories(
         .collect::<Vec<_>>()
         .join("\n");
 
+    // Surface labels that 2+ other pages link to but no page is named for —
+    // those are first-class topic candidates the LLM should consider when
+    // proposing new pages from orphan memories. The orphan-by-count signal
+    // is the "the rest of the wiki is asking for this page" feed; feeding
+    // it here closes the loop instead of leaving it as a queryable metric
+    // nothing consumes. Best-effort: a failure logs and falls through.
+    let orphan_labels = db.list_orphan_link_labels(2).await.unwrap_or_default();
+    let orphan_hint = if orphan_labels.is_empty() {
+        String::new()
+    } else {
+        let formatted = orphan_labels
+            .iter()
+            .map(|(label, count)| format!("[[{label}]] ({count} other pages)"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!(
+            "\n\nTopics other pages already link to but aren't pages yet — \
+             promote a memory cluster into a new page when the orphan memories \
+             match one of these labels:\n{formatted}"
+        )
+    };
+
     let user_prompt = format!(
-        "Unassigned memories:\n{}\n\nExisting concepts:\n{}",
-        memories_text, concepts_text
+        "Unassigned memories:\n{}\n\nExisting concepts:\n{}{}",
+        memories_text, concepts_text, orphan_hint
     );
 
     let response = llm

--- a/crates/origin-core/src/synthesis/mod.rs
+++ b/crates/origin-core/src/synthesis/mod.rs
@@ -10,3 +10,4 @@ pub mod distill;
 pub mod emergence;
 pub mod recaps;
 pub mod refinement_queue;
+pub mod wikilinks;

--- a/crates/origin-core/src/synthesis/wikilinks.rs
+++ b/crates/origin-core/src/synthesis/wikilinks.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wikilink extraction + resolution.
+//!
+//! Pages are written with `[[Label]]` link syntax. The distill prompt emits
+//! them, users write them by hand. The daemon's job is to:
+//!   1. Pull `[[Label]]` occurrences out of a page body.
+//!   2. Resolve each label against current page titles (case-insensitive,
+//!      trimmed). No fuzzy matching in v1 — the LLM's job is to use exact
+//!      titles, and the orphan-by-label feed surfaces drift.
+//!   3. Persist resolved/unresolved pairs into the `page_links` table so the
+//!      refinery can re-resolve later (when a target page is created) and
+//!      emergence can mine repeated orphan labels as topic candidates.
+//!
+//! The extraction regex deliberately rejects pipe-aliased links (`[[Target|alias]]`)
+//! by capturing only the label segment; if Obsidian-style aliases become
+//! load-bearing later we'll plumb the alias separately, but the link's
+//! identity is the target label, not the visible text.
+
+use crate::db::MemoryDB;
+use crate::error::OriginError;
+use std::collections::HashSet;
+
+/// A `[[Label]]` reference parsed out of a page body. `target_page_id` is
+/// `None` when the resolver couldn't find a matching page title — those rows
+/// land in `page_links` with NULL target so the refinery's orphan resolve
+/// phase can pick them up later.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Wikilink {
+    pub label: String,
+    pub target_page_id: Option<String>,
+}
+
+/// Pull every `[[...]]` occurrence out of `content`. Returns labels in the
+/// order they appear, deduplicated case-insensitively (a label is the link's
+/// identity, not its location — a page that mentions `[[Rust]]` four times
+/// produces one outbound edge, not four). Whitespace inside the braces is
+/// trimmed; empty labels (`[[]]`) are dropped.
+///
+/// The label is whatever sits between `[[` and the first `|` or `]]` — so
+/// `[[Target|alias]]` extracts as `"Target"`.
+pub fn extract_wikilinks(content: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'[' && bytes[i + 1] == b'[' {
+            // Find the matching `]]`. UTF-8 safe because we only compare
+            // bytes against ASCII `]` / `|`, never slice on a non-ASCII
+            // boundary — the slice endpoints are always at ASCII positions.
+            let start = i + 2;
+            let mut j = start;
+            let mut end = None;
+            while j + 1 < bytes.len() {
+                if bytes[j] == b']' && bytes[j + 1] == b']' {
+                    end = Some(j);
+                    break;
+                }
+                j += 1;
+            }
+            match end {
+                Some(close) => {
+                    // Stop at the first `|` so aliased links extract the
+                    // target, not the display text.
+                    let pipe = content[start..close].find('|');
+                    let raw_label = match pipe {
+                        Some(p) => &content[start..start + p],
+                        None => &content[start..close],
+                    };
+                    let label = raw_label.trim().to_string();
+                    if !label.is_empty() {
+                        let key = label.to_lowercase();
+                        if seen.insert(key) {
+                            out.push(label);
+                        }
+                    }
+                    i = close + 2;
+                    continue;
+                }
+                None => break, // unmatched `[[` at end of input — bail
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Resolve each extracted label against the current `pages` table.
+/// Case-insensitive exact match on title, restricted to `status='active'`.
+/// Unresolved labels keep `target_page_id = None` so the caller can persist
+/// them as orphan rows.
+pub async fn resolve_against_pages(
+    db: &MemoryDB,
+    labels: &[String],
+) -> Result<Vec<Wikilink>, OriginError> {
+    let mut out = Vec::with_capacity(labels.len());
+    for label in labels {
+        let target = db.find_active_page_id_by_title(label).await?;
+        out.push(Wikilink {
+            label: label.clone(),
+            target_page_id: target,
+        });
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_single_link() {
+        let v = extract_wikilinks("hello [[Rust Ownership]] world");
+        assert_eq!(v, vec!["Rust Ownership"]);
+    }
+
+    #[test]
+    fn extract_multiple_links_preserve_order() {
+        let v = extract_wikilinks("[[Alpha]] then [[Beta]] then [[Gamma]]");
+        assert_eq!(v, vec!["Alpha", "Beta", "Gamma"]);
+    }
+
+    #[test]
+    fn extract_dedups_case_insensitively() {
+        let v = extract_wikilinks("[[Origin]] and [[origin]] and [[ORIGIN]]");
+        // Keep first-seen casing as the canonical label.
+        assert_eq!(v, vec!["Origin"]);
+    }
+
+    #[test]
+    fn extract_handles_aliased_links() {
+        let v = extract_wikilinks("see [[Rust Ownership|borrowing rules]] for more");
+        assert_eq!(v, vec!["Rust Ownership"]);
+    }
+
+    #[test]
+    fn extract_drops_empty_labels() {
+        let v = extract_wikilinks("[[]] and [[   ]] are noise");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn extract_ignores_unmatched_brackets() {
+        // Unmatched `[[` at end of input must not panic or slice past the
+        // buffer.
+        let v = extract_wikilinks("legit [[Foo]] then trailing [[");
+        assert_eq!(v, vec!["Foo"]);
+    }
+
+    #[test]
+    fn extract_handles_utf8_payload() {
+        let v = extract_wikilinks("café [[Naïve Bayes]] résumé");
+        assert_eq!(v, vec!["Naïve Bayes"]);
+    }
+
+    #[test]
+    fn extract_strips_inner_whitespace() {
+        let v = extract_wikilinks("[[  Spaces  ]]");
+        assert_eq!(v, vec!["Spaces"]);
+    }
+
+    #[test]
+    fn extract_returns_empty_for_no_links() {
+        let v = extract_wikilinks("plain prose with [no brackets] only");
+        assert!(v.is_empty());
+    }
+}

--- a/crates/origin-core/src/synthesis/wikilinks.rs
+++ b/crates/origin-core/src/synthesis/wikilinks.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Wikilink extraction + resolution.
+//! Wikilink graph for distilled pages.
 //!
 //! Pages are written with `[[Label]]` link syntax. The distill prompt emits
 //! them, users write them by hand. The daemon's job is to:
@@ -11,85 +11,55 @@
 //!      refinery can re-resolve later (when a target page is created) and
 //!      emergence can mine repeated orphan labels as topic candidates.
 //!
-//! The extraction regex deliberately rejects pipe-aliased links (`[[Target|alias]]`)
-//! by capturing only the label segment; if Obsidian-style aliases become
-//! load-bearing later we'll plumb the alias separately, but the link's
-//! identity is the target label, not the visible text.
+//! Parsing delegates to `sources::obsidian::extract_wikilinks` — that module
+//! already handles code-block exclusion, aliased links, and heading anchors
+//! correctly. Here we strip the structural details (heading / display /
+//! embed flag) down to the target label, since the link's identity for
+//! graph purposes is the target, not the display text.
 
 use crate::db::MemoryDB;
 use crate::error::OriginError;
+use crate::sources::obsidian;
 use std::collections::HashSet;
 
-/// A `[[Label]]` reference parsed out of a page body. `target_page_id` is
-/// `None` when the resolver couldn't find a matching page title — those rows
-/// land in `page_links` with NULL target so the refinery's orphan resolve
-/// phase can pick them up later.
+/// A wikilink reference stored in or read from the `page_links` table.
+/// `target_page_id` is `None` when the resolver couldn't find a matching
+/// page title — those rows persist with NULL target so the refinery's
+/// orphan-resolve phase can pick them up later.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Wikilink {
     pub label: String,
     pub target_page_id: Option<String>,
 }
 
-/// Pull every `[[...]]` occurrence out of `content`. Returns labels in the
-/// order they appear, deduplicated case-insensitively (a label is the link's
-/// identity, not its location — a page that mentions `[[Rust]]` four times
-/// produces one outbound edge, not four). Whitespace inside the braces is
-/// trimmed; empty labels (`[[]]`) are dropped.
-///
-/// The label is whatever sits between `[[` and the first `|` or `]]` — so
-/// `[[Target|alias]]` extracts as `"Target"`.
+/// Pull every `[[Label]]` reference out of `content`, returning labels in
+/// document order, deduplicated case-insensitively. Skips embeds (`![[...]]`,
+/// reserved for transclusion) and links inside fenced code blocks. The
+/// obsidian regex naturally rejects targets containing `]`, `|`, or `#`
+/// so malformed input like `[[[[foo]]]]` or `[[foo]bar]]` produces nothing.
 pub fn extract_wikilinks(content: &str) -> Vec<String> {
+    let parsed = obsidian::extract_wikilinks(content);
     let mut out: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
-    let bytes = content.as_bytes();
-    let mut i = 0;
-    while i + 1 < bytes.len() {
-        if bytes[i] == b'[' && bytes[i + 1] == b'[' {
-            // Find the matching `]]`. UTF-8 safe because we only compare
-            // bytes against ASCII `]` / `|`, never slice on a non-ASCII
-            // boundary — the slice endpoints are always at ASCII positions.
-            let start = i + 2;
-            let mut j = start;
-            let mut end = None;
-            while j + 1 < bytes.len() {
-                if bytes[j] == b']' && bytes[j + 1] == b']' {
-                    end = Some(j);
-                    break;
-                }
-                j += 1;
-            }
-            match end {
-                Some(close) => {
-                    // Stop at the first `|` so aliased links extract the
-                    // target, not the display text.
-                    let pipe = content[start..close].find('|');
-                    let raw_label = match pipe {
-                        Some(p) => &content[start..start + p],
-                        None => &content[start..close],
-                    };
-                    let label = raw_label.trim().to_string();
-                    // Reject labels that carry stray brackets — those come
-                    // from malformed input like `[[[[foo]]]]` (extracts
-                    // `[[foo`) or `[[foo]bar]]` (extracts `foo]bar`).
-                    // Garbage labels would pollute page_links and the
-                    // orphan-by-count feed. The skipped occurrence still
-                    // advances `i` past the close so the rest of the body
-                    // keeps parsing.
-                    let well_formed =
-                        !label.is_empty() && !label.contains('[') && !label.contains(']');
-                    if well_formed {
-                        let key = label.to_lowercase();
-                        if seen.insert(key) {
-                            out.push(label);
-                        }
-                    }
-                    i = close + 2;
-                    continue;
-                }
-                None => break, // unmatched `[[` at end of input — bail
-            }
+    for link in parsed {
+        if link.is_embed {
+            continue;
         }
-        i += 1;
+        let label = link.target.trim().to_string();
+        if label.is_empty() {
+            continue;
+        }
+        // Obsidian's regex accepts `[` inside the target since `[^\]|#]+`
+        // doesn't exclude it — so `[[[[foo]]]]` captures `[[foo`. Reject
+        // labels that carry stray brackets; they'd poison page_links and
+        // the orphan-by-count feed.
+        if label.contains('[') || label.contains(']') {
+            continue;
+        }
+        let key = label.to_lowercase();
+        if seen.insert(key) {
+            out.push(label);
+        }
     }
     out
 }
@@ -132,40 +102,43 @@ mod tests {
     #[test]
     fn extract_dedups_case_insensitively() {
         let v = extract_wikilinks("[[Origin]] and [[origin]] and [[ORIGIN]]");
-        // Keep first-seen casing as the canonical label.
+        // Keep first-seen casing.
         assert_eq!(v, vec!["Origin"]);
     }
 
     #[test]
     fn extract_handles_aliased_links() {
+        // Obsidian regex captures `target` as group 2; display text is
+        // stripped here.
         let v = extract_wikilinks("see [[Rust Ownership|borrowing rules]] for more");
         assert_eq!(v, vec!["Rust Ownership"]);
     }
 
     #[test]
-    fn extract_drops_empty_labels() {
-        let v = extract_wikilinks("[[]] and [[   ]] are noise");
-        assert!(v.is_empty());
+    fn extract_strips_heading_anchor() {
+        // `[[Page#Section]]` reduces to the target page.
+        let v = extract_wikilinks("see [[Rust Ownership#borrowing]] below");
+        assert_eq!(v, vec!["Rust Ownership"]);
     }
 
     #[test]
-    fn extract_ignores_unmatched_brackets() {
-        // Unmatched `[[` at end of input must not panic or slice past the
-        // buffer.
-        let v = extract_wikilinks("legit [[Foo]] then trailing [[");
-        assert_eq!(v, vec!["Foo"]);
+    fn extract_skips_embeds() {
+        // Embeds (`![[...]]`) are for transclusion — out of scope for the
+        // graph. Plain `[[...]]` is the citation link.
+        let v = extract_wikilinks("![[Diagram]] then [[Real Link]]");
+        assert_eq!(v, vec!["Real Link"]);
+    }
+
+    #[test]
+    fn extract_skips_code_block_wikilinks() {
+        let v = extract_wikilinks("real [[A]]\n\n```\n[[NotALink]]\n```\n\nmore [[B]]");
+        assert_eq!(v, vec!["A", "B"]);
     }
 
     #[test]
     fn extract_handles_utf8_payload() {
         let v = extract_wikilinks("café [[Naïve Bayes]] résumé");
         assert_eq!(v, vec!["Naïve Bayes"]);
-    }
-
-    #[test]
-    fn extract_strips_inner_whitespace() {
-        let v = extract_wikilinks("[[  Spaces  ]]");
-        assert_eq!(v, vec!["Spaces"]);
     }
 
     #[test]
@@ -176,23 +149,24 @@ mod tests {
 
     #[test]
     fn extract_rejects_nested_brackets() {
-        // `[[[[foo]]]]` matches `[[` then walks to first `]]`, would yield
-        // `"[[foo"`. Reject it — that label would poison the orphan feed.
+        // `[[[[foo]]]]` — obsidian regex captures target `[[foo` (it allows
+        // `[` inside the target group). The bracket post-filter drops it.
         let v = extract_wikilinks("noise [[[[foo]]]] more");
         assert!(v.is_empty());
     }
 
     #[test]
     fn extract_rejects_stray_closing_bracket() {
-        // `[[foo]bar]]` walks to the SECOND `]]` and yields `"foo]bar"`.
-        // Reject.
+        // `[[foo]bar]]` — obsidian regex fails to find a complete
+        // `[[...]]` since target stops at the inner `]` but `\]\]` isn't
+        // there immediately after. Nothing captured.
         let v = extract_wikilinks("noise [[foo]bar]] more");
         assert!(v.is_empty());
     }
 
     #[test]
-    fn extract_keeps_well_formed_after_rejecting_garbage() {
-        // Garbage followed by a real link — extractor must recover.
+    fn extract_keeps_well_formed_after_garbage() {
+        // Bracket post-filter drops the captured `[[foo`; real link survives.
         let v = extract_wikilinks("[[[[foo]]]] and [[Real Link]] keep going");
         assert_eq!(v, vec!["Real Link"]);
     }

--- a/crates/origin-core/src/synthesis/wikilinks.rs
+++ b/crates/origin-core/src/synthesis/wikilinks.rs
@@ -68,7 +68,16 @@ pub fn extract_wikilinks(content: &str) -> Vec<String> {
                         None => &content[start..close],
                     };
                     let label = raw_label.trim().to_string();
-                    if !label.is_empty() {
+                    // Reject labels that carry stray brackets — those come
+                    // from malformed input like `[[[[foo]]]]` (extracts
+                    // `[[foo`) or `[[foo]bar]]` (extracts `foo]bar`).
+                    // Garbage labels would pollute page_links and the
+                    // orphan-by-count feed. The skipped occurrence still
+                    // advances `i` past the close so the rest of the body
+                    // keeps parsing.
+                    let well_formed =
+                        !label.is_empty() && !label.contains('[') && !label.contains(']');
+                    if well_formed {
                         let key = label.to_lowercase();
                         if seen.insert(key) {
                             out.push(label);
@@ -163,5 +172,28 @@ mod tests {
     fn extract_returns_empty_for_no_links() {
         let v = extract_wikilinks("plain prose with [no brackets] only");
         assert!(v.is_empty());
+    }
+
+    #[test]
+    fn extract_rejects_nested_brackets() {
+        // `[[[[foo]]]]` matches `[[` then walks to first `]]`, would yield
+        // `"[[foo"`. Reject it — that label would poison the orphan feed.
+        let v = extract_wikilinks("noise [[[[foo]]]] more");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn extract_rejects_stray_closing_bracket() {
+        // `[[foo]bar]]` walks to the SECOND `]]` and yields `"foo]bar"`.
+        // Reject.
+        let v = extract_wikilinks("noise [[foo]bar]] more");
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn extract_keeps_well_formed_after_rejecting_garbage() {
+        // Garbage followed by a real link — extractor must recover.
+        let v = extract_wikilinks("[[[[foo]]]] and [[Real Link]] keep going");
+        assert_eq!(v, vec!["Real Link"]);
     }
 }

--- a/crates/origin-core/src/tuning.rs
+++ b/crates/origin-core/src/tuning.rs
@@ -111,6 +111,9 @@ fn d_false() -> bool {
 fn d_10_usize() -> usize {
     10
 }
+fn d_12_usize() -> usize {
+    12
+}
 fn d_50_usize() -> usize {
     50
 }
@@ -316,6 +319,14 @@ pub struct DistillationConfig {
     /// for the runaway-cluster failure mode (see spec 2026-04-25).
     #[serde(default = "d_50_usize")]
     pub max_unlinked_cluster_size: usize,
+    /// Hard cap on size of entity- or community-grouped clusters before the
+    /// agent's coherence check rejects them as grab-bags. A 12+ prose-memory
+    /// cluster at the default 0.73 similarity is almost always a community
+    /// pile (e.g. cid=16 "Origin" sweeping in unrelated sub-topics). When a
+    /// grouped sub-cluster exceeds this, re-split once at threshold +0.05
+    /// (cap 0.92) and drop sub-clusters that still overflow.
+    #[serde(default = "d_12_usize")]
+    pub max_grouped_cluster_size: usize,
     /// Minimum source-memory overlap required for a page to pass the
     /// retrieval-time relevance gate. A page is included in chat context
     /// only if at least this many of its source memories appear in the
@@ -580,6 +591,7 @@ impl Default for DistillationConfig {
             page_growth_threshold: d_075(),
             page_boost: d_13_f32(),
             max_unlinked_cluster_size: d_50_usize(),
+            max_grouped_cluster_size: d_12_usize(),
             page_min_overlap: d_2_usize(),
             export_vault_path: None,
         }
@@ -758,6 +770,12 @@ score_threshold = 0.25
     fn distillation_config_default_has_unlinked_cluster_cap() {
         let cfg = DistillationConfig::default();
         assert_eq!(cfg.max_unlinked_cluster_size, 50);
+    }
+
+    #[test]
+    fn distillation_config_default_has_grouped_cluster_cap() {
+        let cfg = DistillationConfig::default();
+        assert_eq!(cfg.max_grouped_cluster_size, 12);
     }
 
     #[test]

--- a/crates/origin-mcp/src/client.rs
+++ b/crates/origin-mcp/src/client.rs
@@ -120,6 +120,20 @@ impl OriginClient {
         Self::parse_response(&bytes)
     }
 
+    /// PUT request with JSON body, deserialize JSON response.
+    pub async fn put<B: Serialize, R: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<R, OriginError> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .send_with_retry(|| self.client.put(&url).json(body))
+            .await?;
+        let bytes = Self::read_body(resp).await?;
+        Self::parse_response(&bytes)
+    }
+
     /// Query the daemon's /api/health, compare versions, and return a
     /// human-readable warning if origin-mcp is older than the daemon's minor.
     /// Returns None if compatible OR if the daemon is unreachable / response

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -280,6 +280,14 @@ pub struct GetPageParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetPageLinksParams {
+    #[schemars(
+        description = "Page id (e.g. 'page_abc'). Returns inbound + outbound wikilink graph for that page."
+    )]
+    pub page_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListMemoriesParams {
     #[schemars(
         description = "Filter by memory type (e.g. 'fact', 'preference', 'decision'). Optional."
@@ -822,6 +830,16 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
+    pub async fn get_page_links_impl(&self, page_id: &str) -> Result<CallToolResult, McpError> {
+        let path = format!("/api/pages/{}/links", page_id);
+        let resp: serde_json::Value = match self.client.get(&path).await {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "get_page_links")),
+        };
+        let pretty = serde_json::to_string_pretty(&resp).unwrap_or_else(|_| resp.to_string());
+        Ok(CallToolResult::success(vec![Content::text(pretty)]))
+    }
+
     pub async fn list_memories_impl(
         &self,
         params: ListMemoriesParams,
@@ -1130,6 +1148,23 @@ impl OriginMcpServer {
         Parameters(params): Parameters<GetPageParams>,
     ) -> Result<CallToolResult, McpError> {
         self.get_page_impl(&params.page_id).await
+    }
+
+    #[tool(
+        description = "Fetch the wikilink graph centered on one page: `outbound` (labels parsed out of this page's body, with target_page_id set when matched; NULL means broken/orphan) and `inbound` (active pages whose body cites this title). Use this for the /read preview to surface 'N inbound, M broken' without parsing the full body.",
+        annotations(
+            title = "Get page links",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn get_page_links(
+        &self,
+        Parameters(params): Parameters<GetPageLinksParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.get_page_links_impl(&params.page_id).await
     }
 
     #[tool(
@@ -2794,6 +2829,7 @@ mod tests {
             "update_page",
             "delete_page",
             "get_page",
+            "get_page_links",
             "list_memories",
             "search_pages",
             "list_pages_recent",

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -252,6 +252,26 @@ pub struct DeletePageParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct UpdatePageParams {
+    #[schemars(
+        description = "Page id (e.g. 'page_abc' or legacy 'concept_abc'). Get it from the `stale_pages` block in distill output."
+    )]
+    pub page_id: String,
+    #[schemars(
+        description = "Refreshed markdown body — same wiki-prose style as create_page. Replaces the existing content."
+    )]
+    pub content: String,
+    #[schemars(
+        description = "Full source_memory_ids list for the refreshed page — typically the stale page's existing list (carry through from distill output)."
+    )]
+    pub source_memory_ids: Vec<String>,
+    #[schemars(
+        description = "Optional one-sentence summary. Omit to keep the existing summary; pass empty string to clear it."
+    )]
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct GetPageParams {
     #[schemars(
         description = "Page id (e.g. 'page_abc' or legacy 'concept_abc'). For title-based lookup, search via recall or the daemon's /api/pages/search."
@@ -748,6 +768,26 @@ impl OriginMcpServer {
         ))]))
     }
 
+    pub async fn update_page_impl(
+        &self,
+        params: UpdatePageParams,
+    ) -> Result<CallToolResult, McpError> {
+        let req = origin_types::requests::RefreshPageRequest {
+            content: params.content,
+            source_memory_ids: params.source_memory_ids,
+            summary: params.summary,
+        };
+        let path = format!("/api/pages/{}", params.page_id);
+        let _: serde_json::Value = match self.client.put(&path, &req).await {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "update_page")),
+        };
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Refreshed page {}",
+            params.page_id
+        ))]))
+    }
+
     pub async fn delete_page_impl(&self, page_id: &str) -> Result<CallToolResult, McpError> {
         if self.transport == TransportMode::Http {
             return Ok(CallToolResult::error(vec![Content::text(
@@ -1045,6 +1085,23 @@ impl OriginMcpServer {
         Parameters(params): Parameters<CreatePageParams>,
     ) -> Result<CallToolResult, McpError> {
         self.create_page_impl(params).await
+    }
+
+    #[tool(
+        description = "Refresh a stale page in place. Replaces content + source_memory_ids + optional summary, clears the daemon's stale_reason in the same call. Preserves page_id, created_at, and bumps version monotonically — external [[wikilinks]] keep working. Use this on entries in the /distill response's `stale_pages` block instead of delete_page + create_page (which churned ids and lost version history).",
+        annotations(
+            title = "Refresh page",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn update_page(
+        &self,
+        Parameters(params): Parameters<UpdatePageParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.update_page_impl(params).await
     }
 
     #[tool(
@@ -2669,6 +2726,62 @@ mod tests {
         assert_eq!(req.limit, 100);
     }
 
+    // --- UpdatePageParams ---
+
+    #[test]
+    fn test_update_page_params_minimal() {
+        let json =
+            r#"{"page_id": "page_abc", "content": "fresh body", "source_memory_ids": ["mem_1"]}"#;
+        let params: UpdatePageParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.page_id, "page_abc");
+        assert_eq!(params.content, "fresh body");
+        assert_eq!(params.source_memory_ids, vec!["mem_1"]);
+        assert!(params.summary.is_none());
+    }
+
+    #[test]
+    fn test_update_page_params_with_summary() {
+        let json = r#"{
+            "page_id": "page_abc",
+            "content": "body",
+            "source_memory_ids": ["mem_1", "mem_2"],
+            "summary": "Refreshed claim."
+        }"#;
+        let params: UpdatePageParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.summary.as_deref(), Some("Refreshed claim."));
+        assert_eq!(params.source_memory_ids.len(), 2);
+    }
+
+    #[test]
+    fn test_update_page_params_missing_required_fails() {
+        // Missing source_memory_ids is a hard fail — refresh without sources
+        // would orphan the page from its provenance trail.
+        let json = r#"{"page_id": "page_abc", "content": "body"}"#;
+        let result = serde_json::from_str::<UpdatePageParams>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_page_request_body_shape() {
+        let params = UpdatePageParams {
+            page_id: "page_abc".into(),
+            content: "Body".into(),
+            source_memory_ids: vec!["mem_1".into()],
+            summary: Some("S".into()),
+        };
+        let req = origin_types::requests::RefreshPageRequest {
+            content: params.content,
+            source_memory_ids: params.source_memory_ids,
+            summary: params.summary,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["content"], "Body");
+        assert_eq!(json["source_memory_ids"], serde_json::json!(["mem_1"]));
+        assert_eq!(json["summary"], "S");
+        // page_id stays in the URL, never the body.
+        assert!(json.get("page_id").is_none());
+    }
+
     // --- Tool registration ---
 
     #[test]
@@ -2678,6 +2791,7 @@ mod tests {
             "create_entity",
             "create_relation",
             "create_page",
+            "update_page",
             "delete_page",
             "get_page",
             "list_memories",

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -786,7 +786,10 @@ impl OriginMcpServer {
             summary: params.summary,
         };
         let path = format!("/api/pages/{}", params.page_id);
-        let _: serde_json::Value = match self.client.put(&path, &req).await {
+        // Typed end-to-end: a wire-shape drift on the daemon side fails at
+        // deserialize instead of silently returning the no-op "Refreshed"
+        // line. Same discipline as PR #77's search_pages / list_pages_recent.
+        let _: origin_types::responses::SuccessResponse = match self.client.put(&path, &req).await {
             Ok(r) => r,
             Err(e) => return Ok(tool_error(e, "update_page")),
         };
@@ -832,11 +835,12 @@ impl OriginMcpServer {
 
     pub async fn get_page_links_impl(&self, page_id: &str) -> Result<CallToolResult, McpError> {
         let path = format!("/api/pages/{}/links", page_id);
-        let resp: serde_json::Value = match self.client.get(&path).await {
+        // Typed end-to-end via PageLinksResponse — keeps wire shape pinned.
+        let resp: origin_types::responses::PageLinksResponse = match self.client.get(&path).await {
             Ok(r) => r,
             Err(e) => return Ok(tool_error(e, "get_page_links")),
         };
-        let pretty = serde_json::to_string_pretty(&resp).unwrap_or_else(|_| resp.to_string());
+        let pretty = serde_json::to_string_pretty(&resp).unwrap_or_else(|_| String::new());
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -3199,36 +3199,37 @@ pub async fn handle_get_snapshot_captures_with_content(
 pub async fn handle_get_page_links(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(id): Path<String>,
-) -> Result<Json<serde_json::Value>, ServerError> {
+) -> Result<Json<origin_types::responses::PageLinksResponse>, ServerError> {
     let db = {
         let s = state.read().await;
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
-    let outbound = db
+    let outbound_raw = db
         .get_page_outbound_links(&id)
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?;
-    let inbound = db
+    let inbound_raw = db
         .get_page_inbound_links(&id)
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?;
-    let outbound_json: Vec<serde_json::Value> = outbound
+    let outbound = outbound_raw
         .into_iter()
-        .map(|l| {
-            serde_json::json!({
-                "label": l.label,
-                "target_page_id": l.target_page_id,
-            })
+        .map(|l| origin_types::responses::PageLinkOutbound {
+            label: l.label,
+            target_page_id: l.target_page_id,
         })
         .collect();
-    let inbound_json: Vec<serde_json::Value> = inbound
+    let inbound = inbound_raw
         .into_iter()
-        .map(|(src, label)| serde_json::json!({"source_page_id": src, "label": label}))
+        .map(|(src, label)| origin_types::responses::PageLinkInbound {
+            source_page_id: src,
+            label,
+        })
         .collect();
-    Ok(Json(serde_json::json!({
-        "outbound": outbound_json,
-        "inbound": inbound_json,
-    })))
+    Ok(Json(origin_types::responses::PageLinksResponse {
+        outbound,
+        inbound,
+    }))
 }
 
 #[derive(Debug, Default, serde::Deserialize)]

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -3204,6 +3204,113 @@ pub async fn handle_update_page(
     Ok(Json(origin_types::responses::SuccessResponse { ok: true }))
 }
 
+/// PUT /api/pages/{id}
+///
+/// Agent-side refresh of a page from its current sources. Replaces content,
+/// source list, optional summary; clears `stale_reason` so the refinery's
+/// re-distill skips on its next tick (CAS pattern — see refinery
+/// `re_distill_stale_pages`). Distinct from POST `/api/pages/{id}`
+/// (manual edit, flips `user_edited`, preserves sources).
+///
+/// Atomicity mirrors `handle_create_page`: write md first, persist DB index
+/// second, roll back md on DB failure. Old md content is held in memory
+/// for the rollback path so a failed DB update doesn't leave a stale .md
+/// without a matching row.
+pub async fn handle_refresh_page(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(id): Path<String>,
+    Json(req): Json<origin_types::requests::RefreshPageRequest>,
+) -> Result<Json<origin_types::responses::SuccessResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+
+    let existing = db
+        .get_page(&id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?
+        .ok_or_else(|| ServerError::ValidationError(format!("page {} not found", id)))?;
+
+    let knowledge_path = origin_core::config::load_config().knowledge_path_or_default();
+    let writer = origin_core::export::knowledge::KnowledgeWriter::new(knowledge_path.clone());
+
+    // Snapshot the current md content for rollback. If the file is missing
+    // we tolerate it — the page may have been created before the projection
+    // existed; the rollback then becomes a remove_page.
+    let existing_state_file = writer.page_filename(&id);
+    let existing_md_content = existing_state_file
+        .as_ref()
+        .and_then(|f| std::fs::read_to_string(knowledge_path.join(f)).ok());
+
+    // Build the refreshed Page for md rendering. Bump version + last_modified
+    // mirror what `update_page_content` writes to the DB row.
+    let now = chrono::Utc::now().to_rfc3339();
+    let refreshed_summary = match &req.summary {
+        Some(s) => Some(s.clone()),
+        None => existing.summary.clone(),
+    };
+    let refreshed_page = origin_core::pages::Page {
+        id: existing.id.clone(),
+        title: existing.title.clone(),
+        summary: refreshed_summary.clone(),
+        content: req.content.clone(),
+        entity_id: existing.entity_id.clone(),
+        domain: existing.domain.clone(),
+        source_memory_ids: req.source_memory_ids.clone(),
+        version: existing.version + 1,
+        status: existing.status.clone(),
+        created_at: existing.created_at.clone(),
+        last_compiled: now.clone(),
+        last_modified: now.clone(),
+        sources_updated_count: 0,
+        stale_reason: None,
+        user_edited: existing.user_edited,
+        relevance_score: 0.0,
+    };
+
+    // 1. md-first
+    writer
+        .write_page(&refreshed_page)
+        .map_err(|e| ServerError::IngestFailed(format!("write_page: {}", e)))?;
+
+    // 2. DB index — content + sources + summary + clear staleness.
+    let source_refs: Vec<&str> = req.source_memory_ids.iter().map(String::as_str).collect();
+    let db_result: Result<(), origin_core::error::OriginError> = async {
+        db.update_page_content(&id, &req.content, &source_refs, "agent_refresh")
+            .await?;
+        if req.summary.is_some() {
+            db.update_page_summary(&id, req.summary.as_deref()).await?;
+        }
+        db.clear_page_staleness(&id).await?;
+        Ok(())
+    }
+    .await;
+
+    if let Err(e) = db_result {
+        // Roll back md to the snapshotted content so the two stores stay
+        // consistent. If the file existed before and we have its bytes,
+        // rewrite them; otherwise drop the projection.
+        let rollback = match (existing_state_file, existing_md_content) {
+            (Some(filename), Some(prev)) => {
+                std::fs::write(knowledge_path.join(filename), prev).map_err(|io| io.to_string())
+            }
+            _ => writer.remove_page(&id).map_err(|err| err.to_string()),
+        };
+        if let Err(rb) = rollback {
+            tracing::warn!(
+                "[page] PUT failed and md rollback also failed for {}: db_err={}, rollback_err={}",
+                id,
+                e,
+                rb
+            );
+        }
+        return Err(ServerError::IngestFailed(e.to_string()));
+    }
+
+    Ok(Json(origin_types::responses::SuccessResponse { ok: true }))
+}
+
 // ===== Recent activity feed =====
 
 #[derive(Debug, Default, serde::Deserialize)]

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -3301,6 +3301,22 @@ pub async fn handle_refresh_page(
     Path(id): Path<String>,
     Json(req): Json<origin_types::requests::RefreshPageRequest>,
 ) -> Result<Json<origin_types::responses::SuccessResponse>, ServerError> {
+    // Validate the body before touching the filesystem. Empty content would
+    // produce an empty md; empty source list would orphan the page from its
+    // provenance trail — both contradict the route's documented contract.
+    if req.content.trim().is_empty() {
+        return Err(ServerError::ValidationError(
+            "content must not be empty".into(),
+        ));
+    }
+    if req.source_memory_ids.is_empty() {
+        return Err(ServerError::ValidationError(
+            "source_memory_ids must not be empty — refresh keeps the page \
+             linked to its sources"
+                .into(),
+        ));
+    }
+
     let db = {
         let s = state.read().await;
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
@@ -3325,9 +3341,20 @@ pub async fn handle_refresh_page(
 
     // Build the refreshed Page for md rendering. Bump version + last_modified
     // mirror what `update_page_content` writes to the DB row.
+    //
+    // Summary semantics: `None` keeps the existing summary. `Some(s)` where
+    // `s` is non-empty replaces it. `Some("")` clears it — empty string maps
+    // to NULL in the DB so `IS NULL` filters work (per origin-core's NULL
+    // semantics rule). The MCP tool description documents this; normalize
+    // here so the daemon never stores a literal empty string.
     let now = chrono::Utc::now().to_rfc3339();
-    let refreshed_summary = match &req.summary {
-        Some(s) => Some(s.clone()),
+    let summary_update: Option<Option<String>> = match &req.summary {
+        Some(s) if s.is_empty() => Some(None),
+        Some(s) => Some(Some(s.clone())),
+        None => None,
+    };
+    let refreshed_summary = match &summary_update {
+        Some(opt) => opt.clone(),
         None => existing.summary.clone(),
     };
     let refreshed_page = origin_core::pages::Page {
@@ -3359,8 +3386,8 @@ pub async fn handle_refresh_page(
     let db_result: Result<(), origin_core::error::OriginError> = async {
         db.update_page_content(&id, &req.content, &source_refs, "agent_refresh")
             .await?;
-        if req.summary.is_some() {
-            db.update_page_summary(&id, req.summary.as_deref()).await?;
+        if let Some(opt) = &summary_update {
+            db.update_page_summary(&id, opt.as_deref()).await?;
         }
         db.clear_page_staleness(&id).await?;
         Ok(())

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -2145,6 +2145,16 @@ pub async fn handle_create_page(
         return Err(ServerError::IngestFailed(e.to_string()));
     }
 
+    // Back-resolve any orphan wikilinks that point at this title. Existing
+    // pages that wrote `[[New Title]]` before this page existed land as
+    // NULL targets in page_links; this walks them and flips matching rows
+    // so inbound links light up immediately. Cheap — one SELECT DISTINCT
+    // over a small table + per-label UPDATE. Failures are logged but the
+    // route still returns success: the next refinery tick covers it.
+    if let Err(e) = db.resolve_orphan_page_links().await {
+        tracing::warn!("[page] orphan link resolve failed after create {id}: {e}");
+    }
+
     Ok(Json(serde_json::json!({ "id": id })))
 }
 

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -3179,6 +3179,86 @@ pub async fn handle_get_snapshot_captures_with_content(
 }
 
 /// POST /api/memory/{id}/update-page
+/// GET /api/pages/{id}/links
+///
+/// Returns the wikilink graph centered on a page: outbound (labels parsed
+/// out of this page's body, with resolved target_page_id when matched) and
+/// inbound (every active page whose body links to this title). Used by
+/// `/read` to surface "3 inbound, 2 broken" without the caller having to
+/// fetch + parse the full body.
+pub async fn handle_get_page_links(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let outbound = db
+        .get_page_outbound_links(&id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    let inbound = db
+        .get_page_inbound_links(&id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    let outbound_json: Vec<serde_json::Value> = outbound
+        .into_iter()
+        .map(|l| {
+            serde_json::json!({
+                "label": l.label,
+                "target_page_id": l.target_page_id,
+            })
+        })
+        .collect();
+    let inbound_json: Vec<serde_json::Value> = inbound
+        .into_iter()
+        .map(|(src, label)| serde_json::json!({"source_page_id": src, "label": label}))
+        .collect();
+    Ok(Json(serde_json::json!({
+        "outbound": outbound_json,
+        "inbound": inbound_json,
+    })))
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+pub struct OrphanLinksQuery {
+    /// Minimum number of distinct source pages reaching for the same label.
+    /// Default 2 — single-source orphans are usually typos, not emergence
+    /// signal.
+    #[serde(default)]
+    pub min_count: Option<i64>,
+}
+
+/// GET /api/pages/orphan-links
+///
+/// Group every unresolved wikilink label across the graph by hit count. A
+/// label reached for by N independent pages is a topic-discovery signal:
+/// emergence can prioritize building a page on it. Capped at 100 rows;
+/// callers needing more should raise min_count and re-issue.
+pub async fn handle_list_orphan_links(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    axum::extract::Query(q): axum::extract::Query<OrphanLinksQuery>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let min_count = q.min_count.unwrap_or(2).max(1);
+    let labels = db
+        .list_orphan_link_labels(min_count)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    let payload: Vec<serde_json::Value> = labels
+        .into_iter()
+        .map(|(label, count)| serde_json::json!({"label": label, "count": count}))
+        .collect();
+    Ok(Json(serde_json::json!({
+        "min_count": min_count,
+        "orphan_labels": payload,
+    })))
+}
+
 pub async fn handle_update_page(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(id): Path<String>,

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -210,6 +210,10 @@ pub fn build_router(state: SharedState) -> Router {
             get(routes::handle_recent_page_changes),
         )
         .route(
+            "/api/pages/orphan-links",
+            get(memory_routes::handle_list_orphan_links),
+        )
+        .route(
             "/api/pages/{id}/export",
             post(memory_routes::handle_export_page),
         )
@@ -222,6 +226,10 @@ pub fn build_router(state: SharedState) -> Router {
         .route(
             "/api/pages/{id}/sources",
             get(memory_routes::handle_get_page_sources),
+        )
+        .route(
+            "/api/pages/{id}/links",
+            get(memory_routes::handle_get_page_links),
         )
         .route(
             "/api/pages/{id}/archive",

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -215,7 +215,9 @@ pub fn build_router(state: SharedState) -> Router {
         )
         .route(
             "/api/pages/{id}",
-            get(memory_routes::handle_get_page).delete(memory_routes::handle_delete_page),
+            get(memory_routes::handle_get_page)
+                .put(memory_routes::handle_refresh_page)
+                .delete(memory_routes::handle_delete_page),
         )
         .route(
             "/api/pages/{id}/sources",

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -718,6 +718,16 @@ pub async fn handle_distill(
 
     let scoped = target.is_some();
 
+    // Capture scope filters before moving `target` into distill_pages_scoped
+    // so we can use them to scope the stale-page list below.
+    let (stale_entity_filter, stale_domain_filter) = match &target {
+        Some(origin_core::synthesis::distill::DistillTarget::Entity { id, .. }) => {
+            (Some(id.clone()), None)
+        }
+        Some(origin_core::synthesis::distill::DistillTarget::Domain(d)) => (None, Some(d.clone())),
+        Some(origin_core::synthesis::distill::DistillTarget::Page(_)) | None => (None, None),
+    };
+
     let result = origin_core::refinery::distill_pages_scoped(
         db,
         None, // route never invokes daemon LLM; caller synthesizes pending
@@ -780,11 +790,44 @@ pub async fn handle_distill(
         filtered_pending.push(payload);
     }
 
+    // Surface stale pages so the agent's `/distill` skill can refresh them
+    // via PUT /api/pages/{id}. Restrict to `source_updated` — `source_conflict`
+    // is the user-edited escalation and needs a human-in-the-loop UX, not an
+    // auto-refresh. Scoped by entity/domain when the target was scoped.
+    let stale_pages_list = db
+        .list_stale_pages_scoped(
+            "source_updated",
+            stale_entity_filter.as_deref(),
+            stale_domain_filter.as_deref(),
+        )
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+
+    let stale_pages_payload: Vec<serde_json::Value> = stale_pages_list
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "page_id": p.id,
+                "title": p.title,
+                "summary": p.summary,
+                "source_memory_ids": p.source_memory_ids,
+                "sources_updated_count": p.sources_updated_count,
+                "stale_reason": p.stale_reason,
+                "user_edited": p.user_edited,
+            })
+        })
+        .collect();
+    // 10 is the LIMIT inside list_stale_pages_scoped. Surface a hint so the
+    // skill can tell the user to re-run instead of silently dropping rows.
+    let stale_truncated = stale_pages_list.len() == 10;
+
     Ok(Json(serde_json::json!({
         "pages_created": result.created.len(),
         "scoped": scoped,
         "created_ids": result.created,
         "pending": filtered_pending,
+        "stale_pages": stale_pages_payload,
+        "stale_truncated": stale_truncated,
     })))
 }
 

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -821,6 +821,20 @@ pub async fn handle_distill(
     // skill can tell the user to re-run instead of silently dropping rows.
     let stale_truncated = stale_pages_list.len() == 10;
 
+    // Surface the orphan-wikilink feed so the skill can prompt the user to
+    // distill a page on a topic that other pages already reach for. Cheap:
+    // one GROUP BY against page_links, capped at 100. Threshold N=2 means
+    // a single typo doesn't show up — needs at least two distinct pages
+    // citing the same label before it counts as signal.
+    let orphan_topics_raw = db
+        .list_orphan_link_labels(2)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    let orphan_topics: Vec<serde_json::Value> = orphan_topics_raw
+        .into_iter()
+        .map(|(label, count)| serde_json::json!({"label": label, "count": count}))
+        .collect();
+
     Ok(Json(serde_json::json!({
         "pages_created": result.created.len(),
         "scoped": scoped,
@@ -828,6 +842,7 @@ pub async fn handle_distill(
         "pending": filtered_pending,
         "stale_pages": stale_pages_payload,
         "stale_truncated": stale_truncated,
+        "orphan_topics": orphan_topics,
     })))
 }
 

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -821,19 +821,37 @@ pub async fn handle_distill(
     // skill can tell the user to re-run instead of silently dropping rows.
     let stale_truncated = stale_pages_list.len() == 10;
 
+    // Walk orphan rows in case a page minted earlier in this pass (or by
+    // a concurrent create_page call) now matches an existing orphan label.
+    // The refinery's Emergence phase does the same on its tick; doing it
+    // inline here keeps the route's response (and the skill's view of the
+    // graph) consistent without waiting up to a poll interval.
+    if let Err(e) = db.resolve_orphan_page_links().await {
+        tracing::warn!("[distill] orphan link resolve failed: {e}");
+    }
+
     // Surface the orphan-wikilink feed so the skill can prompt the user to
     // distill a page on a topic that other pages already reach for. Cheap:
     // one GROUP BY against page_links, capped at 100. Threshold N=2 means
     // a single typo doesn't show up — needs at least two distinct pages
     // citing the same label before it counts as signal.
-    let orphan_topics_raw = db
-        .list_orphan_link_labels(2)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-    let orphan_topics: Vec<serde_json::Value> = orphan_topics_raw
-        .into_iter()
-        .map(|(label, count)| serde_json::json!({"label": label, "count": count}))
-        .collect();
+    //
+    // Only surface on unscoped passes. A scoped `/distill rust` user
+    // doesn't want generic topic suggestions from elsewhere in the graph;
+    // that would confuse them about what "scope" means. The unscoped
+    // global pass (`/distill deep` or bare `/distill` outside a repo) is
+    // the right place for this feed.
+    let orphan_topics: Vec<serde_json::Value> = if scoped {
+        Vec::new()
+    } else {
+        let raw = db
+            .list_orphan_link_labels(2)
+            .await
+            .map_err(|e| ServerError::Internal(e.to_string()))?;
+        raw.into_iter()
+            .map(|(label, count)| serde_json::json!({"label": label, "count": count}))
+            .collect()
+    };
 
     Ok(Json(serde_json::json!({
         "pages_created": result.created.len(),

--- a/crates/origin-server/src/scheduler.rs
+++ b/crates/origin-server/src/scheduler.rs
@@ -196,6 +196,29 @@ pub fn spawn_scheduler(shared: SharedState, write_signal: WriteSignal) {
 
             let now = Instant::now();
 
+            // --- 0. Filesystem page watcher: md → DB ---
+            //
+            // md is canonical. When the user edits a page in Obsidian / VS
+            // Code / etc., reflect the change back into the DB so refinery
+            // and search stay aligned with what the user actually wrote.
+            // Cheap: a dir scan + frontmatter parse + content compare per
+            // file. No LLM, no embedding, no network. Skips files whose
+            // origin_version frontmatter trails the DB (daemon wrote
+            // last). Runs every poll so freshness ≈ POLL_INTERVAL.
+            let knowledge_path = origin_core::config::load_config().knowledge_path_or_default();
+            match origin_core::sources::page_watcher::sync_filesystem_edits(&db, &knowledge_path)
+                .await
+            {
+                Ok(stats) if stats.applied > 0 => {
+                    tracing::info!(
+                        "[scheduler] page-watcher applied {} fs_edit(s)",
+                        stats.applied
+                    );
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!("[scheduler] page-watcher error: {e}"),
+            }
+
             // --- 1. BurstEnd: per-agent adaptive gap detection ---
             let snap = write_signal.snapshot();
             for (agent, timestamps) in &snap {

--- a/crates/origin-types/src/requests.rs
+++ b/crates/origin-types/src/requests.rs
@@ -423,6 +423,23 @@ pub struct UpdatePageRequest {
     pub content: String,
 }
 
+/// Body for `PUT /api/pages/{id}` — agent-side refresh of a stale page.
+///
+/// Distinct from `UpdatePageRequest` (manual content edit via POST) because:
+///  - `source_memory_ids` is replaced, not preserved.
+///  - `summary` is optionally updated.
+///  - The handler clears `stale_reason` in the same transaction.
+///
+/// v1 deliberately excludes title / entity_id / domain changes — slug rename
+/// has its own concurrent-read failure mode and lands as a separate route.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RefreshPageRequest {
+    pub content: String,
+    pub source_memory_ids: Vec<String>,
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
 // ===== Concept Export =====
 
 /// Request body for `POST /api/pages/export` (bulk export all pages to an Obsidian vault).

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -236,6 +236,29 @@ pub struct SearchPagesResponse {
     pub pages: Vec<Page>,
 }
 
+/// Wikilink graph centered on a single page. Outbound = labels parsed
+/// out of this page's body; `target_page_id` is `None` for orphans.
+/// Inbound = active pages whose body cites this title.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PageLinksResponse {
+    pub outbound: Vec<PageLinkOutbound>,
+    pub inbound: Vec<PageLinkInbound>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PageLinkOutbound {
+    pub label: String,
+    /// `None` when the resolver couldn't find a matching active page —
+    /// surfaces in the orphan-by-count feed via /api/pages/orphan-links.
+    pub target_page_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PageLinkInbound {
+    pub source_page_id: String,
+    pub label: String,
+}
+
 // ===== Import =====
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -6,7 +6,7 @@ description: >
   the daemon couldn't (no LLM or cluster too big). Invoked as
   `/distill [target]`.
 argument-hint: "[page_id_or_entity_or_domain]"
-allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__distill", "mcp__plugin_origin_origin__create_page", "mcp__plugin_origin_origin__delete_page", "Bash"]
+allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__distill", "mcp__plugin_origin_origin__create_page", "mcp__plugin_origin_origin__update_page", "mcp__plugin_origin_origin__delete_page", "Bash"]
 ---
 
 # /distill
@@ -66,7 +66,14 @@ JSON. Possible shapes:
     { "source_ids": [...], "contents": [...], "entity_id": ...,
       "entity_name": ..., "domain": ..., "estimated_tokens": ... },
     ...
-  ]
+  ],
+  "stale_pages": [
+    { "page_id": ..., "title": ..., "summary": ...,
+      "source_memory_ids": [...], "stale_reason": "source_updated",
+      "user_edited": false, "sources_updated_count": 3 },
+    ...
+  ],
+  "stale_truncated": false
 }
 ```
 
@@ -137,23 +144,53 @@ create_page(title="...", summary="...", content="...",
             source_memory_ids=[...])
 ```
 
-**Refresh candidate** (`existing_page_id` is set) — replace the old
-page with the refreshed one via delete then create.
-
-⚠ The two calls are NOT atomic as a pair. `delete_page` cleans DB + md
-atomically, and `create_page` writes the new pair atomically, but a
-daemon restart or network blip between them leaves the page gone with
-no replacement. Recovery is simple: re-run `/distill` — clustering
-will rediscover the same memories and the flow restarts. Note that
-the new page gets a fresh page id; any external reference to the old
-id breaks. A proper `PUT /api/pages/{id}` route would close both gaps
-but is tracked separately.
+**Refresh candidate** (`existing_page_id` is set) — replace the body
+in place via the `update_page` MCP tool. This is a single atomic
+call: replaces content + source list + optional summary, clears the
+daemon's `stale_reason`, bumps version, preserves page_id +
+created_at so external `[[wikilinks]]` keep working.
 
 ```
-delete_page(page_id="<existing_page_id>")
-create_page(title="...", summary="...", content="...",
-            source_memory_ids=cluster.source_ids, ...)
+update_page(page_id=cluster.existing_page_id,
+            content="...",
+            source_memory_ids=cluster.source_ids,
+            summary="...")
 ```
+
+### 3.5 Refresh stale pages
+
+The `stale_pages` block in the response lists pages whose sources
+changed since last compile. Shape:
+
+```
+stale_pages: [
+  { page_id, title, summary, source_memory_ids,
+    sources_updated_count, stale_reason, user_edited },
+  ...
+]
+stale_truncated: <bool>   # true when 10+ stale pages exist
+```
+
+For each stale page:
+
+- **`user_edited == true`** → never auto-rewrite. The user touched
+  the page; the upstream memories also changed. Surface in the
+  "Conflict" report block and stop. The user resolves by hand.
+- **`user_edited == false`** → fetch source memories via `recall`
+  (or `Bash: curl -fsS http://127.0.0.1:7878/api/pages/<id>/sources`),
+  run the same coherence check used for clusters, then call
+  `update_page` with the existing `source_memory_ids` and freshly
+  synthesized prose.
+
+```
+update_page(page_id=stale.page_id,
+            content="<refreshed prose>",
+            source_memory_ids=stale.source_memory_ids,
+            summary="<optional refreshed claim>")
+```
+
+When `stale_truncated == true`, tell the user "more stale pages
+remain — re-run `/distill` after this pass to continue."
 
 ### 4. Report terse
 
@@ -186,8 +223,27 @@ topics scatter; would produce a grab-bag page):
   ...
 ```
 
-When both happened in the same pass — some synthesized, some skipped
-— emit both blocks back-to-back.
+**If at least one stale page was refreshed:**
+
+```
+Refreshed K stale page(s):
+  - <Title>  (~/.origin/pages/<slug>.md)
+  ...
+```
+
+**If at least one stale page was skipped because `user_edited`:**
+
+```
+Conflict on L stale page(s) — page has user edits, sources also
+changed. Open and reconcile manually:
+  - <Title>  (~/.origin/pages/<slug>.md)
+```
+
+Distinct wording from the coherence-skip block so the user can tell
+the two reasons apart at a glance.
+
+Emit the blocks back-to-back when more than one outcome happened in
+the same pass.
 
 When the only outcome is skipped clusters (and `pending` was
 non-empty), still emit the Skipped block. Do **not** report "up to

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -73,7 +73,11 @@ JSON. Possible shapes:
       "user_edited": false, "sources_updated_count": 3 },
     ...
   ],
-  "stale_truncated": false
+  "stale_truncated": false,
+  "orphan_topics": [
+    { "label": "Topic Z", "count": 3 },
+    ...
+  ]
 }
 ```
 
@@ -191,6 +195,25 @@ update_page(page_id=stale.page_id,
 
 When `stale_truncated == true`, tell the user "more stale pages
 remain — re-run `/distill` after this pass to continue."
+
+### 3.6 Surface orphan-topic suggestions
+
+`orphan_topics` lists wikilink labels that 2+ existing pages reach
+for but no page is named for. Each entry is a topic-discovery
+signal — other pages are asking for this page.
+
+Do **not** auto-create pages from this list — the agent doesn't have
+the source memories at hand, and an empty-stub page is worse than no
+page. Surface them in the report so the user can choose to run
+`/distill <label>` intentionally:
+
+```
+Topic suggestions (other pages link here, no page yet):
+  - "Topic Z"  (3 pages reference it)
+  - "Other"    (2 pages reference it)
+```
+
+Skip the section when `orphan_topics` is empty.
 
 ### 4. Report terse
 

--- a/plugin/skills/read/SKILL.md
+++ b/plugin/skills/read/SKILL.md
@@ -5,7 +5,7 @@ description: >
   summary, source count, and the local md path. Full body lives on disk —
   open with the user's editor. Invoked as `/read <title_or_id>`.
 argument-hint: "<title_or_id>"
-allowed-tools: ["mcp__plugin_origin_origin__get_page", "mcp__plugin_origin_origin__search_pages", "Bash"]
+allowed-tools: ["mcp__plugin_origin_origin__get_page", "mcp__plugin_origin_origin__search_pages", "mcp__plugin_origin_origin__get_page_links", "Bash"]
 ---
 
 # /read
@@ -73,15 +73,26 @@ block from section 1.
 
 ## Output shape
 
-Always print exactly these five lines (no body):
+Always print exactly these six lines (no body):
 
 ```
 Title:    <title>
 Summary:  <one sentence>
 Sources:  <N> memories
 Domain:   <domain or (none)>
+Links:    <N inbound, M outbound (<K> broken)>
 Open:     ~/.origin/pages/<slug>.md
 ```
+
+The `Links:` line reports the wikilink graph centered on this page. Call
+`get_page_links(page_id="<id>")` right after `get_page` and count:
+
+- inbound = `len(inbound)`
+- outbound = `len(outbound)`
+- broken = outbound entries where `target_page_id` is null
+
+Omit the parenthetical when broken is zero. Drop the line entirely if
+inbound + outbound is zero.
 
 Don't paraphrase the title, don't trim the summary, don't decorate the
 preview. The block is one screen, predictable, easy to skim.


### PR DESCRIPTION
## Summary

Closes the core llm-wiki pattern gaps the daemon had been missing. Ten `fix:` commits, ~2500 LOC, all on top of `main`. After-hours timestamps so release-please picks them up cleanly without bumping minor.

Shipped pattern pieces (in order of dependency):

- **`user_edited` flag now writes** — manual edits flip the column inside the same SQL UPDATE as the body write. Refinery's `re_distill_stale_pages` escalation branch finally fires. (`e3cc975d`)
- **Cluster discipline** — oversized re-split extended from the unlinked bucket to community + entity buckets via a shared helper, new `max_grouped_cluster_size` knob (default 12). Stops the 99-memory "Origin" grab-bag. (`9846aab5`)
- **Atomic refresh route** — `PUT /api/pages/{id}` keeps page id + bumps version + clears stale in one call. md-first with rollback. `/api/distill` response surfaces `stale_pages` so the skill can drive refresh. Refinery CAS via single conditional UPDATE — no TOCTOU. (`fc301a9f`, `58d3d096`)
- **Wikilink graph** — Migration 47 adds `page_links` with `(source, label_key)` PK. `synthesis/wikilinks.rs` extracts via the existing obsidian regex. Refinery resolves orphans after Emergence. `GET /api/pages/{id}/links` + `/api/pages/orphan-links`. (`55f960b9`)
- **Adversarial-review fixes folded in** — page_sources prune on PUT (silent provenance corruption fix), CAS tightening, summary normalize, validation, label_key cross-page grouping, archived-source filter, mutex hold fix. (`091e8507`)
- **Extractor merge** — drop hand-rolled byte-walker, delegate to existing obsidian::extract_wikilinks. Picks up code-block skip + alias + heading anchor handling. (`c77f0903`)
- **Filesystem watcher** — poll-based, scheduler tick step 0, reads md frontmatter via reused obsidian parser, applies fs_edit to DB, re-projects md so consecutive edits stay in sync. (`82129026`)
- **Closes the loop** — distill prompt now seeds existing titles for exact-match wikilinks. /read surfaces N inbound / M broken via new MCP get_page_links. orphan-by-count feeds emergence LLM prompt AND /distill skill report as topic suggestions. (`09ed8114`, `dd279b4f`)

## Test plan

- [x] `cargo test -p origin-core --lib` — 974 pass
- [x] `cargo test -p origin-server` — 44 pass
- [x] `cargo test -p origin-mcp --lib` — 133 pass
- [x] `cargo clippy --workspace --no-deps` clean
- [ ] CI workspace clippy + test pass
- [ ] Local smoke test: daemon on isolated port, exercise PUT, fs_edit, get_page_links, orphan_topics surfacing
- [ ] Independent adversarial review of new commits since the first batch
- [ ] Manual verification on a populated DB that distill prompt with title list produces resolving wikilinks

## What's NOT in this PR

- Stability lifecycle (Gap 2 — `draft`/`stable`/`frozen`)
- Scheduled whole-graph deep-distill pass (Gap 3)
- Title rename + heading anchors (v2)
- `notify`-crate event-driven watcher (v1 is poll-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)