### PR TITLE
fix(release): correct plugin.json path in validate-versions.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "origin"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "origin-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "origin-mcp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "origin-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "origin-types"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "serde",

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -8,7 +8,7 @@ TAG_VER="${RELEASE_TAG#v}"
 VTXT_VER=$(cat version.txt | tr -d '[:space:]')
 WS_VER=$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)".*/\1/')
 NPM_VER=$(jq -r .version crates/origin-mcp/npm/package.json)
-PLUGIN_VER=$(jq -r .version .claude-plugin/plugin.json)
+PLUGIN_VER=$(jq -r .version plugin/.claude-plugin/plugin.json)
 
 echo "Tag:         $TAG_VER"
 echo "version.txt: $VTXT_VER"

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -4,21 +4,21 @@ set -euo pipefail
 TMPDIR_TEST=$(mktemp -d)
 trap "rm -rf $TMPDIR_TEST" EXIT
 
-mkdir -p "$TMPDIR_TEST/crates/origin-mcp/npm" "$TMPDIR_TEST/.claude-plugin"
+mkdir -p "$TMPDIR_TEST/crates/origin-mcp/npm" "$TMPDIR_TEST/plugin/.claude-plugin"
 echo "0.5.0" > "$TMPDIR_TEST/version.txt"
 cat > "$TMPDIR_TEST/Cargo.toml" <<EOF
 [workspace.package]
 version = "0.5.0"   # x-release-please-version
 EOF
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/crates/origin-mcp/npm/package.json"
-echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/.claude-plugin/plugin.json"
+echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json"
 
 # Test 1: all match → exit 0
 (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh")
 echo "PASS test 1: all matching"
 
 # Test 2: mismatch → exit 1
-echo '{"version": "0.4.9"}' > "$TMPDIR_TEST/.claude-plugin/plugin.json"
+echo '{"version": "0.4.9"}' > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json"
 if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
     echo "FAIL test 2: should have detected drift"
     exit 1


### PR DESCRIPTION
## Summary

- `scripts/validate-versions.sh` read `.claude-plugin/plugin.json`, but the plugin manifest actually lives at `plugin/.claude-plugin/plugin.json`. This made the v0.5.2 release.yml fail at the pre-flight step (`jq: error: Could not open file ...`), aborting the daemon binary build.
- `scripts/validate-versions.test.sh` mirrored the same wrong path, so the unit test passed against fake fixtures and never caught the drift in real usage.

Fix both files. Verified locally:
- `RELEASE_TAG=v0.5.2 bash scripts/validate-versions.sh` → all five sources reconcile at `0.5.2`.
- `bash scripts/validate-versions.test.sh` → both cases pass.

## Failing run

https://github.com/7xuanlu/origin/actions/runs/25707806064 (release.yml on tag `v0.5.2`)

## Test plan

- [x] Unit test passes (`bash scripts/validate-versions.test.sh`)
- [x] Live check passes against actual `v0.5.2` tag (`RELEASE_TAG=v0.5.2 bash scripts/validate-versions.sh`)
- [ ] CI green on this PR
- [ ] After merge, future release-please bumps trigger a clean release.yml run

## Note about v0.5.2 binaries

This patch fixes the path so future releases work. The v0.5.2 GitHub release exists but has no daemon/MCP binary attachments because the build aborted before that step. Recovering them requires re-running `release.yml` after either (a) force-retagging `v0.5.2` at the fix commit (force tag push, destructive — needs explicit OK) or (b) shipping `v0.5.3` with this fix and treating `v0.5.2` as a no-binary release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)