### PR TITLE
fix(topic_match): entity match must also satisfy similarity threshold

### DIFF
--- a/crates/origin-core/src/topic_match.rs
+++ b/crates/origin-core/src/topic_match.rs
@@ -50,7 +50,13 @@ pub struct TopicMatchCandidate {
 /// - One matches: 0.80 (partial context)
 /// - Neither: 0.90 (semantic-only, very conservative)
 ///
-/// Priority: entity overlap > title+embedding > embedding-only.
+/// Priority: entity overlap (with similarity ≥ `threshold_exact`)
+/// > title+embedding > embedding-only.
+///
+/// Note: entity overlap *alone* is not enough. Multiple atomic captures
+/// during a single `/handoff` are all anchored to the same entity but carry
+/// distinct content; a pure entity-id match would coalesce them. Entity
+/// match still wins ties when paired with sufficient embedding similarity.
 pub async fn find_topic_match(
     db: &MemoryDB,
     title: &str,
@@ -81,15 +87,21 @@ pub async fn find_topic_match(
         ..Default::default()
     };
 
-    // Step 1: Entity ID overlap (strongest signal — bypasses thresholds).
+    // Step 1: Entity ID overlap — strong signal, but content must also be
+    // similar enough to avoid coalescing distinct ideas about the same
+    // entity. Earlier versions returned on entity-id match alone, which
+    // silently dropped data when multiple atomic captures during one
+    // `/handoff` were all anchored to the same entity.
     if let Some(eid) = entity_id {
-        if let Some(matched) = candidates
-            .iter()
-            .find(|c| c.entity_id.as_deref() == Some(eid))
+        if let Some((matched, sim)) =
+            best_entity_match(&candidates, eid, content_embedding, config.threshold_exact)
         {
             signals.entity_match = true;
+            signals.embedding_similarity = Some(sim);
             log::info!(
-                "[topic_match] entity match: entity={eid} → source_id={}",
+                "[topic_match] entity match (sim={:.3} ≥ threshold_exact={:.2}): entity={eid} → source_id={}",
+                sim,
+                config.threshold_exact,
                 matched.source_id
             );
             return Ok(TopicMatchResult {
@@ -161,6 +173,27 @@ pub async fn find_topic_match(
     Ok(no_match)
 }
 
+/// Among `candidates` with `entity_id == eid`, return the one with the
+/// highest embedding-cosine similarity to `content_embedding` — but only
+/// if that similarity is at least `threshold`. Pure helper, no DB access,
+/// no I/O.
+///
+/// Returns `None` when no candidate shares the entity id, or when the
+/// best entity-matched candidate's similarity falls below `threshold`.
+fn best_entity_match<'a>(
+    candidates: &'a [TopicMatchCandidate],
+    eid: &str,
+    content_embedding: &[f32],
+    threshold: f64,
+) -> Option<(&'a TopicMatchCandidate, f64)> {
+    candidates
+        .iter()
+        .filter(|c| c.entity_id.as_deref() == Some(eid))
+        .map(|c| (c, cosine_similarity(content_embedding, &c.embedding)))
+        .filter(|(_, sim)| *sim >= threshold)
+        .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+}
+
 /// Compute cosine similarity between two f32 embedding vectors.
 /// Returns 0.0 for empty or mismatched-length vectors.
 pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f64 {
@@ -212,5 +245,112 @@ mod tests {
         let a = vec![1.0f32, 0.0];
         let b = vec![0.0f32, 1.0, 0.0];
         assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    // --- best_entity_match ---
+
+    fn candidate(
+        source_id: &str,
+        entity_id: Option<&str>,
+        embedding: Vec<f32>,
+    ) -> TopicMatchCandidate {
+        TopicMatchCandidate {
+            source_id: source_id.into(),
+            title: "t".into(),
+            content: "c".into(),
+            entity_id: entity_id.map(|s| s.into()),
+            embedding,
+            domain: None,
+            memory_type: None,
+        }
+    }
+
+    #[test]
+    fn entity_match_returns_none_when_no_entity_overlap() {
+        let candidates = vec![
+            candidate("a", Some("Alice"), vec![1.0, 0.0, 0.0]),
+            candidate("b", Some("Bob"), vec![1.0, 0.0, 0.0]),
+        ];
+        let probe = vec![1.0f32, 0.0, 0.0];
+        assert!(best_entity_match(&candidates, "Carol", &probe, 0.70).is_none());
+    }
+
+    #[test]
+    fn entity_match_filters_by_similarity_threshold() {
+        // Two captures anchored to the same entity but with orthogonal
+        // embeddings — distinct ideas about the same topic. Must NOT match.
+        let candidates = vec![candidate("existing", Some("Origin"), vec![1.0, 0.0, 0.0])];
+        let probe = vec![0.0f32, 1.0, 0.0]; // orthogonal => sim = 0.0
+        assert!(
+            best_entity_match(&candidates, "Origin", &probe, 0.70).is_none(),
+            "entity match alone must NOT coalesce when content differs (sim < threshold)"
+        );
+    }
+
+    #[test]
+    fn entity_match_returns_high_similarity_candidate() {
+        let candidates = vec![candidate("existing", Some("Origin"), vec![1.0, 0.0, 0.0])];
+        let probe = vec![1.0f32, 0.0, 0.0]; // identical => sim = 1.0
+        let result = best_entity_match(&candidates, "Origin", &probe, 0.70);
+        assert!(result.is_some());
+        let (matched, sim) = result.unwrap();
+        assert_eq!(matched.source_id, "existing");
+        assert!((sim - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn entity_match_picks_best_among_multiple_entity_candidates() {
+        // Two existing memories share entity "Origin"; one is a close match,
+        // the other is moderately related. Helper must pick the close match,
+        // not just the first.
+        let candidates = vec![
+            candidate("low_sim", Some("Origin"), vec![1.0, 0.0, 0.0]),
+            candidate("high_sim", Some("Origin"), vec![0.95, 0.31, 0.0]),
+        ];
+        let probe = vec![0.95f32, 0.31, 0.0];
+        let (matched, _) = best_entity_match(&candidates, "Origin", &probe, 0.70).unwrap();
+        assert_eq!(matched.source_id, "high_sim");
+    }
+
+    #[test]
+    fn entity_match_ignores_candidates_without_entity_id() {
+        let candidates = vec![
+            candidate("no_entity", None, vec![1.0, 0.0, 0.0]),
+            candidate(
+                "with_entity",
+                Some("Origin"),
+                vec![0.5, 0.5, std::f32::consts::FRAC_1_SQRT_2],
+            ),
+        ];
+        let probe = vec![0.5f32, 0.5, std::f32::consts::FRAC_1_SQRT_2];
+        let (matched, _) = best_entity_match(&candidates, "Origin", &probe, 0.70).unwrap();
+        assert_eq!(matched.source_id, "with_entity");
+    }
+
+    /// Regression for 2026-05-11: four atomic /handoff captures all
+    /// anchored to entity="Origin" but carrying distinct decisions
+    /// previously coalesced into a single in-place upsert (returning the
+    /// same source_id `mem_60c6f1b75dd1` for all four). With the
+    /// threshold guard, each pair-wise check against the existing memory
+    /// must return None when content similarity is low.
+    #[test]
+    fn distinct_captures_same_entity_do_not_coalesce() {
+        let existing = candidate("existing", Some("Origin"), vec![1.0, 0.0, 0.0, 0.0]);
+        let candidates = vec![existing];
+        // Four distinct embeddings, each orthogonal-ish to the existing one
+        let captures = [
+            vec![0.0f32, 1.0, 0.0, 0.0],
+            vec![0.0f32, 0.0, 1.0, 0.0],
+            vec![0.0f32, 0.0, 0.0, 1.0],
+            vec![0.5f32, 0.5, 0.5, 0.5], // mixed but still orthogonal to e1
+        ];
+        for probe in captures.iter() {
+            let result = best_entity_match(&candidates, "Origin", probe, 0.70);
+            assert!(
+                result.is_none(),
+                "distinct content sharing entity must not coalesce; sim={:.3}",
+                cosine_similarity(probe, &candidates[0].embedding)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

`find_topic_match` short-circuited on entity-id overlap without checking embedding similarity. Distinct content sharing an entity tag would all collide on the first existing match → `upsert_memory_in_place` → only the last write survived. Caller's response still carried the existing memory's `source_id`, hiding the loss.

This is the bug behind the **MCP ingest-batcher coalesce concern** flagged in the 2026-05-11 handoff status. The earlier diagnosis blamed `ingest_batcher.rs`; that was wrong — the batcher's per-request response routing is correct. The root cause is one block in `topic_match.rs`.

## Evidence

- 2026-05-11 19:14 PT handoff: 4 atomic captures (all `entity="Origin"`, distinct content) returned the same `source_id` `mem_60c6f1b75dd1`.
- 2026-05-11 19:15 PT handoff (parallel session): independent reproduction — 7 atomic captures collapsed to 3 distinct ids; recall verification confirmed 5 of 7 unrecoverable.
- Reading `crates/origin-core/src/topic_match.rs:84-101` (pre-fix): step 1 returns on entity-id match alone. Comment even claims this is intentional ("entity overlap — bypasses thresholds"). The bypass is the bug.

## Fix

Extract entity-match candidate selection into a pure helper `best_entity_match(candidates, eid, embedding, threshold)`:

1. Filter candidates to those sharing `entity_id == eid`.
2. Score each by cosine similarity to the incoming `content_embedding`.
3. Drop any below `config.threshold_exact` (0.70 by default).
4. Return the highest-similarity survivor, or `None`.

`find_topic_match` calls the helper for step 1. When no entity-shared candidate clears `threshold_exact`, it falls through to the existing FTS-title (step 2) and tiered-similarity (step 3) logic. Entity match still wins when content is genuinely similar; distinct content sharing only an entity no longer coalesces.

## Test plan

- [x] 6 new unit tests on `best_entity_match`: no entity overlap, threshold filter on orthogonal embeddings, exact-match returned, best-of-many selection, candidates without `entity_id` ignored, regression replay of the 2026-05-11 /handoff pattern (4 orthogonal embeddings, same entity, all return `None`).
- [x] All 21 `topic_match` tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] Pre-commit + pre-push hooks passed.
- [ ] CI `Test & Lint` green.
- [ ] Manual smoke after deploy: replay the /handoff scenario (4 atomic captures, same entity, distinct content) on a fresh daemon build → verify each returns a distinct `source_id` and recall retrieves all four.

## Recovery for already-lost captures

This fix is forward-only — captures already coalesced are not recoverable from the DB. After this lands and a new daemon ships, re-capture the lost content from the session log narratives at `~/.origin/sessions/2026-05-11-19{14,15}-*.md`.

## Notes

- No schema change. No wire-type change. No daemon-side route change. Just one block in `topic_match.rs` + the pure helper + unit tests.
- The `feedback`/`lesson` memory files written during the 2026-05-11 handoffs that blame `ingest_batcher.rs` are now misattributed. Will update them after merge to point at the real cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)