### PR TITLE
fix(memory_routes): drop silent topic-match upsert from write path

### DIFF
--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -356,12 +356,22 @@ pub async fn handle_store_memory(
         None
     };
 
-    // --- Topic-match check (pre-batcher) ---
-    // Run before building RawDocument. If the incoming memory matches an existing
-    // topic (same domain+type, similar embedding), upsert in place and return early,
-    // skipping the batcher and avoiding duplicates.
-    // When a protected memory is matched we fall through to normal store but flag
-    // the new memory as a pending revision so the UI can surface it for review.
+    // --- Topic-match check (pre-batcher, protected-flag only) ---
+    //
+    // Used solely to flag `pending_revision` when an incoming memory's topic
+    // overlaps a PROTECTED memory (stability = "protected"). For non-protected
+    // topic matches we used to upsert in place; that silently collapsed
+    // distinct captures that happened to share topic context (same entity /
+    // domain / type + similar phrasing). The 2026-05-11 /handoff incident
+    // documented in `lesson_topic_match_entity_bypass.md` lost 5 of 7 atomic
+    // captures to this path.
+    //
+    // New contract: non-protected topic matches do NOT short-circuit the write
+    // path. Every capture stores as a new memory with a fresh `source_id`.
+    // Any consolidation of similar-but-distinct memories is a refinery
+    // concern, not a write-path concern (matches Mem0 v2.0 + the dominant
+    // production memory-system pattern: hash-only dedup at write, periodic
+    // consolidation later).
     let mut topic_match_protected_id: Option<String> = None;
     {
         let (db_arc, topic_cfg) = {
@@ -370,7 +380,7 @@ pub async fn handle_store_memory(
         };
 
         if let Some(ref db) = db_arc {
-            // Compute embedding synchronously (CPU-bound, no DB lock needed)
+            // Compute embedding synchronously (CPU-bound, no DB lock needed).
             let embedding_result = db.generate_embeddings(&[trimmed_content.to_string()]);
 
             if let Ok(ref embeddings) = embedding_result {
@@ -388,95 +398,22 @@ pub async fn handle_store_memory(
 
                     if let Ok(ref result) = match_result {
                         if let Some(ref matched_source_id) = result.matched_source_id {
-                            // Trust guardrail: don't overwrite protected memories in place.
                             let is_protected = db
                                 .is_memory_protected(matched_source_id)
                                 .await
                                 .unwrap_or(false);
 
-                            if !is_protected {
-                                let upsert_result = db
-                                    .upsert_memory_in_place(
-                                        matched_source_id,
-                                        trimmed_content,
-                                        content_embedding,
-                                        req.source_agent.as_deref(),
-                                        None, // incoming_source_id N/A (no new id yet)
-                                        topic_cfg.changelog_cap,
-                                    )
-                                    .await;
-
-                                if let Ok(()) = upsert_result {
-                                    // Spawn async staleness check for linked concepts.
-                                    let db_clone = db.clone();
-                                    let msid = matched_source_id.clone();
-                                    let old_emb = result.old_embedding.clone();
-                                    let new_emb = content_embedding.clone();
-                                    let handle = tokio::spawn(async move {
-                                        let sim = old_emb.as_deref().map(|oe| {
-                                            origin_core::topic_match::cosine_similarity(
-                                                oe, &new_emb,
-                                            )
-                                        });
-                                        if let Ok(pages) =
-                                            db_clone.get_pages_for_memory(&msid).await
-                                        {
-                                            for page in pages {
-                                                let stale_reason = match sim {
-                                                    Some(s) if s > 0.90 => None, // trivial
-                                                    Some(s) if s > 0.60 => Some("source_updated"),
-                                                    _ => Some("source_conflict"),
-                                                };
-                                                if let Some(reason) = stale_reason {
-                                                    let _ = db_clone
-                                                        .set_page_stale(&page.id, reason)
-                                                        .await;
-                                                } else {
-                                                    let _ = db_clone
-                                                        .increment_page_sources_updated(&page.id)
-                                                        .await;
-                                                }
-                                            }
-                                        }
-                                    });
-                                    tokio::spawn(async move {
-                                        if let Err(e) = handle.await {
-                                            tracing::warn!(
-                                                "[topic_match] staleness check task panicked: {e}"
-                                            );
-                                        }
-                                    });
-
-                                    tracing::info!(
-                                        "[topic_match] upserted in place: source_id={matched_source_id} signals={:?}",
-                                        result.signals
-                                    );
-                                    return Ok(Json(StoreMemoryResponse {
-                                        source_id: matched_source_id.clone(),
-                                        chunks_created: 1,
-                                        memory_type: validated_memory_type
-                                            .clone()
-                                            .unwrap_or_else(|| "fact".to_string()),
-                                        entity_id: resolved_entity_id,
-                                        quality: None,
-                                        warnings: vec![],
-                                        extraction_method: "agent".to_string(),
-                                        enrichment: "not_needed".to_string(),
-                                        hint: "topic_updated".to_string(),
-                                    }));
-                                } else if let Err(ref e) = upsert_result {
-                                    tracing::warn!(
-                                        "[topic_match] upsert_memory_in_place failed, \
-                                         falling through to normal store: {e}"
-                                    );
-                                }
-                            } else {
+                            if is_protected {
                                 tracing::info!(
                                     "[topic_match] matched protected memory {matched_source_id}, \
                                      storing as new pending_revision"
                                 );
                                 topic_match_protected_id = Some(matched_source_id.clone());
                             }
+                            // Non-protected topic match: no longer collapsed
+                            // into the existing row. The incoming memory
+                            // stores as new; periodic consolidation belongs
+                            // in the refinery.
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

PR #83 fixed the entity-id bypass inside `find_topic_match` but smoke testing showed the data-loss symptom persisted. Three atomic captures sharing `entity` + `domain` + `memory_type` with similar boilerplate phrasing (embedding sim ~0.85) hit step 3's `(domain=match, type=match)` tier at threshold 0.70 and all upserted in place. Last write won. Same /handoff symptom as the original incident.

Threshold tuning was the wrong frame. **Production memory systems do not silently merge on the write path.** Mem0 v2.0 hash-dedups exact matches and stores everything else as new (fuzzy consolidation is a periodic phase). Zep, LangMem, Letta, Neo4j's agent-memory pattern, and the [community "production memory patterns" guidance](https://dev.to/dohkoai/8-ai-agent-memory-patterns-for-production-systems-beyond-basic-rag-5795) all warn specifically against silent threshold-based merge on the write path.

## Change

Remove the non-protected `upsert_memory_in_place` branch from `handle_store_memory`. The pre-batcher block still:
- Computes the incoming content's embedding.
- Calls `find_topic_match` to discover candidates.
- Calls `is_memory_protected` on any match.
- Sets `topic_match_protected_id` (used to flag `pending_revision` later) when the match is a **protected** memory.

Non-protected matches now fall through to the normal store path. The incoming memory gets a fresh `source_id` and is stored as new.

What's untouched:
- `QualityGate` novelty rejection (≥0.95 sim → 422 with `similar_to`) — loud, explicit, the right guard for near-identical duplicates.
- `find_topic_match` itself (still callable; the consolidation refinery will use it later).
- `upsert_memory_in_place` (still used elsewhere, e.g. agent-driven corrections via supersedes).
- Protected-memory pending-revision flow.

## Test plan

- [x] `cargo check -p origin-server` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace --lib` passed (29 / 981 origin-core / origin-server / others).
- [x] Release build of `origin-server` succeeds.
- [x] **Smoke test on live daemon**: rebuilt + reinstalled `~/.origin/bin/origin-server`. Fired 3 atomic captures sharing `entity="SmokeTestEntity2"`, `domain="test-no-topic-match"`, `memory_type="fact"`, with boilerplate-similar text. Pre-fix behavior would coalesce these into one `source_id`. Result with this PR: 3 distinct `source_id`s (`mem_3e9831f07da2`, `mem_a61b55b15df1`, `mem_5996282732ad`), all three returned by `POST /api/memory/list?domain=test-no-topic-match`.
- [ ] CI `Test & Lint` green.
- [ ] After merge: rebuild daemon from main, re-run smoke test on a fresh build to confirm.

## Follow-ups (not in this PR)

- **Refinery consolidation phase** for similar-but-distinct memories. The `find_topic_match` logic + `upsert_memory_in_place` are still in the codebase, just no longer wired into the write path. Refinery is the right home for periodic merging.
- **Recover the captures lost on 2026-05-11**. Content lives in the session-log narratives at `~/.origin/sessions/2026-05-11-19{14,15}-*.md`. Re-capture after daemon rebuild from main.
- **Audit other call sites**. `upsert_memory_in_place` is still exposed; any path that calls it on a non-protected memory will reintroduce the silent-merge pattern. Searching the codebase for direct callers is worth a follow-up.

## Refs

- Symptom recap: `~/.claude/projects/-Users-lucian-Repos-origin/memory/lesson_topic_match_entity_bypass.md`
- Patterns survey (this session): `~/.claude/projects/-Users-lucian-Repos-origin/memory/reference_agent_coding_discipline_sources.md`
- Prior fix that addressed the entity bypass but missed the broader case: PR #83 (`06707722`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)