### PR TITLE
fix: get_page_sources MCP tool + auto-commit retry (close skill ↔ MCP boundary)

### DIFF
--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -852,10 +852,7 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
-    pub async fn get_page_sources_impl(
-        &self,
-        page_id: &str,
-    ) -> Result<CallToolResult, McpError> {
+    pub async fn get_page_sources_impl(&self, page_id: &str) -> Result<CallToolResult, McpError> {
         let path = format!("/api/pages/{}/sources", page_id);
         // Daemon returns Vec<PageSourceWithMemory> directly (no envelope key).
         let resp: Vec<PageSourceWithMemory> = match self.client.get(&path).await {

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -288,6 +288,14 @@ pub struct GetPageLinksParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct GetPageSourcesParams {
+    #[schemars(
+        description = "Page id (e.g. 'page_abc'). Returns the source memories that distilled into this page, each enriched with the memory's metadata for display."
+    )]
+    pub page_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListMemoriesParams {
     #[schemars(
         description = "Filter by memory type (e.g. 'fact', 'preference', 'decision'). Optional."
@@ -844,6 +852,25 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
+    pub async fn get_page_sources_impl(
+        &self,
+        page_id: &str,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!("/api/pages/{}/sources", page_id);
+        // Daemon returns Vec<PageSourceWithMemory> directly (no envelope key).
+        let resp: Vec<PageSourceWithMemory> = match self.client.get(&path).await {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "get_page_sources")),
+        };
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} sources\n{}",
+            resp.len(),
+            pretty
+        ))]))
+    }
+
     pub async fn list_memories_impl(
         &self,
         params: ListMemoriesParams,
@@ -1169,6 +1196,23 @@ impl OriginMcpServer {
         Parameters(params): Parameters<GetPageLinksParams>,
     ) -> Result<CallToolResult, McpError> {
         self.get_page_links_impl(&params.page_id).await
+    }
+
+    #[tool(
+        description = "Fetch the source memories of a page — the memory ids the page was distilled from, each enriched with the memory's title, content, type, and domain. The /distill skill uses this on the stale-page refresh path: get_page returns ids, get_page_sources returns the full memory content needed to re-synthesize prose.",
+        annotations(
+            title = "Get page sources",
+            read_only_hint = true,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn get_page_sources(
+        &self,
+        Parameters(params): Parameters<GetPageSourcesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.get_page_sources_impl(&params.page_id).await
     }
 
     #[tool(

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -6,7 +6,6 @@
 //! `origin_types::*` at call sites directly.
 
 pub use origin_types::memory::{RecentActivityItem, SearchResult};
-pub use origin_types::PageSourceWithMemory;
 pub use origin_types::requests::{
     ChatContextRequest, CreateConceptRequest, CreateEntityRequest, CreateRelationRequest,
     ListMemoriesRequest, SearchMemoryRequest, SearchPagesRequest, StoreMemoryRequest,
@@ -15,3 +14,4 @@ pub use origin_types::responses::{
     ChatContextResponse, CreateEntityResponse, CreateRelationResponse, DeleteResponse,
     ListMemoriesResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
+pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -6,6 +6,7 @@
 //! `origin_types::*` at call sites directly.
 
 pub use origin_types::memory::{RecentActivityItem, SearchResult};
+pub use origin_types::PageSourceWithMemory;
 pub use origin_types::requests::{
     ChatContextRequest, CreateConceptRequest, CreateEntityRequest, CreateRelationRequest,
     ListMemoriesRequest, SearchMemoryRequest, SearchPagesRequest, StoreMemoryRequest,

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -284,14 +284,22 @@ Rules:
 
 ## Auto-commit ~/.origin/
 
+After writing the pages above, snapshot the change so the user can `git
+log` their memory's life timeline. Defensive — silent skip if `git` is
+missing or `~/.origin/` is not a repo yet.
+
 ```
-Bash: cd ~/.origin 2>/dev/null && [ -d .git ] && git add -A && \
-      git -c user.name=Origin -c user.email=daemon@origin.local \
-          commit --quiet -m "distill: <N> pages" \
-          || true
+Bash: git -C ~/.origin add -A && \
+      git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+          commit --quiet -m "distill: <N> pages" 2>/dev/null || \
+      (sleep 1 && git -C ~/.origin add -A && \
+       git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+           commit --quiet -m "distill: <N> pages" 2>/dev/null) || true
 ```
 
-Skip when no diff.
+The retry handles index.lock races — the daemon may be writing to
+`~/.origin/` at the same moment (auto-commit from captures). One-second
+wait is enough for the daemon to release the lock.
 
 ## When to use
 

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -6,7 +6,7 @@ description: >
   the daemon couldn't (no LLM or cluster too big). Invoked as
   `/distill [target]`.
 argument-hint: "[page_id_or_entity_or_domain]"
-allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__distill", "mcp__plugin_origin_origin__create_page", "mcp__plugin_origin_origin__update_page", "mcp__plugin_origin_origin__delete_page", "Bash"]
+allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__distill", "mcp__plugin_origin_origin__create_page", "mcp__plugin_origin_origin__update_page", "mcp__plugin_origin_origin__delete_page", "mcp__plugin_origin_origin__get_page_sources", "Bash"]
 ---
 
 # /distill
@@ -180,11 +180,10 @@ For each stale page:
 - **`user_edited == true`** → never auto-rewrite. The user touched
   the page; the upstream memories also changed. Surface in the
   "Conflict" report block and stop. The user resolves by hand.
-- **`user_edited == false`** → fetch source memories via `recall`
-  (or `Bash: curl -fsS http://127.0.0.1:7878/api/pages/<id>/sources`),
-  run the same coherence check used for clusters, then call
-  `update_page` with the existing `source_memory_ids` and freshly
-  synthesized prose.
+- **`user_edited == false`** → fetch source memories via
+  `get_page_sources(page_id="<id>")`, run the same coherence check
+  used for clusters, then call `update_page` with the existing
+  `source_memory_ids` and freshly synthesized prose.
 
 ```
 update_page(page_id=stale.page_id,

--- a/plugin/skills/forget/SKILL.md
+++ b/plugin/skills/forget/SKILL.md
@@ -48,8 +48,14 @@ KnowledgeWriter unlinks the file), snapshot the change. Defensive —
 silent skip if `git` missing, `~/.origin/` not a repo, or no diff.
 
 ```
-Bash: cd ~/.origin 2>/dev/null && [ -d .git ] && git add -A && \
-      git diff --cached --quiet || \
-      git -c user.name=Origin -c user.email=daemon@origin.local \
-          commit --quiet -m "forget: <source_id>" || true
+Bash: git -C ~/.origin add -A && \
+      git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+          commit --quiet -m "forget: <source_id>" 2>/dev/null || \
+      (sleep 1 && git -C ~/.origin add -A && \
+       git -C ~/.origin -c user.name=Origin -c user.email=daemon@origin.local \
+           commit --quiet -m "forget: <source_id>" 2>/dev/null) || true
 ```
+
+The retry handles index.lock races — the daemon may be writing to
+`~/.origin/` at the same moment (auto-commit from captures). One-second
+wait is enough for the daemon to release the lock.


### PR DESCRIPTION
## Summary

Closes the last two skill ↔ MCP boundary gaps after PR #76 (memory-type registry), PR #77 (search_pages + list_pages_recent MCP), and PR #78 (llm-wiki foundations).

- **`get_page_sources` MCP tool** — typed wrapper for `GET /api/pages/{id}/sources` (daemon already returned `Vec<PageSourceWithMemory>`, no MCP exposure existed). `/distill` skill stale-page refresh path swaps the curl shell for one `get_page_sources()` call. Closes the last raw-HTTP path to an MCP-eligible endpoint in any skill (init `/api/health` curl stays — liveness probe, no MCP equivalent).
- **`/distill` + `/forget` auto-commit retry** — aligns to the handoff skill pattern from `01f87da9`: `git -C ~/.origin` style (no cwd mutation), one-second retry after first attempt to handle index.lock races when the daemon's refinery is mid-write to ~/.origin.

## Files

- `crates/origin-mcp/src/{tools.rs,types.rs}` — new `GetPageSourcesParams` + `get_page_sources_impl` + `#[tool]` registration; re-export `PageSourceWithMemory` from origin-types
- `plugin/skills/distill/SKILL.md` — `allowed-tools` += `get_page_sources`; stale-page refresh branch switches from curl to MCP; auto-commit block updated
- `plugin/skills/forget/SKILL.md` — auto-commit block updated to handoff pattern with retry

## Test plan

- [ ] CI green (clippy workspace + origin-mcp lib tests already pass locally)
- [ ] Manual: invoke `get_page_sources` MCP tool against a populated page id; expect typed Vec<PageSourceWithMemory> JSON
- [ ] Manual: trigger /distill on stale-page scope; expect refresh path via MCP not curl
- [ ] Manual: rapid /distill while daemon refinery is writing; expect retry to absorb index.lock collision

## Version impact

`fix:` prefix → patch bump only (0.5.2 → 0.5.3). One commit has `feat:` body (new MCP tool) but PR title controls squash-merge message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)