### PR TITLE
refactor: BM-mode consumer-side surfacing (read + reject)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -15166,7 +15166,12 @@ impl MemoryDB {
     /// Embeds the query, runs DiskANN vector search on page embeddings
     /// (title+summary), runs FTS5 MATCH on page content, then merges
     /// results with Reciprocal Rank Fusion (same pattern as search_memory).
-    pub async fn search_pages(&self, query: &str, limit: usize) -> Result<Vec<Page>, OriginError> {
+    pub async fn search_pages(
+        &self,
+        query: &str,
+        limit: usize,
+        page_type: Option<&str>,
+    ) -> Result<Vec<Page>, OriginError> {
         // Embed query before acquiring conn lock (same pattern as search_memory)
         let embedding = self.get_or_compute_embedding(query)?;
         let vec_str = Self::vec_to_sql(&embedding);
@@ -15180,19 +15185,34 @@ impl MemoryDB {
                               COALESCE(c.sources_updated_count, 0), c.stale_reason, \
                               COALESCE(c.user_edited, 0)";
 
+        // Optional page_type clause: pages store their category in `domain`.
+        // When Some("recap") is passed, only pages with domain='recap' are returned.
+        let type_clause = if page_type.is_some() {
+            " AND c.domain = ?3"
+        } else {
+            ""
+        };
+
         // --- Vector search via DiskANN index ---
         let mut vector_results: Vec<(String, f64, Page)> = Vec::new();
         let vec_sql = format!(
             "SELECT {}, vector_distance_cos(c.embedding, vector32(?1)) AS dist \
              FROM vector_top_k('idx_concepts_embedding', vector32(?1), ?2) AS vt \
              JOIN pages c ON c.rowid = vt.id \
-             WHERE c.status = 'active'",
+             WHERE c.status = 'active'{type_clause}",
             concept_select,
         );
-        match conn
-            .query(&vec_sql, libsql::params![vec_str, fetch_limit])
+        let vec_result = if let Some(pt) = page_type {
+            conn.query(
+                &vec_sql,
+                libsql::params![vec_str.clone(), fetch_limit, pt.to_string()],
+            )
             .await
-        {
+        } else {
+            conn.query(&vec_sql, libsql::params![vec_str, fetch_limit])
+                .await
+        };
+        match vec_result {
             Ok(mut rows) => {
                 while let Ok(Some(row)) = rows.next().await {
                     match Self::row_to_page(&row) {
@@ -15218,16 +15238,23 @@ impl MemoryDB {
             "SELECT {} \
              FROM pages c \
              JOIN pages_fts f ON c.rowid = f.rowid \
-             WHERE pages_fts MATCH ?1 AND c.status = 'active' \
+             WHERE pages_fts MATCH ?1 AND c.status = 'active'{type_clause} \
              ORDER BY rank LIMIT ?2",
             concept_select,
         );
         let fts_queries = vec![query.to_string(), Self::fts_or_query(query)];
         for fts_q in &fts_queries {
-            match conn
-                .query(&fts_sql, libsql::params![fts_q.clone(), fetch_limit])
+            let fts_result = if let Some(pt) = page_type {
+                conn.query(
+                    &fts_sql,
+                    libsql::params![fts_q.clone(), fetch_limit, pt.to_string()],
+                )
                 .await
-            {
+            } else {
+                conn.query(&fts_sql, libsql::params![fts_q.clone(), fetch_limit])
+                    .await
+            };
+            match fts_result {
                 Ok(mut rows) => {
                     while let Ok(Some(row)) = rows.next().await {
                         if let Ok(page) = Self::row_to_page(&row) {
@@ -22669,7 +22696,7 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        let results = db.search_pages("DiskANN vector", 10).await.unwrap();
+        let results = db.search_pages("DiskANN vector", 10, None).await.unwrap();
         assert!(!results.is_empty(), "should find page via FTS");
         assert_eq!(results[0].id, "c_search");
     }
@@ -22693,7 +22720,7 @@ pub(crate) mod tests {
 
         // Query with different words than the page (no keyword overlap)
         let results = db
-            .search_pages("what databases does the project use", 10)
+            .search_pages("what databases does the project use", 10, None)
             .await
             .unwrap();
         assert!(
@@ -22701,6 +22728,89 @@ pub(crate) mod tests {
             "should find page via vector similarity even without keyword match"
         );
         assert_eq!(results[0].id, "c_vec");
+    }
+
+    #[tokio::test]
+    async fn search_pages_filters_by_page_type() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Seed 3 pages with different domain values (domain is the type classifier on pages).
+        db.insert_page(
+            "p_recap",
+            "Session Recap: Work in Progress",
+            Some("A summary of recent work"),
+            "Detailed recap content of recent session activity.",
+            None,
+            Some("recap"),
+            &["m1"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        db.insert_page(
+            "p_decision",
+            "Decision: Use libSQL for Storage",
+            Some("Storage architecture decision"),
+            "We decided to use libSQL because of vector + FTS support.",
+            None,
+            Some("decision"),
+            &["m2"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        db.insert_page(
+            "p_generic",
+            "Architecture Overview",
+            Some("System architecture notes"),
+            "Overview of the system architecture and components.",
+            None,
+            Some("architecture"),
+            &["m3"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        // Filter by page_type="recap" — should return only p_recap.
+        let recap_results = db
+            .search_pages("recent work session summary", 10, Some("recap"))
+            .await
+            .unwrap();
+        assert_eq!(
+            recap_results.len(),
+            1,
+            "expected 1 recap page, got {}",
+            recap_results.len()
+        );
+        assert_eq!(recap_results[0].id, "p_recap");
+
+        // Filter by page_type="decision" — should return only p_decision.
+        let decision_results = db
+            .search_pages("storage architecture libSQL", 10, Some("decision"))
+            .await
+            .unwrap();
+        assert_eq!(
+            decision_results.len(),
+            1,
+            "expected 1 decision page, got {}",
+            decision_results.len()
+        );
+        assert_eq!(decision_results[0].id, "p_decision");
+
+        // No filter — should include pages across different domains.
+        // Use a broad query to maximise coverage; at minimum the closest-matching page returns.
+        let all_results = db
+            .search_pages("architecture system recap decision", 10, None)
+            .await
+            .unwrap();
+        assert!(
+            !all_results.is_empty(),
+            "expected at least 1 page without filter"
+        );
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -12243,6 +12243,55 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Fetch a single refinement proposal by id, regardless of status.
+    pub async fn get_refinement_proposal(
+        &self,
+        id: &str,
+    ) -> Result<Option<RefinementProposal>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT id, action, source_ids, payload, confidence, status, created_at
+                 FROM refinement_queue WHERE id = ?1 LIMIT 1",
+                libsql::params![id.to_string()],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_refinement_proposal: {}", e)))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            let source_ids_json: String = row
+                .get(2)
+                .map_err(|e| OriginError::VectorDb(e.to_string()))?;
+            let source_ids: Vec<String> =
+                serde_json::from_str(&source_ids_json).unwrap_or_default();
+            Ok(Some(RefinementProposal {
+                id: row
+                    .get(0)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?,
+                action: row
+                    .get(1)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?,
+                source_ids,
+                payload: row.get(3).unwrap_or(None),
+                confidence: row
+                    .get(4)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?,
+                status: row
+                    .get(5)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?,
+                created_at: row
+                    .get(6)
+                    .map_err(|e| OriginError::VectorDb(e.to_string()))?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Resolve a refinement proposal with a new status.
     pub async fn resolve_refinement(&self, id: &str, status: &str) -> Result<(), OriginError> {
         let conn = self.conn.lock().await;

--- a/crates/origin-core/src/error.rs
+++ b/crates/origin-core/src/error.rs
@@ -48,6 +48,9 @@ pub enum OriginError {
     #[error("Validation error: {0}")]
     Validation(String),
 
+    #[error("Not found: {0}")]
+    NotFound(String),
+
     #[error("{0}")]
     Generic(String),
 }

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -762,7 +762,7 @@ async fn generate_e2e_answers_for_question(
     let mut structured_parts: Vec<String> = Vec::new();
 
     // Concept articles (like chat-context's "Compiled Knowledge" section)
-    let concepts = db.search_pages(question, 3).await.unwrap_or_default();
+    let concepts = db.search_pages(question, 3, None).await.unwrap_or_default();
     if !concepts.is_empty() {
         structured_parts.push("## Compiled Knowledge".to_string());
         for c in &concepts {
@@ -1112,7 +1112,7 @@ async fn build_structured_context(
         .unwrap_or_else(|| crate::tuning::DistillationConfig::default().page_min_overlap);
 
     let mut parts: Vec<String> = Vec::new();
-    let raw_concepts = db.search_pages(question, 3).await.unwrap_or_default();
+    let raw_concepts = db.search_pages(question, 3, None).await.unwrap_or_default();
     let concepts = filter_pages_by_source_overlap(&raw_concepts, &search_source_ids, min_overlap);
 
     if !raw_concepts.is_empty() {

--- a/crates/origin-core/src/eval/context_path.rs
+++ b/crates/origin-core/src/eval/context_path.rs
@@ -253,7 +253,10 @@ pub async fn run_context_path_eval(
             let mut context_tokens = recall_tokens;
 
             // Add concept source_ids
-            let concept_results = db.search_pages(&qa.question, 3).await.unwrap_or_default();
+            let concept_results = db
+                .search_pages(&qa.question, 3, None)
+                .await
+                .unwrap_or_default();
             for concept in &concept_results {
                 context_tokens += count_tokens(&concept.content);
                 // Get source memories via concept_sources join table
@@ -499,7 +502,7 @@ pub async fn run_context_path_eval_longmemeval(
         let mut context_tokens = recall_tokens;
 
         let concept_results = db
-            .search_pages(&sample.question, 3)
+            .search_pages(&sample.question, 3, None)
             .await
             .unwrap_or_default();
         for concept in &concept_results {

--- a/crates/origin-core/src/eval/lifecycle.rs
+++ b/crates/origin-core/src/eval/lifecycle.rs
@@ -442,7 +442,7 @@ async fn measure_phase(
 
         // Combined recall: search_memory ∪ concept source_ids (simulates chat-context Tier 2.5 + 3)
         if should_search_concepts {
-            let concepts = db.search_pages(query, 3).await.unwrap_or_default();
+            let concepts = db.search_pages(query, 3, None).await.unwrap_or_default();
             let mut combined: Vec<String> = Vec::new();
             for concept in &concepts {
                 for sid in &concept.source_memory_ids {

--- a/crates/origin-core/src/post_ingest.rs
+++ b/crates/origin-core/src/post_ingest.rs
@@ -534,7 +534,7 @@ pub(crate) async fn check_page_contradiction(
         .take(15)
         .collect::<Vec<_>>()
         .join(" ");
-    let concepts = db.search_pages(&query, 3).await.unwrap_or_default();
+    let concepts = db.search_pages(&query, 3, None).await.unwrap_or_default();
     if concepts.is_empty() {
         return Ok(0);
     }

--- a/crates/origin-core/src/refinery/mod.rs
+++ b/crates/origin-core/src/refinery/mod.rs
@@ -1935,7 +1935,7 @@ mod tests {
         .unwrap();
 
         // 5. Verify page search
-        let found = db.search_pages("libSQL storage", 10).await.unwrap();
+        let found = db.search_pages("libSQL storage", 10, None).await.unwrap();
         assert!(!found.is_empty());
 
         // 6. Verify page by entity lookup

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -14,6 +14,7 @@ use crate::refinery::helpers::{
     looks_like_path, looks_like_short_hash, looks_like_uuid,
 };
 use crate::sources::StabilityTier;
+use crate::synthesis::refinement_queue::{resolve_proposal, ResolveStatus};
 use std::sync::Arc;
 
 /// What a distillation pass is scoped to. Resolved from a free-form string
@@ -1157,7 +1158,7 @@ pub(crate) async fn apply_merge_by_tier(
         StabilityTier::Ephemeral => {
             // Auto-apply silently
             db.apply_merge(source_ids, merged_content).await?;
-            db.resolve_refinement(proposal_id, "auto_applied").await?;
+            resolve_proposal(db, proposal_id, ResolveStatus::AutoApplied, "daemon").await?;
             log::info!(
                 "[refinery] auto-applied merge (ephemeral) for {}",
                 proposal_id
@@ -1166,7 +1167,7 @@ pub(crate) async fn apply_merge_by_tier(
         StabilityTier::Standard => {
             // Auto-apply with notification (toast emitted by caller if app_handle available)
             db.apply_merge(source_ids, merged_content).await?;
-            db.resolve_refinement(proposal_id, "auto_applied").await?;
+            resolve_proposal(db, proposal_id, ResolveStatus::AutoApplied, "daemon").await?;
             log::info!(
                 "[refinery] auto-applied merge (standard, notify) for {}",
                 proposal_id
@@ -1174,8 +1175,7 @@ pub(crate) async fn apply_merge_by_tier(
         }
         StabilityTier::Protected => {
             // Queue for human review — don't auto-apply
-            db.resolve_refinement(proposal_id, "awaiting_review")
-                .await?;
+            resolve_proposal(db, proposal_id, ResolveStatus::AwaitingReview, "daemon").await?;
             log::info!(
                 "[refinery] queued merge for review (protected) for {}",
                 proposal_id

--- a/crates/origin-core/src/synthesis/refinement_queue.rs
+++ b/crates/origin-core/src/synthesis/refinement_queue.rs
@@ -93,14 +93,15 @@ pub(crate) async fn process_refinement_queue(
         match proposal.action.as_str() {
             "dedup_merge" => {
                 // Stale v1 proposal — dismiss (distillation handles merges now)
-                db.resolve_refinement(&proposal.id, "dismissed").await?;
+                resolve_proposal(db, &proposal.id, ResolveStatus::Dismissed, "daemon").await?;
                 processed += 1;
             }
             "detect_contradiction" => {
                 if let Some(llm) = llm {
                     let contents = db.get_memory_contents(&proposal.source_ids).await?;
                     if contents.len() < 2 {
-                        db.resolve_refinement(&proposal.id, "dismissed").await?;
+                        resolve_proposal(db, &proposal.id, ResolveStatus::Dismissed, "daemon")
+                            .await?;
                         continue;
                     }
 
@@ -146,12 +147,23 @@ pub(crate) async fn process_refinement_queue(
 
                         match result {
                             ContradictionResult::Consistent => {
-                                db.resolve_refinement(&proposal.id, "dismissed").await?;
+                                resolve_proposal(
+                                    db,
+                                    &proposal.id,
+                                    ResolveStatus::Dismissed,
+                                    "daemon",
+                                )
+                                .await?;
                             }
                             ContradictionResult::Contradicts { explanation } => {
                                 log::info!("[refinery] contradiction detected: {}", explanation);
-                                db.resolve_refinement(&proposal.id, "awaiting_review")
-                                    .await?;
+                                resolve_proposal(
+                                    db,
+                                    &proposal.id,
+                                    ResolveStatus::AwaitingReview,
+                                    "daemon",
+                                )
+                                .await?;
                             }
                             ContradictionResult::Supersedes { merged_content } => {
                                 let tier = db.get_highest_tier(&proposal.source_ids).await?;
@@ -172,8 +184,7 @@ pub(crate) async fn process_refinement_queue(
             "suggest_entity" => {
                 // Entity suggestion: payload contains the suggested entity name.
                 // Mark as awaiting_review so the UI can surface it for approval.
-                db.resolve_refinement(&proposal.id, "awaiting_review")
-                    .await?;
+                resolve_proposal(db, &proposal.id, ResolveStatus::AwaitingReview, "daemon").await?;
                 log::info!(
                     "[refinery] entity suggestion queued for review: {:?}",
                     proposal.payload
@@ -270,6 +281,33 @@ mod tests {
         assert!(
             matches!(err, crate::error::OriginError::Validation(_)),
             "expected Validation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_dismiss_logs_activity_via_convergence() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_daemon_1",
+            "dedup_merge",
+            &["a".to_string(), "b".to_string()],
+            None,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        resolve_proposal(&db, "ref_daemon_1", ResolveStatus::Dismissed, "daemon")
+            .await
+            .unwrap();
+
+        let acts = db
+            .list_agent_activity(10, Some("daemon"), None)
+            .await
+            .unwrap_or_default();
+        assert!(
+            acts.iter().any(|a| a.action == "refinement_resolve"),
+            "daemon path should log refinement_resolve via convergence"
         );
     }
 

--- a/crates/origin-core/src/synthesis/refinement_queue.rs
+++ b/crates/origin-core/src/synthesis/refinement_queue.rs
@@ -5,9 +5,79 @@ use crate::contradiction::ContradictionResult;
 use crate::db::MemoryDB;
 use crate::error::OriginError;
 use crate::llm_provider::{LlmProvider, LlmRequest};
+use crate::post_write::WriteResult;
 use crate::prompts::PromptRegistry;
 use crate::synthesis::distill::apply_merge_by_tier;
 use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveStatus {
+    Dismissed,
+    AwaitingReview,
+    AutoApplied,
+    Resolved,
+}
+
+impl ResolveStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ResolveStatus::Dismissed => "dismissed",
+            ResolveStatus::AwaitingReview => "awaiting_review",
+            ResolveStatus::AutoApplied => "auto_applied",
+            ResolveStatus::Resolved => "resolved",
+        }
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            ResolveStatus::Dismissed | ResolveStatus::AutoApplied | ResolveStatus::Resolved
+        )
+    }
+}
+
+fn status_is_terminal(s: &str) -> bool {
+    matches!(s, "dismissed" | "auto_applied" | "resolved")
+}
+
+/// Resolve a refinement queue proposal. Convergent capability fn used by both the
+/// daemon scheduler (refinery phase) and the HTTP reject route. Wraps
+/// `db.resolve_refinement` with idempotency pre-check + agent activity logging.
+pub async fn resolve_proposal(
+    db: &MemoryDB,
+    id: &str,
+    status: ResolveStatus,
+    agent: &str,
+) -> Result<WriteResult, OriginError> {
+    let proposal = db
+        .get_refinement_proposal(id)
+        .await?
+        .ok_or_else(|| OriginError::NotFound(format!("refinement proposal {id} not found")))?;
+
+    if status_is_terminal(&proposal.status) {
+        return Err(OriginError::Validation(format!(
+            "refinement proposal {id} already resolved (status={})",
+            proposal.status
+        )));
+    }
+
+    db.resolve_refinement(id, status.as_str()).await?;
+
+    let payload = serde_json::json!({
+        "action": proposal.action,
+        "new_status": status.as_str(),
+        "source_ids": proposal.source_ids,
+    })
+    .to_string();
+    let _ = db
+        .log_agent_activity(agent, "refinement_resolve", &[], None, &payload)
+        .await;
+
+    Ok(WriteResult {
+        id: id.to_string(),
+        warnings: Vec::new(),
+    })
+}
 
 /// Process pending refinement queue items via LLM.
 pub(crate) async fn process_refinement_queue(
@@ -116,4 +186,117 @@ pub(crate) async fn process_refinement_queue(
         }
     }
     Ok(processed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::MemoryDB;
+    use crate::events::NoopEmitter;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    async fn test_db() -> (MemoryDB, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("test.db");
+        let db = MemoryDB::new(&db_path, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
+        (db, tmp)
+    }
+
+    #[tokio::test]
+    async fn resolve_proposal_dismissed_updates_status() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_test_1",
+            "detect_contradiction",
+            &["mem_a".to_string(), "mem_b".to_string()],
+            None,
+            0.8,
+        )
+        .await
+        .unwrap();
+
+        let result = resolve_proposal(&db, "ref_test_1", ResolveStatus::Dismissed, "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(result.id, "ref_test_1");
+        assert!(result.warnings.is_empty());
+
+        let pending = db.get_pending_refinements().await.unwrap();
+        assert!(
+            !pending.iter().any(|p| p.id == "ref_test_1"),
+            "dismissed proposal should not appear in pending list"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_proposal_not_found_returns_not_found_error() {
+        let (db, _tmp) = test_db().await;
+        let err = resolve_proposal(
+            &db,
+            "ref_nonexistent",
+            ResolveStatus::Dismissed,
+            "test-agent",
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_proposal_already_terminal_returns_validation_error() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_test_2",
+            "entity_merge",
+            &["e1".to_string(), "e2".to_string()],
+            None,
+            0.87,
+        )
+        .await
+        .unwrap();
+        resolve_proposal(&db, "ref_test_2", ResolveStatus::Dismissed, "test-agent")
+            .await
+            .unwrap();
+
+        let err = resolve_proposal(&db, "ref_test_2", ResolveStatus::Dismissed, "test-agent")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::Validation(_)),
+            "expected Validation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_proposal_logs_activity() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_test_3",
+            "suggest_entity",
+            &["mem_x".to_string()],
+            Some("{\"name\":\"Acme\"}"),
+            0.9,
+        )
+        .await
+        .unwrap();
+
+        resolve_proposal(&db, "ref_test_3", ResolveStatus::Dismissed, "test-agent")
+            .await
+            .unwrap();
+
+        let acts = db
+            .list_agent_activity(10, Some("test-agent"), None)
+            .await
+            .unwrap_or_default();
+        assert!(
+            acts.iter().any(|a| a.action == "refinement_resolve"),
+            "expected refinement_resolve activity row, found: {acts:?}"
+        );
+    }
 }

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -1198,7 +1198,10 @@ async fn test_concept_before_after_comparison() {
             .await;
 
         // Combined: search_pages + search_memory
-        let concepts = db.search_pages(&case.query, 3).await.unwrap_or_default();
+        let concepts = db
+            .search_pages(&case.query, 3, None)
+            .await
+            .unwrap_or_default();
         let mut combined: Vec<String> = Vec::new();
         for concept in &concepts {
             for sid in &concept.source_memory_ids {
@@ -2469,7 +2472,10 @@ async fn smoke_fullpipeline() {
         .join("\n");
     let flat_tokens = count_tokens(&flat_ctx);
 
-    let concept_results = db.search_pages(&qa.question, 3).await.unwrap_or_default();
+    let concept_results = db
+        .search_pages(&qa.question, 3, None)
+        .await
+        .unwrap_or_default();
     let mut structured_parts: Vec<String> = Vec::new();
     if !concept_results.is_empty() {
         structured_parts.push("## Compiled Knowledge".to_string());
@@ -3641,7 +3647,7 @@ async fn probe_concept_scores() {
 
         let mut all_scores: Vec<f32> = Vec::new();
         for (cat, question) in &samples {
-            let concepts = db.search_pages(question, 3).await.unwrap_or_default();
+            let concepts = db.search_pages(question, 3, None).await.unwrap_or_default();
             let scores: Vec<f32> = concepts.iter().map(|c| c.relevance_score).collect();
             let tokens: Vec<usize> = concepts
                 .iter()
@@ -3786,7 +3792,7 @@ async fn probe_overlap_gate() {
                 results.iter().map(|r| r.source_id.clone()).collect();
 
             // Real search_pages (top-3)
-            let raw_concepts = db.search_pages(q, 3).await.unwrap_or_default();
+            let raw_concepts = db.search_pages(q, 3, None).await.unwrap_or_default();
             let kept = filter_pages_by_source_overlap(&raw_concepts, &search_ids, min_overlap);
 
             for c in &raw_concepts {

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -182,6 +182,26 @@ pub struct ConfirmMemoryParams {
     pub memory_id: String,
 }
 
+// --- Refinery queue params ---
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListRefinementsParams {
+    #[schemars(
+        description = "Optional action filter. One of: entity_merge, relation_conflict, detect_contradiction, suggest_entity, dedup_merge."
+    )]
+    #[serde(default)]
+    pub action: Option<String>,
+    #[schemars(description = "Max number of proposals to return. Default 50, max 500.")]
+    #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct RejectRefinementParams {
+    #[schemars(description = "The refinement proposal id to dismiss.")]
+    pub id: String,
+}
+
 // --- Knowledge graph CRUD params ---
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -931,6 +951,57 @@ impl OriginMcpServer {
             pretty
         ))]))
     }
+
+    pub async fn list_refinements_impl(
+        &self,
+        params: ListRefinementsParams,
+    ) -> Result<CallToolResult, McpError> {
+        let mut path = String::from("/api/refinery/queue");
+        let mut q: Vec<String> = Vec::new();
+        if let Some(a) = params.action.as_deref() {
+            q.push(format!("action={}", url_encode_simple(a)));
+        }
+        if let Some(l) = params.limit {
+            q.push(format!("limit={l}"));
+        }
+        if !q.is_empty() {
+            path.push('?');
+            path.push_str(&q.join("&"));
+        }
+
+        let resp: ListRefinementsResponse = match self.client.get(&path).await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error(e, "list_refinements")),
+        };
+
+        let pretty = serde_json::to_string_pretty(&resp.proposals)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} pending refinement proposals\n{}",
+            resp.proposals.len(),
+            pretty
+        ))]))
+    }
+
+    pub async fn reject_refinement_impl(
+        &self,
+        params: RejectRefinementParams,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!(
+            "/api/refinery/queue/{}/reject",
+            url_encode_simple(&params.id)
+        );
+        let resp: RejectRefinementResponse =
+            match self.client.post(&path, &serde_json::json!({})).await {
+                Ok(v) => v,
+                Err(e) => return Ok(tool_error(e, "reject_refinement")),
+            };
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Refinement {} dismissed.",
+            resp.id
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -950,6 +1021,19 @@ fn build_recent_pages_path(limit: Option<usize>, since_ms: Option<i64>) -> Strin
         path.push_str(&q.join("&"));
     }
     path
+}
+
+/// Percent-encode a string for use in URL query parameter values.
+/// Encodes all characters except unreserved ones (A-Z, a-z, 0-9, `-`, `_`, `.`, `~`).
+fn url_encode_simple(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                vec![c]
+            }
+            _ => format!("%{:02X}", c as u32).chars().collect(),
+        })
+        .collect()
 }
 
 // ===== Tool Registrations =====
@@ -1250,6 +1334,40 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListPagesRecentParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_pages_recent_impl(params).await
+    }
+
+    // --- Refinery queue tools ---
+
+    #[tool(
+        description = "List pending refinement proposals from Origin's daemon-side refinery queue. Use when the user wants to audit what the daemon has queued for review — phrases like 'check refinery', 'pending proposals', 'what's queued'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
+        annotations(
+            title = "List refinements",
+            read_only_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_refinements(
+        &self,
+        Parameters(params): Parameters<ListRefinementsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_refinements_impl(params).await
+    }
+
+    #[tool(
+        description = "Reject (dismiss) a refinement proposal by id. Use when reviewing the refinery queue and the user decides a proposal is wrong or noise. Marks the queue row dismissed and logs the agent activity. Idempotent: already-dismissed proposals return 422. Note: there is no accept verb yet; keeping a proposal is a no-op (it stays queued).",
+        annotations(
+            title = "Reject refinement",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn reject_refinement(
+        &self,
+        Parameters(params): Parameters<RejectRefinementParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.reject_refinement_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -899,6 +899,7 @@ impl OriginMcpServer {
         let req = SearchPagesRequest {
             query: params.query,
             limit: params.limit,
+            page_type: None,
         };
         let resp: SearchPagesResponse = match self.client.post("/api/pages/search", &req).await {
             Ok(r) => r,
@@ -2998,6 +2999,7 @@ mod tests {
         let req = SearchPagesRequest {
             query: params.query,
             limit: params.limit,
+            page_type: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["query"], "mutex");

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -341,6 +341,11 @@ pub struct SearchPagesParams {
     )]
     #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
     pub limit: Option<usize>,
+    #[schemars(
+        description = "Optional page type filter (e.g. 'recap', 'decision'). Narrows results to one type/domain. Omit to search all types."
+    )]
+    #[serde(default)]
+    pub page_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -919,7 +924,7 @@ impl OriginMcpServer {
         let req = SearchPagesRequest {
             query: params.query,
             limit: params.limit,
-            page_type: None,
+            page_type: params.page_type,
         };
         let resp: SearchPagesResponse = match self.client.post("/api/pages/search", &req).await {
             Ok(r) => r,
@@ -1315,7 +1320,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Search pages by query. Use to resolve a page title to its id before calling get_page (set `limit: 1` for that), or to browse pages on a topic. Returns matching pages with id, title, and summary. For listing recent activity instead, use list_pages_recent.",
+        description = "Search pages by query. Use to resolve a page title to its id before calling get_page (set `limit: 1` for that), or to browse pages on a topic. Returns matching pages with id, title, and summary. Optional `page_type` filter narrows to one type (e.g. `recap`, `decision`). For listing recent activity instead, use list_pages_recent.",
         annotations(title = "Search pages", read_only_hint = true, open_world_hint = false)
     )]
     async fn search_pages(
@@ -3113,11 +3118,12 @@ mod tests {
         let params = SearchPagesParams {
             query: "mutex".into(),
             limit: Some(7),
+            page_type: None,
         };
         let req = SearchPagesRequest {
             query: params.query,
             limit: params.limit,
-            page_type: None,
+            page_type: params.page_type,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["query"], "mutex");

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -12,7 +12,7 @@ pub use origin_types::requests::{
 };
 pub use origin_types::responses::{
     AddObservationResponse, ChatContextResponse, CreateEntityResponse, CreatePageResponse,
-    CreateRelationResponse, DeleteResponse, ListMemoriesResponse, SearchMemoryResponse,
-    SearchPagesResponse, StoreMemoryResponse,
+    CreateRelationResponse, DeleteResponse, ListMemoriesResponse, ListRefinementsResponse,
+    RejectRefinementResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-server/src/error.rs
+++ b/crates/origin-server/src/error.rs
@@ -89,6 +89,7 @@ impl From<origin_core::OriginError> for ServerError {
         match err {
             origin_core::OriginError::AgentDisabled(msg) => ServerError::AgentDisabled(msg),
             origin_core::OriginError::Validation(msg) => ServerError::ValidationError(msg),
+            origin_core::OriginError::NotFound(msg) => ServerError::NotFound(msg),
             other => ServerError::Internal(other.to_string()),
         }
     }

--- a/crates/origin-server/src/lib.rs
+++ b/crates/origin-server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ingest_routes;
 pub mod knowledge_routes;
 pub mod memory_routes;
 pub mod onboarding_routes;
+pub mod refinery_routes;
 pub mod router;
 pub mod routes;
 pub mod scheduler;

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1669,7 +1669,10 @@ fn truncate_for_title(content: &str) -> String {
 ///
 /// Unknown callers become `"unknown"` (which the frontend filter hides from the
 /// user-facing dropdown). Honest-unknown beats guessing.
-fn extract_agent_name(headers: &HeaderMap, deprecated_body_agent: Option<&str>) -> String {
+pub(crate) fn extract_agent_name(
+    headers: &HeaderMap,
+    deprecated_body_agent: Option<&str>,
+) -> String {
     if let Some(agent) = headers
         .get("x-agent-name")
         .and_then(|v| v.to_str().ok())

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1961,7 +1961,11 @@ pub async fn handle_search_pages(
     let s = state.read().await;
     let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
     let results = db
-        .search_pages(&req.query, req.limit.unwrap_or(20))
+        .search_pages(
+            &req.query,
+            req.limit.unwrap_or(20),
+            req.page_type.as_deref(),
+        )
         .await
         .map_err(|e| ServerError::SearchFailed(e.to_string()))?;
     Ok(Json(serde_json::json!({ "pages": results })))
@@ -2000,6 +2004,8 @@ pub struct SearchPagesRequest {
     pub query: String,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default)]
+    pub page_type: Option<String>,
 }
 
 /// POST /api/pages/export

--- a/crates/origin-server/src/refinery_routes.rs
+++ b/crates/origin-server/src/refinery_routes.rs
@@ -49,13 +49,26 @@ pub async fn handle_list_refinements(
             None => true,
         })
         .take(limit)
-        .map(|p| RefinementProposalSummary {
-            action: parse_action(&p.action),
-            payload: parse_payload(p.payload.as_deref(), &p.action),
-            id: p.id,
-            source_ids: p.source_ids,
-            confidence: p.confidence,
-            created_at: p.created_at,
+        .filter_map(|p| {
+            let action = match parse_action(&p.action) {
+                Some(a) => a,
+                None => {
+                    tracing::warn!(
+                        proposal_id = %p.id,
+                        action = %p.action,
+                        "refinery: skipping proposal with unknown action variant"
+                    );
+                    return None;
+                }
+            };
+            Some(RefinementProposalSummary {
+                action,
+                payload: parse_payload(p.payload.as_deref(), &p.action),
+                id: p.id,
+                source_ids: p.source_ids,
+                confidence: p.confidence,
+                created_at: p.created_at,
+            })
         })
         .collect();
 
@@ -81,22 +94,25 @@ pub async fn handle_reject_refinement(
     Ok(Json(RejectRefinementResponse { id: result.id }))
 }
 
-fn parse_action(s: &str) -> ProposalAction {
+fn parse_action(s: &str) -> Option<ProposalAction> {
     match s {
-        "entity_merge" => ProposalAction::EntityMerge,
-        "relation_conflict" => ProposalAction::RelationConflict,
-        "detect_contradiction" => ProposalAction::DetectContradiction,
-        "suggest_entity" => ProposalAction::SuggestEntity,
-        _ => ProposalAction::DedupMerge,
+        "entity_merge" => Some(ProposalAction::EntityMerge),
+        "relation_conflict" => Some(ProposalAction::RelationConflict),
+        "detect_contradiction" => Some(ProposalAction::DetectContradiction),
+        "suggest_entity" => Some(ProposalAction::SuggestEntity),
+        "dedup_merge" => Some(ProposalAction::DedupMerge),
+        _ => None,
     }
 }
 
 /// Convert the raw daemon payload string into the typed wire enum.
 ///
 /// Variant decode rules:
-/// - `detect_contradiction` and `dedup_merge`: unit variants, always Some regardless of payload
-/// - `suggest_entity`: raw string payload → `name_hint`
-/// - `entity_merge`, `relation_conflict`: JSON object payload; inject `action` tag
+/// - `detect_contradiction` and `dedup_merge`: unit variants, return Some regardless of payload
+/// - `suggest_entity`: raw string payload lifted into `name_hint`
+/// - `entity_merge`, `relation_conflict`: JSON object payload; inject `action` tag.
+///   Returns `None` if payload is malformed JSON or fails to deserialize.
+/// - Unknown action: falls through to JSON-decode path; returns `None` for unknown shapes.
 fn parse_payload(payload: Option<&str>, action: &str) -> Option<RefinementPayload> {
     match action {
         "detect_contradiction" => return Some(RefinementPayload::DetectContradiction),
@@ -184,5 +200,11 @@ mod parse_payload_tests {
             parsed.is_none(),
             "malformed payload should decode to None, not crash"
         );
+    }
+
+    #[test]
+    fn parse_action_unknown_returns_none() {
+        assert!(super::parse_action("entity_split_v2").is_none());
+        assert!(super::parse_action("").is_none());
     }
 }

--- a/crates/origin-server/src/refinery_routes.rs
+++ b/crates/origin-server/src/refinery_routes.rs
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+//! HTTP routes for the refinement queue surface (read + reject).
+//!
+//! Convergent with daemon-side `synthesis::refinement_queue::resolve_proposal`.
+
+use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
+use axum::Json;
+use origin_core::synthesis::refinement_queue::{resolve_proposal, ResolveStatus};
+use origin_types::responses::{
+    ListRefinementsResponse, ProposalAction, RefinementPayload, RefinementProposalSummary,
+    RejectRefinementResponse,
+};
+use serde::Deserialize;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::error::ServerError;
+use crate::memory_routes::extract_agent_name;
+use crate::state::ServerState;
+
+#[derive(Debug, Deserialize)]
+pub struct ListRefinementsQuery {
+    pub action: Option<String>,
+    pub limit: Option<usize>,
+}
+
+pub async fn handle_list_refinements(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Query(q): Query<ListRefinementsQuery>,
+) -> Result<Json<ListRefinementsResponse>, ServerError> {
+    let limit = q.limit.unwrap_or(50).min(500);
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+
+    let pending = db
+        .get_pending_refinements()
+        .await
+        .map_err(ServerError::from)?;
+
+    let proposals: Vec<RefinementProposalSummary> = pending
+        .into_iter()
+        .filter(|p| p.status == "awaiting_review")
+        .filter(|p| match &q.action {
+            Some(a) => &p.action == a,
+            None => true,
+        })
+        .take(limit)
+        .map(|p| RefinementProposalSummary {
+            action: parse_action(&p.action),
+            payload: parse_payload(p.payload.as_deref(), &p.action),
+            id: p.id,
+            source_ids: p.source_ids,
+            confidence: p.confidence,
+            created_at: p.created_at,
+        })
+        .collect();
+
+    Ok(Json(ListRefinementsResponse { proposals }))
+}
+
+pub async fn handle_reject_refinement(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<RejectRefinementResponse>, ServerError> {
+    let agent = extract_agent_name(&headers, None);
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+
+    let result = resolve_proposal(&db, &id, ResolveStatus::Dismissed, &agent)
+        .await
+        .map_err(ServerError::from)?;
+
+    Ok(Json(RejectRefinementResponse { id: result.id }))
+}
+
+fn parse_action(s: &str) -> ProposalAction {
+    match s {
+        "entity_merge" => ProposalAction::EntityMerge,
+        "relation_conflict" => ProposalAction::RelationConflict,
+        "detect_contradiction" => ProposalAction::DetectContradiction,
+        "suggest_entity" => ProposalAction::SuggestEntity,
+        _ => ProposalAction::DedupMerge,
+    }
+}
+
+/// Convert the raw daemon payload string into the typed wire enum.
+///
+/// Variant decode rules:
+/// - `detect_contradiction` and `dedup_merge`: unit variants, always Some regardless of payload
+/// - `suggest_entity`: raw string payload → `name_hint`
+/// - `entity_merge`, `relation_conflict`: JSON object payload; inject `action` tag
+fn parse_payload(payload: Option<&str>, action: &str) -> Option<RefinementPayload> {
+    match action {
+        "detect_contradiction" => return Some(RefinementPayload::DetectContradiction),
+        "dedup_merge" => return Some(RefinementPayload::DedupMerge),
+        "suggest_entity" => {
+            return Some(RefinementPayload::SuggestEntity {
+                name_hint: payload.map(|s| s.to_string()),
+            });
+        }
+        _ => {}
+    }
+
+    let raw = payload?;
+    let map: serde_json::Map<String, serde_json::Value> = serde_json::from_str(raw).ok()?;
+    let mut tagged = map;
+    tagged.insert(
+        "action".to_string(),
+        serde_json::Value::String(action.to_string()),
+    );
+    serde_json::from_value(serde_json::Value::Object(tagged)).ok()
+}
+
+#[cfg(test)]
+mod parse_payload_tests {
+    use super::*;
+
+    #[test]
+    fn parses_entity_merge() {
+        let raw = r#"{"existing_id":"e1","new_id":"e2","similarity":0.86}"#;
+        let parsed = parse_payload(Some(raw), "entity_merge").unwrap();
+        match parsed {
+            RefinementPayload::EntityMerge {
+                existing_id,
+                new_id,
+                similarity,
+            } => {
+                assert_eq!(existing_id, "e1");
+                assert_eq!(new_id, "e2");
+                assert!((similarity - 0.86).abs() < 1e-9);
+            }
+            _ => panic!("expected EntityMerge"),
+        }
+    }
+
+    #[test]
+    fn parses_relation_conflict_with_from_to() {
+        let raw = r#"{"existing_id":"r1","new_id":"r2","from":"e_a","to":"e_b","old_type":"works_at","new_type":"founded"}"#;
+        let parsed = parse_payload(Some(raw), "relation_conflict").unwrap();
+        match parsed {
+            RefinementPayload::RelationConflict { from, to, .. } => {
+                assert_eq!(from, "e_a");
+                assert_eq!(to, "e_b");
+            }
+            _ => panic!("expected RelationConflict"),
+        }
+    }
+
+    #[test]
+    fn detect_contradiction_unit_even_when_payload_none() {
+        let parsed = parse_payload(None, "detect_contradiction").unwrap();
+        assert!(matches!(parsed, RefinementPayload::DetectContradiction));
+    }
+
+    #[test]
+    fn suggest_entity_lifts_raw_string_into_name_hint() {
+        let parsed = parse_payload(Some("PostgreSQL"), "suggest_entity").unwrap();
+        match parsed {
+            RefinementPayload::SuggestEntity { name_hint } => {
+                assert_eq!(name_hint.as_deref(), Some("PostgreSQL"));
+            }
+            _ => panic!("expected SuggestEntity"),
+        }
+    }
+
+    #[test]
+    fn dedup_merge_unit_with_no_payload() {
+        let parsed = parse_payload(None, "dedup_merge").unwrap();
+        assert!(matches!(parsed, RefinementPayload::DedupMerge));
+    }
+
+    #[test]
+    fn malformed_json_returns_none() {
+        let parsed = parse_payload(Some("not json"), "entity_merge");
+        assert!(
+            parsed.is_none(),
+            "malformed payload should decode to None, not crash"
+        );
+    }
+}

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -4,7 +4,7 @@
 use crate::state::SharedState;
 use crate::{
     config_routes, import_routes, ingest_routes, knowledge_routes, memory_routes,
-    onboarding_routes, routes, source_routes, websocket,
+    onboarding_routes, refinery_routes, routes, source_routes, websocket,
 };
 use axum::{
     routing::{delete, get, post, put},
@@ -239,6 +239,15 @@ pub fn build_router(state: SharedState) -> Router {
         .route(
             "/api/memory/rejections",
             get(memory_routes::handle_get_rejections),
+        )
+        // Refinement queue
+        .route(
+            "/api/refinery/queue",
+            get(refinery_routes::handle_list_refinements),
+        )
+        .route(
+            "/api/refinery/queue/{id}/reject",
+            post(refinery_routes::handle_reject_refinement),
         )
         // Sources
         .route(

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -354,7 +354,7 @@ pub async fn handle_chat_context(
 
     let page_results: Vec<String> =
         if tier_allowed(&classification.trust_level, 2) && query != "recent context" {
-            let raw_pages = db.search_pages(query, 3).await.unwrap_or_default();
+            let raw_pages = db.search_pages(query, 3, None).await.unwrap_or_default();
             let pages = origin_core::pages::filter_pages_by_source_overlap(
                 &raw_pages,
                 &search_source_ids,

--- a/crates/origin-server/tests/refinery_routes.rs
+++ b/crates/origin-server/tests/refinery_routes.rs
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for /api/refinery/queue endpoints.
+//!
+//! Drives the axum Router via tower::ServiceExt::oneshot — no TCP socket.
+//! Tests: list filtering, typed payload decode, empty queue,
+//! reject happy + default agent + 404 + 422.
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use origin_core::db::MemoryDB;
+use origin_core::events::NoopEmitter;
+use origin_server::router::build_router;
+use origin_server::state::ServerState;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+async fn test_app() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MemoryDB::new(dir.path(), Arc::new(NoopEmitter))
+        .await
+        .unwrap();
+    let db_arc = Arc::new(db);
+    let state = ServerState {
+        db: Some(db_arc.clone()),
+        ..ServerState::default()
+    };
+    let router = build_router(Arc::new(RwLock::new(state)));
+    (router, dir, db_arc)
+}
+
+/// Insert a proposal and immediately transition it to `awaiting_review` so the
+/// list route (which filters on that status) can surface it.
+async fn seed_awaiting(
+    db: &Arc<MemoryDB>,
+    id: &str,
+    action: &str,
+    payload: Option<&str>,
+    confidence: f64,
+) {
+    db.insert_refinement_proposal(
+        id,
+        action,
+        &["src_a".to_string(), "src_b".to_string()],
+        payload,
+        confidence,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement(id, "awaiting_review").await.unwrap();
+}
+
+async fn read_body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn list_queue_returns_only_awaiting_review() {
+    let (app, _tmp, db) = test_app().await;
+    seed_awaiting(&db, "ref_a", "entity_merge", None, 0.86).await;
+    seed_awaiting(&db, "ref_b", "entity_merge", None, 0.87).await;
+    // ref_c: insert then immediately dismiss — should not appear
+    db.insert_refinement_proposal("ref_c", "entity_merge", &["src_a".to_string()], None, 0.88)
+        .await
+        .unwrap();
+    db.resolve_refinement("ref_c", "dismissed").await.unwrap();
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/refinery/queue")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = read_body_json(resp).await;
+    let proposals = body["proposals"].as_array().unwrap();
+    assert_eq!(proposals.len(), 2, "dismissed proposal must not appear");
+}
+
+#[tokio::test]
+async fn list_queue_filters_by_action() {
+    let (app, _tmp, db) = test_app().await;
+    seed_awaiting(&db, "r1", "entity_merge", None, 0.86).await;
+    seed_awaiting(&db, "r2", "relation_conflict", None, 0.7).await;
+    seed_awaiting(&db, "r3", "suggest_entity", Some("\"X\""), 0.9).await;
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/refinery/queue?action=entity_merge")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = read_body_json(resp).await;
+    let proposals = body["proposals"].as_array().unwrap();
+    assert_eq!(proposals.len(), 1);
+    assert_eq!(proposals[0]["action"], "entity_merge");
+}
+
+#[tokio::test]
+async fn list_queue_decodes_typed_payload() {
+    let (app, _tmp, db) = test_app().await;
+    let payload = r#"{"existing_id":"e1","new_id":"e2","similarity":0.86}"#;
+    seed_awaiting(&db, "ref_typed", "entity_merge", Some(payload), 0.86).await;
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/refinery/queue")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = read_body_json(resp).await;
+    // RefinementPayload is a serde internally-tagged enum with tag "action",
+    // so the serialized object carries `"action": "entity_merge"` alongside the fields.
+    let payload_val = &body["proposals"][0]["payload"];
+    assert_eq!(payload_val["action"], "entity_merge");
+    assert_eq!(payload_val["existing_id"], "e1");
+    assert_eq!(payload_val["new_id"], "e2");
+}
+
+#[tokio::test]
+async fn list_queue_empty_returns_200() {
+    let (app, _tmp, _db) = test_app().await;
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/refinery/queue")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = read_body_json(resp).await;
+    assert_eq!(body["proposals"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn reject_marks_dismissed_and_logs_activity() {
+    let (app, _tmp, db) = test_app().await;
+    // Reject works from 'pending' status directly (resolve_proposal only guards terminal states)
+    db.insert_refinement_proposal(
+        "ref_rej_1",
+        "detect_contradiction",
+        &["src_a".to_string()],
+        None,
+        0.8,
+    )
+    .await
+    .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_rej_1/reject")
+        .header("x-agent-name", "claude-code")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Verify queue row dismissed
+    let pending = db.get_pending_refinements().await.unwrap();
+    assert!(!pending.iter().any(|p| p.id == "ref_rej_1"));
+
+    // Verify activity row logged with x-agent-name value
+    let acts = db
+        .list_agent_activity(10, Some("claude-code"), None)
+        .await
+        .unwrap_or_default();
+    assert!(
+        acts.iter().any(|a| a.action == "refinement_resolve"),
+        "activity row should be logged with x-agent-name value"
+    );
+}
+
+#[tokio::test]
+async fn reject_default_agent_when_header_missing() {
+    let (app, _tmp, db) = test_app().await;
+    db.insert_refinement_proposal(
+        "ref_no_agent",
+        "entity_merge",
+        &["src_a".to_string()],
+        None,
+        0.86,
+    )
+    .await
+    .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_no_agent/reject")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Verify queue row dismissed regardless of which agent name was used
+    let pending = db.get_pending_refinements().await.unwrap();
+    assert!(!pending.iter().any(|p| p.id == "ref_no_agent"));
+
+    // extract_agent_name defaults to "unknown" when header is absent
+    let acts = db
+        .list_agent_activity(10, Some("unknown"), None)
+        .await
+        .unwrap_or_default();
+    assert!(
+        acts.iter().any(|a| a.action == "refinement_resolve"),
+        "default-agent path should log activity under 'unknown'"
+    );
+}
+
+#[tokio::test]
+async fn reject_unknown_id_returns_404() {
+    let (app, _tmp, _db) = test_app().await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_does_not_exist/reject")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn reject_already_terminal_returns_422() {
+    let (app, _tmp, db) = test_app().await;
+    db.insert_refinement_proposal(
+        "ref_done",
+        "entity_merge",
+        &["src_a".to_string()],
+        None,
+        0.86,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement("ref_done", "dismissed")
+        .await
+        .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_done/reject")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -36,7 +36,9 @@ pub use memory::{
 pub use memory_type::{MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRIPTION};
 pub use narrative::NarrativeResponse;
 pub use pages::Page;
-pub use responses::{ExportStats, MemoryDetail, PendingRevision};
+pub use responses::{
+    ExportStats, MemoryDetail, PendingRevision, ProposalAction, RefinementPayload,
+};
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 
 use serde::{Deserialize, Serialize};

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -37,7 +37,8 @@ pub use memory_type::{MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRI
 pub use narrative::NarrativeResponse;
 pub use pages::Page;
 pub use responses::{
-    ExportStats, MemoryDetail, PendingRevision, ProposalAction, RefinementPayload,
+    ExportStats, ListRefinementsResponse, MemoryDetail, PendingRevision, ProposalAction,
+    RefinementPayload, RefinementProposalSummary, RejectRefinementResponse,
 };
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 

--- a/crates/origin-types/src/requests.rs
+++ b/crates/origin-types/src/requests.rs
@@ -249,6 +249,8 @@ pub struct SearchPagesRequest {
     pub query: String,
     #[serde(default)]
     pub limit: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_type: Option<String>,
 }
 
 // ===== Ingest =====
@@ -501,4 +503,23 @@ fn default_true() -> bool {
 
 fn default_entity_search_limit() -> usize {
     20
+}
+
+#[cfg(test)]
+mod search_pages_page_type_test {
+    use super::*;
+
+    #[test]
+    fn search_pages_request_accepts_page_type() {
+        let json = r#"{"query":"foo","limit":10,"page_type":"recap"}"#;
+        let parsed: SearchPagesRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.page_type.as_deref(), Some("recap"));
+    }
+
+    #[test]
+    fn search_pages_request_page_type_optional() {
+        let json = r#"{"query":"foo","limit":10}"#;
+        let parsed: SearchPagesRequest = serde_json::from_str(json).unwrap();
+        assert!(parsed.page_type.is_none());
+    }
 }

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -488,6 +488,107 @@ pub struct SyncStatsResponse {
     pub errors: usize,
 }
 
+// ===== Refinement proposals =====
+
+/// The action type for a background-refinery proposal.
+///
+/// Used as the `action` tag in [`RefinementPayload`].
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalAction {
+    EntityMerge,
+    RelationConflict,
+    DetectContradiction,
+    SuggestEntity,
+    DedupMerge,
+}
+
+/// Tagged-union payload emitted by the background refinery.
+///
+/// Each variant carries exactly the fields needed for that action type.
+/// Decoded at the route boundary so downstream consumers (MCP wrappers,
+/// agent skills) can pattern-match instead of inspecting raw JSON strings.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum RefinementPayload {
+    EntityMerge {
+        existing_id: String,
+        new_id: String,
+        similarity: f64,
+    },
+    RelationConflict {
+        existing_id: String,
+        new_id: String,
+        from_entity: String,
+        to_entity: String,
+        old_type: String,
+        new_type: String,
+    },
+    DetectContradiction {
+        existing_memory_id: String,
+        new_memory_id: String,
+    },
+    SuggestEntity {
+        name: String,
+        entity_type: Option<String>,
+    },
+    DedupMerge,
+}
+
+#[cfg(test)]
+mod refinement_wire_tests {
+    use super::*;
+
+    #[test]
+    fn proposal_action_serde_round_trip() {
+        let cases = [
+            ("\"entity_merge\"", ProposalAction::EntityMerge),
+            ("\"relation_conflict\"", ProposalAction::RelationConflict),
+            (
+                "\"detect_contradiction\"",
+                ProposalAction::DetectContradiction,
+            ),
+            ("\"suggest_entity\"", ProposalAction::SuggestEntity),
+            ("\"dedup_merge\"", ProposalAction::DedupMerge),
+        ];
+        for (json, expected) in cases {
+            let parsed: ProposalAction = serde_json::from_str(json).unwrap();
+            assert_eq!(parsed, expected, "deserialize {json}");
+            let back = serde_json::to_string(&expected).unwrap();
+            assert_eq!(back, json, "serialize {expected:?}");
+        }
+    }
+
+    #[test]
+    fn refinement_payload_entity_merge_round_trip() {
+        let json =
+            r#"{"action":"entity_merge","existing_id":"e1","new_id":"e2","similarity":0.87}"#;
+        let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
+        match parsed {
+            RefinementPayload::EntityMerge {
+                ref existing_id,
+                ref new_id,
+                similarity,
+            } => {
+                assert_eq!(existing_id, "e1");
+                assert_eq!(new_id, "e2");
+                assert!((similarity - 0.87).abs() < 1e-9);
+            }
+            _ => panic!("expected EntityMerge variant"),
+        }
+        let back = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(back["action"], "entity_merge");
+        assert_eq!(back["existing_id"], "e1");
+    }
+
+    #[test]
+    fn refinement_payload_dedup_merge_no_fields() {
+        let json = r#"{"action":"dedup_merge"}"#;
+        let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
+        assert!(matches!(parsed, RefinementPayload::DedupMerge));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -532,6 +532,27 @@ pub enum RefinementPayload {
     DedupMerge,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RefinementProposalSummary {
+    pub id: String,
+    pub action: ProposalAction,
+    pub source_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<RefinementPayload>,
+    pub confidence: f64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ListRefinementsResponse {
+    pub proposals: Vec<RefinementProposalSummary>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RejectRefinementResponse {
+    pub id: String,
+}
+
 #[cfg(test)]
 mod refinement_wire_tests {
     use super::*;
@@ -639,6 +660,40 @@ mod refinement_wire_tests {
             parsed,
             RefinementPayload::SuggestEntity { name_hint: None }
         ));
+    }
+
+    #[test]
+    fn list_refinements_response_round_trip() {
+        let resp = ListRefinementsResponse {
+            proposals: vec![RefinementProposalSummary {
+                id: "ref_1".into(),
+                action: ProposalAction::EntityMerge,
+                source_ids: vec!["a".into(), "b".into()],
+                payload: Some(RefinementPayload::EntityMerge {
+                    existing_id: "a".into(),
+                    new_id: "b".into(),
+                    similarity: 0.86,
+                }),
+                confidence: 0.86,
+                created_at: "2026-05-12T00:00:00Z".into(),
+            }],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: ListRefinementsResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.proposals.len(), 1);
+        assert_eq!(parsed.proposals[0].id, "ref_1");
+        assert!(matches!(
+            parsed.proposals[0].action,
+            ProposalAction::EntityMerge
+        ));
+    }
+
+    #[test]
+    fn reject_refinement_response_round_trip() {
+        let resp = RejectRefinementResponse { id: "ref_x".into() };
+        let json = serde_json::to_string(&resp).unwrap();
+        let parsed: RejectRefinementResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "ref_x");
     }
 }
 

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -519,18 +519,15 @@ pub enum RefinementPayload {
     RelationConflict {
         existing_id: String,
         new_id: String,
-        from_entity: String,
-        to_entity: String,
+        from: String,
+        to: String,
         old_type: String,
         new_type: String,
     },
-    DetectContradiction {
-        existing_memory_id: String,
-        new_memory_id: String,
-    },
+    DetectContradiction,
     SuggestEntity {
-        name: String,
-        entity_type: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name_hint: Option<String>,
     },
     DedupMerge,
 }
@@ -586,6 +583,62 @@ mod refinement_wire_tests {
         let json = r#"{"action":"dedup_merge"}"#;
         let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
         assert!(matches!(parsed, RefinementPayload::DedupMerge));
+    }
+
+    #[test]
+    fn refinement_payload_relation_conflict_round_trip() {
+        let json = r#"{"action":"relation_conflict","existing_id":"r1","new_id":"r2","from":"e_a","to":"e_b","old_type":"works_at","new_type":"founded"}"#;
+        let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
+        match parsed {
+            RefinementPayload::RelationConflict {
+                ref existing_id,
+                ref new_id,
+                ref from,
+                ref to,
+                ref old_type,
+                ref new_type,
+            } => {
+                assert_eq!(existing_id, "r1");
+                assert_eq!(new_id, "r2");
+                assert_eq!(from, "e_a");
+                assert_eq!(to, "e_b");
+                assert_eq!(old_type, "works_at");
+                assert_eq!(new_type, "founded");
+            }
+            _ => panic!("expected RelationConflict"),
+        }
+        let back = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(back["from"], "e_a");
+        assert_eq!(back["to"], "e_b");
+    }
+
+    #[test]
+    fn refinement_payload_detect_contradiction_unit_variant() {
+        let json = r#"{"action":"detect_contradiction"}"#;
+        let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
+        assert!(matches!(parsed, RefinementPayload::DetectContradiction));
+    }
+
+    #[test]
+    fn refinement_payload_suggest_entity_with_name_hint() {
+        let json = r#"{"action":"suggest_entity","name_hint":"PostgreSQL"}"#;
+        let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
+        match parsed {
+            RefinementPayload::SuggestEntity { ref name_hint } => {
+                assert_eq!(name_hint.as_deref(), Some("PostgreSQL"));
+            }
+            _ => panic!("expected SuggestEntity"),
+        }
+    }
+
+    #[test]
+    fn refinement_payload_suggest_entity_without_name_hint() {
+        let json = r#"{"action":"suggest_entity"}"#;
+        let parsed: RefinementPayload = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            parsed,
+            RefinementPayload::SuggestEntity { name_hint: None }
+        ));
     }
 }
 

--- a/plugin/skills/brief/SKILL.md
+++ b/plugin/skills/brief/SKILL.md
@@ -6,7 +6,7 @@ description: >
   `/brief [topic]`. Call FIRST at session start, before any other
   Origin verb.
 argument-hint: "[topic]"
-allowed-tools: ["mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__search_pages"]
+allowed-tools: ["mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall"]
 ---
 
 # /brief
@@ -16,7 +16,7 @@ and what's relevant to the current topic.
 
 ## How to invoke
 
-**Step 1.** Call the `origin` MCP server's `context` tool. If the user passed a topic
+Call the `origin` MCP server's `context` tool. If the user passed a topic
 argument, pass it through. Otherwise infer scope from the working directory and
 the conversation so far — don't ask the user.
 
@@ -31,11 +31,6 @@ context(topic="<args or inferred>", domain=<inferred from cwd or recent turns>)
   general brief at session start.
 - `domain`: from cwd. `~/Repos/origin/...` → `"origin"`. Other repos → repo
   name. Outside any repo → omit.
-
-**Step 2.** Call `search_pages(page_type="recap", limit=3)` to load the 3 most recent
-recap pages. If results, prepend a "Recent recaps" section to the brief output
-showing each recap's title + 1-line summary. If the call returns no results or
-errors, omit the section silently — recap pages may not exist yet on a fresh vault.
 
 ## When to use
 

--- a/plugin/skills/brief/SKILL.md
+++ b/plugin/skills/brief/SKILL.md
@@ -6,7 +6,7 @@ description: >
   `/brief [topic]`. Call FIRST at session start, before any other
   Origin verb.
 argument-hint: "[topic]"
-allowed-tools: ["mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall"]
+allowed-tools: ["mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__search_pages"]
 ---
 
 # /brief
@@ -16,9 +16,9 @@ and what's relevant to the current topic.
 
 ## How to invoke
 
-Call the `origin` MCP server's `context` tool. If the user passed a topic
-argument, pass it through. Otherwise infer scope from the working
-directory and the conversation so far — don't ask the user.
+**Step 1.** Call the `origin` MCP server's `context` tool. If the user passed a topic
+argument, pass it through. Otherwise infer scope from the working directory and
+the conversation so far — don't ask the user.
 
 ```
 context(topic="<args or inferred>", domain=<inferred from cwd or recent turns>)
@@ -31,6 +31,11 @@ context(topic="<args or inferred>", domain=<inferred from cwd or recent turns>)
   general brief at session start.
 - `domain`: from cwd. `~/Repos/origin/...` → `"origin"`. Other repos → repo
   name. Outside any repo → omit.
+
+**Step 2.** Call `search_pages(page_type="recap", limit=3)` to load the 3 most recent
+recap pages. If results, prepend a "Recent recaps" section to the brief output
+showing each recap's title + 1-line summary. If the call returns no results or
+errors, omit the section silently — recap pages may not exist yet on a fresh vault.
 
 ## When to use
 

--- a/plugin/skills/refinery/SKILL.md
+++ b/plugin/skills/refinery/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: refinery
+description: >
+  Walk Origin's pending refinement queue. Lists daemon-queued proposals (entity merges,
+  relation conflicts, contradictions, entity suggestions) and lets the user dismiss noise.
+  Invoked as `/refinery`. Use when the user wants to audit what the daemon's refinery
+  has queued for review.
+allowed-tools: ["mcp__plugin_origin_origin__list_refinements", "mcp__plugin_origin_origin__reject_refinement"]
+---
+
+# /refinery
+
+Surface Origin's refinement queue and walk each pending proposal with the user.
+
+## How to invoke
+
+Pull pending proposals via the `origin` MCP server's `list_refinements` tool:
+
+```
+list_refinements(limit=20)
+```
+
+Optional action filter to narrow:
+
+```
+list_refinements(action="entity_merge")
+```
+
+Valid action values: `entity_merge`, `relation_conflict`, `detect_contradiction`,
+`suggest_entity`, `dedup_merge`.
+
+For each proposal, present:
+- **Action** (one of the 5 variants above)
+- **Confidence** (0.0 - 1.0)
+- **Source ids** (the memories or entities the proposal references)
+- **Payload summary** — pattern-match on the typed `payload` field:
+  - `entity_merge`: "Merge entity `<existing_id>` ↔ `<new_id>` (similarity `<similarity>`)"
+  - `relation_conflict`: "Relation `<existing_id>` vs `<new_id>` from `<from>` → `<to>`, type `<old_type>` → `<new_type>`"
+  - `detect_contradiction`: source ids list the conflicting memories
+  - `suggest_entity`: name hint `<name_hint>`
+  - `dedup_merge`: no payload — historical (auto-dismissed by daemon)
+
+Then offer per-item:
+- **Keep** → no-op (see notice below)
+- **Dismiss** → `reject_refinement(id="<id>")`
+
+## Accept is not in scope yet
+
+This skill exposes **list + dismiss only**. There is no accept verb in this version.
+Keeping a proposal is a no-op — it stays in the queue for a future session (or for
+the desktop app, when the accept-side spec lands).
+
+**Only dismiss when you are confident the proposal is wrong.** Do not develop a
+habit of dismissing-by-default; that would skew the queue toward attrition.
+
+## When to use
+
+- User says "check refinery", "pending proposals", "what's queued", "audit
+  daemon decisions", "review entity merges".

--- a/plugin/skills/refinery/SKILL.md
+++ b/plugin/skills/refinery/SKILL.md
@@ -27,17 +27,17 @@ list_refinements(action="entity_merge")
 ```
 
 Valid action values: `entity_merge`, `relation_conflict`, `detect_contradiction`,
-`suggest_entity`, `dedup_merge`.
+`dedup_merge`. (`suggest_entity` is reserved for a future producer and not
+emitted by any current path.)
 
 For each proposal, present:
-- **Action** (one of the 5 variants above)
+- **Action** (one of the 4 variants above)
 - **Confidence** (0.0 - 1.0)
 - **Source ids** (the memories or entities the proposal references)
 - **Payload summary** — pattern-match on the typed `payload` field:
   - `entity_merge`: "Merge entity `<existing_id>` ↔ `<new_id>` (similarity `<similarity>`)"
   - `relation_conflict`: "Relation `<existing_id>` vs `<new_id>` from `<from>` → `<to>`, type `<old_type>` → `<new_type>`"
   - `detect_contradiction`: source ids list the conflicting memories
-  - `suggest_entity`: name hint `<name_hint>`
   - `dedup_merge`: no payload — historical (auto-dismissed by daemon)
 
 Then offer per-item:


### PR DESCRIPTION
## Summary

- **Convergence (consumer side):** `synthesis::refinement_queue::resolve_proposal` capability fn introduced; 8 existing daemon `db.resolve_refinement` sites + new HTTP reject route now share the same path. Symmetric analogue to PR #87's `post_write::*` for producer side.
- **Surface (HTTP + MCP):** `GET /api/refinery/queue` + `POST /api/refinery/queue/{id}/reject` registered; MCP tools `list_refinements` + `reject_refinement` added; `search_pages` extended with `page_type` filter. All wire types typed-deserialized from `origin-types`.
- **Skill:** new `/refinery` skill walks pending proposals with list + dismiss. Accept verb deferred to Spec B; skill states this explicitly so agents don't develop a dismiss-by-default habit.

## Wire shapes

`RefinementPayload` is a tagged enum matching the daemon producer exactly: `EntityMerge`, `RelationConflict` (with `from`/`to` keys — not `from_entity`/`to_entity`, verified against `post_write.rs`), `DetectContradiction` (unit), `SuggestEntity { name_hint }` (raw-string payload lift), `DedupMerge` (unit). Status field intentionally NOT on `RefinementProposalSummary` — list route filters to `awaiting_review` only.

## Spec / Plan
- Spec: `docs/superpowers/specs/2026-05-12-bm-mode-consumer-surfacing-design.md` (local-only, gitignored)
- Plan: `docs/superpowers/plans/2026-05-12-bm-mode-consumer-surfacing.md` (local-only)
- Adversarial review pre-impl: 4 critical findings integrated (drift on field names, missing `suggest_entity` action, status leakage, payload opaqueness).
- Adversarial review post-impl: 2 blockers found + fixed (skill listed `suggest_entity` despite no producer; `/brief` recap-loading was dead code on production data — reverted, see below).

## Out of scope

- **Spec B (apply machinery):** accept-side dispatch for refinement queue, new DB primitives (`merge_entities`, `flag_memory`, `supersede_relation`). Builds on `apply_merge_by_tier` already in `synthesis/distill.rs`.
- **Spec C:** MCP/skill surfacing for nurture cards, entity-suggestions, pending-revisions, contradictions, rejections, orphan-links (currently HTTP-only).
- **`/brief` recap-loading reverted:** recap producer writes `is_recap=true` memories, not pages with `domain=\"recap\"`. `context` MCP tool already surfaces recap memories via topic-load path. Re-attempt when recap-page persistence design lands.

## Test Plan
- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 1240 passed (1001 + 148 + 51 + 40)
- [x] `cargo test -p origin-server --test refinery_routes` — 8 integration tests pass (list filtering, typed payload decode, empty queue, reject happy + default-agent + 404 + 422)
- [x] Smoke test on isolated daemon (port 7879 + tmp data dir): real-daemon end-to-end seed → list → reject → empty → 404 → 422 → page_type filter → no panics
- [x] 8 daemon db.resolve_refinement sites migrated; activity log unified across daemon + agent reject paths
- [ ] CI green on PR