### PR TITLE
docs: use self-hosted plugin install

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ The daemon does the memory chores in the background: stores what matters, dedupl
 ### Claude Code — 30 seconds
 
 ```text
-/plugin install origin@claude-plugins-official
+/plugin marketplace add 7xuanlu/origin
+/plugin install origin@7xuanlu
 /init
 ```
 
 If Claude Code asks for a restart after installing, restart once, then run `/init`. The plugin handles daemon setup, MCP wiring, Basic Memory mode, and the first round-trip check.
+
+`7xuanlu` is the GitHub repo owner. If you fork Origin, use your own handle in both commands.
 
 Plugin details and daily commands: [plugin/](plugin/.claude-plugin/README.md).
 

--- a/plugin/.claude-plugin/README.md
+++ b/plugin/.claude-plugin/README.md
@@ -5,7 +5,8 @@ AI work memory for Claude Code. Origin carries sessions, decisions, lessons, and
 ## 30-Second Setup
 
 ```text
-0s   /plugin install origin@claude-plugins-official
+0s   /plugin marketplace add 7xuanlu/origin
+     /plugin install origin@7xuanlu
 5s   restart Claude Code
 10s  /init   auto-installs daemon if missing, configures Basic Memory,
             verifies daemon + MCP + round-trip, prints "Origin ready"
@@ -20,17 +21,13 @@ if the daemon ever stops.
 ## Install
 
 ```text
-/plugin install origin@claude-plugins-official
-```
-
-For local development against this repository, add this repo as a marketplace instead:
-
-```text
 /plugin marketplace add 7xuanlu/origin
 /plugin install origin@7xuanlu
 ```
 
-The development marketplace is defined in [`../../.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json) (at the repo root). The plugin metadata is defined in [`plugin.json`](plugin.json). MCP configuration is in [`../.mcp.json`](../.mcp.json) (this plugin's `.mcp.json`), which delegates to [`../bin/origin-mcp-runner.sh`](../bin/origin-mcp-runner.sh).
+`7xuanlu` is the GitHub repo owner. If you fork Origin, use your own handle.
+
+The marketplace is defined in [`../../.claude-plugin/marketplace.json`](../../.claude-plugin/marketplace.json) (at the repo root). The plugin metadata is defined in [`plugin.json`](plugin.json). MCP configuration is in [`../.mcp.json`](../.mcp.json) (this plugin's `.mcp.json`), which delegates to [`../bin/origin-mcp-runner.sh`](../bin/origin-mcp-runner.sh).
 
 The runner picks the MCP server binary in three paths, in order:
 

--- a/plugin/skills/init/SKILL.md
+++ b/plugin/skills/init/SKILL.md
@@ -3,7 +3,7 @@ name: init
 description: >
   Frictionless setup. Detects missing daemon, installs it, configures Basic
   Memory mode, and verifies the full plugin → MCP → daemon round-trip. Run
-  after `/plugin install origin@claude-plugins-official`, or any time the user says "set up
+  after `/plugin install origin@7xuanlu`, or any time the user says "set up
   origin", "is origin working", "fix origin".
 allowed-tools: ["Bash", "mcp__plugin_origin_origin__doctor", "mcp__plugin_origin_origin__context"]
 ---
@@ -120,7 +120,7 @@ work in Basic Memory mode.
 
 ## When to use
 
-- Right after `/plugin install origin@claude-plugins-official`.
+- Right after `/plugin install origin@7xuanlu`.
 - Hook printed "daemon down — run /origin:init".
 - User says "set up origin", "is it working", "reinstall origin".
 


### PR DESCRIPTION
## Summary
- switch README Claude Code setup to the working self-hosted marketplace install
- update plugin README and /init skill text to use origin@7xuanlu
- remove stale claude-plugins-official install references until official directory propagation is actually live

## Test Plan
- git diff --check HEAD~1..HEAD
- rg confirmed no remaining claude-plugins-official references in README.md, plugin/, or .claude-plugin/
- pre-commit passed