### PR TITLE
feat: BM-mode consumer-side accept dispatch

### DIFF
--- a/crates/origin-core/src/synthesis/refinement_queue.rs
+++ b/crates/origin-core/src/synthesis/refinement_queue.rs
@@ -80,6 +80,100 @@ pub async fn resolve_proposal(
     })
 }
 
+/// Outcome of `apply_refinement`. Returned by the HTTP route and MCP tool.
+#[derive(Debug)]
+pub struct AcceptOutcome {
+    pub id: String,
+    pub action_applied: String,
+}
+
+/// Apply a refinement queue proposal using sensible defaults per action variant.
+/// Single dispatch point for both daemon-internal accept paths (none today; reserved)
+/// and agent HTTP triggers. Wraps PR1's idempotent primitives + atomic `resolve_proposal`.
+///
+/// Defaults:
+/// - `entity_merge`: existing entity (source_ids[1]) wins as canonical, new (source_ids[0]) folds in as alias.
+/// - `relation_conflict`: new relation (source_ids[0]) wins, existing (source_ids[1]) deleted.
+/// - `detect_contradiction`: previously-stored memory (source_ids[1]) flagged pending_revision=1.
+/// - `suggest_entity`, `dedup_merge`, unknown: returns Validation (422).
+pub async fn apply_refinement(
+    db: &MemoryDB,
+    id: &str,
+    agent: &str,
+) -> Result<AcceptOutcome, OriginError> {
+    let prop = db
+        .get_refinement_proposal(id)
+        .await?
+        .ok_or_else(|| OriginError::NotFound(format!("refinement proposal {id} not found")))?;
+
+    // Mirror the terminal-status set from resolve_refinement_if_open SQL.
+    if matches!(
+        prop.status.as_str(),
+        "dismissed" | "auto_applied" | "resolved"
+    ) {
+        return Err(OriginError::Validation(format!(
+            "refinement proposal {id} already resolved (status={})",
+            prop.status
+        )));
+    }
+
+    match prop.action.as_str() {
+        "entity_merge" => {
+            let new_id = prop.source_ids.first().ok_or_else(|| {
+                OriginError::Validation("entity_merge missing source_ids[0]".into())
+            })?;
+            let existing_id = prop.source_ids.get(1).ok_or_else(|| {
+                OriginError::Validation("entity_merge missing source_ids[1]".into())
+            })?;
+            db.merge_entities(existing_id, new_id).await?;
+        }
+        "relation_conflict" => {
+            let new_id = prop.source_ids.first().ok_or_else(|| {
+                OriginError::Validation("relation_conflict missing source_ids[0]".into())
+            })?;
+            let existing_id = prop.source_ids.get(1).ok_or_else(|| {
+                OriginError::Validation("relation_conflict missing source_ids[1]".into())
+            })?;
+            db.supersede_relation(existing_id, new_id).await?;
+        }
+        "detect_contradiction" => {
+            let existing_mem = prop.source_ids.get(1).ok_or_else(|| {
+                OriginError::Validation("detect_contradiction missing source_ids[1]".into())
+            })?;
+            db.flag_memory_for_revision(existing_mem).await?;
+        }
+        "suggest_entity" => {
+            return Err(OriginError::Validation(
+                "action 'suggest_entity' has no accept path (reserved for future producer)".into(),
+            ));
+        }
+        "dedup_merge" => {
+            return Err(OriginError::Validation(
+                "action 'dedup_merge' has no accept path (deprecated stale-v1 variant)".into(),
+            ));
+        }
+        other => {
+            return Err(OriginError::Validation(format!("unknown action: {other}")));
+        }
+    }
+
+    resolve_proposal(db, id, ResolveStatus::Resolved, agent).await?;
+
+    let payload = serde_json::json!({
+        "action": prop.action,
+        "source_ids": prop.source_ids,
+    })
+    .to_string();
+    let _ = db
+        .log_agent_activity(agent, "refinement_apply", &prop.source_ids, None, &payload)
+        .await;
+
+    Ok(AcceptOutcome {
+        id: id.to_string(),
+        action_applied: prop.action,
+    })
+}
+
 /// Process pending refinement queue items via LLM.
 pub(crate) async fn process_refinement_queue(
     db: &MemoryDB,
@@ -392,6 +486,344 @@ mod tests {
         assert_eq!(
             resolve_count, 1,
             "activity log should record exactly one resolve, got {resolve_count}"
+        );
+    }
+
+    // ==================== apply_refinement ====================
+
+    async fn seed_entity_merge_proposal(db: &MemoryDB, id: &str) -> (String, String) {
+        let new_ent = db
+            .create_entity("Acme Corporation", "organization", None)
+            .await
+            .unwrap();
+        let existing_ent = db
+            .create_entity("Acme Corp", "organization", None)
+            .await
+            .unwrap();
+        db.insert_refinement_proposal(
+            id,
+            "entity_merge",
+            &[new_ent.clone(), existing_ent.clone()],
+            None,
+            0.87,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE refinement_queue SET status = 'awaiting_review' WHERE id = ?1",
+                libsql::params![id],
+            )
+            .await
+            .unwrap();
+        }
+        (new_ent, existing_ent)
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_entity_merge_default_existing_wins() {
+        let (db, _tmp) = test_db().await;
+        let (new_ent, existing_ent) = seed_entity_merge_proposal(&db, "ref_em_1").await;
+
+        let outcome = apply_refinement(&db, "ref_em_1", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(outcome.action_applied, "entity_merge");
+
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM entities WHERE id = ?1",
+                libsql::params![existing_ent],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(count, 1, "existing entity should remain canonical");
+
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM entities WHERE id = ?1",
+                libsql::params![new_ent],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(count, 0, "new entity should be merged away");
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_relation_conflict_default_new_wins() {
+        let (db, _tmp) = test_db().await;
+        let from = db.create_entity("Alice", "person", None).await.unwrap();
+        let to = db
+            .create_entity("Acme", "organization", None)
+            .await
+            .unwrap();
+        let existing_rel = db
+            .create_relation(&from, &to, "works_at", None, Some(0.5), None, None)
+            .await
+            .unwrap();
+        let new_rel = db
+            .create_relation(&from, &to, "leads", None, Some(0.9), None, None)
+            .await
+            .unwrap();
+        db.insert_refinement_proposal(
+            "ref_rc_1",
+            "relation_conflict",
+            &[new_rel.clone(), existing_rel.clone()],
+            None,
+            0.7,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE refinement_queue SET status = 'awaiting_review' WHERE id = ?1",
+                libsql::params!["ref_rc_1"],
+            )
+            .await
+            .unwrap();
+        }
+
+        let outcome = apply_refinement(&db, "ref_rc_1", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(outcome.action_applied, "relation_conflict");
+
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM relations WHERE id = ?1",
+                libsql::params![new_rel],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(count, 1, "new relation (winner) should remain");
+
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM relations WHERE id = ?1",
+                libsql::params![existing_rel],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(count, 0, "existing relation (loser) should be deleted");
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_detect_contradiction_flags_existing() {
+        let (db, _tmp) = test_db().await;
+        let new_mem = format!("mem_{}", uuid::Uuid::new_v4().simple());
+        let existing_mem = format!("mem_{}", uuid::Uuid::new_v4().simple());
+        {
+            let conn = db.conn.lock().await;
+            for sid in &[new_mem.clone(), existing_mem.clone()] {
+                conn.execute(
+                    "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                                            chunk_type, source_agent, domain, confidence, confirmed, \
+                                            last_modified, memory_type, pending_revision) \
+                     VALUES (?1, ?2, 'memory', ?3, 'test', 0, 'text', NULL, 'general', 1.0, 0, 1712707200, 'fact', 0)",
+                    libsql::params![sid.clone(), "x".to_string(), sid.clone()],
+                )
+                .await
+                .unwrap();
+            }
+        }
+        db.insert_refinement_proposal(
+            "ref_dc_1",
+            "detect_contradiction",
+            &[new_mem.clone(), existing_mem.clone()],
+            None,
+            0.8,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE refinement_queue SET status = 'awaiting_review' WHERE id = ?1",
+                libsql::params!["ref_dc_1"],
+            )
+            .await
+            .unwrap();
+        }
+
+        let outcome = apply_refinement(&db, "ref_dc_1", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(outcome.action_applied, "detect_contradiction");
+
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT pending_revision FROM memories WHERE source_id = ?1",
+                libsql::params![existing_mem],
+            )
+            .await
+            .unwrap();
+        let f: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(f, 1, "existing memory should be flagged for revision");
+
+        let mut rows = conn
+            .query(
+                "SELECT pending_revision FROM memories WHERE source_id = ?1",
+                libsql::params![new_mem],
+            )
+            .await
+            .unwrap();
+        let f: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(f, 0, "new memory should NOT be flagged");
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_suggest_entity_returns_422() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_se_1",
+            "suggest_entity",
+            &["x".into()],
+            Some("{\"name\":\"Acme\"}"),
+            0.9,
+        )
+        .await
+        .unwrap();
+        let err = apply_refinement(&db, "ref_se_1", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::Validation(_)),
+            "expected Validation for suggest_entity, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_dedup_merge_returns_422() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_dm_1",
+            "dedup_merge",
+            &["a".into(), "b".into()],
+            None,
+            0.95,
+        )
+        .await
+        .unwrap();
+        let err = apply_refinement(&db, "ref_dm_1", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::Validation(_)),
+            "expected Validation for dedup_merge, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_unknown_action_returns_422() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal("ref_uk_1", "future_action_xyz", &["a".into()], None, 0.5)
+            .await
+            .unwrap();
+        let err = apply_refinement(&db, "ref_uk_1", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::Validation(_)),
+            "expected Validation for unknown action, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_missing_id_returns_404() {
+        let (db, _tmp) = test_db().await;
+        let err = apply_refinement(&db, "ref_nonexistent", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_terminal_proposal_returns_422() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_term_1",
+            "entity_merge",
+            &["a".into(), "b".into()],
+            None,
+            0.85,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE refinement_queue SET status = 'resolved' WHERE id = ?1",
+                libsql::params!["ref_term_1"],
+            )
+            .await
+            .unwrap();
+        }
+        let err = apply_refinement(&db, "ref_term_1", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::Validation(_)),
+            "expected Validation (terminal), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_logs_both_apply_and_resolve_activity() {
+        let (db, _tmp) = test_db().await;
+        let _ = seed_entity_merge_proposal(&db, "ref_log_1").await;
+
+        apply_refinement(&db, "ref_log_1", "test-agent")
+            .await
+            .unwrap();
+
+        let acts = db
+            .list_agent_activity(20, Some("test-agent"), None)
+            .await
+            .unwrap_or_default();
+        let apply_count = acts
+            .iter()
+            .filter(|a| a.action == "refinement_apply")
+            .count();
+        let resolve_count = acts
+            .iter()
+            .filter(|a| a.action == "refinement_resolve")
+            .count();
+        assert_eq!(
+            apply_count, 1,
+            "exactly one refinement_apply row, got {apply_count}"
+        );
+        assert_eq!(
+            resolve_count, 1,
+            "exactly one refinement_resolve row, got {resolve_count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_idempotent_via_resolve_race() {
+        let (db, _tmp) = test_db().await;
+        let _ = seed_entity_merge_proposal(&db, "ref_race_1").await;
+
+        apply_refinement(&db, "ref_race_1", "client-a")
+            .await
+            .unwrap();
+        let err = apply_refinement(&db, "ref_race_1", "client-b")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::error::OriginError::Validation(_)),
+            "second accept should 422, got {err:?}"
         );
     }
 }

--- a/crates/origin-core/src/synthesis/refinement_queue.rs
+++ b/crates/origin-core/src/synthesis/refinement_queue.rs
@@ -286,6 +286,21 @@ pub(crate) async fn process_refinement_queue(
                 );
                 processed += 1;
             }
+            "entity_merge" | "relation_conflict" => {
+                // Producer wrote pending; surface for human review (Spec A list endpoint
+                // filters by awaiting_review status). Accept dispatch is agent-triggered,
+                // not daemon-auto.
+                //
+                // Guard on status=='pending' to avoid spamming refinement_resolve activity
+                // rows every tick on already-promoted proposals: get_pending_refinements
+                // returns proposals with status NOT IN (terminal), so awaiting_review
+                // proposals would re-match and re-log without this guard.
+                if proposal.status == "pending" {
+                    resolve_proposal(db, &proposal.id, ResolveStatus::AwaitingReview, "daemon")
+                        .await?;
+                }
+                processed += 1;
+            }
             _ => {
                 log::debug!("[refinery] unknown action: {}", proposal.action);
             }
@@ -824,6 +839,115 @@ mod tests {
         assert!(
             matches!(err, crate::error::OriginError::Validation(_)),
             "second accept should 422, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_arm_promotes_pending_entity_merge_to_awaiting_review() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_pending_em",
+            "entity_merge",
+            &["a".into(), "b".into()],
+            None,
+            0.87,
+        )
+        .await
+        .unwrap();
+        // status defaults to 'pending'
+        let tuning = crate::tuning::RefineryConfig::default();
+        let prompts = crate::prompts::PromptRegistry::default();
+        let processed = process_refinement_queue(&db, None, &prompts, &tuning)
+            .await
+            .unwrap();
+        assert!(
+            processed >= 1,
+            "process_refinement_queue should report >=1 processed"
+        );
+
+        let prop = db
+            .get_refinement_proposal("ref_pending_em")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            prop.status, "awaiting_review",
+            "pending entity_merge should promote to awaiting_review"
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_arm_promotes_pending_relation_conflict_to_awaiting_review() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_pending_rc",
+            "relation_conflict",
+            &["a".into(), "b".into()],
+            None,
+            0.7,
+        )
+        .await
+        .unwrap();
+        let tuning = crate::tuning::RefineryConfig::default();
+        let prompts = crate::prompts::PromptRegistry::default();
+        let processed = process_refinement_queue(&db, None, &prompts, &tuning)
+            .await
+            .unwrap();
+        assert!(processed >= 1);
+
+        let prop = db
+            .get_refinement_proposal("ref_pending_rc")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(prop.status, "awaiting_review");
+    }
+
+    #[tokio::test]
+    async fn daemon_arm_skips_already_awaiting_review() {
+        let (db, _tmp) = test_db().await;
+        db.insert_refinement_proposal(
+            "ref_aw_em",
+            "entity_merge",
+            &["a".into(), "b".into()],
+            None,
+            0.87,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE refinement_queue SET status = 'awaiting_review' WHERE id = ?1",
+                libsql::params!["ref_aw_em"],
+            )
+            .await
+            .unwrap();
+        }
+
+        let tuning = crate::tuning::RefineryConfig::default();
+        let prompts = crate::prompts::PromptRegistry::default();
+        let _ = process_refinement_queue(&db, None, &prompts, &tuning)
+            .await
+            .unwrap();
+
+        // Verify NO new refinement_resolve activity row was logged by the daemon
+        // for this already-awaiting proposal (status guard skipped resolve_proposal).
+        // get_pending_refinements returns proposals with status NOT IN (terminal),
+        // so awaiting_review still shows; the test asserts no spurious daemon activity.
+        let acts = db
+            .list_agent_activity(50, Some("daemon"), None)
+            .await
+            .unwrap_or_default();
+        // No activity rows produced for this proposal at all (it never went through
+        // resolve_proposal in this tick). Check by counting "refinement_resolve" rows.
+        let count = acts
+            .iter()
+            .filter(|a| a.action == "refinement_resolve")
+            .count();
+        assert_eq!(
+            count, 0,
+            "no spurious resolve activity for already-awaiting proposal"
         );
     }
 }

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -202,6 +202,12 @@ pub struct RejectRefinementParams {
     pub id: String,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct AcceptRefinementParams {
+    #[schemars(description = "The refinement proposal id (e.g. \"merge_abc123_def456\").")]
+    pub id: String,
+}
+
 // --- Knowledge graph CRUD params ---
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1056,6 +1062,26 @@ impl OriginMcpServer {
             resp.id
         ))]))
     }
+
+    pub async fn accept_refinement_impl(
+        &self,
+        params: AcceptRefinementParams,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!(
+            "/api/refinery/queue/{}/accept",
+            url_encode_simple(&params.id)
+        );
+        let resp: AcceptRefinementResponse =
+            match self.client.post(&path, &serde_json::json!({})).await {
+                Ok(v) => v,
+                Err(e) => return Ok(tool_error(e, "accept_refinement")),
+            };
+
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "Refinement {} accepted (action={}).",
+            resp.id, resp.action_applied
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1456,6 +1482,27 @@ impl OriginMcpServer {
         Parameters(params): Parameters<RejectRefinementParams>,
     ) -> Result<CallToolResult, McpError> {
         self.reject_refinement_impl(params).await
+    }
+
+    #[tool(
+        description = "Apply a refinement queue proposal using sensible defaults. \
+            entity_merge: existing entity wins as canonical. \
+            relation_conflict: new relation supersedes. \
+            detect_contradiction: previously-stored memory flagged for revision. \
+            Returns 422 for suggest_entity (no producer) and dedup_merge (deprecated).",
+        annotations(
+            title = "Accept refinement",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn accept_refinement(
+        &self,
+        Parameters(params): Parameters<AcceptRefinementParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.accept_refinement_impl(params).await
     }
 }
 
@@ -3280,5 +3327,26 @@ mod tests {
                 "`{name}` must declare read_only_hint=true"
             );
         }
+    }
+
+    #[test]
+    fn accept_refinement_response_typed_deserialize() {
+        let raw = r#"{"id":"ref_xyz","action_applied":"entity_merge"}"#;
+        let parsed: AcceptRefinementResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.id, "ref_xyz");
+        assert_eq!(parsed.action_applied, "entity_merge");
+    }
+
+    #[test]
+    fn accept_refinement_response_rejects_extra_envelope() {
+        // Daemon must not wrap successful response under an extra key — the
+        // lesson_mcp_typed_deserialize guard. This test verifies a non-typed
+        // shape fails to deserialize loud.
+        let wrong = r#"{"data":{"id":"ref_xyz","action_applied":"entity_merge"}}"#;
+        let result: Result<AcceptRefinementResponse, _> = serde_json::from_str(wrong);
+        assert!(
+            result.is_err(),
+            "envelope-wrapped response must fail typed deserialize"
+        );
     }
 }

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -11,9 +11,10 @@ pub use origin_types::requests::{
     ListMemoriesRequest, SearchMemoryRequest, SearchPagesRequest, StoreMemoryRequest,
 };
 pub use origin_types::responses::{
-    AddObservationResponse, ChatContextResponse, CreateEntityResponse, CreatePageResponse,
-    CreateRelationResponse, DeleteResponse, ListMemoriesResponse, ListMemoryRevisionsResponse,
-    ListPageRevisionsResponse, ListRefinementsResponse, MemoryRevisionEntry, PageChangelogEntry,
-    RejectRefinementResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
+    AcceptRefinementResponse, AddObservationResponse, ChatContextResponse, CreateEntityResponse,
+    CreatePageResponse, CreateRelationResponse, DeleteResponse, ListMemoriesResponse,
+    ListMemoryRevisionsResponse, ListPageRevisionsResponse, ListRefinementsResponse,
+    MemoryRevisionEntry, PageChangelogEntry, RejectRefinementResponse, SearchMemoryResponse,
+    SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-server/src/refinery_routes.rs
+++ b/crates/origin-server/src/refinery_routes.rs
@@ -6,10 +6,10 @@
 use axum::extract::{Path, Query, State};
 use axum::http::HeaderMap;
 use axum::Json;
-use origin_core::synthesis::refinement_queue::{resolve_proposal, ResolveStatus};
+use origin_core::synthesis::refinement_queue::{apply_refinement, resolve_proposal, ResolveStatus};
 use origin_types::responses::{
-    ListRefinementsResponse, ProposalAction, RefinementPayload, RefinementProposalSummary,
-    RejectRefinementResponse,
+    AcceptRefinementResponse, ListRefinementsResponse, ProposalAction, RefinementPayload,
+    RefinementProposalSummary, RejectRefinementResponse,
 };
 use serde::Deserialize;
 use std::sync::Arc;
@@ -92,6 +92,28 @@ pub async fn handle_reject_refinement(
         .map_err(ServerError::from)?;
 
     Ok(Json(RejectRefinementResponse { id: result.id }))
+}
+
+pub async fn handle_accept_refinement(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<AcceptRefinementResponse>, ServerError> {
+    let agent = extract_agent_name(&headers, None);
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+
+    let outcome = apply_refinement(&db, &id, &agent)
+        .await
+        .map_err(ServerError::from)?;
+
+    Ok(Json(AcceptRefinementResponse {
+        id: outcome.id,
+        action_applied: outcome.action_applied,
+    }))
 }
 
 fn parse_action(s: &str) -> Option<ProposalAction> {

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -257,6 +257,10 @@ pub fn build_router(state: SharedState) -> Router {
             "/api/refinery/queue/{id}/reject",
             post(refinery_routes::handle_reject_refinement),
         )
+        .route(
+            "/api/refinery/queue/{id}/accept",
+            post(refinery_routes::handle_accept_refinement),
+        )
         // Sources
         .route(
             "/api/sources",

--- a/crates/origin-server/tests/refinery_routes.rs
+++ b/crates/origin-server/tests/refinery_routes.rs
@@ -257,3 +257,166 @@ async fn reject_already_terminal_returns_422() {
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
 }
+
+// ── accept endpoint tests ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn accept_entity_merge_flow() {
+    let (app, _tmp, db) = test_app().await;
+
+    let new_id = db
+        .create_entity("Acme Corporation", "organization", None)
+        .await
+        .unwrap();
+    let existing_id = db
+        .create_entity("Acme Corp", "organization", None)
+        .await
+        .unwrap();
+    db.insert_refinement_proposal(
+        "ref_accept_em",
+        "entity_merge",
+        &[new_id.clone(), existing_id.clone()],
+        None,
+        0.87,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement_if_open("ref_accept_em", "awaiting_review")
+        .await
+        .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_accept_em/accept")
+        .header("x-agent-name", "test-agent")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = read_body_json(resp).await;
+    assert_eq!(body["id"], "ref_accept_em");
+    assert_eq!(body["action_applied"], "entity_merge");
+
+    // existing_id (canonical) survives; new_id (alias) is merged away
+    assert!(
+        db.get_entity_detail(&existing_id).await.is_ok(),
+        "canonical entity should still exist"
+    );
+    assert!(
+        db.get_entity_detail(&new_id).await.is_err(),
+        "merged-away entity should be deleted"
+    );
+}
+
+#[tokio::test]
+async fn accept_returns_404_for_unknown_id() {
+    let (app, _tmp, _db) = test_app().await;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_nonexistent/accept")
+        .header("x-agent-name", "test-agent")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn accept_returns_422_for_suggest_entity() {
+    let (app, _tmp, db) = test_app().await;
+    db.insert_refinement_proposal(
+        "ref_se_route",
+        "suggest_entity",
+        &["x".into()],
+        Some("\"Acme\""),
+        0.9,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement_if_open("ref_se_route", "awaiting_review")
+        .await
+        .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_se_route/accept")
+        .header("x-agent-name", "test-agent")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn accept_returns_422_for_already_resolved() {
+    let (app, _tmp, db) = test_app().await;
+    db.insert_refinement_proposal(
+        "ref_done_accept",
+        "entity_merge",
+        &["a".into(), "b".into()],
+        None,
+        0.85,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement_if_open("ref_done_accept", "resolved")
+        .await
+        .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_done_accept/accept")
+        .header("x-agent-name", "test-agent")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn accept_logs_apply_and_resolve_activity_with_agent() {
+    let (app, _tmp, db) = test_app().await;
+    let new_id = db
+        .create_entity("Acme Corporation", "organization", None)
+        .await
+        .unwrap();
+    let existing_id = db
+        .create_entity("Acme Corp", "organization", None)
+        .await
+        .unwrap();
+    db.insert_refinement_proposal(
+        "ref_acc_log",
+        "entity_merge",
+        &[new_id, existing_id],
+        None,
+        0.87,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement_if_open("ref_acc_log", "awaiting_review")
+        .await
+        .unwrap();
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/refinery/queue/ref_acc_log/accept")
+        .header("x-agent-name", "claude-code")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let acts = db
+        .list_agent_activity(20, Some("claude-code"), None)
+        .await
+        .unwrap();
+    assert!(
+        acts.iter().any(|a| a.action == "refinement_apply"),
+        "should log refinement_apply"
+    );
+    assert!(
+        acts.iter().any(|a| a.action == "refinement_resolve"),
+        "should log refinement_resolve"
+    );
+}

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -606,6 +606,12 @@ pub struct RejectRefinementResponse {
     pub id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcceptRefinementResponse {
+    pub id: String,
+    pub action_applied: String,
+}
+
 #[cfg(test)]
 mod refinement_wire_tests {
     use super::*;

--- a/plugin/skills/refinery/SKILL.md
+++ b/plugin/skills/refinery/SKILL.md
@@ -41,7 +41,7 @@ For each proposal, present:
   - `dedup_merge`: no payload — historical (auto-dismissed by daemon)
 
 Then offer per-item:
-- **Accept** → `accept_refinement(id="<id>")` — applies the change with sensible defaults (see below)
+- **Accept** → `accept_refinement(id="<id>")`: applies the change with sensible defaults (see below)
 - **Dismiss** → `reject_refinement(id="<id>")`
 
 **Only dismiss when you are confident the proposal is wrong.** Do not develop a

--- a/plugin/skills/refinery/SKILL.md
+++ b/plugin/skills/refinery/SKILL.md
@@ -5,7 +5,7 @@ description: >
   relation conflicts, contradictions, entity suggestions) and lets the user dismiss noise.
   Invoked as `/refinery`. Use when the user wants to audit what the daemon's refinery
   has queued for review.
-allowed-tools: ["mcp__plugin_origin_origin__list_refinements", "mcp__plugin_origin_origin__reject_refinement"]
+allowed-tools: ["mcp__plugin_origin_origin__list_refinements", "mcp__plugin_origin_origin__reject_refinement", "mcp__plugin_origin_origin__accept_refinement"]
 ---
 
 # /refinery
@@ -41,17 +41,23 @@ For each proposal, present:
   - `dedup_merge`: no payload — historical (auto-dismissed by daemon)
 
 Then offer per-item:
-- **Keep** → no-op (see notice below)
+- **Accept** → `accept_refinement(id="<id>")` — applies the change with sensible defaults (see below)
 - **Dismiss** → `reject_refinement(id="<id>")`
-
-## Accept is not in scope yet
-
-This skill exposes **list + dismiss only**. There is no accept verb in this version.
-Keeping a proposal is a no-op — it stays in the queue for a future session (or for
-the desktop app, when the accept-side spec lands).
 
 **Only dismiss when you are confident the proposal is wrong.** Do not develop a
 habit of dismissing-by-default; that would skew the queue toward attrition.
+
+## Accept a proposal
+
+Use `accept_refinement(id)` to apply the proposed change using sensible defaults.
+
+- **entity_merge:** existing entity wins as canonical. The new entity folds in as an alias. All relations, observations, and memories re-point to the canonical entity.
+- **relation_conflict:** new relation supersedes. Old relation is deleted.
+- **detect_contradiction:** previously-stored memory flagged with `pending_revision=1` for human revisit. The new memory is left unchanged. Accept here means "the contradiction is genuine and the established memory needs attention", not "the new memory wins".
+
+If the default is wrong for your case, reject instead and edit manually via the relevant memory, entity, or relation endpoint.
+
+`suggest_entity` and `dedup_merge` proposals return 422 on accept. `suggest_entity` is reserved for a future producer. `dedup_merge` is deprecated (distillation handles it now). Reject those instead.
 
 ## When to use
 


### PR DESCRIPTION
## Summary

PR2 of Spec B 2-PR split. Builds on PR #93 (refactor primitives + race fix) to ship the agent-visible `accept_refinement(id)` verb. Closes the consumer-side surfacing loop: agents can now list, accept, and reject refinement queue proposals through one symmetric surface.

- **New capability fn** `synthesis::refinement_queue::apply_refinement(db, id, agent)` dispatches by action (3 live variants + 2 reserved-as-422). Calls PR1's idempotent primitives (`merge_entities`, `supersede_relation`, `flag_memory_for_revision`), then resolves the proposal via the atomic `resolve_proposal(.., Resolved, agent)`.
- **Daemon arms** in `process_refinement_queue` promote `entity_merge` and `relation_conflict` proposals from `pending` to `awaiting_review`. Status-guarded on `proposal.status == "pending"` to avoid spamming `refinement_resolve` activity rows every tick on already-promoted proposals.
- **HTTP** `POST /api/refinery/queue/{id}/accept` mirrors `/reject` exactly. Reads `x-agent-name`, calls `apply_refinement`, maps `OriginError` to 404 / 422 / 500 via existing `From` impl.
- **MCP tool** `accept_refinement` with typed deserialization (`AcceptRefinementResponse` from `origin-types`), envelope-guard test included. Mirrors `reject_refinement` shape.
- **`/refinery` skill** documents the accept verb + per-action defaults. Removes the prior "Accept is not in scope yet" notice.

## Defaults (documented in skill + apply_refinement doc-comment)

- `entity_merge`: existing entity wins as canonical. New entity folds in as alias.
- `relation_conflict`: new relation supersedes. Old relation deleted.
- `detect_contradiction`: previously-stored memory flagged `pending_revision=1` for human revisit. New memory unchanged.
- `suggest_entity` and `dedup_merge` return 422 on accept. `suggest_entity` is reserved for a future producer. `dedup_merge` is deprecated.

If the default is wrong, reject instead and edit manually via the relevant entity/relation/memory endpoint.

## Test plan

- [x] 13 new unit tests on `apply_refinement` and daemon arms (origin-core lib total 1060 to 1073).
- [x] 5 new HTTP integration tests on the accept route (refinery_routes integration: 8 to 13).
- [x] 2 new MCP typed-deserialize tests including envelope-guard (origin-mcp lib total 148 to 150).
- [x] Smoke test on isolated daemon (port 7879, /tmp/origin-smoke-accept): seed `entity_merge` proposal at `awaiting_review`, list surfaces it, accept returns 200, entity row reduced from 2 to 1 in DB, re-accept returns 422, unknown id returns 404, suggest_entity returns 422. No panics in daemon log.
- [x] Workspace clippy clean.

## Notes from final adversarial review

- **Wire types verified field-for-field across all three layers** (no Spec A drift): `AcceptOutcome { id, action_applied }` core capability fn ↔ `AcceptRefinementResponse { id, action_applied }` wire ↔ MCP typed deserialize. No `warnings` field (adversarial pre-impl review caught it as speculative surface; spec dropped it).
- **`apply_refinement` dispatch ordering verified** against PR1 producer convention (`source_ids = [new, existing]`): entity_merge merges existing as canonical, relation_conflict deletes existing, detect_contradiction flags source_ids[1] = existing memory.
- **Terminal-status guard set** (`dismissed | auto_applied | resolved`) matches PR1's `resolve_refinement_if_open` SQL exactly. Single source of truth preserved.
- **Daemon arm `status == "pending"` guard** prevents `refinement_resolve` activity spam every tick. Regression-tested via `daemon_arm_skips_already_awaiting_review`.
- Lock-across-await audit clean: handler scopes `state.read()` guard, drops before `apply_refinement` await.
- Skill prose em-dash audit: one new em-dash flagged on accept bullet, fixed in commit `dbc165b6` (colon replacement). Pre-existing em-dashes on lines 37/41 left untouched per surgical-change rule.

## Spec reference

`docs/superpowers/specs/2026-05-12-bm-mode-consumer-accept-design.md` (gitignored). PR2 scope: §4.2 + §4.3 + §5 + §6 + §7 + §10 + §11.1-3 + §12 PR2 task list.

## Version bump intent

`feat:` prefix per spec §12. release-please will bump 0.5.3 to 0.6.0.