### PR TITLE
docs: link README demo preview to YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The daemon does the memory chores in the background: stores what matters, dedupl
 
 **Status:** Early preview. Expect fast iteration and some sharp edges.
 
-[![Watch the Origin demo](./docs/assets/demo-preview.gif)](https://github.com/user-attachments/assets/50522d51-5da5-4c82-a3df-9577c632797d)
+[![Watch the Origin demo](./docs/assets/demo-preview.gif)](https://youtu.be/k37gjWVPHwI)
 
 ---
 


### PR DESCRIPTION
## Summary
- Keep the README demo as the repo-hosted animated GIF preview.
- Link the preview to the YouTube demo instead of the GitHub user-attachment MP4.
- Avoid GitHub auto-transforming the block into an inline MP4 attachment player.

## Test Plan
- git diff --check
- rg confirms README has the YouTube link and no user-attachments demo link