### PR TITLE
refactor: BM-mode curation read MCPs (Spec C-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "origin"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "origin-core"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3062,7 +3062,7 @@ dependencies = [
 
 [[package]]
 name = "origin-mcp"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "origin-server"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "origin-types"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "serde",

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -11565,6 +11565,63 @@ impl MemoryDB {
         }
     }
 
+    /// List staged revisions awaiting human accept/dismiss.
+    ///
+    /// Returns `(target_source_id, revision_source_id, revision_content,
+    /// source_agent, last_modified)` for every row where
+    /// `pending_revision = 1` AND `supersedes IS NOT NULL` AND
+    /// `source = 'memory'`. Sorted newest-first by `last_modified`
+    /// (the only `NOT NULL` timestamp on memories; `created_at` is
+    /// nullable pre-migration-21).
+    ///
+    /// The partial index `idx_memories_pending_revision` covers the
+    /// primary `pending_revision != 0` filter; the residual `source` and
+    /// `supersedes IS NOT NULL` scan is bounded by human-attention
+    /// cardinality.
+    pub async fn list_pending_revisions(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<origin_types::responses::PendingRevisionItem>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT supersedes, source_id, content, source_agent, last_modified \
+                 FROM memories \
+                 WHERE pending_revision = 1 \
+                   AND supersedes IS NOT NULL \
+                   AND source = 'memory' \
+                 ORDER BY last_modified DESC \
+                 LIMIT ?1",
+                libsql::params![limit as i64],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("list_pending_revisions: {e}")))?;
+
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("list_pending_revisions row: {e}")))?
+        {
+            out.push(origin_types::responses::PendingRevisionItem {
+                target_source_id: row
+                    .get::<String>(0)
+                    .map_err(|e| OriginError::VectorDb(format!("col 0: {e}")))?,
+                revision_source_id: row
+                    .get::<String>(1)
+                    .map_err(|e| OriginError::VectorDb(format!("col 1: {e}")))?,
+                revision_content: row
+                    .get::<String>(2)
+                    .map_err(|e| OriginError::VectorDb(format!("col 2: {e}")))?,
+                source_agent: row.get::<Option<String>>(3).unwrap_or(None),
+                last_modified: row
+                    .get::<i64>(4)
+                    .map_err(|e| OriginError::VectorDb(format!("col 4: {e}")))?,
+            });
+        }
+        Ok(out)
+    }
+
     // ==================== Session / Activity Methods ====================
 
     /// Insert or update an activity record.
@@ -20898,6 +20955,168 @@ pub(crate) mod tests {
         // No more pending revision
         let pr = db.get_pending_revision_for("dismiss_target").await.unwrap();
         assert!(pr.is_none());
+    }
+
+    // ==================== list_pending_revisions ====================
+
+    /// Test-only helper: insert a minimal memory row via `upsert_documents`,
+    /// controlling `source_id`, `content`, `source`, `source_agent`,
+    /// `supersedes`, `pending_revision`, and `last_modified` explicitly.
+    /// Covers only the columns needed by `list_pending_revisions` tests;
+    /// not intended for production use.
+    async fn insert_memory_for_test(
+        db: &MemoryDB,
+        source_id: &str,
+        content: &str,
+        source: &str,
+        source_agent: Option<&str>,
+        supersedes: Option<&str>,
+        pending_revision: bool,
+        last_modified: i64,
+    ) {
+        let doc = RawDocument {
+            source: source.to_string(),
+            source_id: source_id.to_string(),
+            title: format!("title-{}", source_id),
+            content: content.to_string(),
+            source_agent: source_agent.map(|s| s.to_string()),
+            supersedes: supersedes.map(|s| s.to_string()),
+            pending_revision,
+            last_modified,
+            ..Default::default()
+        };
+        db.upsert_documents(vec![doc]).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_pending_revisions_returns_target_source_id() {
+        let (db, _dir) = test_db().await;
+
+        // Insert a target memory
+        insert_memory_for_test(
+            &db,
+            "mem_target",
+            "Original content",
+            "memory",
+            Some("alice"),
+            None,
+            false,
+            1_715_000_000,
+        )
+        .await;
+
+        // Insert a revision row that supersedes the target, flagged as pending
+        insert_memory_for_test(
+            &db,
+            "mem_rev",
+            "Revised content",
+            "memory",
+            Some("bob"),
+            Some("mem_target"),
+            true,
+            1_715_000_100,
+        )
+        .await;
+
+        let items = db.list_pending_revisions(10).await.unwrap();
+        assert_eq!(items.len(), 1, "expected 1 pending revision, got {items:?}");
+        let item = &items[0];
+        assert_eq!(item.target_source_id, "mem_target");
+        assert_eq!(item.revision_source_id, "mem_rev");
+        assert_eq!(item.revision_content, "Revised content");
+        assert_eq!(item.source_agent.as_deref(), Some("bob"));
+        assert_eq!(item.last_modified, 1_715_000_100);
+    }
+
+    #[tokio::test]
+    async fn list_pending_revisions_orders_newest_first() {
+        let (db, _dir) = test_db().await;
+        insert_memory_for_test(&db, "mem_t1", "t1", "memory", None, None, false, 1).await;
+        insert_memory_for_test(&db, "mem_t2", "t2", "memory", None, None, false, 2).await;
+        insert_memory_for_test(
+            &db,
+            "mem_r1",
+            "rev1",
+            "memory",
+            None,
+            Some("mem_t1"),
+            true,
+            100,
+        )
+        .await;
+        insert_memory_for_test(
+            &db,
+            "mem_r2",
+            "rev2",
+            "memory",
+            None,
+            Some("mem_t2"),
+            true,
+            200,
+        )
+        .await;
+
+        let items = db.list_pending_revisions(10).await.unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[0].revision_source_id, "mem_r2",
+            "newest (last_modified=200) first"
+        );
+        assert_eq!(items[1].revision_source_id, "mem_r1");
+    }
+
+    #[tokio::test]
+    async fn list_pending_revisions_respects_limit() {
+        let (db, _dir) = test_db().await;
+        for i in 0..5_i64 {
+            insert_memory_for_test(
+                &db,
+                &format!("mem_t{i}"),
+                "t",
+                "memory",
+                None,
+                None,
+                false,
+                i,
+            )
+            .await;
+            insert_memory_for_test(
+                &db,
+                &format!("mem_r{i}"),
+                "rev",
+                "memory",
+                None,
+                Some(&format!("mem_t{i}")),
+                true,
+                100 + i,
+            )
+            .await;
+        }
+        let items = db.list_pending_revisions(3).await.unwrap();
+        assert_eq!(items.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_pending_revisions_skips_non_pending_and_no_supersedes() {
+        let (db, _dir) = test_db().await;
+        // Non-pending revision (pending=false, has supersedes)
+        insert_memory_for_test(&db, "mem_t1", "t1", "memory", None, None, false, 1).await;
+        insert_memory_for_test(
+            &db,
+            "mem_r1",
+            "rev1",
+            "memory",
+            None,
+            Some("mem_t1"),
+            false,
+            100,
+        )
+        .await;
+        // Pending but no supersedes (defensive: shouldn't match)
+        insert_memory_for_test(&db, "mem_orphan", "orphan", "memory", None, None, true, 200).await;
+
+        let items = db.list_pending_revisions(10).await.unwrap();
+        assert_eq!(items.len(), 0);
     }
 
     // ==================== search_entities_by_vector ====================

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -20964,6 +20964,7 @@ pub(crate) mod tests {
     /// `supersedes`, `pending_revision`, and `last_modified` explicitly.
     /// Covers only the columns needed by `list_pending_revisions` tests;
     /// not intended for production use.
+    #[allow(clippy::too_many_arguments)]
     async fn insert_memory_for_test(
         db: &MemoryDB,
         source_id: &str,

--- a/crates/origin-mcp/src/client.rs
+++ b/crates/origin-mcp/src/client.rs
@@ -22,6 +22,7 @@ pub fn discover_origin_url(cli_url: Option<String>) -> String {
 pub struct OriginClient {
     client: Client,
     base_url: String,
+    agent_name: Option<String>,
 }
 
 /// Max retries on connection errors (daemon restarting).
@@ -35,7 +36,14 @@ impl OriginClient {
         Self {
             client: Client::new(),
             base_url,
+            agent_name: None,
         }
+    }
+
+    /// Set the agent name to be sent as `x-agent-name` header on every request.
+    pub fn with_agent_name(mut self, name: String) -> Self {
+        self.agent_name = Some(name);
+        self
     }
 
     /// Retry a request on connection errors (daemon restarting).
@@ -93,7 +101,16 @@ impl OriginClient {
     /// GET request, deserialize JSON response.
     pub async fn get<R: DeserializeOwned>(&self, path: &str) -> Result<R, OriginError> {
         let url = format!("{}{}", self.base_url, path);
-        let resp = self.send_with_retry(|| self.client.get(&url)).await?;
+        let agent = self.agent_name.clone();
+        let resp = self
+            .send_with_retry(|| {
+                let mut req = self.client.get(&url);
+                if let Some(a) = agent.as_deref() {
+                    req = req.header("x-agent-name", a);
+                }
+                req
+            })
+            .await?;
         let bytes = Self::read_body(resp).await?;
         Self::parse_response(&bytes)
     }
@@ -105,8 +122,15 @@ impl OriginClient {
         body: &B,
     ) -> Result<R, OriginError> {
         let url = format!("{}{}", self.base_url, path);
+        let agent = self.agent_name.clone();
         let resp = self
-            .send_with_retry(|| self.client.post(&url).json(body))
+            .send_with_retry(|| {
+                let mut req = self.client.post(&url).json(body);
+                if let Some(a) = agent.as_deref() {
+                    req = req.header("x-agent-name", a);
+                }
+                req
+            })
             .await?;
         let bytes = Self::read_body(resp).await?;
         Self::parse_response(&bytes)
@@ -115,7 +139,16 @@ impl OriginClient {
     /// DELETE request, deserialize JSON response.
     pub async fn delete<R: DeserializeOwned>(&self, path: &str) -> Result<R, OriginError> {
         let url = format!("{}{}", self.base_url, path);
-        let resp = self.send_with_retry(|| self.client.delete(&url)).await?;
+        let agent = self.agent_name.clone();
+        let resp = self
+            .send_with_retry(|| {
+                let mut req = self.client.delete(&url);
+                if let Some(a) = agent.as_deref() {
+                    req = req.header("x-agent-name", a);
+                }
+                req
+            })
+            .await?;
         let bytes = Self::read_body(resp).await?;
         Self::parse_response(&bytes)
     }
@@ -127,8 +160,15 @@ impl OriginClient {
         body: &B,
     ) -> Result<R, OriginError> {
         let url = format!("{}{}", self.base_url, path);
+        let agent = self.agent_name.clone();
         let resp = self
-            .send_with_retry(|| self.client.put(&url).json(body))
+            .send_with_retry(|| {
+                let mut req = self.client.put(&url).json(body);
+                if let Some(a) = agent.as_deref() {
+                    req = req.header("x-agent-name", a);
+                }
+                req
+            })
             .await?;
         let bytes = Self::read_body(resp).await?;
         Self::parse_response(&bytes)

--- a/crates/origin-mcp/src/main.rs
+++ b/crates/origin-mcp/src/main.rs
@@ -113,7 +113,7 @@ async fn run_stdio(origin_url: Option<String>) -> anyhow::Result<()> {
     let base_url = discover_origin_url(origin_url);
     tracing::info!("Connecting to Origin at {}", base_url);
 
-    let client = OriginClient::new(base_url);
+    let client = OriginClient::new(base_url).with_agent_name("claude-code".into());
 
     if let Some(msg) = client.version_handshake().await {
         tracing::warn!("{msg}");

--- a/crates/origin-mcp/src/serve.rs
+++ b/crates/origin-mcp/src/serve.rs
@@ -36,7 +36,8 @@ async fn health() -> impl IntoResponse {
 }
 
 pub async fn run_serve(config: ServeConfig) -> anyhow::Result<()> {
-    let client = OriginClient::new(config.origin_url.clone());
+    let client =
+        OriginClient::new(config.origin_url.clone()).with_agent_name(config.agent_name.clone());
     let agent_name = config.agent_name.clone();
     let user_id = config.user_id.clone();
     let token = config.token.clone();

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -438,6 +438,9 @@ pub struct ListNurtureParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListEntitySuggestionsParams {}
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListPendingImportsParams {}
+
 // ===== Internal Implementations =====
 
 fn format_capture_success(resp: &StoreMemoryResponse) -> String {
@@ -1294,6 +1297,24 @@ impl OriginMcpServer {
             pretty
         ))]))
     }
+
+    pub async fn list_pending_imports_impl(
+        &self,
+        _params: ListPendingImportsParams,
+    ) -> Result<CallToolResult, McpError> {
+        let resp: Vec<origin_types::import::PendingImport> =
+            match self.client.get("/api/imports/pending").await {
+                Ok(v) => v,
+                Err(e) => return Ok(tool_error(e, "list_pending_imports")),
+            };
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} pending import(s)\n{}",
+            resp.len(),
+            pretty
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1838,6 +1859,25 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListEntitySuggestionsParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_entity_suggestions_impl(params).await
+    }
+
+    #[tool(
+        description = "List in-flight chat-history imports awaiting processing or completion. \
+                       Use when the user asks 'what imports are running', 'is my Claude.ai \
+                       export done', or to surface import progress. Returns id, vendor, \
+                       stage, source path, processed/total conversation counts.",
+        annotations(
+            title = "List pending imports",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_pending_imports(
+        &self,
+        Parameters(params): Parameters<ListPendingImportsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_pending_imports_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -451,6 +451,13 @@ pub struct ListRejectionsParams {
     pub reason: Option<String>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListPendingRevisionsParams {
+    /// Maximum rows to return. Server defaults to 50, clamps to 500.
+    #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
+    pub limit: Option<usize>,
+}
+
 // ===== Internal Implementations =====
 
 fn format_capture_success(resp: &StoreMemoryResponse) -> String {
@@ -1356,6 +1363,28 @@ impl OriginMcpServer {
             pretty
         ))]))
     }
+
+    pub async fn list_pending_revisions_impl(
+        &self,
+        params: ListPendingRevisionsParams,
+    ) -> Result<CallToolResult, McpError> {
+        let path = match params.limit {
+            Some(l) => format!("/api/memory/pending-revisions?limit={}", l.clamp(1, 500)),
+            None => "/api/memory/pending-revisions".to_string(),
+        };
+        let resp: Vec<origin_types::responses::PendingRevisionItem> =
+            match self.client.get(&path).await {
+                Ok(v) => v,
+                Err(e) => return Ok(tool_error(e, "list_pending_revisions")),
+            };
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} pending revision(s)\n{}",
+            resp.len(),
+            pretty
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1935,6 +1964,27 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListRejectionsParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_rejections_impl(params).await
+    }
+
+    #[tool(
+        description = "List memories awaiting human accept/dismiss because a newer version \
+                       was proposed (Protected tier supersede). Use when the user asks \
+                       'what revisions are pending', 'show me memories awaiting approval'. \
+                       Each item carries target_source_id (the memory being revised: pass \
+                       THIS to accept_pending_revision in PR2) and revision_content for \
+                       display. Optional `limit` caps results (default 50, max 500).",
+        annotations(
+            title = "List pending revisions",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_pending_revisions(
+        &self,
+        Parameters(params): Parameters<ListPendingRevisionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_pending_revisions_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -423,6 +423,18 @@ pub struct ListPagesRecentParams {
     pub since_ms: Option<i64>,
 }
 
+// --- Curation read params ---
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListNurtureParams {
+    /// Maximum cards to return. Default 50. Clamped to 1..=500.
+    #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
+    pub limit: Option<usize>,
+    /// Restrict to a single domain/space.
+    #[serde(default)]
+    pub domain: Option<String>,
+}
+
 // ===== Internal Implementations =====
 
 fn format_capture_success(resp: &StoreMemoryResponse) -> String {
@@ -1229,6 +1241,38 @@ impl OriginMcpServer {
             resp.id, resp.action_applied
         ))]))
     }
+
+    pub async fn list_nurture_impl(
+        &self,
+        params: ListNurtureParams,
+    ) -> Result<CallToolResult, McpError> {
+        let mut path = String::from("/api/memory/nurture");
+        let mut q: Vec<String> = Vec::new();
+        if let Some(l) = params.limit {
+            q.push(format!("limit={}", l.clamp(1, 500)));
+        }
+        if let Some(d) = params.domain.as_deref().filter(|s| !s.is_empty()) {
+            q.push(format!("domain={}", url_encode_simple(d)));
+        }
+        if !q.is_empty() {
+            path.push('?');
+            path.push_str(&q.join("&"));
+        }
+
+        let resp: origin_types::responses::NurtureCardsResponse = match self.client.get(&path).await
+        {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error(e, "list_nurture")),
+        };
+
+        let pretty = serde_json::to_string_pretty(&resp.cards)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} nurture cards\n{}",
+            resp.cards.len(),
+            pretty
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1735,6 +1779,24 @@ impl OriginMcpServer {
         Parameters(params): Parameters<AcceptRefinementParams>,
     ) -> Result<CallToolResult, McpError> {
         self.accept_refinement_impl(params).await
+    }
+
+    // --- Curation read tools ---
+
+    #[tool(
+        description = "List nurture cards — memories flagged for human attention because they are unconfirmed, low-confidence, or have been queued for review by the daemon. Use when the user wants to audit what needs review: phrases like 'what needs my attention', 'unconfirmed memories', 'nurture queue'. Returns memory items with metadata. Optional `limit` caps results (default 50, max 500). Optional `domain` restricts to one topic space. Distinct from `list_pending` (which lists all unconfirmed captures) and `list_refinements` (which lists daemon-generated merge/conflict proposals).",
+        annotations(
+            title = "List nurture cards",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_nurture(
+        &self,
+        Parameters(params): Parameters<ListNurtureParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_nurture_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -441,6 +441,16 @@ pub struct ListEntitySuggestionsParams {}
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListPendingImportsParams {}
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListRejectionsParams {
+    /// Maximum records to return. Default 50. Clamped to 1..=500.
+    #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
+    pub limit: Option<usize>,
+    /// Filter by rejection reason code (e.g. "duplicate", "low_quality").
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
 // ===== Internal Implementations =====
 
 fn format_capture_success(resp: &StoreMemoryResponse) -> String {
@@ -1315,6 +1325,37 @@ impl OriginMcpServer {
             pretty
         ))]))
     }
+
+    pub async fn list_rejections_impl(
+        &self,
+        params: ListRejectionsParams,
+    ) -> Result<CallToolResult, McpError> {
+        let mut path = String::from("/api/memory/rejections");
+        let mut q: Vec<String> = Vec::new();
+        if let Some(l) = params.limit {
+            q.push(format!("limit={}", l.clamp(1, 500)));
+        }
+        if let Some(r) = params.reason.as_deref().filter(|s| !s.is_empty()) {
+            q.push(format!("reason={}", url_encode_simple(r)));
+        }
+        if !q.is_empty() {
+            path.push('?');
+            path.push_str(&q.join("&"));
+        }
+
+        let resp: Vec<origin_types::memory::RejectionRecord> = match self.client.get(&path).await {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error(e, "list_rejections")),
+        };
+
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} rejection(s)\n{}",
+            resp.len(),
+            pretty
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1878,6 +1919,22 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListPendingImportsParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_pending_imports_impl(params).await
+    }
+
+    #[tool(
+        description = "List quality-gate rejections: memories the daemon discarded before storing, due to low quality, duplication, or other filters. Use when the user asks 'what did Origin reject', 'what was filtered out', or to diagnose why captures are not appearing. Returns rejection records with reason code, detail, and similarity info. Optional `limit` caps results (default 50, max 500). Optional `reason` filters by rejection reason code (e.g. 'duplicate', 'low_quality').",
+        annotations(
+            title = "List rejections",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_rejections(
+        &self,
+        Parameters(params): Parameters<ListRejectionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_rejections_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -1327,7 +1327,7 @@ impl OriginMcpServer {
         _params: ListPendingImportsParams,
     ) -> Result<CallToolResult, McpError> {
         let resp: Vec<origin_types::import::PendingImport> =
-            match self.client.get("/api/imports/pending").await {
+            match self.client.get("/api/import/state").await {
                 Ok(v) => v,
                 Err(e) => return Ok(tool_error(e, "list_pending_imports")),
             };

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -435,6 +435,9 @@ pub struct ListNurtureParams {
     pub domain: Option<String>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListEntitySuggestionsParams {}
+
 // ===== Internal Implementations =====
 
 fn format_capture_success(resp: &StoreMemoryResponse) -> String {
@@ -1273,6 +1276,24 @@ impl OriginMcpServer {
             pretty
         ))]))
     }
+
+    pub async fn list_entity_suggestions_impl(
+        &self,
+        _params: ListEntitySuggestionsParams,
+    ) -> Result<CallToolResult, McpError> {
+        let resp: Vec<origin_types::entities::EntitySuggestion> =
+            match self.client.get("/api/memory/entity-suggestions").await {
+                Ok(v) => v,
+                Err(e) => return Ok(tool_error(e, "list_entity_suggestions")),
+            };
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} entity suggestion(s)\n{}",
+            resp.len(),
+            pretty
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1797,6 +1818,26 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListNurtureParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_nurture_impl(params).await
+    }
+
+    #[tool(
+        description = "List entity-suggestion proposals from the refinery queue \
+                       (action='suggest_entity'). Use when the user asks 'what entities \
+                       does the daemon want to create' or wants to triage merge-vs-create \
+                       decisions. Returns id, proposed entity_name, source_ids, confidence. \
+                       Pair with PR2's approve/dismiss verbs once they land.",
+        annotations(
+            title = "List entity suggestions",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_entity_suggestions(
+        &self,
+        Parameters(params): Parameters<ListEntitySuggestionsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_entity_suggestions_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -458,6 +458,13 @@ pub struct ListPendingRevisionsParams {
     pub limit: Option<usize>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListOrphanLinksParams {
+    /// Minimum reference count a label must have to appear. Default 1. Daemon clamps via `.max(1)`.
+    #[serde(default, deserialize_with = "deserialize_optional_i64_lenient")]
+    pub min_count: Option<i64>,
+}
+
 // ===== Internal Implementations =====
 
 fn format_capture_success(resp: &StoreMemoryResponse) -> String {
@@ -1385,6 +1392,28 @@ impl OriginMcpServer {
             pretty
         ))]))
     }
+
+    pub async fn list_orphan_links_impl(
+        &self,
+        params: ListOrphanLinksParams,
+    ) -> Result<CallToolResult, McpError> {
+        let path = match params.min_count {
+            Some(n) => format!("/api/pages/orphan-links?min_count={}", n.max(1)),
+            None => "/api/pages/orphan-links".to_string(),
+        };
+        let resp: origin_types::responses::OrphanLinksResponse = match self.client.get(&path).await
+        {
+            Ok(v) => v,
+            Err(e) => return Ok(tool_error(e, "list_orphan_links")),
+        };
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} orphan link(s)\n{}",
+            resp.orphan_labels.len(),
+            pretty
+        ))]))
+    }
 }
 
 /// Build the `/api/pages/recent` URL with optional `limit` + `since_ms` query
@@ -1985,6 +2014,26 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListPendingRevisionsParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_pending_revisions_impl(params).await
+    }
+
+    #[tool(
+        description = "List wiki-link labels that appear in page bodies but have no matching \
+                       page title. Use when the user asks 'what links are broken', 'orphan links', \
+                       or wants to find knowledge gaps. Returns label names and reference counts. \
+                       Optional `min_count` filters to labels referenced at least N times \
+                       (default 1, minimum 1).",
+        annotations(
+            title = "List orphan links",
+            read_only_hint = true,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn list_orphan_links(
+        &self,
+        Parameters(params): Parameters<ListOrphanLinksParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_orphan_links_impl(params).await
     }
 }
 

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -1784,7 +1784,7 @@ impl OriginMcpServer {
     // --- Curation read tools ---
 
     #[tool(
-        description = "List nurture cards — memories flagged for human attention because they are unconfirmed, low-confidence, or have been queued for review by the daemon. Use when the user wants to audit what needs review: phrases like 'what needs my attention', 'unconfirmed memories', 'nurture queue'. Returns memory items with metadata. Optional `limit` caps results (default 50, max 500). Optional `domain` restricts to one topic space. Distinct from `list_pending` (which lists all unconfirmed captures) and `list_refinements` (which lists daemon-generated merge/conflict proposals).",
+        description = "List nurture cards: memories flagged for human attention because they are unconfirmed, low-confidence, or have been queued for review by the daemon. Use when the user wants to audit what needs review: phrases like 'what needs my attention', 'unconfirmed memories', 'nurture queue'. Returns memory items with metadata. Optional `limit` caps results (default 50, max 500). Optional `domain` restricts to one topic space. Distinct from `list_pending` (which lists all unconfirmed captures) and `list_refinements` (which lists daemon-generated merge/conflict proposals).",
         annotations(
             title = "List nurture cards",
             read_only_hint = true,

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -6,7 +6,7 @@
 //! `origin_types::*` at call sites directly.
 
 pub use origin_types::entities::EntitySuggestion;
-pub use origin_types::memory::{RecentActivityItem, SearchResult};
+pub use origin_types::memory::{RecentActivityItem, RejectionRecord, SearchResult};
 pub use origin_types::requests::{
     ChatContextRequest, CreateConceptRequest, CreateEntityRequest, CreateRelationRequest,
     ListMemoriesRequest, SearchMemoryRequest, SearchPagesRequest, StoreMemoryRequest,

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -14,7 +14,7 @@ pub use origin_types::responses::{
     AcceptRefinementResponse, AddObservationResponse, ChatContextResponse, CreateEntityResponse,
     CreatePageResponse, CreateRelationResponse, DeleteResponse, ListMemoriesResponse,
     ListMemoryRevisionsResponse, ListPageRevisionsResponse, ListRefinementsResponse,
-    MemoryRevisionEntry, PageChangelogEntry, RejectRefinementResponse, SearchMemoryResponse,
-    SearchPagesResponse, StoreMemoryResponse,
+    MemoryRevisionEntry, NurtureCardsResponse, PageChangelogEntry, RejectRefinementResponse,
+    SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -15,7 +15,7 @@ pub use origin_types::responses::{
     AcceptRefinementResponse, AddObservationResponse, ChatContextResponse, CreateEntityResponse,
     CreatePageResponse, CreateRelationResponse, DeleteResponse, ListMemoriesResponse,
     ListMemoryRevisionsResponse, ListPageRevisionsResponse, ListRefinementsResponse,
-    MemoryRevisionEntry, NurtureCardsResponse, PageChangelogEntry, RejectRefinementResponse,
-    SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
+    MemoryRevisionEntry, NurtureCardsResponse, OrphanLink, OrphanLinksResponse, PageChangelogEntry,
+    RejectRefinementResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -5,6 +5,7 @@
 //! cross-repo refactor; later PRs may remove the module entirely and import
 //! `origin_types::*` at call sites directly.
 
+pub use origin_types::entities::EntitySuggestion;
 pub use origin_types::memory::{RecentActivityItem, SearchResult};
 pub use origin_types::requests::{
     ChatContextRequest, CreateConceptRequest, CreateEntityRequest, CreateRelationRequest,

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1474,3 +1474,120 @@ async fn list_pending_revisions_http_500() {
         "error message must mention HTTP 500; got: {text}"
     );
 }
+
+// ===== list_orphan_links =====
+
+use origin_mcp::tools::ListOrphanLinksParams;
+use origin_types::responses::{OrphanLink, OrphanLinksResponse};
+
+#[tokio::test]
+async fn list_orphan_links_happy_path() {
+    let (mock, client) = setup().await;
+    let body = OrphanLinksResponse {
+        min_count: 2,
+        orphan_labels: vec![OrphanLink {
+            label: "Rust".into(),
+            count: 4,
+        }],
+    };
+    Mock::given(method("GET"))
+        .and(path("/api/pages/orphan-links"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_orphan_links_impl(ListOrphanLinksParams { min_count: None })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.contains("Rust"), "label must appear in output: {text}");
+    assert!(text.contains("4"), "count must appear in output: {text}");
+}
+
+#[tokio::test]
+async fn list_orphan_links_envelope_guard() {
+    let (mock, client) = setup().await;
+    // Wrong key: "labels" instead of "orphan_labels". Typed deserialization must fail loud.
+    Mock::given(method("GET"))
+        .and(path("/api/pages/orphan-links"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "min_count": 2,
+            "labels": []
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_orphan_links_impl(ListOrphanLinksParams { min_count: None })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        result.is_error.unwrap_or(false),
+        "wrong key 'labels' instead of 'orphan_labels' must surface as tool error; got: {text}"
+    );
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("missing"),
+        "error message must describe parse failure; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_orphan_links_passes_min_count() {
+    let (mock, client) = setup().await;
+    let body = OrphanLinksResponse {
+        min_count: 5,
+        orphan_labels: vec![],
+    };
+    Mock::given(method("GET"))
+        .and(path("/api/pages/orphan-links"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    server
+        .list_orphan_links_impl(ListOrphanLinksParams { min_count: Some(5) })
+        .await
+        .unwrap();
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1);
+    let url = received[0].url.to_string();
+    assert!(
+        url.contains("min_count=5"),
+        "expected min_count=5 in query; got: {url}"
+    );
+}
+
+#[tokio::test]
+async fn list_orphan_links_http_500() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/pages/orphan-links"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_orphan_links_impl(ListOrphanLinksParams { min_count: None })
+        .await
+        .expect("list_orphan_links_impl must not return Err on HTTP 500");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "HTTP 500 must surface as tool error"
+    );
+    let text = text_of(&result);
+    assert!(
+        text.contains("500"),
+        "error message must mention HTTP 500; got: {text}"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1066,7 +1066,7 @@ async fn list_entity_suggestions_empty() {
     let (mock, client) = setup().await;
     Mock::given(method("GET"))
         .and(path("/api/memory/entity-suggestions"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(&Vec::<EntitySuggestion>::new()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<EntitySuggestion>::new()))
         .mount(&mock)
         .await;
 

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1190,3 +1190,152 @@ async fn list_pending_imports_http_500() {
     let text = text_of(&result);
     assert!(text.to_lowercase().contains("error") || text.contains("500"));
 }
+
+// ===== list_rejections =====
+
+use origin_mcp::tools::ListRejectionsParams;
+use origin_types::memory::RejectionRecord;
+
+fn sample_rejection_record(id: &str) -> RejectionRecord {
+    RejectionRecord {
+        id: id.into(),
+        content: "Low quality content.".into(),
+        source_agent: Some("test-agent".into()),
+        rejection_reason: "low_quality".into(),
+        rejection_detail: Some("Quality score below threshold.".into()),
+        similarity_score: None,
+        similar_to_source_id: None,
+        created_at: 1715000000,
+    }
+}
+
+#[tokio::test]
+async fn list_rejections_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/rejections"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(vec![sample_rejection_record("rej_abc1")]),
+        )
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_rejections_impl(ListRejectionsParams {
+            limit: None,
+            reason: None,
+        })
+        .await
+        .expect("list_rejections_impl failed");
+
+    let text = text_of(&result);
+    assert!(
+        text.starts_with("1 rejection(s)"),
+        "expected '1 rejection(s)' header; got: {text}"
+    );
+    assert!(
+        text.contains("rej_abc1"),
+        "expected rejection id in output; got: {text}"
+    );
+    assert!(
+        text.contains("low_quality"),
+        "expected rejection_reason in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_rejections_envelope_guard() {
+    // Daemon must return a raw array. If it wraps under a key, typed
+    // deserialization fails loud instead of returning an empty list silently.
+    // Regression guard for lesson_mcp_typed_deserialize.
+    let wrong = serde_json::json!({ "data": [] });
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/rejections"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&wrong))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_rejections_impl(ListRejectionsParams {
+            limit: None,
+            reason: None,
+        })
+        .await
+        .expect("list_rejections_impl returned Err unexpectedly");
+
+    let text = text_of(&result);
+    assert!(
+        result.is_error.unwrap_or(false),
+        "envelope-wrapped response must surface as tool error; got: {text}"
+    );
+    assert!(
+        text.contains("Failed to parse"),
+        "error message must mention parse failure; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_rejections_passes_query_params() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/rejections"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<RejectionRecord>::new()))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    server
+        .list_rejections_impl(ListRejectionsParams {
+            limit: Some(30),
+            reason: Some("duplicate".into()),
+        })
+        .await
+        .expect("list_rejections_impl failed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1);
+    let url = received[0].url.to_string();
+    assert!(
+        url.contains("limit=30"),
+        "expected limit=30 in query; got: {url}"
+    );
+    assert!(
+        url.contains("reason=duplicate"),
+        "expected reason=duplicate in query; got: {url}"
+    );
+}
+
+#[tokio::test]
+async fn list_rejections_http_500() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/rejections"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_rejections_impl(ListRejectionsParams {
+            limit: None,
+            reason: None,
+        })
+        .await
+        .expect("list_rejections_impl must not return Err on HTTP 500");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "HTTP 500 must surface as tool error"
+    );
+    let text = text_of(&result);
+    assert!(
+        text.contains("500"),
+        "error message must mention HTTP 500; got: {text}"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -737,3 +737,104 @@ async fn t12_forward_compat_response_missing_extraction_method() {
     assert_eq!(parsed.extraction_method, "unknown");
     assert!(parsed.warnings.is_empty());
 }
+
+#[tokio::test]
+async fn origin_client_sends_x_agent_name_header() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("claude-code".into());
+
+    let response = StoreMemoryResponse {
+        source_id: "mem_xan1".into(),
+        chunks_created: 1,
+        memory_type: "fact".into(),
+        entity_id: None,
+        quality: None,
+        warnings: vec![],
+        extraction_method: "none".into(),
+        enrichment: String::new(),
+        hint: String::new(),
+    };
+    Mock::given(method("POST"))
+        .and(path("/api/memory/store"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    server
+        .capture_impl(CaptureParams {
+            content: "header test".into(),
+            memory_type: None,
+            domain: None,
+            entity: None,
+            confidence: None,
+            supersedes: None,
+            structured_fields: None,
+            retrieval_cue: None,
+        })
+        .await
+        .expect("capture_impl failed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let headers = &received[0].headers;
+    let value = headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "claude-code",
+        "x-agent-name header must equal the configured agent name"
+    );
+}
+
+#[tokio::test]
+async fn origin_client_omits_x_agent_name_when_unset() {
+    let (mock, client) = setup().await;
+
+    let response = StoreMemoryResponse {
+        source_id: "mem_xan2".into(),
+        chunks_created: 1,
+        memory_type: "fact".into(),
+        entity_id: None,
+        quality: None,
+        warnings: vec![],
+        extraction_method: "none".into(),
+        enrichment: String::new(),
+        hint: String::new(),
+    };
+    Mock::given(method("POST"))
+        .and(path("/api/memory/store"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    server
+        .capture_impl(CaptureParams {
+            content: "no header test".into(),
+            memory_type: None,
+            domain: None,
+            entity: None,
+            confidence: None,
+            supersedes: None,
+            structured_fields: None,
+            retrieval_cue: None,
+        })
+        .await
+        .expect("capture_impl failed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let headers = &received[0].headers;
+    assert!(
+        headers.get("x-agent-name").is_none(),
+        "x-agent-name header must be absent when agent_name is not set"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1096,3 +1096,97 @@ async fn list_entity_suggestions_http_500() {
     let text = text_of(&result);
     assert!(text.to_lowercase().contains("error") || text.contains("500"));
 }
+
+// ===== list_pending_imports =====
+
+use origin_mcp::tools::ListPendingImportsParams;
+use origin_types::import::PendingImport;
+
+fn sample_pending_import(id: &str) -> PendingImport {
+    PendingImport {
+        id: id.into(),
+        vendor: "claude".into(),
+        stage: "ingest".into(),
+        source_path: "/tmp/import.zip".into(),
+        processed_conversations: 5,
+        total_conversations: Some(20),
+    }
+}
+
+#[tokio::test]
+async fn list_pending_imports_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/imports/pending"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(vec![sample_pending_import("imp_1")]),
+        )
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_imports_impl(ListPendingImportsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.contains("imp_1"));
+    assert!(text.contains("claude"));
+}
+
+#[tokio::test]
+async fn list_pending_imports_envelope_guard() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/imports/pending"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"items": []})))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_imports_impl(ListPendingImportsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("invalid"),
+        "expected error signal, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_pending_imports_empty() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/imports/pending"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<PendingImport>::new()))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_imports_impl(ListPendingImportsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.contains("0 pending import"), "got: {text}");
+}
+
+#[tokio::test]
+async fn list_pending_imports_http_500() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/imports/pending"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_imports_impl(ListPendingImportsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.to_lowercase().contains("error") || text.contains("500"));
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1339,3 +1339,138 @@ async fn list_rejections_http_500() {
         "error message must mention HTTP 500; got: {text}"
     );
 }
+
+// ===== list_pending_revisions =====
+
+use origin_mcp::tools::ListPendingRevisionsParams;
+use origin_types::responses::PendingRevisionItem;
+
+fn sample_pending_revision_item(target: &str, rev: &str) -> PendingRevisionItem {
+    PendingRevisionItem {
+        target_source_id: target.into(),
+        revision_source_id: rev.into(),
+        revision_content: "Revised body".into(),
+        source_agent: Some("claude-code".into()),
+        last_modified: 1_715_000_000,
+    }
+}
+
+#[tokio::test]
+async fn list_pending_revisions_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/pending-revisions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(vec![sample_pending_revision_item("mem_target", "mem_rev")]),
+        )
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_revisions_impl(ListPendingRevisionsParams { limit: None })
+        .await
+        .expect("list_pending_revisions_impl failed");
+
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_target"),
+        "target_source_id must appear in output: {text}"
+    );
+    assert!(
+        text.contains("Revised body"),
+        "revision_content must appear in output: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_pending_revisions_envelope_guard() {
+    // Daemon must return target_source_id, not target.
+    // Wrong key: "target" instead of "target_source_id". Typed deserialization
+    // must fail loud, surfacing the missing field. This is the C1 regression guard.
+    let wrong = serde_json::json!([
+        {
+            "target": "mem_t",
+            "revision_source_id": "mem_r",
+            "revision_content": "x",
+            "source_agent": null,
+            "last_modified": 0
+        }
+    ]);
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/pending-revisions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&wrong))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_revisions_impl(ListPendingRevisionsParams { limit: None })
+        .await
+        .expect("list_pending_revisions_impl returned Err unexpectedly");
+
+    let text = text_of(&result);
+    assert!(
+        result.is_error.unwrap_or(false),
+        "wrong key 'target' instead of 'target_source_id' must surface as tool error; got: {text}"
+    );
+    assert!(
+        text.contains("Failed to parse"),
+        "error message must mention parse failure; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_pending_revisions_passes_limit() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/pending-revisions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<PendingRevisionItem>::new()))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    server
+        .list_pending_revisions_impl(ListPendingRevisionsParams { limit: Some(25) })
+        .await
+        .expect("list_pending_revisions_impl failed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1);
+    let url = received[0].url.to_string();
+    assert!(
+        url.contains("limit=25"),
+        "expected limit=25 in query; got: {url}"
+    );
+}
+
+#[tokio::test]
+async fn list_pending_revisions_http_500() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/pending-revisions"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_revisions_impl(ListPendingRevisionsParams { limit: None })
+        .await
+        .expect("list_pending_revisions_impl must not return Err on HTTP 500");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "HTTP 500 must surface as tool error"
+    );
+    let text = text_of(&result);
+    assert!(
+        text.contains("500"),
+        "error message must mention HTTP 500; got: {text}"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -10,12 +10,12 @@
 
 use origin_mcp::client::OriginClient;
 use origin_mcp::tools::{
-    CaptureParams, ContextParams, OriginMcpServer, RecallParams, TransportMode,
+    CaptureParams, ContextParams, ListNurtureParams, OriginMcpServer, RecallParams, TransportMode,
 };
-use origin_types::memory::SearchResult;
+use origin_types::memory::{MemoryItem, SearchResult};
 use origin_types::responses::{
-    ChatContextResponse, DeleteResponse, KnowledgeContext, ProfileContext, SearchMemoryResponse,
-    StoreMemoryResponse, TierTokenEstimates,
+    ChatContextResponse, DeleteResponse, KnowledgeContext, NurtureCardsResponse, ProfileContext,
+    SearchMemoryResponse, StoreMemoryResponse, TierTokenEstimates,
 };
 use rmcp::model::{CallToolResult, RawContent};
 use wiremock::matchers::{method, path};
@@ -836,5 +836,168 @@ async fn origin_client_omits_x_agent_name_when_unset() {
     assert!(
         headers.get("x-agent-name").is_none(),
         "x-agent-name header must be absent when agent_name is not set"
+    );
+}
+
+fn sample_memory_item() -> MemoryItem {
+    MemoryItem {
+        source_id: "mem_nurture1".into(),
+        title: "Test nurture card".into(),
+        content: "This memory needs review.".into(),
+        summary: None,
+        memory_type: Some("fact".into()),
+        domain: Some("work".into()),
+        source_agent: Some("test-agent".into()),
+        confidence: Some(0.7),
+        confirmed: false,
+        stability: None,
+        pinned: false,
+        supersedes: None,
+        last_modified: 1715000000,
+        chunk_count: 1,
+        entity_id: None,
+        quality: None,
+        is_recap: false,
+        enrichment_status: "done".into(),
+        supersede_mode: "soft".into(),
+        structured_fields: None,
+        retrieval_cue: None,
+        access_count: 0,
+        source_text: None,
+        version: 1,
+        changelog: None,
+        pending_revision: false,
+        merged_from: None,
+    }
+}
+
+#[tokio::test]
+async fn list_nurture_happy_path() {
+    let (mock, client) = setup().await;
+    let response = NurtureCardsResponse {
+        cards: vec![sample_memory_item()],
+    };
+    Mock::given(method("GET"))
+        .and(path("/api/memory/nurture"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_nurture_impl(ListNurtureParams {
+            limit: None,
+            domain: None,
+        })
+        .await
+        .expect("list_nurture_impl failed");
+
+    let text = text_of(&result);
+    assert!(
+        text.starts_with("1 nurture cards"),
+        "expected '1 nurture cards' header; got: {text}"
+    );
+    assert!(
+        text.contains("mem_nurture1"),
+        "expected source_id in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_nurture_envelope_guard() {
+    // Daemon must not wrap response under an extra key. If it does, typed
+    // deserialization fails loud instead of returning an empty list silently.
+    // Regression guard for lesson_mcp_typed_deserialize.
+    let wrong = serde_json::json!({ "data": { "cards": [] } });
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/nurture"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&wrong))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_nurture_impl(ListNurtureParams {
+            limit: None,
+            domain: None,
+        })
+        .await
+        .expect("list_nurture_impl returned Err unexpectedly");
+
+    // tool_error path: isError=true text contains "Failed to parse"
+    let text = text_of(&result);
+    assert!(
+        result.is_error.unwrap_or(false),
+        "envelope-wrapped response must surface as tool error; got: {text}"
+    );
+    assert!(
+        text.contains("Failed to parse"),
+        "error message must mention parse failure; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_nurture_passes_query_params() {
+    let (mock, client) = setup().await;
+    let response = NurtureCardsResponse { cards: vec![] };
+    // Use a broad path matcher; we inspect the URL manually.
+    Mock::given(method("GET"))
+        .and(path("/api/memory/nurture"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    server
+        .list_nurture_impl(ListNurtureParams {
+            limit: Some(25),
+            domain: Some("work".into()),
+        })
+        .await
+        .expect("list_nurture_impl failed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1);
+    let url = received[0].url.to_string();
+    assert!(
+        url.contains("limit=25"),
+        "expected limit=25 in query; got: {url}"
+    );
+    assert!(
+        url.contains("domain=work"),
+        "expected domain=work in query; got: {url}"
+    );
+}
+
+#[tokio::test]
+async fn list_nurture_http_500() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/nurture"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("internal error"))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_nurture_impl(ListNurtureParams {
+            limit: None,
+            domain: None,
+        })
+        .await
+        .expect("list_nurture_impl must not return Err on HTTP 500");
+
+    assert!(
+        result.is_error.unwrap_or(false),
+        "HTTP 500 must surface as tool error"
+    );
+    let text = text_of(&result);
+    assert!(
+        text.contains("500"),
+        "error message must mention HTTP 500; got: {text}"
     );
 }

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1117,7 +1117,7 @@ fn sample_pending_import(id: &str) -> PendingImport {
 async fn list_pending_imports_happy_path() {
     let (mock, client) = setup().await;
     Mock::given(method("GET"))
-        .and(path("/api/imports/pending"))
+        .and(path("/api/import/state"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(vec![sample_pending_import("imp_1")]),
         )
@@ -1138,7 +1138,7 @@ async fn list_pending_imports_happy_path() {
 async fn list_pending_imports_envelope_guard() {
     let (mock, client) = setup().await;
     Mock::given(method("GET"))
-        .and(path("/api/imports/pending"))
+        .and(path("/api/import/state"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"items": []})))
         .mount(&mock)
         .await;
@@ -1159,7 +1159,7 @@ async fn list_pending_imports_envelope_guard() {
 async fn list_pending_imports_empty() {
     let (mock, client) = setup().await;
     Mock::given(method("GET"))
-        .and(path("/api/imports/pending"))
+        .and(path("/api/import/state"))
         .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<PendingImport>::new()))
         .mount(&mock)
         .await;
@@ -1177,7 +1177,7 @@ async fn list_pending_imports_empty() {
 async fn list_pending_imports_http_500() {
     let (mock, client) = setup().await;
     Mock::given(method("GET"))
-        .and(path("/api/imports/pending"))
+        .and(path("/api/import/state"))
         .respond_with(ResponseTemplate::new(500))
         .mount(&mock)
         .await;

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1001,3 +1001,98 @@ async fn list_nurture_http_500() {
         "error message must mention HTTP 500; got: {text}"
     );
 }
+
+// ===== list_entity_suggestions =====
+
+use origin_mcp::tools::ListEntitySuggestionsParams;
+use origin_types::entities::EntitySuggestion;
+
+fn sample_entity_suggestion(id: &str, name: &str) -> EntitySuggestion {
+    EntitySuggestion {
+        id: id.into(),
+        entity_name: Some(name.into()),
+        source_ids: vec!["mem_a".into()],
+        confidence: 0.8,
+        created_at: "2026-05-12T00:00:00Z".into(),
+    }
+}
+
+#[tokio::test]
+async fn list_entity_suggestions_happy_path() {
+    let (mock, client) = setup().await;
+    let body = vec![sample_entity_suggestion("sug_1", "PostgreSQL")];
+    Mock::given(method("GET"))
+        .and(path("/api/memory/entity-suggestions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_entity_suggestions_impl(ListEntitySuggestionsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.contains("PostgreSQL"));
+    assert!(text.contains("sug_1"));
+}
+
+#[tokio::test]
+async fn list_entity_suggestions_envelope_guard() {
+    let (mock, client) = setup().await;
+    // Wrong shape: object instead of array
+    Mock::given(method("GET"))
+        .and(path("/api/memory/entity-suggestions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestions": []
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_entity_suggestions_impl(ListEntitySuggestionsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("invalid"),
+        "expected error signal, got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn list_entity_suggestions_empty() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/entity-suggestions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&Vec::<EntitySuggestion>::new()))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_entity_suggestions_impl(ListEntitySuggestionsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.contains("0 entity suggestion"), "got: {text}");
+}
+
+#[tokio::test]
+async fn list_entity_suggestions_http_500() {
+    let (mock, client) = setup().await;
+    Mock::given(method("GET"))
+        .and(path("/api/memory/entity-suggestions"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_entity_suggestions_impl(ListEntitySuggestionsParams {})
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(text.to_lowercase().contains("error") || text.contains("500"));
+}

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -3109,7 +3109,7 @@ pub struct OrphanLinksQuery {
 pub async fn handle_list_orphan_links(
     State(state): State<Arc<RwLock<ServerState>>>,
     axum::extract::Query(q): axum::extract::Query<OrphanLinksQuery>,
-) -> Result<Json<serde_json::Value>, ServerError> {
+) -> Result<Json<origin_types::responses::OrphanLinksResponse>, ServerError> {
     let db = {
         let s = state.read().await;
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
@@ -3119,14 +3119,14 @@ pub async fn handle_list_orphan_links(
         .list_orphan_link_labels(min_count)
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?;
-    let payload: Vec<serde_json::Value> = labels
+    let orphan_labels = labels
         .into_iter()
-        .map(|(label, count)| serde_json::json!({"label": label, "count": count}))
+        .map(|(label, count)| origin_types::responses::OrphanLink { label, count })
         .collect();
-    Ok(Json(serde_json::json!({
-        "min_count": min_count,
-        "orphan_labels": payload,
-    })))
+    Ok(Json(origin_types::responses::OrphanLinksResponse {
+        min_count: min_count as usize,
+        orphan_labels,
+    }))
 }
 
 pub async fn handle_update_page(

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -2848,6 +2848,33 @@ pub async fn handle_unpin_memory(
     Ok(Json(origin_types::responses::SuccessResponse { ok: true }))
 }
 
+#[derive(Debug, Deserialize)]
+pub struct PendingRevisionsQuery {
+    #[serde(default = "default_pending_revisions_limit")]
+    pub limit: usize,
+}
+
+fn default_pending_revisions_limit() -> usize {
+    50
+}
+
+/// GET /api/memory/pending-revisions?limit=N
+pub async fn handle_list_pending_revisions(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    axum::extract::Query(q): axum::extract::Query<PendingRevisionsQuery>,
+) -> Result<Json<Vec<origin_types::responses::PendingRevisionItem>>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let limit = q.limit.clamp(1, 500);
+    let items = db
+        .list_pending_revisions(limit)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    Ok(Json(items))
+}
+
 /// GET /api/memory/pending-revision/{source_id}
 pub async fn handle_get_pending_revision(
     State(state): State<Arc<RwLock<ServerState>>>,

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -434,6 +434,10 @@ pub fn build_router(state: SharedState) -> Router {
             post(memory_routes::handle_unpin_memory),
         )
         .route(
+            "/api/memory/pending-revisions",
+            get(memory_routes::handle_list_pending_revisions),
+        )
+        .route(
             "/api/memory/pending-revision/{source_id}",
             get(memory_routes::handle_get_pending_revision),
         )

--- a/crates/origin-server/tests/common/mod.rs
+++ b/crates/origin-server/tests/common/mod.rs
@@ -9,6 +9,25 @@ use origin_server::state::ServerState;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// Insert a page with a single wikilink reference whose target does not exist,
+/// producing an orphan `page_links` row (`target_page_id IS NULL`).
+///
+/// The `[[orphan_label]]` syntax in content causes `insert_page` to call
+/// `refresh_page_wikilinks`, which writes a `page_links` row with
+/// `target_page_id = NULL` (orphan) because no page with that title exists yet.
+pub async fn insert_page_with_orphan_link(
+    db: &Arc<MemoryDB>,
+    page_id: &str,
+    page_title: &str,
+    orphan_label: &str,
+) {
+    let now = chrono::Utc::now().to_rfc3339();
+    let content = format!("References [[{orphan_label}]] in this page.");
+    db.insert_page(page_id, page_title, None, &content, None, None, &[], &now)
+        .await
+        .expect("insert_page must succeed in test fixture");
+}
+
 /// Build a test app and return `(router, tmp, db_arc)`.
 ///
 /// The caller binds `_tmp` to keep the `TempDir` alive for the test's

--- a/crates/origin-server/tests/common/mod.rs
+++ b/crates/origin-server/tests/common/mod.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared helpers for origin-server integration tests.
+
+use origin_core::db::MemoryDB;
+use origin_core::events::NoopEmitter;
+use origin_core::sources::RawDocument;
+use origin_server::router::build_router;
+use origin_server::state::ServerState;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Build a test app and return `(router, db_arc)`.
+///
+/// The underlying `TempDir` is intentionally leaked: integration tests run
+/// to completion before the process exits, so the OS reclaims the temp files.
+/// This avoids lifetime complications when the caller only needs a 2-tuple.
+pub async fn test_app() -> (axum::Router, Arc<MemoryDB>) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    // Leak the dir so the temp path stays valid for the test's lifetime.
+    std::mem::forget(dir);
+
+    let db = MemoryDB::new(&path, Arc::new(NoopEmitter)).await.unwrap();
+    let db_arc = Arc::new(db);
+    let state = ServerState {
+        db: Some(db_arc.clone()),
+        ..ServerState::default()
+    };
+    let router = build_router(Arc::new(RwLock::new(state)));
+    (router, db_arc)
+}
+
+/// Insert a memory row directly via `upsert_documents`.
+///
+/// Matches the `insert_memory_for_test` helper used in `origin-core`'s DB
+/// unit tests. All NOT NULL columns in `memories` are covered.
+pub async fn insert_memory(
+    db: &Arc<MemoryDB>,
+    source_id: &str,
+    content: &str,
+    source: &str,
+    source_agent: Option<&str>,
+    supersedes: Option<&str>,
+    pending_revision: bool,
+    last_modified: i64,
+) {
+    let doc = RawDocument {
+        source: source.to_string(),
+        source_id: source_id.to_string(),
+        title: format!("title-{}", source_id),
+        content: content.to_string(),
+        source_agent: source_agent.map(|s| s.to_string()),
+        supersedes: supersedes.map(|s| s.to_string()),
+        pending_revision,
+        last_modified,
+        ..Default::default()
+    };
+    db.upsert_documents(vec![doc]).await.unwrap();
+}

--- a/crates/origin-server/tests/common/mod.rs
+++ b/crates/origin-server/tests/common/mod.rs
@@ -9,31 +9,29 @@ use origin_server::state::ServerState;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-/// Build a test app and return `(router, db_arc)`.
+/// Build a test app and return `(router, tmp, db_arc)`.
 ///
-/// The underlying `TempDir` is intentionally leaked: integration tests run
-/// to completion before the process exits, so the OS reclaims the temp files.
-/// This avoids lifetime complications when the caller only needs a 2-tuple.
-pub async fn test_app() -> (axum::Router, Arc<MemoryDB>) {
+/// The caller binds `_tmp` to keep the `TempDir` alive for the test's
+/// duration; it drops (and cleans up) when the test function returns.
+pub async fn test_app() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().to_path_buf();
-    // Leak the dir so the temp path stays valid for the test's lifetime.
-    std::mem::forget(dir);
-
-    let db = MemoryDB::new(&path, Arc::new(NoopEmitter)).await.unwrap();
+    let db = MemoryDB::new(dir.path(), Arc::new(NoopEmitter))
+        .await
+        .unwrap();
     let db_arc = Arc::new(db);
     let state = ServerState {
         db: Some(db_arc.clone()),
         ..ServerState::default()
     };
     let router = build_router(Arc::new(RwLock::new(state)));
-    (router, db_arc)
+    (router, dir, db_arc)
 }
 
 /// Insert a memory row directly via `upsert_documents`.
 ///
 /// Matches the `insert_memory_for_test` helper used in `origin-core`'s DB
 /// unit tests. All NOT NULL columns in `memories` are covered.
+#[allow(clippy::too_many_arguments)]
 pub async fn insert_memory(
     db: &Arc<MemoryDB>,
     source_id: &str,

--- a/crates/origin-server/tests/curation_read_routes.rs
+++ b/crates/origin-server/tests/curation_read_routes.rs
@@ -18,7 +18,7 @@ async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Resp
 
 #[tokio::test]
 async fn list_pending_revisions_returns_target_id_not_revision_id() {
-    let (app, db) = test_app().await;
+    let (app, _tmp, db) = test_app().await;
 
     // Target memory (not pending, no supersedes)
     insert_memory(
@@ -68,7 +68,7 @@ async fn list_pending_revisions_returns_target_id_not_revision_id() {
 
 #[tokio::test]
 async fn list_pending_revisions_round_trips_through_accept() {
-    let (app, db) = test_app().await;
+    let (app, _tmp, db) = test_app().await;
     insert_memory(&db, "mem_t", "Orig", "memory", None, None, false, 1).await;
     insert_memory(&db, "mem_r", "Rev", "memory", None, Some("mem_t"), true, 2).await;
 
@@ -85,7 +85,7 @@ async fn list_pending_revisions_round_trips_through_accept() {
     .await;
 
     let target = &items[0].target_source_id;
-    // Call existing accept primitive — proves the id from list is action-compatible
+    // Call existing accept primitive. Proves the id from list is action-compatible.
     db.accept_pending_revision(target)
         .await
         .expect("accept must succeed with target_source_id from list");
@@ -93,7 +93,7 @@ async fn list_pending_revisions_round_trips_through_accept() {
 
 #[tokio::test]
 async fn list_pending_revisions_orders_newest_first() {
-    let (app, db) = test_app().await;
+    let (app, _tmp, db) = test_app().await;
     insert_memory(&db, "mem_t1", "t", "memory", None, None, false, 1).await;
     insert_memory(&db, "mem_t2", "t", "memory", None, None, false, 2).await;
     insert_memory(
@@ -136,7 +136,7 @@ async fn list_pending_revisions_orders_newest_first() {
 
 #[tokio::test]
 async fn list_pending_revisions_clamps_limit() {
-    let (app, db) = test_app().await;
+    let (app, _tmp, db) = test_app().await;
     for i in 0..3 {
         insert_memory(
             &db,
@@ -177,7 +177,7 @@ async fn list_pending_revisions_clamps_limit() {
 
 #[tokio::test]
 async fn list_pending_revisions_empty_on_clean_db() {
-    let (app, _db) = test_app().await;
+    let (app, _tmp, _db) = test_app().await;
     let resp = app
         .oneshot(
             Request::builder()

--- a/crates/origin-server/tests/curation_read_routes.rs
+++ b/crates/origin-server/tests/curation_read_routes.rs
@@ -3,11 +3,11 @@
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use origin_types::responses::PendingRevisionItem;
+use origin_types::responses::{OrphanLinksResponse, PendingRevisionItem};
 use tower::ServiceExt;
 
 mod common;
-use common::{insert_memory, test_app};
+use common::{insert_memory, insert_page_with_orphan_link, test_app};
 
 async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
     let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
@@ -190,4 +190,42 @@ async fn list_pending_revisions_empty_on_clean_db() {
     assert_eq!(resp.status(), StatusCode::OK);
     let items: Vec<PendingRevisionItem> = body_as_json(resp).await;
     assert!(items.is_empty());
+}
+
+#[tokio::test]
+async fn orphan_links_returns_typed_envelope() {
+    let (app, _tmp, db) = test_app().await;
+
+    // Two pages both referencing "Missing" — an orphan because no page with
+    // that title exists. With min_count=2 both must appear for the label to
+    // surface; this exercises the threshold and the typed envelope shape.
+    insert_page_with_orphan_link(&db, "page1", "Source page", "Missing").await;
+    insert_page_with_orphan_link(&db, "page2", "Other source", "Missing").await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/pages/orphan-links?min_count=2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: OrphanLinksResponse = body_as_json(resp).await;
+
+    assert_eq!(body.min_count, 2, "min_count echo must match query param");
+    assert_eq!(
+        body.orphan_labels.len(),
+        1,
+        "exactly one orphan label expected (got {:?})",
+        body.orphan_labels
+    );
+    let entry = &body.orphan_labels[0];
+    assert_eq!(entry.label, "Missing", "label must be the wikilink text");
+    assert_eq!(
+        entry.count, 2,
+        "count must be the number of distinct source pages"
+    );
 }

--- a/crates/origin-server/tests/curation_read_routes.rs
+++ b/crates/origin-server/tests/curation_read_routes.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for read-only curation routes.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use origin_types::responses::PendingRevisionItem;
+use tower::ServiceExt;
+
+mod common;
+use common::{insert_memory, test_app};
+
+async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
+    let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).expect("response body is valid JSON of expected type")
+}
+
+#[tokio::test]
+async fn list_pending_revisions_returns_target_id_not_revision_id() {
+    let (app, db) = test_app().await;
+
+    // Target memory (not pending, no supersedes)
+    insert_memory(
+        &db,
+        "mem_target",
+        "Original",
+        "memory",
+        None,
+        None,
+        false,
+        1_000,
+    )
+    .await;
+    // Revision row pending, supersedes target
+    insert_memory(
+        &db,
+        "mem_rev",
+        "Revised",
+        "memory",
+        Some("agent-1"),
+        Some("mem_target"),
+        true,
+        2_000,
+    )
+    .await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/memory/pending-revisions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let items: Vec<PendingRevisionItem> = body_as_json(resp).await;
+    assert_eq!(items.len(), 1, "got {items:?}");
+    assert_eq!(
+        items[0].target_source_id, "mem_target",
+        "regression: list must return target id, not revision row id (adversarial C1)"
+    );
+    assert_eq!(items[0].revision_source_id, "mem_rev");
+    assert_eq!(items[0].revision_content, "Revised");
+}
+
+#[tokio::test]
+async fn list_pending_revisions_round_trips_through_accept() {
+    let (app, db) = test_app().await;
+    insert_memory(&db, "mem_t", "Orig", "memory", None, None, false, 1).await;
+    insert_memory(&db, "mem_r", "Rev", "memory", None, Some("mem_t"), true, 2).await;
+
+    let items: Vec<PendingRevisionItem> = body_as_json(
+        app.oneshot(
+            Request::builder()
+                .uri("/api/memory/pending-revisions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+
+    let target = &items[0].target_source_id;
+    // Call existing accept primitive — proves the id from list is action-compatible
+    db.accept_pending_revision(target)
+        .await
+        .expect("accept must succeed with target_source_id from list");
+}
+
+#[tokio::test]
+async fn list_pending_revisions_orders_newest_first() {
+    let (app, db) = test_app().await;
+    insert_memory(&db, "mem_t1", "t", "memory", None, None, false, 1).await;
+    insert_memory(&db, "mem_t2", "t", "memory", None, None, false, 2).await;
+    insert_memory(
+        &db,
+        "mem_r1",
+        "old",
+        "memory",
+        None,
+        Some("mem_t1"),
+        true,
+        100,
+    )
+    .await;
+    insert_memory(
+        &db,
+        "mem_r2",
+        "new",
+        "memory",
+        None,
+        Some("mem_t2"),
+        true,
+        200,
+    )
+    .await;
+
+    let items: Vec<PendingRevisionItem> = body_as_json(
+        app.oneshot(
+            Request::builder()
+                .uri("/api/memory/pending-revisions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+    assert_eq!(items[0].revision_source_id, "mem_r2");
+    assert_eq!(items[1].revision_source_id, "mem_r1");
+}
+
+#[tokio::test]
+async fn list_pending_revisions_clamps_limit() {
+    let (app, db) = test_app().await;
+    for i in 0..3 {
+        insert_memory(
+            &db,
+            &format!("mem_t{i}"),
+            "t",
+            "memory",
+            None,
+            None,
+            false,
+            i,
+        )
+        .await;
+        insert_memory(
+            &db,
+            &format!("mem_r{i}"),
+            "r",
+            "memory",
+            None,
+            Some(&format!("mem_t{i}")),
+            true,
+            100 + i,
+        )
+        .await;
+    }
+    let items: Vec<PendingRevisionItem> = body_as_json(
+        app.oneshot(
+            Request::builder()
+                .uri("/api/memory/pending-revisions?limit=2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap(),
+    )
+    .await;
+    assert_eq!(items.len(), 2);
+}
+
+#[tokio::test]
+async fn list_pending_revisions_empty_on_clean_db() {
+    let (app, _db) = test_app().await;
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/memory/pending-revisions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let items: Vec<PendingRevisionItem> = body_as_json(resp).await;
+    assert!(items.is_empty());
+}

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -38,8 +38,9 @@ pub use narrative::NarrativeResponse;
 pub use pages::Page;
 pub use responses::{
     ExportStats, ListMemoryRevisionsResponse, ListPageRevisionsResponse, ListRefinementsResponse,
-    MemoryDetail, MemoryRevisionEntry, PageChangelogEntry, PendingRevision, ProposalAction,
-    RefinementPayload, RefinementProposalSummary, RejectRefinementResponse,
+    MemoryDetail, MemoryRevisionEntry, OrphanLink, OrphanLinksResponse, PageChangelogEntry,
+    PendingRevision, PendingRevisionItem, ProposalAction, RefinementPayload,
+    RefinementProposalSummary, RejectRefinementResponse,
 };
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -941,7 +941,7 @@ mod tests {
         };
         let decoded: OrphanLinksResponse =
             serde_json::from_str(&serde_json::to_string(&resp).unwrap()).unwrap();
-        assert_eq!(decoded.orphan_labels.len(), 0);
+        assert_eq!(decoded, resp);
     }
 
     #[test]
@@ -958,7 +958,6 @@ mod tests {
         assert_eq!(json["revision_source_id"], "mem_rev");
         assert_eq!(json["revision_content"], "new body");
         let decoded: PendingRevisionItem = serde_json::from_value(json).unwrap();
-        assert_eq!(decoded.target_source_id, "mem_target");
-        assert_eq!(decoded.last_modified, 1_715_000_000);
+        assert_eq!(decoded, item);
     }
 }

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -756,6 +756,38 @@ mod refinement_wire_tests {
     }
 }
 
+/// One orphaned page link label aggregated across sources.
+///
+/// `count` is how many distinct source pages reference this label
+/// without a matching target page existing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrphanLink {
+    pub label: String,
+    pub count: i64,
+}
+
+/// Response for `GET /api/pages/orphan-links`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OrphanLinksResponse {
+    pub min_count: usize,
+    pub orphan_labels: Vec<OrphanLink>,
+}
+
+/// One pending revision awaiting human accept/dismiss.
+///
+/// `target_source_id` is the memory being revised; pass it to
+/// `accept_pending_revision` or `dismiss_pending_revision`.
+/// `revision_source_id` is the staged revision row itself, exposed
+/// for diagnostics and round-tripping (not for the action call).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PendingRevisionItem {
+    pub target_source_id: String,
+    pub revision_source_id: String,
+    pub revision_content: String,
+    pub source_agent: Option<String>,
+    pub last_modified: i64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -883,5 +915,50 @@ mod tests {
         assert!(parsed.knowledge.decisions.is_empty());
         assert!(parsed.knowledge.relevant_memories.is_empty());
         assert!(parsed.knowledge.graph_context.is_empty());
+    }
+
+    #[test]
+    fn orphan_links_response_golden_string() {
+        let resp = OrphanLinksResponse {
+            min_count: 2,
+            orphan_labels: vec![OrphanLink {
+                label: "Rust".to_string(),
+                count: 3,
+            }],
+        };
+        let s = serde_json::to_string(&resp).unwrap();
+        assert_eq!(
+            s,
+            r#"{"min_count":2,"orphan_labels":[{"label":"Rust","count":3}]}"#
+        );
+    }
+
+    #[test]
+    fn orphan_links_response_empty_round_trip() {
+        let resp = OrphanLinksResponse {
+            min_count: 1,
+            orphan_labels: vec![],
+        };
+        let decoded: OrphanLinksResponse =
+            serde_json::from_str(&serde_json::to_string(&resp).unwrap()).unwrap();
+        assert_eq!(decoded.orphan_labels.len(), 0);
+    }
+
+    #[test]
+    fn pending_revision_item_round_trip() {
+        let item = PendingRevisionItem {
+            target_source_id: "mem_target".into(),
+            revision_source_id: "mem_rev".into(),
+            revision_content: "new body".into(),
+            source_agent: Some("claude-code".into()),
+            last_modified: 1_715_000_000,
+        };
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["target_source_id"], "mem_target");
+        assert_eq!(json["revision_source_id"], "mem_rev");
+        assert_eq!(json["revision_content"], "new body");
+        let decoded: PendingRevisionItem = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.target_source_id, "mem_target");
+        assert_eq!(decoded.last_modified, 1_715_000_000);
     }
 }


### PR DESCRIPTION
## Summary

Surface six daemon curation routes to MCP clients as read-only tools so the `/review` skill (and any future curation skill) can list what needs human attention.

- **6 read-only MCP wrappers** added to `origin-mcp`: `list_nurture`, `list_entity_suggestions`, `list_pending_imports`, `list_rejections`, `list_pending_revisions`, `list_orphan_links`. All typed-deserialize wire shapes per `lesson_mcp_typed_deserialize` (no `serde_json::Value`).
- **1 new HTTP list route**: `GET /api/memory/pending-revisions` (collection form; the existing `/api/memory/pending-revision/{source_id}` was single-source only). The new wire type `PendingRevisionItem` carries both `target_source_id` (for accept/dismiss) and `revision_source_id` (for diagnostics), fixing the adversarial-review C1 finding (revision row's own id was useless to the consumer).
- **1 typed wire-shape fix**: `handle_list_orphan_links` retyped from `Json<serde_json::Value>` to `Json<OrphanLinksResponse>`. Wire bytes are byte-identical; a golden-string test in `origin-types` pins the exact serialization.
- **x-agent-name header plumbing**: `OriginClient` gains an optional `agent_name` field via `with_agent_name(...)`; `main.rs` and `serve.rs` wire it through. Forward-compat for PR2 mutate paths.

This is **Spec C-1**, the first of three PRs decomposing Spec C. PR2 (Spec C-2) adds the corresponding mutate wrappers (entity-suggestion approve/dismiss, revision accept/dismiss, contradiction dismiss) plus capability-fn convergence. PR3 (Spec C-3) updates the `/review` skill to compose the new tools.

## Background

Spec went through pre-implementation adversarial review (Opus, fresh-eye) which caught 5 critical findings, all integrated before code was written:

- **C1**: list query returned revision-row source_id instead of target_source_id; accept/dismiss take the target id. Fixed via new `PendingRevisionItem.target_source_id` field selecting `supersedes` as column 0 of the query.
- **C2**: `ORDER BY created_at` is unsound (column is nullable pre-migration-21); switched to `ORDER BY last_modified` (NOT NULL).
- **C3**: partial index on `pending_revision != 0` doesn't cover `source = 'memory'` filter; documented as acceptable since pending-revision cardinality is bounded by human attention.
- **C4**: byte-identical wire-shape claim for orphan-links needed a lock; added golden-string test.
- **C5**: bundled-wrapper tasks violated bite-sized rule; split into per-wrapper tasks (11 total).

Final post-implementation adversarial review caught two more:

- **Final C1**: `list_pending_imports` wrapper called `/api/imports/pending`, but the daemon route is `/api/import/state`. Mocks matched the wrapper URL so unit tests passed while a live daemon call would 404. Fixed in `b5470bab`.
- **Final I1**: `with_agent_name` was dead code; `main.rs` and `serve.rs` never called it. Wired in `b5470bab`.

A live smoke test against an isolated daemon on port 7900 with a fresh temp data dir confirmed both new routes return HTTP 200 with the expected typed shapes.

## Verification

- `cargo test --workspace --lib`: per-crate green (origin-types 43, origin-core 1077, origin-server 51, origin-mcp 151)
- `cargo test -p origin-server --tests`: 9 integration tests including `list_pending_revisions_returns_target_id_not_revision_id` (C1 regression guard) and `list_pending_revisions_round_trips_through_accept` (proves the listed id is action-compatible)
- `cargo test -p origin-mcp --tests`: 39 type-contract tests including envelope-guard regressions per wrapper
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Smoke test: PASS (isolated daemon on port 7900, new routes return typed shapes)

## Test Plan

- [ ] CI green
- [ ] Spot-check via Claude Code MCP client: `list_nurture`, `list_orphan_links`, `list_pending_revisions` each return typed structured results
- [ ] Confirm `x-agent-name` header lands in daemon logs for at least one invocation

## Notes

- A few in-PR commits use `feat:` prefix. The PR is squash-merged with `refactor:` title so release-please will not bump the version (0.5.3 to 0.6.0 stays pending from PR #96).
- AGENTS.md note "SQL tables remain `concepts`/`concept_sources` historically" is stale post-PR #68 + migration 46 (the active table is `pages`). Not addressed here; flagged for follow-up doc fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)