### PR TITLE
feat: BM-mode curation mutate MCPs (Spec C-2)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -28738,7 +28738,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn accept_pending_revision_is_transactional_on_partial_failure() {
+    async fn accept_pending_revision_happy_path_then_not_found_on_recall() {
         // Seed: insert a target memory and a pending revision for it.
         let (db, _tmp) = test_db().await;
         let now = chrono::Utc::now().timestamp();

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -11477,7 +11477,7 @@ impl MemoryDB {
 
     /// Accept a pending revision for a target memory. The `target_source_id` is the
     /// original memory being superseded. This finds the pending revision that supersedes it,
-    /// activates it, and suppresses the original.
+    /// activates it, and suppresses the original. Both UPDATEs are wrapped in BEGIN/COMMIT.
     pub async fn accept_pending_revision(&self, target_source_id: &str) -> Result<(), OriginError> {
         let conn = self.conn.lock().await;
 
@@ -11498,27 +11498,47 @@ impl MemoryDB {
             row.get::<String>(0)
                 .map_err(|e| OriginError::VectorDb(e.to_string()))?
         } else {
-            return Err(OriginError::VectorDb(format!(
-                "No pending revision found for source_id: {}",
+            return Err(OriginError::NotFound(format!(
+                "No pending revision for source_id: {}",
                 target_source_id
             )));
         };
 
-        // Activate the revision
-        conn.execute(
-            "UPDATE memories SET pending_revision = 0, confirmed = 1, stability = 'confirmed', confidence = 1.0 WHERE source_id = ?1",
-            libsql::params![revision_source_id.clone()],
-        )
-        .await
-        .map_err(|e| OriginError::VectorDb(format!("accept_pending_revision activate: {}", e)))?;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("accept_pending_revision begin: {}", e)))?;
 
-        // Suppress the original
-        conn.execute(
-            "UPDATE memories SET confirmed = 0, stability = 'new' WHERE source_id = ?1",
-            libsql::params![target_source_id.to_string()],
-        )
-        .await
-        .map_err(|e| OriginError::VectorDb(format!("accept_pending_revision suppress: {}", e)))?;
+        let activate_result = conn
+            .execute(
+                "UPDATE memories SET pending_revision = 0, confirmed = 1, stability = 'confirmed', confidence = 1.0 WHERE source_id = ?1",
+                libsql::params![revision_source_id.clone()],
+            )
+            .await;
+        if let Err(e) = activate_result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(OriginError::VectorDb(format!(
+                "accept_pending_revision activate: {}",
+                e
+            )));
+        }
+
+        let suppress_result = conn
+            .execute(
+                "UPDATE memories SET confirmed = 0, stability = 'new' WHERE source_id = ?1",
+                libsql::params![target_source_id.to_string()],
+            )
+            .await;
+        if let Err(e) = suppress_result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(OriginError::VectorDb(format!(
+                "accept_pending_revision suppress: {}",
+                e
+            )));
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("accept_pending_revision commit: {}", e)))?;
 
         Ok(())
     }
@@ -11538,8 +11558,8 @@ impl MemoryDB {
             .await
             .map_err(|e| OriginError::VectorDb(format!("dismiss_pending_revision: {}", e)))?;
         if rows_affected == 0 {
-            return Err(OriginError::VectorDb(format!(
-                "No pending revision found for source_id: {}",
+            return Err(OriginError::NotFound(format!(
+                "No pending revision for source_id: {}",
                 target_source_id
             )));
         }
@@ -28686,6 +28706,111 @@ pub(crate) mod tests {
             r1 + r2,
             1,
             "exactly one caller should see rows=1, got {r1} + {r2}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_pending_revision_returns_not_found_variant_on_missing() {
+        let (db, _tmp) = test_db().await;
+        let err = db
+            .accept_pending_revision("mem_does_not_exist")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, OriginError::NotFound(_)),
+            "expected NotFound, got {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn dismiss_pending_revision_returns_not_found_variant_on_missing() {
+        let (db, _tmp) = test_db().await;
+        let err = db
+            .dismiss_pending_revision("mem_does_not_exist")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, OriginError::NotFound(_)),
+            "expected NotFound, got {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn accept_pending_revision_is_transactional_on_partial_failure() {
+        // Seed: insert a target memory and a pending revision for it.
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().timestamp();
+        // mem_target is the original; mem_revision supersedes it with pending_revision=true
+        insert_memory_for_test(
+            &db,
+            "mem_target",
+            "original content",
+            "memory",
+            Some("test-agent"),
+            None,
+            false,
+            now,
+        )
+        .await;
+        insert_memory_for_test(
+            &db,
+            "mem_revision",
+            "revised content",
+            "memory",
+            Some("test-agent"),
+            None,
+            true,
+            now,
+        )
+        .await;
+        // Mark mem_revision as pending revision for mem_target.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE memories SET supersedes = ?1, pending_revision = 1 WHERE source_id = ?2",
+                libsql::params!["mem_target".to_string(), "mem_revision".to_string()],
+            )
+            .await
+            .unwrap();
+        }
+
+        // First call should succeed.
+        db.accept_pending_revision("mem_target").await.unwrap();
+
+        // After accept: revision is now `pending_revision = 0`, original is suppressed.
+        {
+            let conn = db.conn.lock().await;
+            let mut rows = conn
+                .query(
+                    "SELECT pending_revision FROM memories WHERE source_id = 'mem_revision'",
+                    libsql::params![],
+                )
+                .await
+                .unwrap();
+            let row = rows.next().await.unwrap().unwrap();
+            let pr: i64 = row.get(0).unwrap();
+            assert_eq!(pr, 0, "revision should be activated (pending_revision=0)");
+
+            let mut rows2 = conn
+                .query(
+                    "SELECT confirmed FROM memories WHERE source_id = 'mem_target'",
+                    libsql::params![],
+                )
+                .await
+                .unwrap();
+            let row2 = rows2.next().await.unwrap().unwrap();
+            let confirmed: i64 = row2.get(0).unwrap();
+            assert_eq!(confirmed, 0, "original should be suppressed (confirmed=0)");
+        }
+
+        // Second call should return NotFound (revision row no longer has pending_revision=1).
+        let err = db.accept_pending_revision("mem_target").await.unwrap_err();
+        assert!(
+            matches!(err, OriginError::NotFound(_)),
+            "expected NotFound on re-call, got {:?}",
+            err
         );
     }
 }

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -789,6 +789,23 @@ pub async fn accept_pending_revision(
     })
 }
 
+/// Dismiss a pending memory revision. Canonical entry for both
+/// agent-triggered (`/api/memory/revision/{id}/dismiss`) and daemon-internal
+/// triggers. Deletes the pending revision row; the original is untouched.
+/// Returns `NotFound` if no pending revision exists for the target.
+pub async fn dismiss_pending_revision(
+    db: &MemoryDB,
+    target_source_id: &str,
+    agent: &str,
+) -> Result<origin_types::RevisionDismissResponse, OriginError> {
+    db.dismiss_pending_revision(target_source_id).await?;
+    log_activity_best_effort(db, agent, "revision_dismiss", target_source_id).await;
+    Ok(origin_types::RevisionDismissResponse {
+        target_source_id: target_source_id.to_string(),
+        wrote: true,
+    })
+}
+
 fn is_valid_snake_case_relation(s: &str) -> bool {
     if s.is_empty() {
         return false;
@@ -1599,6 +1616,41 @@ mod tests {
             .await
             .unwrap();
         let err = accept_pending_revision(&db, "mem_arr_target", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OriginError::NotFound(_)));
+    }
+
+    // ── dismiss_pending_revision ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dismiss_pending_revision_writes_and_logs_on_first_call() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        seed_pending_revision(&db, "mem_dpr_target", "mem_dpr_rev").await;
+        let result = dismiss_pending_revision(&db, "mem_dpr_target", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(result.target_source_id, "mem_dpr_target");
+        assert!(result.wrote);
+    }
+
+    #[tokio::test]
+    async fn dismiss_pending_revision_returns_not_found_on_missing_id() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        let err = dismiss_pending_revision(&db, "mem_nope", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OriginError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn dismiss_pending_revision_returns_not_found_on_re_call() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        seed_pending_revision(&db, "mem_dpr2_target", "mem_dpr2_rev").await;
+        dismiss_pending_revision(&db, "mem_dpr2_target", "test-agent")
+            .await
+            .unwrap();
+        let err = dismiss_pending_revision(&db, "mem_dpr2_target", "test-agent")
             .await
             .unwrap_err();
         assert!(matches!(err, OriginError::NotFound(_)));

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -806,6 +806,23 @@ pub async fn dismiss_pending_revision(
     })
 }
 
+/// Dismiss all awaiting-review contradiction flags for a memory. Canonical
+/// entry for both agent-triggered (`/api/memory/contradiction/{source_id}/dismiss`)
+/// and daemon-internal triggers. `wrote: true` is best-effort: the DB method
+/// silently no-ops when no rows match. See spec §3 for the caveat.
+pub async fn dismiss_contradiction(
+    db: &MemoryDB,
+    source_id: &str,
+    agent: &str,
+) -> Result<origin_types::ContradictionDismissResponse, OriginError> {
+    db.dismiss_contradiction_for_source(source_id).await?;
+    log_activity_best_effort(db, agent, "contradiction_dismiss", source_id).await;
+    Ok(origin_types::ContradictionDismissResponse {
+        source_id: source_id.to_string(),
+        wrote: true,
+    })
+}
+
 fn is_valid_snake_case_relation(s: &str) -> bool {
     if s.is_empty() {
         return false;
@@ -1746,5 +1763,49 @@ mod tests {
         let row = rows.next().await.unwrap().unwrap();
         let count: i64 = row.get(0).unwrap();
         assert_eq!(count, 1, "should log exactly once");
+    }
+
+    // ── dismiss_contradiction ────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dismiss_contradiction_writes_and_returns_wrote_true() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        let result = dismiss_contradiction(&db, "mem_any_source_id", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(result.source_id, "mem_any_source_id");
+        assert!(result.wrote);
+    }
+
+    #[tokio::test]
+    async fn dismiss_contradiction_logs_activity_once_per_call() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        dismiss_contradiction(&db, "mem_one", "test-agent")
+            .await
+            .unwrap();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM agent_activity WHERE action = 'contradiction_dismiss' AND memory_ids = 'mem_one'",
+                libsql::params![],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let count: i64 = row.get(0).unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn dismiss_contradiction_swallows_no_rows_matched() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        // No contradiction rows seeded — DB method is silent-idempotent
+        let result = dismiss_contradiction(&db, "mem_no_contradictions", "test-agent")
+            .await
+            .unwrap();
+        assert!(
+            result.wrote,
+            "wrote=true even with no rows matched (best-effort signal per §3 caveat)"
+        );
     }
 }

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -759,6 +759,36 @@ pub async fn dismiss_entity_suggestion(
     }
 }
 
+/// Accept a pending memory revision. Canonical entry for both agent-triggered
+/// (`/api/memory/revision/{id}/accept`) and daemon-internal accept-dispatch.
+/// Activates the revision row, suppresses the original, and logs activity.
+/// Returns `NotFound` if no pending revision exists for the target.
+pub async fn accept_pending_revision(
+    db: &MemoryDB,
+    target_source_id: &str,
+    agent: &str,
+) -> Result<origin_types::RevisionAcceptResponse, OriginError> {
+    // Pre-fetch the revision row id so we can return it in the response,
+    // since the DB method consumes the row before returning.
+    let pending = db.get_pending_revision_for(target_source_id).await?;
+    let Some(pending) = pending else {
+        return Err(OriginError::NotFound(format!(
+            "No pending revision for {}",
+            target_source_id
+        )));
+    };
+    let revision_source_id = pending.source_id.clone();
+
+    db.accept_pending_revision(target_source_id).await?;
+    log_activity_best_effort(db, agent, "revision_accept", target_source_id).await;
+
+    Ok(origin_types::RevisionAcceptResponse {
+        target_source_id: target_source_id.to_string(),
+        revision_source_id,
+        wrote: true,
+    })
+}
+
 fn is_valid_snake_case_relation(s: &str) -> bool {
     if s.is_empty() {
         return false;
@@ -1516,6 +1546,59 @@ mod tests {
             .await
             .unwrap();
         let err = dismiss_entity_suggestion(&db, "ref_d2", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OriginError::NotFound(_)));
+    }
+
+    // ── accept_pending_revision ──────────────────────────────────────────────
+
+    async fn seed_pending_revision(db: &MemoryDB, target: &str, revision: &str) {
+        let now = chrono::Utc::now().timestamp();
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, domain, source_agent, created_at, last_modified, confirmed, stability, source) VALUES (?1, ?1, ?1, 'original content', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 1, 'confirmed', 'memory')",
+            libsql::params![target.to_string(), now],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, domain, source_agent, created_at, last_modified, confirmed, stability, source, supersedes, pending_revision) VALUES (?1, ?1, ?1, 'revised content', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 0, 'new', 'memory', ?3, 1)",
+            libsql::params![revision.to_string(), now, target.to_string()],
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn accept_pending_revision_writes_and_logs_on_first_call() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        seed_pending_revision(&db, "mem_apr_target", "mem_apr_rev").await;
+        let result = accept_pending_revision(&db, "mem_apr_target", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(result.target_source_id, "mem_apr_target");
+        assert_eq!(result.revision_source_id, "mem_apr_rev");
+        assert!(result.wrote);
+    }
+
+    #[tokio::test]
+    async fn accept_pending_revision_returns_not_found_on_missing_id() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        let err = accept_pending_revision(&db, "mem_nope", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OriginError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn accept_pending_revision_returns_not_found_on_re_call_after_success() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        seed_pending_revision(&db, "mem_arr_target", "mem_arr_rev").await;
+        accept_pending_revision(&db, "mem_arr_target", "test-agent")
+            .await
+            .unwrap();
+        let err = accept_pending_revision(&db, "mem_arr_target", "test-agent")
             .await
             .unwrap_err();
         assert!(matches!(err, OriginError::NotFound(_)));

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -1486,7 +1486,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn approve_entity_suggestion_resolves_existing_entity_when_alias_hits() {
+    async fn approve_entity_suggestion_resolves_existing_entity_when_exact_name_matches() {
         let (db, _tmp) = crate::db::tests::test_db().await;
         // Pre-create an entity with name "Acme Corp"
         db.create_entity("Acme Corp", "manual", None).await.unwrap();

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -20,6 +20,24 @@ pub struct WriteResult {
     pub wrote: bool,
 }
 
+/// Best-effort activity logger used by curation-mutate capability fns.
+/// Failure to log does not fail the operation — matches the pattern in
+/// `create_entity`, `create_relation`, etc.
+pub(crate) async fn log_activity_best_effort(
+    db: &MemoryDB,
+    agent: &str,
+    action: &str,
+    target_id: &str,
+) {
+    let target = target_id.to_string();
+    if let Err(e) = db
+        .log_agent_activity(agent, action, std::slice::from_ref(&target), None, "")
+        .await
+    {
+        log::warn!("[{}] activity log failed: {}", action, e);
+    }
+}
+
 /// Create or resolve an entity. Canonical entry point for both
 /// agent-triggered (`/api/memory/entities`) and daemon-internal
 /// (`kg/entity_extraction.rs`) writes.
@@ -649,6 +667,65 @@ pub async fn update_page(
         id: page_id.to_string(),
         warnings,
         wrote: true,
+    })
+}
+
+/// Approve a pending entity suggestion. Canonical entry for both
+/// agent-triggered (`/api/memory/entity-suggestions/{id}/approve`) and
+/// daemon-internal accept-dispatch.
+///
+/// Resolves the suggested entity name through `post_write::create_entity`
+/// (4-step resolution + idempotency), then reweaves entity links and marks
+/// the refinement row completed. Returns `wrote: false` if the suggestion
+/// resolved to an existing entity. Returns `NotFound` if the suggestion id
+/// is unknown or already resolved.
+pub async fn approve_entity_suggestion(
+    db: &MemoryDB,
+    suggestion_id: &str,
+    agent: &str,
+    entity_link_distance: f64,
+) -> Result<origin_types::EntitySuggestionApproveResponse, OriginError> {
+    let pending = db.get_pending_refinements().await?;
+    let proposal = pending
+        .iter()
+        .find(|p| p.id == suggestion_id && p.action == "suggest_entity")
+        .ok_or_else(|| {
+            OriginError::NotFound(format!(
+                "entity suggestion {} not found or already resolved",
+                suggestion_id
+            ))
+        })?;
+
+    let entity_name = proposal
+        .payload
+        .clone()
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    let create_result = create_entity(
+        db,
+        CreateEntityRequest {
+            name: entity_name.clone(),
+            entity_type: "auto".to_string(),
+            domain: None,
+            source_agent: Some(agent.to_string()),
+            confidence: None,
+        },
+        agent,
+    )
+    .await?;
+
+    let linked = crate::refinery::reweave_entity_links(db, 20, entity_link_distance).await?;
+    db.resolve_refinement_if_open(suggestion_id, "completed")
+        .await?;
+
+    log_activity_best_effort(db, agent, "entity_suggestion_approve", suggestion_id).await;
+
+    Ok(origin_types::EntitySuggestionApproveResponse {
+        suggestion_id: suggestion_id.to_string(),
+        entity_id: create_result.id,
+        entity_name,
+        memories_linked: linked as u32,
+        wrote: create_result.wrote,
     })
 }
 
@@ -1365,5 +1442,97 @@ mod tests {
             page_after.version, version_before,
             "version must not bump on no-op"
         );
+    }
+
+    // ── approve_entity_suggestion ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn approve_entity_suggestion_creates_new_entity_when_name_unknown() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        // Seed a pending refinement_queue row of action=suggest_entity.
+        // Table schema: (id, action, source_ids TEXT, payload, confidence, status, created_at).
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) VALUES (?1, 'suggest_entity', '[]', ?2, 0.9, 'awaiting_review')",
+                libsql::params![
+                    "ref_sugg_1".to_string(),
+                    "Acme Corp".to_string(),
+                ],
+            ).await.unwrap();
+        }
+
+        let result = approve_entity_suggestion(&db, "ref_sugg_1", "test-agent", 0.1)
+            .await
+            .unwrap();
+
+        assert_eq!(result.suggestion_id, "ref_sugg_1");
+        assert_eq!(result.entity_name, "Acme Corp");
+        assert!(result.wrote, "new entity should have wrote=true");
+        assert!(!result.entity_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn approve_entity_suggestion_returns_not_found_on_missing_suggestion_id() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        let err = approve_entity_suggestion(&db, "ref_does_not_exist", "test-agent", 0.1)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, OriginError::NotFound(_)),
+            "expected NotFound, got {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn approve_entity_suggestion_resolves_existing_entity_when_alias_hits() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        // Pre-create an entity with name "Acme Corp"
+        db.create_entity("Acme Corp", "manual", None).await.unwrap();
+        // Seed a pending refinement with the same name
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) VALUES (?1, 'suggest_entity', '[]', ?2, 0.9, 'awaiting_review')",
+                libsql::params!["ref_sugg_2".to_string(), "Acme Corp".to_string()],
+            ).await.unwrap();
+        }
+
+        let result = approve_entity_suggestion(&db, "ref_sugg_2", "test-agent", 0.1)
+            .await
+            .unwrap();
+
+        assert!(
+            !result.wrote,
+            "existing entity should resolve with wrote=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn approve_entity_suggestion_logs_activity_exactly_once() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) VALUES (?1, 'suggest_entity', '[]', ?2, 0.9, 'awaiting_review')",
+                libsql::params!["ref_sugg_3".to_string(), "Once Only Corp".to_string()],
+            ).await.unwrap();
+        }
+
+        approve_entity_suggestion(&db, "ref_sugg_3", "test-agent", 0.1)
+            .await
+            .unwrap();
+
+        // Count agent_activity rows with action = 'entity_suggestion_approve' for this id.
+        // log_agent_activity canonicalizes "test-agent" → "test-agent" (already canonical).
+        let conn = db.conn.lock().await;
+        let mut rows = conn.query(
+            "SELECT COUNT(*) FROM agent_activity WHERE action = 'entity_suggestion_approve' AND memory_ids = 'ref_sugg_3'",
+            libsql::params![],
+        ).await.unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let count: i64 = row.get(0).unwrap();
+        assert_eq!(count, 1, "should log exactly once");
     }
 }

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -729,6 +729,36 @@ pub async fn approve_entity_suggestion(
     })
 }
 
+/// Dismiss a pending entity suggestion. Canonical entry for both
+/// agent-triggered (`/api/memory/entity-suggestions/{id}/dismiss`) and
+/// daemon-internal triggers. Returns `NotFound` if the suggestion id is
+/// unknown or already resolved.
+pub async fn dismiss_entity_suggestion(
+    db: &MemoryDB,
+    suggestion_id: &str,
+    agent: &str,
+) -> Result<origin_types::EntitySuggestionDismissResponse, OriginError> {
+    let pending = db.get_pending_refinements().await?;
+    let proposal = pending
+        .iter()
+        .find(|p| p.id == suggestion_id && p.action == "suggest_entity");
+    match proposal {
+        None => Err(OriginError::NotFound(format!(
+            "entity suggestion {} not found or already resolved",
+            suggestion_id
+        ))),
+        Some(_) => {
+            db.resolve_refinement_if_open(suggestion_id, "dismissed")
+                .await?;
+            log_activity_best_effort(db, agent, "entity_suggestion_dismiss", suggestion_id).await;
+            Ok(origin_types::EntitySuggestionDismissResponse {
+                suggestion_id: suggestion_id.to_string(),
+                wrote: true,
+            })
+        }
+    }
+}
+
 fn is_valid_snake_case_relation(s: &str) -> bool {
     if s.is_empty() {
         return false;
@@ -1442,6 +1472,53 @@ mod tests {
             page_after.version, version_before,
             "version must not bump on no-op"
         );
+    }
+
+    // ── dismiss_entity_suggestion ────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dismiss_entity_suggestion_writes_and_logs_on_first_call() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) VALUES (?1, 'suggest_entity', '[]', ?2, 0.9, 'awaiting_review')",
+                libsql::params!["ref_d1".to_string(), "DismissMe".to_string()],
+            ).await.unwrap();
+        }
+        let result = dismiss_entity_suggestion(&db, "ref_d1", "test-agent")
+            .await
+            .unwrap();
+        assert_eq!(result.suggestion_id, "ref_d1");
+        assert!(result.wrote);
+    }
+
+    #[tokio::test]
+    async fn dismiss_entity_suggestion_returns_not_found_on_missing_id() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        let err = dismiss_entity_suggestion(&db, "ref_does_not_exist", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OriginError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn dismiss_entity_suggestion_returns_not_found_on_re_call_after_success() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) VALUES (?1, 'suggest_entity', '[]', ?2, 0.9, 'awaiting_review')",
+                libsql::params!["ref_d2".to_string(), "DismissTwice".to_string()],
+            ).await.unwrap();
+        }
+        dismiss_entity_suggestion(&db, "ref_d2", "test-agent")
+            .await
+            .unwrap();
+        let err = dismiss_entity_suggestion(&db, "ref_d2", "test-agent")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, OriginError::NotFound(_)));
     }
 
     // ── approve_entity_suggestion ────────────────────────────────────────────

--- a/crates/origin-mcp/Cargo.toml
+++ b/crates/origin-mcp/Cargo.toml
@@ -42,3 +42,5 @@ origin-types = { workspace = true }
 tempfile = "3"
 portpicker = "0.1"
 wiremock = "0.6"
+origin-server = { path = "../origin-server" }
+origin-core = { path = "../origin-core" }

--- a/crates/origin-mcp/src/client.rs
+++ b/crates/origin-mcp/src/client.rs
@@ -136,6 +136,24 @@ impl OriginClient {
         Self::parse_response(&bytes)
     }
 
+    /// POST request with empty body, deserialize JSON response.
+    /// Used for mutate endpoints where the id is in the path and no body is needed.
+    pub async fn post_empty<R: DeserializeOwned>(&self, path: &str) -> Result<R, OriginError> {
+        let url = format!("{}{}", self.base_url, path);
+        let agent = self.agent_name.clone();
+        let resp = self
+            .send_with_retry(|| {
+                let mut req = self.client.post(&url);
+                if let Some(a) = agent.as_deref() {
+                    req = req.header("x-agent-name", a);
+                }
+                req
+            })
+            .await?;
+        let bytes = Self::read_body(resp).await?;
+        Self::parse_response(&bytes)
+    }
+
     /// DELETE request, deserialize JSON response.
     pub async fn delete<R: DeserializeOwned>(&self, path: &str) -> Result<R, OriginError> {
         let url = format!("{}{}", self.base_url, path);

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -439,6 +439,12 @@ pub struct ListNurtureParams {
 pub struct ListEntitySuggestionsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ApproveEntitySuggestionRequest {
+    /// The refinement_queue id of the pending entity suggestion to approve.
+    pub suggestion_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListPendingImportsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1322,6 +1328,27 @@ impl OriginMcpServer {
         ))]))
     }
 
+    pub async fn approve_entity_suggestion_impl(
+        &self,
+        req: ApproveEntitySuggestionRequest,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!(
+            "/api/memory/entity-suggestions/{}/approve",
+            req.suggestion_id
+        );
+        let response = match self
+            .client
+            .post_empty::<EntitySuggestionApproveResponse>(&path)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "approve_entity_suggestion")),
+        };
+        let pretty = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(pretty)]))
+    }
+
     pub async fn list_pending_imports_impl(
         &self,
         _params: ListPendingImportsParams,
@@ -1958,6 +1985,26 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListEntitySuggestionsParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_entity_suggestions_impl(params).await
+    }
+
+    #[tool(
+        description = "Approve a pending entity suggestion. Creates the suggested entity in \
+                       the knowledge graph and links related memories. Returns the created \
+                       entity id, entity name, and link count. Returns an error if the \
+                       suggestion id is unknown or already resolved.",
+        annotations(
+            title = "Approve entity suggestion",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn approve_entity_suggestion(
+        &self,
+        Parameters(req): Parameters<ApproveEntitySuggestionRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.approve_entity_suggestion_impl(req).await
     }
 
     #[tool(

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -463,6 +463,12 @@ pub struct DismissRevisionRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DismissContradictionRequest {
+    /// The source_id of the memory whose contradiction flags should be dismissed.
+    pub source_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListPendingImportsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1424,6 +1430,24 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
+    pub async fn dismiss_contradiction_impl(
+        &self,
+        req: DismissContradictionRequest,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!("/api/memory/contradiction/{}/dismiss", req.source_id);
+        let response = match self
+            .client
+            .post_empty::<ContradictionDismissResponse>(&path)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "dismiss_contradiction")),
+        };
+        let pretty = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(pretty)]))
+    }
+
     pub async fn list_pending_imports_impl(
         &self,
         _params: ListPendingImportsParams,
@@ -2138,6 +2162,24 @@ impl OriginMcpServer {
         Parameters(req): Parameters<DismissRevisionRequest>,
     ) -> Result<CallToolResult, McpError> {
         self.dismiss_revision_impl(req).await
+    }
+
+    #[tool(
+        description = "Dismiss all awaiting-review contradiction flags for a memory. Idempotent. \
+                       Returns wrote:true even if no rows matched.",
+        annotations(
+            title = "Dismiss contradiction",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = false
+        )
+    )]
+    async fn dismiss_contradiction(
+        &self,
+        Parameters(req): Parameters<DismissContradictionRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.dismiss_contradiction_impl(req).await
     }
 
     #[tool(

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -457,6 +457,12 @@ pub struct AcceptRevisionRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DismissRevisionRequest {
+    /// The source_id of the memory whose pending revision should be dismissed.
+    pub target_source_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListPendingImportsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1400,6 +1406,24 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
+    pub async fn dismiss_revision_impl(
+        &self,
+        req: DismissRevisionRequest,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!("/api/memory/revision/{}/dismiss", req.target_source_id);
+        let response = match self
+            .client
+            .post_empty::<RevisionDismissResponse>(&path)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "dismiss_revision")),
+        };
+        let pretty = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(pretty)]))
+    }
+
     pub async fn list_pending_imports_impl(
         &self,
         _params: ListPendingImportsParams,
@@ -2095,6 +2119,25 @@ impl OriginMcpServer {
         Parameters(req): Parameters<AcceptRevisionRequest>,
     ) -> Result<CallToolResult, McpError> {
         self.accept_revision_impl(req).await
+    }
+
+    #[tool(
+        description = "Dismiss a pending memory revision. Deletes the revision row; the original \
+                       memory is unchanged. Returns an error if no pending revision exists for \
+                       that target.",
+        annotations(
+            title = "Dismiss revision",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn dismiss_revision(
+        &self,
+        Parameters(req): Parameters<DismissRevisionRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.dismiss_revision_impl(req).await
     }
 
     #[tool(

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -445,6 +445,12 @@ pub struct ApproveEntitySuggestionRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct DismissEntitySuggestionRequest {
+    /// The refinement_queue id of the pending entity suggestion to dismiss.
+    pub suggestion_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListPendingImportsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1349,6 +1355,27 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
+    pub async fn dismiss_entity_suggestion_impl(
+        &self,
+        req: DismissEntitySuggestionRequest,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!(
+            "/api/memory/entity-suggestions/{}/dismiss",
+            req.suggestion_id
+        );
+        let response = match self
+            .client
+            .post_empty::<EntitySuggestionDismissResponse>(&path)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "dismiss_entity_suggestion")),
+        };
+        let pretty = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(pretty)]))
+    }
+
     pub async fn list_pending_imports_impl(
         &self,
         _params: ListPendingImportsParams,
@@ -2005,6 +2032,25 @@ impl OriginMcpServer {
         Parameters(req): Parameters<ApproveEntitySuggestionRequest>,
     ) -> Result<CallToolResult, McpError> {
         self.approve_entity_suggestion_impl(req).await
+    }
+
+    #[tool(
+        description = "Dismiss a pending entity suggestion. Marks the refinement row resolved \
+                       without creating an entity. Returns an error if the suggestion id is \
+                       unknown or already resolved.",
+        annotations(
+            title = "Dismiss entity suggestion",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn dismiss_entity_suggestion(
+        &self,
+        Parameters(req): Parameters<DismissEntitySuggestionRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.dismiss_entity_suggestion_impl(req).await
     }
 
     #[tool(

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -451,6 +451,12 @@ pub struct DismissEntitySuggestionRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct AcceptRevisionRequest {
+    /// The source_id of the memory whose pending revision should be accepted.
+    pub target_source_id: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListPendingImportsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1376,6 +1382,24 @@ impl OriginMcpServer {
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 
+    pub async fn accept_revision_impl(
+        &self,
+        req: AcceptRevisionRequest,
+    ) -> Result<CallToolResult, McpError> {
+        let path = format!("/api/memory/revision/{}/accept", req.target_source_id);
+        let response = match self
+            .client
+            .post_empty::<RevisionAcceptResponse>(&path)
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "accept_revision")),
+        };
+        let pretty = serde_json::to_string_pretty(&response)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(pretty)]))
+    }
+
     pub async fn list_pending_imports_impl(
         &self,
         _params: ListPendingImportsParams,
@@ -2051,6 +2075,26 @@ impl OriginMcpServer {
         Parameters(req): Parameters<DismissEntitySuggestionRequest>,
     ) -> Result<CallToolResult, McpError> {
         self.dismiss_entity_suggestion_impl(req).await
+    }
+
+    #[tool(
+        description = "Accept a pending memory revision. Replaces the target memory's content \
+                       with the proposed revision content and removes the revision row from the \
+                       pending list. Returns the consumed revision id. Returns an error if no \
+                       pending revision exists for that target.",
+        annotations(
+            title = "Accept revision",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn accept_revision(
+        &self,
+        Parameters(req): Parameters<AcceptRevisionRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        self.accept_revision_impl(req).await
     }
 
     #[tool(

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -13,9 +13,10 @@ pub use origin_types::requests::{
 };
 pub use origin_types::responses::{
     AcceptRefinementResponse, AddObservationResponse, ChatContextResponse, CreateEntityResponse,
-    CreatePageResponse, CreateRelationResponse, DeleteResponse, ListMemoriesResponse,
-    ListMemoryRevisionsResponse, ListPageRevisionsResponse, ListRefinementsResponse,
-    MemoryRevisionEntry, NurtureCardsResponse, OrphanLink, OrphanLinksResponse, PageChangelogEntry,
-    RejectRefinementResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
+    CreatePageResponse, CreateRelationResponse, DeleteResponse, EntitySuggestionApproveResponse,
+    ListMemoriesResponse, ListMemoryRevisionsResponse, ListPageRevisionsResponse,
+    ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse, OrphanLink,
+    OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse, SearchMemoryResponse,
+    SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -17,6 +17,6 @@ pub use origin_types::responses::{
     EntitySuggestionDismissResponse, ListMemoriesResponse, ListMemoryRevisionsResponse,
     ListPageRevisionsResponse, ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse,
     OrphanLink, OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse,
-    SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
+    RevisionAcceptResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -17,6 +17,7 @@ pub use origin_types::responses::{
     EntitySuggestionDismissResponse, ListMemoriesResponse, ListMemoryRevisionsResponse,
     ListPageRevisionsResponse, ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse,
     OrphanLink, OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse,
-    RevisionAcceptResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
+    RevisionAcceptResponse, RevisionDismissResponse, SearchMemoryResponse, SearchPagesResponse,
+    StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -12,12 +12,12 @@ pub use origin_types::requests::{
     ListMemoriesRequest, SearchMemoryRequest, SearchPagesRequest, StoreMemoryRequest,
 };
 pub use origin_types::responses::{
-    AcceptRefinementResponse, AddObservationResponse, ChatContextResponse, CreateEntityResponse,
-    CreatePageResponse, CreateRelationResponse, DeleteResponse, EntitySuggestionApproveResponse,
-    EntitySuggestionDismissResponse, ListMemoriesResponse, ListMemoryRevisionsResponse,
-    ListPageRevisionsResponse, ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse,
-    OrphanLink, OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse,
-    RevisionAcceptResponse, RevisionDismissResponse, SearchMemoryResponse, SearchPagesResponse,
-    StoreMemoryResponse,
+    AcceptRefinementResponse, AddObservationResponse, ChatContextResponse,
+    ContradictionDismissResponse, CreateEntityResponse, CreatePageResponse, CreateRelationResponse,
+    DeleteResponse, EntitySuggestionApproveResponse, EntitySuggestionDismissResponse,
+    ListMemoriesResponse, ListMemoryRevisionsResponse, ListPageRevisionsResponse,
+    ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse, OrphanLink,
+    OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse, RevisionAcceptResponse,
+    RevisionDismissResponse, SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -14,9 +14,9 @@ pub use origin_types::requests::{
 pub use origin_types::responses::{
     AcceptRefinementResponse, AddObservationResponse, ChatContextResponse, CreateEntityResponse,
     CreatePageResponse, CreateRelationResponse, DeleteResponse, EntitySuggestionApproveResponse,
-    ListMemoriesResponse, ListMemoryRevisionsResponse, ListPageRevisionsResponse,
-    ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse, OrphanLink,
-    OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse, SearchMemoryResponse,
-    SearchPagesResponse, StoreMemoryResponse,
+    EntitySuggestionDismissResponse, ListMemoriesResponse, ListMemoryRevisionsResponse,
+    ListPageRevisionsResponse, ListRefinementsResponse, MemoryRevisionEntry, NurtureCardsResponse,
+    OrphanLink, OrphanLinksResponse, PageChangelogEntry, RejectRefinementResponse,
+    SearchMemoryResponse, SearchPagesResponse, StoreMemoryResponse,
 };
 pub use origin_types::PageSourceWithMemory;

--- a/crates/origin-mcp/tests/real_router.rs
+++ b/crates/origin-mcp/tests/real_router.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-crate integration test for Spec C-2 mutate wrappers.
+//!
+//! Adversarial-finding mitigation from PR #101: pure wiremock cannot prove
+//! URL alignment between wrapper and daemon route. This test boots the real
+//! `origin-server::router::build_router` in-process and invokes each wrapper
+//! through a real HTTP server. If a wrapper URL drifts from a daemon route,
+//! the real router returns 404 and the assertion fails.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use origin_core::{db::MemoryDB, NoopEmitter};
+use origin_mcp::{
+    client::OriginClient,
+    tools::{
+        AcceptRevisionRequest, ApproveEntitySuggestionRequest, DismissContradictionRequest,
+        DismissEntitySuggestionRequest, DismissRevisionRequest, OriginMcpServer, TransportMode,
+    },
+};
+use origin_types::{
+    ContradictionDismissResponse, EntitySuggestionApproveResponse, EntitySuggestionDismissResponse,
+    RawDocument, RevisionAcceptResponse, RevisionDismissResponse,
+};
+use rmcp::model::{CallToolResult, RawContent};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+async fn boot_test_server() -> (String, Arc<MemoryDB>) {
+    let tmp = tempfile::tempdir().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let db = Arc::new(
+        MemoryDB::new(&db_path, Arc::new(NoopEmitter))
+            .await
+            .unwrap(),
+    );
+
+    let state = Arc::new(RwLock::new(origin_server::state::ServerState {
+        db: Some(db.clone()),
+        ..origin_server::state::ServerState::default()
+    }));
+    let router = origin_server::router::build_router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr: SocketAddr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    // Keep the tempdir alive for the process lifetime via intentional forget.
+    std::mem::forget(tmp);
+    (format!("http://{}", addr), db)
+}
+
+fn make_server(base_url: &str) -> OriginMcpServer {
+    let client = OriginClient::new(base_url.to_string()).with_agent_name("test-agent".to_string());
+    OriginMcpServer::new(client, TransportMode::Stdio, "test-agent".into(), None)
+}
+
+/// Extract the text body from a successful CallToolResult.
+fn text_of(result: &CallToolResult) -> String {
+    for content in &result.content {
+        if let RawContent::Text(t) = &content.raw {
+            return t.text.clone();
+        }
+    }
+    panic!(
+        "expected at least one text Content block; got: {:?}",
+        result.content
+    );
+}
+
+/// Seed a `suggest_entity` refinement row via public API.
+async fn seed_suggest_entity(db: &MemoryDB, id: &str, entity_name: &str) {
+    db.insert_refinement_proposal(id, "suggest_entity", &[], Some(entity_name), 0.9)
+        .await
+        .unwrap();
+}
+
+/// Seed a pending revision via public API (upsert_documents).
+///
+/// The target memory is a normal confirmed memory; the revision memory has
+/// `pending_revision: true` and `supersedes: Some(target_source_id)`.
+async fn seed_pending_revision(db: &MemoryDB, target_source_id: &str, revision_source_id: &str) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    // Insert target (original, confirmed)
+    db.upsert_documents(vec![RawDocument {
+        source: "memory".to_string(),
+        source_id: target_source_id.to_string(),
+        title: "original".to_string(),
+        content: "original content".to_string(),
+        last_modified: now,
+        confirmed: Some(true),
+        stability: Some("confirmed".to_string()),
+        memory_type: Some("fact".to_string()),
+        ..RawDocument::default()
+    }])
+    .await
+    .unwrap();
+
+    // Insert revision (pending_revision=true, supersedes=target)
+    db.upsert_documents(vec![RawDocument {
+        source: "memory".to_string(),
+        source_id: revision_source_id.to_string(),
+        title: "revision".to_string(),
+        content: "revised content".to_string(),
+        last_modified: now,
+        confirmed: Some(false),
+        stability: Some("new".to_string()),
+        memory_type: Some("fact".to_string()),
+        supersedes: Some(target_source_id.to_string()),
+        pending_revision: true,
+        ..RawDocument::default()
+    }])
+    .await
+    .unwrap();
+}
+
+/// Seed a contradiction refinement row (detect_contradiction, awaiting_review).
+async fn seed_contradiction(db: &MemoryDB, proposal_id: &str, source_id: &str) {
+    db.insert_refinement_proposal(
+        proposal_id,
+        "detect_contradiction",
+        &[source_id.to_string()],
+        None,
+        0.9,
+    )
+    .await
+    .unwrap();
+    // Upgrade from default 'pending' to 'awaiting_review' so dismiss finds it.
+    db.resolve_refinement_if_open(proposal_id, "awaiting_review")
+        .await
+        .unwrap();
+}
+
+/// Count agent_activity rows matching action + agent.
+async fn activity_count(db: &MemoryDB, action: &str, agent: &str) -> usize {
+    db.list_agent_activity(100, Some(agent), None)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.action == action)
+        .count()
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn approve_entity_suggestion_aligns_with_real_router() {
+    let (base_url, db) = boot_test_server().await;
+    seed_suggest_entity(&db, "ref_real_1", "RealCorp").await;
+
+    let server = make_server(&base_url);
+    let result = server
+        .approve_entity_suggestion_impl(ApproveEntitySuggestionRequest {
+            suggestion_id: "ref_real_1".into(),
+        })
+        .await
+        .unwrap();
+
+    let body = text_of(&result);
+    let parsed: EntitySuggestionApproveResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed.suggestion_id, "ref_real_1");
+    assert_eq!(parsed.entity_name, "RealCorp");
+
+    // Activity row proves the request reached the right route.
+    assert_eq!(
+        activity_count(&db, "entity_suggestion_approve", "test-agent").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_aligns_with_real_router() {
+    let (base_url, db) = boot_test_server().await;
+    seed_suggest_entity(&db, "ref_real_2", "DismissReal").await;
+
+    let server = make_server(&base_url);
+    let result = server
+        .dismiss_entity_suggestion_impl(DismissEntitySuggestionRequest {
+            suggestion_id: "ref_real_2".into(),
+        })
+        .await
+        .unwrap();
+
+    let body = text_of(&result);
+    let parsed: EntitySuggestionDismissResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed.suggestion_id, "ref_real_2");
+    assert!(parsed.wrote);
+
+    assert_eq!(
+        activity_count(&db, "entity_suggestion_dismiss", "test-agent").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn accept_revision_aligns_with_real_router() {
+    let (base_url, db) = boot_test_server().await;
+    seed_pending_revision(&db, "mem_real_acc", "mem_real_acc_rev").await;
+
+    let server = make_server(&base_url);
+    let result = server
+        .accept_revision_impl(AcceptRevisionRequest {
+            target_source_id: "mem_real_acc".into(),
+        })
+        .await
+        .unwrap();
+
+    let body = text_of(&result);
+    let parsed: RevisionAcceptResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed.target_source_id, "mem_real_acc");
+    assert_eq!(parsed.revision_source_id, "mem_real_acc_rev");
+
+    assert_eq!(
+        activity_count(&db, "revision_accept", "test-agent").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn dismiss_revision_aligns_with_real_router() {
+    let (base_url, db) = boot_test_server().await;
+    seed_pending_revision(&db, "mem_real_dis", "mem_real_dis_rev").await;
+
+    let server = make_server(&base_url);
+    let result = server
+        .dismiss_revision_impl(DismissRevisionRequest {
+            target_source_id: "mem_real_dis".into(),
+        })
+        .await
+        .unwrap();
+
+    let body = text_of(&result);
+    let parsed: RevisionDismissResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed.target_source_id, "mem_real_dis");
+    assert!(parsed.wrote);
+
+    assert_eq!(
+        activity_count(&db, "revision_dismiss", "test-agent").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_aligns_with_real_router() {
+    let (base_url, db) = boot_test_server().await;
+    seed_contradiction(&db, "ref_real_contra", "mem_real_contra").await;
+
+    let server = make_server(&base_url);
+    let result = server
+        .dismiss_contradiction_impl(DismissContradictionRequest {
+            source_id: "mem_real_contra".into(),
+        })
+        .await
+        .unwrap();
+
+    let body = text_of(&result);
+    let parsed: ContradictionDismissResponse = serde_json::from_str(&body).unwrap();
+    assert_eq!(parsed.source_id, "mem_real_contra");
+    assert!(parsed.wrote);
+
+    // Activity row proves request reached the right route.
+    assert_eq!(
+        activity_count(&db, "contradiction_dismiss", "test-agent").await,
+        1,
+        "activity row should prove request reached the right route"
+    );
+
+    // State-flip is the adversarial guard for this test: silent-idempotent dismiss
+    // cannot be detected by 404, so we verify the row flipped to 'dismissed'.
+    let proposal = db
+        .get_refinement_proposal("ref_real_contra")
+        .await
+        .unwrap()
+        .expect("proposal should still exist");
+    assert_eq!(
+        proposal.status, "dismissed",
+        "refinement_queue row should be flipped to dismissed"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1920,3 +1920,126 @@ async fn dismiss_entity_suggestion_forwards_x_agent_name() {
         "x-agent-name header must equal configured agent name"
     );
 }
+
+// ===== accept_revision =====
+
+use origin_mcp::tools::AcceptRevisionRequest;
+
+#[tokio::test]
+async fn accept_revision_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_target/accept"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "target_source_id": "mem_target",
+            "revision_source_id": "mem_rev",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .accept_revision_impl(AcceptRevisionRequest {
+            target_source_id: "mem_target".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_target"),
+        "expected target_source_id in output; got: {text}"
+    );
+    assert!(
+        text.contains("mem_rev"),
+        "expected revision_source_id in output; got: {text}"
+    );
+    assert!(
+        text.contains("true"),
+        "expected wrote=true in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn accept_revision_envelope_guard_ignores_extra_fields() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_target/accept"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "target_source_id": "mem_target",
+            "revision_source_id": "mem_rev",
+            "wrote": true,
+            "unexpected_field": "should be ignored",
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .accept_revision_impl(AcceptRevisionRequest {
+            target_source_id: "mem_target".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_target"),
+        "expected target_source_id in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn accept_revision_404() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_missing/accept"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .accept_revision_impl(AcceptRevisionRequest {
+            target_source_id: "mem_missing".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("404"),
+        "expected error signal on 404; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn accept_revision_forwards_x_agent_name() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("test-agent".into());
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_hdr/accept"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "target_source_id": "mem_hdr",
+            "revision_source_id": "mem_rev",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    server
+        .accept_revision_impl(AcceptRevisionRequest {
+            target_source_id: "mem_hdr".into(),
+        })
+        .await
+        .unwrap();
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let value = received[0]
+        .headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "test-agent",
+        "x-agent-name header must equal configured agent name"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1804,3 +1804,119 @@ async fn approve_entity_suggestion_forwards_x_agent_name() {
         "x-agent-name header must equal configured agent name"
     );
 }
+
+// ===== dismiss_entity_suggestion =====
+
+use origin_mcp::tools::DismissEntitySuggestionRequest;
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_1/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestion_id": "ref_1",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_entity_suggestion_impl(DismissEntitySuggestionRequest {
+            suggestion_id: "ref_1".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("ref_1"),
+        "expected suggestion_id in output; got: {text}"
+    );
+    assert!(
+        text.contains("true"),
+        "expected wrote=true in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_envelope_guard_ignores_extra_fields() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_2/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestion_id": "ref_2",
+            "wrote": true,
+            "unexpected_field": "should be ignored",
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_entity_suggestion_impl(DismissEntitySuggestionRequest {
+            suggestion_id: "ref_2".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("ref_2"),
+        "expected suggestion_id in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_returns_error_on_daemon_404() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_404/dismiss"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_entity_suggestion_impl(DismissEntitySuggestionRequest {
+            suggestion_id: "ref_404".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("404"),
+        "expected error signal on 404; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_forwards_x_agent_name() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("test-agent".into());
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_hdr/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestion_id": "ref_hdr",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    server
+        .dismiss_entity_suggestion_impl(DismissEntitySuggestionRequest {
+            suggestion_id: "ref_hdr".into(),
+        })
+        .await
+        .unwrap();
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let value = received[0]
+        .headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "test-agent",
+        "x-agent-name header must equal configured agent name"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -2043,3 +2043,119 @@ async fn accept_revision_forwards_x_agent_name() {
         "x-agent-name header must equal configured agent name"
     );
 }
+
+// ===== dismiss_revision =====
+
+use origin_mcp::tools::DismissRevisionRequest;
+
+#[tokio::test]
+async fn dismiss_revision_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_target/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "target_source_id": "mem_target",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_revision_impl(DismissRevisionRequest {
+            target_source_id: "mem_target".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_target"),
+        "expected target_source_id in output; got: {text}"
+    );
+    assert!(
+        text.contains("true"),
+        "expected wrote=true in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_revision_envelope_guard() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_target/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "target_source_id": "mem_target",
+            "wrote": true,
+            "unexpected_field": "should be ignored",
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_revision_impl(DismissRevisionRequest {
+            target_source_id: "mem_target".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_target"),
+        "expected target_source_id in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_revision_404() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_missing/dismiss"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_revision_impl(DismissRevisionRequest {
+            target_source_id: "mem_missing".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("404"),
+        "expected error signal on 404; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_revision_forwards_x_agent_name() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("test-agent".into());
+    Mock::given(method("POST"))
+        .and(path("/api/memory/revision/mem_hdr/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "target_source_id": "mem_hdr",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    server
+        .dismiss_revision_impl(DismissRevisionRequest {
+            target_source_id: "mem_hdr".into(),
+        })
+        .await
+        .unwrap();
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let value = received[0]
+        .headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "test-agent",
+        "x-agent-name header must equal configured agent name"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1679,3 +1679,128 @@ async fn origin_client_post_empty_deserializes_typed_response() {
         "expected deleted=true in deserialized response"
     );
 }
+
+// ===== approve_entity_suggestion =====
+
+use origin_mcp::tools::ApproveEntitySuggestionRequest;
+
+#[tokio::test]
+async fn approve_entity_suggestion_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_1/approve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestion_id": "ref_1",
+            "entity_id": "ent_42",
+            "entity_name": "Acme",
+            "memories_linked": 3,
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .approve_entity_suggestion_impl(ApproveEntitySuggestionRequest {
+            suggestion_id: "ref_1".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("ent_42"),
+        "expected entity_id in output; got: {text}"
+    );
+    assert!(
+        text.contains("true"),
+        "expected wrote=true in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_envelope_guard_ignores_extra_fields() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_2/approve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestion_id": "ref_2",
+            "entity_id": "ent_99",
+            "entity_name": "Bee",
+            "memories_linked": 0,
+            "wrote": false,
+            "unexpected_field": "should be ignored",
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .approve_entity_suggestion_impl(ApproveEntitySuggestionRequest {
+            suggestion_id: "ref_2".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("ent_99"),
+        "expected entity_id in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_returns_error_on_daemon_404() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_404/approve"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("not found"))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .approve_entity_suggestion_impl(ApproveEntitySuggestionRequest {
+            suggestion_id: "ref_404".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("404"),
+        "expected error signal on 404; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_forwards_x_agent_name() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("test-agent".into());
+    Mock::given(method("POST"))
+        .and(path("/api/memory/entity-suggestions/ref_hdr/approve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "suggestion_id": "ref_hdr",
+            "entity_id": "e1",
+            "entity_name": "X",
+            "memories_linked": 0,
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    server
+        .approve_entity_suggestion_impl(ApproveEntitySuggestionRequest {
+            suggestion_id: "ref_hdr".into(),
+        })
+        .await
+        .unwrap();
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let value = received[0]
+        .headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "test-agent",
+        "x-agent-name header must equal configured agent name"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -2159,3 +2159,117 @@ async fn dismiss_revision_forwards_x_agent_name() {
         "x-agent-name header must equal configured agent name"
     );
 }
+
+use origin_mcp::tools::DismissContradictionRequest;
+
+#[tokio::test]
+async fn dismiss_contradiction_happy_path() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/contradiction/mem_x/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "source_id": "mem_x",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_contradiction_impl(DismissContradictionRequest {
+            source_id: "mem_x".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_x"),
+        "expected source_id in output; got: {text}"
+    );
+    assert!(
+        text.contains("true"),
+        "expected wrote=true in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_envelope_guard() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/contradiction/mem_y/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "source_id": "mem_y",
+            "wrote": true,
+            "noise": "ok",
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_contradiction_impl(DismissContradictionRequest {
+            source_id: "mem_y".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_y"),
+        "expected source_id in output; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_500_surfaces_as_error() {
+    let (mock, client) = setup().await;
+    Mock::given(method("POST"))
+        .and(path("/api/memory/contradiction/mem_500/dismiss"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    let result = server
+        .dismiss_contradiction_impl(DismissContradictionRequest {
+            source_id: "mem_500".into(),
+        })
+        .await
+        .unwrap();
+    let text = text_of(&result);
+    assert!(
+        text.to_lowercase().contains("error") || text.contains("500"),
+        "expected error signal on 500; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_forwards_x_agent_name() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("test-agent".into());
+    Mock::given(method("POST"))
+        .and(path("/api/memory/contradiction/mem_hdr/dismiss"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "source_id": "mem_hdr",
+            "wrote": true,
+        })))
+        .mount(&mock)
+        .await;
+    let server = make_server(client);
+    server
+        .dismiss_contradiction_impl(DismissContradictionRequest {
+            source_id: "mem_hdr".into(),
+        })
+        .await
+        .unwrap();
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let value = received[0]
+        .headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "test-agent",
+        "x-agent-name header must equal configured agent name"
+    );
+}

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -1591,3 +1591,91 @@ async fn list_orphan_links_http_500() {
         "error message must mention HTTP 500; got: {text}"
     );
 }
+
+// ===== OriginClient::post_empty =====
+
+#[tokio::test]
+async fn origin_client_post_empty_uses_post_verb() {
+    let (mock, client) = setup().await;
+    let response = DeleteResponse { deleted: true };
+    Mock::given(method("POST"))
+        .and(path("/api/memory/confirm/mem_abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let _: DeleteResponse = client
+        .post_empty("/api/memory/confirm/mem_abc")
+        .await
+        .expect("post_empty should succeed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    assert_eq!(
+        received[0].method.as_str(),
+        "POST",
+        "expected POST verb, got: {}",
+        received[0].method
+    );
+    assert!(
+        received[0].body.is_empty(),
+        "expected empty request body, got {} bytes",
+        received[0].body.len()
+    );
+}
+
+#[tokio::test]
+async fn origin_client_post_empty_forwards_x_agent_name() {
+    let mock = MockServer::start().await;
+    let client = OriginClient::new(mock.uri()).with_agent_name("test-agent".into());
+    let response = DeleteResponse { deleted: true };
+    Mock::given(method("POST"))
+        .and(path("/api/memory/confirm/mem_xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let _: DeleteResponse = client
+        .post_empty("/api/memory/confirm/mem_xyz")
+        .await
+        .expect("post_empty should succeed");
+
+    let received = mock
+        .received_requests()
+        .await
+        .expect("wiremock captured no requests");
+    assert_eq!(received.len(), 1, "expected exactly 1 request");
+    let headers = &received[0].headers;
+    let value = headers
+        .get("x-agent-name")
+        .expect("x-agent-name header must be present");
+    assert_eq!(
+        value.to_str().expect("header value is valid utf-8"),
+        "test-agent",
+        "x-agent-name header must equal configured agent name"
+    );
+}
+
+#[tokio::test]
+async fn origin_client_post_empty_deserializes_typed_response() {
+    let (mock, client) = setup().await;
+    let response = DeleteResponse { deleted: true };
+    Mock::given(method("POST"))
+        .and(path("/api/memory/confirm/mem_typed"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let result: DeleteResponse = client
+        .post_empty("/api/memory/confirm/mem_typed")
+        .await
+        .expect("post_empty should deserialize typed response");
+
+    assert!(
+        result.deleted,
+        "expected deleted=true in deserialized response"
+    );
+}

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1482,14 +1482,16 @@ pub async fn handle_reclassify_memory(
 
 pub async fn handle_accept_revision(
     State(state): State<Arc<RwLock<ServerState>>>,
+    headers: axum::http::HeaderMap,
     Path(id): Path<String>,
-) -> Result<Json<serde_json::Value>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
-    db.accept_pending_revision(&id)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-    Ok(Json(serde_json::json!({ "accepted": true })))
+) -> Result<Json<origin_types::RevisionAcceptResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.as_ref().ok_or(ServerError::DbNotInitialized)?.clone()
+    };
+    let agent = extract_agent_name(&headers, None);
+    let result = origin_core::post_write::accept_pending_revision(&db, &id, &agent).await?;
+    Ok(Json(result))
 }
 
 pub async fn handle_dismiss_revision(

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1590,44 +1590,20 @@ pub async fn handle_get_entity_suggestions(
 
 pub async fn handle_approve_entity_suggestion(
     State(state): State<Arc<RwLock<ServerState>>>,
+    headers: axum::http::HeaderMap,
     Path(id): Path<String>,
-) -> Result<Json<serde_json::Value>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
-
-    let pending = db
-        .get_pending_refinements()
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-    let proposal = pending
-        .iter()
-        .find(|p| p.id == id && p.action == "suggest_entity")
-        .ok_or(ServerError::NotFound(format!("suggestion {}", id)))?;
-
-    let entity_name = proposal
-        .payload
-        .clone()
-        .unwrap_or_else(|| "Unknown".to_string());
-
-    let entity_id = db
-        .create_entity(&entity_name, "auto", None)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-
-    let entity_link_distance = s.tuning.refinery.entity_link_distance;
-    let linked = origin_core::refinery::reweave_entity_links(db, 20, entity_link_distance)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-
-    db.resolve_refinement_if_open(&id, "completed")
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-
-    Ok(Json(serde_json::json!({
-        "entity_id": entity_id,
-        "entity_name": entity_name,
-        "memories_linked": linked,
-    })))
+) -> Result<Json<origin_types::EntitySuggestionApproveResponse>, ServerError> {
+    let (db, entity_link_distance) = {
+        let s = state.read().await;
+        let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?.clone();
+        let d = s.tuning.refinery.entity_link_distance;
+        (db, d)
+    };
+    let agent = extract_agent_name(&headers, None);
+    let result =
+        origin_core::post_write::approve_entity_suggestion(&db, &id, &agent, entity_link_distance)
+            .await?;
+    Ok(Json(result))
 }
 
 pub async fn handle_dismiss_entity_suggestion(

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1608,14 +1608,16 @@ pub async fn handle_approve_entity_suggestion(
 
 pub async fn handle_dismiss_entity_suggestion(
     State(state): State<Arc<RwLock<ServerState>>>,
+    headers: axum::http::HeaderMap,
     Path(id): Path<String>,
-) -> Result<Json<serde_json::Value>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
-    db.resolve_refinement_if_open(&id, "dismissed")
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-    Ok(Json(serde_json::json!({ "dismissed": true })))
+) -> Result<Json<origin_types::EntitySuggestionDismissResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.as_ref().ok_or(ServerError::DbNotInitialized)?.clone()
+    };
+    let agent = extract_agent_name(&headers, None);
+    let result = origin_core::post_write::dismiss_entity_suggestion(&db, &id, &agent).await?;
+    Ok(Json(result))
 }
 
 // ===== Helpers =====

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1496,14 +1496,16 @@ pub async fn handle_accept_revision(
 
 pub async fn handle_dismiss_revision(
     State(state): State<Arc<RwLock<ServerState>>>,
+    headers: axum::http::HeaderMap,
     Path(id): Path<String>,
-) -> Result<Json<serde_json::Value>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
-    db.dismiss_pending_revision(&id)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-    Ok(Json(serde_json::json!({ "dismissed": true })))
+) -> Result<Json<origin_types::RevisionDismissResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.as_ref().ok_or(ServerError::DbNotInitialized)?.clone()
+    };
+    let agent = extract_agent_name(&headers, None);
+    let result = origin_core::post_write::dismiss_pending_revision(&db, &id, &agent).await?;
+    Ok(Json(result))
 }
 
 /// POST /api/memory/contradiction/{source_id}/dismiss

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -3,7 +3,7 @@ use crate::error::ServerError;
 use crate::state::ServerState;
 use axum::{
     extract::{Path, State},
-    http::{HeaderMap, StatusCode},
+    http::HeaderMap,
     response::Json,
 };
 use origin_core::sources::compute_effective_confidence;
@@ -1514,16 +1514,16 @@ pub async fn handle_dismiss_revision(
 /// Returns 200 OK whether or not any rows were matched (idempotent).
 pub async fn handle_dismiss_contradiction(
     State(state): State<Arc<RwLock<ServerState>>>,
+    headers: axum::http::HeaderMap,
     Path(source_id): Path<String>,
-) -> Result<StatusCode, ServerError> {
+) -> Result<Json<origin_types::ContradictionDismissResponse>, ServerError> {
     let db = {
         let s = state.read().await;
-        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+        s.db.as_ref().ok_or(ServerError::DbNotInitialized)?.clone()
     };
-    db.dismiss_contradiction_for_source(&source_id)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
-    Ok(StatusCode::OK)
+    let agent = extract_agent_name(&headers, None);
+    let result = origin_core::post_write::dismiss_contradiction(&db, &source_id, &agent).await?;
+    Ok(Json(result))
 }
 
 // ===== Enrichment Status =====

--- a/crates/origin-server/tests/common/mod.rs
+++ b/crates/origin-server/tests/common/mod.rs
@@ -46,6 +46,21 @@ pub async fn test_app() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
     (router, dir, db_arc)
 }
 
+/// Count `agent_activity` rows matching both `action` and `agent_name`.
+/// Used by curation mutate HTTP tests to verify activity logging without
+/// requiring direct access to the private `conn` field.
+pub async fn count_activity_for_action_and_agent(
+    db: &Arc<MemoryDB>,
+    action: &str,
+    agent_name: &str,
+) -> i64 {
+    let rows = db
+        .list_agent_activity(1000, Some(agent_name), None)
+        .await
+        .unwrap();
+    rows.iter().filter(|r| r.action == action).count() as i64
+}
+
 /// Insert a memory row directly via `upsert_documents`.
 ///
 /// Matches the `insert_memory_for_test` helper used in `origin-core`'s DB

--- a/crates/origin-server/tests/common/mod.rs
+++ b/crates/origin-server/tests/common/mod.rs
@@ -15,6 +15,7 @@ use tokio::sync::RwLock;
 /// The `[[orphan_label]]` syntax in content causes `insert_page` to call
 /// `refresh_page_wikilinks`, which writes a `page_links` row with
 /// `target_page_id = NULL` (orphan) because no page with that title exists yet.
+#[allow(dead_code)]
 pub async fn insert_page_with_orphan_link(
     db: &Arc<MemoryDB>,
     page_id: &str,
@@ -32,6 +33,7 @@ pub async fn insert_page_with_orphan_link(
 ///
 /// The caller binds `_tmp` to keep the `TempDir` alive for the test's
 /// duration; it drops (and cleans up) when the test function returns.
+#[allow(dead_code)]
 pub async fn test_app() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
     let dir = tempfile::tempdir().unwrap();
     let db = MemoryDB::new(dir.path(), Arc::new(NoopEmitter))
@@ -49,6 +51,7 @@ pub async fn test_app() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
 /// Count `agent_activity` rows matching both `action` and `agent_name`.
 /// Used by curation mutate HTTP tests to verify activity logging without
 /// requiring direct access to the private `conn` field.
+#[allow(dead_code)]
 pub async fn count_activity_for_action_and_agent(
     db: &Arc<MemoryDB>,
     action: &str,
@@ -66,6 +69,7 @@ pub async fn count_activity_for_action_and_agent(
 /// Matches the `insert_memory_for_test` helper used in `origin-core`'s DB
 /// unit tests. All NOT NULL columns in `memories` are covered.
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub async fn insert_memory(
     db: &Arc<MemoryDB>,
     source_id: &str,

--- a/crates/origin-server/tests/curation_mutate_routes.rs
+++ b/crates/origin-server/tests/curation_mutate_routes.rs
@@ -12,6 +12,7 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use origin_types::{
     EntitySuggestionApproveResponse, EntitySuggestionDismissResponse, RevisionAcceptResponse,
+    RevisionDismissResponse,
 };
 use tower::ServiceExt;
 
@@ -374,5 +375,96 @@ async fn accept_revision_threads_x_agent_name() {
         .unwrap();
     let count =
         common::count_activity_for_action_and_agent(&db, "revision_accept", "openai-test").await;
+    assert_eq!(count, 1);
+}
+
+// ── dismiss_pending_revision HTTP tests ─────────────────────────────────────
+
+#[tokio::test]
+async fn dismiss_revision_succeeds_and_returns_typed_response() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_pending_revision_in_test_app(&db, "mem_dr1_target", "mem_dr1_rev").await;
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_dr1_target/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed: RevisionDismissResponse = body_as_json(response).await;
+    assert_eq!(parsed.target_source_id, "mem_dr1_target");
+    assert!(parsed.wrote);
+}
+
+#[tokio::test]
+async fn dismiss_revision_returns_404_on_missing() {
+    let (router, _tmp, _db) = common::test_app().await;
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_missing/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn dismiss_revision_returns_404_on_re_call() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_pending_revision_in_test_app(&db, "mem_dr2_target", "mem_dr2_rev").await;
+    let first = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_dr2_target/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    let second = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_dr2_target/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn dismiss_revision_threads_x_agent_name() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_pending_revision_in_test_app(&db, "mem_dr3_target", "mem_dr3_rev").await;
+    router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_dr3_target/dismiss")
+                .header("x-agent-name", "zed-test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let count =
+        common::count_activity_for_action_and_agent(&db, "revision_dismiss", "zed-test").await;
     assert_eq!(count, 1);
 }

--- a/crates/origin-server/tests/curation_mutate_routes.rs
+++ b/crates/origin-server/tests/curation_mutate_routes.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+//! HTTP integration tests for Spec C-2 curation mutate routes.
+//! Boots the real Axum router with a temp-dir MemoryDB and asserts:
+//!   - typed responses match the wire-type structs
+//!   - missing ids return HTTP 404 (Shape A/B/C)
+//!   - re-call returns HTTP 404 (row consumed after first approve)
+//!   - x-agent-name header threads into agent_activity rows
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use origin_types::EntitySuggestionApproveResponse;
+use tower::ServiceExt;
+
+async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
+    let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).expect("response body is valid JSON of expected type")
+}
+
+/// Seed a `suggest_entity` row via the public `insert_refinement_proposal` API.
+async fn seed_entity_suggestion(
+    db: &std::sync::Arc<origin_core::db::MemoryDB>,
+    id: &str,
+    entity_name: &str,
+) {
+    db.insert_refinement_proposal(id, "suggest_entity", &[], Some(entity_name), 0.9)
+        .await
+        .expect("seed_entity_suggestion must succeed");
+    // insert_refinement_proposal uses INSERT OR REPLACE with default status='pending'.
+    // get_pending_refinements queries both 'pending' and 'awaiting_review', so this works.
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_creates_entity_and_returns_typed_response() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_entity_suggestion(&db, "ref_a1", "Acme Corp").await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_a1/approve")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed: EntitySuggestionApproveResponse = body_as_json(response).await;
+    assert_eq!(parsed.suggestion_id, "ref_a1");
+    assert_eq!(parsed.entity_name, "Acme Corp");
+    assert!(parsed.wrote);
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_returns_404_on_missing_id() {
+    let (router, _tmp, _db) = common::test_app().await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_missing/approve")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_threads_x_agent_name_into_activity_log() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_entity_suggestion(&db, "ref_attr_1", "AttrCorp").await;
+
+    router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_attr_1/approve")
+                .header("x-agent-name", "claude-code-test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // canonicalize_agent_id("claude-code-test") = "claude-code-test" (already canonical)
+    let count = common::count_activity_for_action_and_agent(
+        &db,
+        "entity_suggestion_approve",
+        "claude-code-test",
+    )
+    .await;
+    assert_eq!(
+        count, 1,
+        "should log exactly one approve activity row attributed to claude-code-test"
+    );
+}
+
+#[tokio::test]
+async fn approve_entity_suggestion_returns_404_on_re_call() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_entity_suggestion(&db, "ref_recall_1", "RecallCo").await;
+
+    // First call: should succeed
+    let first = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_recall_1/approve")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+
+    // Second call: should 404 (proposal is resolved, no longer in awaiting_review/pending)
+    let second = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_recall_1/approve")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/origin-server/tests/curation_mutate_routes.rs
+++ b/crates/origin-server/tests/curation_mutate_routes.rs
@@ -3,14 +3,14 @@
 //! Boots the real Axum router with a temp-dir MemoryDB and asserts:
 //!   - typed responses match the wire-type structs
 //!   - missing ids return HTTP 404 (Shape A/B/C)
-//!   - re-call returns HTTP 404 (row consumed after first approve)
+//!   - re-call returns HTTP 404 (row consumed after first approve/dismiss)
 //!   - x-agent-name header threads into agent_activity rows
 
 mod common;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use origin_types::EntitySuggestionApproveResponse;
+use origin_types::{EntitySuggestionApproveResponse, EntitySuggestionDismissResponse};
 use tower::ServiceExt;
 
 async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
@@ -139,4 +139,107 @@ async fn approve_entity_suggestion_returns_404_on_re_call() {
         .await
         .unwrap();
     assert_eq!(second.status(), StatusCode::NOT_FOUND);
+}
+
+// ── dismiss_entity_suggestion ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_succeeds_and_returns_typed_response() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_entity_suggestion(&db, "ref_dd1", "X").await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_dd1/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed: EntitySuggestionDismissResponse = body_as_json(response).await;
+    assert_eq!(parsed.suggestion_id, "ref_dd1");
+    assert!(parsed.wrote);
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_returns_404_on_missing_id() {
+    let (router, _tmp, _db) = common::test_app().await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_missing/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_returns_404_on_re_call() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_entity_suggestion(&db, "ref_dd2", "Y").await;
+
+    let first = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_dd2/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_dd2/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn dismiss_entity_suggestion_threads_x_agent_name() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_entity_suggestion(&db, "ref_dd3", "Z").await;
+
+    router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/entity-suggestions/ref_dd3/dismiss")
+                .header("x-agent-name", "cursor-test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let count = common::count_activity_for_action_and_agent(
+        &db,
+        "entity_suggestion_dismiss",
+        "cursor-test",
+    )
+    .await;
+    assert_eq!(count, 1);
 }

--- a/crates/origin-server/tests/curation_mutate_routes.rs
+++ b/crates/origin-server/tests/curation_mutate_routes.rs
@@ -11,8 +11,8 @@ mod common;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use origin_types::{
-    EntitySuggestionApproveResponse, EntitySuggestionDismissResponse, RevisionAcceptResponse,
-    RevisionDismissResponse,
+    ContradictionDismissResponse, EntitySuggestionApproveResponse, EntitySuggestionDismissResponse,
+    RevisionAcceptResponse, RevisionDismissResponse,
 };
 use tower::ServiceExt;
 
@@ -467,4 +467,104 @@ async fn dismiss_revision_threads_x_agent_name() {
     let count =
         common::count_activity_for_action_and_agent(&db, "revision_dismiss", "zed-test").await;
     assert_eq!(count, 1);
+}
+
+// ── dismiss_contradiction ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn dismiss_contradiction_returns_200_with_typed_response_even_for_unknown_id() {
+    let (router, _tmp, _db) = common::test_app().await;
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/contradiction/mem_unknown/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed: ContradictionDismissResponse = body_as_json(response).await;
+    assert_eq!(parsed.source_id, "mem_unknown");
+    assert!(parsed.wrote);
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_threads_x_agent_name() {
+    let (router, _tmp, db) = common::test_app().await;
+    router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/contradiction/mem_attr/dismiss")
+                .header("x-agent-name", "mcp-test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let count =
+        common::count_activity_for_action_and_agent(&db, "contradiction_dismiss", "mcp-test").await;
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_idempotent_re_call_remains_wrote_true() {
+    let (router, _tmp, _db) = common::test_app().await;
+    for _ in 0..3 {
+        let response = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/memory/contradiction/mem_idem/dismiss")
+                    .header("x-agent-name", "test-agent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let parsed: ContradictionDismissResponse = body_as_json(response).await;
+        assert!(parsed.wrote);
+    }
+}
+
+#[tokio::test]
+async fn dismiss_contradiction_flips_awaiting_review_row_to_dismissed() {
+    let (router, _tmp, db) = common::test_app().await;
+    // Seed a detect_contradiction proposal (status=pending), then promote to awaiting_review.
+    db.insert_refinement_proposal(
+        "ref_contra_1",
+        "detect_contradiction",
+        &["mem_target".to_string()],
+        None,
+        0.9,
+    )
+    .await
+    .unwrap();
+    db.resolve_refinement_if_open("ref_contra_1", "awaiting_review")
+        .await
+        .unwrap();
+
+    router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/contradiction/mem_target/dismiss")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let proposal = db
+        .get_refinement_proposal("ref_contra_1")
+        .await
+        .unwrap()
+        .expect("ref_contra_1 must exist after dismiss");
+    assert_eq!(proposal.status, "dismissed");
 }

--- a/crates/origin-server/tests/curation_mutate_routes.rs
+++ b/crates/origin-server/tests/curation_mutate_routes.rs
@@ -10,7 +10,9 @@ mod common;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use origin_types::{EntitySuggestionApproveResponse, EntitySuggestionDismissResponse};
+use origin_types::{
+    EntitySuggestionApproveResponse, EntitySuggestionDismissResponse, RevisionAcceptResponse,
+};
 use tower::ServiceExt;
 
 async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
@@ -241,5 +243,136 @@ async fn dismiss_entity_suggestion_threads_x_agent_name() {
         "cursor-test",
     )
     .await;
+    assert_eq!(count, 1);
+}
+
+// ── accept_pending_revision ──────────────────────────────────────────────────
+
+async fn seed_pending_revision_in_test_app(
+    db: &std::sync::Arc<origin_core::db::MemoryDB>,
+    target: &str,
+    revision: &str,
+) {
+    let now = chrono::Utc::now().timestamp();
+    use origin_types::RawDocument;
+    // Seed the original (target) memory as confirmed
+    db.upsert_documents(vec![RawDocument {
+        source_id: target.to_string(),
+        title: format!("title-{target}"),
+        content: "original content".to_string(),
+        source: "memory".to_string(),
+        source_agent: Some("claude-code".to_string()),
+        last_modified: now,
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+    // Seed the revision row pointing at the target with pending_revision=true
+    db.upsert_documents(vec![RawDocument {
+        source_id: revision.to_string(),
+        title: format!("title-{revision}"),
+        content: "revised content".to_string(),
+        source: "memory".to_string(),
+        source_agent: Some("claude-code".to_string()),
+        last_modified: now,
+        supersedes: Some(target.to_string()),
+        pending_revision: true,
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn accept_revision_succeeds_and_returns_typed_response() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_pending_revision_in_test_app(&db, "mem_ar1_target", "mem_ar1_rev").await;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_ar1_target/accept")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed: RevisionAcceptResponse = body_as_json(response).await;
+    assert_eq!(parsed.target_source_id, "mem_ar1_target");
+    assert_eq!(parsed.revision_source_id, "mem_ar1_rev");
+    assert!(parsed.wrote);
+}
+
+#[tokio::test]
+async fn accept_revision_returns_404_on_missing_target() {
+    let (router, _tmp, _db) = common::test_app().await;
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_missing/accept")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn accept_revision_returns_404_on_re_call() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_pending_revision_in_test_app(&db, "mem_ar2_target", "mem_ar2_rev").await;
+
+    let first = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_ar2_target/accept")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_ar2_target/accept")
+                .header("x-agent-name", "test-agent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn accept_revision_threads_x_agent_name() {
+    let (router, _tmp, db) = common::test_app().await;
+    seed_pending_revision_in_test_app(&db, "mem_ar3_target", "mem_ar3_rev").await;
+    router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/revision/mem_ar3_target/accept")
+                .header("x-agent-name", "openai-test")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let count =
+        common::count_activity_for_action_and_agent(&db, "revision_accept", "openai-test").await;
     assert_eq!(count, 1);
 }

--- a/crates/origin-types/src/lib.rs
+++ b/crates/origin-types/src/lib.rs
@@ -37,10 +37,12 @@ pub use memory_type::{MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRI
 pub use narrative::NarrativeResponse;
 pub use pages::Page;
 pub use responses::{
+    ContradictionDismissResponse, EntitySuggestionApproveResponse, EntitySuggestionDismissResponse,
     ExportStats, ListMemoryRevisionsResponse, ListPageRevisionsResponse, ListRefinementsResponse,
     MemoryDetail, MemoryRevisionEntry, OrphanLink, OrphanLinksResponse, PageChangelogEntry,
     PendingRevision, PendingRevisionItem, ProposalAction, RefinementPayload,
-    RefinementProposalSummary, RejectRefinementResponse,
+    RefinementProposalSummary, RejectRefinementResponse, RevisionAcceptResponse,
+    RevisionDismissResponse,
 };
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -788,6 +788,141 @@ pub struct PendingRevisionItem {
     pub last_modified: i64,
 }
 
+// ===== Curation mutate responses (Spec C-2) =====
+
+/// Response returned by `POST /api/memory/entity-suggestions/{id}/approve`.
+/// Carries the created (or resolved) entity id, link count, and the wrote flag
+/// from the nested `create_entity` capability fn. `wrote: false` means the
+/// suggestion resolved to an existing entity via alias/exact-name/vector match.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EntitySuggestionApproveResponse {
+    pub suggestion_id: String,
+    pub entity_id: String,
+    pub entity_name: String,
+    pub memories_linked: u32,
+    pub wrote: bool,
+}
+
+/// Response returned by `POST /api/memory/entity-suggestions/{id}/dismiss`.
+/// `wrote: true` always (404 on missing/already-resolved).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EntitySuggestionDismissResponse {
+    pub suggestion_id: String,
+    pub wrote: bool,
+}
+
+/// Response returned by `POST /api/memory/revision/{id}/accept`.
+/// Carries the now-consumed revision row id so agents can correlate with
+/// their `list_pending_revisions` cache.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RevisionAcceptResponse {
+    pub target_source_id: String,
+    pub revision_source_id: String,
+    pub wrote: bool,
+}
+
+/// Response returned by `POST /api/memory/revision/{id}/dismiss`.
+/// `wrote: true` always (404 on missing).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RevisionDismissResponse {
+    pub target_source_id: String,
+    pub wrote: bool,
+}
+
+/// Response returned by `POST /api/memory/contradiction/{source_id}/dismiss`.
+/// `wrote: true` is best-effort: the daemon's underlying DB method silently
+/// no-ops when no rows match. Wrapper cannot distinguish dismiss-of-existing
+/// from dismiss-of-nothing without an extra SELECT (out of scope).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContradictionDismissResponse {
+    pub source_id: String,
+    pub wrote: bool,
+}
+
+#[cfg(test)]
+mod mutation_response_tests {
+    use super::*;
+
+    #[test]
+    fn entity_suggestion_approve_response_serializes_byte_identical() {
+        let r = EntitySuggestionApproveResponse {
+            suggestion_id: "ref_123".into(),
+            entity_id: "ent_456".into(),
+            entity_name: "Acme Corp".into(),
+            memories_linked: 7,
+            wrote: true,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert_eq!(
+            json,
+            r#"{"suggestion_id":"ref_123","entity_id":"ent_456","entity_name":"Acme Corp","memories_linked":7,"wrote":true}"#
+        );
+    }
+
+    #[test]
+    fn entity_suggestion_dismiss_response_serializes_byte_identical() {
+        let r = EntitySuggestionDismissResponse {
+            suggestion_id: "ref_123".into(),
+            wrote: true,
+        };
+        assert_eq!(
+            serde_json::to_string(&r).unwrap(),
+            r#"{"suggestion_id":"ref_123","wrote":true}"#
+        );
+    }
+
+    #[test]
+    fn revision_accept_response_serializes_byte_identical() {
+        let r = RevisionAcceptResponse {
+            target_source_id: "mem_target".into(),
+            revision_source_id: "mem_rev".into(),
+            wrote: true,
+        };
+        assert_eq!(
+            serde_json::to_string(&r).unwrap(),
+            r#"{"target_source_id":"mem_target","revision_source_id":"mem_rev","wrote":true}"#
+        );
+    }
+
+    #[test]
+    fn revision_dismiss_response_serializes_byte_identical() {
+        let r = RevisionDismissResponse {
+            target_source_id: "mem_target".into(),
+            wrote: true,
+        };
+        assert_eq!(
+            serde_json::to_string(&r).unwrap(),
+            r#"{"target_source_id":"mem_target","wrote":true}"#
+        );
+    }
+
+    #[test]
+    fn contradiction_dismiss_response_serializes_byte_identical() {
+        let r = ContradictionDismissResponse {
+            source_id: "mem_abc".into(),
+            wrote: true,
+        };
+        assert_eq!(
+            serde_json::to_string(&r).unwrap(),
+            r#"{"source_id":"mem_abc","wrote":true}"#
+        );
+    }
+
+    #[test]
+    fn entity_suggestion_approve_response_round_trips() {
+        let r = EntitySuggestionApproveResponse {
+            suggestion_id: "ref_123".into(),
+            entity_id: "ent_456".into(),
+            entity_name: "Acme".into(),
+            memories_linked: 0,
+            wrote: false,
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        let decoded: EntitySuggestionApproveResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, r);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Five mutate-side MCP tools for BM-mode curation, with capability-fn convergence in `origin-core::post_write`. Daemon-internal and agent-triggered call paths now share the same code.

- **5 new MCP tools:** `approve_entity_suggestion`, `dismiss_entity_suggestion`, `accept_revision`, `dismiss_revision`, `dismiss_contradiction`
- **5 new capability fns** in `origin-core::post_write` (Shape A/B/C/D per spec §4.3)
- **5 handler retrofits** in `origin-server`: typed responses + `?` propagation + `x-agent-name` activity logging
- **5 typed wire-response structs** in `origin-types` with golden-bytes tests
- **3 DB-method surgical fixes** in `db.rs`:
  - `accept_pending_revision` and `dismiss_pending_revision` return `OriginError::NotFound` (was `VectorDb` → mapped to HTTP 500)
  - `accept_pending_revision` now wraps two UPDATE statements in BEGIN/COMMIT with ROLLBACK
- **`OriginClient::post_empty<R>`** mirrored from `get<R>` for body-less POST endpoints
- **Cross-crate real-router integration test** (5 tests) that boots `origin_server::router::build_router` in-process to catch URL drift (per PR #101 adversarial finding)

Version bump: pre-1.0 minor 0.5.3 → 0.6.0.

## Test plan

- [x] origin-types lib: 49 passing (43 baseline + 6 golden-bytes)
- [x] origin-core lib: ~1098 passing (1079 baseline + 19 new: 3 DB regression + 16 post_write unit)
- [x] origin-server lib: 51 passing (unchanged)
- [x] origin-server curation_mutate_routes: 20 new HTTP integration tests
- [x] origin-mcp lib + type_contract: 174 passing (151 baseline + 23 new: 3 post_empty + 20 wrapper wiremock)
- [x] origin-mcp real_router: 5 new cross-crate integration tests
- [x] Workspace clippy -D warnings: clean
- [x] Smoke test on isolated daemon (port 7879): all 5 routes return correct status codes with typed envelopes, no panics

Total new tests: 73 (target was 69 per spec §6.7).

## Adversarial review

- Pre-impl spec review (Opus): 5 critical findings integrated before plan write
- Per-task spec + code-quality reviews: all APPROVED
- Final post-impl adversarial review (Opus): READY_TO_MERGE, zero critical/important findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)