### PR TITLE
fix(distill): respect user_edited + thread knowledge_path + add /distill rebuild

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -14784,6 +14784,36 @@ impl MemoryDB {
         Ok(results)
     }
 
+    /// Like `list_pages` but filters to pages flagged stale and not user-edited.
+    /// Ordered by most-stale-first (`sources_updated_count` desc) then oldest-write-first.
+    /// Used by the refinery refresh path to prioritize work and skip locked pages.
+    pub async fn list_pages_stale(
+        &self,
+        status: &str,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Page>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT id, title, summary, content, entity_id, domain, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]')
+                 FROM pages
+                 WHERE status = ?1
+                   AND stale_reason IS NOT NULL
+                   AND COALESCE(user_edited, 0) = 0
+                 ORDER BY COALESCE(sources_updated_count, 0) DESC, last_modified ASC
+                 LIMIT ?2 OFFSET ?3",
+                libsql::params![status, limit, offset],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("list_pages_stale: {e}")))?;
+        let mut results = Vec::new();
+        while let Ok(Some(row)) = rows.next().await {
+            results.push(Self::row_to_page(&row)?);
+        }
+        Ok(results)
+    }
+
     /// List pages, optionally filtered by domain.
     pub async fn list_pages_by_domain(
         &self,
@@ -28811,6 +28841,45 @@ pub(crate) mod tests {
             matches!(err, OriginError::NotFound(_)),
             "expected NotFound on re-call, got {:?}",
             err
+        );
+    }
+
+    #[tokio::test]
+    async fn list_pages_stale_filters_and_orders() {
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Insert 3 pages: A stale untouched, B stale user-edited, C not stale.
+        db.insert_page("page_a", "A", None, "body a", None, None, &["mem_1"], &now)
+            .await
+            .unwrap();
+        db.insert_page("page_b", "B", None, "body b", None, None, &["mem_2"], &now)
+            .await
+            .unwrap();
+        db.insert_page("page_c", "C", None, "body c", None, None, &["mem_3"], &now)
+            .await
+            .unwrap();
+
+        db.set_page_stale("page_a", "source_updated").await.unwrap();
+        db.set_page_stale("page_b", "source_updated").await.unwrap();
+        // Mark B as user_edited via fs_edit update.
+        db.try_update_page_content_with_changelog(
+            "page_b",
+            "user prose",
+            &["mem_2"],
+            "fs_edit",
+            false,
+            "User-edited content",
+        )
+        .await
+        .unwrap();
+
+        let stale = db.list_pages_stale("active", 10, 0).await.unwrap();
+        let ids: Vec<&str> = stale.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["page_a"],
+            "only stale, non-user-edited pages returned"
         );
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -14814,6 +14814,21 @@ impl MemoryDB {
         Ok(results)
     }
 
+    /// Clear the user_edited flag and mark the page stale with reason "manual_force".
+    /// Used by the `/distill rebuild` force path so the next refinery pass regenerates
+    /// the page from sources. The stale_reason ensures the CAS branch of update_page
+    /// can write through afterwards.
+    pub async fn clear_user_edited(&self, page_id: &str) -> Result<(), OriginError> {
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "UPDATE pages SET user_edited = 0, stale_reason = 'manual_force' WHERE id = ?1",
+            libsql::params![page_id],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("clear_user_edited: {e}")))?;
+        Ok(())
+    }
+
     /// List pages, optionally filtered by domain.
     pub async fn list_pages_by_domain(
         &self,
@@ -28880,6 +28895,38 @@ pub(crate) mod tests {
             ids,
             vec!["page_a"],
             "only stale, non-user-edited pages returned"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_user_edited_unlocks_page_and_sets_stale() {
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page("page_x", "X", None, "body", None, None, &["mem_1"], &now)
+            .await
+            .unwrap();
+        // Promote user_edited via fs_edit.
+        db.try_update_page_content_with_changelog(
+            "page_x",
+            "user prose",
+            &["mem_1"],
+            "fs_edit",
+            false,
+            "user-edited",
+        )
+        .await
+        .unwrap();
+        let before = db.get_page("page_x").await.unwrap().unwrap();
+        assert!(before.user_edited, "precondition: page should be locked");
+
+        db.clear_user_edited("page_x").await.unwrap();
+
+        let after = db.get_page("page_x").await.unwrap().unwrap();
+        assert!(!after.user_edited, "clear_user_edited should unlock");
+        assert_eq!(
+            after.stale_reason.as_deref(),
+            Some("manual_force"),
+            "clear_user_edited should mark stale so refinery picks it up"
         );
     }
 }

--- a/crates/origin-core/src/refinery/mod.rs
+++ b/crates/origin-core/src/refinery/mod.rs
@@ -509,7 +509,7 @@ pub async fn run_periodic_steep_with_api(
         }
     {
         let phase = run_phase(Phase::ReDistill, || async {
-            let changed = redistill_changed_pages(db_ref, compile_llm, prompts).await?;
+            let changed = redistill_changed_pages(db_ref, compile_llm, prompts, kp_ref).await?;
             // Also re-distill concepts explicitly marked stale by topic-key upserts.
             let stale = re_distill_stale_pages(db_ref, compile_llm, prompts).await?;
             let count = changed + stale;
@@ -728,6 +728,7 @@ pub(crate) async fn redistill_changed_pages(
     db: &MemoryDB,
     llm: Option<&Arc<dyn LlmProvider>>,
     prompts: &PromptRegistry,
+    knowledge_path: Option<&std::path::Path>,
 ) -> Result<usize, OriginError> {
     let llm = match llm {
         Some(l) if l.is_available() => l,
@@ -743,7 +744,7 @@ pub(crate) async fn redistill_changed_pages(
             continue;
         }
 
-        match recompile_single_page(db, llm, prompts, page).await {
+        match recompile_single_page(db, llm, prompts, page, knowledge_path).await {
             Ok(true) => recompiled += 1,
             Ok(false) => {}
             Err(e) => log::warn!("[re-distill] failed for '{}': {}", page.title, e),

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -574,7 +574,7 @@ pub async fn distill_pages_scoped(
     target: Option<DistillTarget>,
 ) -> Result<DistillResult, OriginError> {
     if let Some(DistillTarget::Page(ref page_id)) = target {
-        let updated = deep_distill_single(db, llm, prompts, page_id).await?;
+        let updated = deep_distill_single(db, llm, prompts, page_id, knowledge_path).await?;
         return Ok(DistillResult {
             created: if updated {
                 vec![page_id.clone()]
@@ -963,7 +963,7 @@ pub async fn deep_distill_pages(
     // 3. Recompile ALL active concepts (not just changed ones — full refresh)
     let all_active = db.list_pages("active", 200, 0).await?;
     for page in &all_active {
-        match recompile_single_page(db, llm_ref, prompts, page).await {
+        match recompile_single_page(db, llm_ref, prompts, page, knowledge_path).await {
             Ok(true) => total += 1,
             Ok(false) => {}
             Err(e) => log::warn!(
@@ -999,6 +999,7 @@ pub(crate) async fn recompile_single_page(
     llm: &Arc<dyn LlmProvider>,
     prompts: &PromptRegistry,
     page: &crate::pages::Page,
+    knowledge_path: Option<&std::path::Path>,
 ) -> Result<bool, OriginError> {
     let memories = db
         .get_memory_contents_by_ids(&page.source_memory_ids)
@@ -1045,7 +1046,7 @@ pub(crate) async fn recompile_single_page(
                 .trim()
                 .to_string();
             if !content.is_empty() {
-                let _ = crate::post_write::update_page(
+                let result = crate::post_write::update_page(
                     db,
                     &page.id,
                     UpdatePageRequest {
@@ -1053,12 +1054,28 @@ pub(crate) async fn recompile_single_page(
                         source_memory_ids: page.source_memory_ids.clone(),
                     },
                     "re_distill",
-                    false,
-                    None,
+                    true,
+                    knowledge_path,
                 )
                 .await?;
-                log::info!("[re-distill] refreshed page '{}'", page.title);
-                return Ok(true);
+                if result.wrote {
+                    log::info!("[re-distill] refreshed page '{}'", page.title);
+                    return Ok(true);
+                } else {
+                    if let Err(e) = db
+                        .log_agent_activity(
+                            "system",
+                            "page_skip_user_edited",
+                            std::slice::from_ref(&page.id),
+                            None,
+                            &format!("re_distill yielded for '{}'", page.title),
+                        )
+                        .await
+                    {
+                        log::warn!("[re-distill] activity log failed: {e}");
+                    }
+                    return Ok(false);
+                }
             }
         }
         Ok(_) => log::warn!("[re-distill] empty output for '{}'", page.title),
@@ -1077,6 +1094,7 @@ pub async fn deep_distill_single(
     llm: Option<&Arc<dyn LlmProvider>>,
     prompts: &PromptRegistry,
     page_id: &str,
+    knowledge_path: Option<&std::path::Path>,
 ) -> Result<bool, OriginError> {
     let llm = match llm {
         Some(l) if l.is_available() => l,
@@ -1142,7 +1160,7 @@ pub async fn deep_distill_single(
         return Ok(false);
     }
 
-    let _ = crate::post_write::update_page(
+    let result = crate::post_write::update_page(
         db,
         page_id,
         UpdatePageRequest {
@@ -1150,18 +1168,34 @@ pub async fn deep_distill_single(
             source_memory_ids: page.source_memory_ids.clone(),
         },
         "distill",
-        false,
-        None,
+        true,
+        knowledge_path,
     )
     .await?;
 
-    log::info!(
-        "[distill] re-distilled page '{}' (v{}->v{})",
-        page.title,
-        page.version,
-        page.version + 1
-    );
-    Ok(true)
+    if result.wrote {
+        log::info!(
+            "[distill] re-distilled page '{}' (v{}->v{})",
+            page.title,
+            page.version,
+            page.version + 1
+        );
+        Ok(true)
+    } else {
+        if let Err(e) = db
+            .log_agent_activity(
+                "system",
+                "page_skip_user_edited",
+                &[page_id.to_string()],
+                None,
+                &format!("distill yielded for '{}'", page.title),
+            )
+            .await
+        {
+            log::warn!("[distill] activity log failed: {e}");
+        }
+        Ok(false)
+    }
 }
 
 /// Apply a merge result based on the stability tier of the involved memories.
@@ -1201,4 +1235,69 @@ pub(crate) async fn apply_merge_by_tier(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_provider::MockProvider;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn recompile_single_page_re_projects_md_when_path_passed() {
+        let (db, _db_dir) = crate::db::tests::test_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let now_ts = chrono::Utc::now().timestamp();
+
+        // Insert a seed memory row directly so get_memory_contents_by_ids returns it.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, domain, source_agent, created_at, last_modified, confirmed, stability, source) \
+                 VALUES (?1, ?1, ?1, 'seed content', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 1, 'confirmed', 'memory')",
+                libsql::params!["mem_seed".to_string(), now_ts],
+            )
+            .await
+            .unwrap();
+        }
+
+        // Insert a page that cites that memory, then mark it stale.
+        db.insert_page(
+            "page_a",
+            "Topic A",
+            None,
+            "original body",
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.set_page_stale("page_a", "source_updated").await.unwrap();
+
+        let llm: Arc<dyn LlmProvider> = Arc::new(MockProvider::new("recompiled body"));
+        let prompts = PromptRegistry::default();
+        let page = db.get_page("page_a").await.unwrap().unwrap();
+
+        let updated = recompile_single_page(&db, &llm, &prompts, &page, Some(knowledge_dir.path()))
+            .await
+            .unwrap();
+        assert!(updated, "recompile should write");
+
+        // Verify md file was re-projected into the knowledge directory.
+        let entries: Vec<_> = std::fs::read_dir(knowledge_dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().map(|x| x == "md").unwrap_or(false))
+            .collect();
+        assert_eq!(entries.len(), 1, "exactly one md file");
+        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert!(
+            content.contains("recompiled body"),
+            "md body should reflect LLM output"
+        );
+    }
 }

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -976,8 +976,14 @@ pub async fn deep_distill_pages(
 
     // 4. Global review — merge/split/create analysis
     if all_active.len() >= 5 {
-        match crate::synthesis::emergence::global_page_review(db, llm_ref, prompts, &all_active)
-            .await
+        match crate::synthesis::emergence::global_page_review(
+            db,
+            llm_ref,
+            prompts,
+            &all_active,
+            knowledge_path,
+        )
+        .await
         {
             Ok(n) => {
                 total += n;

--- a/crates/origin-core/src/synthesis/distill.rs
+++ b/crates/origin-core/src/synthesis/distill.rs
@@ -960,9 +960,14 @@ pub async fn deep_distill_pages(
         Err(e) => log::warn!("[deep_distill] orphan assignment failed: {}", e),
     }
 
-    // 3. Recompile ALL active concepts (not just changed ones — full refresh)
-    let all_active = db.list_pages("active", 200, 0).await?;
-    for page in &all_active {
+    // 3. Refresh stale, non-user-edited pages. Cap 20 per fire so the refinery
+    //    returns control promptly; subsequent fires drain the rest. Order = most-stale
+    //    first (sources_updated_count desc).
+    const DEEP_DISTILL_REFRESH_CAP: i64 = 20;
+    let stale_pages = db
+        .list_pages_stale("active", DEEP_DISTILL_REFRESH_CAP, 0)
+        .await?;
+    for page in &stale_pages {
         match recompile_single_page(db, llm_ref, prompts, page, knowledge_path).await {
             Ok(true) => total += 1,
             Ok(false) => {}
@@ -974,7 +979,9 @@ pub async fn deep_distill_pages(
         }
     }
 
-    // 4. Global review — merge/split/create analysis
+    // 4. Global review — merge/split/create analysis. Needs the full active set
+    //    (not just stale pages) to propose merges/splits across all concepts.
+    let all_active = db.list_pages("active", 200, 0).await?;
     if all_active.len() >= 5 {
         match crate::synthesis::emergence::global_page_review(
             db,
@@ -1305,5 +1312,73 @@ mod tests {
             content.contains("recompiled body"),
             "md body should reflect LLM output"
         );
+    }
+
+    #[tokio::test]
+    async fn deep_distill_pages_only_recompiles_stale_non_user_edited() {
+        let (db, _db_dir) = crate::db::tests::test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        let now_ts = chrono::Utc::now().timestamp();
+
+        // Insert a seed memory row so get_memory_contents_by_ids returns it.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, domain, source_agent, created_at, last_modified, confirmed, stability, source) \
+                 VALUES (?1, ?1, ?1, 'seed content', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 1, 'confirmed', 'memory')",
+                libsql::params!["mem_1".to_string(), now_ts],
+            )
+            .await
+            .unwrap();
+        }
+
+        // 3 pages: stale clean (page_a), stale user-edited (page_b), not stale (page_c).
+        db.insert_page("page_a", "A", None, "body a", None, None, &["mem_1"], &now)
+            .await
+            .unwrap();
+        db.insert_page("page_b", "B", None, "body b", None, None, &["mem_1"], &now)
+            .await
+            .unwrap();
+        db.insert_page("page_c", "C", None, "body c", None, None, &["mem_1"], &now)
+            .await
+            .unwrap();
+
+        db.set_page_stale("page_a", "source_updated").await.unwrap();
+        db.set_page_stale("page_b", "source_updated").await.unwrap();
+
+        // Lock page_b via fs_edit — sets user_edited=1 (require_stale=false to force).
+        db.try_update_page_content_with_changelog(
+            "page_b",
+            "user prose b",
+            &["mem_1"],
+            "fs_edit",
+            false,
+            "user-edited",
+        )
+        .await
+        .unwrap();
+
+        let llm: Arc<dyn crate::llm_provider::LlmProvider> =
+            Arc::new(crate::llm_provider::MockProvider::new("recompiled"));
+        let prompts = crate::prompts::PromptRegistry::default();
+        let tuning = crate::tuning::DistillationConfig::default();
+
+        let _ =
+            crate::synthesis::distill::deep_distill_pages(&db, Some(&llm), &prompts, &tuning, None)
+                .await
+                .unwrap();
+
+        let a = db.get_page("page_a").await.unwrap().unwrap();
+        let b = db.get_page("page_b").await.unwrap().unwrap();
+        let c = db.get_page("page_c").await.unwrap().unwrap();
+        assert_eq!(
+            a.content, "recompiled",
+            "stale clean page should be refreshed"
+        );
+        assert_eq!(
+            b.content, "user prose b",
+            "user-edited page must NOT be touched"
+        );
+        assert_eq!(c.content, "body c", "non-stale page must NOT be touched");
     }
 }

--- a/crates/origin-core/src/synthesis/emergence.rs
+++ b/crates/origin-core/src/synthesis/emergence.rs
@@ -224,6 +224,7 @@ pub(crate) async fn global_page_review(
     llm: &Arc<dyn LlmProvider>,
     prompts: &PromptRegistry,
     concepts: &[crate::pages::Page],
+    knowledge_path: Option<&std::path::Path>,
 ) -> Result<usize, OriginError> {
     let concepts_text: String = concepts
         .iter()
@@ -268,31 +269,54 @@ pub(crate) async fn global_page_review(
                     if let (Ok(Some(keep)), Ok(Some(remove))) =
                         (db.get_page(keep_id).await, db.get_page(remove_id).await)
                     {
+                        // Skip the merge if either side is user-edited. Archiving a
+                        // user-edited remove page would discard authored prose; merging
+                        // into a user-edited keep would orphan the watcher's view.
+                        if keep.user_edited || remove.user_edited {
+                            log::info!("[merge] skipping {}→{}: user_edited", remove_id, keep_id);
+                            continue;
+                        }
+
                         let mut merged_sources = keep.source_memory_ids.clone();
                         for sid in &remove.source_memory_ids {
                             if !merged_sources.contains(sid) {
                                 merged_sources.push(sid.clone());
                             }
                         }
-                        let _ = crate::post_write::update_page(
+
+                        let result = crate::post_write::update_page(
                             db,
                             keep_id,
                             UpdatePageRequest {
                                 content: keep.content.clone(),
                                 source_memory_ids: merged_sources,
                             },
-                            "re_distill",
-                            false,
-                            None,
+                            "refinery_merge",
+                            true,
+                            knowledge_path,
                         )
                         .await;
-                        let _ = db.archive_page(remove_id).await;
-                        changes += 1;
-                        log::info!(
-                            "[distill] merged page '{}' into '{}'",
-                            remove.title,
-                            keep.title
-                        );
+
+                        match result {
+                            Ok(crate::post_write::WriteResult { wrote: true, .. }) => {
+                                let _ = db.archive_page(remove_id).await;
+                                changes += 1;
+                                log::info!(
+                                    "[distill] merged page '{}' into '{}'",
+                                    remove.title,
+                                    keep.title
+                                );
+                            }
+                            Ok(crate::post_write::WriteResult { wrote: false, .. }) => {
+                                // CAS lost the race: fs_edit landed between pre-check and SQL UPDATE.
+                                log::info!(
+                                    "[merge] CAS skipped {}→{}: late fs_edit",
+                                    remove_id,
+                                    keep_id
+                                );
+                            }
+                            Err(e) => log::warn!("[merge] update_page failed for {keep_id}: {e}"),
+                        }
                     }
                 }
             }
@@ -314,4 +338,91 @@ pub(crate) async fn global_page_review(
     }
 
     Ok(changes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_provider::MockProvider;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn global_page_review_skips_merge_when_keep_is_user_edited() {
+        let (db, _tmp) = crate::db::tests::test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        let now_ts = chrono::Utc::now().timestamp();
+
+        // Insert two seed memory rows directly.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, domain, source_agent, created_at, last_modified, confirmed, stability, source) \
+                 VALUES (?1, ?1, 'seed', 'fact', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 1, 'confirmed', 'memory')",
+                libsql::params!["mem_1".to_string(), now_ts],
+            )
+            .await
+            .unwrap();
+            conn.execute(
+                "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, domain, source_agent, created_at, last_modified, confirmed, stability, source) \
+                 VALUES (?1, ?1, 'seed two', 'fact', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 1, 'confirmed', 'memory')",
+                libsql::params!["mem_2".to_string(), now_ts],
+            )
+            .await
+            .unwrap();
+        }
+
+        db.insert_page(
+            "page_keep",
+            "Keep",
+            None,
+            "keep body",
+            None,
+            None,
+            &["mem_1"],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.insert_page(
+            "page_remove",
+            "Remove",
+            None,
+            "remove body",
+            None,
+            None,
+            &["mem_2"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        // Lock the keep page via fs_edit (sets user_edited=1).
+        db.try_update_page_content_with_changelog(
+            "page_keep",
+            "user prose",
+            &["mem_1"],
+            "fs_edit",
+            false,
+            "user-edited",
+        )
+        .await
+        .unwrap();
+
+        let llm: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(
+            r#"{"merges": [{"keep": "page_keep", "remove": "page_remove"}], "splits": [], "missing": []}"#,
+        ));
+        let prompts = PromptRegistry::default();
+        let active = db.list_pages("active", 100, 0).await.unwrap();
+
+        let changes = global_page_review(&db, &llm, &prompts, &active, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            changes, 0,
+            "merge should be skipped when keep is user_edited"
+        );
+        let remove = db.get_page("page_remove").await.unwrap().unwrap();
+        assert_eq!(remove.status, "active", "remove page must NOT be archived");
+    }
 }

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -163,6 +163,12 @@ pub struct DistillParams {
     )]
     #[serde(default, alias = "page_id")]
     pub target: Option<String>,
+
+    #[schemars(
+        description = "When true, clears the user_edited flag on the target page before recompile. Use for /distill rebuild <page> to explicitly wipe user prose and regenerate from sources. Only valid when target is a single page id; the daemon ignores it otherwise. Requires daemon LLM."
+    )]
+    #[serde(default)]
+    pub force: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -802,10 +808,14 @@ impl OriginMcpServer {
     }
 
     pub async fn distill_impl(&self, params: DistillParams) -> Result<CallToolResult, McpError> {
-        let body = match params.target.as_deref() {
-            Some(t) if !t.is_empty() => serde_json::json!({ "target": t }),
-            _ => serde_json::json!({}),
-        };
+        let mut body = serde_json::Map::new();
+        if let Some(t) = params.target.as_deref().filter(|t| !t.is_empty()) {
+            body.insert("target".into(), serde_json::Value::String(t.to_string()));
+        }
+        if params.force.unwrap_or(false) {
+            body.insert("force".into(), serde_json::Value::Bool(true));
+        }
+        let body = serde_json::Value::Object(body);
         match self
             .client
             .post::<serde_json::Value, serde_json::Value>("/api/distill", &body)
@@ -4122,5 +4132,21 @@ mod tests {
             result.is_err(),
             "envelope-wrapped response must fail typed deserialize"
         );
+    }
+
+    // ===== DistillParams force field =====
+
+    #[test]
+    fn distill_params_deserializes_force() {
+        let p: DistillParams =
+            serde_json::from_str(r#"{"target":"page_xyz","force":true}"#).unwrap();
+        assert_eq!(p.target.as_deref(), Some("page_xyz"));
+        assert_eq!(p.force, Some(true));
+    }
+
+    #[test]
+    fn distill_params_defaults_force_to_none() {
+        let p: DistillParams = serde_json::from_str(r#"{"target":"foo"}"#).unwrap();
+        assert_eq!(p.force, None);
     }
 }

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -942,6 +942,14 @@ pub async fn handle_redistill(
         Some(config.knowledge_path_or_default())
     };
 
+    // Clear user_edited and mark stale so the CAS gate inside
+    // deep_distill_single (require_stale=true) lets this pass through.
+    // This preserves the original contract of the route: always recompile
+    // the page regardless of its current stale state.
+    db.clear_user_edited(&page_id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+
     let prefer_llm = api_llm.or(llm);
     if prefer_llm.map(|p| p.is_available()).unwrap_or(false) {
         let updated = origin_core::refinery::deep_distill_single(

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -668,6 +668,13 @@ pub struct DistillRequest {
     /// domain value → scoped distill; anything else → 404-ish hint payload.
     #[serde(default, alias = "page_id")]
     pub target: Option<String>,
+
+    /// When true, clears `user_edited` on the resolved page before recompile.
+    /// Used by `/distill rebuild <page>` to opt into wiping user prose.
+    /// Only valid when target resolves to a single page; otherwise returns a hint.
+    /// Requires daemon LLM.
+    #[serde(default)]
+    pub force: bool,
 }
 
 /// POST /api/distill
@@ -693,6 +700,8 @@ pub async fn handle_distill(
             .ok_or(ServerError::Internal("DB not initialized".into()))?;
     let prompts = &s.prompts;
     let tuning = &s.tuning.distillation;
+    let llm = s.llm.as_ref();
+    let api_llm = s.api_llm.as_ref();
 
     let knowledge_path = {
         let config = origin_core::config::load_config();
@@ -715,6 +724,50 @@ pub async fn handle_distill(
         }
         _ => None,
     };
+
+    // Force path: clear user_edited and run a full deep_distill_single.
+    // Only valid when target resolves to a single page; all other targets
+    // (entity, domain, none) return a hint payload.
+    if req.force {
+        match &target {
+            Some(origin_core::synthesis::distill::DistillTarget::Page(page_id)) => {
+                db.clear_user_edited(page_id)
+                    .await
+                    .map_err(|e| ServerError::Internal(e.to_string()))?;
+                let prefer_llm = api_llm.or(llm);
+                if prefer_llm.map(|p| p.is_available()).unwrap_or(false) {
+                    let updated = origin_core::refinery::deep_distill_single(
+                        db,
+                        prefer_llm,
+                        prompts,
+                        page_id,
+                        knowledge_path.as_deref(),
+                    )
+                    .await?;
+                    return Ok(Json(serde_json::json!({
+                        "status": "ok",
+                        "force": true,
+                        "page_id": page_id,
+                        "updated": updated,
+                    })));
+                } else {
+                    return Ok(Json(serde_json::json!({
+                        "status": "skipped",
+                        "force": true,
+                        "page_id": page_id,
+                        "updated": false,
+                        "hint": "force rebuild needs an LLM in the daemon — install an on-device model or set an Anthropic key via `origin setup` / `/origin:doctor`",
+                    })));
+                }
+            }
+            _ => {
+                return Ok(Json(serde_json::json!({
+                    "unresolved": req.target.clone().unwrap_or_default(),
+                    "hint": "force=true only valid when target is a single page id",
+                })));
+            }
+        }
+    }
 
     let scoped = target.is_some();
 
@@ -1097,5 +1150,30 @@ mod recent_endpoints_tests {
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
         assert_eq!(response.status(), 503);
+    }
+}
+
+#[cfg(test)]
+mod distill_request_tests {
+    use super::DistillRequest;
+
+    #[test]
+    fn distill_request_deserializes_force() {
+        let r: DistillRequest =
+            serde_json::from_str(r#"{"target":"page_xyz","force":true}"#).unwrap();
+        assert_eq!(r.target.as_deref(), Some("page_xyz"));
+        assert!(r.force);
+    }
+
+    #[test]
+    fn distill_request_defaults_force_to_false() {
+        let r: DistillRequest = serde_json::from_str(r#"{"target":"foo"}"#).unwrap();
+        assert!(!r.force);
+    }
+
+    #[test]
+    fn distill_request_rejects_unknown_field() {
+        let r = serde_json::from_str::<DistillRequest>(r#"{"bogus":true}"#);
+        assert!(r.is_err(), "deny_unknown_fields should reject unknown keys");
     }
 }

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -884,10 +884,21 @@ pub async fn handle_redistill(
     let api_llm = s.api_llm.as_ref();
     let prompts = &s.prompts;
 
+    let knowledge_path = {
+        let config = origin_core::config::load_config();
+        Some(config.knowledge_path_or_default())
+    };
+
     let prefer_llm = api_llm.or(llm);
     if prefer_llm.map(|p| p.is_available()).unwrap_or(false) {
-        let updated =
-            origin_core::refinery::deep_distill_single(db, prefer_llm, prompts, &page_id).await?;
+        let updated = origin_core::refinery::deep_distill_single(
+            db,
+            prefer_llm,
+            prompts,
+            &page_id,
+            knowledge_path.as_deref(),
+        )
+        .await?;
         Ok(Json(serde_json::json!({
             "status": "ok",
             "updated": updated,

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -5,7 +5,7 @@ description: >
   daemon clusters and synthesizes what it can; agent finishes whatever
   the daemon couldn't (no LLM or cluster too big). Invoked as
   `/distill [target]`.
-argument-hint: "[page_id_or_entity_or_domain]"
+argument-hint: "[target | rebuild <page-id> | deep]"
 allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__distill", "mcp__plugin_origin_origin__create_page", "mcp__plugin_origin_origin__update_page", "mcp__plugin_origin_origin__delete_page", "mcp__plugin_origin_origin__get_page_sources", "Bash"]
 ---
 
@@ -13,6 +13,20 @@ allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin_
 
 Force a distillation pass now. The daemon's background refinery runs
 on its own clock; `/distill` is the explicit user-triggered pass.
+
+## Mental model
+
+Distillation is four operations bundled into one flow:
+
+- **emerge** — cluster new memories into new pages
+- **absorb** — assign orphan memories to existing pages, propose new pages
+  from topics that 2+ existing pages link to but no page is named for
+- **refresh** — regenerate stale pages from their source memories (only when
+  the user has not edited the page; pages you have touched stay locked)
+- **merge** — combine duplicate pages flagged by the daemon's global review
+
+The default flow runs all four. The `rebuild` verb is a destructive opt-in
+that overrides the lock on a single page.
 
 ## Single flow
 
@@ -45,6 +59,13 @@ Bash: top=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); \
 - Output → use it (e.g. `origin`).
 - Not a git repo → fall back to `basename "$PWD"`.
 - Reserved keyword `deep` → no scope (global pass).
+- Reserved keyword sequence `rebuild <page-id>` → call
+  `distill(target=<page-id>, force=true)`. Confirms "Rebuild page <id>?
+  Your edits will be wiped, page regenerates from sources." before
+  proceeding. Skip the rest of this skill — single-page rebuild does
+  not produce `pending` clusters; the daemon's response shape is
+  `{"status": "ok", "force": true, "page_id": ..., "updated": true}`.
+  Report verbatim.
 
 For `/distill <arg>` → forward `<arg>` to `target`.
 
@@ -179,7 +200,9 @@ For each stale page:
 
 - **`user_edited == true`** → never auto-rewrite. The user touched
   the page; the upstream memories also changed. Surface in the
-  "Conflict" report block and stop. The user resolves by hand.
+  "Conflict" report block and stop. The user resolves by hand, OR
+  runs `/distill rebuild <page-id>` to wipe their edits and
+  regenerate from sources.
 - **`user_edited == false`** → fetch source memories via
   `get_page_sources(page_id="<id>")`, run the same coherence check
   used for clusters, then call `update_page` with the existing
@@ -320,6 +343,10 @@ wait is enough for the daemon to release the lock.
 - User says "distill", "synthesize", "rebuild the page on X".
 - After a bulk import — daemon refinery handles this in the background;
   user can force a pass for immediate visibility.
+- `/distill rebuild <page-id>` when you want to wipe a page you
+  previously edited and have the daemon regenerate from current
+  sources. Destructive: your prose goes away. Use after you are
+  done curating a page and want it back on the auto-refresh path.
 
 ## When NOT to use
 

--- a/plugin/skills/read/SKILL.md
+++ b/plugin/skills/read/SKILL.md
@@ -86,6 +86,23 @@ Open:     ~/.origin/pages/<slug>.md
 ⚠ Stale: <stale_reason> — run /distill to refresh
 ```
 
+**Lock banner rule:**
+
+When the page payload returned by `get_page` has `user_edited == true`,
+prepend this line as the very first line of the rendered output, before
+the title:
+
+```
+🔒 You've edited this page. Auto-refresh paused. `/distill rebuild <page-id>` to unlock.
+```
+
+Substitute `<page-id>` with the actual `page.id` value. When
+`user_edited` is false or absent, omit this line entirely.
+
+The lock means the daemon's refinery will not auto-rewrite this page's
+prose from sources — edits stay until the user explicitly runs
+`/distill rebuild` to wipe and regenerate.
+
 **Version line rules:**
 
 - Always show `v<N>`. When `version` is null or missing, omit the line.


### PR DESCRIPTION
## Summary

Make `deep_distill_pages` respect the `user_edited` flag (was dead code per mem_11a687aa8cdc), fix md/DB divergence by threading `knowledge_path` through recompile + merge paths, scope refinery refresh to stale-only with cap=20, and add a `/distill rebuild <page-id>` opt-in destructive override.

## Why

- Today's `recompile_single_page` calls `update_page(... require_stale=false, knowledge_path=None)`. `require_stale=false` skips the CAS branch that gates on `user_edited`; refinery silently overwrites user-authored pages.
- `knowledge_path=None` means md never re-projects after refinery writes. Watcher reads stale md, version mismatch, `Outcome::SkippedDaemonAhead` — md and DB diverge.
- `deep_distill_pages` step 3 walks all 200 active pages on every fire. Bulk-import scenario flips 80 pages stale → 80 × 5s LLM blocking. No prioritization.
- No user-facing escape hatch: once a page is user-edited, no way to opt back into auto-refresh without manual DB surgery.

## Changes

10 commits, ~250 LoC across `origin-core`, `origin-server`, `origin-mcp`, and 2 skill docs:

- `MemoryDB::list_pages_stale` filters `stale_reason IS NOT NULL AND user_edited=0`, ordered most-stale-first
- `MemoryDB::clear_user_edited` sets `user_edited=0, stale_reason='manual_force'` (used by force-rebuild)
- `recompile_single_page`, `deep_distill_single`, `global_page_review` merges: CAS gate engaged (`require_stale=true`), `knowledge_path` threaded for md re-projection
- `global_page_review` merges: pre-check both sides for `user_edited`; archive remove only when keep update wrote
- `deep_distill_pages` step 3: `list_pages_stale("active", 20, 0)` (was `list_pages("active", 200, 0)`); step 4 fetches active separately for merge proposals
- `POST /api/distill` accepts `force: bool` — when true + target is a page, clears `user_edited` then calls `deep_distill_single`. New typed `DistillParams.force: Option<bool>` on MCP
- `handle_redistill` (`POST /api/distill/{page_id}`) calls `clear_user_edited` first so CAS gate passes — preserves pre-branch "always rewrite" contract
- `/distill` skill: `rebuild <page-id>` verb + 4-verb mental model (emerge/absorb/refresh/merge) in docs
- `/read` skill: 🔒 lock banner when `user_edited=true` pointing to `/distill rebuild`

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 1359 pass / 0 fail / 14 ignored
- [x] New unit tests: `list_pages_stale_filters_and_orders`, `clear_user_edited_unlocks_page_and_sets_stale`, `recompile_single_page_re_projects_md_when_path_passed`, `global_page_review_skips_merge_when_keep_is_user_edited`, `deep_distill_pages_only_recompiles_stale_non_user_edited`, `distill_request_*` (3 tests), `distill_params_*` (2 tests)
- [x] Smoke test against running daemon: health OK, store memory OK, `/api/distill {}` clean response, `/api/distill {force:true,target:"page_x"}` hits force branch and returns structured `skipped/hint` payload (LLM unavailable), no panics
- [x] Final adversarial review: 1 blocker (B1 — `handle_redistill` regression on CAS gate) found and fixed in commit `8225707a`; 9 deferrable concerns logged as follow-up

## Follow-up work

- `re_distill_stale_pages` (refinery/mod.rs:866) still passes `knowledge_path=None` — same md/DB divergence pattern in sibling refinery phase. Out of spec scope; tracked separately.
- 9 concerns from final review (misleading activity log kind, race-window opacity, full-flow integration test, etc.) batched into one cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)