### PR TITLE
fix: capture inline contradiction signal + surface bug fix

### DIFF
--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -2564,6 +2564,7 @@ mod tests {
             extraction_method: "llm".into(),
             enrichment: String::new(),
             hint: String::new(),
+            triggered_revisions: vec![],
         };
         let msg = format_capture_success(&resp);
         assert_eq!(msg, "Stored mem_abc");
@@ -2584,6 +2585,7 @@ mod tests {
             extraction_method: "agent".into(),
             enrichment: String::new(),
             hint: String::new(),
+            triggered_revisions: vec![],
         };
         let msg = format_capture_success(&resp);
         assert!(msg.starts_with("Stored mem_abc"));

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -511,6 +511,15 @@ fn format_capture_success(resp: &StoreMemoryResponse) -> String {
             msg.push_str(&format!("\n  - {}", warning));
         }
     }
+    if !resp.triggered_revisions.is_empty() {
+        msg.push_str("\n\nTriggered revisions (protected memories now flagged):");
+        for target_id in &resp.triggered_revisions {
+            msg.push_str(&format!("\n  - {target_id}"));
+        }
+        msg.push_str(
+            "\n\nAction: accept (accept_revision) | dismiss (dismiss_revision) | leave (decide later)",
+        );
+    }
     msg
 }
 
@@ -2591,6 +2600,45 @@ mod tests {
         assert!(msg.starts_with("Stored mem_abc"));
         assert!(msg.contains("Warnings:"));
         assert!(msg.contains("decision memory missing required 'claim' field"));
+    }
+
+    #[test]
+    fn format_capture_success_surfaces_triggered_revisions() {
+        let resp = StoreMemoryResponse {
+            source_id: "mem_new".into(),
+            chunks_created: 1,
+            memory_type: "fact".into(),
+            entity_id: None,
+            quality: None,
+            warnings: vec![],
+            extraction_method: "agent".into(),
+            enrichment: String::new(),
+            hint: String::new(),
+            triggered_revisions: vec!["mem_protected_target".to_string()],
+        };
+        let out = format_capture_success(&resp);
+        assert!(out.contains("Triggered revisions"));
+        assert!(out.contains("mem_protected_target"));
+        assert!(out.contains("accept_revision"));
+        assert!(out.contains("dismiss_revision"));
+    }
+
+    #[test]
+    fn format_capture_success_omits_section_when_empty() {
+        let resp = StoreMemoryResponse {
+            source_id: "mem_new".into(),
+            chunks_created: 1,
+            memory_type: "fact".into(),
+            entity_id: None,
+            quality: None,
+            warnings: vec![],
+            extraction_method: "agent".into(),
+            enrichment: String::new(),
+            hint: String::new(),
+            triggered_revisions: vec![],
+        };
+        let out = format_capture_success(&resp);
+        assert!(!out.contains("Triggered revisions"));
     }
 
     #[test]

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -111,6 +111,7 @@ async fn t1_remember_roundtrip() {
         enrichment: String::new(),
 
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -156,6 +157,7 @@ async fn t2_remember_surfaces_warnings_when_present() {
         enrichment: String::new(),
 
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -210,6 +212,7 @@ async fn t3_structured_fields_schema_is_object() {
         enrichment: String::new(),
 
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -332,6 +335,7 @@ async fn t5_memory_type_hint_preserved_without_forcing_domain() {
         enrichment: String::new(),
 
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -554,6 +558,7 @@ async fn t10_remember_request_does_not_contain_user_id() {
         enrichment: String::new(),
 
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -603,6 +608,7 @@ async fn t11_extraction_method_none_not_in_text() {
         enrichment: String::new(),
 
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -753,6 +759,7 @@ async fn origin_client_sends_x_agent_name_header() {
         extraction_method: "none".into(),
         enrichment: String::new(),
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))
@@ -805,6 +812,7 @@ async fn origin_client_omits_x_agent_name_when_unset() {
         extraction_method: "none".into(),
         enrichment: String::new(),
         hint: String::new(),
+        triggered_revisions: vec![],
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/store"))

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -402,8 +402,15 @@ pub async fn handle_store_memory(
 
     // A topic-match against a protected memory also flags this as a pending revision.
     let pending_revision = topic_match_protected_id.is_some();
-    // Agent-declared supersedes: trust the caller directly, no auto-detection.
-    let final_supersedes = req.supersedes.clone();
+    // Agent-declared supersedes takes priority. If caller didn't pass one and
+    // topic-match against a protected memory fired, auto-set supersedes so the
+    // new memory is properly linked as a revision-of-protected. Without this,
+    // list_pending_revisions (filters by `supersedes IS NOT NULL`) can't find
+    // the row and /brief surfaces nothing.
+    let final_supersedes = req
+        .supersedes
+        .clone()
+        .or_else(|| topic_match_protected_id.clone());
 
     let agent_for_activity = {
         let s = state.read().await;
@@ -965,6 +972,10 @@ pub async fn handle_store_memory(
         extraction_method,
         enrichment,
         hint,
+        triggered_revisions: topic_match_protected_id
+            .as_ref()
+            .map(|id| vec![id.clone()])
+            .unwrap_or_default(),
     }))
 }
 

--- a/crates/origin-server/tests/common/mod.rs
+++ b/crates/origin-server/tests/common/mod.rs
@@ -3,6 +3,7 @@
 
 use origin_core::db::MemoryDB;
 use origin_core::events::NoopEmitter;
+use origin_core::quality_gate::QualityGate;
 use origin_core::sources::RawDocument;
 use origin_server::router::build_router;
 use origin_server::state::ServerState;
@@ -42,6 +43,32 @@ pub async fn test_app() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
     let db_arc = Arc::new(db);
     let state = ServerState {
         db: Some(db_arc.clone()),
+        ..ServerState::default()
+    };
+    let router = build_router(Arc::new(RwLock::new(state)));
+    (router, dir, db_arc)
+}
+
+/// Build a test app with the quality gate disabled.
+///
+/// Use this when the test needs to store memories through the HTTP API
+/// (exercising the full store handler) but the novelty filter would
+/// otherwise reject content that is intentionally similar to an existing
+/// memory — e.g., when testing the topic-match-protected path.
+#[allow(dead_code)]
+pub async fn test_app_no_gate() -> (axum::Router, tempfile::TempDir, Arc<MemoryDB>) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = MemoryDB::new(dir.path(), Arc::new(NoopEmitter))
+        .await
+        .unwrap();
+    let db_arc = Arc::new(db);
+    let gate_cfg = origin_core::tuning::GateConfig {
+        enabled: false,
+        ..Default::default()
+    };
+    let state = ServerState {
+        db: Some(db_arc.clone()),
+        quality_gate: QualityGate::new(gate_cfg),
         ..ServerState::default()
     };
     let router = build_router(Arc::new(RwLock::new(state)));

--- a/crates/origin-server/tests/triggered_revisions.rs
+++ b/crates/origin-server/tests/triggered_revisions.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for the topic-match-protected -> triggered_revisions fix.
+//!
+//! Verifies:
+//!   1. Storing a memory against a protected target auto-sets `supersedes` so
+//!      `list_pending_revisions` surfaces the row (the bug: supersedes=NULL
+//!      caused it to be invisible).
+//!   2. The `/api/memory/store` response includes `triggered_revisions` with
+//!      the matched target id.
+//!
+//! These tests use `test_app_no_gate()` so the quality-gate novelty filter
+//! does not reject content that is intentionally similar to an existing
+//! protected memory. The topic-match + pending-revision path is exercised
+//! with the gate out of the way.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use origin_types::responses::{PendingRevisionItem, StoreMemoryResponse};
+use tower::ServiceExt;
+
+async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
+    let bytes = axum::body::to_bytes(response.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).expect("response body is valid JSON of expected type")
+}
+
+/// Store a memory via the HTTP API and return the response.
+///
+/// `domain` + `memory_type` are included in the request body so that
+/// topic-match uses the "exact domain+type" threshold (0.70) rather than
+/// the stricter semantic-only threshold (0.90). This matters for test
+/// content that sits at ~0.77 cosine similarity.
+async fn store_memory_via_http(
+    router: &axum::Router,
+    content: &str,
+    memory_type: &str,
+    domain: &str,
+) -> axum::http::Response<Body> {
+    let body = serde_json::json!({
+        "content": content,
+        "memory_type": memory_type,
+        "domain": domain,
+    });
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/memory/store")
+                .header("content-type", "application/json")
+                .header("x-agent-name", "test-agent")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+/// List pending revisions via the HTTP API.
+async fn list_pending_revisions(router: &axum::Router) -> Vec<PendingRevisionItem> {
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/memory/pending-revisions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "pending-revisions endpoint must return 200"
+    );
+    body_as_json(resp).await
+}
+
+#[tokio::test]
+async fn topic_match_protected_auto_sets_supersedes_and_surfaces_in_pending_revisions() {
+    let (router, _tmp, db) = common::test_app_no_gate().await;
+
+    // Seed the target memory via HTTP with explicit domain + memory_type.
+    // Using the same domain/type for both seed and capture means topic-match
+    // uses threshold_exact=0.70 rather than threshold_none=0.90 (semantic
+    // only). The TDD-vs-BDD content sits at ~0.77 cosine similarity, which
+    // falls above 0.70 but below 0.90 — exact-match threshold needed here.
+    let seed_resp = store_memory_via_http(
+        &router,
+        "I prefer TDD because it catches regressions early.",
+        "preference",
+        "engineering",
+    )
+    .await;
+    assert_eq!(
+        seed_resp.status(),
+        StatusCode::OK,
+        "seed store must succeed"
+    );
+    let seed: StoreMemoryResponse = body_as_json(seed_resp).await;
+    let protected_id = seed.source_id.clone();
+
+    // Mark as confirmed (= protected) so is_memory_protected returns true.
+    db.confirm_memory(&protected_id)
+        .await
+        .expect("confirm_memory must succeed");
+
+    // Store a contradicting capture via HTTP with matching domain + type.
+    let resp = store_memory_via_http(
+        &router,
+        "I prefer BDD over TDD because specs stay closer to requirements.",
+        "preference",
+        "engineering",
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "contradicting capture must succeed"
+    );
+    let store_resp: StoreMemoryResponse = body_as_json(resp).await;
+
+    // Verify triggered_revisions is populated in the store response.
+    assert_eq!(
+        store_resp.triggered_revisions,
+        vec![protected_id.clone()],
+        "triggered_revisions must contain the matched protected target id"
+    );
+
+    // Verify the new memory surfaces in list_pending_revisions (the bug: without
+    // auto-set of supersedes, list_pending_revisions filtered by
+    // `supersedes IS NOT NULL` and returned nothing).
+    let pending = list_pending_revisions(&router).await;
+    assert!(
+        !pending.is_empty(),
+        "pending revisions must be non-empty after topic-match-protected capture"
+    );
+    assert_eq!(
+        pending[0].target_source_id, protected_id,
+        "pending revision must reference the protected target"
+    );
+    assert_eq!(
+        pending[0].revision_source_id, store_resp.source_id,
+        "pending revision_source_id must match the newly stored memory"
+    );
+}
+
+#[tokio::test]
+async fn non_protected_topic_match_does_not_set_triggered_revisions() {
+    let (router, _tmp, _db) = common::test_app_no_gate().await;
+
+    // Seed a memory that is NOT protected (stability = 'new', not confirmed).
+    // No confirm call follows, so is_memory_protected returns false.
+    let seed_resp = store_memory_via_http(
+        &router,
+        "I prefer TDD because it catches regressions early.",
+        "preference",
+        "engineering",
+    )
+    .await;
+    assert_eq!(
+        seed_resp.status(),
+        StatusCode::OK,
+        "seed store must succeed"
+    );
+
+    let resp = store_memory_via_http(
+        &router,
+        "I prefer BDD over TDD because specs stay closer to requirements.",
+        "preference",
+        "engineering",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let store_resp: StoreMemoryResponse = body_as_json(resp).await;
+
+    // Non-protected match must NOT populate triggered_revisions.
+    assert!(
+        store_resp.triggered_revisions.is_empty(),
+        "triggered_revisions must be empty when matched memory is not protected"
+    );
+
+    // And pending-revisions must be empty too.
+    let pending = list_pending_revisions(&router).await;
+    assert!(
+        pending.is_empty(),
+        "no pending revisions expected for non-protected topic match"
+    );
+}

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -41,6 +41,13 @@ pub struct StoreMemoryResponse {
     /// fields as failure. Empty when the store completed fully sync.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub hint: String,
+    /// Source IDs of protected memories now flagged for human revision
+    /// because this capture's topic-match upsert fired against them. Empty
+    /// when no contradictions detected. Skills should surface these inline
+    /// to the user with accept/dismiss verbs (see `accept_revision` /
+    /// `dismiss_revision` MCP tools).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub triggered_revisions: Vec<String>,
 }
 
 fn default_extraction_method() -> String {
@@ -1003,6 +1010,7 @@ mod tests {
             extraction_method: "none".into(),
             enrichment: "not_needed".into(),
             hint: String::new(),
+            triggered_revisions: vec![],
         };
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"enrichment\":\"not_needed\""));
@@ -1013,6 +1021,48 @@ mod tests {
         let parsed: StoreMemoryResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.enrichment, "not_needed");
         assert_eq!(parsed.hint, "");
+    }
+
+    #[test]
+    fn store_memory_response_triggered_revisions_serializes_when_non_empty() {
+        let r = StoreMemoryResponse {
+            source_id: "mem_new".into(),
+            chunks_created: 1,
+            memory_type: "fact".into(),
+            entity_id: None,
+            quality: None,
+            warnings: vec![],
+            extraction_method: "none".into(),
+            enrichment: "not_needed".into(),
+            hint: String::new(),
+            triggered_revisions: vec!["mem_target_abc".to_string()],
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(
+            json.contains("\"triggered_revisions\":[\"mem_target_abc\"]"),
+            "triggered_revisions must appear in JSON when non-empty, got: {json}"
+        );
+    }
+
+    #[test]
+    fn store_memory_response_triggered_revisions_skips_when_empty() {
+        let r = StoreMemoryResponse {
+            source_id: "mem_new".into(),
+            chunks_created: 1,
+            memory_type: "fact".into(),
+            entity_id: None,
+            quality: None,
+            warnings: vec![],
+            extraction_method: "none".into(),
+            enrichment: "not_needed".into(),
+            hint: String::new(),
+            triggered_revisions: vec![],
+        };
+        let json = serde_json::to_string(&r).unwrap();
+        assert!(
+            !json.contains("triggered_revisions"),
+            "triggered_revisions must be absent from JSON when empty, got: {json}"
+        );
     }
 
     #[test]

--- a/plugin/skills/capture/SKILL.md
+++ b/plugin/skills/capture/SKILL.md
@@ -106,3 +106,26 @@ one.
 
 - End of session bulk store → use `/handoff` (multi-item batch).
 - Pulling memories back out → use `/recall`.
+
+## Post-capture contradiction signal
+
+After `capture` returns, check `response.triggered_revisions`. If empty, do nothing. The capture stored cleanly.
+
+If non-empty, render an inline block to the user:
+
+```
+Stored mem_new.
+
+This capture topic-matches a protected memory now flagged for revision:
+  - mem_target_abc
+
+Action: accept (replace original content) | dismiss (drop the revision) | leave (decide later)
+```
+
+Inline verb map:
+
+- accept: `accept_revision(target_source_id="mem_target_abc")`
+- dismiss: `dismiss_revision(target_source_id="mem_target_abc")`
+- leave: no call; surfaces again in next `/brief`
+
+This closes the async gap between trigger and surface. The user resolves contradictions in-flow without waiting for the next session.

--- a/plugin/skills/capture/SKILL.md
+++ b/plugin/skills/capture/SKILL.md
@@ -5,7 +5,7 @@ description: >
   when the user states a preference, makes a decision, corrects you, or
   shares a durable fact. Invoked as `/capture <content>`.
 argument-hint: "<content>"
-allowed-tools: ["mcp__plugin_origin_origin__capture", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__create_entity", "mcp__plugin_origin_origin__create_relation", "Bash"]
+allowed-tools: ["mcp__plugin_origin_origin__capture", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__create_entity", "mcp__plugin_origin_origin__create_relation", "mcp__plugin_origin_origin__accept_revision", "mcp__plugin_origin_origin__dismiss_revision", "Bash"]
 ---
 
 # /capture


### PR DESCRIPTION
## Summary

- **Bug fix (P0):** `memory_routes.rs::handle_store_memory` topic-match-against-protected branch sets `pending_revision = 1` on the new memory but never set `supersedes`. Query `list_pending_revisions` filters on `supersedes IS NOT NULL AND pending_revision = 1` (db.rs:11622), so the `/brief` pending-revisions surface (shipped in PR #107) was empty in production. Fixed: when `topic_match_protected_id.is_some()` and caller did not pass `supersedes`, auto-set `final_supersedes = Some(matched_protected_id)`.
- **UX feature:** `StoreMemoryResponse` gains `triggered_revisions: Vec<String>` containing target IDs flagged by this capture. The `/capture` skill body and MCP wrapper render an inline accept/dismiss block when non-empty. Closes async gap: contradiction surfaces in-flow, not at next `/brief`.
- `/capture` skill `allowed-tools` expanded to include `accept_revision` + `dismiss_revision` for inline invocation.

## Why two changes in one PR

The bug fix and UX feature are codependent: the inline signal carries the matched target ID, which only becomes a valid revision target once the supersedes auto-set lands.

## Test plan

- [x] Golden-bytes unit tests for `triggered_revisions` serialization (empty skipped, non-empty included).
- [x] Integration test: protected topic-match returns target_id + list_pending_revisions surfaces row.
- [x] MCP unit tests for `format_capture_success`.
- [x] cargo clippy + fmt clean.
- [x] Adversarial review (Opus) caught 1 CRITICAL + 2 IMPORTANT before merge; all resolved.

## Known follow-up

Gate-vs-topic-match ordering: novelty_threshold may reject contradicting captures before topic-match runs. Separate PR.

## Version bump

`fix:` → 0.6.3 → 0.6.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)