### PR TITLE
fix: handoff pending-captures preview + list_pending plumbing (Spec C-3b)

### DIFF
--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -154,6 +154,7 @@ impl OriginClient {
             memory_type,
             domain: None,
             limit: limit.unwrap_or(100),
+            confirmed: None,
         };
         let resp = self
             .http

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7573,6 +7573,7 @@ impl MemoryDB {
                 stability: None, // not fetched in list_indexed_files aggregate query
                 pinned: row.get::<i64>(12).unwrap_or(0) != 0,
                 created_at: 0, // not fetched in list_indexed_files aggregate query
+                content: String::new(), // not fetched in list_indexed_files aggregate query
             });
         }
         Ok(files)
@@ -8385,8 +8386,13 @@ impl MemoryDB {
                 params.push(1i64.into());
                 idx += 1;
             } else {
-                // NULL means "not yet confirmed" — include both explicit 0 and NULL
+                // NULL means "not yet confirmed" — include both explicit 0 and NULL.
+                // Also exclude archived supersedes and recap rows to match the
+                // same set returned by list_unconfirmed_memories.
                 conditions.push("(confirmed = 0 OR confirmed IS NULL)".to_string());
+                conditions
+                    .push("(supersede_mode IS NULL OR supersede_mode != 'archive')".to_string());
+                conditions.push("(is_recap IS NULL OR is_recap != 1)".to_string());
             }
         }
 
@@ -8409,7 +8415,8 @@ impl MemoryDB {
                     MAX(last_modified) as last_modified, MAX(summary) as summary,
                     MAX(memory_type), MAX(domain), MAX(source_agent),
                     MAX(CAST(confidence AS REAL)), MAX(confirmed), MAX(pinned),
-                    MAX(created_at) as created_at
+                    MAX(created_at) as created_at,
+                    MAX(content) as content
              FROM memories
              {}
              GROUP BY source_id
@@ -8442,6 +8449,10 @@ impl MemoryDB {
                 stability: None, // not fetched in list_filtered aggregate query
                 pinned: row.get::<i64>(12).unwrap_or(0) != 0,
                 created_at: row.get::<Option<i64>>(13).unwrap_or(None).unwrap_or(0),
+                content: row
+                    .get::<Option<String>>(14)
+                    .unwrap_or(None)
+                    .unwrap_or_default(),
             });
         }
 
@@ -19085,6 +19096,103 @@ pub(crate) mod tests {
         let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
         assert!(ids.contains(&"mem_unconf_a"), "missing mem_unconf_a");
         assert!(ids.contains(&"mem_unconf_b"), "missing mem_unconf_b");
+    }
+
+    #[tokio::test]
+    async fn test_list_filtered_confirmed_false_excludes_is_recap() {
+        let (db, _dir) = test_db().await;
+
+        // A normal unconfirmed memory — should appear.
+        insert_memory_with_confirmed(&db, "mem_normal", "normal unconfirmed content", 0, 1000)
+            .await;
+
+        // A recap row (is_recap=1, confirmed=0) — must NOT appear.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT OR REPLACE INTO memories \
+                 (id, source, source_id, title, content, chunk_index, chunk_type, word_count, \
+                  last_modified, confirmed, created_at, stability, supersede_mode, is_recap) \
+                 VALUES ('id_mem_recap', 'memory', 'mem_recap', 'recap-title', 'recap body', \
+                         0, 'text', 5, 2000, 0, 2000, 'new', 'hide', 1)",
+                (),
+            )
+            .await
+            .expect("insert recap failed");
+        }
+
+        let results = db
+            .list_filtered_confirmed(Some("memory"), None, None, Some(false), 100)
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(ids.contains(&"mem_normal"), "mem_normal must appear");
+        assert!(
+            !ids.contains(&"mem_recap"),
+            "mem_recap (is_recap=1) must be excluded"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_filtered_confirmed_false_excludes_archive_supersede_mode() {
+        let (db, _dir) = test_db().await;
+
+        // A normal unconfirmed memory — should appear.
+        insert_memory_with_confirmed(&db, "mem_normal2", "normal unconfirmed content 2", 0, 1000)
+            .await;
+
+        // An archived row (supersede_mode='archive', confirmed=0) — must NOT appear.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT OR REPLACE INTO memories \
+                 (id, source, source_id, title, content, chunk_index, chunk_type, word_count, \
+                  last_modified, confirmed, created_at, stability, supersede_mode) \
+                 VALUES ('id_mem_arch', 'memory', 'mem_arch', 'arch-title', 'arch body', \
+                         0, 'text', 5, 2000, 0, 2000, 'new', 'archive')",
+                (),
+            )
+            .await
+            .expect("insert archive failed");
+        }
+
+        let results = db
+            .list_filtered_confirmed(Some("memory"), None, None, Some(false), 100)
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(ids.contains(&"mem_normal2"), "mem_normal2 must appear");
+        assert!(
+            !ids.contains(&"mem_arch"),
+            "mem_arch (supersede_mode=archive) must be excluded"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_filtered_confirmed_false_content_populated() {
+        let (db, _dir) = test_db().await;
+
+        insert_memory_with_confirmed(
+            &db,
+            "mem_content_test",
+            "unconfirmed content about sprockets",
+            0,
+            1000,
+        )
+        .await;
+
+        let results = db
+            .list_filtered_confirmed(Some("memory"), None, None, Some(false), 100)
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].content, "unconfirmed content about sprockets",
+            "content field must be populated"
+        );
     }
 
     #[tokio::test]

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7572,6 +7572,7 @@ impl MemoryDB {
                 confirmed: row.get::<Option<i64>>(11).unwrap_or(None).map(|v| v != 0),
                 stability: None, // not fetched in list_indexed_files aggregate query
                 pinned: row.get::<i64>(12).unwrap_or(0) != 0,
+                created_at: 0, // not fetched in list_indexed_files aggregate query
             });
         }
         Ok(files)
@@ -8344,6 +8345,19 @@ impl MemoryDB {
         domain: Option<&str>,
         limit: usize,
     ) -> Result<Vec<IndexedFileInfo>, OriginError> {
+        self.list_filtered_confirmed(source, memory_type, domain, None, limit)
+            .await
+    }
+
+    /// Like `list_filtered` but with an optional `confirmed` predicate.
+    pub async fn list_filtered_confirmed(
+        &self,
+        source: Option<&str>,
+        memory_type: Option<&str>,
+        domain: Option<&str>,
+        confirmed: Option<bool>,
+        limit: usize,
+    ) -> Result<Vec<IndexedFileInfo>, OriginError> {
         let conn = self.conn.lock().await;
 
         let mut conditions = Vec::new();
@@ -8365,6 +8379,16 @@ impl MemoryDB {
             params.push(d.to_string().into());
             idx += 1;
         }
+        if let Some(c) = confirmed {
+            if c {
+                conditions.push(format!("confirmed = ?{}", idx));
+                params.push(1i64.into());
+                idx += 1;
+            } else {
+                // NULL means "not yet confirmed" — include both explicit 0 and NULL
+                conditions.push("(confirmed = 0 OR confirmed IS NULL)".to_string());
+            }
+        }
 
         // Exclude superseded memories and pending revisions
         conditions.push("pending_revision = 0".to_string());
@@ -8384,7 +8408,8 @@ impl MemoryDB {
                     MAX(url) as url, COUNT(*) as chunk_count,
                     MAX(last_modified) as last_modified, MAX(summary) as summary,
                     MAX(memory_type), MAX(domain), MAX(source_agent),
-                    MAX(CAST(confidence AS REAL)), MAX(confirmed), MAX(pinned)
+                    MAX(CAST(confidence AS REAL)), MAX(confirmed), MAX(pinned),
+                    MAX(created_at) as created_at
              FROM memories
              {}
              GROUP BY source_id
@@ -8416,6 +8441,7 @@ impl MemoryDB {
                 confirmed: row.get::<Option<i64>>(11).unwrap_or(None).map(|v| v != 0),
                 stability: None, // not fetched in list_filtered aggregate query
                 pinned: row.get::<i64>(12).unwrap_or(0) != 0,
+                created_at: row.get::<Option<i64>>(13).unwrap_or(None).unwrap_or(0),
             });
         }
 
@@ -18983,6 +19009,83 @@ pub(crate) mod tests {
     }
 
     // ==================== list_filtered ====================
+
+    /// Insert a memory with an explicit `confirmed` value (0 or 1) and a given `created_at`.
+    async fn insert_memory_with_confirmed(
+        db: &MemoryDB,
+        source_id: &str,
+        content: &str,
+        confirmed: i64,
+        created_at: i64,
+    ) {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT OR REPLACE INTO memories \
+             (id, source, source_id, title, content, chunk_index, chunk_type, word_count, \
+              last_modified, confirmed, created_at, stability, supersede_mode) \
+             VALUES (?1, 'memory', ?2, ?3, ?4, 0, 'text', 10, ?5, ?6, ?7, 'new', 'hide')",
+            libsql::params![
+                format!("id_{}", source_id),
+                source_id,
+                format!("title-{}", source_id),
+                content,
+                created_at,
+                confirmed,
+                created_at
+            ],
+        )
+        .await
+        .expect("insert_memory_with_confirmed failed");
+    }
+
+    #[tokio::test]
+    async fn test_list_filtered_confirmed_false_filters_unconfirmed() {
+        let (db, _dir) = test_db().await;
+
+        // Seed: one confirmed, two unconfirmed
+        insert_memory_with_confirmed(&db, "mem_conf", "confirmed content about widgets", 1, 1000)
+            .await;
+        insert_memory_with_confirmed(
+            &db,
+            "mem_unconf_a",
+            "unconfirmed content about sprockets",
+            0,
+            2000,
+        )
+        .await;
+        insert_memory_with_confirmed(
+            &db,
+            "mem_unconf_b",
+            "unconfirmed content about gears",
+            0,
+            3000,
+        )
+        .await;
+
+        let results = db
+            .list_filtered_confirmed(Some("memory"), None, None, Some(false), 100)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            results.len(),
+            2,
+            "expected 2 unconfirmed rows, got {:?}",
+            results.iter().map(|r| &r.source_id).collect::<Vec<_>>()
+        );
+        assert!(
+            results.iter().all(|r| r.confirmed == Some(false)),
+            "all results must be unconfirmed"
+        );
+        // created_at must be populated (non-zero)
+        assert!(
+            results.iter().all(|r| r.created_at > 0),
+            "created_at must be populated"
+        );
+        let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(ids.contains(&"mem_unconf_a"), "missing mem_unconf_a");
+        assert!(ids.contains(&"mem_unconf_b"), "missing mem_unconf_b");
+    }
 
     #[tokio::test]
     async fn test_list_filtered_by_source() {

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -847,12 +847,18 @@ impl OriginMcpServer {
         params: ListPendingParams,
     ) -> Result<CallToolResult, McpError> {
         let limit = params.limit.unwrap_or(20).min(100);
-        let path = format!("/api/memory/list?confirmed=false&limit={}", limit);
-        let value: serde_json::Value = match self.client.get(&path).await {
-            Ok(v) => v,
+        let req = ListMemoriesRequest {
+            memory_type: None,
+            domain: None,
+            confirmed: Some(false),
+            limit,
+        };
+        let resp: ListMemoriesResponse = match self.client.post("/api/memory/list", &req).await {
+            Ok(r) => r,
             Err(e) => return Ok(tool_error(e, "list_pending")),
         };
-        let body = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+        let body = serde_json::to_string_pretty(&resp.memories)
+            .unwrap_or_else(|e| format!("serialization error: {e}"));
         Ok(CallToolResult::success(vec![Content::text(body)]))
     }
 
@@ -1184,6 +1190,7 @@ impl OriginMcpServer {
             memory_type: params.memory_type,
             domain: params.domain,
             limit: params.limit.unwrap_or(100),
+            confirmed: None,
         };
         let resp: ListMemoriesResponse = match self.client.post("/api/memory/list", &req).await {
             Ok(r) => r,
@@ -3779,6 +3786,7 @@ mod tests {
             memory_type: params.memory_type,
             domain: params.domain,
             limit: params.limit.unwrap_or(100),
+            confirmed: None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["memory_type"], "fact");
@@ -3797,6 +3805,7 @@ mod tests {
             memory_type: params.memory_type,
             domain: params.domain,
             limit: params.limit.unwrap_or(100),
+            confirmed: None,
         };
         assert_eq!(req.limit, 100);
     }

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -2065,6 +2065,7 @@ async fn t_list_pending_uses_post_with_confirmed_false() {
             stability: None,
             pinned: false,
             created_at: 1_000_000,
+            content: String::new(),
         }],
     };
 

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -10,12 +10,14 @@
 
 use origin_mcp::client::OriginClient;
 use origin_mcp::tools::{
-    CaptureParams, ContextParams, ListNurtureParams, OriginMcpServer, RecallParams, TransportMode,
+    CaptureParams, ContextParams, ListNurtureParams, ListPendingParams, OriginMcpServer,
+    RecallParams, TransportMode,
 };
-use origin_types::memory::{MemoryItem, SearchResult};
+use origin_types::memory::{IndexedFileInfo, MemoryItem, SearchResult};
 use origin_types::responses::{
-    ChatContextResponse, DeleteResponse, KnowledgeContext, NurtureCardsResponse, ProfileContext,
-    SearchMemoryResponse, StoreMemoryResponse, TierTokenEstimates,
+    ChatContextResponse, DeleteResponse, KnowledgeContext, ListMemoriesResponse,
+    NurtureCardsResponse, ProfileContext, SearchMemoryResponse, StoreMemoryResponse,
+    TierTokenEstimates,
 };
 use rmcp::model::{CallToolResult, RawContent};
 use wiremock::matchers::{method, path};
@@ -2038,5 +2040,57 @@ async fn dismiss_contradiction_forwards_x_agent_name() {
         value.to_str().expect("header value is valid utf-8"),
         "test-agent",
         "x-agent-name header must equal configured agent name"
+    );
+}
+
+#[tokio::test]
+async fn t_list_pending_uses_post_with_confirmed_false() {
+    let (mock, client) = setup().await;
+
+    let response = ListMemoriesResponse {
+        memories: vec![IndexedFileInfo {
+            source_id: "mem_pending1".into(),
+            title: "Pending capture".into(),
+            source: "memory".into(),
+            url: None,
+            chunk_count: 1,
+            last_modified: 1_000_000,
+            summary: None,
+            processing: false,
+            memory_type: Some("fact".into()),
+            domain: None,
+            source_agent: Some("claude-code".into()),
+            confidence: None,
+            confirmed: Some(false),
+            stability: None,
+            pinned: false,
+            created_at: 1_000_000,
+        }],
+    };
+
+    Mock::given(method("POST"))
+        .and(path("/api/memory/list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response))
+        .mount(&mock)
+        .await;
+
+    let server = make_server(client);
+    let result = server
+        .list_pending_impl(ListPendingParams { limit: Some(10) })
+        .await
+        .expect("list_pending_impl failed");
+
+    let text = text_of(&result);
+    assert!(
+        text.contains("mem_pending1"),
+        "expected source_id in output; got: {text}"
+    );
+
+    // Verify the request used POST with confirmed=false in the body
+    let body = captured_body(&mock).await;
+    assert_eq!(
+        body["confirmed"],
+        serde_json::json!(false),
+        "list_pending must send confirmed=false in POST body; got: {body}"
     );
 }

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1060,7 +1060,7 @@ pub async fn handle_confirm_memory(
     Ok(Json(ConfirmResponse { confirmed }))
 }
 
-/// GET /api/memory/list
+/// POST /api/memory/list
 pub async fn handle_list_memories(
     State(state): State<Arc<RwLock<ServerState>>>,
     Json(req): Json<ListMemoriesRequest>,
@@ -1068,10 +1068,11 @@ pub async fn handle_list_memories(
     let s = state.read().await;
     let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
     let memories = db
-        .list_filtered(
+        .list_filtered_confirmed(
             Some("memory"),
             req.memory_type.as_deref(),
             req.domain.as_deref(),
+            req.confirmed,
             req.limit,
         )
         .await

--- a/crates/origin-server/tests/route_convergence.rs
+++ b/crates/origin-server/tests/route_convergence.rs
@@ -319,3 +319,69 @@ async fn page_revisions_known_page_returns_envelope() {
         "fresh page should have empty changelog entries: {body}"
     );
 }
+
+// ── POST /api/memory/list with confirmed filter ──────────────────────────────
+
+#[tokio::test]
+async fn list_memories_confirmed_false_filters_unconfirmed() {
+    use origin_core::sources::RawDocument;
+
+    let (app, db, _dir) = test_app_with_db().await;
+
+    // Insert one confirmed and one unconfirmed memory directly via DB.
+    let doc_confirmed = RawDocument {
+        source: "memory".to_string(),
+        source_id: "mem_conf_001".to_string(),
+        title: "Confirmed memory".to_string(),
+        content: "Some confirmed content about widgets.".to_string(),
+        last_modified: 1_000_000,
+        ..Default::default()
+    };
+    let doc_unconfirmed = RawDocument {
+        source: "memory".to_string(),
+        source_id: "mem_unconf_001".to_string(),
+        title: "Unconfirmed memory".to_string(),
+        content: "Some unconfirmed content about gears.".to_string(),
+        last_modified: 2_000_000,
+        ..Default::default()
+    };
+    db.upsert_documents(vec![doc_confirmed, doc_unconfirmed])
+        .await
+        .unwrap();
+    // Flip the confirmed memory to confirmed=true via the public API
+    db.confirm_memory("mem_conf_001").await.unwrap();
+
+    // POST /api/memory/list with confirmed=false
+    let (status, body) = json_post(
+        &app,
+        "/api/memory/list",
+        None,
+        serde_json::json!({"confirmed": false, "limit": 50}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let memories = body["memories"].as_array().expect("memories array");
+    let ids: Vec<&str> = memories
+        .iter()
+        .filter_map(|m| m["source_id"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&"mem_unconf_001"),
+        "unconfirmed memory must appear; got: {ids:?}"
+    );
+    assert!(
+        !ids.contains(&"mem_conf_001"),
+        "confirmed memory must not appear; got: {ids:?}"
+    );
+
+    // created_at must be present and non-null
+    let unconf = memories
+        .iter()
+        .find(|m| m["source_id"].as_str() == Some("mem_unconf_001"))
+        .expect("unconfirmed memory in response");
+    assert!(
+        unconf["created_at"].is_number(),
+        "created_at must be a number; got: {unconf}"
+    );
+}

--- a/crates/origin-types/src/memory.rs
+++ b/crates/origin-types/src/memory.rs
@@ -196,6 +196,11 @@ pub struct IndexedFileInfo {
     /// Defaults to 0 for rows from before migration 21.
     #[serde(default)]
     pub created_at: i64,
+    /// The full memory content. Populated by `list_filtered_confirmed` for
+    /// unconfirmed-review surfaces. Empty string when the producer did not
+    /// include it (e.g. aggregate file-list queries).
+    #[serde(default)]
+    pub content: String,
 }
 
 /// Home dashboard statistics.
@@ -447,6 +452,7 @@ mod indexed_file_info_created_at_test {
             stability: None,
             pinned: false,
             created_at,
+            content: String::new(),
         }
     }
 
@@ -465,6 +471,25 @@ mod indexed_file_info_created_at_test {
             "confidence":null,"confirmed":null,"stability":null,"pinned":false}"#;
         let info: IndexedFileInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.created_at, 0);
+    }
+
+    #[test]
+    fn content_round_trips() {
+        let mut info = make_info(9999);
+        info.content = "memory body".to_string();
+        let json = serde_json::to_string(&info).unwrap();
+        let back: IndexedFileInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.content, "memory body");
+    }
+
+    #[test]
+    fn content_defaults_to_empty_when_missing() {
+        let json = r#"{"source_id":"x","title":"T","source":"memory","url":null,
+            "chunk_count":1,"last_modified":1000,"processing":false,
+            "memory_type":null,"domain":null,"source_agent":null,
+            "confidence":null,"confirmed":null,"stability":null,"pinned":false}"#;
+        let info: IndexedFileInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.content, "");
     }
 }
 

--- a/crates/origin-types/src/memory.rs
+++ b/crates/origin-types/src/memory.rs
@@ -191,6 +191,11 @@ pub struct IndexedFileInfo {
     pub confirmed: Option<bool>,
     pub stability: Option<String>,
     pub pinned: bool,
+    /// Unix timestamp (seconds) when the memory was first created.
+    /// Populated from the `memories.created_at` column (migration 21).
+    /// Defaults to 0 for rows from before migration 21.
+    #[serde(default)]
+    pub created_at: i64,
 }
 
 /// Home dashboard statistics.
@@ -418,6 +423,49 @@ pub struct RecentActivityItem {
     pub snippet: Option<String>,
     pub timestamp_ms: u64,
     pub badge: ActivityBadge,
+}
+
+#[cfg(test)]
+mod indexed_file_info_created_at_test {
+    use super::*;
+
+    fn make_info(created_at: i64) -> IndexedFileInfo {
+        IndexedFileInfo {
+            source_id: "mem_abc".into(),
+            title: "Title".into(),
+            source: "memory".into(),
+            url: None,
+            chunk_count: 1,
+            last_modified: 1000,
+            summary: None,
+            processing: false,
+            memory_type: None,
+            domain: None,
+            source_agent: None,
+            confidence: None,
+            confirmed: None,
+            stability: None,
+            pinned: false,
+            created_at,
+        }
+    }
+
+    #[test]
+    fn created_at_serializes_in_json() {
+        let info = make_info(1234);
+        let s = serde_json::to_string(&info).unwrap();
+        assert!(s.contains("\"created_at\":1234"), "got: {s}");
+    }
+
+    #[test]
+    fn created_at_defaults_to_zero_when_missing() {
+        let json = r#"{"source_id":"x","title":"T","source":"memory","url":null,
+            "chunk_count":1,"last_modified":1000,"processing":false,
+            "memory_type":null,"domain":null,"source_agent":null,
+            "confidence":null,"confirmed":null,"stability":null,"pinned":false}"#;
+        let info: IndexedFileInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.created_at, 0);
+    }
 }
 
 #[cfg(test)]

--- a/crates/origin-types/src/requests.rs
+++ b/crates/origin-types/src/requests.rs
@@ -54,6 +54,8 @@ pub struct ListMemoriesRequest {
     pub domain: Option<String>,
     #[serde(default = "default_list_limit")]
     pub limit: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub confirmed: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -526,5 +528,34 @@ mod search_pages_page_type_test {
         let json = r#"{"query":"foo","limit":10}"#;
         let parsed: SearchPagesRequest = serde_json::from_str(json).unwrap();
         assert!(parsed.page_type.is_none());
+    }
+}
+
+#[cfg(test)]
+mod list_memories_confirmed_test {
+    use super::*;
+
+    #[test]
+    fn confirmed_false_serializes_to_json() {
+        let req = ListMemoriesRequest {
+            memory_type: None,
+            domain: None,
+            limit: 20,
+            confirmed: Some(false),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"confirmed\":false"), "got: {s}");
+    }
+
+    #[test]
+    fn confirmed_none_skips_serialization() {
+        let req = ListMemoriesRequest {
+            memory_type: None,
+            domain: None,
+            limit: 20,
+            confirmed: None,
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(!s.contains("confirmed"), "got: {s}");
     }
 }

--- a/plugin/skills/handoff/SKILL.md
+++ b/plugin/skills/handoff/SKILL.md
@@ -43,9 +43,19 @@ list_pending(limit=50)
 ```
 
 The MCP returns memory rows with `source_id`, `content`, `created_at`, and
-other metadata. Client-side filter to rows where `created_at >= <lastHandoff>`
-(both as Unix seconds). These are captures this session produced that the
-quality gate left unconfirmed (untrusted-source captures).
+other metadata. Convert `lastHandoff` (ISO-8601 string, e.g.
+`2026-05-13T22:50:00Z`) to a Unix epoch seconds integer before filtering:
+
+```
+Bash: date -j -f %Y-%m-%dT%H:%M:%SZ "$lastHandoff" +%s
+```
+
+Or in your scripting language of choice (Python's `datetime.fromisoformat`,
+JavaScript's `Date.parse`, etc.). Save the result as `lastHandoffEpoch`.
+
+Then filter the response rows: keep where `row.created_at >= lastHandoffEpoch`.
+These are captures this session produced that the quality gate left unconfirmed
+(untrusted-source captures).
 
 If the filtered list is empty, say nothing. Proceed to Step 2.
 

--- a/plugin/skills/handoff/SKILL.md
+++ b/plugin/skills/handoff/SKILL.md
@@ -3,8 +3,9 @@ name: handoff
 description: >
   End-of-session ritual. Captures decisions, lessons, gotchas, and open
   threads. Writes a narrative session log to ~/.origin/sessions/ and stores
-  granular memories via Origin MCP. Invoked as `/handoff`.
-allowed-tools: ["Bash", "mcp__plugin_origin_origin__capture"]
+  granular memories via Origin MCP. Previews any unconfirmed captures from
+  the current session before closing. Invoked as `/handoff`.
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__capture", "mcp__plugin_origin_origin__list_pending"]
 ---
 
 # /handoff
@@ -32,6 +33,36 @@ Bash: cd_repo=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); echo "${cd
 
 Read `~/.origin/sessions/_status/handoff-<project>.json` for `lastHandoff`
 timestamp (ISO-8601). If file missing, default to "12 hours ago".
+
+### 1.5 Pending-captures preview
+
+After establishing `<lastHandoff>`, call:
+
+```
+list_pending(limit=50)
+```
+
+The MCP returns memory rows with `source_id`, `content`, `created_at`, and
+other metadata. Client-side filter to rows where `created_at >= <lastHandoff>`
+(both as Unix seconds). These are captures this session produced that the
+quality gate left unconfirmed (untrusted-source captures).
+
+If the filtered list is empty, say nothing. Proceed to Step 2.
+
+If non-empty, render a preview block once, before the existing capture flow:
+
+```
+Pending captures this session (<N> total, top 3 shown):
+
+1. mem_xyz789  "..."  (untrusted source: <agent>)
+2. ...
+
+Default: proceed (captures stay pending). Opt in by running
+`/review captures` before re-invoking /handoff if you want to walk them.
+```
+
+Do NOT prompt for per-item action inline. The user proceeds with /handoff
+regardless; the preview is informational only.
 
 ### 2. Gather session context (parallel, only if git repo)
 


### PR DESCRIPTION
## Summary

Closes the Spec C-3b ticket. Three Rust plumbing fixes unblock the `/handoff` pending-captures preview shipped in the same PR.

### Rust plumbing fixes

- `ListMemoriesRequest` gains `confirmed: Option<bool>` (`crates/origin-types/src/requests.rs`).
- `IndexedFileInfo` gains `content: String` + `created_at: i64` (`crates/origin-types/src/memory.rs`). Both default-serde-safe additive fields.
- `db.list_filtered` extended via `list_filtered_confirmed`: filters on `confirmed` and populates `created_at` + `content`. For `confirmed=Some(false)` branch, matches `list_unconfirmed_memories` semantics exactly: excludes `is_recap=1` and `supersede_mode='archive'` rows (single source of truth for "unconfirmed for review").
- `list_pending` MCP wrapper switches from broken `GET /api/memory/list?confirmed=false&limit=N` to `POST /api/memory/list` with typed `ListMemoriesRequest` body.

### Skill update

`/handoff` SKILL.md gains a new section 1.5 "Pending-captures preview" between Step 1 and Step 2. Surfaces session-scoped (`created_at >= lastHandoffEpoch`) unconfirmed captures with proceed-default semantics (no per-item prompt). Top-3 cap with a link to `/review captures` for full walk. Silent if zero.

The skill body explicitly instructs the agent to convert `lastHandoff` (ISO-8601) to Unix epoch seconds before comparing to integer `created_at`. Otherwise the comparison is silent garbage.

## Test plan

- [x] `cargo build --workspace`: clean.
- [x] `cargo test -p origin-types --lib`: 54 passed (new `content_round_trips`, `content_defaults_to_empty_when_missing` + existing).
- [x] `cargo test -p origin-core --lib -- --test-threads=1`: 1100 passed (3 new: `test_list_filtered_confirmed_false_excludes_is_recap`, `..._excludes_archive_supersede_mode`, `..._content_populated`).
- [x] `cargo test -p origin-server`: integration test seeding confirmed+unconfirmed memories asserts POST filter works end-to-end.
- [x] `cargo test -p origin-mcp`: 55 passed (new wiremock for POST path with `confirmed=false` body).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --all --check`: clean.
- [x] Adversarial review (Opus) caught 2 CRITICAL + 1 IMPORTANT (missing content field, missing ISO-to-epoch conversion, divergent SQL predicates) — all resolved before merge.

## Version bump

`fix:` → 0.6.7 → 0.6.8 (release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)