### PR TITLE
docs(agents): update required-check name to conclusion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ cat .release-please-manifest.json
 
 ### Branch protection
 
-Main branch has: required CI ("Test & Lint") before merge, no force pushes, no deletion. `enforce_admins: false` so the repo owner can push directly for hotfixes. Force push requires temporarily enabling it via API (remember to re-disable after).
+Main branch has: required CI (`conclusion` — aggregate gate over `fmt` + `lint` + `test`, rust-lang convention from cargo / rustup / rust-analyzer) before merge, no force pushes, no deletion. `enforce_admins: false` so the repo owner can push directly for hotfixes. Force push requires temporarily enabling it via API (remember to re-disable after).
 
 ### Git hooks (auto-activated)
 


### PR DESCRIPTION
## Summary

Follow-up to PR #117. Branch-protection section in `AGENTS.md` referenced `Test & Lint`, which was renamed to `conclusion` in PR #117 (rust-lang aggregate-gate convention).

Branch-protection rule on `main` was already updated via gh api during the PR #117 merge:

```
required_status_checks.contexts: ["conclusion"]
```

This PR just syncs the doc string. No code change.

## Test plan

- [ ] CI green (`conclusion` job)
- [ ] No code paths touched
- [ ] Grep `Test & Lint` -> zero hits in repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)