### PR TITLE
docs(agents): update pages.rs note for migration 46 schema rename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ All business logic lives here. No tauri, no axum. Framework-agnostic.
 | `llm_classifier.rs` | Higher-level classification orchestration |
 | `refinery.rs` | Background refinement queue — dedup, auto-linking, consolidation |
 | `post_ingest.rs` | Post-ingest enrichment (dedup check, entity linking, title enrich, recap, page growth) |
-| `pages.rs` | Type definitions for the `Page` struct (synthesized wiki entries distilled from memory clusters). Actual clustering + distillation live in `db.rs` + `refinery.rs`. SQL tables remain `concepts`/`concept_sources` historically. |
+| `pages.rs` | Type definitions for the `Page` struct (synthesized wiki entries distilled from memory clusters). Actual clustering + distillation live in `db.rs` + `refinery.rs`. SQL tables are `pages`/`page_sources` (renamed from `concepts`/`concept_sources` in migration 46). |
 | `spaces.rs` | Spaces / tag store |
 | `narrative.rs` | Profile narrative assembly (editorial prose) |
 | `briefing.rs` | Daily briefing assembly |


### PR DESCRIPTION
## Summary

- AGENTS.md `pages.rs` table-description note said "SQL tables remain `concepts`/`concept_sources` historically". Migration 46 renamed both tables (`db.rs:4248-4392`); the note is now wrong.
- One-line fix to reflect current schema.

## Files touched

- `AGENTS.md` (+1 / -1, line 253).

## Test plan

- [ ] CI green (no-bump `docs:` prefix)
- [ ] Grep no longer flags AGENTS.md as stale: `git grep "concept_sources"` returns only legacy migration-history references in `db.rs` (expected — old migration code retained for replay) + CHANGELOG entries (historical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)