### PR TITLE
fix: soft-archive supersede_relation via activity payload

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -8905,27 +8905,59 @@ impl MemoryDB {
         }
     }
 
-    /// Hard-delete the losing relation. Idempotent: DELETE on missing row is a no-op.
-    /// `winner_id` is accepted for activity-log payload at the capability fn layer;
-    /// existence not verified here (allows recovery if winner was also deleted out-of-band).
+    /// Hard-delete the losing relation and return a JSON snapshot of the row
+    /// for the caller to record in activity-log payload (soft-archive via log,
+    /// not via schema column). `Ok(None)` when loser_id does not exist.
+    /// `winner_id` is accepted for activity-log payload at the capability fn
+    /// layer; existence not verified here.
     pub async fn supersede_relation(
         &self,
         loser_id: &str,
         winner_id: &str,
-    ) -> Result<(), OriginError> {
+    ) -> Result<Option<serde_json::Value>, OriginError> {
         if loser_id == winner_id {
             return Err(OriginError::Validation(
                 "supersede_relation: loser and winner are the same id".into(),
             ));
         }
         let conn = self.conn.lock().await;
+
+        let mut rows = conn
+            .query(
+                "SELECT id, from_entity, to_entity, relation_type, source_agent, \
+                        confidence, explanation, source_memory_id, created_at \
+                 FROM relations WHERE id = ?1",
+                libsql::params![loser_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("supersede_relation select: {e}")))?;
+
+        let snapshot = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("supersede_relation row: {e}")))?
+            .map(|row| {
+                serde_json::json!({
+                    "id":               row.get::<String>(0).ok(),
+                    "from_entity":      row.get::<String>(1).ok(),
+                    "to_entity":        row.get::<String>(2).ok(),
+                    "relation_type":    row.get::<String>(3).ok(),
+                    "source_agent":     row.get::<String>(4).ok(),
+                    "confidence":       row.get::<f64>(5).ok(),
+                    "explanation":      row.get::<String>(6).ok(),
+                    "source_memory_id": row.get::<String>(7).ok(),
+                    "created_at":       row.get::<i64>(8).ok(),
+                })
+            });
+        drop(rows);
+
         conn.execute(
             "DELETE FROM relations WHERE id = ?1",
             libsql::params![loser_id],
         )
         .await
         .map_err(|e| OriginError::VectorDb(format!("supersede_relation: {e}")))?;
-        Ok(())
+        Ok(snapshot)
     }
 
     /// Set `pending_revision = 1` on all chunks matching `source_id`. Idempotent
@@ -28823,6 +28855,61 @@ pub(crate) mod tests {
             matches!(err, crate::error::OriginError::Validation(_)),
             "expected Validation, got {err:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn supersede_relation_returns_snapshot_of_loser() {
+        let (db, _tmp) = test_db().await;
+        let from = db.create_entity("Alice", "person", None).await.unwrap();
+        let to = db.create_entity("Carol", "person", None).await.unwrap();
+        let loser = db
+            .create_relation(
+                &from,
+                &to,
+                "knows",
+                Some("test-agent"),
+                Some(0.5),
+                Some("met at conference"),
+                Some("mem_abc"),
+            )
+            .await
+            .unwrap();
+        let winner = db
+            .create_relation(&from, &to, "manages", None, Some(0.9), None, None)
+            .await
+            .unwrap();
+
+        let snapshot = db
+            .supersede_relation(&loser, &winner)
+            .await
+            .unwrap()
+            .expect("snapshot present when loser existed");
+
+        assert_eq!(snapshot["id"], serde_json::json!(loser));
+        assert_eq!(snapshot["from_entity"], serde_json::json!(from));
+        assert_eq!(snapshot["to_entity"], serde_json::json!(to));
+        assert_eq!(snapshot["relation_type"], serde_json::json!("knows"));
+        assert_eq!(snapshot["source_agent"], serde_json::json!("test-agent"));
+        assert_eq!(snapshot["confidence"], serde_json::json!(0.5));
+        assert_eq!(
+            snapshot["explanation"],
+            serde_json::json!("met at conference")
+        );
+        assert_eq!(snapshot["source_memory_id"], serde_json::json!("mem_abc"));
+        assert!(
+            snapshot["created_at"].is_i64(),
+            "created_at should be present"
+        );
+    }
+
+    #[tokio::test]
+    async fn supersede_relation_returns_none_when_loser_missing() {
+        let (db, _tmp) = test_db().await;
+        let snapshot = db
+            .supersede_relation("rel_nonexistent", "rel_winner")
+            .await
+            .unwrap();
+        assert!(snapshot.is_none(), "no snapshot when loser did not exist");
     }
 
     // ==================== flag_memory_for_revision ====================

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -262,7 +262,7 @@ pub async fn create_relation(
         for (existing_id, existing_type) in &existing {
             if existing_id != &id && existing_type != rt {
                 match db.supersede_relation(existing_id, &id).await {
-                    Ok(()) => {
+                    Ok(archived) => {
                         warnings.push(format!(
                             "auto-superseded existing relation ({}-{}-{}); newer relation now active",
                             req.from_entity, existing_type, req.to_entity
@@ -274,6 +274,7 @@ pub async fn create_relation(
                             "to": req.to_entity,
                             "old_type": existing_type,
                             "new_type": rt,
+                            "archived": archived,
                         })
                         .to_string();
                         if let Err(e) = db
@@ -1048,6 +1049,66 @@ mod tests {
         assert!(
             !pending.iter().any(|p| p.action == "relation_conflict"),
             "no relation_conflict proposal should be queued"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_relation_conflict_payload_contains_archived_snapshot() {
+        let (db, _dir) = test_db().await;
+        let alice = db
+            .store_entity("Alice", "person", None, Some("test"), None)
+            .await
+            .unwrap();
+        let bob = db
+            .store_entity("Bob", "person", None, Some("test"), None)
+            .await
+            .unwrap();
+
+        // Existing relation carries full metadata that hard-delete would lose.
+        let req_knows = CreateRelationRequest {
+            from_entity: alice.clone(),
+            to_entity: bob.clone(),
+            relation_type: "knows".to_string(),
+            source_agent: Some("test".to_string()),
+            confidence: Some(0.72),
+            explanation: Some("met at offsite".to_string()),
+            source_memory_id: Some("mem_seed".to_string()),
+        };
+        let knows_id = create_relation(&db, req_knows, "test-agent")
+            .await
+            .unwrap()
+            .id;
+
+        // Conflicting different-type relation triggers auto-supersede.
+        let req_likes = CreateRelationRequest {
+            from_entity: alice.clone(),
+            to_entity: bob.clone(),
+            relation_type: "likes".to_string(),
+            source_agent: Some("test".to_string()),
+            confidence: None,
+            explanation: None,
+            source_memory_id: None,
+        };
+        create_relation(&db, req_likes, "test-agent").await.unwrap();
+
+        let activity = db.list_agent_activity(50, None, None).await.unwrap();
+        let entry = activity
+            .iter()
+            .find(|a| a.action == "relation_supersede_auto")
+            .expect("relation_supersede_auto activity entry");
+
+        let detail = entry.detail.as_ref().expect("payload detail present");
+        let payload: serde_json::Value = serde_json::from_str(detail).expect("payload is JSON");
+        let archived = &payload["archived"];
+        assert_eq!(archived["id"], serde_json::json!(knows_id));
+        assert_eq!(archived["relation_type"], serde_json::json!("knows"));
+        assert_eq!(archived["confidence"], serde_json::json!(0.72));
+        assert_eq!(archived["explanation"], serde_json::json!("met at offsite"));
+        assert_eq!(archived["source_memory_id"], serde_json::json!("mem_seed"));
+        assert_eq!(archived["source_agent"], serde_json::json!("test"));
+        assert!(
+            archived["created_at"].is_i64(),
+            "archived created_at present"
         );
     }
 


### PR DESCRIPTION
## Summary
- `supersede_relation` returns `Option<Value>` snapshot of the deleted row (id, from_entity, to_entity, relation_type, source_agent, confidence, explanation, source_memory_id, created_at) before hard-delete.
- `post_write::create_relation` auto-supersede caller merges snapshot into `relation_supersede_auto` activity payload as `archived` field.
- PR #111 follow-up. Recovers confidence / explanation / source_memory_id from the activity log instead of losing them on hard-delete. No schema change.

## Test plan
- [x] `cargo test -p origin-core --lib supersede_relation` — 5/5 pass (incl. 2 new: snapshot contents, none-when-missing).
- [x] `cargo test -p origin-core --lib post_write` — 38/38 pass (incl. 1 new: payload contains archived snapshot).
- [x] `cargo test -p origin-core --lib` — 1103/1103 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)