### PR TITLE
fix(skills): /brief reads status file first + /review drops stale C-3b note

### DIFF
--- a/plugin/skills/brief/SKILL.md
+++ b/plugin/skills/brief/SKILL.md
@@ -1,21 +1,55 @@
 ---
 name: brief
 description: >
-  Session-start briefing from Origin. Loads identity, preferences, and
-  topic-relevant memories so the agent walks in with context. Surfaces any
-  memories the daemon has flagged for human revision before the session uses
-  them. Invoked as `/brief [topic]`. Call FIRST at session start, before any
-  other Origin verb.
+  Session-start briefing from Origin. Reads the project status file (the
+  /handoff-maintained ledger of Active/Backlog work), then loads identity,
+  preferences, and topic-relevant memories so the agent walks in with context.
+  Surfaces any memories the daemon has flagged for human revision before the
+  session uses them. Invoked as `/brief [topic]`. Call FIRST at session start,
+  before any other Origin verb.
 argument-hint: "[topic]"
-allowed-tools: ["mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__list_pending_revisions", "mcp__plugin_origin_origin__accept_revision", "mcp__plugin_origin_origin__dismiss_revision"]
+allowed-tools: ["Bash", "mcp__plugin_origin_origin__context", "mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin__list_pending_revisions", "mcp__plugin_origin_origin__accept_revision", "mcp__plugin_origin_origin__dismiss_revision"]
 ---
 
 # /brief
 
-Pull a curated session brief from Origin: who the user is, what they prefer,
-and what's relevant to the current topic.
+Pull a curated session brief from Origin. Three sources, in order:
 
-## How to invoke
+1. **Project status file** — what `/handoff` last wrote. Authoritative for
+   "what's left to do" right now.
+2. **`context` MCP** — identity, preferences, topic-relevant memories.
+   Background, not ledger.
+3. **`list_pending_revisions`** — daemon-flagged memories awaiting review.
+
+Status file wins on "what's next" because memories rank by topic similarity
+and surface stale items alongside fresh ones; the status file is the live
+ledger maintained per session.
+
+## 1. Read project status file first
+
+Detect project root:
+
+```
+Bash: cd_repo=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); echo "${cd_repo:-no-git}"
+```
+
+- If output is a path → `<project>` = basename (e.g. `origin`).
+- If `no-git` → `<project>` = cwd basename.
+
+Read `~/.origin/sessions/_status/<project>.md`:
+
+```
+Bash: cat ~/.origin/sessions/_status/<project>.md
+```
+
+If the file exists, render its `## Last session`, `## Active`, and `## Backlog`
+sections verbatim at the top of the brief output, under a heading like
+`Status (last session <date>)`. This is the authoritative "what's left" frame.
+
+If the file is missing, say nothing about it. First-time projects haven't
+been handed off yet.
+
+## 2. Call context
 
 Call the `origin` MCP server's `context` tool. If the user passed a topic
 argument, pass it through. Otherwise infer scope from the working directory and
@@ -48,11 +82,17 @@ context(topic="<args or inferred>", domain=<inferred from cwd or recent turns>)
 
 ## How to use the result
 
+Treat the status file as the live ledger (what's next), and the `context`
+memories as background (how the user thinks). When the status file says an
+item is done but a memory still says it's pending, trust the status file —
+memories don't auto-supersede. If you see drift, flag it inline rather than
+parrot the stale memory.
+
 Model how the user thinks. Their preferences, corrections, and past decisions
 tell you how they want to be helped, not just what they already know. Don't
 just look things up: adjust your behavior.
 
-## Pending revisions check
+## 3. Pending revisions check
 
 After loading context, call:
 

--- a/plugin/skills/review/SKILL.md
+++ b/plugin/skills/review/SKILL.md
@@ -15,11 +15,9 @@ allowed-tools: ["mcp__plugin_origin_origin__list_pending", "mcp__plugin_origin_o
 Power-user audit lever. Most users do not need /review in daily flow:
 
 - **Pending revisions** surface in `/brief` automatically (top 3 with inline accept/dismiss).
+- **Pending captures from this session** surface in `/handoff`'s preview
+  block (top 3, informational). Use `/review captures` for the deep walk.
 - **Orphan wikilinks** surface in `/distill`'s topic-suggestion block.
-- **Pending captures from this session**: *coming in a follow-up PR*; the
-  underlying MCP wrapper needs plumbing fixes first. For now, use the
-  scoped `/review captures` walk below if you want to audit unconfirmed
-  captures.
 
 Use /review only when you want the deep walk those skills intentionally do not force.
 
@@ -29,11 +27,6 @@ Use /review only when you want the deep walk those skills intentionally do not f
   unfiltered by session). Per item: accept (`confirm_memory`), edit
   (`capture` with `supersedes=<old_id>` then `forget(old_id)`), or
   reject (`forget`).
-
-  Known issue (tracked as `mem_bd4611b5cc69`): the `list_pending` MCP wrapper
-  currently has plumbing problems and may return empty or wrong-shape
-  results. If `/review captures` shows nothing while you know captures
-  are pending, the underlying MCP fix is tracked in Spec C-3b.
 
 - `/review revisions`: walk every pending revision (`list_pending_revisions`,
   no cap). Per item: accept (`accept_revision`), dismiss (`dismiss_revision`),


### PR DESCRIPTION
## Summary

- `/brief` now reads `~/.origin/sessions/_status/<project>.md` (the `/handoff`-maintained Active/Backlog ledger) before calling the `context` MCP. Status file wins on "what's next"; context provides background.
- `/review` drops the stale C-3b plumbing warning. PR #114 (`4fe5fbae`) shipped the `list_pending` MCP fix; route users to `/handoff`'s preview block for session-scoped pending captures.

## Why

`context` ranks memories by topic similarity. Stale items (e.g. P0 pipeline audit from 2026-04-22, chatgpt-import rebase note) surface alongside fresh ones because memories don't auto-supersede. The status file is the live ledger; `/brief` should read it first.

## Test plan

- [ ] Next `/brief` invocation in this repo renders `## Last session` / `## Active` / `## Backlog` from `~/.origin/sessions/_status/origin.md` before the context summary.
- [ ] In a fresh repo without `~/.origin/sessions/_status/<name>.md`, `/brief` silently skips the status block.
- [ ] `/review` no longer references `mem_bd4611b5cc69` or Spec C-3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)