### PR TITLE
fix(ci): main-canary filter eval::token_efficiency → eval::retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         run: cargo nextest run -p origin-core --lib --test chat_import_e2e --test distillation_quality
       - name: Run embedding-only eval (main only)
         if: github.ref == 'refs/heads/main'
-        run: cargo nextest run -p origin-core --lib --run-ignored=only eval::token_efficiency
+        run: cargo nextest run -p origin-core --lib --run-ignored=only eval::retrieval
 
   # Aggregate gate for branch protection. `if: always()` lets docs-only PRs
   # (where fmt/lint/test skipped via detect-changes) report success instead of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Origin runs across several layers. The split is driven by three questions: **(1)
 | **L3 pre-push** | `cargo clippy --workspace --all-targets`, `cargo test --workspace --lib` | Local | `git push` | ~60-90s | Yes |
 | **L4 CI on PR** | Same checks workspace-wide; tests for types + server + CLI; core lib tests + chat_import_e2e + distillation_quality | GitHub (`ci.yml`) | Every PR | ~10min | Yes (required) |
 | **L5 coverage on PR** | `cargo llvm-cov` on origin-core + origin-server only | GitHub (`coverage.yml`) | Every PR | ~10min | **No (informational)** |
-| **L6 main canary** | Embedding-only eval (`cargo test -p origin-core --lib eval::token_efficiency -- --ignored`) | GitHub (`ci.yml`) | Push to `main` | ~10min | No (post-merge) |
+| **L6 main canary** | Embedding-only eval (`cargo test -p origin-core --lib eval::retrieval -- --ignored`) | GitHub (`ci.yml`) | Push to `main` | ~10min | No (post-merge) |
 | **L7 manual local** | `bash scripts/coverage.sh` (HTML coverage), GPU eval suite (`cargo test -- --ignored`), Anthropic batch judge (`ANTHROPIC_API_KEY=... cargo test ...`) | Your laptop | On demand | minutes-hours | No |
 | **L8 pre-release** | Full eval suite vs saved baseline. Record deltas in vault/memory **never git** (Apache-2.0 public-repo rule for daemon; treat numbers as private until you have signed-off baselines) | Your laptop | Per release | hours | Soft gate |
 


### PR DESCRIPTION
## Summary
- Main-canary `cargo nextest run … eval::token_efficiency` matches 0 tests, exits 4, has been silently failing on every push to main since the module was renamed.
- `eval/mod.rs:23` has `pub use retrieval as token_efficiency` — symbol-level alias only. Nextest's `--run-ignored=only <filter>` matches test paths, not re-export names, so the canary skips all 1118 tests.
- Fix: filter `eval::retrieval` in both `.github/workflows/ci.yml:127` and the L6 row in `AGENTS.md`.

L6 is non-gating ("No (post-merge)" in the test-responsibilities table) so this never blocked a merge, but it produced a false-red on the main branch indefinitely.

## Test plan
- [ ] CI on this PR: PR-level lanes pass as usual (canary doesn't run on non-main branches per `if: github.ref == 'refs/heads/main'`).
- [ ] After merge: post-merge main canary actually executes the ignored eval tests instead of skip-and-fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)