### PR TITLE
fix(mcp): list_spaces tool + activate doc-path space filter

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -6126,20 +6126,55 @@ impl MemoryDB {
         source_filter: Option<&str>,
         space: Option<&str>,
     ) -> Result<Vec<SearchResult>, OriginError> {
-        // TODO(PR-C): documents/chunks table currently lacks a `space` column.
-        // The parameter is accepted for API symmetry but ignored on the doc path.
-        // PR-C will add the schema and wire the filter through.
-        let _ = space;
         let embedding = self.get_or_compute_embedding(query)?;
         let vec_str = Self::vec_to_sql(&embedding);
         let fetch_limit = (limit * 3) as i64;
 
         let conn = self.conn.lock().await;
 
+        // Build filter conditions shared by vector and FTS paths.
+        // Conditions use bare `?` placeholders; each branch renumbers them
+        // starting at ?3 to follow the path-specific positional params.
+        let mut filter_conditions: Vec<String> = Vec::new();
+        let mut filter_values: Vec<libsql::Value> = Vec::new();
+        if let Some(filter) = source_filter {
+            filter_conditions.push("c.source = ?".to_string());
+            filter_values.push(libsql::Value::Text(filter.to_string()));
+        }
+        if let Some(sp) = space {
+            if sp == "uncategorized" {
+                filter_conditions.push("c.space IS NULL".to_string());
+            } else {
+                filter_conditions.push("c.space = ?".to_string());
+                filter_values.push(libsql::Value::Text(sp.to_string()));
+            }
+        }
+
         // --- Vector search ---
         let mut vector_results: Vec<SearchResult> = Vec::new();
         {
-            let sql = if source_filter.is_some() {
+            // Renumber placeholders: ?1 = vec_str, ?2 = fetch_limit, ?3.. = filters.
+            let mut vec_where_parts: Vec<String> = Vec::new();
+            let mut param_idx = 3usize;
+            for cond in &filter_conditions {
+                let mut numbered = String::new();
+                for ch in cond.chars() {
+                    if ch == '?' {
+                        numbered.push_str(&format!("?{}", param_idx));
+                        param_idx += 1;
+                    } else {
+                        numbered.push(ch);
+                    }
+                }
+                vec_where_parts.push(numbered);
+            }
+            let vec_filter = if vec_where_parts.is_empty() {
+                String::new()
+            } else {
+                format!(" AND {}", vec_where_parts.join(" AND "))
+            };
+
+            let sql = format!(
                 "SELECT c.id, c.content, c.source, c.source_id, c.title, c.summary, c.url,
                         c.chunk_index, c.last_modified, c.chunk_type, c.language, c.byte_start,
                         c.byte_end, c.semantic_unit, c.memory_type, c.space, c.source_agent,
@@ -6150,32 +6185,17 @@ impl MemoryDB {
                         vector_distance_cos(c.embedding, vector32(?1))
                  FROM vector_top_k('memories_vec_idx', vector32(?1), ?2) AS vt
                  JOIN memories c ON c.rowid = vt.id
-                 WHERE c.pending_revision = 0 AND c.source = ?3"
-            } else {
-                "SELECT c.id, c.content, c.source, c.source_id, c.title, c.summary, c.url,
-                        c.chunk_index, c.last_modified, c.chunk_type, c.language, c.byte_start,
-                        c.byte_end, c.semantic_unit, c.memory_type, c.space, c.source_agent,
-                        c.confidence, c.confirmed, c.stability, c.supersedes,
-                        c.entity_id, c.quality, c.is_recap, c.supersede_mode,
-                        c.structured_fields, c.retrieval_cue, c.source_text,
-                        c.version, c.pending_revision,
-                        vector_distance_cos(c.embedding, vector32(?1))
-                 FROM vector_top_k('memories_vec_idx', vector32(?1), ?2) AS vt
-                 JOIN memories c ON c.rowid = vt.id
-                 WHERE c.pending_revision = 0"
-            };
+                 WHERE c.pending_revision = 0{}",
+                vec_filter
+            );
 
-            let rows_result = if let Some(filter) = source_filter {
-                conn.query(
-                    sql,
-                    libsql::params![vec_str.clone(), fetch_limit, filter.to_string()],
-                )
-                .await
-            } else {
-                conn.query(sql, libsql::params![vec_str, fetch_limit]).await
-            };
+            let mut params: Vec<libsql::Value> = vec![
+                libsql::Value::Text(vec_str.clone()),
+                libsql::Value::Integer(fetch_limit),
+            ];
+            params.extend(filter_values.clone());
 
-            match rows_result {
+            match conn.query(&sql, params).await {
                 Ok(mut rows) => {
                     while let Ok(Some(row)) = rows.next().await {
                         let distance: f64 = row.get(30).unwrap_or(1.0);
@@ -6197,7 +6217,28 @@ impl MemoryDB {
         // --- FTS search ---
         let mut fts_results: Vec<SearchResult> = Vec::new();
         {
-            let fts_sql = if source_filter.is_some() {
+            // Renumber placeholders: ?1 = query, ?2 = fetch_limit, ?3.. = filters.
+            let mut fts_where_parts: Vec<String> = Vec::new();
+            let mut param_idx = 3usize;
+            for cond in &filter_conditions {
+                let mut numbered = String::new();
+                for ch in cond.chars() {
+                    if ch == '?' {
+                        numbered.push_str(&format!("?{}", param_idx));
+                        param_idx += 1;
+                    } else {
+                        numbered.push(ch);
+                    }
+                }
+                fts_where_parts.push(numbered);
+            }
+            let fts_extra = if fts_where_parts.is_empty() {
+                String::new()
+            } else {
+                format!(" AND {}", fts_where_parts.join(" AND "))
+            };
+
+            let fts_sql = format!(
                 "SELECT c.id, c.content, c.source, c.source_id, c.title, c.summary, c.url,
                         c.chunk_index, c.last_modified, c.chunk_type, c.language, c.byte_start,
                         c.byte_end, c.semantic_unit, c.memory_type, c.space, c.source_agent,
@@ -6208,37 +6249,19 @@ impl MemoryDB {
                         fts.rank
                  FROM memories_fts fts
                  JOIN memories c ON fts.rowid = c.rowid
-                 WHERE memories_fts MATCH ?1 AND c.pending_revision = 0 AND c.source = ?3
+                 WHERE memories_fts MATCH ?1 AND c.pending_revision = 0{}
                  ORDER BY fts.rank
-                 LIMIT ?2"
-            } else {
-                "SELECT c.id, c.content, c.source, c.source_id, c.title, c.summary, c.url,
-                        c.chunk_index, c.last_modified, c.chunk_type, c.language, c.byte_start,
-                        c.byte_end, c.semantic_unit, c.memory_type, c.space, c.source_agent,
-                        c.confidence, c.confirmed, c.stability, c.supersedes,
-                        c.entity_id, c.quality, c.is_recap, c.supersede_mode,
-                        c.structured_fields, c.retrieval_cue, c.source_text,
-                        c.version, c.pending_revision,
-                        fts.rank
-                 FROM memories_fts fts
-                 JOIN memories c ON fts.rowid = c.rowid
-                 WHERE memories_fts MATCH ?1 AND c.pending_revision = 0
-                 ORDER BY fts.rank
-                 LIMIT ?2"
-            };
+                 LIMIT ?2",
+                fts_extra
+            );
 
-            let fts_result = if let Some(filter) = source_filter {
-                conn.query(
-                    fts_sql,
-                    libsql::params![query.to_string(), fetch_limit, filter.to_string()],
-                )
-                .await
-            } else {
-                conn.query(fts_sql, libsql::params![query.to_string(), fetch_limit])
-                    .await
-            };
+            let mut params: Vec<libsql::Value> = vec![
+                libsql::Value::Text(query.to_string()),
+                libsql::Value::Integer(fetch_limit),
+            ];
+            params.extend(filter_values.clone());
 
-            match fts_result {
+            match conn.query(&fts_sql, params).await {
                 Ok(mut rows) => {
                     while let Ok(Some(row)) = rows.next().await {
                         let rank: f64 = row.get(30).unwrap_or(0.0);

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -451,6 +451,9 @@ pub struct ListNurtureParams {
 pub struct ListEntitySuggestionsParams {}
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct ListSpacesParams {}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AcceptRevisionRequest {
     /// The source_id of the memory whose pending revision should be accepted.
     pub target_source_id: String,
@@ -1285,6 +1288,23 @@ impl OriginMcpServer {
         ))]))
     }
 
+    pub async fn list_spaces_impl(
+        &self,
+        _params: ListSpacesParams,
+    ) -> Result<CallToolResult, McpError> {
+        let resp: Vec<Space> = match self.client.get("/api/spaces").await {
+            Ok(r) => r,
+            Err(e) => return Ok(tool_error(e, "list_spaces")),
+        };
+        let pretty = serde_json::to_string_pretty(&resp)
+            .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::text(format!(
+            "{} spaces\n{}",
+            resp.len(),
+            pretty
+        ))]))
+    }
+
     pub async fn list_refinements_impl(
         &self,
         params: ListRefinementsParams,
@@ -2038,6 +2058,17 @@ impl OriginMcpServer {
         Parameters(params): Parameters<ListPagesRecentParams>,
     ) -> Result<CallToolResult, McpError> {
         self.list_pages_recent_impl(params).await
+    }
+
+    #[tool(
+        description = "List all spaces in this Origin instance. Use when the user asks 'what spaces exist', 'list my topics', or to discover space names before passing one as a filter to search_memory / list_nurture. Returns each space's name, description, memory_count, entity_count, and timestamps.",
+        annotations(title = "List spaces", read_only_hint = true, open_world_hint = false)
+    )]
+    async fn list_spaces(
+        &self,
+        Parameters(params): Parameters<ListSpacesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.list_spaces_impl(params).await
     }
 
     // --- Refinery queue tools ---
@@ -4298,6 +4329,7 @@ mod tests {
             "list_memories",
             "search_pages",
             "list_pages_recent",
+            "list_spaces",
         ] {
             assert!(
                 descriptions.contains_key(name),

--- a/crates/origin-mcp/src/types.rs
+++ b/crates/origin-mcp/src/types.rs
@@ -6,7 +6,7 @@
 //! `origin_types::*` at call sites directly.
 
 pub use origin_types::entities::EntitySuggestion;
-pub use origin_types::memory::{RecentActivityItem, RejectionRecord, SearchResult};
+pub use origin_types::memory::{RecentActivityItem, RejectionRecord, SearchResult, Space};
 pub use origin_types::requests::{
     ChatContextRequest, CreateConceptRequest, CreateEntityRequest, CreateRelationRequest,
     ListMemoriesRequest, SearchMemoryRequest, SearchPagesRequest, StoreMemoryRequest,

--- a/crates/origin-mcp/tests/list_spaces_e2e.rs
+++ b/crates/origin-mcp/tests/list_spaces_e2e.rs
@@ -1,0 +1,106 @@
+//! E2E: MCP `list_spaces` tool round-trips through the daemon HTTP layer.
+//!
+//! Uses wiremock to stand in for the daemon (same pattern as `space_roundtrip_e2e.rs`).
+//! Verifies that:
+//!   (a) `list_spaces` issues a GET to `/api/spaces`
+//!   (b) the daemon's `Vec<Space>` response is rendered with a count prefix and
+//!       includes each space's name in the formatted output
+//!   (c) an empty array is rendered as "0 spaces"
+
+use origin_mcp::client::OriginClient;
+use origin_mcp::tools::{ListSpacesParams, OriginMcpServer, TransportMode};
+use origin_types::memory::Space;
+use rmcp::model::RawContent;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_server(client: OriginClient) -> OriginMcpServer {
+    OriginMcpServer::new(client, TransportMode::Stdio, "test-agent".into(), None)
+}
+
+fn text_of(result: &rmcp::model::CallToolResult) -> String {
+    for content in &result.content {
+        if let RawContent::Text(text) = &content.raw {
+            return text.text.clone();
+        }
+    }
+    panic!(
+        "expected at least one text Content block; got: {:?}",
+        result.content
+    );
+}
+
+fn space_fixture(name: &str, memory_count: u64) -> Space {
+    Space {
+        id: format!("space_{name}"),
+        name: name.to_string(),
+        description: None,
+        suggested: false,
+        starred: false,
+        sort_order: 0,
+        memory_count,
+        entity_count: 0,
+        created_at: 0.0,
+        updated_at: 0.0,
+    }
+}
+
+#[tokio::test]
+async fn mcp_list_spaces_renders_daemon_response() {
+    let mock = MockServer::start().await;
+
+    let body = vec![space_fixture("alpha", 2), space_fixture("beta", 1)];
+    Mock::given(method("GET"))
+        .and(path("/api/spaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = OriginClient::new(mock.uri());
+    let server = make_server(client);
+    let result = server
+        .list_spaces_impl(ListSpacesParams {})
+        .await
+        .expect("list_spaces_impl must succeed");
+
+    let rendered = text_of(&result);
+    assert!(
+        rendered.starts_with("2 spaces"),
+        "rendered output must begin with count prefix, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("\"alpha\""),
+        "rendered output must contain space name 'alpha', got: {rendered}"
+    );
+    assert!(
+        rendered.contains("\"beta\""),
+        "rendered output must contain space name 'beta', got: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn mcp_list_spaces_empty_array_renders_zero_count() {
+    let mock = MockServer::start().await;
+
+    let body: Vec<Space> = vec![];
+    Mock::given(method("GET"))
+        .and(path("/api/spaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let client = OriginClient::new(mock.uri());
+    let server = make_server(client);
+    let result = server
+        .list_spaces_impl(ListSpacesParams {})
+        .await
+        .expect("list_spaces_impl must succeed on empty body");
+
+    let rendered = text_of(&result);
+    assert!(
+        rendered.starts_with("0 spaces"),
+        "empty rendered output must begin with '0 spaces', got: {rendered}"
+    );
+}

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1731,8 +1731,10 @@ pub struct UpdateSpaceRequest {
 pub async fn handle_list_spaces(
     State(state): State<Arc<RwLock<ServerState>>>,
 ) -> Result<Json<Vec<origin_core::db::Space>>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
     let spaces = db
         .list_spaces()
         .await

--- a/crates/origin-server/tests/list_spaces_e2e.rs
+++ b/crates/origin-server/tests/list_spaces_e2e.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+//! E2E acceptance: GET /api/spaces returns a populated Vec<Space>.
+//!
+//! Two tests:
+//!   - `list_spaces_returns_seeded_spaces`: seed 2 memories into space=alpha and
+//!     1 into space=beta (with explicit create_space calls), then assert the
+//!     endpoint returns both spaces with correct memory_count values.
+//!   - `list_spaces_empty_db_returns_empty_array`: empty DB, assert 200 + `[]`.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use origin_core::sources::RawDocument;
+use origin_types::Space;
+use tower::ServiceExt;
+
+async fn body_as_json<T: serde::de::DeserializeOwned>(response: axum::http::Response<Body>) -> T {
+    let bytes = axum::body::to_bytes(response.into_body(), 256 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).expect("response body is valid JSON of expected type")
+}
+
+async fn get_spaces(router: &axum::Router) -> (StatusCode, Vec<Space>) {
+    let resp = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/spaces")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let spaces: Vec<Space> = body_as_json(resp).await;
+    (status, spaces)
+}
+
+#[tokio::test]
+async fn list_spaces_returns_seeded_spaces() {
+    let (router, _tmp, db) = common::test_app().await;
+
+    db.create_space("alpha", None, false)
+        .await
+        .expect("create_space alpha must succeed");
+    db.create_space("beta", None, false)
+        .await
+        .expect("create_space beta must succeed");
+
+    for (source_id, content, space) in [
+        ("mem_alpha_1", "Alpha content one", "alpha"),
+        ("mem_alpha_2", "Alpha content two", "alpha"),
+        ("mem_beta_1", "Beta content one", "beta"),
+    ] {
+        let doc = RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: format!("title-{}", source_id),
+            content: content.to_string(),
+            space: Some(space.to_string()),
+            last_modified: chrono::Utc::now().timestamp(),
+            confirmed: None,
+            stability: Some("new".to_string()),
+            pending_revision: false,
+            supersede_mode: "hide".to_string(),
+            enrichment_status: "raw".to_string(),
+            ..RawDocument::default()
+        };
+        db.upsert_documents(vec![doc])
+            .await
+            .unwrap_or_else(|e| panic!("upsert_documents failed for {source_id}: {e}"));
+        db.confirm_memory(source_id)
+            .await
+            .unwrap_or_else(|e| panic!("confirm_memory failed for {source_id}: {e}"));
+    }
+
+    let (status, spaces) = get_spaces(&router).await;
+    assert_eq!(status, StatusCode::OK, "GET /api/spaces must return 200");
+
+    let names: Vec<&str> = spaces.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"alpha"),
+        "response must contain space 'alpha', got: {names:?}"
+    );
+    assert!(
+        names.contains(&"beta"),
+        "response must contain space 'beta', got: {names:?}"
+    );
+
+    let alpha = spaces.iter().find(|s| s.name == "alpha").unwrap();
+    let beta = spaces.iter().find(|s| s.name == "beta").unwrap();
+
+    assert_eq!(
+        alpha.memory_count, 2,
+        "alpha must have memory_count=2, got {}",
+        alpha.memory_count
+    );
+    assert_eq!(
+        beta.memory_count, 1,
+        "beta must have memory_count=1, got {}",
+        beta.memory_count
+    );
+}
+
+#[tokio::test]
+async fn list_spaces_empty_db_returns_empty_array() {
+    let (router, _tmp, _db) = common::test_app().await;
+
+    let (status, spaces) = get_spaces(&router).await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "GET /api/spaces must return 200 on empty DB"
+    );
+    assert!(
+        spaces.is_empty(),
+        "empty DB must return [], got: {spaces:?}"
+    );
+}

--- a/crates/origin-server/tests/search_docpath_space_e2e.rs
+++ b/crates/origin-server/tests/search_docpath_space_e2e.rs
@@ -1,20 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
-//! E2E: doc-path `/api/search` currently ignores the space filter.
+//! E2E: doc-path `/api/search` honors the `space` filter.
 //!
-//! This is documented behavior pending PR-C, which will add a `space` column
-//! to the documents/chunks tables and wire the doc-path filter to honor it.
-//! Until then, sending `space=alpha` with `source_filter != "memory"` returns
-//! all documents regardless of the filter value — the space parameter is
-//! explicitly discarded in `MemoryDB::search` (see `origin-core/src/db.rs`,
-//! the `TODO(PR-C)` comment).
-//!
-//! This test pins the current no-op behavior so a future PR-C author knows
-//! exactly where to update the assertion.
+//! Activated in PR-C. Previously the parameter was accepted but discarded in
+//! `MemoryDB::search` (the `memories` table has a `space` column but the WHERE
+//! clause did not reference it). PR-C wires the filter into both the vector and
+//! FTS branches.
 
 mod common;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use origin_core::sources::RawDocument;
 use origin_types::memory::SearchResult;
 use serde::Deserialize;
 use tower::ServiceExt;
@@ -24,7 +20,6 @@ struct SearchResponse {
     results: Vec<SearchResult>,
 }
 
-/// POST `/api/search` with a given body and return the deserialized response.
 async fn post_search(router: &axum::Router, body: serde_json::Value) -> SearchResponse {
     let resp = router
         .clone()
@@ -45,60 +40,38 @@ async fn post_search(router: &axum::Router, body: serde_json::Value) -> SearchRe
     serde_json::from_slice(&bytes).expect("response body must be valid SearchResponse JSON")
 }
 
-/// POST `/api/ingest/text` to insert a document with the given source and content.
-async fn ingest_doc(router: &axum::Router, source_id: &str, source: &str, content: &str) {
-    let body = serde_json::json!({
-        "source": source,
-        "source_id": source_id,
-        "title": format!("doc-{source_id}"),
-        "content": content,
-    });
-    let resp = router
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/ingest/text")
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&body).unwrap()))
-                .unwrap(),
-        )
+async fn seed_doc(
+    db: &std::sync::Arc<origin_core::db::MemoryDB>,
+    source_id: &str,
+    content: &str,
+    space: &str,
+) {
+    let doc = RawDocument {
+        source: "local_files".to_string(),
+        source_id: source_id.to_string(),
+        title: format!("doc-{source_id}"),
+        content: content.to_string(),
+        space: Some(space.to_string()),
+        last_modified: chrono::Utc::now().timestamp(),
+        confirmed: None,
+        stability: Some("new".to_string()),
+        pending_revision: false,
+        supersede_mode: "hide".to_string(),
+        enrichment_status: "raw".to_string(),
+        ..RawDocument::default()
+    };
+    db.upsert_documents(vec![doc])
         .await
-        .unwrap();
-    assert_eq!(
-        resp.status(),
-        StatusCode::OK,
-        "/api/ingest/text must return 200 for source_id={source_id}"
-    );
+        .unwrap_or_else(|e| panic!("upsert_documents failed for {source_id}: {e}"));
 }
 
 #[tokio::test]
-async fn doc_search_space_filter_is_noop_until_pr_c() {
-    let (router, _tmp, _db) = common::test_app().await;
+async fn doc_search_filters_by_space_alpha() {
+    let (router, _tmp, db) = common::test_app().await;
 
-    // Ingest two documents under a non-"memory" source.
-    // Neither gets a space tag — ingest/text does not accept a space field
-    // (the handler hard-codes `space: None`). The chunks table also lacks a
-    // `space` column, so the space filter has nowhere to operate even if it
-    // were wired through.
-    ingest_doc(
-        &router,
-        "doc_alpha_001",
-        "local_files",
-        "unique_alpha_content",
-    )
-    .await;
-    ingest_doc(
-        &router,
-        "doc_beta_001",
-        "local_files",
-        "unique_beta_content",
-    )
-    .await;
+    seed_doc(&db, "doc_alpha_001", "unique_alpha_content", "alpha").await;
+    seed_doc(&db, "doc_beta_001", "unique_beta_content", "beta").await;
 
-    // Search with source_filter="local_files" (not "memory") and space="alpha".
-    // The code path hits `MemoryDB::search`, which explicitly discards `space`
-    // (see TODO(PR-C) at origin-core/src/db.rs). Both documents must appear.
     let response = post_search(
         &router,
         serde_json::json!({
@@ -110,25 +83,6 @@ async fn doc_search_space_filter_is_noop_until_pr_c() {
     )
     .await;
 
-    // Both docs must appear because the filter is a no-op.
-    //
-    // IF THIS ASSERTION STARTS FAILING: you have likely wired the space filter
-    // through to the doc path (PR-C work). Update this test to assert true
-    // filter behavior: with space=alpha only the alpha-tagged doc should appear,
-    // and the beta-tagged doc must not.
-    assert!(
-        response.results.len() >= 2,
-        "doc-path space filter is a no-op until PR-C — both docs must still return, \
-         got {} result(s): {:?}",
-        response.results.len(),
-        response
-            .results
-            .iter()
-            .map(|r| r.source_id.as_str())
-            .collect::<Vec<_>>()
-    );
-
-    // Confirm both documents are actually present in the results.
     let source_ids: Vec<&str> = response
         .results
         .iter()
@@ -136,13 +90,75 @@ async fn doc_search_space_filter_is_noop_until_pr_c() {
         .collect();
     assert!(
         source_ids.contains(&"doc_alpha_001"),
-        "doc_alpha_001 must be in results regardless of space filter; got: {:?}",
-        source_ids
+        "alpha-tagged doc must appear when space=alpha; got: {source_ids:?}"
+    );
+    assert!(
+        !source_ids.contains(&"doc_beta_001"),
+        "beta-tagged doc must NOT appear when space=alpha; got: {source_ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn doc_search_filters_by_space_beta() {
+    let (router, _tmp, db) = common::test_app().await;
+
+    seed_doc(&db, "doc_alpha_001", "unique_alpha_content", "alpha").await;
+    seed_doc(&db, "doc_beta_001", "unique_beta_content", "beta").await;
+
+    let response = post_search(
+        &router,
+        serde_json::json!({
+            "query": "content",
+            "limit": 10,
+            "source_filter": "local_files",
+            "space": "beta",
+        }),
+    )
+    .await;
+
+    let source_ids: Vec<&str> = response
+        .results
+        .iter()
+        .map(|r| r.source_id.as_str())
+        .collect();
+    assert!(
+        source_ids.contains(&"doc_beta_001"),
+        "beta-tagged doc must appear when space=beta; got: {source_ids:?}"
+    );
+    assert!(
+        !source_ids.contains(&"doc_alpha_001"),
+        "alpha-tagged doc must NOT appear when space=beta; got: {source_ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn doc_search_no_space_returns_all() {
+    let (router, _tmp, db) = common::test_app().await;
+
+    seed_doc(&db, "doc_alpha_001", "unique_alpha_content", "alpha").await;
+    seed_doc(&db, "doc_beta_001", "unique_beta_content", "beta").await;
+
+    let response = post_search(
+        &router,
+        serde_json::json!({
+            "query": "content",
+            "limit": 10,
+            "source_filter": "local_files",
+        }),
+    )
+    .await;
+
+    let source_ids: Vec<&str> = response
+        .results
+        .iter()
+        .map(|r| r.source_id.as_str())
+        .collect();
+    assert!(
+        source_ids.contains(&"doc_alpha_001"),
+        "alpha doc must appear when space is unset; got: {source_ids:?}"
     );
     assert!(
         source_ids.contains(&"doc_beta_001"),
-        "doc_beta_001 must be in results regardless of space filter (proves filter is no-op); \
-         got: {:?}",
-        source_ids
+        "beta doc must appear when space is unset; got: {source_ids:?}"
     );
 }


### PR DESCRIPTION
## Summary

Closes out the user-facing space-scoping story from PR-A (#123).

- **MCP `list_spaces` tool** — empty-Params reader that returns `Vec<Space>` from `GET /api/spaces`. Wiremock e2e covers happy path + empty array. Tool-registration test extended to assert presence.
- **Doc-path space filter** — `MemoryDB::search` rewritten to use the dynamic-clause + param-renumbering pattern already in `search_memory`. Both vector and FTS branches now honor `c.space = ?` (or `c.space IS NULL` for `space=uncategorized`). The previous `let _ = space;` no-op is gone.
- **PR-A's pinned no-op e2e flipped** — `search_docpath_space_e2e.rs` now asserts space filtering works (3 tests: filter alpha, filter beta, no-filter returns all). Seeded directly via `db.upsert_documents` since `/api/ingest/text` doesn't accept a space field.
- **Behavior lock for existing `GET /api/spaces`** — new `list_spaces_e2e.rs` (seeded + empty-DB), assertions on `memory_count`.
- **RwLock guard hygiene** — `handle_list_spaces` was holding the read guard across `db.list_spaces().await`. Refactored to clone `Arc<MemoryDB>` first (matches batch-4 handler pattern). Other handlers in the same file still hold guards across await; out of PR-C scope.

## Notes

- The `memories` table already had a `space` column populated by `upsert_documents`; the filter only needed wiring. The original `TODO(PR-C)` comment claimed the chunks table lacked it, but the real chunks table is `memories` and has it.
- Adversarial review pass: no blockers. Two pre-existing latent issues flagged for follow-up: (a) sibling space handlers still hold read guards across await; (b) `MemoryDB::search` vector path doesn't apply `supersedes_exclusion` while `search_memory` does.
- `fix:` prefix to keep release-please at patch bump (per AGENTS.md).

## Test plan
- [x] `cargo test -p origin-server --test list_spaces_e2e` — 2/2 green
- [x] `cargo test -p origin-server --test search_docpath_space_e2e` — 3/3 green (red→green TDD)
- [x] `cargo test -p origin-mcp --test list_spaces_e2e` — 2/2 green
- [x] `cargo test --workspace --lib` — 1391 lib tests, all green
- [x] `cargo test -p origin-server --tests` — all e2e green
- [x] `cargo test -p origin-mcp --tests` — all e2e green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)