### PR TITLE
ci: drop debuginfo from test job artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,10 @@ jobs:
     needs: [detect-changes, fmt]
     if: "needs.detect-changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(main): release')"
     runs-on: ubuntu-24.04
+    env:
+      # Drop debuginfo from test artifacts. CI has no debugger attached and the
+      # build cache stays warm via rust-cache. Trims linker time + cache size.
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13


### PR DESCRIPTION
## Summary

Drops debuginfo from CI test artifacts. Measured **−75s ≈ 12% faster** on test-job wall-clock vs PR #126's head-to-head baseline (same main commit, same toolchain, same rust-cache key family). CI never attaches a debugger so debuginfo is dead weight.

## Measurement

| PR | Test-job start | Test-job end | Duration |
|---|---|---|---|
| #126 baseline | 05:08:09Z | 05:18:27Z | 618s |
| #127 with `DEBUG=0` | 05:10:09Z | 05:19:12Z | 543s |

## Mechanism

- linker has less work — debuginfo sections often dominate test-binary link time
- rust-cache writes a smaller artifact on save (cache key family unchanged)
- no impact on test runtime, just compile + link

## Caveat

Stack traces in test failures will be slightly less helpful. Local pre-push runs (`cargo clippy --workspace --all-targets`, `cargo test --workspace --lib`) keep full debuginfo because they're outside the workflow env. Re-enable temporarily with `CARGO_PROFILE_TEST_DEBUG=1` in a one-off PR if needed to debug a stubborn CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)