### PR TITLE
fix: make origin CLI own runtime setup

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml crates/origin-mcp/npm/package.json plugin/.claude-plugin/plugin.json plugin/bin/origin-mcp-runner.sh plugin/skills/init/SKILL.md
+          git add Cargo.toml crates/origin-mcp/npm/package.json crates/origin-cli/npm/package.json plugin/.claude-plugin/plugin.json plugin/bin/origin-mcp-runner.sh plugin/skills/init/SKILL.md
           if ! git diff --cached --quiet; then
             git commit -m "chore: sync versions to $(cat version.txt | tr -d '[:space:]')"
             git push origin HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,17 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
+      - name: Build origin CLI (release)
+        run: cargo build --release -p origin --target aarch64-apple-darwin
+
       - name: Build origin-server (release)
         run: cargo build --release -p origin-server --target aarch64-apple-darwin
 
       - name: Build origin-mcp (release)
         run: cargo build --release -p origin-mcp --target aarch64-apple-darwin
+
+      - name: Smoke test origin CLI
+        run: ./target/aarch64-apple-darwin/release/origin --help
 
       - name: Smoke test origin-server
         run: ./target/aarch64-apple-darwin/release/origin-server --help
@@ -72,20 +78,22 @@ jobs:
 
           ## Install
 
-          **Desktop app:** Download from [origin-app releases](https://github.com/7xuanlu/origin-app/releases/latest).
+          **Origin setup (local runtime + daemon):**
+          \`\`\`
+          npx -y @7xuanlu/origin setup
+          \`\`\`
 
-          **MCP integration (latest stable channel):**
+          **MCP connector only:**
           \`\`\`
           npx -y origin-mcp
           \`\`\`
 
-          **Exact release on this page:**
+          **Exact release setup:**
           \`\`\`
-          ORIGIN_RELEASE_TAG=${RELEASE_TAG} npx -y origin-mcp
+          ORIGIN_RELEASE_TAG=${RELEASE_TAG} npx -y @7xuanlu/origin setup
           \`\`\`
-          Uses isolated port/data-dir defaults so it does not replace the stable runtime.
 
-          **Developer (headless daemon, latest stable):**
+          **Shell installer:**
           \`\`\`
           curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/main/install.sh | bash
           \`\`\`
@@ -96,7 +104,7 @@ jobs:
           \`\`\`
           Downloads exact binaries and prints manual isolated daemon/MCP setup steps.
 
-          > Origin works in Basic Memory mode without a local LLM or API key. Local models are opt-in from \`origin model install\` or the desktop app.
+          > Origin works in local memory mode without a local model or API key. Distill cycles are opt-in with \`origin model install\` or \`origin key set anthropic\`.
           INSTALL_EOF
 
           # Strip leading whitespace from heredoc indentation
@@ -114,6 +122,15 @@ jobs:
             --notes-file release-body.md \
             $PRERELEASE_FLAG \
             || gh release edit "$RELEASE_TAG" --notes-file release-body.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload standalone origin CLI binary
+        run: |
+          cp target/aarch64-apple-darwin/release/origin origin-aarch64-apple-darwin
+          gh release upload "$RELEASE_TAG" \
+            origin-aarch64-apple-darwin \
+            --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -224,8 +241,16 @@ jobs:
         run: |
           VERSION="${RELEASE_TAG#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-      - name: Publish
+      - name: Sync setup package version from tag
+        working-directory: crates/origin-cli/npm
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+      - name: Publish origin-mcp
         working-directory: crates/origin-mcp/npm
+        run: npm publish --provenance --access public
+      - name: Publish @7xuanlu/origin
+        working-directory: crates/origin-cli/npm
         run: npm publish --provenance --access public
 
   update-homebrew:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,11 @@ Origin is a Cargo workspace with 5 crates: `origin-types`, `origin-core`, `origi
 cargo run -p origin-server                # listens on 127.0.0.1:7878
 
 # Or start the daemon as a managed launchd service:
-cargo build -p origin-server
-./target/debug/origin-server install      # writes plist, launchctl load
-./target/debug/origin-server status
-./target/debug/origin-server uninstall    # when done
+cargo build -p origin -p origin-server
+./target/debug/origin setup --basic       # configure local memory
+./target/debug/origin install             # writes plist, launchctl load
+./target/debug/origin status
+./target/debug/origin uninstall           # when done
 
 # Workspace-level builds
 cargo check --workspace
@@ -117,7 +118,7 @@ Releases are automated via [release-please](https://github.com/googleapis/releas
 **How it works:**
 1. Every push to `main`, release-please scans new commits and maintains an open "release PR" that accumulates changes and updates `CHANGELOG.md`.
 2. When you're ready to ship, merge the release PR. That triggers a GitHub release (draft) + git tag.
-3. The `v*` tag push triggers `.github/workflows/release.yml`, which builds the daemon (`origin-server`) and `origin-mcp`, uploads standalone binaries to the release, and publishes it.
+3. The `v*` tag push triggers `.github/workflows/release.yml`, which builds `origin`, `origin-server`, and `origin-mcp`, uploads standalone binaries to the release, and publishes it.
 4. The release-please workflow also syncs daemon `Cargo.toml` versions on the release branch (release-please can't handle Cargo workspaces reliably with `simple` release type).
 
 **Commit messages control version bumps.** Pre-1.0:
@@ -155,7 +156,7 @@ cat .release-please-manifest.json
 
 **Never delete a release tag without also cleaning up the commit history.** If you need to undo a release version, you must rewrite the commit message that release-please created (`git filter-branch --msg-filter`), delete the tag, delete the GitHub Release, and rename the merged PR title via API. Otherwise release-please will keep bumping from the old version.
 
-**The `release.yml` workflow ships the daemon side.** It handles: origin-server (cargo build), origin-mcp (cargo build, same workspace), standalone binary uploads, and crates.io publishing for `origin-types` + `origin-mcp`. It does NOT build a desktop bundle — origin-app builds its own DMG in its own repo.
+**The `release.yml` workflow ships the local runtime.** It handles: origin CLI, origin-server, origin-mcp, standalone binary uploads, crates.io publishing for `origin-types` + `origin-mcp`, and npm publishing for `origin-mcp` + `@7xuanlu/origin`. It does NOT build a desktop bundle — origin-app builds its own DMG in its own repo.
 
 ### Branch protection
 
@@ -179,9 +180,9 @@ The repo is a Cargo workspace with 5 crates:
 | Crate | Role | Key dependencies |
 |---|---|---|
 | `crates/origin-types` | Shared API boundary types (request/response, memory, entities). Lightweight: serde + serde_json + anyhow only. Consumed by `origin-mcp`, `origin-app` (separate repo, via crates.io), and any other downstream tool. | serde |
-| `crates/origin-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, refinery, pages, export, eval. **Must have NO axum or tauri dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
+| `crates/origin-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, distill cycles, pages, export, eval. **Must have NO axum or tauri dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/origin-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `origin-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
-| `crates/origin-cli` | CLI binary `origin`. Talks to daemon HTTP via `origin-types`. Subcommands: status/search/recall/store/list/agents/install/setup. | reqwest, clap |
+| `crates/origin-cli` | CLI binary `origin`. Talks to daemon HTTP via `origin-types` and owns setup/service commands. Subcommands: status/search/recall/store/list/agents/install/setup/model/key/doctor. | reqwest, clap |
 | `crates/origin-mcp` | MCP server binary that bridges MCP clients (Claude Code, Cursor, Codex, Claude Desktop, etc.) to the daemon HTTP API. Stdio + streamable-HTTP transports via the `rmcp` crate. Ships as a standalone binary + npm package (`npx -y origin-mcp`). | rmcp, reqwest, schemars |
 
 The daemon (`origin-server`) is the single source of truth. External tools (the desktop app, MCP clients via `origin-mcp`, `origin` CLI, curl) all talk HTTP to the same daemon. `origin-mcp` source lives in this monorepo; at runtime it's a separate process the MCP client spawns.
@@ -248,7 +249,7 @@ All business logic lives here. No tauri, no axum. Framework-agnostic.
 | `merge.rs` | Memory merging, pattern extraction, contradiction detection |
 | `llm_provider.rs` | `LlmProvider` trait + `ApiProvider` (Anthropic API) + `OnDeviceProvider` shim |
 | `llm_classifier.rs` | Higher-level classification orchestration |
-| `refinery.rs` | Background refinement queue — dedup, auto-linking, consolidation |
+| `refinery.rs` | Distill-cycle orchestration, dedup, auto-linking, consolidation |
 | `post_ingest.rs` | Post-ingest enrichment (dedup check, entity linking, title enrich, recap, page growth) |
 | `pages.rs` | Type definitions for the `Page` struct (synthesized wiki entries distilled from memory clusters). Actual clustering + distillation live in `db.rs` + `refinery.rs`. SQL tables are `pages`/`page_sources` (renamed from `concepts`/`concept_sources` in migration 46). |
 | `spaces.rs` | Spaces / tag store |
@@ -260,7 +261,7 @@ All business logic lives here. No tauri, no axum. Framework-agnostic.
 | `context_packager.rs` | Context bundle → prompt packaging |
 | `importer.rs` | File importer pipeline |
 | `quality_gate.rs` | Pre-store quality gate |
-| `tuning.rs` | Tuning config (refinery, distillation, weights) |
+| `tuning.rs` | Tuning config (distill cycles, distillation, weights) |
 | `schema.rs` | Memory schema definitions (formerly `memory_schema.rs`) |
 | `prompts/` | Prompt registry (defaults + override dir loader) |
 | `chunker/` | Code-aware, Markdown-aware, fixed-size chunking |
@@ -278,7 +279,7 @@ HTTP daemon — owns the Axum router + all routes. All handlers operate on `Arc<
 
 | Module | Purpose |
 |---|---|
-| `main.rs` | Binary entry — clap subcommands (`install`/`uninstall`/`status`/daemon), tracing init, port binding with existing-daemon fallback, `MemoryDB::new`, LLM provider init, background tasks, `axum::serve` |
+| `main.rs` | Binary entry — daemon startup plus internal maintenance commands, tracing init, port binding with existing-daemon fallback, `MemoryDB::new`, LLM provider init, background tasks, `axum::serve` |
 | `state.rs` | `ServerState` struct with `db: Option<Arc<MemoryDB>>`, `llm`, `prompts`, `tuning`, `quality_gate`, `space_store`, `access_tracker`, `llm_processing_ids`, `watch_paths`. `SharedState = Arc<RwLock<ServerState>>` |
 | `router.rs` | `build_router(state) -> axum::Router` — all route registrations |
 | `routes.rs` | General endpoints: health, search, context, chat-context, status, profile/agents |
@@ -290,7 +291,7 @@ HTTP daemon — owns the Axum router + all routes. All handlers operate on `Arc<
 | `import_routes.rs` | Bulk import endpoints |
 | `config_routes.rs` | Config read/write endpoints |
 | `onboarding_routes.rs` | First-run wizard / milestone state |
-| `scheduler.rs` | Background periodic tasks (refinery ticks, distillation, etc.) |
+| `scheduler.rs` | Background periodic tasks (distill cycles, distillation, etc.) |
 | `websocket.rs` | `/ws/updates` |
 | `error.rs` | `ServerError` + axum `IntoResponse` impl |
 | `resources/com.origin.server.plist` | launchd plist template (embedded via `include_str!`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Origin is a local-first personal AI memory layer. We welcome bug fixes, features, tests, docs, and design feedback.
 
-This repo holds the daemon (`origin-server`), the CLI (`origin`), and the shared types/core (`origin-types`, `origin-core`). The Tauri desktop app lives in [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app); the MCP server lives in [7xuanlu/origin-mcp](https://github.com/7xuanlu/origin-mcp). Bug reports for any of those pieces are welcome here or on the corresponding repo.
+This repo holds the daemon (`origin-server`), the CLI (`origin`), the MCP server (`origin-mcp`), and the shared types/core (`origin-types`, `origin-core`). The Tauri desktop app lives in [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app). Bug reports for the local runtime, CLI, MCP server, and plugin are welcome here.
 
 ## Development Setup
 
@@ -23,9 +23,10 @@ cargo run -p origin-server
 Or install as a launchd service:
 
 ```bash
-cargo build --release -p origin-server
-./target/release/origin-server install
-./target/release/origin-server status
+cargo build --release -p origin -p origin-server
+./target/release/origin setup --basic
+./target/release/origin install
+./target/release/origin status
 ```
 
 > First build can take several minutes while `llama.cpp` compiles for Metal.
@@ -53,9 +54,10 @@ cargo clippy --workspace --all-targets -- -D warnings
 ## Architecture Overview
 
 - **Shared types**: `crates/origin-types` (Apache-2.0). Lightweight wire types shared with `origin-mcp` and `origin-app` via crates.io.
-- **Core logic**: `crates/origin-core` (Apache-2.0). DB, embeddings, LLM engine, search, knowledge graph, refinery, eval. No tauri / no axum dependencies.
+- **Core logic**: `crates/origin-core` (Apache-2.0). DB, embeddings, LLM engine, search, knowledge graph, distill cycles, eval. No tauri / no axum dependencies.
 - **HTTP daemon**: `crates/origin-server` (Apache-2.0), serves `127.0.0.1:7878`.
-- **CLI binary**: `crates/origin-cli` (Apache-2.0). The `origin` command for setup, install, search, recall, etc.
+- **CLI binary**: `crates/origin-cli` (Apache-2.0). The `origin` command for setup, service management, search, recall, etc.
+- **MCP server**: `crates/origin-mcp` (Apache-2.0). The connector spawned by Claude Code, Cursor, Codex, and other MCP clients.
 - **Desktop app** (separate repo): [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app), AGPL-3.0-only.
 - **Database**: libSQL (vectors + knowledge graph + FTS).
 
@@ -91,6 +93,6 @@ These conventions keep the codebase consistent. See `CLAUDE.md` for the full lis
 
 ## License
 
-This repo is Apache-2.0: `crates/origin-types`, `crates/origin-core`, `crates/origin-server`, and `crates/origin-cli`. The desktop app in [origin-app](https://github.com/7xuanlu/origin-app) is AGPL-3.0-only. The MCP server in [origin-mcp](https://github.com/7xuanlu/origin-mcp) is MIT.
+This repo is Apache-2.0: `crates/origin-types`, `crates/origin-core`, `crates/origin-server`, `crates/origin-cli`, `crates/origin-mcp`, and the Claude Code plugin files. The desktop app in [origin-app](https://github.com/7xuanlu/origin-app) is AGPL-3.0-only.
 
 By contributing, you agree that your changes will be licensed under the license that applies to the files you modify.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3014,11 +3014,14 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "dirs",
+ "origin-core",
  "origin-types",
  "predicates",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,24 @@ The daemon does the memory chores in the background: stores what matters, dedupl
 /init
 ```
 
-If Claude Code asks for a restart after installing, restart once, then run `/init`. The plugin handles daemon setup, MCP wiring, Basic Memory mode, and the first round-trip check.
+If Claude Code asks for a restart after installing, restart once, then run `/init`. The plugin handles daemon setup, MCP wiring, local memory setup, and the first round-trip check.
 
 `7xuanlu` is the GitHub repo owner. If you fork Origin, use your own handle in both commands.
 
 Plugin details and daily commands: [plugin/](plugin/.claude-plugin/README.md).
 
-### Other MCP clients (Cursor, Codex, Claude Desktop, Gemini CLI…)
+### Other MCP clients and terminal use
 
-Add Origin to any client that accepts a JSON `mcpServers` entry:
+Set up the local Origin runtime:
+
+```bash
+npx -y @7xuanlu/origin setup
+```
+
+That installs the `origin` CLI, `origin-server` daemon, and `origin-mcp` connector into `~/.origin/bin/`, configures local memory, registers the daemon with launchd, and verifies status.
+CLI details: [crates/origin-cli](crates/origin-cli/README.md).
+
+Then add the MCP connector to Cursor, Codex, Claude Desktop, Gemini CLI, or any client that accepts a JSON `mcpServers` entry:
 
 ```json
 {
@@ -49,11 +58,7 @@ Add Origin to any client that accepts a JSON `mcpServers` entry:
 }
 ```
 
-`npx -y origin-mcp` runs the connector on demand. If the local daemon is missing, Origin prints the setup command.
-
-### Terminal / daemon setup
-
-For automation, servers, or pre-flight installs without the Claude Code plugin, use the `origin` launcher. See [crates/origin-server](crates/origin-server/README.md) for `origin setup`, `origin install`, `origin status`, model setup, and service commands.
+The `origin-mcp` connector runs on demand and talks to the local Origin daemon from setup above.
 
 ---
 
@@ -86,14 +91,14 @@ Token efficiency on LoCoMo: 168 tokens per query instead of 4,505 for full repla
 
 ## Repo Map
 
-Origin is daemon-first. `origin-server` owns the local database, embeddings, refinery, knowledge graph, and HTTP API on `127.0.0.1:7878`. The plugin, MCP server, CLI, and local tools are thin clients over that daemon.
+Origin is daemon-first. `origin-server` owns the local database, embeddings, distill cycles, knowledge graph, and HTTP API on `127.0.0.1:7878`. The plugin, MCP server, CLI, and local tools are thin clients over that daemon.
 
 | Path | What lives there |
 | --- | --- |
-| [crates/origin-core](crates/origin-core/README.md) | Storage, search, embeddings, refinery, graph, pages, export, eval. |
-| [crates/origin-server](crates/origin-server/README.md) | Local daemon, setup, launchd service, HTTP API. |
+| [crates/origin-core](crates/origin-core/README.md) | Storage, search, embeddings, distill cycles, graph, pages, export, eval. |
+| [crates/origin-server](crates/origin-server/README.md) | Local daemon and HTTP API. |
 | [crates/origin-mcp](crates/origin-mcp/README.md) | MCP server, tools, npm package. |
-| [crates/origin-cli](crates/origin-cli/README.md) | Source-built developer CLI for daemon search, recall, store, list, and agents. |
+| [crates/origin-cli](crates/origin-cli/README.md) | User CLI for setup, service management, search, recall, store, list, agents, model/key setup, and doctor. |
 | [plugin/](plugin/.claude-plugin/README.md) | Claude Code plugin (`plugin.json`, skills, hooks, `.mcp.json`). Marketplace entry at root [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json) lists this plugin via `source: "./plugin"`. |
 | [docs/eval](docs/eval/README.md) | Benchmark workflow and methodology. |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,12 @@
 # Releasing Origin (daemon side)
 
-This document covers releases of the daemon (`origin-server`), CLI (`origin`), and shared crates (`origin-types`, `origin-core`). The desktop app ships from [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app) on its own release cadence; the MCP server ships from [7xuanlu/origin-mcp](https://github.com/7xuanlu/origin-mcp).
+This document covers releases of the local runtime: `origin` CLI, `origin-server` daemon, `origin-mcp` connector, and shared crates (`origin-types`, `origin-core`). The desktop app ships from [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app) on its own release cadence.
 
 ## How release-please works
 
 Merge conventional commits to `main` (e.g. `feat:`, `fix:`, `chore:`). The `release-please` workflow opens a "Release PR" automatically, bumping the version and updating `CHANGELOG.md`. Merge that PR to cut the release. Release-please then creates the git tag, which triggers the `release.yml` build workflow.
 
-The `.release-please-manifest.json` is the canonical version source. The release-please workflow syncs all daemon `Cargo.toml` files via the `# x-release-please-version` marker.
+The `.release-please-manifest.json` is the canonical version source. The release-please workflow syncs Cargo manifests, npm package manifests, plugin metadata, and pinned install URLs from `version.txt`.
 
 ## Manual override: bump-version.sh
 
@@ -16,7 +16,7 @@ If you need to cut a release without release-please (hotfix, first release, vers
 bash scripts/bump-version.sh 0.2.0
 ```
 
-This updates all daemon `Cargo.toml` files, regenerates `Cargo.lock`, and shows a diff summary. Review the diff, stage the files, and push. Then create and push the tag manually:
+This updates workspace Cargo versions, npm package manifests, plugin metadata, and pinned plugin URLs. Review the diff, stage the files, and push. Then create and push the tag manually:
 
 ```bash
 git tag v0.2.0
@@ -27,28 +27,19 @@ The `release.yml` workflow triggers on any `v*` tag push.
 
 ## Version consistency gate
 
-The `release.yml` workflow validates that the pushed tag version matches `crates/origin-server/Cargo.toml` before building. If out of sync, the build fails with instructions to run `bump-version.sh`.
+The `release.yml` workflow validates that the pushed tag version matches `version.txt`, workspace Cargo, npm package manifests, and plugin metadata before building. If out of sync, the build fails with instructions to run `bump-version.sh`.
 
 ## What the release workflow does
 
-1. Validates version consistency (tag vs. `crates/origin-server/Cargo.toml`).
-2. Builds `origin-server` for `aarch64-apple-darwin`.
-3. Builds `origin-mcp` from the separate repo via `cargo install --git`.
-4. Smoke-tests the daemon binary (`--help`).
-5. Creates the GitHub release with standalone binaries attached.
-6. After the release job succeeds, `publish-crates` publishes `origin-types` to crates.io if it changed since the previous tag.
+1. Validates version consistency.
+2. Builds `origin`, `origin-server`, and `origin-mcp` for `aarch64-apple-darwin`.
+3. Smoke-tests `origin --help` and `origin-server --help`.
+4. Creates the GitHub release with standalone binaries attached.
+5. Publishes `origin-types` and `origin-mcp` to crates.io.
+6. Publishes `origin-mcp` and `@7xuanlu/origin` to npm.
+7. Updates the Homebrew tap for `origin-mcp`.
 
-**Note:** The `origin-mcp` npm package is published from the [origin-mcp repo](https://github.com/7xuanlu/origin-mcp), not from this repo. That repo owns all origin-mcp distribution: npm, crates.io, and Homebrew. The desktop DMG is built from [origin-app](https://github.com/7xuanlu/origin-app); see its `RELEASING.md` for that pipeline.
-
-## Cross-repo coordination with origin-mcp
-
-`origin-mcp` lives in a separate repo (`~/Repos/origin-mcp`, MIT license). The release workflow pulls its binary directly from that repo via `cargo install --git`. There is no automated version pinning between the two repos. Steps for a coordinated release:
-
-1. Release `origin-mcp` first (or ensure `main` is in a good state).
-2. Tag and push `origin` as described above.
-3. The workflow will install the latest `origin-mcp` from `main` of that repo.
-
-If you need to pin to a specific `origin-mcp` commit or tag, edit the `cargo install --git` step in `release.yml`.
+`origin-mcp` now lives in this monorepo under `crates/origin-mcp` and shares the workspace Apache-2.0 license. The desktop DMG is still built from [origin-app](https://github.com/7xuanlu/origin-app); see its `RELEASING.md` for that pipeline.
 
 ## Required secrets
 

--- a/crates/origin-cli/Cargo.toml
+++ b/crates/origin-cli/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Origin CLI. Talk to the local Origin daemon from your terminal."
+description = "Origin CLI for setup, service management, and local AI work memory."
 default-run = "origin"
 publish = false
 
@@ -13,8 +13,10 @@ name = "origin"
 path = "src/main.rs"
 
 [dependencies]
+origin-core = { workspace = true }
 origin-types = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+dirs = { workspace = true }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -24,3 +26,4 @@ anyhow = "1"
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+tempfile = { workspace = true }

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -1,8 +1,6 @@
 # origin-cli
 
-Origin CLI. Talk to the local Origin daemon from your terminal.
-
-Note: the release installer also creates an `origin` launcher for setup and service commands such as `origin setup`, `origin install`, and `origin doctor`. This crate is the source-built developer CLI for search, recall, store, list, and agent-management commands.
+Origin's product CLI. Use it to set up the local runtime, manage the daemon service, search and recall memory, store new memories, configure models/API keys, and run doctor checks.
 
 License: Apache-2.0.
 
@@ -31,11 +29,59 @@ export ORIGIN_HOST=http://127.0.0.1:7878  # default
 
 ### `origin status`
 
-Show daemon health + version.
+Show daemon, launchd service, model, and API key state.
 
 ```bash
 origin status
 origin status --format json
+```
+
+### `origin setup`
+
+Configure Origin's runtime mode.
+
+```bash
+origin setup                  # interactive
+origin setup --basic          # local memory, no local model or API key
+origin setup --model qwen3-4b # download/select a local model
+origin setup --anthropic-api-key-env ANTHROPIC_API_KEY
+```
+
+### `origin install` / `origin uninstall`
+
+Register or remove the macOS LaunchAgent. The service runs the sibling `origin-server` binary next to `origin`.
+
+```bash
+origin install
+origin uninstall
+```
+
+### `origin doctor`
+
+Diagnose daemon reachability, launchd state, model setup, and API key setup.
+
+```bash
+origin doctor
+```
+
+### `origin model`
+
+Manage opt-in local models.
+
+```bash
+origin model list
+origin model status
+origin model install qwen3-4b
+```
+
+### `origin key`
+
+Manage provider API keys.
+
+```bash
+origin key status
+origin key set anthropic --env ANTHROPIC_API_KEY
+origin key clear anthropic
 ```
 
 ### `origin search <query>`

--- a/crates/origin-cli/npm/package.json
+++ b/crates/origin-cli/npm/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@7xuanlu/origin",
+  "version": "0.6.0",
+  "description": "Frictionless setup for Origin, the local runtime for AI work memory.",
+  "license": "Apache-2.0",
+  "bin": {
+    "origin": "run.js"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/7xuanlu/origin.git",
+    "directory": "crates/origin-cli/npm"
+  },
+  "files": [
+    "run.js"
+  ]
+}

--- a/crates/origin-cli/npm/run.js
+++ b/crates/origin-cli/npm/run.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+const childProcess = require("child_process");
+const fs = require("fs");
+const https = require("https");
+const os = require("os");
+const path = require("path");
+
+const REPO = "7xuanlu/origin";
+const TARGET = "aarch64-apple-darwin";
+const REQUESTED_TAG = process.env.ORIGIN_RELEASE_TAG || process.env.ORIGIN_TAG || "";
+const BINARIES = ["origin", "origin-server", "origin-mcp"];
+
+function safeTag(tag) {
+  return tag.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function binDir() {
+  if (REQUESTED_TAG) {
+    return path.join(os.homedir(), ".origin", "releases", safeTag(REQUESTED_TAG));
+  }
+  return path.join(os.homedir(), ".origin", "bin");
+}
+
+function githubApiUrl() {
+  if (REQUESTED_TAG) {
+    return `https://api.github.com/repos/${REPO}/releases/tags/${REQUESTED_TAG}`;
+  }
+  return `https://api.github.com/repos/${REPO}/releases/latest`;
+}
+
+function request(url, headers = {}) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { "User-Agent": "@7xuanlu/origin", ...headers } }, (res) => {
+        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          res.resume();
+          resolve(request(res.headers.location, headers));
+          return;
+        }
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          res.resume();
+          reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+          return;
+        }
+        resolve(res);
+      })
+      .on("error", reject);
+  });
+}
+
+async function fetchJson(url) {
+  const res = await request(url, { Accept: "application/vnd.github+json" });
+  let body = "";
+  for await (const chunk of res) {
+    body += chunk;
+  }
+  return JSON.parse(body);
+}
+
+async function download(url, dest) {
+  const res = await request(url);
+  await new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(dest, { mode: 0o755 });
+    res.pipe(file);
+    file.on("finish", () => file.close(resolve));
+    file.on("error", reject);
+  });
+}
+
+function run(command, args) {
+  const result = childProcess.spawnSync(command, args, { stdio: "inherit" });
+  if (result.error) throw result.error;
+  process.exitCode = result.status || 0;
+  if (process.exitCode !== 0) {
+    process.exit(process.exitCode);
+  }
+}
+
+function printPathHint(dir) {
+  const entries = (process.env.PATH || "").split(path.delimiter);
+  if (entries.includes(dir)) return;
+
+  process.stderr.write(
+    `\nOrigin binaries are installed in ${dir}.\n` +
+      `Add them to your shell PATH if you want to run origin directly:\n\n` +
+      `  export PATH="${dir}:$PATH"\n\n`
+  );
+}
+
+async function installBinaries() {
+  if (process.platform !== "darwin" || process.arch !== "arm64") {
+    throw new Error("Origin setup currently supports macOS Apple Silicon only.");
+  }
+
+  const release = await fetchJson(githubApiUrl());
+  const tag = release.tag_name;
+  if (!tag) throw new Error("Could not determine Origin release tag.");
+
+  const dir = binDir();
+  fs.mkdirSync(dir, { recursive: true });
+
+  for (const name of BINARIES) {
+    const dest = path.join(dir, name);
+    const url = `https://github.com/${REPO}/releases/download/${tag}/${name}-${TARGET}`;
+    process.stderr.write(`Downloading ${name} ${tag}...\n`);
+    await download(url, dest);
+    fs.chmodSync(dest, 0o755);
+  }
+
+  return dir;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dir = await installBinaries();
+  const origin = path.join(dir, "origin");
+
+  if (args[0] === "setup") {
+    const setupArgs = args.slice(1);
+    run(origin, ["setup", ...(setupArgs.length ? setupArgs : ["--basic"])]);
+    run(origin, ["install"]);
+    run(origin, ["status", "--format", "table"]);
+    printPathHint(dir);
+    return;
+  }
+
+  run(origin, args.length ? args : ["--help"]);
+}
+
+main().catch((err) => {
+  console.error(`origin setup failed: ${err.message}`);
+  process.exit(1);
+});

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -20,6 +20,13 @@ use origin_types::{
 
 const DEFAULT_HOST: &str = "http://127.0.0.1:7878";
 
+pub fn origin_host_from_env() -> String {
+    std::env::var("ORIGIN_HOST")
+        .unwrap_or_else(|_| DEFAULT_HOST.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
 pub struct OriginClient {
     base_url: String,
     http: reqwest::Client,
@@ -28,17 +35,11 @@ pub struct OriginClient {
 impl OriginClient {
     /// Create a client using `ORIGIN_HOST` env var, or default to `http://127.0.0.1:7878`.
     pub fn from_env() -> Self {
-        let base_url = std::env::var("ORIGIN_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string());
-        // Strip trailing slash so URL joins are predictable.
-        let base_url = base_url.trim_end_matches('/').to_string();
+        let base_url = origin_host_from_env();
         Self {
             base_url,
             http: reqwest::Client::new(),
         }
-    }
-
-    pub fn base_url(&self) -> &str {
-        &self.base_url
     }
 
     /// GET /api/health — daemon liveness + version.

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -5,5 +5,7 @@ pub mod agents;
 pub mod list;
 pub mod recall;
 pub mod search;
+pub mod service;
+pub mod setup;
 pub mod status;
 pub mod store;

--- a/crates/origin-cli/src/commands/service.rs
+++ b/crates/origin-cli/src/commands/service.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+//! LaunchAgent management for the local Origin daemon.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::client::origin_host_from_env;
+
+pub(crate) const PLIST_LABEL: &str = "com.origin.server";
+const PLIST_TEMPLATE: &str =
+    include_str!("../../../origin-server/resources/com.origin.server.plist");
+
+pub fn plist_path() -> PathBuf {
+    dirs::home_dir()
+        .expect("HOME not set")
+        .join("Library/LaunchAgents")
+        .join(format!("{}.plist", PLIST_LABEL))
+}
+
+fn log_dir() -> PathBuf {
+    dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("origin")
+        .join("logs")
+}
+
+pub(crate) fn sibling_server_path_for_origin(origin_exe: &Path) -> PathBuf {
+    origin_exe
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("origin-server")
+}
+
+fn current_server_path() -> Result<PathBuf> {
+    let origin_exe = std::env::current_exe().context("cannot determine origin CLI path")?;
+    let server = sibling_server_path_for_origin(&origin_exe);
+    if !server.exists() {
+        anyhow::bail!(
+            "origin-server not found next to origin at {}. Re-run the Origin installer.",
+            server.display()
+        );
+    }
+    Ok(server)
+}
+
+pub(crate) fn plist_content(server_path: &Path, log_path: &Path) -> String {
+    PLIST_TEMPLATE
+        .replace("__ORIGIN_SERVER_PATH__", &server_path.to_string_lossy())
+        .replace("__LOG_PATH__", &log_path.to_string_lossy())
+}
+
+pub fn install() -> Result<()> {
+    let plist = plist_path();
+    let log_path = log_dir();
+    let server_path = current_server_path()?;
+
+    std::fs::create_dir_all(&log_path)?;
+
+    if let Some(parent) = plist.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    if plist.exists() {
+        let _ = std::process::Command::new("launchctl")
+            .arg("unload")
+            .arg(&plist)
+            .output();
+    }
+
+    std::fs::write(&plist, plist_content(&server_path, &log_path))?;
+    println!("Wrote {}", plist.display());
+
+    let output = std::process::Command::new("launchctl")
+        .arg("load")
+        .arg(&plist)
+        .output()?;
+
+    if output.status.success() {
+        println!(
+            "Loaded {} - daemon will start automatically on login",
+            PLIST_LABEL
+        );
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("launchctl load failed: {}", stderr);
+    }
+
+    Ok(())
+}
+
+pub fn uninstall() -> Result<()> {
+    let plist = plist_path();
+
+    if !plist.exists() {
+        println!("{} is not installed", PLIST_LABEL);
+        return Ok(());
+    }
+
+    let output = std::process::Command::new("launchctl")
+        .arg("unload")
+        .arg(&plist)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("launchctl unload warning: {}", stderr);
+    }
+
+    std::fs::remove_file(&plist)?;
+    println!(
+        "Removed {} - daemon will no longer auto-start",
+        plist.display()
+    );
+
+    Ok(())
+}
+
+pub async fn print_status() -> Result<()> {
+    let plist = plist_path();
+
+    if plist.exists() {
+        println!("Plist: {} (installed)", plist.display());
+    } else {
+        println!("Plist: not installed");
+    }
+
+    let output = std::process::Command::new("launchctl")
+        .arg("list")
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let registered = stdout.lines().any(|line| line.contains(PLIST_LABEL));
+    println!(
+        "Launchd: {}",
+        if registered {
+            "registered"
+        } else {
+            "not registered"
+        }
+    );
+
+    let url = format!("{}/api/health", origin_host_from_env());
+    match reqwest::get(&url).await {
+        Ok(resp) if resp.status().is_success() => {
+            let body = resp.text().await.unwrap_or_default();
+            println!("Health: ok ({})", url);
+            println!("{}", body);
+        }
+        Ok(resp) => {
+            println!("Health: unhealthy (status {})", resp.status());
+        }
+        Err(e) => {
+            println!("Health: not reachable ({})", e);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_origin_server_next_to_origin_cli() {
+        let origin = Path::new("/tmp/origin/bin/origin");
+        assert_eq!(
+            sibling_server_path_for_origin(origin),
+            PathBuf::from("/tmp/origin/bin/origin-server")
+        );
+    }
+
+    #[test]
+    fn plist_points_launchd_at_origin_server() {
+        let server = Path::new("/tmp/origin/bin/origin-server");
+        let log_path = Path::new("/tmp/origin/logs");
+        let content = plist_content(server, log_path);
+
+        assert!(content.contains("/tmp/origin/bin/origin-server"));
+        assert!(!content.contains("/tmp/origin/bin/origin</string>"));
+        assert!(content.contains("/tmp/origin/logs"));
+    }
+}

--- a/crates/origin-cli/src/commands/setup.rs
+++ b/crates/origin-cli/src/commands/setup.rs
@@ -5,6 +5,8 @@ use clap::{Subcommand, ValueEnum};
 use origin_core::{config, on_device_models};
 use std::io::{self, Write};
 
+use crate::client::origin_host_from_env;
+
 #[derive(Clone, Debug)]
 pub struct SetupArgs {
     pub basic: bool,
@@ -56,8 +58,9 @@ pub enum KeyProvider {
 pub async fn run_setup(args: SetupArgs) -> anyhow::Result<()> {
     if args.basic {
         configure_basic_memory()?;
-        println!("Origin is set up in Basic Memory mode.");
-        println!("Storage, search, recall, and MCP memory work without a local LLM or API key.");
+        println!("Origin is set up for local memory.");
+        println!("Storage, search, recall, and MCP memory work without a local model or API key.");
+        println!("Distill cycles stay off until you choose a local model or Anthropic key.");
         return Ok(());
     }
 
@@ -137,9 +140,9 @@ pub async fn run_doctor() -> anyhow::Result<()> {
 
     println!();
     if has_key || has_cached_model {
-        println!("Refinery: ready for richer extraction and background synthesis.");
+        println!("Distill cycles: ready for richer extraction and page synthesis.");
     } else {
-        println!("Refinery: limited until you choose a local model or Anthropic key.");
+        println!("Distill cycles: off until you choose a local model or Anthropic key.");
         println!("  Run: origin model install");
         println!("  Or:  origin key set anthropic");
     }
@@ -156,19 +159,19 @@ pub async fn print_runtime_status() -> anyhow::Result<()> {
 async fn interactive_setup() -> anyhow::Result<()> {
     println!("Set up Origin");
     println!();
-    println!("1) Basic Memory");
-    println!("   Store, search, recall, and MCP memory. No local LLM or API key.");
+    println!("1) Local Memory");
+    println!("   Store, search, recall, and MCP memory. No local model or API key.");
     println!("2) Local Model");
-    println!("   Download a local model for richer extraction and background synthesis.");
+    println!("   Download a local model for private distill cycles.");
     println!("3) Anthropic Key");
-    println!("   Use your Anthropic API key for stronger synthesis. Memory stays local.");
+    println!("   Use your Anthropic API key for stronger distill cycles. Memory stays local.");
     println!();
 
     let choice = prompt_line("Choose 1, 2, or 3 [1]: ")?;
     match choice.trim() {
         "" | "1" => {
             configure_basic_memory()?;
-            println!("Origin is set up in Basic Memory mode.");
+            println!("Origin is set up for local memory.");
             Ok(())
         }
         "2" => {
@@ -343,8 +346,7 @@ fn configured_model() -> Option<&'static on_device_models::OnDeviceModel> {
 }
 
 async fn print_daemon_health() {
-    let port = origin_port();
-    let url = format!("http://127.0.0.1:{}/api/health", port);
+    let url = origin_url("/api/health");
     match reqwest::get(&url).await {
         Ok(resp) if resp.status().is_success() => println!("Daemon: running on {}", url),
         Ok(resp) => println!("Daemon: unhealthy ({})", resp.status()),
@@ -352,15 +354,8 @@ async fn print_daemon_health() {
     }
 }
 
-fn origin_port() -> u16 {
-    std::env::var("ORIGIN_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(7878)
-}
-
 fn origin_url(path: &str) -> String {
-    format!("http://127.0.0.1:{}{}", origin_port(), path)
+    format!("{}{}", origin_host_from_env(), path)
 }
 
 async fn post_json(path: &str, body: &serde_json::Value) -> anyhow::Result<serde_json::Value> {

--- a/crates/origin-cli/src/commands/status.rs
+++ b/crates/origin-cli/src/commands/status.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-//! `origin status` — show daemon health + version.
+//! `origin status` — show daemon, service, model, and key state.
 
 use anyhow::Result;
 
+use super::{service, setup};
 use crate::client::OriginClient;
 use crate::output::{print_json, OutputFormat};
 
@@ -10,27 +11,25 @@ use crate::output::{print_json, OutputFormat};
 /// `quiet` suppresses success output; errors still propagate via `?` to stderr.
 /// We still hit the daemon under `quiet` to surface connection failures via exit code.
 pub async fn run(client: &OriginClient, format: OutputFormat, quiet: bool) -> Result<()> {
-    let health = client.health().await?;
     if quiet {
+        let _health = client.health().await?;
         return Ok(());
     }
     match format {
-        OutputFormat::Json => {
-            print_json(&health)?;
-        }
+        OutputFormat::Json => match client.health().await {
+            Ok(health) => print_json(&health)?,
+            Err(err) => {
+                let status = serde_json::json!({
+                    "status": "unreachable",
+                    "error": err.to_string(),
+                });
+                print_json(&status)?;
+            }
+        },
         OutputFormat::Table => {
-            println!("Origin daemon");
-            println!("  Status:        {}", health.status);
-            println!(
-                "  DB:            {}",
-                if health.db_initialized {
-                    "initialized"
-                } else {
-                    "uninitialized"
-                }
-            );
-            println!("  Version:       {}", health.version);
-            println!("  Host:          {}", client.base_url());
+            println!("Origin runtime");
+            service::print_status().await?;
+            setup::print_runtime_status().await?;
         }
         OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
     }

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -10,7 +10,7 @@ use output::OutputFormat;
 #[command(
     name = "origin",
     version,
-    about = "Origin CLI. Talk to the local Origin daemon."
+    about = "Origin CLI. Set up and use the local Origin runtime."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -27,8 +27,39 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Show daemon health + version.
+    /// Show daemon, service, model, and API key state.
     Status,
+    /// Guided setup for local memory, a local model, or an Anthropic key.
+    Setup {
+        /// Set up without a model or API key.
+        #[arg(long)]
+        basic: bool,
+        /// Download and select a local model, for example qwen3-4b.
+        #[arg(long, value_name = "MODEL_ID")]
+        model: Option<String>,
+        /// Read an Anthropic key from this environment variable.
+        #[arg(long = "anthropic-api-key-env", value_name = "ENV_VAR")]
+        anthropic_api_key_env: Option<String>,
+        /// Skip confirmation prompts where possible.
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+    /// Install the Origin daemon as a macOS LaunchAgent.
+    Install,
+    /// Uninstall the Origin LaunchAgent.
+    Uninstall,
+    /// Diagnose daemon, model, and API key setup.
+    Doctor,
+    /// Manage local models.
+    Model {
+        #[command(subcommand)]
+        command: commands::setup::ModelCommand,
+    },
+    /// Manage provider API keys.
+    Key {
+        #[command(subcommand)]
+        command: commands::setup::KeyCommand,
+    },
     /// Search memories by query (vector + FTS hybrid).
     Search {
         /// Search query.
@@ -77,6 +108,25 @@ async fn main() -> anyhow::Result<()> {
     let format = cli.format.resolve();
     match cli.command {
         Commands::Status => commands::status::run(&client, format, cli.quiet).await?,
+        Commands::Setup {
+            basic,
+            model,
+            anthropic_api_key_env,
+            yes,
+        } => {
+            commands::setup::run_setup(commands::setup::SetupArgs {
+                basic,
+                model,
+                anthropic_api_key_env,
+                yes,
+            })
+            .await?
+        }
+        Commands::Install => commands::service::install()?,
+        Commands::Uninstall => commands::service::uninstall()?,
+        Commands::Doctor => commands::setup::run_doctor().await?,
+        Commands::Model { command } => commands::setup::run_model(command).await?,
+        Commands::Key { command } => commands::setup::run_key(command).await?,
         Commands::Search { query, limit } => {
             commands::search::run(&client, format, cli.quiet, query, limit).await?
         }

--- a/crates/origin-cli/tests/cli_integration.rs
+++ b/crates/origin-cli/tests/cli_integration.rs
@@ -3,9 +3,97 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
 
 fn cli() -> Command {
     Command::cargo_bin("origin").expect("origin binary built")
+}
+
+fn cli_with_isolated_runtime(runtime: &IsolatedRuntime) -> Command {
+    let mut cmd = cli();
+    cmd.env("HOME", runtime.home.path())
+        .env("ORIGIN_DATA_DIR", runtime.data.path())
+        .env("ORIGIN_HOST", "http://127.0.0.1:9")
+        .env(
+            "PATH",
+            format!(
+                "{}:{}",
+                runtime.fake_bin.path().display(),
+                std::env::var("PATH").unwrap_or_default()
+            ),
+        );
+    cmd
+}
+
+struct IsolatedRuntime {
+    root: TempDir,
+    home: TempDir,
+    data: TempDir,
+    fake_bin: TempDir,
+}
+
+impl IsolatedRuntime {
+    fn new() -> Self {
+        let root = tempfile::tempdir().expect("temp root");
+        let home = tempfile::tempdir_in(root.path()).expect("temp home");
+        let data = tempfile::tempdir_in(root.path()).expect("temp data");
+        let fake_bin = tempfile::tempdir_in(root.path()).expect("temp fake bin");
+        write_fake_launchctl(fake_bin.path());
+        ensure_sibling_origin_server();
+        Self {
+            root,
+            home,
+            data,
+            fake_bin,
+        }
+    }
+
+    fn plist_path(&self) -> PathBuf {
+        self.home
+            .path()
+            .join("Library/LaunchAgents/com.origin.server.plist")
+    }
+
+    fn config_path(&self) -> PathBuf {
+        self.data.path().join("config.json")
+    }
+
+    fn root_exists(&self) -> bool {
+        self.root.path().exists()
+    }
+}
+
+fn write_fake_launchctl(fake_bin: &Path) {
+    let path = fake_bin.join("launchctl");
+    fs::write(
+        &path,
+        "#!/bin/sh\ncase \"$1\" in\n  list) exit 0 ;;\n  load|unload) echo \"fake launchctl $1 $2\"; exit 0 ;;\n  *) echo \"fake launchctl $@\"; exit 0 ;;\nesac\n",
+    )
+    .expect("write fake launchctl");
+    let mut perms = fs::metadata(&path)
+        .expect("fake launchctl metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod fake launchctl");
+}
+
+fn ensure_sibling_origin_server() {
+    let origin_bin = assert_cmd::cargo::cargo_bin("origin");
+    let server = origin_bin
+        .parent()
+        .expect("origin binary has parent")
+        .join("origin-server");
+    if !server.exists() {
+        fs::write(&server, "#!/bin/sh\nexit 0\n").expect("write fake origin-server sibling");
+        let mut perms = fs::metadata(&server)
+            .expect("fake origin-server metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(server, perms).expect("chmod fake origin-server");
+    }
 }
 
 #[test]
@@ -28,8 +116,36 @@ fn version_flag() {
 
 #[test]
 fn each_subcommand_has_help() {
-    for sub in ["status", "search", "recall", "store", "list", "agents"] {
+    for sub in [
+        "status",
+        "search",
+        "recall",
+        "store",
+        "list",
+        "agents",
+        "setup",
+        "install",
+        "uninstall",
+        "doctor",
+        "model",
+        "key",
+    ] {
         cli().args([sub, "--help"]).assert().success();
+    }
+}
+
+#[test]
+fn setup_subcommands_have_help() {
+    for args in [
+        &["setup", "--help"][..],
+        &["model", "list", "--help"][..],
+        &["model", "install", "--help"][..],
+        &["model", "status", "--help"][..],
+        &["key", "status", "--help"][..],
+        &["key", "set", "--help"][..],
+        &["key", "clear", "--help"][..],
+    ] {
+        cli().args(args).assert().success();
     }
 }
 
@@ -55,4 +171,90 @@ fn agents_edit_no_flags_bails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("No fields to update"));
+}
+
+#[test]
+fn status_json_succeeds_when_daemon_is_unreachable() {
+    cli()
+        .env("ORIGIN_HOST", "http://127.0.0.1:9")
+        .args(["status", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"unreachable\""));
+}
+
+#[test]
+fn status_table_uses_origin_host_for_health_probe() {
+    let runtime = IsolatedRuntime::new();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["status", "--format", "table"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Health: not reachable"))
+        .stdout(predicate::str::contains("http://127.0.0.1:9/api/health"));
+}
+
+#[test]
+fn doctor_uses_origin_host_for_health_probe() {
+    cli()
+        .env("ORIGIN_HOST", "http://127.0.0.1:9")
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Daemon: not reachable on http://127.0.0.1:9/api/health",
+        ));
+}
+
+#[test]
+fn setup_install_status_uninstall_roundtrip_isolated() {
+    let runtime = IsolatedRuntime::new();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["setup", "--basic"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Origin is set up for local memory",
+        ))
+        .stdout(predicate::str::contains("Distill cycles stay off"));
+
+    let config = fs::read_to_string(runtime.config_path()).expect("config written");
+    assert!(config.contains(r#""setup_completed": true"#));
+    assert!(config.contains(r#""on_device_model": null"#));
+    assert!(config.contains(r#""anthropic_api_key": null"#));
+
+    cli_with_isolated_runtime(&runtime)
+        .arg("install")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Wrote"))
+        .stdout(predicate::str::contains("Loaded com.origin.server"));
+
+    let plist = fs::read_to_string(runtime.plist_path()).expect("plist written");
+    assert!(plist.contains("<string>com.origin.server</string>"));
+    assert!(plist.contains("origin-server"));
+    assert!(!plist.contains("origin</string>"));
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["status", "--format", "json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"unreachable\""));
+
+    cli_with_isolated_runtime(&runtime)
+        .arg("uninstall")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("daemon will no longer auto-start"));
+
+    assert!(
+        !runtime.plist_path().exists(),
+        "uninstall removes launchd plist"
+    );
+    assert!(
+        runtime.root_exists(),
+        "temp runtime remains alive until test end"
+    );
 }

--- a/crates/origin-core/README.md
+++ b/crates/origin-core/README.md
@@ -6,22 +6,22 @@ Business logic for Origin. This crate has no Axum or Tauri dependency. The daemo
 
 - libSQL storage, FTS5, vector search, Reciprocal Rank Fusion
 - embedding generation through FastEmbed
-- optional on-device LLM provider through `llama-cpp-2`
+- optional on-device model provider through `llama-cpp-2`
 - memory classification, extraction, quality gates, deduplication, and contradiction checks
 - knowledge graph entities, relations, and observations
 - page distillation and Markdown/Obsidian export
-- refinery phases that maintain memory quality over time
+- distill cycles that maintain memory quality over time
 - LoCoMo and LongMemEval evaluation harnesses
 
 ## Core Flow
 
 1. A client stores text through the daemon.
 2. `origin-core` validates and stores the raw memory.
-3. Post-ingest enrichment links entities, deduplicates, and queues refinement.
-4. The refinery compiles related memories into pages and refreshes existing pages.
+3. Post-ingest enrichment links entities, deduplicates, and queues review proposals.
+4. Distill cycles compile related memories into pages and refresh existing pages.
 5. Recall combines vector search, full-text search, graph context, and relevant pages.
 
-Basic Memory mode does storage and retrieval without a local LLM or API key. Extraction, richer refinement, and page synthesis require an on-device model or configured provider.
+Local memory mode does storage and retrieval without a local model or API key. Extraction, richer distill cycles, and page synthesis require an on-device model or configured provider.
 
 ## Important Modules
 
@@ -30,10 +30,10 @@ Basic Memory mode does storage and retrieval without a local LLM or API key. Ext
 | `db.rs` | `MemoryDB`, migrations, storage, search, graph, pages. |
 | `quality_gate.rs` | Pre-store acceptance and warnings. |
 | `post_ingest.rs` | Dedup, entity linking, title enrichment, recap, page growth. |
-| `refinery.rs` and `refinery/` | Background maintenance phases. |
+| `refinery.rs` and `refinery/` | Distill-cycle implementation and background maintenance phases. |
 | `pages.rs` | Page type and page relevance helpers. |
 | `export/` | Markdown, Obsidian, JSON, zip, and PDF export surfaces. |
-| `engine.rs` | On-device LLM wrapper. |
+| `engine.rs` | On-device model wrapper. |
 | `llm_provider.rs` | Provider abstraction for API and local model paths. |
 | `eval/` | Benchmark runners and analysis helpers. |
 

--- a/crates/origin-core/src/quality_gate.rs
+++ b/crates/origin-core/src/quality_gate.rs
@@ -1029,7 +1029,7 @@ mod integration_tests {
             "The LLM formatter thread captures a tokio runtime handle for async database calls",
             "Config is persisted as JSON at the standard macOS Application Support directory path",
             "Meeting with the design team is scheduled for every Wednesday at two PM Pacific",
-            "The project uses AGPL-3.0-only license for the main app and MIT for the MCP server",
+            "The desktop app uses AGPL-3.0-only while the local runtime uses Apache-2.0",
             "Batch SQL operations should always be wrapped in BEGIN COMMIT transactions for atomicity",
             "The ambient capture system is disabled by default as part of the memory-layer pivot",
             "Frame comparison uses a 3-tier approach with downscaling hashing and Hellinger distance",

--- a/crates/origin-mcp/README.md
+++ b/crates/origin-mcp/README.md
@@ -1,8 +1,8 @@
 # origin-mcp
 
-MCP server for [Origin](https://github.com/7xuanlu/origin). It lets Claude Code, Cursor, Codex, Claude Desktop, Windsurf, Gemini CLI, and other MCP clients read and write to the local Origin daemon through the [Model Context Protocol](https://modelcontextprotocol.io).
+MCP server for [Origin](https://github.com/7xuanlu/origin). It lets Claude Code, Cursor, Codex, Claude Desktop, Gemini CLI, and other MCP clients read and write to the local Origin daemon through the [Model Context Protocol](https://modelcontextprotocol.io).
 
-Origin owns storage, search, embeddings, pages, and background refinement. `origin-mcp` is the connector.
+Origin owns storage, search, embeddings, pages, and distill cycles. `origin-mcp` is the connector.
 
 ## Install
 
@@ -63,11 +63,11 @@ origin-mcp --origin-url http://127.0.0.1:7879
 
 ## Setup Modes
 
-Origin works immediately in **Basic Memory** mode: storage, search, recall, and MCP memory are available without a local LLM or API key.
+Origin works immediately in **local memory** mode: storage, search, recall, and MCP memory are available without a local model or API key.
 
-Users can opt into more expensive/refined behavior:
+Users can opt into more expensive distill cycles:
 
-- **On-device model:** private extraction and refinement after `origin model install`.
+- **On-device model:** private extraction and distillation after `origin model install`.
 - **Anthropic key:** richer extraction and page synthesis after `origin key set anthropic`.
 
 ## Agent Guidance

--- a/crates/origin-mcp/npm/package.json
+++ b/crates/origin-mcp/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "origin-mcp",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Personal memory layer for AI agents - MCP server",
   "keywords": [
     "mcp",

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -191,7 +191,7 @@ pub struct ConfirmMemoryParams {
     pub memory_id: String,
 }
 
-// --- Refinery queue params ---
+// --- Review proposal params ---
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListRefinementsParams {
@@ -207,13 +207,13 @@ pub struct ListRefinementsParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct RejectRefinementParams {
-    #[schemars(description = "The refinement proposal id to dismiss.")]
+    #[schemars(description = "The review proposal id to dismiss.")]
     pub id: String,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct AcceptRefinementParams {
-    #[schemars(description = "The refinement proposal id (e.g. \"merge_abc123_def456\").")]
+    #[schemars(description = "The review proposal id (e.g. \"merge_abc123_def456\").")]
     pub id: String,
 }
 
@@ -530,9 +530,9 @@ fn daemon_setup_hint() -> &'static str {
     "Install the local Origin runtime and run `origin setup`.
 
 Setup choices:
-- Basic Memory: store, search, and recall now. No model download or API key.
-- On-device Model: private local extraction and background refinement after model download.
-- Anthropic Key: richer extraction and background refinement using your API key.
+- Local Memory: store, search, and recall now. No model download or API key.
+- On-device Model: private local extraction and distill cycles after model download.
+- Anthropic Key: richer extraction and distill cycles using your API key.
 
 Install:
   curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/main/install.sh | bash
@@ -584,7 +584,7 @@ fn format_doctor_message(status: &serde_json::Value) -> String {
         .unwrap_or(false);
 
     let mode_label = match mode {
-        "basic-memory" => "Basic Memory",
+        "basic-memory" => "Local Memory",
         "local-model" => "On-device Model",
         "anthropic-key" => "Anthropic Key",
         other => other,
@@ -606,9 +606,9 @@ fn format_doctor_message(status: &serde_json::Value) -> String {
         None => "not selected".to_string(),
     };
     let refinement_line = if anthropic_key_configured || local_model_loaded.is_some() {
-        "enabled (richer extraction and background refinement are active)"
+        "enabled (richer extraction and page synthesis are active)"
     } else if setup_completed {
-        "paused (Basic Memory stores, searches, and recalls now. Choose an on-device model or Anthropic key for richer extraction.)"
+        "off (local memory stores, searches, and recalls now. Choose an on-device model or Anthropic key for richer extraction.)"
     } else {
         "not configured"
     };
@@ -619,7 +619,7 @@ fn format_doctor_message(status: &serde_json::Value) -> String {
          Mode: {mode_label}\n\
          Anthropic key: {}\n\
          On-device model: {local_model_line}\n\
-         Background refinement: {refinement_line}",
+         Distill cycles: {refinement_line}",
         if setup_completed {
             "completed"
         } else {
@@ -634,12 +634,12 @@ fn format_doctor_message(status: &serde_json::Value) -> String {
 
     if !setup_completed {
         msg.push_str(
-            "\n\nRun `origin setup` to choose Basic Memory, On-device Model, or Anthropic Key.",
+            "\n\nRun `origin setup` to choose Local Memory, On-device Model, or Anthropic Key.",
         );
     } else if !anthropic_key_configured && local_model_loaded.is_none() {
         msg.push_str(
-            "\n\nBasic Memory works now: capture, recall, and context are available. \
-             To enable richer extraction and background refinement, run `origin model install` \
+            "\n\nLocal memory works now: capture, recall, and context are available. \
+             To enable richer extraction and distill cycles, run `origin model install` \
              or `origin key set anthropic`.",
         );
     }
@@ -1330,7 +1330,7 @@ impl OriginMcpServer {
         let pretty = serde_json::to_string_pretty(&resp.proposals)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "{} pending refinement proposals\n{}",
+            "{} pending review proposals\n{}",
             resp.proposals.len(),
             pretty
         ))]))
@@ -1342,8 +1342,8 @@ impl OriginMcpServer {
     ) -> Result<CallToolResult, McpError> {
         if self.transport == TransportMode::Http {
             return Ok(CallToolResult::error(vec![Content::text(
-                "Refinement operations are not available over remote connections. \
-                 Use local MCP on the machine running Origin to reject refinements."
+                "Review proposal operations are not available over remote connections. \
+                 Use local MCP on the machine running Origin to reject proposals."
                     .to_string(),
             )]));
         }
@@ -1358,7 +1358,7 @@ impl OriginMcpServer {
             };
 
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Refinement {} dismissed.",
+            "Review proposal {} dismissed.",
             resp.id
         ))]))
     }
@@ -1369,8 +1369,8 @@ impl OriginMcpServer {
     ) -> Result<CallToolResult, McpError> {
         if self.transport == TransportMode::Http {
             return Ok(CallToolResult::error(vec![Content::text(
-                "Refinement operations are not available over remote connections. \
-                 Use local MCP on the machine running Origin to accept refinements."
+                "Review proposal operations are not available over remote connections. \
+                 Use local MCP on the machine running Origin to accept proposals."
                     .to_string(),
             )]));
         }
@@ -1385,7 +1385,7 @@ impl OriginMcpServer {
             };
 
         Ok(CallToolResult::success(vec![Content::text(format!(
-            "Refinement {} accepted (action={}).",
+            "Review proposal {} accepted (action={}).",
             resp.id, resp.action_applied
         ))]))
     }
@@ -1703,7 +1703,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Diagnose the local Origin runtime. This is not part of the memory loop. Use only when Origin tools fail, when onboarding a new MCP client, or when the user asks why setup, extraction, or background refinement is paused. Reports daemon reachability, setup mode, Basic Memory, On-device Model, Anthropic key state, and on-device model state.",
+        description = "Diagnose the local Origin runtime. This is not part of the memory loop. Use only when Origin tools fail, when onboarding a new MCP client, or when the user asks why setup, extraction, or distill cycles are off. Reports daemon reachability, setup mode, Local Memory, On-device Model, Anthropic key state, and on-device model state.",
         annotations(title = "Doctor", read_only_hint = true, open_world_hint = false)
     )]
     async fn doctor(&self) -> Result<CallToolResult, McpError> {
@@ -1775,7 +1775,7 @@ impl OriginMcpServer {
     // --- Knowledge graph CRUD ---
 
     #[tool(
-        description = "Create an entity in the knowledge graph. Use when the user names a person, project, tool, or place that isn't yet linked, or when you need a stable id to anchor memories or pages to. The daemon's post-ingest enrichment usually creates entities automatically when an LLM is configured — call this explicitly only when there is no LLM (Basic Memory mode) or you need the id back synchronously.",
+        description = "Create an entity in the knowledge graph. Use when the user names a person, project, tool, or place that isn't yet linked, or when you need a stable id to anchor memories or pages to. The daemon's post-ingest enrichment usually creates entities automatically when a model or Anthropic key is configured — call this explicitly when distill cycles are off or you need the id back synchronously.",
         annotations(
             title = "Create entity",
             read_only_hint = false,
@@ -1792,7 +1792,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Create a directed relation between two entities in the knowledge graph. Use sparingly — most relations come out of the daemon's enrichment when an LLM is configured. Call this explicitly to record a relation the user articulated that the daemon couldn't infer, or in Basic Memory mode where extraction does not run.",
+        description = "Create a directed relation between two entities in the knowledge graph. Use sparingly — most relations come out of the daemon's enrichment when a model or Anthropic key is configured. Call this explicitly to record a relation the user articulated that the daemon couldn't infer, or when distill cycles are off.",
         annotations(
             title = "Create relation",
             read_only_hint = false,
@@ -1809,7 +1809,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Attach a factual observation to an existing entity in the knowledge graph. Use sparingly — most observations come from daemon LLM extraction. Call explicitly when the user articulates a fact about a person/project/tool that the daemon couldn't infer, or when running in Basic Memory mode where on-device extraction does not run. Requires the entity_id; resolve via search_entities first if you only have the name. Returns 422 if entity does not exist.",
+        description = "Attach a factual observation to an existing entity in the knowledge graph. Use sparingly — most observations come from daemon extraction. Call explicitly when the user articulates a fact about a person/project/tool that the daemon couldn't infer, or when distill cycles are off. Requires the entity_id; resolve via search_entities first if you only have the name. Returns 422 if entity does not exist.",
         annotations(
             title = "Create observation",
             read_only_hint = false,
@@ -1826,7 +1826,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Confirm (or unconfirm) an entity in the knowledge graph — flips its stability flag from tentative to durable. Call when the user explicitly affirms or revokes an extracted entity (\"yes that's right\", \"no that's wrong\"), or when you have high confidence after seeing the entity reused across multiple contexts. Unconfirmed entities may be pruned by background refinement; confirmed ones persist. Defaults confirmed=true if omitted. Do NOT call for every extracted entity — most should stay unconfirmed and let background refinement decide. Not available over remote HTTP MCP transport (local stdio only).",
+        description = "Confirm (or unconfirm) an entity in the knowledge graph — flips its stability flag from tentative to durable. Call when the user explicitly affirms or revokes an extracted entity (\"yes that's right\", \"no that's wrong\"), or when you have high confidence after seeing the entity reused across multiple contexts. Unconfirmed entities may be pruned by distill cycles; confirmed ones persist. Defaults confirmed=true if omitted. Do NOT call for every extracted entity — most should stay unconfirmed and let distill cycles decide. Not available over remote HTTP MCP transport (local stdio only).",
         annotations(
             title = "Confirm entity",
             read_only_hint = false,
@@ -1860,7 +1860,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Confirm (or unconfirm) an observation — flips its stability flag from tentative to durable. Call when the user explicitly affirms a specific fact attached to an entity (\"yes Alice does prefer tabs\"), or when you observe the same fact restated across multiple sources. Unconfirmed observations may be pruned by background refinement; confirmed ones persist. Defaults confirmed=true if omitted. Do NOT call for every observation you create — let background refinement promote them when warranted. Not available over remote HTTP MCP transport (local stdio only).",
+        description = "Confirm (or unconfirm) an observation — flips its stability flag from tentative to durable. Call when the user explicitly affirms a specific fact attached to an entity (\"yes Alice does prefer tabs\"), or when you observe the same fact restated across multiple sources. Unconfirmed observations may be pruned by distill cycles; confirmed ones persist. Defaults confirmed=true if omitted. Do NOT call for every observation you create — let distill cycles promote them when warranted. Not available over remote HTTP MCP transport (local stdio only).",
         annotations(
             title = "Confirm observation",
             read_only_hint = false,
@@ -2071,12 +2071,12 @@ impl OriginMcpServer {
         self.list_spaces_impl(params).await
     }
 
-    // --- Refinery queue tools ---
+    // --- Review proposal tools ---
 
     #[tool(
-        description = "List pending refinement proposals from Origin's daemon-side refinery queue. Use when the user wants to audit what the daemon has queued for review — phrases like 'check refinery', 'pending proposals', 'what's queued'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
+        description = "List pending review proposals from Origin's daemon-side queue. Use when the user wants to audit what the daemon has queued for review — phrases like 'pending proposals', 'what's queued', 'check review queue'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
         annotations(
-            title = "List refinements",
+            title = "List review proposals",
             read_only_hint = true,
             open_world_hint = false
         )
@@ -2089,9 +2089,9 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Reject (dismiss) a refinement proposal by id. Use when reviewing the refinery queue and the user decides a proposal is wrong or noise. Marks the queue row dismissed and logs the agent activity. Idempotent: already-dismissed proposals return 422. Note: there is no accept verb yet; keeping a proposal is a no-op (it stays queued). Not available over remote HTTP MCP transport (local stdio only).",
+        description = "Reject (dismiss) a review proposal by id. Use when reviewing the daemon queue and the user decides a proposal is wrong or noise. Marks the queue row dismissed and logs the agent activity. Idempotent: already-dismissed proposals return 422. Note: there is no accept verb yet; keeping a proposal is a no-op (it stays queued). Not available over remote HTTP MCP transport (local stdio only).",
         annotations(
-            title = "Reject refinement",
+            title = "Reject review proposal",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = true,
@@ -2106,14 +2106,14 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Apply a refinement queue proposal using sensible defaults. \
+        description = "Apply a review queue proposal using sensible defaults. \
             entity_merge: existing entity wins as canonical. \
             relation_conflict: new relation supersedes. \
             detect_contradiction: previously-stored memory flagged for revision. \
             Returns 422 for suggest_entity (no producer) and dedup_merge (deprecated). \
             Not available over remote HTTP MCP transport (local stdio only).",
         annotations(
-            title = "Accept refinement",
+            title = "Accept review proposal",
             read_only_hint = false,
             destructive_hint = false,
             idempotent_hint = true,
@@ -2146,7 +2146,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "List entity-suggestion proposals from the refinery queue \
+        description = "List entity-suggestion proposals from the daemon review queue \
                        (action='suggest_entity'). Use when the user asks 'what entities \
                        does the daemon want to create' or wants to triage merge-vs-create \
                        decisions. Returns id, proposed entity_name, source_ids, confidence. \
@@ -2721,7 +2721,7 @@ mod tests {
     }
 
     #[test]
-    fn doctor_basic_memory_message_sets_expectations() {
+    fn doctor_local_memory_message_sets_expectations() {
         let msg = format_doctor_message(&serde_json::json!({
             "setup_completed": true,
             "mode": "basic-memory",
@@ -2731,10 +2731,10 @@ mod tests {
             "local_model_cached": false
         }));
 
-        assert!(msg.contains("Mode: Basic Memory"));
+        assert!(msg.contains("Mode: Local Memory"));
         assert!(msg.contains("On-device model: not selected"));
-        assert!(msg.contains("Background refinement: paused"));
-        assert!(msg.contains("Basic Memory works now: capture, recall, and context are available"));
+        assert!(msg.contains("Distill cycles: off"));
+        assert!(msg.contains("Local memory works now: capture, recall, and context are available"));
         assert!(msg.contains("origin model install"));
         assert!(msg.contains("origin key set anthropic"));
     }
@@ -2755,8 +2755,8 @@ mod tests {
             msg.contains("On-device model: qwen3-1.7b (downloaded, loaded)"),
             "{msg}"
         );
-        assert!(msg.contains("Background refinement: enabled"), "{msg}");
-        assert!(!msg.contains("Basic Memory works now"));
+        assert!(msg.contains("Distill cycles: enabled"), "{msg}");
+        assert!(!msg.contains("Local memory works now"));
     }
 
     #[test]
@@ -2772,7 +2772,7 @@ mod tests {
 
         assert!(msg.contains("Setup: not completed"));
         assert!(msg.contains("Run `origin setup`"));
-        assert!(msg.contains("Basic Memory, On-device Model, or Anthropic Key"));
+        assert!(msg.contains("Local Memory, On-device Model, or Anthropic Key"));
     }
 
     #[test]
@@ -3902,7 +3902,7 @@ mod tests {
         let descriptions = tool_descriptions();
         let status = descriptions.get("doctor").expect("doctor tool exists");
         assert!(
-            status.contains("Basic Memory"),
+            status.contains("Local Memory"),
             "doctor description must mention setup modes, got: {status}"
         );
         assert!(

--- a/crates/origin-server/README.md
+++ b/crates/origin-server/README.md
@@ -1,32 +1,28 @@
 # origin-server
 
-Local daemon for Origin. It owns the database, embeddings, search, refinery, page distillation, knowledge graph, and HTTP API on `127.0.0.1:7878`.
+Local daemon for Origin. It owns the database, embeddings, search, distill cycles, page distillation, knowledge graph, and HTTP API on `127.0.0.1:7878`.
 
 ## Headless install
 
-Most users install Origin through the [Claude Code plugin](../../plugin/.claude-plugin/README.md), which auto-runs the install script the first time `/init` runs. This page is for the other 10% — automation, servers, CI, or pre-flight installs without the plugin.
+Most users install Origin through the [Claude Code plugin](../../plugin/.claude-plugin/README.md), which auto-runs the install script the first time `/init` runs. This page is for daemon internals. For terminal setup, use the product CLI:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/main/install.sh | bash
-export PATH="$HOME/.origin/bin:$PATH"
-origin setup --basic       # non-interactive Basic Memory mode (default)
-origin install             # register the launchd service
-origin status              # verify
+npx -y @7xuanlu/origin setup
 ```
 
-The installer downloads `origin-server` and `origin-mcp` into `~/.origin/bin/` and creates a small `origin` launcher.
+The installer downloads `origin`, `origin-server`, and `origin-mcp` into `~/.origin/bin/`. The `origin` CLI owns setup and service management; `origin-server` is the daemon binary launchd runs.
 
 ## Setup modes
 
 ```bash
-origin setup                  # interactive (1=Basic, 2=on-device model, 3=Anthropic key)
-origin setup --basic          # non-interactive Basic Memory — used by the plugin's /init
+origin setup                  # interactive (1=local memory, 2=on-device model, 3=Anthropic key)
+origin setup --basic          # non-interactive local memory setup used by the plugin's /init
 origin model install          # opt into a local Qwen model (llama.cpp + Metal)
 origin key set anthropic      # opt into Anthropic-backed extraction (BYOK)
 origin doctor                 # diagnose daemon, model, and key state
 ```
 
-Basic Memory works without a local LLM or API key: store, search, recall, and MCP memory are available immediately. On-device models and Anthropic keys unlock background refinery — auto entity extraction, page synthesis, recaps, knowledge-graph rethink.
+Local memory works without a local model or API key: store, search, recall, and MCP memory are available immediately. On-device models and Anthropic keys unlock distill cycles: auto entity extraction, page synthesis, recaps, and knowledge-graph rethink.
 
 ## Data layout
 
@@ -63,9 +59,10 @@ cargo run -p origin-server
 Or build a release binary and install it as a launchd service:
 
 ```bash
-cargo build --release -p origin-server
-./target/release/origin-server install
-./target/release/origin-server status
+cargo build --release -p origin -p origin-server
+./target/release/origin setup --basic
+./target/release/origin install
+./target/release/origin status
 ```
 
 First build takes several minutes while `llama.cpp` compiles for Metal.

--- a/crates/origin-server/src/cmd_backfill.rs
+++ b/crates/origin-server/src/cmd_backfill.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-//! `backfill-stale-concepts` CLI subcommand.
+//! `backfill-stale-pages` internal CLI subcommand.
 //!
-//! Deletes archived pages that look like Mode B failures (large
+//! Deletes archived pages that look like old distillation failures (large
 //! source_memory_ids, no entity, no domain, not user-edited). Source memories
-//! are NOT modified — see spec 2026-04-25-bad-page-distill-fix-design.md
-//! for the rationale and follow-up steps required to re-distill them.
+//! are NOT modified.
 //!
-//! `concept_sources` rows are deleted automatically via ON DELETE CASCADE.
+//! `page_sources` rows are deleted automatically via ON DELETE CASCADE.
 
 use anyhow::{anyhow, Context, Result};
 use origin_core::db::MemoryDB;
@@ -75,7 +74,7 @@ pub async fn run(dry_run: bool) -> anyhow::Result<()> {
 
     // Step 4: confirm.
     print!(
-        "Delete {} page(s) and their concept_sources rows? (y/N): ",
+        "Delete {} page(s) and their page_sources rows? (y/N): ",
         candidates.len()
     );
     io::stdout().flush().ok();
@@ -90,7 +89,7 @@ pub async fn run(dry_run: bool) -> anyhow::Result<()> {
     }
 
     // Step 5: delete.
-    // concept_sources rows cascade automatically (ON DELETE CASCADE FK).
+    // page_sources rows cascade automatically (ON DELETE CASCADE FK).
     let mut deleted = 0usize;
     for c in &candidates {
         db.delete_page(&c.id)
@@ -105,7 +104,7 @@ pub async fn run(dry_run: bool) -> anyhow::Result<()> {
     );
     println!();
     println!("Next steps to re-distill the freed sources:");
-    println!("  - Sources with enrichment_steps rows will be eligible on next refinery tick.");
+    println!("  - Sources with enrichment_steps rows will be eligible on the next distill cycle.");
     println!("  - Raw sources need re-enrichment first. Either:");
     println!("    (a) Re-import: touch the original source files (e.g., `touch ~/second-brain/inbox/*.md`)");
     println!("    (b) Wait for entity_backfill to gradually backfill entity_ids");

--- a/crates/origin-server/src/config_routes.rs
+++ b/crates/origin-server/src/config_routes.rs
@@ -269,7 +269,7 @@ pub async fn handle_get_on_device_model(
     let models: Vec<OnDeviceModelEntry> =
         on_device_models::MODELS.iter().map(model_entry).collect();
     // Resolve selected against registry so stale config values map to the default,
-    // but keep Basic Memory distinct from "default local model selected".
+    // but keep local memory distinct from "default local model selected".
     let selected = cfg
         .on_device_model
         .as_deref()

--- a/crates/origin-server/src/main.rs
+++ b/crates/origin-server/src/main.rs
@@ -2,7 +2,6 @@
 //! Origin headless daemon — runs the memory server without Tauri.
 
 mod cmd_backfill;
-mod cmd_setup;
 
 // All other modules live in the library target (src/lib.rs) so that
 // integration tests in tests/ can reference them as origin_server::<mod>.
@@ -17,7 +16,12 @@ use tokio::sync::RwLock;
 
 /// Origin memory daemon — headless HTTP server.
 #[derive(Parser)]
-#[command(name = "origin", bin_name = "origin", version, about)]
+#[command(
+    name = "origin-server",
+    bin_name = "origin-server",
+    version,
+    about = "Origin headless HTTP daemon."
+)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -37,42 +41,9 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Guided setup for Basic Memory, a local model, or an Anthropic key.
-    Setup {
-        /// Set up without a model or API key.
-        #[arg(long)]
-        basic: bool,
-        /// Download and select a local model, for example qwen3-4b.
-        #[arg(long, value_name = "MODEL_ID")]
-        model: Option<String>,
-        /// Read an Anthropic key from this environment variable.
-        #[arg(long = "anthropic-api-key-env", value_name = "ENV_VAR")]
-        anthropic_api_key_env: Option<String>,
-        /// Skip confirmation prompts where possible.
-        #[arg(short = 'y', long)]
-        yes: bool,
-    },
-    /// Diagnose daemon, model, and API key setup.
-    Doctor,
-    /// Manage local models.
-    Model {
-        #[command(subcommand)]
-        command: cmd_setup::ModelCommand,
-    },
-    /// Manage provider API keys.
-    Key {
-        #[command(subcommand)]
-        command: cmd_setup::KeyCommand,
-    },
-    /// Install as a macOS LaunchAgent (auto-start on login).
-    Install,
-    /// Uninstall the LaunchAgent.
-    Uninstall,
-    /// Show daemon, model, and API key status.
-    Status,
-    /// Delete archived stale concepts (Mode B cleanup). See spec
-    /// 2026-04-25-bad-page-distill-fix-design.md. Daemon must be stopped first.
-    BackfillStaleConcepts {
+    /// Internal maintenance: delete archived stale pages. Daemon must be stopped first.
+    #[command(name = "backfill-stale-pages", hide = true)]
+    BackfillStalePages {
         /// Print candidates without modifying the database.
         #[arg(long)]
         dry_run: bool,
@@ -80,145 +51,6 @@ enum Command {
 }
 
 pub(crate) const PLIST_LABEL: &str = "com.origin.server";
-const PLIST_TEMPLATE: &str = include_str!("../resources/com.origin.server.plist");
-
-fn plist_path() -> std::path::PathBuf {
-    dirs::home_dir()
-        .expect("HOME not set")
-        .join("Library/LaunchAgents")
-        .join(format!("{}.plist", PLIST_LABEL))
-}
-
-fn log_dir() -> std::path::PathBuf {
-    dirs::data_local_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join("origin")
-        .join("logs")
-}
-
-fn current_exe_path() -> String {
-    std::env::current_exe()
-        .expect("cannot determine own path")
-        .to_string_lossy()
-        .to_string()
-}
-
-fn cmd_install() -> anyhow::Result<()> {
-    let plist = plist_path();
-    let log_path = log_dir();
-
-    // Ensure log directory exists
-    std::fs::create_dir_all(&log_path)?;
-
-    // Substitute placeholders
-    let content = PLIST_TEMPLATE
-        .replace("__ORIGIN_SERVER_PATH__", &current_exe_path())
-        .replace("__LOG_PATH__", &log_path.to_string_lossy());
-
-    // Ensure LaunchAgents directory exists
-    if let Some(parent) = plist.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    // Unload first if already installed (ignore errors)
-    if plist.exists() {
-        let _ = std::process::Command::new("launchctl")
-            .args(["unload", &plist.to_string_lossy()])
-            .output();
-    }
-
-    std::fs::write(&plist, content)?;
-    println!("Wrote {}", plist.display());
-
-    let output = std::process::Command::new("launchctl")
-        .args(["load", &plist.to_string_lossy()])
-        .output()?;
-
-    if output.status.success() {
-        println!(
-            "Loaded {} — daemon will start automatically on login",
-            PLIST_LABEL
-        );
-    } else {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!("launchctl load failed: {}", stderr);
-    }
-
-    Ok(())
-}
-
-fn cmd_uninstall() -> anyhow::Result<()> {
-    let plist = plist_path();
-
-    if !plist.exists() {
-        println!("{} is not installed", PLIST_LABEL);
-        return Ok(());
-    }
-
-    let output = std::process::Command::new("launchctl")
-        .args(["unload", &plist.to_string_lossy()])
-        .output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        eprintln!("launchctl unload warning: {}", stderr);
-    }
-
-    std::fs::remove_file(&plist)?;
-    println!(
-        "Removed {} — daemon will no longer auto-start",
-        plist.display()
-    );
-
-    Ok(())
-}
-
-async fn cmd_status() -> anyhow::Result<()> {
-    let plist = plist_path();
-
-    // Check plist exists
-    if plist.exists() {
-        println!("Plist: {} (installed)", plist.display());
-    } else {
-        println!("Plist: not installed");
-    }
-
-    // Check launchctl
-    let output = std::process::Command::new("launchctl")
-        .args(["list"])
-        .output()?;
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let registered = stdout.lines().any(|line| line.contains(PLIST_LABEL));
-    println!(
-        "Launchd: {}",
-        if registered {
-            "registered"
-        } else {
-            "not registered"
-        }
-    );
-
-    // Health check
-    let port: u16 = std::env::var("ORIGIN_PORT")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(7878);
-    let url = format!("http://127.0.0.1:{}/api/health", port);
-    match reqwest::get(&url).await {
-        Ok(resp) if resp.status().is_success() => {
-            let body = resp.text().await.unwrap_or_default();
-            println!("Health: ok (port {})\n{}", port, body);
-        }
-        Ok(resp) => {
-            println!("Health: unhealthy (status {})", resp.status());
-        }
-        Err(e) => {
-            println!("Health: not reachable ({})", e);
-        }
-    }
-
-    Ok(())
-}
 
 async fn run_daemon() -> anyhow::Result<()> {
     // Logging
@@ -403,9 +235,9 @@ async fn run_daemon() -> anyhow::Result<()> {
     }
 
     // One-time backfill: if the knowledge directory is empty but the DB has
-    // active concepts, write them all to disk. Handles the case where
-    // concepts were created before KnowledgeWriter was wired up, or via a
-    // code path that bypasses the writer.
+    // active pages, write them all to disk. Handles the case where pages were
+    // created before KnowledgeWriter was wired up, or via a code path that
+    // bypasses the writer.
     //
     // We gate on a `.origin/.backfill-attempted` marker file (created on
     // first attempt regardless of outcome) so this block only runs once per
@@ -433,10 +265,10 @@ async fn run_daemon() -> anyhow::Result<()> {
 
         if !already_attempted && !has_md_files {
             match db_arc.list_pages("active", 10_000, 0).await {
-                Ok(concepts) if !concepts.is_empty() => {
+                Ok(pages) if !pages.is_empty() => {
                     tracing::info!(
-                        "[backfill] knowledge dir empty; writing {} concepts to {}",
-                        concepts.len(),
+                        "[backfill] knowledge dir empty; writing {} pages to {}",
+                        pages.len(),
                         knowledge_path.display()
                     );
                     let writer = origin_core::export::knowledge::KnowledgeWriter::new(
@@ -444,7 +276,7 @@ async fn run_daemon() -> anyhow::Result<()> {
                     );
                     let mut written = 0usize;
                     let mut failed = 0usize;
-                    for page in &concepts {
+                    for page in &pages {
                         match writer.write_page(page) {
                             Ok(_) => written += 1,
                             Err(e) => {
@@ -457,7 +289,7 @@ async fn run_daemon() -> anyhow::Result<()> {
                             }
                         }
                     }
-                    tracing::info!("[backfill] wrote {} concepts, {} failed", written, failed);
+                    tracing::info!("[backfill] wrote {} pages, {} failed", written, failed);
 
                     // Create the marker file so we don't re-run the
                     // backfill on every subsequent startup — even if every
@@ -475,9 +307,8 @@ async fn run_daemon() -> anyhow::Result<()> {
                     }
                 }
                 Ok(_) => {
-                    // DB has no concepts yet — nothing to backfill. Don't
-                    // create the marker; the next startup after concepts
-                    // exist should retry.
+                    // DB has no pages yet — nothing to backfill. Don't create
+                    // the marker; the next startup after pages exist should retry.
                 }
                 Err(e) => {
                     tracing::warn!("[backfill] list_pages failed: {}", e);
@@ -823,30 +654,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     match cli.command {
-        Some(Command::Setup {
-            basic,
-            model,
-            anthropic_api_key_env,
-            yes,
-        }) => {
-            cmd_setup::run_setup(cmd_setup::SetupArgs {
-                basic,
-                model,
-                anthropic_api_key_env,
-                yes,
-            })
-            .await
-        }
-        Some(Command::Doctor) => cmd_setup::run_doctor().await,
-        Some(Command::Model { command }) => cmd_setup::run_model(command).await,
-        Some(Command::Key { command }) => cmd_setup::run_key(command).await,
-        Some(Command::Install) => cmd_install(),
-        Some(Command::Uninstall) => cmd_uninstall(),
-        Some(Command::Status) => {
-            cmd_status().await?;
-            cmd_setup::print_runtime_status().await
-        }
-        Some(Command::BackfillStaleConcepts { dry_run }) => cmd_backfill::run(dry_run).await,
+        Some(Command::BackfillStalePages { dry_run }) => cmd_backfill::run(dry_run).await,
         None => run_daemon().await,
     }
 }

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -921,7 +921,7 @@ pub async fn handle_distill(
 /// POST /api/distill/{page_id}
 ///
 /// Re-distill a single page. Requires the daemon to have an LLM available
-/// (on-device or Anthropic key). When no LLM is configured (Basic Memory
+/// (on-device or Anthropic key). When no model/key is configured (local memory
 /// mode) the route returns a 200 with a hint payload instead of a 500 —
 /// the caller's intent (refresh this page) can't be honored, but the
 /// failure mode is documented in the response so the skill can surface

--- a/crates/origin-types/README.md
+++ b/crates/origin-types/README.md
@@ -5,7 +5,7 @@ Shared wire-format types for [Origin](https://github.com/7xuanlu/origin) — a p
 This crate defines the HTTP API request/response types and core enums used by:
 - `origin-server` (HTTP backend daemon)
 - `origin-mcp` (MCP server wrapper for AI tools)
-- `origin` (source-built developer CLI)
+- `origin` (product CLI)
 - downstream local clients that talk to the Origin daemon
 
 ## Stability

--- a/install.sh
+++ b/install.sh
@@ -90,25 +90,18 @@ download_binary() {
   ok "Downloaded ${name}"
 }
 
+download_binary "origin"
 download_binary "origin-server"
 download_binary "origin-mcp"
 
 # ── Permissions ───────────────────────────────────────────────────────────────
 
-chmod +x "${BIN_DIR}/origin-server" "${BIN_DIR}/origin-mcp"
-
-cat > "${BIN_DIR}/origin" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "${DIR}/origin-server" "$@"
-EOF
-chmod +x "${BIN_DIR}/origin"
+chmod +x "${BIN_DIR}/origin" "${BIN_DIR}/origin-server" "${BIN_DIR}/origin-mcp"
 
 # Clear macOS quarantine attribute (unsigned binaries downloaded from the internet)
+xattr -cr "${BIN_DIR}/origin"        2>/dev/null || true
 xattr -cr "${BIN_DIR}/origin-server" 2>/dev/null || true
 xattr -cr "${BIN_DIR}/origin-mcp"    2>/dev/null || true
-xattr -cr "${BIN_DIR}/origin"        2>/dev/null || true
 
 ok "Permissions set"
 
@@ -167,7 +160,7 @@ if [[ -z "${REQUESTED_TAG}" ]]; then
   printf '\n'
   printf '  2. Set up Origin:\n'
   printf '\n'
-  printf '       origin setup\n'
+  printf '       origin setup --basic\n'
   printf '\n'
   printf '  3. Register Origin as a background service (launchd):\n'
   printf '\n'
@@ -196,7 +189,7 @@ else
   printf '\n'
   printf '  2. Start this exact tagged daemon in an isolated runtime:\n'
   printf '\n'
-  printf '       origin --port %s --data-dir "%s"\n' "${EXACT_RUNTIME_PORT}" "${EXACT_RUNTIME_DATA_DIR}"
+  printf '       origin-server --port %s --data-dir "%s"\n' "${EXACT_RUNTIME_PORT}" "${EXACT_RUNTIME_DATA_DIR}"
   printf '\n'
   printf '  3. Add this exact-release MCP server to Claude Desktop or Cursor:\n'
   printf '\n'
@@ -216,8 +209,8 @@ else
   printf '     That replaces the stable com.origin.server LaunchAgent.\n'
   printf '\n'
 fi
-printf '\033[1;33mNote:\033[0m Origin can store and retrieve memories without a local LLM or API key.\n'
-printf '      Local models are opt-in with `origin model install` or from the desktop app settings.\n'
+printf '\033[1;33mNote:\033[0m Origin can store and retrieve memories without a local model or API key.\n'
+printf '      Distill cycles are opt-in with `origin model install`.\n'
 printf '      Anthropic can be configured with `origin key set anthropic`.\n'
 if [[ -n "${REQUESTED_TAG}" ]]; then
   printf '      Manual release page for this install: %s\n' "${RELEASE_PAGE}"

--- a/plugin/.claude-plugin/README.md
+++ b/plugin/.claude-plugin/README.md
@@ -8,7 +8,7 @@ AI work memory for Claude Code. Origin carries sessions, decisions, lessons, and
 0s   /plugin marketplace add 7xuanlu/origin
      /plugin install origin@7xuanlu
 5s   restart Claude Code
-10s  /init   auto-installs daemon if missing, configures Basic Memory,
+10s  /init   auto-installs daemon if missing, configures local memory,
             verifies daemon + MCP + round-trip, prints "Origin ready"
 30s  /brief  (or /capture <something to remember>)
 ```
@@ -74,28 +74,28 @@ A `SessionStart` hook (`hooks/check-daemon.sh`) probes the local daemon at `127.
 
 Browse with `open ~/.origin/` (Finder), `code ~/.origin/` (VS Code), or symlink `~/.origin/pages/` into an Obsidian vault for the graph view. No Tauri app required.
 
-## Basic Memory mode and agent-side LLM phases
+## Local memory and agent-side model phases
 
-By default `/init` configures **Basic Memory**: no model download, no API
+By default `/init` configures **local memory**: no model download, no API
 key, no prompts. The daemon stores, embeds, dedupes, and serves hybrid
-search — it does *not* do LLM-heavy work like classification, entity
-extraction, page synthesis, or reranking.
+search. Model-backed work like classification, entity extraction, page
+synthesis, and reranking stays opt-in.
 
-The skills compensate. Where the daemon would normally call its LLM, the
+The skills compensate. Where the daemon would normally call a model, the
 skill asks Claude itself to do the equivalent step and posts the result
 back via HTTP:
 
-| Phase | LLM-equipped daemon | Basic Memory + skill |
+| Phase | Model-equipped daemon | Local memory + skill |
 |---|---|---|
 | Pick `memory_type` | daemon classifier | `/capture` picks one of 6 types from content |
 | Extract entities/relations | daemon `extract.rs` | `/capture` POSTs to `/api/memory/entities` and `/api/memory/relations` |
-| Synthesize a page | daemon refinery + `/distill` | `/distill` reads the cluster, writes the page, POSTs to `/api/pages` |
+| Synthesize a page | daemon distill cycles + `/distill` | `/distill` reads the cluster, writes the page, POSTs to `/api/pages` |
 | Expand a query / rerank hits | daemon expansion + rerank | `/recall` rewrites the query before search and reorders hits after |
 
 The daemon stays the single writer and storage owner. Claude does the
-thinking. This is why Basic Memory works without an API key or
+thinking. This is why local memory works without an API key or
 on-device model — and why the same skills also work when you later add
-an LLM. The skills detect the daemon's capabilities and fall through to
+one. The skills detect the daemon's capabilities and fall through to
 the agent path when needed.
 
 ## Skill Files

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "origin",
   "description": "AI work memory for Claude Code. Carries sessions, decisions, lessons, and project context forward, then turns them into searchable memory and wiki pages.",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "author": {
     "name": "Qi-Xuan Lu",
     "url": "https://github.com/7xuanlu"

--- a/plugin/bin/origin-mcp-runner.sh
+++ b/plugin/bin/origin-mcp-runner.sh
@@ -28,4 +28,4 @@ if [ -n "${ORIGIN_MCP_DEV_BIN:-}" ] && [ -x "${ORIGIN_MCP_DEV_BIN}" ]; then
   exec "${ORIGIN_MCP_DEV_BIN}" "$@"
 fi
 
-exec npx -y origin-mcp@^0.5.3 "$@"
+exec npx -y origin-mcp@^0.6.0 "$@"

--- a/plugin/skills/capture/SKILL.md
+++ b/plugin/skills/capture/SKILL.md
@@ -28,8 +28,8 @@ capture(content="<args, written as a full sentence with WHY>",
 
 ### `memory_type` — agent picks one of 6
 
-The daemon classifies when it has an LLM. In Basic Memory mode it does
-not, so the agent picks the type from the content itself. Use this
+The daemon classifies when a local model or API key is configured. In
+local memory mode it does not, so the agent picks the type from the content itself. Use this
 mapping:
 
 | Type | Use for |

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -11,7 +11,7 @@ allowed-tools: ["mcp__plugin_origin_origin__recall", "mcp__plugin_origin_origin_
 
 # /distill
 
-Force a distillation pass now. The daemon's background refinery runs
+Force a distillation pass now. The daemon's background distill cycles run
 on its own clock; `/distill` is the explicit user-triggered pass.
 
 ## Mental model
@@ -37,8 +37,8 @@ One POST to the daemon. Response splits into:
 - `pending`: clusters the daemon couldn't finish. The agent
   synthesizes each in this session and POSTs them back to `/api/pages`.
 
-Trigger timing is the only thing that differs between the background
-refinery and this skill. Code path is the same; daemon hands back
+Trigger timing is the only thing that differs between background distill
+cycles and this skill. Code path is the same; daemon hands back
 clusters when it can't synthesize; whoever called fills in the rest.
 
 ## Flow
@@ -341,7 +341,7 @@ wait is enough for the daemon to release the lock.
 ## When to use
 
 - User says "distill", "synthesize", "rebuild the page on X".
-- After a bulk import — daemon refinery handles this in the background;
+- After a bulk import — daemon distill cycles handle this in the background;
   user can force a pass for immediate visibility.
 - `/distill rebuild <page-id>` when you want to wipe a page you
   previously edited and have the daemon regenerate from current

--- a/plugin/skills/help/SKILL.md
+++ b/plugin/skills/help/SKILL.md
@@ -20,7 +20,7 @@ abbreviating, no embellishing. The user is asking for the menu.
 ```
 Origin plugin — daily verbs
 
-  /init         set up Origin (auto-installs daemon + Basic Memory)
+  /init         set up Origin (auto-installs daemon + local memory)
   /brief        load identity + topic context (start of session)
   /capture <x>  save one durable memory in flow
   /recall <q>   search local memory
@@ -66,9 +66,9 @@ Three classes of artifact:
 
 Daemon must run at 127.0.0.1:7878. Hook prints "/origin:init" if down.
 
-Optional upgrades for richer features (refinery, page synthesis):
+Optional upgrades for richer distill cycles:
   origin model install            local Qwen, no API cost
-  origin key set anthropic        cloud LLM, higher quality
+  origin key set anthropic        Anthropic API, higher quality
 ```
 
 ## When to use

--- a/plugin/skills/init/SKILL.md
+++ b/plugin/skills/init/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: init
 description: >
-  Frictionless setup. Detects missing daemon, installs it, configures Basic
-  Memory mode, and verifies the full plugin → MCP → daemon round-trip. Run
+  Frictionless setup. Detects missing daemon, installs it, configures local
+  memory, and verifies the full plugin → MCP → daemon round-trip. Run
   after `/plugin install origin@7xuanlu`, or any time the user says "set up
   origin", "is origin working", "fix origin".
 allowed-tools: ["Bash", "mcp__plugin_origin_origin__doctor", "mcp__plugin_origin_origin__context"]
@@ -11,7 +11,7 @@ allowed-tools: ["Bash", "mcp__plugin_origin_origin__doctor", "mcp__plugin_origin
 # /init
 
 Self-healing setup. Goal: 30 seconds, two user actions max (install plugin,
-type /init). Default backend is Basic Memory — no LLM, no API key, no
+type /init). Default backend is local memory — no local model, no API key, no
 prompts. Local model and Anthropic key are opt-in upgrades documented in
 `/help`.
 
@@ -40,10 +40,10 @@ Bash: command -v origin >/dev/null 2>&1 && echo present || echo absent
 If `absent`, run the installer (no human prompts):
 
 ```
-Bash: curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/v0.5.3/install.sh | bash
+Bash: curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/v0.6.0/install.sh | bash
 ```
 
-Then add it to PATH for the current session and configure Basic Memory
+Then add it to PATH for the current session and configure local memory
 non-interactively:
 
 ```
@@ -78,7 +78,7 @@ Call the `origin` MCP server's `doctor` tool:
 doctor()
 ```
 
-Expected: Basic Memory configured (no model, no key). Capture the mode
+Expected: local memory configured (no model, no key). Capture the mode
 string for the final report.
 
 ### 5. MCP round-trip
@@ -110,13 +110,13 @@ once so the user sees the verb cheat-sheet without asking.
 ## Optional upgrades (don't auto-run)
 
 Mention these in the ready report only if the user explicitly asks for
-"richer features" or asks about LLM-backed extraction:
+"richer features" or asks about model-backed extraction:
 
-- `origin model install` — local Qwen for background refinement.
+- `origin model install` — local Qwen for distill cycles.
 - `origin key set anthropic` — Anthropic for stronger synthesis.
 
 Default flow ignores both. Storage, search, recall, and MCP memory all
-work in Basic Memory mode.
+work in local memory mode.
 
 ## When to use
 

--- a/plugin/skills/read/SKILL.md
+++ b/plugin/skills/read/SKILL.md
@@ -19,7 +19,7 @@ keeps chat scannable, dodges Bash output truncation, and respects the
 
 Two shapes accepted:
 
-1. **Page id** (starts with `page_` or `concept_`) → direct fetch.
+1. **Page id** (starts with `page_`; legacy `concept_` ids still work) → direct fetch.
 2. **Title or freeform word** → search, pick best match, fetch.
 
 Both end with the same preview block.
@@ -99,7 +99,7 @@ the title:
 Substitute `<page-id>` with the actual `page.id` value. When
 `user_edited` is false or absent, omit this line entirely.
 
-The lock means the daemon's refinery will not auto-rewrite this page's
+The lock means daemon distill cycles will not auto-rewrite this page's
 prose from sources — edits stay until the user explicitly runs
 `/distill rebuild` to wipe and regenerate.
 

--- a/plugin/skills/recall/SKILL.md
+++ b/plugin/skills/recall/SKILL.md
@@ -16,9 +16,10 @@ helps.
 
 ## Two phases
 
-When the daemon has an LLM it can rerank and expand server-side. In Basic
-Memory mode it cannot. The skill always does **agent-side expansion and
-rerank** itself — cheap, makes results good in both modes.
+When a local model or API key is configured, the daemon can rerank and
+expand server-side. In local memory mode it cannot. The skill always does
+**agent-side expansion and rerank** itself — cheap, makes results good in
+both modes.
 
 ### Phase 1 — expand the query (agent-side)
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -39,9 +39,11 @@ for dep in origin-types origin-core; do
 done
 echo "  Updated Cargo.toml (workspace.dependencies origin-types/origin-core)"
 
-# 2. npm wrapper package.json
+# 2. npm wrapper package.json files
 (cd crates/origin-mcp/npm && npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version >/dev/null)
+(cd crates/origin-cli/npm && npm version "$NEW_VERSION" --no-git-tag-version --allow-same-version >/dev/null)
 echo "  Updated crates/origin-mcp/npm/package.json"
+echo "  Updated crates/origin-cli/npm/package.json"
 
 # 3. Claude plugin manifest (moved under plugin/ subdir in v0.5.0)
 PLUGIN_MANIFEST="plugin/.claude-plugin/plugin.json"

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -8,7 +8,10 @@ TMPDIR_TEST=$(mktemp -d "${TMPDIR:-/tmp}/bump-version-test.XXXXXX")
 trap "rm -rf $TMPDIR_TEST" EXIT
 
 mkdir -p "$TMPDIR_TEST/crates/origin-mcp/npm"
-mkdir -p "$TMPDIR_TEST/.claude-plugin"
+mkdir -p "$TMPDIR_TEST/crates/origin-cli/npm"
+mkdir -p "$TMPDIR_TEST/plugin/.claude-plugin"
+mkdir -p "$TMPDIR_TEST/plugin/bin"
+mkdir -p "$TMPDIR_TEST/plugin/skills/init"
 
 cat > "$TMPDIR_TEST/version.txt" <<EOF
 0.5.0
@@ -23,8 +26,20 @@ cat > "$TMPDIR_TEST/crates/origin-mcp/npm/package.json" <<EOF
 {"name": "origin-mcp", "version": "0.4.1"}
 EOF
 
-cat > "$TMPDIR_TEST/.claude-plugin/plugin.json" <<EOF
+cat > "$TMPDIR_TEST/crates/origin-cli/npm/package.json" <<EOF
+{"name": "@7xuanlu/origin", "version": "0.4.1"}
+EOF
+
+cat > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json" <<EOF
 {"name": "origin", "version": "0.4.1"}
+EOF
+
+cat > "$TMPDIR_TEST/plugin/bin/origin-mcp-runner.sh" <<EOF
+exec npx -y origin-mcp@^0.4.1 "\$@"
+EOF
+
+cat > "$TMPDIR_TEST/plugin/skills/init/SKILL.md" <<EOF
+Bash: curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/v0.4.1/install.sh | bash
 EOF
 
 # Run script in temp dir
@@ -32,10 +47,14 @@ EOF
 
 # Assert all manifests bumped to 0.5.0
 WS_VER=$(grep -E '^version = ' "$TMPDIR_TEST/Cargo.toml" | sed -E 's/version = "([^"]+)".*/\1/')
-NPM_VER=$(jq -r .version "$TMPDIR_TEST/crates/origin-mcp/npm/package.json")
-PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/.claude-plugin/plugin.json")
+MCP_NPM_VER=$(jq -r .version "$TMPDIR_TEST/crates/origin-mcp/npm/package.json")
+ORIGIN_NPM_VER=$(jq -r .version "$TMPDIR_TEST/crates/origin-cli/npm/package.json")
+PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json")
 
 [[ "$WS_VER" == "0.5.0" ]]   || { echo "FAIL: Cargo.toml not bumped (got $WS_VER)"; exit 1; }
-[[ "$NPM_VER" == "0.5.0" ]]  || { echo "FAIL: npm not bumped (got $NPM_VER)"; exit 1; }
+[[ "$MCP_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: origin-mcp npm not bumped (got $MCP_NPM_VER)"; exit 1; }
+[[ "$ORIGIN_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: @7xuanlu/origin npm not bumped (got $ORIGIN_NPM_VER)"; exit 1; }
 [[ "$PLUGIN_VER" == "0.5.0" ]] || { echo "FAIL: plugin not bumped (got $PLUGIN_VER)"; exit 1; }
+grep -q 'origin-mcp@\^0.5.0' "$TMPDIR_TEST/plugin/bin/origin-mcp-runner.sh" || { echo "FAIL: runner pin not bumped"; exit 1; }
+grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin/skills/init/SKILL.md" || { echo "FAIL: init skill installer not bumped"; exit 1; }
 echo "PASS: bump-version.sh syncs all manifests"

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -7,16 +7,18 @@ TAG_VER="${RELEASE_TAG#v}"
 
 VTXT_VER=$(cat version.txt | tr -d '[:space:]')
 WS_VER=$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)".*/\1/')
-NPM_VER=$(jq -r .version crates/origin-mcp/npm/package.json)
+MCP_NPM_VER=$(jq -r .version crates/origin-mcp/npm/package.json)
+ORIGIN_NPM_VER=$(jq -r .version crates/origin-cli/npm/package.json)
 PLUGIN_VER=$(jq -r .version plugin/.claude-plugin/plugin.json)
 
 echo "Tag:         $TAG_VER"
 echo "version.txt: $VTXT_VER"
 echo "Cargo:       $WS_VER"
-echo "npm:         $NPM_VER"
+echo "origin-mcp npm: $MCP_NPM_VER"
+echo "@7xuanlu/origin npm: $ORIGIN_NPM_VER"
 echo "Plugin:      $PLUGIN_VER"
 
-if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$NPM_VER" != "$TAG_VER" || "$PLUGIN_VER" != "$TAG_VER" ]]; then
+if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$MCP_NPM_VER" != "$TAG_VER" || "$ORIGIN_NPM_VER" != "$TAG_VER" || "$PLUGIN_VER" != "$TAG_VER" ]]; then
     echo "ERROR: version drift — bump-version.sh likely failed in release-please.yml"
     exit 1
 fi

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -4,13 +4,14 @@ set -euo pipefail
 TMPDIR_TEST=$(mktemp -d)
 trap "rm -rf $TMPDIR_TEST" EXIT
 
-mkdir -p "$TMPDIR_TEST/crates/origin-mcp/npm" "$TMPDIR_TEST/plugin/.claude-plugin"
+mkdir -p "$TMPDIR_TEST/crates/origin-mcp/npm" "$TMPDIR_TEST/crates/origin-cli/npm" "$TMPDIR_TEST/plugin/.claude-plugin"
 echo "0.5.0" > "$TMPDIR_TEST/version.txt"
 cat > "$TMPDIR_TEST/Cargo.toml" <<EOF
 [workspace.package]
 version = "0.5.0"   # x-release-please-version
 EOF
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/crates/origin-mcp/npm/package.json"
+echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/crates/origin-cli/npm/package.json"
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json"
 
 # Test 1: all match → exit 0


### PR DESCRIPTION
## Summary
- Makes `origin` the shipped product CLI for setup, service management, status, model/key setup, and local memory configuration.
- Updates release/install/npm flows so `npx -y @7xuanlu/origin setup` downloads `origin`, `origin-server`, and `origin-mcp`, then configures and starts the daemon.
- Refreshes README/plugin docs and version-sync checks around the plugin route, MCP connector, and setup package.

## Test Plan
- `cargo test -p origin`
- `cargo test -p origin-mcp`
- `cargo clippy -p origin -p origin-mcp --all-targets -- -D warnings`
- `RELEASE_TAG=v0.6.0 bash scripts/validate-versions.sh`
- `bash scripts/bump-version.test.sh`
- `bash scripts/validate-versions.test.sh`
- `npm pack --dry-run` in `crates/origin-cli/npm` and `crates/origin-mcp/npm`
- `bash -n plugin/bin/origin-mcp-runner.sh plugin/hooks/check-daemon.sh install.sh`
- `ORIGIN_MCP_DEV_BIN=/bin/echo plugin/bin/origin-mcp-runner.sh --probe`
- `git diff --check`