### PR TITLE
fix(server): clone Arc<MemoryDB> before await in 3 space-mutate handlers

### DIFF
--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1746,8 +1746,10 @@ pub async fn handle_create_space(
     State(state): State<Arc<RwLock<ServerState>>>,
     Json(req): Json<CreateSpaceRequest>,
 ) -> Result<Json<origin_core::db::Space>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
     let space = db
         .create_space(&req.name, req.description.as_deref(), false)
         .await
@@ -1760,8 +1762,10 @@ pub async fn handle_update_space(
     Path(name): Path<String>,
     Json(req): Json<UpdateSpaceRequest>,
 ) -> Result<Json<origin_core::db::Space>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
     let new_name = req.new_name.as_deref().unwrap_or(&name);
     let space = db
         .update_space(&name, new_name, req.description.as_deref())
@@ -1774,8 +1778,10 @@ pub async fn handle_delete_space(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(name): Path<String>,
 ) -> Result<Json<serde_json::Value>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
     db.delete_space(&name, "keep")
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?;


### PR DESCRIPTION
## Summary

`handle_create_space`, `handle_update_space`, and `handle_delete_space` in `crates/origin-server/src/memory_routes.rs` held the `ServerState` read guard across the `db.await` call. AGENTS.md "Never hold a tokio::sync::RwLock guard across .await" — a long-running DB write blocks every other reader until it finishes.

Same surgical fix that PR #126 applied to `handle_list_spaces` last session — clone the `Arc<MemoryDB>` inside a scoped block so the guard drops before the await:

```rust
let db = {
    let s = state.read().await;
    s.db.clone().ok_or(ServerError::DbNotInitialized)?
};
db.create_space(...).await?
```

Flagged twice — once in PR-C's audit (Task A pre-flight) and once in PR-C's adversarial review.

## Scope

- `crates/origin-server/src/memory_routes.rs` lines 1745–1783 only
- 12 insertions, 6 deletions
- No behaviour change beyond lock release timing

## Test plan

- [x] `cargo check -p origin-server` clean
- [x] `cargo test -p origin-server --lib` — 54 / 54 pass
- [ ] CI green

## Out of scope

- `handle_get_nurture_cards` / `handle_get_rejections` / `handle_search` also hold guards across `.await` — same pattern but those aren't space handlers; defer to a separate lock-hygiene sweep.
- `MemoryDB::search` doc-path is missing `supersedes_exclusion` (asymmetric with `search_memory`) — flagged from the same audit; defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)