### PR TITLE
fix(server): clone Arc<MemoryDB> before await in 3 remaining handlers

### DIFF
--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1811,8 +1811,10 @@ pub async fn handle_get_nurture_cards(
     State(state): State<Arc<RwLock<ServerState>>>,
     axum::extract::Query(query): axum::extract::Query<NurtureCardsQuery>,
 ) -> Result<Json<NurtureCardsResponse>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
     let cards = db
         .get_nurture_cards(query.limit, query.space.as_deref())
         .await
@@ -1830,11 +1832,13 @@ pub async fn handle_get_rejections(
         .and_then(|v| v.parse().ok())
         .unwrap_or(50)
         .min(500);
-    let reason = params.get("reason").map(|s| s.as_str());
+    let reason_owned = params.get("reason").cloned();
 
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
-    let records = db.get_rejections(limit, reason).await?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let records = db.get_rejections(limit, reason_owned.as_deref()).await?;
     Ok(Json(records))
 }
 

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -95,33 +95,33 @@ pub async fn handle_search(
 ) -> Result<Json<SearchResponse>, ServerError> {
     let start = std::time::Instant::now();
 
-    let results = {
+    let db = {
         let s = state.read().await;
-        let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
 
-        if req.source_filter.as_deref() == Some("memory") {
-            db.search_memory(
-                &req.query,
-                req.limit,
-                None,
-                req.space.as_deref(),
-                None,
-                None,
-                None,
-                None,
-            )
-            .await
-            .map_err(|e| ServerError::SearchFailed(e.to_string()))?
-        } else {
-            db.search(
-                &req.query,
-                req.limit,
-                req.source_filter.as_deref(),
-                req.space.as_deref(),
-            )
-            .await
-            .map_err(|e| ServerError::SearchFailed(e.to_string()))?
-        }
+    let results = if req.source_filter.as_deref() == Some("memory") {
+        db.search_memory(
+            &req.query,
+            req.limit,
+            None,
+            req.space.as_deref(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .map_err(|e| ServerError::SearchFailed(e.to_string()))?
+    } else {
+        db.search(
+            &req.query,
+            req.limit,
+            req.source_filter.as_deref(),
+            req.space.as_deref(),
+        )
+        .await
+        .map_err(|e| ServerError::SearchFailed(e.to_string()))?
     };
 
     let took_ms = start.elapsed().as_secs_f64() * 1000.0;


### PR DESCRIPTION
## Summary

Completes the lock-hygiene sweep started by PR #126 (`handle_list_spaces`) and PR #129 (3 space-mutate handlers).

Three more handlers held the `ServerState` read guard across the `db.await` call:

- `handle_get_nurture_cards` (`memory_routes.rs:1810`)
- `handle_get_rejections` (`memory_routes.rs:1824`)
- `handle_search` (`routes.rs:92`)

AGENTS.md: *"Never hold a `tokio::sync::RwLock` guard across `.await`."* A long DB call blocks every other reader/writer for the duration.

## Fix

Same Arc-clone-before-await pattern as PR #129:

```rust
let db = {
    let s = state.read().await;
    s.db.clone().ok_or(ServerError::DbNotInitialized)?
};
db.something().await?
```

`handle_get_rejections` also needed `params.get("reason").cloned()` instead of borrowing `&str` from the HashMap, since the borrow would have outlived the guard scope.

## Test plan

- [x] `cargo check -p origin-server` clean
- [x] `cargo test -p origin-server --lib` — 54 / 54 pass
- [ ] CI green

## Out of scope

`memory_routes.rs` has many more `state.read().await` sites. Most either don't `.await` inside the scope or already clone-then-drop. A full audit is a separate concern; this PR closes the three sites flagged in PR-C's adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)