### PR TITLE
docs(readme): pin CI badge to main + push event

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="./docs/assets/social-preview.png" alt="Origin: Where AI work compounds. Decisions, lessons, project context, and wiki pages." width="100%">
 </p>
 
-[![CI](https://github.com/7xuanlu/origin/actions/workflows/ci.yml/badge.svg)](https://github.com/7xuanlu/origin/actions/workflows/ci.yml)
+[![CI](https://github.com/7xuanlu/origin/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/7xuanlu/origin/actions/workflows/ci.yml?query=branch%3Amain)
 [![Release](https://img.shields.io/github/v/release/7xuanlu/origin?sort=semver)](https://github.com/7xuanlu/origin/releases/latest)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
 


### PR DESCRIPTION
## Summary

User reported the README CI badge shows "failed" while the actual main CI is green. Root cause: GitHub's camo image proxy caches the badge SVG until the URL changes. The bare `actions/workflows/ci.yml/badge.svg` URL stayed constant across runs, so camo kept serving the cached (stale) SVG.

Fix: add `?branch=main&event=push` to the badge URL. Two effects:

1. **Forces camo refresh** — URL change = new cache key = fresh fetch immediately.
2. **Future-proof** — badge now explicitly reflects "main, push event" runs. If we ever add scheduled or workflow_dispatch runs, the badge won't get confused.

Link target gets the matching `?query=branch%3Amain` filter so clicking the badge lands on main-only runs.

## Verification

```bash
$ curl -fsSL "https://github.com/7xuanlu/origin/actions/workflows/ci.yml/badge.svg?branch=main&event=push" | grep -c "passing"
3   # green badge confirmed
```

## Scope

`README.md` only. 1 line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)