### PR TITLE
refactor(core): migrate tags subsystem to MemoryDB libSQL

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -4778,6 +4778,50 @@ impl MemoryDB {
                     log::info!("[migration] Migration 50 applied: renamed domain → space on memories/entities/pages + reindexed");
                 }
             }
+
+            // Migration 51: document_tags table for the libSQL tag store.
+            if version < 51 {
+                let conn = self.conn.lock().await;
+                conn.execute("BEGIN", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m51 begin: {e}")))?;
+                let result: Result<(), OriginError> = async {
+                    conn.execute(
+                        "CREATE TABLE IF NOT EXISTS document_tags (
+                            source TEXT NOT NULL,
+                            source_id TEXT NOT NULL,
+                            tag TEXT NOT NULL,
+                            PRIMARY KEY (source, source_id, tag)
+                        )",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m51 create table: {e}")))?;
+                    conn.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_document_tags_tag ON document_tags(tag)",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("m51 create index: {e}")))?;
+                    conn.execute("PRAGMA user_version = 51", ())
+                        .await
+                        .map_err(|e| OriginError::VectorDb(format!("m51 bump: {e}")))?;
+                    Ok(())
+                }
+                .await;
+                match result {
+                    Ok(()) => {
+                        conn.execute("COMMIT", ())
+                            .await
+                            .map_err(|e| OriginError::VectorDb(format!("m51 commit: {e}")))?;
+                        log::info!("[migration] Migration 51 applied: document_tags table created");
+                    }
+                    Err(e) => {
+                        let _ = conn.execute("ROLLBACK", ()).await;
+                        return Err(e);
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -5364,6 +5408,118 @@ impl MemoryDB {
         embedder
             .embed(text_refs, None)
             .map_err(|e| OriginError::Embedding(e.to_string()))
+    }
+
+    // ==================== document_tags ====================
+
+    /// Replace all tags for (source, source_id). Returns the normalized final set.
+    /// Normalization: trim + lowercase; empty entries dropped; deduped.
+    pub async fn set_document_tags(
+        &self,
+        source: &str,
+        source_id: &str,
+        tags: Vec<String>,
+    ) -> Result<Vec<String>, OriginError> {
+        let normalized: std::collections::BTreeSet<String> = tags
+            .into_iter()
+            .map(|t| t.trim().to_lowercase())
+            .filter(|t| !t.is_empty())
+            .collect();
+
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("set_document_tags begin: {e}")))?;
+        let result: Result<(), OriginError> = async {
+            conn.execute(
+                "DELETE FROM document_tags WHERE source = ?1 AND source_id = ?2",
+                libsql::params![source.to_string(), source_id.to_string()],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("set_document_tags delete: {e}")))?;
+            for tag in &normalized {
+                conn.execute(
+                    "INSERT OR IGNORE INTO document_tags (source, source_id, tag) VALUES (?1, ?2, ?3)",
+                    libsql::params![source.to_string(), source_id.to_string(), tag.clone()],
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("set_document_tags insert: {e}")))?;
+            }
+            Ok(())
+        }
+        .await;
+        match result {
+            Ok(()) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| OriginError::VectorDb(format!("set_document_tags commit: {e}")))?;
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        }
+        Ok(normalized.into_iter().collect())
+    }
+
+    /// Get all tags assigned to (source, source_id).
+    pub async fn get_document_tags(
+        &self,
+        source: &str,
+        source_id: &str,
+    ) -> Result<Vec<String>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT tag FROM document_tags WHERE source = ?1 AND source_id = ?2 ORDER BY tag",
+                libsql::params![source.to_string(), source_id.to_string()],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_document_tags: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            out.push(row.get::<String>(0).unwrap_or_default());
+        }
+        Ok(out)
+    }
+
+    /// Delete a tag from all document rows. Returns the number of rows removed.
+    pub async fn delete_tag(&self, name: &str) -> Result<u64, OriginError> {
+        let normalized = name.trim().to_lowercase();
+        if normalized.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.conn.lock().await;
+        let affected = conn
+            .execute(
+                "DELETE FROM document_tags WHERE tag = ?1",
+                libsql::params![normalized],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("delete_tag: {e}")))?;
+        Ok(affected)
+    }
+
+    /// List all distinct tags across all documents.
+    pub async fn list_all_tags(&self) -> Result<Vec<String>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT DISTINCT tag FROM document_tags ORDER BY tag", ())
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("list_all_tags: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            out.push(row.get::<String>(0).unwrap_or_default());
+        }
+        Ok(out)
     }
 
     /// Get memories that need re-embedding (structured content was set but embedding is stale).
@@ -29633,6 +29789,194 @@ pub(crate) mod tests {
         assert!(
             old_idx.next().await.unwrap().is_none(),
             "idx_memories_domain must be dropped after migration 50"
+        );
+    }
+
+    // ── document_tags tests ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_set_and_get_document_tags() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new(
+            &tmp.path().join("test.db"),
+            Arc::new(crate::events::NoopEmitter),
+        )
+        .await
+        .unwrap();
+
+        // Basic set + get.
+        let result = db
+            .set_document_tags(
+                "memory",
+                "doc1",
+                vec![
+                    "Rust".to_string(),
+                    "  TAURI  ".to_string(),
+                    "rust".to_string(), // duplicate after normalization
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(result, vec!["rust", "tauri"]); // BTreeSet: sorted + deduped
+
+        let tags = db.get_document_tags("memory", "doc1").await.unwrap();
+        assert_eq!(tags, vec!["rust", "tauri"]);
+    }
+
+    #[tokio::test]
+    async fn test_set_document_tags_is_idempotent_replace() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new(
+            &tmp.path().join("test.db"),
+            Arc::new(crate::events::NoopEmitter),
+        )
+        .await
+        .unwrap();
+
+        db.set_document_tags(
+            "memory",
+            "doc1",
+            vec!["rust".to_string(), "tauri".to_string()],
+        )
+        .await
+        .unwrap();
+
+        // Re-set with different tags — old ones must be gone.
+        let result = db
+            .set_document_tags("memory", "doc1", vec!["python".to_string()])
+            .await
+            .unwrap();
+        assert_eq!(result, vec!["python"]);
+
+        let tags = db.get_document_tags("memory", "doc1").await.unwrap();
+        assert_eq!(tags, vec!["python"]);
+    }
+
+    #[tokio::test]
+    async fn test_delete_tag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new(
+            &tmp.path().join("test.db"),
+            Arc::new(crate::events::NoopEmitter),
+        )
+        .await
+        .unwrap();
+
+        db.set_document_tags(
+            "memory",
+            "doc1",
+            vec!["rust".to_string(), "tauri".to_string()],
+        )
+        .await
+        .unwrap();
+        db.set_document_tags("memory", "doc2", vec!["rust".to_string()])
+            .await
+            .unwrap();
+
+        let affected = db.delete_tag("rust").await.unwrap();
+        assert_eq!(affected, 2);
+
+        let tags_doc1 = db.get_document_tags("memory", "doc1").await.unwrap();
+        assert_eq!(tags_doc1, vec!["tauri"]);
+
+        let tags_doc2 = db.get_document_tags("memory", "doc2").await.unwrap();
+        assert!(tags_doc2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_all_tags_select_distinct() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new(
+            &tmp.path().join("test.db"),
+            Arc::new(crate::events::NoopEmitter),
+        )
+        .await
+        .unwrap();
+
+        db.set_document_tags(
+            "memory",
+            "doc1",
+            vec!["rust".to_string(), "tauri".to_string()],
+        )
+        .await
+        .unwrap();
+        db.set_document_tags(
+            "memory",
+            "doc2",
+            vec!["rust".to_string(), "wasm".to_string()],
+        )
+        .await
+        .unwrap();
+
+        let all = db.list_all_tags().await.unwrap();
+        // Distinct + sorted: rust appears in both docs but must appear once.
+        assert_eq!(all, vec!["rust", "tauri", "wasm"]);
+    }
+
+    // ── migration 51 replay test ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_migration_51_creates_document_tags_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("test.db");
+
+        // First open: runs all migrations including 51.
+        let db = MemoryDB::new(&db_path, Arc::new(crate::events::NoopEmitter))
+            .await
+            .unwrap();
+
+        // Verify the table and index exist.
+        {
+            let conn = db.conn.lock().await;
+            let mut rows = conn
+                .query(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name='document_tags'",
+                    (),
+                )
+                .await
+                .unwrap();
+            assert!(
+                rows.next().await.unwrap().is_some(),
+                "document_tags table must exist after migration 51"
+            );
+            let mut idx_rows = conn
+                .query(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_document_tags_tag'",
+                    (),
+                )
+                .await
+                .unwrap();
+            assert!(
+                idx_rows.next().await.unwrap().is_some(),
+                "idx_document_tags_tag must exist after migration 51"
+            );
+        }
+
+        // Roll user_version back to 50 and drop the table to simulate a fresh migration.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute("DROP TABLE IF EXISTS document_tags", ())
+                .await
+                .unwrap();
+            conn.execute("PRAGMA user_version = 50", ()).await.unwrap();
+        }
+        drop(db);
+
+        // Re-open — migration 51 re-fires and must recreate the table.
+        let db = MemoryDB::new(&db_path, Arc::new(crate::events::NoopEmitter))
+            .await
+            .unwrap();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='document_tags'",
+                (),
+            )
+            .await
+            .unwrap();
+        assert!(
+            rows.next().await.unwrap().is_some(),
+            "document_tags table must exist after migration 51 replay"
         );
     }
 }

--- a/crates/origin-core/src/spaces.rs
+++ b/crates/origin-core/src/spaces.rs
@@ -1,473 +1,213 @@
 // SPDX-License-Identifier: Apache-2.0
+//! Legacy tag import from the pre-PR-B2 `spaces.db` rusqlite file.
+//!
+//! After PR-B2 ships, tags live in `MemoryDB.document_tags`. This module
+//! exists solely to import any pre-existing `spaces.db` once on daemon
+//! startup and then rename the file so it won't be re-imported.
+//! Once enough users have cycled past this release, the whole module can
+//! be deleted along with the rusqlite dependency.
+
+use crate::db::MemoryDB;
 use crate::error::OriginError;
-use rusqlite::{params, Connection};
-use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
-use std::path::PathBuf;
+use rusqlite::Connection;
+use std::path::{Path, PathBuf};
 
-// ── SpaceStore ──────────────────────────────────────────────────────────
-
-/// Persistent store for document tag assignments and the tag library.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct SpaceStore {
-    pub document_tags: HashMap<String, BTreeSet<String>>,
-    pub tags: BTreeSet<String>,
-}
-
-impl SpaceStore {
-    // ── Helpers ──────────────────────────────────────────────────────
-
-    /// Build a document key from source and source_id.
-    pub fn doc_key(source: &str, source_id: &str) -> String {
-        format!("{}::{}", source, source_id)
-    }
-
-    // ── Tags ────────────────────────────────────────────────────────
-
-    /// Set tags for a document. Normalizes to lowercase and adds to the tag library.
-    pub fn set_document_tags(
-        &mut self,
-        source: &str,
-        source_id: &str,
-        tags: Vec<String>,
-    ) -> Vec<String> {
-        let key = Self::doc_key(source, source_id);
-        let tag_set: BTreeSet<String> = tags
-            .into_iter()
-            .map(|t| t.trim().to_lowercase())
-            .filter(|t| !t.is_empty())
-            .collect();
-
-        // Add all tags to the library
-        for tag in &tag_set {
-            self.tags.insert(tag.clone());
-        }
-
-        if tag_set.is_empty() {
-            self.document_tags.remove(&key);
-        } else {
-            self.document_tags.insert(key, tag_set.clone());
-        }
-
-        tag_set.into_iter().collect()
-    }
-
-    pub fn get_document_tags(&self, source: &str, source_id: &str) -> Vec<String> {
-        let key = Self::doc_key(source, source_id);
-        self.document_tags
-            .get(&key)
-            .map(|s| s.iter().cloned().collect())
-            .unwrap_or_default()
-    }
-
-    /// Delete a tag from the library and all document assignments.
-    pub fn delete_tag(&mut self, name: &str) {
-        let normalized = name.trim().to_lowercase();
-        self.tags.remove(&normalized);
-        for tags in self.document_tags.values_mut() {
-            tags.remove(&normalized);
-        }
-        self.document_tags.retain(|_, v| !v.is_empty());
-    }
-
-    /// Get all tags in the library as a sorted vector.
-    pub fn list_all_tags(&self) -> Vec<String> {
-        self.tags.iter().cloned().collect()
-    }
-
-    // ── Cleanup ─────────────────────────────────────────────────────
-
-    /// Remove all tag data associated with a document.
-    pub fn remove_document(&mut self, source: &str, source_id: &str) {
-        let key = Self::doc_key(source, source_id);
-        self.document_tags.remove(&key);
-    }
-}
-
-// ── Persistence functions ───────────────────────────────────────────────
-
-/// Path to the SQLite database file.
-fn db_path() -> PathBuf {
+fn legacy_db_path() -> PathBuf {
     dirs::data_local_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("origin")
         .join("spaces.db")
 }
 
-/// Path to the legacy JSON file (for migration).
-fn json_path() -> PathBuf {
-    dirs::data_local_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("origin")
-        .join("spaces.json")
+/// Import tags from a legacy `spaces.db` (if present) into MemoryDB,
+/// then rename the file to `spaces.db.migrated-<epoch>` so we don't
+/// re-import on subsequent startups. Returns the count of (source, source_id, tag)
+/// triples imported.
+pub async fn import_legacy_tags(db: &MemoryDB) -> Result<usize, OriginError> {
+    let path = legacy_db_path();
+    if !path.exists() {
+        return Ok(0);
+    }
+    let count = import_from_path(&path, db).await?;
+    let backup = path.with_file_name(format!(
+        "spaces.db.migrated-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    ));
+    if let Err(e) = std::fs::rename(&path, &backup) {
+        log::warn!("[spaces] failed to rename legacy spaces.db after import: {e}");
+    }
+    Ok(count)
 }
 
-// ── SpaceDb ─────────────────────────────────────────────────────────────
-
-/// SQLite-backed persistence layer for the SpaceStore.
-struct SpaceDb {
-    conn: Connection,
-}
-
-impl SpaceDb {
-    /// Open (or create) the spaces database at the given path.
-    fn open(path: &std::path::Path) -> Result<Self, OriginError> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+async fn import_from_path(path: &Path, db: &MemoryDB) -> Result<usize, OriginError> {
+    // Read all rows synchronously via rusqlite, then write to libSQL.
+    let triples: Vec<(String, String, String)> = {
         let conn = Connection::open(path)
-            .map_err(|e| OriginError::Generic(format!("spaces db open: {e}")))?;
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
-            .map_err(|e| OriginError::Generic(format!("spaces db pragma: {e}")))?;
-        let db = Self { conn };
-        db.create_tables()?;
-        Ok(db)
-    }
-
-    fn create_tables(&self) -> Result<(), OriginError> {
-        self.conn
-            .execute_batch(
-                "
-            CREATE TABLE IF NOT EXISTS spaces (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                icon TEXT NOT NULL DEFAULT '',
-                color TEXT NOT NULL DEFAULT 'zinc',
-                pinned INTEGER NOT NULL DEFAULT 0,
-                auto_detected INTEGER NOT NULL DEFAULT 0,
-                created_at INTEGER NOT NULL DEFAULT 0
-            );
-
-            CREATE TABLE IF NOT EXISTS space_rules (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                space_id TEXT NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
-                kind TEXT NOT NULL,
-                pattern TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS activity_streams (
-                id TEXT PRIMARY KEY,
-                space_id TEXT NOT NULL,
-                name TEXT NOT NULL DEFAULT '',
-                started_at INTEGER NOT NULL,
-                ended_at INTEGER,
-                app_sequence TEXT NOT NULL DEFAULT '[]'
-            );
-
-            CREATE TABLE IF NOT EXISTS document_spaces (
-                doc_key TEXT PRIMARY KEY,
-                space_id TEXT NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS document_tags (
-                doc_key TEXT NOT NULL,
-                tag TEXT NOT NULL,
-                PRIMARY KEY (doc_key, tag)
-            );
-
-            CREATE TABLE IF NOT EXISTS tags (
-                name TEXT PRIMARY KEY
-            );
-            ",
+            .map_err(|e| OriginError::Generic(format!("legacy spaces.db open: {e}")))?;
+        // The legacy table may not have a `document_tags` table if the file
+        // was created by a very early version. Ignore if missing.
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='document_tags'",
+                [],
+                |row| row.get::<_, i64>(0),
             )
-            .map_err(|e| OriginError::Generic(format!("spaces db create tables: {e}")))?;
-        Ok(())
-    }
-
-    /// Write the full SpaceStore to SQLite, replacing all rows.
-    fn save_all(&self, store: &SpaceStore) -> Result<(), OriginError> {
-        let tx = self
-            .conn
-            .unchecked_transaction()
-            .map_err(|e| OriginError::Generic(format!("spaces db tx begin: {e}")))?;
-
-        // Clear existing data (spaces/activity_streams/document_spaces tables remain on disk
-        // but are no longer read or written — they are harmless residue from pre-B1)
-        tx.execute_batch(
-            "DELETE FROM document_tags;
-             DELETE FROM tags;",
-        )
-        .map_err(|e| OriginError::Generic(format!("spaces db clear: {e}")))?;
-
-        // ── Document tags ───────────────────────────────────────────
-        for (doc_key, tags) in &store.document_tags {
-            for tag in tags {
-                tx.execute(
-                    "INSERT INTO document_tags (doc_key, tag) VALUES (?1, ?2)",
-                    params![doc_key, tag],
-                )
-                .map_err(|e| OriginError::Generic(format!("spaces db insert doc_tag: {e}")))?;
+            .map(|n| n > 0)
+            .unwrap_or(false);
+        if !table_exists {
+            return Ok(0);
+        }
+        let mut stmt = conn
+            .prepare("SELECT doc_key, tag FROM document_tags")
+            .map_err(|e| OriginError::Generic(format!("legacy spaces.db prepare: {e}")))?;
+        let rows = stmt
+            .query_map([], |row| {
+                let doc_key: String = row.get(0)?;
+                let tag: String = row.get(1)?;
+                Ok((doc_key, tag))
+            })
+            .map_err(|e| OriginError::Generic(format!("legacy spaces.db query: {e}")))?;
+        let mut out = Vec::new();
+        for r in rows {
+            let (doc_key, tag) =
+                r.map_err(|e| OriginError::Generic(format!("legacy spaces.db row: {e}")))?;
+            if let Some((source, source_id)) = doc_key.split_once("::") {
+                let normalized = tag.trim().to_lowercase();
+                if !normalized.is_empty() {
+                    out.push((source.to_string(), source_id.to_string(), normalized));
+                }
             }
         }
-
-        // ── Tags library ────────────────────────────────────────────
-        for tag in &store.tags {
-            tx.execute("INSERT INTO tags (name) VALUES (?1)", params![tag])
-                .map_err(|e| OriginError::Generic(format!("spaces db insert tag: {e}")))?;
-        }
-
-        tx.commit()
-            .map_err(|e| OriginError::Generic(format!("spaces db tx commit: {e}")))?;
-
-        Ok(())
-    }
-
-    /// Load the full SpaceStore from SQLite.
-    fn load_all(&self) -> Result<SpaceStore, OriginError> {
-        // ── Document tags ───────────────────────────────────────────
-        let mut document_tags: HashMap<String, BTreeSet<String>> = HashMap::new();
-        {
-            let mut stmt = self
-                .conn
-                .prepare("SELECT doc_key, tag FROM document_tags")
-                .map_err(|e| OriginError::Generic(format!("spaces db select doc_tags: {e}")))?;
-            let rows = stmt
-                .query_map([], |row| {
-                    let doc_key: String = row.get(0)?;
-                    let tag: String = row.get(1)?;
-                    Ok((doc_key, tag))
-                })
-                .map_err(|e| OriginError::Generic(format!("spaces db query doc_tags: {e}")))?;
-            for row in rows {
-                let (k, t) =
-                    row.map_err(|e| OriginError::Generic(format!("spaces db doc_tag row: {e}")))?;
-                document_tags.entry(k).or_default().insert(t);
-            }
-        }
-
-        // ── Tags library ────────────────────────────────────────────
-        let mut tags: BTreeSet<String> = BTreeSet::new();
-        {
-            let mut stmt = self
-                .conn
-                .prepare("SELECT name FROM tags")
-                .map_err(|e| OriginError::Generic(format!("spaces db select tags: {e}")))?;
-            let rows = stmt
-                .query_map([], |row| row.get(0))
-                .map_err(|e| OriginError::Generic(format!("spaces db query tags: {e}")))?;
-            for row in rows {
-                tags.insert(
-                    row.map_err(|e| OriginError::Generic(format!("spaces db tag row: {e}")))?,
-                );
-            }
-        }
-
-        Ok(SpaceStore {
-            document_tags,
-            tags,
-        })
-    }
-}
-
-// ── Public persistence API (unchanged signatures) ───────────────────────
-
-pub fn load_spaces() -> SpaceStore {
-    let db_path = db_path();
-    let json_path = json_path();
-
-    // Try opening (or creating) the SQLite database
-    let db = match SpaceDb::open(&db_path) {
-        Ok(db) => db,
-        Err(e) => {
-            log::error!("[spaces] failed to open spaces.db: {e}");
-            return SpaceStore::default();
-        }
+        out
     };
 
-    // Migration: if spaces.json exists, import tag data from it into SQLite
-    if json_path.exists() {
-        if let Ok(contents) = std::fs::read_to_string(&json_path) {
-            if let Ok(store) = serde_json::from_str::<SpaceStore>(&contents) {
-                log::info!("[spaces] migrating tag data from spaces.json to SQLite");
-                if let Err(e) = db.save_all(&store) {
-                    log::error!("[spaces] migration save failed: {e}");
-                } else {
-                    // Rename the old file so we don't re-migrate
-                    let migrated = json_path.with_extension("json.migrated");
-                    let _ = std::fs::rename(&json_path, &migrated);
-                }
-                return store;
-            }
-        }
+    if triples.is_empty() {
+        return Ok(0);
     }
 
-    // Load from SQLite (returns empty defaults if DB is freshly created)
-    match db.load_all() {
-        Ok(store) => store,
-        Err(e) => {
-            log::error!("[spaces] failed to load from spaces.db: {e}");
-            SpaceStore::default()
-        }
+    // Group by (source, source_id) so we can use set_document_tags's transaction.
+    let mut by_doc: std::collections::HashMap<(String, String), Vec<String>> =
+        std::collections::HashMap::new();
+    for (s, sid, tag) in &triples {
+        by_doc
+            .entry((s.clone(), sid.clone()))
+            .or_default()
+            .push(tag.clone());
     }
+    for ((source, source_id), tags) in by_doc {
+        db.set_document_tags(&source, &source_id, tags).await?;
+    }
+    Ok(triples.len())
 }
-
-pub fn save_spaces(store: &SpaceStore) -> Result<(), OriginError> {
-    let db = SpaceDb::open(&db_path())?;
-    db.save_all(store)
-}
-
-// ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::events::NoopEmitter;
+    use std::sync::Arc;
 
-    #[test]
-    fn test_default_store_is_empty() {
-        let store = SpaceStore::default();
-        assert!(store.tags.is_empty());
-        assert!(store.document_tags.is_empty());
-    }
+    /// Create a temporary spaces.db with a document_tags table and some rows,
+    /// then assert they end up in MemoryDB after import_from_path.
+    #[tokio::test]
+    async fn test_import_from_path_basic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_file = tmp.path().join("spaces.db");
+        let mem_db_file = tmp.path().join("test.db");
 
-    #[test]
-    fn test_document_tags() {
-        let mut store = SpaceStore::default();
-
-        // Set tags with mixed case
-        let result = store.set_document_tags(
-            "screen",
-            "doc1",
-            vec![
-                "Rust".to_string(),
-                "  TAURI  ".to_string(),
-                "rust".to_string(), // duplicate after normalization
-            ],
-        );
-
-        assert_eq!(result, vec!["rust", "tauri"]); // BTreeSet: sorted + deduped
-
-        // Tags are in the library
-        assert!(store.tags.contains("rust"));
-        assert!(store.tags.contains("tauri"));
-
-        // Retrieve document tags
-        let tags = store.get_document_tags("screen", "doc1");
-        assert_eq!(tags, vec!["rust", "tauri"]);
-
-        // Delete a tag
-        store.delete_tag("rust");
-        assert!(!store.tags.contains("rust"));
-        let tags = store.get_document_tags("screen", "doc1");
-        assert_eq!(tags, vec!["tauri"]);
-    }
-
-    #[test]
-    fn test_remove_document() {
-        let mut store = SpaceStore::default();
-
-        store.set_document_tags("screen", "doc1", vec!["rust".to_string()]);
-
-        // Tags should exist
-        assert!(!store.get_document_tags("screen", "doc1").is_empty());
-
-        // Remove
-        store.remove_document("screen", "doc1");
-        assert!(store.get_document_tags("screen", "doc1").is_empty());
-    }
-
-    #[test]
-    fn test_serialization_roundtrip() {
-        let mut store = SpaceStore::default();
-        store.set_document_tags("screen", "doc1", vec!["rust".to_string()]);
-        let json = serde_json::to_string(&store).unwrap();
-        let deserialized: SpaceStore = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.tags.len(), store.tags.len());
-        assert_eq!(deserialized.document_tags.len(), store.document_tags.len());
-    }
-
-    // ── SQLite persistence tests ────────────────────────────────────
-
-    /// Helper: open an in-memory SpaceDb for tests.
-    fn test_db() -> SpaceDb {
-        let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+        // Write a legacy spaces.db with two docs and some tags.
+        {
+            let conn = Connection::open(&db_file).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE document_tags (doc_key TEXT NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (doc_key, tag));",
+            )
             .unwrap();
-        let db = SpaceDb { conn };
-        db.create_tables().unwrap();
-        db
+            conn.execute(
+                "INSERT INTO document_tags VALUES ('memory::abc123', 'rust')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO document_tags VALUES ('memory::abc123', '  Tauri  ')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO document_tags VALUES ('screen::xyz', 'design')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
+
+        let count = import_from_path(&db_file, &db).await.unwrap();
+        assert_eq!(count, 3);
+
+        let tags_abc = db.get_document_tags("memory", "abc123").await.unwrap();
+        assert_eq!(tags_abc, vec!["rust", "tauri"]); // normalized + sorted
+
+        let tags_xyz = db.get_document_tags("screen", "xyz").await.unwrap();
+        assert_eq!(tags_xyz, vec!["design"]);
     }
 
-    #[test]
-    fn test_sqlite_roundtrip_default_store() {
-        let db = test_db();
-        let original = SpaceStore::default();
-        db.save_all(&original).unwrap();
-        let loaded = db.load_all().unwrap();
+    /// If the legacy file has no document_tags table, import returns 0.
+    #[tokio::test]
+    async fn test_import_from_path_no_table() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_file = tmp.path().join("spaces.db");
+        let mem_db_file = tmp.path().join("test.db");
 
-        assert!(loaded.tags.is_empty());
-        assert!(loaded.document_tags.is_empty());
+        {
+            let conn = Connection::open(&db_file).unwrap();
+            conn.execute_batch("CREATE TABLE spaces (id TEXT PRIMARY KEY);")
+                .unwrap();
+        }
+
+        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
+
+        let count = import_from_path(&db_file, &db).await.unwrap();
+        assert_eq!(count, 0);
     }
 
-    #[test]
-    fn test_sqlite_roundtrip_with_data() {
-        let db = test_db();
-        let mut store = SpaceStore::default();
+    /// doc_keys without "::" are silently skipped.
+    #[tokio::test]
+    async fn test_import_from_path_skips_bad_doc_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_file = tmp.path().join("spaces.db");
+        let mem_db_file = tmp.path().join("test.db");
 
-        // Add tags
-        store.set_document_tags(
-            "screen",
-            "doc1",
-            vec!["rust".to_string(), "tauri".to_string()],
-        );
+        {
+            let conn = Connection::open(&db_file).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE document_tags (doc_key TEXT NOT NULL, tag TEXT NOT NULL, PRIMARY KEY (doc_key, tag));",
+            )
+            .unwrap();
+            // Valid row.
+            conn.execute(
+                "INSERT INTO document_tags VALUES ('memory::good', 'ok')",
+                [],
+            )
+            .unwrap();
+            // Malformed row — no "::".
+            conn.execute("INSERT INTO document_tags VALUES ('baddockey', 'ok')", [])
+                .unwrap();
+        }
 
-        db.save_all(&store).unwrap();
-        let loaded = db.load_all().unwrap();
+        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
 
-        // Document tags
-        assert_eq!(loaded.document_tags.len(), 1);
-        let doc1_tags = loaded.document_tags.get("screen::doc1").unwrap();
-        assert!(doc1_tags.contains("rust"));
-        assert!(doc1_tags.contains("tauri"));
+        let count = import_from_path(&db_file, &db).await.unwrap();
+        assert_eq!(count, 1);
 
-        // Tags library
-        assert!(loaded.tags.contains("rust"));
-        assert!(loaded.tags.contains("tauri"));
-    }
-
-    #[test]
-    fn test_sqlite_save_overwrites_previous() {
-        let db = test_db();
-
-        // Save defaults (empty)
-        let store1 = SpaceStore::default();
-        db.save_all(&store1).unwrap();
-
-        // Save a modified store with tags
-        let mut store2 = SpaceStore::default();
-        store2.set_document_tags("screen", "doc1", vec!["rust".to_string()]);
-        db.save_all(&store2).unwrap();
-
-        let loaded = db.load_all().unwrap();
-        assert!(loaded.tags.contains("rust"));
-        assert_eq!(loaded.document_tags.len(), 1);
-    }
-
-    #[test]
-    fn test_sqlite_migration_from_json() {
-        let dir = std::env::temp_dir().join(format!("origin_test_{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let json_file = dir.join("spaces.json");
-        let db_file = dir.join("spaces.db");
-
-        // Write a JSON file with tag data
-        let mut store = SpaceStore::default();
-        store.set_document_tags("screen", "cap1", vec!["test".to_string()]);
-        let json = serde_json::to_string_pretty(&store).unwrap();
-        std::fs::write(&json_file, &json).unwrap();
-
-        // Open the DB (no existing DB) and migrate
-        let db = SpaceDb::open(&db_file).unwrap();
-        // Simulate migration: load from JSON, save to SQLite
-        let loaded_from_json: SpaceStore =
-            serde_json::from_str(&std::fs::read_to_string(&json_file).unwrap()).unwrap();
-        db.save_all(&loaded_from_json).unwrap();
-
-        // Verify tag data survived migration
-        let reloaded = db.load_all().unwrap();
-        assert!(reloaded.tags.contains("test"));
-
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&dir);
+        let tags = db.get_document_tags("memory", "good").await.unwrap();
+        assert_eq!(tags, vec!["ok"]);
     }
 }

--- a/crates/origin-core/src/spaces.rs
+++ b/crates/origin-core/src/spaces.rs
@@ -117,6 +117,14 @@ mod tests {
         let db_file = tmp.path().join("spaces.db");
         let mem_db_file = tmp.path().join("test.db");
 
+        // Initialize libsql first to match production startup order (MemoryDB::new
+        // before import_legacy_tags). Otherwise rusqlite initializes sqlite3 with
+        // serialized threading and libsql's Builder::new_local panics when it
+        // tries to set its own threading config.
+        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
+
         // Write a legacy spaces.db with two docs and some tags.
         {
             let conn = Connection::open(&db_file).unwrap();
@@ -141,10 +149,6 @@ mod tests {
             .unwrap();
         }
 
-        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
-            .await
-            .unwrap();
-
         let count = import_from_path(&db_file, &db).await.unwrap();
         assert_eq!(count, 3);
 
@@ -162,15 +166,15 @@ mod tests {
         let db_file = tmp.path().join("spaces.db");
         let mem_db_file = tmp.path().join("test.db");
 
+        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
+
         {
             let conn = Connection::open(&db_file).unwrap();
             conn.execute_batch("CREATE TABLE spaces (id TEXT PRIMARY KEY);")
                 .unwrap();
         }
-
-        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
-            .await
-            .unwrap();
 
         let count = import_from_path(&db_file, &db).await.unwrap();
         assert_eq!(count, 0);
@@ -182,6 +186,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let db_file = tmp.path().join("spaces.db");
         let mem_db_file = tmp.path().join("test.db");
+
+        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
+            .await
+            .unwrap();
 
         {
             let conn = Connection::open(&db_file).unwrap();
@@ -199,10 +207,6 @@ mod tests {
             conn.execute("INSERT INTO document_tags VALUES ('baddockey', 'ok')", [])
                 .unwrap();
         }
-
-        let db = MemoryDB::new(&mem_db_file, Arc::new(NoopEmitter))
-            .await
-            .unwrap();
 
         let count = import_from_path(&db_file, &db).await.unwrap();
         assert_eq!(count, 1);

--- a/crates/origin-server/src/main.rs
+++ b/crates/origin-server/src/main.rs
@@ -363,8 +363,16 @@ async fn run_daemon() -> anyhow::Result<()> {
         }
     }
 
-    // Load space store
-    server_state.space_store = origin_core::spaces::load_spaces();
+    // Import any legacy tag data from the pre-PR-B2 spaces.db file.
+    if let Some(ref db_arc) = server_state.db {
+        match origin_core::spaces::import_legacy_tags(db_arc).await {
+            Ok(n) if n > 0 => {
+                tracing::info!("[startup] imported {} legacy tag triples from spaces.db", n)
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("[startup] legacy tags import failed: {e}"),
+        }
+    }
 
     // Spawn the ingest coalescer. HTTP `/api/memory/store` handlers submit
     // fully-built RawDocuments + pre-computed chunk counts; the coalescer

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -256,7 +256,7 @@ pub async fn handle_store_memory(
     };
 
     // Placeholder classification. The async enrichment path will replace
-    // these via `db.apply_enrichment(...)` and `space_store.set_document_tags(...)`
+    // these via `db.apply_enrichment(...)` and `db.set_document_tags(...)`
     // once the LLM has run (typically within a few seconds).
     let memory_type_str = validated_memory_type
         .clone()
@@ -702,8 +702,8 @@ pub async fn handle_store_memory(
     //      replaces the inline LLM calls that used to gate the HTTP response.
     //      Sync path stored placeholder values (memory_type="fact" unless the
     //      caller supplied one; no domain/quality/structured_fields from LLM);
-    //      this phase fills them in via a combined UPDATE. Tags go through
-    //      `space_store` and require a brief write guard.
+    //      this phase fills them in via a combined UPDATE. Tags are written
+    //      directly to MemoryDB via `db.set_document_tags(...)`.
     //
     //   2. `run_post_ingest_enrichment(...)` — entity auto-linking, title
     //      enrichment, page growth. Runs with the enriched fields phase 1 produced.
@@ -875,15 +875,14 @@ pub async fn handle_store_memory(
                     }
                 }
 
-                // Write tags. Brief write guard — synchronous in-memory update.
+                // Write tags to MemoryDB.
                 if !classified_tags_async.is_empty() {
-                    let mut s = state_clone.write().await;
-                    s.space_store.set_document_tags(
-                        "memory",
-                        &source_id_clone,
-                        classified_tags_async,
-                    );
-                    let _ = origin_core::spaces::save_spaces(&s.space_store);
+                    if let Err(e) = db
+                        .set_document_tags("memory", &source_id_clone, classified_tags_async)
+                        .await
+                    {
+                        tracing::warn!("[store_memory async] set_document_tags failed: {e}");
+                    }
                 }
             }
 
@@ -2427,8 +2426,14 @@ pub async fn handle_list_activities(
 pub async fn handle_list_tags(
     State(state): State<Arc<RwLock<ServerState>>>,
 ) -> Result<Json<origin_types::responses::TagsResponse>, ServerError> {
-    let s = state.read().await;
-    let tags: Vec<String> = s.space_store.tags.iter().cloned().collect();
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let tags = db
+        .list_all_tags()
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
     Ok(Json(origin_types::responses::TagsResponse { tags }))
 }
 
@@ -2437,8 +2442,13 @@ pub async fn handle_delete_tag(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(name): Path<String>,
 ) -> Result<Json<origin_types::responses::SuccessResponse>, ServerError> {
-    let mut s = state.write().await;
-    s.space_store.delete_tag(&name);
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    db.delete_tag(&name)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
     Ok(Json(origin_types::responses::SuccessResponse { ok: true }))
 }
 
@@ -2448,10 +2458,14 @@ pub async fn handle_set_document_tags(
     Path(source_id): Path<String>,
     Json(req): Json<origin_types::requests::SetDocumentTagsRequest>,
 ) -> Result<Json<origin_types::responses::TagsResponse>, ServerError> {
-    let mut s = state.write().await;
-    let tags = s
-        .space_store
-        .set_document_tags("memory", &source_id, req.tags);
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let tags = db
+        .set_document_tags("memory", &source_id, req.tags)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
     Ok(Json(origin_types::responses::TagsResponse { tags }))
 }
 
@@ -2475,16 +2489,15 @@ pub async fn handle_suggest_tags(
     State(state): State<Arc<RwLock<ServerState>>>,
     axum::extract::Query(query): axum::extract::Query<SuggestTagsQuery>,
 ) -> Result<Json<origin_types::responses::TagsResponse>, ServerError> {
-    // Read phase: clone db Arc + snapshot the existing tags vec.
-    // Dropping the guard before the awaits keeps writers unblocked.
-    let (db, existing) = {
+    // Read phase: clone db Arc, drop guard, then fetch existing tags from DB.
+    let db = {
         let s = state.read().await;
-        let db = s.db.clone().ok_or(ServerError::DbNotInitialized)?;
-        let existing = s
-            .space_store
-            .get_document_tags(&query.source, &query.source_id);
-        (db, existing)
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
+    let existing = db
+        .get_document_tags(&query.source, &query.source_id)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
 
     let chunks = db
         .get_memories_by_source_id(&query.source, &query.source_id)

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -216,7 +216,7 @@ pub async fn handle_chat_context(
     // the multi-second chain of DB + LLM awaits below. Holding the guard
     // across ~15 sequential awaits (load_memories_by_type, search_*,
     // search_memory_reranked, log_accesses, etc.) would block every writer
-    // to ServerState — e.g. store_memory's space_store update — for the
+    // to ServerState — e.g. store_memory's deferred async work — for the
     // full duration of a rerank call. See CLAUDE.md locking rules.
     let (db_arc, llm, access_tracker, page_min_overlap) = {
         let s = state.read().await;

--- a/crates/origin-server/src/state.rs
+++ b/crates/origin-server/src/state.rs
@@ -8,7 +8,6 @@ use origin_core::db::MemoryDB;
 use origin_core::llm_provider::LlmProvider;
 use origin_core::prompts::PromptRegistry;
 use origin_core::quality_gate::QualityGate;
-use origin_core::spaces::SpaceStore;
 use origin_core::tuning::TuningConfig;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -42,8 +41,6 @@ pub struct ServerState {
     pub access_tracker: AccessTracker,
     /// Pre-store quality gate.
     pub quality_gate: QualityGate,
-    /// Spaces, tags & document assignments.
-    pub space_store: SpaceStore,
     /// Configured directory watch paths.
     pub watch_paths: Vec<PathBuf>,
     /// Write-event tracker for the event-driven steep scheduler.
@@ -69,7 +66,6 @@ impl Default for ServerState {
             tuning: TuningConfig::default(),
             access_tracker: AccessTracker::new(),
             quality_gate: QualityGate::new(origin_core::tuning::GateConfig::default()),
-            space_store: SpaceStore::default(),
             watch_paths: Vec::new(),
             write_signal: WriteSignal::new(),
             ingest_batcher: None,


### PR DESCRIPTION
## Summary

PR-B2 — completes the SpaceStore consolidation started in PR #133. Tags + document-tag assignments move from the legacy `spaces.db` rusqlite store into the main libSQL `MemoryDB`. After this merges, the daemon writes through exactly one database; `spaces.db` becomes legacy-import-only.

The user chose to **drop the standalone `tags` registry table** — `list_all_tags` derives via `SELECT DISTINCT tag FROM document_tags` on demand. No orphan tag preservation.

## Changes

- **Migration 51** (`crates/origin-core/src/db.rs`): new `document_tags(source, source_id, tag)` table with composite PK + `idx_document_tags_tag` index.
- **MemoryDB CRUD** on tags (4 new async methods): `set_document_tags`, `get_document_tags`, `delete_tag`, `list_all_tags`. Normalization (trim + lowercase) lives inside the methods so HTTP handlers can't bypass.
- **spaces.rs**: shrunk 473 → 213 lines. `SpaceStore`, `SpaceDb`, `load_spaces`, `save_spaces`, JSON migration — all gone. What remains is a single one-shot `import_legacy_tags(&MemoryDB)` that reads any pre-existing `spaces.db`, imports rows via `set_document_tags`, then renames the file to `spaces.db.migrated-<epoch>` so it won't re-import. Once enough users cycle past 0.7, the whole module + `rusqlite` dependency can go.
- **`ServerState.space_store` field removed** (state.rs). `main.rs` startup now calls `import_legacy_tags(&db)` instead of `load_spaces()`.
- **HTTP handlers** in `memory_routes.rs`: all 5 tag call sites switched to `db.<method>().await`. Each clones `Arc<MemoryDB>` out of the read guard before the await (AGENTS.md rule). Dropped the `save_spaces()` call after `set_document_tags` — libSQL writes are persistent on commit.

## What's preserved

- HTTP API surface (`GET /api/tags`, `GET /api/suggest-tags`, `PUT /api/documents/{source_id}/tags`, `DELETE /api/tags/{name}`) unchanged from a caller's perspective.
- Tag normalization rule unchanged: `trim().to_lowercase()`, empty filtered.
- Pre-0.7 `spaces.db` files are non-destructively imported on first startup, then renamed. Backup retained for downgrade.

## Test plan

- [x] Migration 51 replay test (rolls user_version back, re-runs, verifies table)
- [x] CRUD unit tests for all 4 new MemoryDB methods (normalization, idempotent re-set, distinct)
- [x] Legacy-import unit test in `spaces.rs` (temp spaces.db → MemoryDB)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — origin-core 1095 / origin-server 176 / origin-cli 54 / origin-mcp 57 / origin-types pass
- [ ] CI green

## Followup

Once 0.7 has been the released version for a few weeks and any user with a pre-0.7 daemon has cycled, a follow-up PR can:
- Delete `crates/origin-core/src/spaces.rs` entirely
- Drop the `rusqlite` dependency from `crates/origin-core/Cargo.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)