### PR TITLE
fix(core): honor ORIGIN_DATA_DIR in spaces.legacy_db_path

### DIFF
--- a/crates/origin-core/src/spaces.rs
+++ b/crates/origin-core/src/spaces.rs
@@ -13,10 +13,17 @@ use rusqlite::Connection;
 use std::path::{Path, PathBuf};
 
 fn legacy_db_path() -> PathBuf {
-    dirs::data_local_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("origin")
-        .join("spaces.db")
+    // Honor ORIGIN_DATA_DIR so scratch / worktree daemons do not reach into
+    // the user's real `~/Library/Application Support/origin/spaces.db` and
+    // rename it out from under a production daemon still running pre-PR-B2.
+    let root = std::env::var_os("ORIGIN_DATA_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join("origin")
+        });
+    root.join("spaces.db")
 }
 
 /// Import tags from a legacy `spaces.db` (if present) into MemoryDB,
@@ -108,6 +115,22 @@ mod tests {
     use super::*;
     use crate::events::NoopEmitter;
     use std::sync::Arc;
+
+    /// `legacy_db_path` must honor `ORIGIN_DATA_DIR` so scratch / worktree
+    /// daemons do not reach into the user's production
+    /// `~/Library/Application Support/origin/spaces.db` and rename it.
+    #[test]
+    fn test_legacy_db_path_honors_origin_data_dir() {
+        // Save + restore so we don't leak env state to other tests.
+        let prev = std::env::var_os("ORIGIN_DATA_DIR");
+        std::env::set_var("ORIGIN_DATA_DIR", "/tmp/origin-spaces-path-test");
+        let p = legacy_db_path();
+        assert_eq!(p, PathBuf::from("/tmp/origin-spaces-path-test/spaces.db"));
+        match prev {
+            Some(v) => std::env::set_var("ORIGIN_DATA_DIR", v),
+            None => std::env::remove_var("ORIGIN_DATA_DIR"),
+        }
+    }
 
     /// Create a temporary spaces.db with a document_tags table and some rows,
     /// then assert they end up in MemoryDB after import_from_path.


### PR DESCRIPTION
## Summary

PR-B2 (#134) shipped with a hidden gotcha: `legacy_db_path()` in `spaces.rs` hardcodes `dirs::data_local_dir()/origin/spaces.db` and ignores `ORIGIN_DATA_DIR`. A scratch daemon started with `ORIGIN_DATA_DIR=/tmp/foo` reaches into the user's real `~/Library/Application Support/origin/spaces.db`, imports its tag rows into the scratch DB, and renames the production file to `spaces.db.migrated-<epoch>` — silently breaking any pre-PR-B2 production daemon still running on the old binary.

Found by smoke-testing the PR-B2 tag CRUD path on an isolated port (`ORIGIN_PORT=7879 ORIGIN_DATA_DIR=/tmp/origin-pr-b2-smoke`): `/api/tags` returned 2026 tag rows on a fresh dir.

## Changes

- `legacy_db_path()` now reads `ORIGIN_DATA_DIR` first, falls back to platform `data_local_dir`. Matches `config::config_path()` pattern.
- Regression test `test_legacy_db_path_honors_origin_data_dir`.

## Test plan

- [x] Unit test asserts ORIGIN_DATA_DIR is honored
- [x] Smoke verified: fresh daemon on isolated dir returns empty `/api/tags`, production `spaces.db` untouched
- [x] Tag CRUD e2e on fixed binary: PUT normalization, replace semantics, DELETE cross-doc, distinct list — all green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)