### PR TITLE
fix(server): clone Arc<MemoryDB> before await in handle_list_memories

### DIFF
--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1110,8 +1110,10 @@ pub async fn handle_list_memories(
     State(state): State<Arc<RwLock<ServerState>>>,
     Json(req): Json<ListMemoriesRequest>,
 ) -> Result<Json<ListMemoriesResponse>, ServerError> {
-    let s = state.read().await;
-    let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    }; // guard dropped here
     let memories = db
         .list_filtered_confirmed(
             Some("memory"),


### PR DESCRIPTION
## Summary

Lock-hygiene gap missed by PR #131 sweep. `handle_list_memories` held a `tokio::sync::RwLock` read guard across the `db.list_filtered_confirmed` await, blocking writers (memory store, ingest) during the query.

Follows the same clone-before-await pattern used in `handle_search`, `handle_get_nurture_cards`, `handle_get_rejections` (PR #131).

Surfaced during PR-B2 smoke testing (post-#135 release-binary verification).

## Changes

- `crates/origin-server/src/memory_routes.rs` — `handle_list_memories` clones `Arc<MemoryDB>` out of the read guard in an inner scope, then awaits `list_filtered_confirmed` on the bare `Arc`. Surgical change, no other refactoring.

## Test plan

- [x] `cargo build -p origin-server`
- [x] `cargo clippy -p origin-server --all-targets -- -D warnings`
- [x] `cargo test -p origin-server --lib` — all 176 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)