### PR TITLE
fix: sync README to npm packages + republish v0.6.0+ with README content

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           filters: |
             rust:
               - 'crates/**'
+              - '!crates/*/npm/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -46,7 +47,7 @@ jobs:
               - 'plugin/**'
               - '.claude-plugin/**'
             npm:
-              - 'crates/origin-mcp/npm/**'
+              - 'crates/*/npm/**'
 
   fmt:
     name: fmt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,12 +246,23 @@ jobs:
         run: |
           VERSION="${RELEASE_TAG#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
+      - name: Copy root README into npm packages
+        # npm renders README.md on the package page. Copying root README ensures
+        # both packages always reflect the current project description rather
+        # than rotting per-package READMEs.
+        run: |
+          cp README.md crates/origin-mcp/npm/README.md
+          cp README.md crates/origin-cli/npm/README.md
       - name: Publish origin-mcp
         working-directory: crates/origin-mcp/npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish @7xuanlu/origin
         working-directory: crates/origin-cli/npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   update-homebrew:
     name: Update Homebrew tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,13 +246,16 @@ jobs:
         run: |
           VERSION="${RELEASE_TAG#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-      - name: Copy root README into npm packages
-        # npm renders README.md on the package page. Copying root README ensures
-        # both packages always reflect the current project description rather
-        # than rotting per-package READMEs.
+      - name: Copy root README and LICENSE into npm packages
+        # npm renders README.md on the package page and surfaces LICENSE on
+        # the package metadata. Copying root files ensures both packages
+        # always reflect the current project description and the same legal
+        # text the daemon ships under.
         run: |
           cp README.md crates/origin-mcp/npm/README.md
           cp README.md crates/origin-cli/npm/README.md
+          cp LICENSE crates/origin-mcp/npm/LICENSE
+          cp LICENSE crates/origin-cli/npm/LICENSE
       - name: Publish origin-mcp
         working-directory: crates/origin-mcp/npm
         run: npm publish --provenance --access public

--- a/crates/origin-cli/npm/.gitignore
+++ b/crates/origin-cli/npm/.gitignore
@@ -1,4 +1,3 @@
-bin/
 node_modules/
 # Generated at release time from root README by release.yml. Don't commit.
 README.md

--- a/crates/origin-cli/npm/.gitignore
+++ b/crates/origin-cli/npm/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
-# Generated at release time from root README by release.yml. Don't commit.
+# Generated at release time from root files by release.yml. Don't commit.
 README.md
+LICENSE

--- a/crates/origin-cli/npm/package.json
+++ b/crates/origin-cli/npm/package.json
@@ -2,6 +2,24 @@
   "name": "@7xuanlu/origin",
   "version": "0.6.0",
   "description": "Frictionless setup for Origin, the local runtime for AI work memory.",
+  "keywords": [
+    "ai-memory",
+    "llm-wiki",
+    "origin",
+    "memory",
+    "ai",
+    "agents",
+    "knowledge",
+    "claude",
+    "chatgpt",
+    "installer",
+    "setup"
+  ],
+  "homepage": "https://github.com/7xuanlu/origin#readme",
+  "bugs": {
+    "url": "https://github.com/7xuanlu/origin/issues"
+  },
+  "author": "7xuanlu <h164654156465@gmail.com>",
   "license": "Apache-2.0",
   "bin": {
     "origin": "run.js"
@@ -18,6 +36,8 @@
     "directory": "crates/origin-cli/npm"
   },
   "files": [
-    "run.js"
+    "run.js",
+    "README.md",
+    "LICENSE"
   ]
 }

--- a/crates/origin-cli/npm/package.json
+++ b/crates/origin-cli/npm/package.json
@@ -1,13 +1,17 @@
 {
   "name": "@7xuanlu/origin",
   "version": "0.6.0",
-  "description": "Frictionless setup for Origin, the local runtime for AI work memory.",
+  "description": "Local-first memory + knowledge layer for AI agents.",
   "keywords": [
     "ai-memory",
     "llm-wiki",
+    "long-term-memory",
+    "local-first",
+    "wiki",
     "origin",
     "memory",
     "ai",
+    "llm",
     "agents",
     "knowledge",
     "claude",
@@ -23,6 +27,9 @@
   "license": "Apache-2.0",
   "bin": {
     "origin": "run.js"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "os": [
     "darwin"

--- a/crates/origin-mcp/npm/.gitignore
+++ b/crates/origin-mcp/npm/.gitignore
@@ -1,4 +1,5 @@
 bin/
 node_modules/
-# Generated at release time from root README by release.yml. Don't commit.
+# Generated at release time from root files by release.yml. Don't commit.
 README.md
+LICENSE

--- a/crates/origin-mcp/npm/package.json
+++ b/crates/origin-mcp/npm/package.json
@@ -4,6 +4,8 @@
   "description": "Personal memory layer for AI agents - MCP server",
   "keywords": [
     "mcp",
+    "ai-memory",
+    "llm-wiki",
     "memory",
     "ai",
     "agents",
@@ -11,6 +13,11 @@
     "chatgpt",
     "origin"
   ],
+  "homepage": "https://github.com/7xuanlu/origin#readme",
+  "bugs": {
+    "url": "https://github.com/7xuanlu/origin/issues"
+  },
+  "author": "7xuanlu <h164654156465@gmail.com>",
   "license": "Apache-2.0",
   "bin": {
     "origin-mcp": "run.js"

--- a/crates/origin-mcp/npm/package.json
+++ b/crates/origin-mcp/npm/package.json
@@ -1,13 +1,17 @@
 {
   "name": "origin-mcp",
   "version": "0.6.0",
-  "description": "Personal memory layer for AI agents - MCP server",
+  "description": "Local-first memory layer for AI agents - MCP server",
   "keywords": [
     "mcp",
     "ai-memory",
     "llm-wiki",
+    "long-term-memory",
+    "local-first",
+    "wiki",
     "memory",
     "ai",
+    "llm",
     "agents",
     "claude",
     "chatgpt",
@@ -24,6 +28,9 @@
   },
   "scripts": {
     "postinstall": "node install.js"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "os": [
     "darwin"


### PR DESCRIPTION
## Summary

Two `.github/workflows/release.yml` fixes prompted by v0.6.0 npm publish pain.

## Changes

### 1. Sync root README to npm packages on publish

New step in `publish-npm` job copies root `README.md` into both `crates/origin-mcp/npm/` and `crates/origin-cli/npm/` before publish. npm shows README on package page → both `npmjs.com/package/origin-mcp` and `npmjs.com/package/@7xuanlu/origin` now display current project info instead of "no readme" tile. Auto-regenerates per release so package READMEs never go stale.

Generated file `README.md` added to both npm dirs' `.gitignore` to prevent local commits of a stale copy.

### 2. NPM_TOKEN fallback for non-OIDC publish

Added `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env to both publish steps. OIDC stays primary (`--provenance` flag preserved). NODE_AUTH_TOKEN provides fallback when a package's npm Trusted Publisher config isn't set — which is what blocked `@7xuanlu/origin` first-publish for v0.6.0 (had to publish manually from local).

## Followup user action (NOT in this PR)

Configure npm Trusted Publisher for `@7xuanlu/origin`:
1. https://www.npmjs.com/package/@7xuanlu/origin/access
2. Add Trusted Publisher → GitHub Actions
3. Owner: `7xuanlu` | Repo: `origin` | Workflow: `release.yml`
4. Save

Once configured, `--provenance` publishes work via OIDC without falling back to NODE_AUTH_TOKEN.

Also: migrate `origin-mcp` ownership to `@7xuanlu` org via https://www.npmjs.com/package/origin-mcp/access → Teams → Add `7xuanlu:developers` (Automation tokens don't have team-management perm, must do via UI).

## Test plan

- [ ] CI green on this PR (this PR doesn't touch release.yml's runtime behavior on PR builds — only on tag pushes)
- [ ] Verify on next release: README appears on both package pages on npmjs.com
- [ ] Verify on next release: publish-npm job succeeds even if Trusted Publisher unconfigured (NODE_AUTH_TOKEN fallback works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)