### PR TITLE
fix: harden MCP setup distribution path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,12 @@ jobs:
         with:
           filters: |
             rust:
-              - 'crates/**'
-              - '!crates/*/npm/**'
+              # Positive-only globs. With dorny/paths-filter's default
+              # `some` quantifier, a negative glob like `!crates/*/npm/**`
+              # makes README-only PRs match this filter.
+              - 'crates/**/*.rs'
+              - 'crates/**/Cargo.toml'
+              - 'crates/*/resources/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,14 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
-      - working-directory: crates/origin-mcp/npm
+      - name: Validate origin-mcp npm package
+        working-directory: crates/origin-mcp/npm
         run: |
           npm pack --dry-run
           node -c run.js
           node -c install.js
+      - name: Validate @7xuanlu/origin npm package
+        working-directory: crates/origin-cli/npm
+        run: |
+          npm pack --dry-run
+          node -c run.js

--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ Set up the local Origin runtime:
 npx -y @7xuanlu/origin setup
 ```
 
+Current setup package supports macOS Apple Silicon, matching the release binaries.
+
 That installs the `origin` CLI, `origin-server` daemon, and `origin-mcp` connector into `~/.origin/bin/`, configures local memory, registers the daemon with launchd, and verifies status.
 For terminal use, start with `origin status`, `origin recall <query>`, or `origin store <text>`. CLI details: [crates/origin-cli](crates/origin-cli/README.md).
 
-Then add the MCP connector to Cursor, Codex, VS Code, Claude Desktop, Gemini CLI, or any client that accepts a JSON `mcpServers` entry:
+Then add the MCP connector to your client. For clients that use a JSON `mcpServers` block:
 
 ```json
 {
@@ -92,7 +94,7 @@ Then add the MCP connector to Cursor, Codex, VS Code, Claude Desktop, Gemini CLI
 }
 ```
 
-The `origin-mcp` connector runs on demand and talks to the local Origin daemon from setup above.
+The `origin-mcp` connector runs on demand and talks to the local Origin daemon from setup above. If your client uses another settings format, use the same command and args.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
   <a href="#what-you-get"><img alt="Obsidian" src="https://img.shields.io/badge/Obsidian-Markdown%20pages-7C3AED"></a>
 </p>
 
-**Stop re-explaining your project to AI. Stop losing your own decisions between sessions.**
+**Your next AI session should pick up the context you built, not lose it in chat history.**
 
-Origin: the local daemon for AI work artifacts. Decisions, lessons, citations, and project context get captured, distilled, and versioned in one store. Every claim cites its source. The daemon rejects pages with empty `source_memory_ids` (HTTP 422). Every write commits to `~/.origin/.git/`. Built for Claude Code, Cursor, Codex, and any MCP client. Five verbs, one binary, ~30 MCP tools.
+Origin gives your daily AI workflow one local home: memory your agents can recall, wiki pages you can read, and source-backed context that captures, distills, and versions decisions, lessons, and project context across chats, projects, and time.
 
 Your agent reads searchable memory, graph context, and hybrid retrieval. You read Markdown artifacts under `~/.origin/`. Same store, two surfaces.
 
@@ -74,16 +74,10 @@ Use this if you want Origin tools in Claude Code without the plugin, or in Codex
 
 ```bash
 npx -y @7xuanlu/origin setup
-origin mcp add claude-code      # or: codex, cursor, claude-desktop, vscode, gemini
+~/.origin/bin/origin mcp add claude-code      # or: codex, cursor, claude-desktop, vscode, gemini
 ```
 
 MCP-only gives agents tools for capture, recall, context, doctor, and page distillation. It does not install Claude Code slash skills like `/brief`, `/handoff`, `/distill`, or `/init`.
-
-Preview a client config change first:
-
-```bash
-origin mcp add cursor --dry-run
-```
 
 ### Terminal runtime setup
 
@@ -93,12 +87,7 @@ Set up the local Origin runtime:
 npx -y @7xuanlu/origin setup
 ```
 
-Published setup binaries currently target macOS Apple Silicon. Intel Mac and Linux support need release binaries, service setup, npm maps, and CI smoke tests before they are advertised.
-
-That installs the `origin` CLI, `origin-server` daemon, and `origin-mcp` connector into `~/.origin/bin/`, configures local memory, registers the daemon with launchd, and verifies status.
-For terminal use, start with `origin status`, `origin recall <query>`, or `origin store <text>`. CLI details: [crates/origin-cli](crates/origin-cli/README.md).
-
-The `origin-mcp` connector runs on demand and talks to the local Origin daemon from setup above. Raw MCP config examples live in [crates/origin-mcp](crates/origin-mcp/README.md).
+Then start with `~/.origin/bin/origin status`, `~/.origin/bin/origin recall <query>`, or `~/.origin/bin/origin store <text>`. CLI details: [crates/origin-cli](crates/origin-cli/README.md).
 
 ---
 
@@ -110,7 +99,7 @@ Origin follows the rhythm of an AI work session, with five verbs you use directl
 2. **During work.** `/capture <thing>` saves a decision, lesson, gotcha, or project fact in flow. `/recall <query>` looks anything up.
 3. **Session ends.** `/handoff` writes what changed, what's still open, and where to continue, so the next run picks up cleanly.
 4. **Between sessions.** The daemon deduplicates overlapping captures and links related ideas in the background. `/distill` synthesizes wiki pages from clusters of related memories when you want a deliberate pass.
-5. **Next session.** `/brief` brings it all back through the plugin or `origin-mcp`, without replaying full chat history.
+5. **Next session.** `/brief` brings it all back in the Claude Code plugin. MCP-only clients call the `context` tool for the same underlying memory without replaying full chat history.
 
 Full skill reference: [plugin/skills](plugin/skills/README.md).
 
@@ -158,7 +147,7 @@ Origin is daemon-first. `origin-server` owns the local database, embeddings, dis
 | [crates/origin-server](crates/origin-server/README.md) | Local daemon and HTTP API.                                                                                                                                                                                 |
 | [crates/origin-mcp](crates/origin-mcp/README.md)       | MCP server, tools, npm package.                                                                                                                                                                            |
 | [crates/origin-cli](crates/origin-cli/README.md)       | User CLI for setup, service management, search, recall, store, list, agents, model/key setup, and doctor.                                                                                                  |
-| [plugin/](plugin/.claude-plugin/README.md)             | Claude Code plugin (`plugin.json`, skills, hooks, `.mcp.json`). Marketplace entry at root `[.claude-plugin/marketplace.json](.claude-plugin/marketplace.json)` lists this plugin via `source: "./plugin"`. |
+| [plugin/](plugin/.claude-plugin/README.md)             | Claude Code plugin (`plugin.json`, skills, hooks, `.mcp.json`).                                                                                                                                           |
 | [docs/eval](docs/eval/README.md)                       | Benchmark workflow and methodology.                                                                                                                                                                        |
 
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 <p align="center">
   <a href="#claude-code-in-30-seconds"><img alt="Claude Code" src="https://img.shields.io/badge/Claude%20Code-plugin-5D4E75"></a>
-  <a href="#other-mcp-clients-and-terminal-use"><img alt="OpenAI Codex" src="https://img.shields.io/badge/OpenAI%20Codex-MCP-111827"></a>
-  <a href="#other-mcp-clients-and-terminal-use"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-MCP-111111"></a>
-  <a href="#other-mcp-clients-and-terminal-use"><img alt="VS Code" src="https://img.shields.io/badge/VS%20Code-MCP-007ACC"></a>
-  <a href="#other-mcp-clients-and-terminal-use"><img alt="Claude Desktop" src="https://img.shields.io/badge/Claude%20Desktop-MCP-D97757"></a>
-  <a href="#other-mcp-clients-and-terminal-use"><img alt="Gemini CLI" src="https://img.shields.io/badge/Gemini%20CLI-MCP-4285F4"></a>
+  <a href="#mcp-only-setup"><img alt="OpenAI Codex" src="https://img.shields.io/badge/OpenAI%20Codex-MCP-111827"></a>
+  <a href="#mcp-only-setup"><img alt="Cursor" src="https://img.shields.io/badge/Cursor-MCP-111111"></a>
+  <a href="#mcp-only-setup"><img alt="VS Code" src="https://img.shields.io/badge/VS%20Code-MCP-007ACC"></a>
+  <a href="#mcp-only-setup"><img alt="Claude Desktop" src="https://img.shields.io/badge/Claude%20Desktop-MCP-D97757"></a>
+  <a href="#mcp-only-setup"><img alt="Gemini CLI" src="https://img.shields.io/badge/Gemini%20CLI-MCP-4285F4"></a>
   <a href="#what-you-get"><img alt="Obsidian" src="https://img.shields.io/badge/Obsidian-Markdown%20pages-7C3AED"></a>
 </p>
 
@@ -68,7 +68,24 @@ Then try `/brief`, `/capture <decision>`, or `/handoff` inside Claude Code.
 
 Plugin details and daily commands: [plugin/](plugin/.claude-plugin/README.md).
 
-### Other MCP clients and terminal use
+### MCP-only setup
+
+Use this if you want Origin tools in Claude Code without the plugin, or in Codex, Cursor, Claude Desktop, VS Code, or Gemini CLI.
+
+```bash
+npx -y @7xuanlu/origin setup
+origin mcp add claude-code      # or: codex, cursor, claude-desktop, vscode, gemini
+```
+
+MCP-only gives agents tools for capture, recall, context, doctor, and page distillation. It does not install Claude Code slash skills like `/brief`, `/handoff`, `/distill`, or `/init`.
+
+Preview a client config change first:
+
+```bash
+origin mcp add cursor --dry-run
+```
+
+### Terminal runtime setup
 
 Set up the local Origin runtime:
 
@@ -76,25 +93,12 @@ Set up the local Origin runtime:
 npx -y @7xuanlu/origin setup
 ```
 
-Current setup package supports macOS Apple Silicon, matching the release binaries.
+Published setup binaries currently target macOS Apple Silicon. Intel Mac and Linux support need release binaries, service setup, npm maps, and CI smoke tests before they are advertised.
 
 That installs the `origin` CLI, `origin-server` daemon, and `origin-mcp` connector into `~/.origin/bin/`, configures local memory, registers the daemon with launchd, and verifies status.
 For terminal use, start with `origin status`, `origin recall <query>`, or `origin store <text>`. CLI details: [crates/origin-cli](crates/origin-cli/README.md).
 
-Then add the MCP connector to your client. For clients that use a JSON `mcpServers` block:
-
-```json
-{
-  "mcpServers": {
-    "origin": {
-      "command": "npx",
-      "args": ["-y", "origin-mcp"]
-    }
-  }
-}
-```
-
-The `origin-mcp` connector runs on demand and talks to the local Origin daemon from setup above. If your client uses another settings format, use the same command and args.
+The `origin-mcp` connector runs on demand and talks to the local Origin daemon from setup above. Raw MCP config examples live in [crates/origin-mcp](crates/origin-mcp/README.md).
 
 ---
 

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -84,6 +84,18 @@ origin key set anthropic --env ANTHROPIC_API_KEY
 origin key clear anthropic
 ```
 
+### `origin mcp add <client>`
+
+Configure Origin MCP for a supported client. This is the MCP-only path for Claude Code users who do not want the plugin, and for Codex, Cursor, Claude Desktop, VS Code, and Gemini CLI.
+
+```bash
+origin mcp add claude-code
+origin mcp add codex
+origin mcp add cursor --dry-run
+```
+
+Supported clients: `claude-code`, `codex`, `gemini`, `cursor`, `claude-desktop`, `vscode`.
+
 ### `origin search <query>`
 
 Search memories (vector + FTS hybrid).

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -6,6 +6,16 @@ License: Apache-2.0.
 
 ## Install
 
+Recommended user setup:
+
+```bash
+npx -y @7xuanlu/origin setup
+```
+
+The setup package currently targets macOS Apple Silicon, matching the published release binaries. It installs `origin`, `origin-server`, and `origin-mcp` into `~/.origin/bin/`, configures local memory, registers the daemon with launchd, and verifies status.
+
+For local development:
+
 ```bash
 cargo install --path crates/origin-cli
 ```
@@ -95,6 +105,14 @@ origin mcp add cursor --dry-run
 ```
 
 Supported clients: `claude-code`, `codex`, `gemini`, `cursor`, `claude-desktop`, `vscode`.
+
+When `origin-mcp` is installed next to the `origin` CLI, the generated config points at that binary. Otherwise it falls back to `npx -y origin-mcp`.
+
+Use `--dry-run` to preview JSON config edits before writing them:
+
+```bash
+origin mcp add cursor --dry-run
+```
 
 ### `origin search <query>`
 

--- a/crates/origin-cli/src/commands/mcp.rs
+++ b/crates/origin-cli/src/commands/mcp.rs
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Configure Origin MCP in supported clients.
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::{Args, Subcommand, ValueEnum};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SERVER_NAME: &str = "origin";
+const SERVER_COMMAND: &str = "npx";
+const SERVER_ARGS: [&str; 2] = ["-y", "origin-mcp"];
+
+#[derive(Subcommand)]
+pub enum McpCommand {
+    /// Add Origin MCP to a supported client.
+    Add(AddArgs),
+}
+
+#[derive(Args)]
+pub struct AddArgs {
+    /// Client to configure.
+    #[arg(value_enum)]
+    client: McpClient,
+    /// Print the command or file edit without changing anything.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum McpClient {
+    /// Claude Code without the Origin plugin.
+    ClaudeCode,
+    /// OpenAI Codex CLI.
+    Codex,
+    /// Gemini CLI.
+    Gemini,
+    /// Cursor editor.
+    Cursor,
+    /// Claude Desktop.
+    ClaudeDesktop,
+    /// VS Code workspace MCP config.
+    #[value(name = "vscode")]
+    Vscode,
+}
+
+pub fn run(command: McpCommand, quiet: bool) -> Result<()> {
+    match command {
+        McpCommand::Add(args) => add(args, quiet),
+    }
+}
+
+fn add(args: AddArgs, quiet: bool) -> Result<()> {
+    match args.client {
+        McpClient::ClaudeCode => add_native(
+            "claude-code",
+            "claude",
+            &["mcp", "remove", SERVER_NAME],
+            &[
+                "mcp",
+                "add",
+                "-s",
+                "user",
+                SERVER_NAME,
+                "--",
+                SERVER_COMMAND,
+                SERVER_ARGS[0],
+                SERVER_ARGS[1],
+            ],
+            args.dry_run,
+            quiet,
+            Some(claude_code_tools_only_note()),
+        ),
+        McpClient::Codex => add_native(
+            "codex",
+            "codex",
+            &["mcp", "remove", SERVER_NAME],
+            &[
+                "mcp",
+                "add",
+                SERVER_NAME,
+                "--",
+                SERVER_COMMAND,
+                SERVER_ARGS[0],
+                SERVER_ARGS[1],
+            ],
+            args.dry_run,
+            quiet,
+            None,
+        ),
+        McpClient::Gemini => add_native(
+            "gemini",
+            "gemini",
+            &["mcp", "remove", "-s", "user", SERVER_NAME],
+            &[
+                "mcp",
+                "add",
+                "-s",
+                "user",
+                SERVER_NAME,
+                SERVER_COMMAND,
+                SERVER_ARGS[0],
+                SERVER_ARGS[1],
+            ],
+            args.dry_run,
+            quiet,
+            None,
+        ),
+        McpClient::Cursor => add_json_config(
+            "cursor",
+            home_path(&[".cursor", "mcp.json"])?,
+            "mcpServers",
+            args.dry_run,
+            quiet,
+        ),
+        McpClient::ClaudeDesktop => add_json_config(
+            "claude-desktop",
+            home_path(&[
+                "Library",
+                "Application Support",
+                "Claude",
+                "claude_desktop_config.json",
+            ])?,
+            "mcpServers",
+            args.dry_run,
+            quiet,
+        ),
+        McpClient::Vscode => {
+            let path = std::env::current_dir()
+                .context("determine current directory")?
+                .join(".vscode")
+                .join("mcp.json");
+            add_json_config("vscode", path, "servers", args.dry_run, quiet)
+        }
+    }
+}
+
+fn add_native(
+    client: &str,
+    binary: &str,
+    remove_args: &[&str],
+    add_args: &[&str],
+    dry_run: bool,
+    quiet: bool,
+    note: Option<&str>,
+) -> Result<()> {
+    if dry_run {
+        println!("Would run:");
+        println!("  {} {}", binary, remove_args.join(" "));
+        println!("  {} {}", binary, add_args.join(" "));
+        if let Some(note) = note {
+            println!();
+            println!("{note}");
+        }
+        return Ok(());
+    }
+
+    run_external(binary, remove_args, true)?;
+    run_external(binary, add_args, false)?;
+
+    if !quiet {
+        println!("Configured Origin MCP for {client}.");
+        if let Some(note) = note {
+            println!("{note}");
+        }
+    }
+    Ok(())
+}
+
+fn run_external(binary: &str, args: &[&str], ignore_failure: bool) -> Result<()> {
+    let status = Command::new(binary)
+        .args(args)
+        .status()
+        .with_context(|| format!("could not run `{binary}`. Is it installed and on PATH?"))?;
+
+    if !status.success() && !ignore_failure {
+        bail!(
+            "`{} {}` failed with status {}",
+            binary,
+            args.join(" "),
+            status
+        );
+    }
+
+    Ok(())
+}
+
+fn add_json_config(
+    client: &str,
+    path: PathBuf,
+    section_name: &str,
+    dry_run: bool,
+    quiet: bool,
+) -> Result<()> {
+    let server = server_json();
+    let mut config = read_json_config(&path)?;
+    let changed = upsert_server(&mut config, section_name, server)?;
+
+    if !changed {
+        if !quiet {
+            println!(
+                "Origin MCP already configured for {client} at {}.",
+                path.display()
+            );
+        }
+        return Ok(());
+    }
+
+    if dry_run {
+        println!("Would update {}:", path.display());
+        println!("{}", serde_json::to_string_pretty(&config)?);
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create config directory {}", parent.display()))?;
+    }
+
+    let backup = if path.exists() {
+        Some(backup_file(&path)?)
+    } else {
+        None
+    };
+
+    write_json_atomic(&path, &config)?;
+
+    if !quiet {
+        println!("Updated {} for Origin MCP.", path.display());
+        if let Some(backup) = backup {
+            println!("Backup: {}", backup.display());
+        }
+    }
+
+    Ok(())
+}
+
+fn read_json_config(path: &Path) -> Result<Value> {
+    if !path.exists() {
+        return Ok(json!({}));
+    }
+
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("invalid JSON in {}", path.display()))
+}
+
+fn upsert_server(config: &mut Value, section_name: &str, server: Value) -> Result<bool> {
+    let root = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("MCP config root must be a JSON object"))?;
+
+    let section = root
+        .entry(section_name.to_string())
+        .or_insert_with(|| json!({}));
+
+    let servers = section
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("`{section_name}` must be a JSON object"))?;
+
+    if servers.get(SERVER_NAME) == Some(&server) {
+        return Ok(false);
+    }
+
+    servers.insert(SERVER_NAME.to_string(), server);
+    Ok(true)
+}
+
+fn server_json() -> Value {
+    json!({
+        "command": SERVER_COMMAND,
+        "args": SERVER_ARGS,
+    })
+}
+
+fn backup_file(path: &Path) -> Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("config path has no file name: {}", path.display()))?
+        .to_string_lossy();
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX epoch")?
+        .as_millis();
+    let backup = path.with_file_name(format!("{file_name}.bak.{stamp}.{}", std::process::id()));
+    fs::copy(path, &backup)
+        .with_context(|| format!("write backup {} from {}", backup.display(), path.display()))?;
+    Ok(backup)
+}
+
+fn write_json_atomic(path: &Path, value: &Value) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("config path has no parent: {}", path.display()))?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow!("config path has no file name: {}", path.display()))?
+        .to_string_lossy();
+    let tmp = parent.join(format!(".{file_name}.tmp.{}", std::process::id()));
+    let body = format!("{}\n", serde_json::to_string_pretty(value)?);
+    fs::write(&tmp, body).with_context(|| format!("write temp config {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("replace {} with {}", path.display(), tmp.display()))?;
+    Ok(())
+}
+
+fn home_path(parts: &[&str]) -> Result<PathBuf> {
+    let mut path = dirs::home_dir().ok_or_else(|| anyhow!("could not determine home directory"))?;
+    for part in parts {
+        path.push(part);
+    }
+    Ok(path)
+}
+
+fn claude_code_tools_only_note() -> &'static str {
+    "Claude Code MCP tools only: remember, recall, context, doctor, and related Origin tools. \
+This does not install Origin plugin skills like /brief, /handoff, /distill, or /init."
+}

--- a/crates/origin-cli/src/commands/mcp.rs
+++ b/crates/origin-cli/src/commands/mcp.rs
@@ -4,14 +4,21 @@
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Subcommand, ValueEnum};
 use serde_json::{json, Value};
+use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const SERVER_NAME: &str = "origin";
-const SERVER_COMMAND: &str = "npx";
-const SERVER_ARGS: [&str; 2] = ["-y", "origin-mcp"];
+const FALLBACK_SERVER_COMMAND: &str = "npx";
+const FALLBACK_SERVER_ARGS: [&str; 2] = ["-y", "origin-mcp"];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ServerCommand {
+    command: String,
+    args: Vec<String>,
+}
 
 #[derive(Subcommand)]
 pub enum McpCommand {
@@ -54,22 +61,12 @@ pub fn run(command: McpCommand, quiet: bool) -> Result<()> {
 }
 
 fn add(args: AddArgs, quiet: bool) -> Result<()> {
+    let server = server_command();
     match args.client {
         McpClient::ClaudeCode => add_native(
             "claude-code",
             "claude",
-            &["mcp", "remove", SERVER_NAME],
-            &[
-                "mcp",
-                "add",
-                "-s",
-                "user",
-                SERVER_NAME,
-                "--",
-                SERVER_COMMAND,
-                SERVER_ARGS[0],
-                SERVER_ARGS[1],
-            ],
+            native_args("mcp", &["add", "-s", "user", SERVER_NAME, "--"], &server),
             args.dry_run,
             quiet,
             Some(claude_code_tools_only_note()),
@@ -77,16 +74,7 @@ fn add(args: AddArgs, quiet: bool) -> Result<()> {
         McpClient::Codex => add_native(
             "codex",
             "codex",
-            &["mcp", "remove", SERVER_NAME],
-            &[
-                "mcp",
-                "add",
-                SERVER_NAME,
-                "--",
-                SERVER_COMMAND,
-                SERVER_ARGS[0],
-                SERVER_ARGS[1],
-            ],
+            native_args("mcp", &["add", SERVER_NAME, "--"], &server),
             args.dry_run,
             quiet,
             None,
@@ -94,17 +82,7 @@ fn add(args: AddArgs, quiet: bool) -> Result<()> {
         McpClient::Gemini => add_native(
             "gemini",
             "gemini",
-            &["mcp", "remove", "-s", "user", SERVER_NAME],
-            &[
-                "mcp",
-                "add",
-                "-s",
-                "user",
-                SERVER_NAME,
-                SERVER_COMMAND,
-                SERVER_ARGS[0],
-                SERVER_ARGS[1],
-            ],
+            native_args("mcp", &["add", "-s", "user", SERVER_NAME], &server),
             args.dry_run,
             quiet,
             None,
@@ -113,6 +91,7 @@ fn add(args: AddArgs, quiet: bool) -> Result<()> {
             "cursor",
             home_path(&[".cursor", "mcp.json"])?,
             "mcpServers",
+            &server,
             args.dry_run,
             quiet,
         ),
@@ -125,6 +104,7 @@ fn add(args: AddArgs, quiet: bool) -> Result<()> {
                 "claude_desktop_config.json",
             ])?,
             "mcpServers",
+            &server,
             args.dry_run,
             quiet,
         ),
@@ -133,7 +113,7 @@ fn add(args: AddArgs, quiet: bool) -> Result<()> {
                 .context("determine current directory")?
                 .join(".vscode")
                 .join("mcp.json");
-            add_json_config("vscode", path, "servers", args.dry_run, quiet)
+            add_json_config("vscode", path, "servers", &server, args.dry_run, quiet)
         }
     }
 }
@@ -141,15 +121,13 @@ fn add(args: AddArgs, quiet: bool) -> Result<()> {
 fn add_native(
     client: &str,
     binary: &str,
-    remove_args: &[&str],
-    add_args: &[&str],
+    add_args: Vec<String>,
     dry_run: bool,
     quiet: bool,
     note: Option<&str>,
 ) -> Result<()> {
     if dry_run {
         println!("Would run:");
-        println!("  {} {}", binary, remove_args.join(" "));
         println!("  {} {}", binary, add_args.join(" "));
         if let Some(note) = note {
             println!();
@@ -158,8 +136,7 @@ fn add_native(
         return Ok(());
     }
 
-    run_external(binary, remove_args, true)?;
-    run_external(binary, add_args, false)?;
+    run_external(binary, &add_args)?;
 
     if !quiet {
         println!("Configured Origin MCP for {client}.");
@@ -170,13 +147,13 @@ fn add_native(
     Ok(())
 }
 
-fn run_external(binary: &str, args: &[&str], ignore_failure: bool) -> Result<()> {
+fn run_external(binary: &str, args: &[String]) -> Result<()> {
     let status = Command::new(binary)
         .args(args)
         .status()
         .with_context(|| format!("could not run `{binary}`. Is it installed and on PATH?"))?;
 
-    if !status.success() && !ignore_failure {
+    if !status.success() {
         bail!(
             "`{} {}` failed with status {}",
             binary,
@@ -192,10 +169,11 @@ fn add_json_config(
     client: &str,
     path: PathBuf,
     section_name: &str,
+    server: &ServerCommand,
     dry_run: bool,
     quiet: bool,
 ) -> Result<()> {
-    let server = server_json();
+    let server = server_json(server);
     let mut config = read_json_config(&path)?;
     let changed = upsert_server(&mut config, section_name, server)?;
 
@@ -210,8 +188,14 @@ fn add_json_config(
     }
 
     if dry_run {
-        println!("Would update {}:", path.display());
-        println!("{}", serde_json::to_string_pretty(&config)?);
+        println!(
+            "Would set `{section_name}.{SERVER_NAME}` in {}:",
+            path.display()
+        );
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&config[section_name][SERVER_NAME])?
+        );
         return Ok(());
     }
 
@@ -268,11 +252,14 @@ fn upsert_server(config: &mut Value, section_name: &str, server: Value) -> Resul
     Ok(true)
 }
 
-fn server_json() -> Value {
-    json!({
-        "command": SERVER_COMMAND,
-        "args": SERVER_ARGS,
-    })
+fn server_json(server: &ServerCommand) -> Value {
+    let mut value = json!({
+        "command": server.command,
+    });
+    if !server.args.is_empty() {
+        value["args"] = json!(server.args);
+    }
+    value
 }
 
 fn backup_file(path: &Path) -> Result<PathBuf> {
@@ -317,4 +304,37 @@ fn home_path(parts: &[&str]) -> Result<PathBuf> {
 fn claude_code_tools_only_note() -> &'static str {
     "Claude Code MCP tools only: remember, recall, context, doctor, and related Origin tools. \
 This does not install Origin plugin skills like /brief, /handoff, /distill, or /init."
+}
+
+fn server_command() -> ServerCommand {
+    if let Some(path) = sibling_origin_mcp() {
+        return ServerCommand {
+            command: path.display().to_string(),
+            args: Vec::new(),
+        };
+    }
+
+    ServerCommand {
+        command: FALLBACK_SERVER_COMMAND.to_string(),
+        args: FALLBACK_SERVER_ARGS
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect(),
+    }
+}
+
+fn sibling_origin_mcp() -> Option<PathBuf> {
+    let exe = env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let candidate = dir.join("origin-mcp");
+    candidate.is_file().then_some(candidate)
+}
+
+fn native_args(prefix: &str, args: &[&str], server: &ServerCommand) -> Vec<String> {
+    let mut out = Vec::with_capacity(1 + args.len() + 1 + server.args.len());
+    out.push(prefix.to_string());
+    out.extend(args.iter().map(|arg| (*arg).to_string()));
+    out.push(server.command.clone());
+    out.extend(server.args.iter().cloned());
+    out
 }

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod agents;
 pub mod list;
+pub mod mcp;
 pub mod recall;
 pub mod search;
 pub mod service;

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -60,6 +60,11 @@ enum Commands {
         #[command(subcommand)]
         command: commands::setup::KeyCommand,
     },
+    /// Configure Origin MCP for supported clients.
+    Mcp {
+        #[command(subcommand)]
+        command: commands::mcp::McpCommand,
+    },
     /// Search memories by query (vector + FTS hybrid).
     Search {
         /// Search query.
@@ -127,6 +132,7 @@ async fn main() -> anyhow::Result<()> {
         Commands::Doctor => commands::setup::run_doctor().await?,
         Commands::Model { command } => commands::setup::run_model(command).await?,
         Commands::Key { command } => commands::setup::run_key(command).await?,
+        Commands::Mcp { command } => commands::mcp::run(command, cli.quiet)?,
         Commands::Search { query, limit } => {
             commands::search::run(&client, format, cli.quiet, query, limit).await?
         }

--- a/crates/origin-cli/tests/cli_integration.rs
+++ b/crates/origin-cli/tests/cli_integration.rs
@@ -80,6 +80,20 @@ fn write_fake_launchctl(fake_bin: &Path) {
     fs::set_permissions(path, perms).expect("chmod fake launchctl");
 }
 
+fn write_fake_command(fake_bin: &Path, name: &str) {
+    let path = fake_bin.join(name);
+    fs::write(
+        &path,
+        "#!/bin/sh\nprintf '%s' \"${0##*/}\" >> \"$ORIGIN_TEST_CLI_LOG\"\nfor arg in \"$@\"; do printf '\\t%s' \"$arg\" >> \"$ORIGIN_TEST_CLI_LOG\"; done\nprintf '\\n' >> \"$ORIGIN_TEST_CLI_LOG\"\nexit 0\n",
+    )
+    .expect("write fake command");
+    let mut perms = fs::metadata(&path)
+        .expect("fake command metadata")
+        .permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).expect("chmod fake command");
+}
+
 fn ensure_sibling_origin_server() {
     let origin_bin = assert_cmd::cargo::cargo_bin("origin");
     let server = origin_bin
@@ -129,9 +143,160 @@ fn each_subcommand_has_help() {
         "doctor",
         "model",
         "key",
+        "mcp",
     ] {
         cli().args([sub, "--help"]).assert().success();
     }
+}
+
+#[test]
+fn mcp_subcommands_have_help() {
+    for args in [&["mcp", "--help"][..], &["mcp", "add", "--help"][..]] {
+        cli().args(args).assert().success();
+    }
+}
+
+#[test]
+fn mcp_add_claude_code_dry_run_explains_tools_only() {
+    let runtime = IsolatedRuntime::new();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["mcp", "add", "claude-code", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "claude mcp add -s user origin -- npx -y origin-mcp",
+        ))
+        .stdout(predicate::str::contains("MCP tools only"))
+        .stdout(predicate::str::contains("/brief"))
+        .stdout(predicate::str::contains("/handoff"))
+        .stdout(predicate::str::contains("/distill"))
+        .stdout(predicate::str::contains("/init"));
+}
+
+#[test]
+fn mcp_add_native_clients_runs_remove_then_add() {
+    let cases = [
+        (
+            "claude-code",
+            "claude",
+            "claude\tmcp\tremove\torigin\nclaude\tmcp\tadd\t-s\tuser\torigin\t--\tnpx\t-y\torigin-mcp\n",
+        ),
+        (
+            "codex",
+            "codex",
+            "codex\tmcp\tremove\torigin\ncodex\tmcp\tadd\torigin\t--\tnpx\t-y\torigin-mcp\n",
+        ),
+        (
+            "gemini",
+            "gemini",
+            "gemini\tmcp\tremove\t-s\tuser\torigin\ngemini\tmcp\tadd\t-s\tuser\torigin\tnpx\t-y\torigin-mcp\n",
+        ),
+    ];
+
+    for (client, binary, expected_log) in cases {
+        let runtime = IsolatedRuntime::new();
+        write_fake_command(runtime.fake_bin.path(), binary);
+        let log = runtime.root.path().join(format!("{client}.log"));
+
+        cli_with_isolated_runtime(&runtime)
+            .env("ORIGIN_TEST_CLI_LOG", &log)
+            .args(["mcp", "add", client])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Configured Origin MCP"));
+
+        assert_eq!(
+            fs::read_to_string(log).expect("fake client log"),
+            expected_log
+        );
+    }
+}
+
+#[test]
+fn mcp_add_cursor_preserves_existing_servers_and_backs_up_changed_origin() {
+    let runtime = IsolatedRuntime::new();
+    let config_path = runtime.home.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().expect("cursor config parent")).unwrap();
+    fs::write(
+        &config_path,
+        r#"{"mcpServers":{"origin":{"command":"old-origin"},"other":{"command":"other-cmd"}}}"#,
+    )
+    .unwrap();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["mcp", "add", "cursor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Updated"));
+
+    let updated = fs::read_to_string(&config_path).expect("updated cursor config");
+    assert!(updated.contains(r#""other""#), "{updated}");
+    assert!(updated.contains(r#""command": "npx""#), "{updated}");
+    assert!(updated.contains(r#""-y""#), "{updated}");
+    assert!(updated.contains(r#""origin-mcp""#), "{updated}");
+
+    let backups: Vec<_> = fs::read_dir(config_path.parent().unwrap())
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("mcp.json.bak.")
+        })
+        .collect();
+    assert_eq!(backups.len(), 1, "expected one backup");
+    let backup = fs::read_to_string(backups[0].path()).expect("backup content");
+    assert!(backup.contains("old-origin"), "{backup}");
+}
+
+#[test]
+fn mcp_add_json_clients_write_expected_config_shapes() {
+    let runtime = IsolatedRuntime::new();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["mcp", "add", "claude-desktop"])
+        .assert()
+        .success();
+    let claude = fs::read_to_string(
+        runtime
+            .home
+            .path()
+            .join("Library/Application Support/Claude/claude_desktop_config.json"),
+    )
+    .expect("claude desktop config");
+    assert!(claude.contains(r#""mcpServers""#), "{claude}");
+    assert!(claude.contains(r#""origin-mcp""#), "{claude}");
+
+    cli_with_isolated_runtime(&runtime)
+        .current_dir(runtime.root.path())
+        .args(["mcp", "add", "vscode"])
+        .assert()
+        .success();
+    let vscode = fs::read_to_string(runtime.root.path().join(".vscode/mcp.json"))
+        .expect("vscode workspace config");
+    assert!(vscode.contains(r#""servers""#), "{vscode}");
+    assert!(vscode.contains(r#""origin-mcp""#), "{vscode}");
+}
+
+#[test]
+fn mcp_add_invalid_json_fails_without_modifying_file() {
+    let runtime = IsolatedRuntime::new();
+    let config_path = runtime.home.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().expect("cursor config parent")).unwrap();
+    fs::write(&config_path, "{not json").unwrap();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["mcp", "add", "cursor"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid JSON"));
+
+    assert_eq!(
+        fs::read_to_string(&config_path).expect("cursor config still exists"),
+        "{not json"
+    );
 }
 
 #[test]

--- a/crates/origin-cli/tests/cli_integration.rs
+++ b/crates/origin-cli/tests/cli_integration.rs
@@ -43,6 +43,7 @@ impl IsolatedRuntime {
         let fake_bin = tempfile::tempdir_in(root.path()).expect("temp fake bin");
         write_fake_launchctl(fake_bin.path());
         ensure_sibling_origin_server();
+        ensure_sibling_origin_mcp();
         Self {
             root,
             home,
@@ -110,6 +111,30 @@ fn ensure_sibling_origin_server() {
     }
 }
 
+fn ensure_sibling_origin_mcp() {
+    let path = origin_mcp_sibling();
+    if !path.exists() {
+        fs::write(&path, "#!/bin/sh\nexit 0\n").expect("write fake origin-mcp sibling");
+        let mut perms = fs::metadata(&path)
+            .expect("fake origin-mcp metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms).expect("chmod fake origin-mcp");
+    }
+}
+
+fn origin_mcp_sibling() -> PathBuf {
+    let origin_bin = assert_cmd::cargo::cargo_bin("origin");
+    origin_bin
+        .parent()
+        .expect("origin binary has parent")
+        .join("origin-mcp")
+}
+
+fn origin_mcp_sibling_arg() -> String {
+    origin_mcp_sibling().display().to_string()
+}
+
 #[test]
 fn top_level_help() {
     cli()
@@ -164,9 +189,10 @@ fn mcp_add_claude_code_dry_run_explains_tools_only() {
         .args(["mcp", "add", "claude-code", "--dry-run"])
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "claude mcp add -s user origin -- npx -y origin-mcp",
-        ))
+        .stdout(predicate::str::contains(format!(
+            "claude mcp add -s user origin -- {}",
+            origin_mcp_sibling_arg()
+        )))
         .stdout(predicate::str::contains("MCP tools only"))
         .stdout(predicate::str::contains("/brief"))
         .stdout(predicate::str::contains("/handoff"))
@@ -175,22 +201,23 @@ fn mcp_add_claude_code_dry_run_explains_tools_only() {
 }
 
 #[test]
-fn mcp_add_native_clients_runs_remove_then_add() {
+fn mcp_add_native_clients_run_add_without_destructive_remove() {
+    let origin_mcp = origin_mcp_sibling_arg();
     let cases = [
         (
             "claude-code",
             "claude",
-            "claude\tmcp\tremove\torigin\nclaude\tmcp\tadd\t-s\tuser\torigin\t--\tnpx\t-y\torigin-mcp\n",
+            format!("claude\tmcp\tadd\t-s\tuser\torigin\t--\t{origin_mcp}\n"),
         ),
         (
             "codex",
             "codex",
-            "codex\tmcp\tremove\torigin\ncodex\tmcp\tadd\torigin\t--\tnpx\t-y\torigin-mcp\n",
+            format!("codex\tmcp\tadd\torigin\t--\t{origin_mcp}\n"),
         ),
         (
             "gemini",
             "gemini",
-            "gemini\tmcp\tremove\t-s\tuser\torigin\ngemini\tmcp\tadd\t-s\tuser\torigin\tnpx\t-y\torigin-mcp\n",
+            format!("gemini\tmcp\tadd\t-s\tuser\torigin\t{origin_mcp}\n"),
         ),
     ];
 
@@ -208,7 +235,7 @@ fn mcp_add_native_clients_runs_remove_then_add() {
 
         assert_eq!(
             fs::read_to_string(log).expect("fake client log"),
-            expected_log
+            expected_log.as_str()
         );
     }
 }
@@ -232,9 +259,11 @@ fn mcp_add_cursor_preserves_existing_servers_and_backs_up_changed_origin() {
 
     let updated = fs::read_to_string(&config_path).expect("updated cursor config");
     assert!(updated.contains(r#""other""#), "{updated}");
-    assert!(updated.contains(r#""command": "npx""#), "{updated}");
-    assert!(updated.contains(r#""-y""#), "{updated}");
-    assert!(updated.contains(r#""origin-mcp""#), "{updated}");
+    assert!(
+        updated.contains(&format!(r#""command": "{}""#, origin_mcp_sibling_arg())),
+        "{updated}"
+    );
+    assert!(updated.contains("origin-mcp"), "{updated}");
 
     let backups: Vec<_> = fs::read_dir(config_path.parent().unwrap())
         .unwrap()
@@ -249,6 +278,30 @@ fn mcp_add_cursor_preserves_existing_servers_and_backs_up_changed_origin() {
     assert_eq!(backups.len(), 1, "expected one backup");
     let backup = fs::read_to_string(backups[0].path()).expect("backup content");
     assert!(backup.contains("old-origin"), "{backup}");
+}
+
+#[test]
+fn mcp_add_cursor_dry_run_prints_only_origin_block() {
+    let runtime = IsolatedRuntime::new();
+    let config_path = runtime.home.path().join(".cursor/mcp.json");
+    fs::create_dir_all(config_path.parent().expect("cursor config parent")).unwrap();
+    fs::write(
+        &config_path,
+        r#"{"mcpServers":{"private":{"command":"secret-tool","env":{"API_KEY":"SECRET_TOKEN"}}}}"#,
+    )
+    .unwrap();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["mcp", "add", "cursor", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("mcpServers.origin"))
+        .stdout(predicate::str::contains("origin-mcp"))
+        .stdout(predicate::str::contains("SECRET_TOKEN").not())
+        .stdout(predicate::str::contains("secret-tool").not());
+
+    let unchanged = fs::read_to_string(&config_path).expect("cursor config unchanged");
+    assert!(unchanged.contains("SECRET_TOKEN"), "{unchanged}");
 }
 
 #[test]
@@ -267,7 +320,7 @@ fn mcp_add_json_clients_write_expected_config_shapes() {
     )
     .expect("claude desktop config");
     assert!(claude.contains(r#""mcpServers""#), "{claude}");
-    assert!(claude.contains(r#""origin-mcp""#), "{claude}");
+    assert!(claude.contains("origin-mcp"), "{claude}");
 
     cli_with_isolated_runtime(&runtime)
         .current_dir(runtime.root.path())
@@ -277,7 +330,7 @@ fn mcp_add_json_clients_write_expected_config_shapes() {
     let vscode = fs::read_to_string(runtime.root.path().join(".vscode/mcp.json"))
         .expect("vscode workspace config");
     assert!(vscode.contains(r#""servers""#), "{vscode}");
-    assert!(vscode.contains(r#""origin-mcp""#), "{vscode}");
+    assert!(vscode.contains("origin-mcp"), "{vscode}");
 }
 
 #[test]

--- a/crates/origin-cli/tests/distribution.rs
+++ b/crates/origin-cli/tests/distribution.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Distribution and packaging contract tests for Origin's user-facing setup paths.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::TempDir;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("origin-cli is nested under crates/")
+        .to_path_buf()
+}
+
+fn read_json(relative: &str) -> Value {
+    let path = repo_root().join(relative);
+    let raw =
+        fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    serde_json::from_str(&raw).unwrap_or_else(|err| panic!("parse {}: {err}", path.display()))
+}
+
+fn assert_file(relative: &str) {
+    let path = repo_root().join(relative);
+    assert!(path.is_file(), "missing file: {}", path.display());
+}
+
+fn json_string<'a>(value: &'a Value, key: &str) -> &'a str {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("missing string field `{key}` in {value}"))
+}
+
+#[test]
+fn plugin_distribution_contains_required_files() {
+    for path in [
+        ".claude-plugin/marketplace.json",
+        "plugin/.claude-plugin/plugin.json",
+        "plugin/.claude-plugin/README.md",
+        "plugin/.mcp.json",
+        "plugin/bin/origin-mcp-runner.sh",
+        "plugin/hooks/hooks.json",
+        "plugin/hooks/check-daemon.sh",
+        "plugin/skills/brief/SKILL.md",
+        "plugin/skills/capture/SKILL.md",
+        "plugin/skills/handoff/SKILL.md",
+        "plugin/skills/init/SKILL.md",
+        "plugin/skills/distill/SKILL.md",
+    ] {
+        assert_file(path);
+    }
+}
+
+#[test]
+fn plugin_marketplace_points_at_bundled_plugin() {
+    let marketplace = read_json(".claude-plugin/marketplace.json");
+    assert_eq!(json_string(&marketplace, "name"), "7xuanlu");
+
+    let plugin = marketplace["plugins"]
+        .as_array()
+        .and_then(|plugins| plugins.iter().find(|plugin| plugin["name"] == "origin"))
+        .expect("marketplace lists origin plugin");
+
+    assert_eq!(plugin["source"], "./plugin");
+    assert!(
+        plugin["description"]
+            .as_str()
+            .expect("description")
+            .contains("MCP memory"),
+        "marketplace description should mention MCP memory"
+    );
+}
+
+#[test]
+fn plugin_manifest_and_mcp_launcher_stay_in_sync() {
+    let plugin = read_json("plugin/.claude-plugin/plugin.json");
+    assert_eq!(json_string(&plugin, "name"), "origin");
+    assert_eq!(json_string(&plugin, "license"), "Apache-2.0");
+    assert_eq!(json_string(&plugin, "category"), "memory");
+
+    let keywords = plugin["keywords"].as_array().expect("keywords array");
+    for keyword in ["claude-code", "memory", "mcp", "local-first"] {
+        assert!(
+            keywords.iter().any(|value| value == keyword),
+            "missing plugin keyword {keyword}"
+        );
+    }
+
+    let mcp = read_json("plugin/.mcp.json");
+    let origin = &mcp["mcpServers"]["origin"];
+    assert_eq!(
+        json_string(origin, "command"),
+        "${CLAUDE_PLUGIN_ROOT}/bin/origin-mcp-runner.sh"
+    );
+}
+
+#[test]
+fn npm_package_allowlists_match_release_generated_files() {
+    let setup_pkg = read_json("crates/origin-cli/npm/package.json");
+    assert_eq!(json_string(&setup_pkg, "name"), "@7xuanlu/origin");
+    assert_eq!(setup_pkg["bin"]["origin"], "run.js");
+    assert_eq!(setup_pkg["license"], "Apache-2.0");
+    assert_eq!(setup_pkg["os"], serde_json::json!(["darwin"]));
+    assert_eq!(setup_pkg["cpu"], serde_json::json!(["arm64"]));
+    assert_eq!(
+        setup_pkg["files"],
+        serde_json::json!(["run.js", "README.md", "LICENSE"])
+    );
+
+    let mcp_pkg = read_json("crates/origin-mcp/npm/package.json");
+    assert_eq!(json_string(&mcp_pkg, "name"), "origin-mcp");
+    assert_eq!(mcp_pkg["bin"]["origin-mcp"], "run.js");
+    assert_eq!(mcp_pkg["scripts"]["postinstall"], "node install.js");
+    assert_eq!(mcp_pkg["license"], "Apache-2.0");
+    assert_eq!(mcp_pkg["os"], serde_json::json!(["darwin"]));
+    assert_eq!(mcp_pkg["cpu"], serde_json::json!(["arm64"]));
+    assert_eq!(
+        mcp_pkg["files"],
+        serde_json::json!(["install.js", "run.js", "README.md", "LICENSE"])
+    );
+}
+
+#[test]
+fn release_workflow_publishes_cli_and_mcp_npm_packages() {
+    let workflow = fs::read_to_string(repo_root().join(".github/workflows/release.yml"))
+        .expect("read release workflow");
+    for needle in [
+        "Build origin CLI (release)",
+        "Build origin-server (release)",
+        "Build origin-mcp (release)",
+        "Publish origin-mcp",
+        "Publish @7xuanlu/origin",
+        "cp README.md crates/origin-mcp/npm/README.md",
+        "cp README.md crates/origin-cli/npm/README.md",
+        "origin-aarch64-apple-darwin",
+        "origin-server-aarch64-apple-darwin",
+        "origin-mcp-aarch64-apple-darwin",
+    ] {
+        assert!(
+            workflow.contains(needle),
+            "release workflow missing `{needle}`"
+        );
+    }
+}
+
+#[test]
+#[ignore = "manual smoke: requires real codex CLI and may download origin-mcp through npx"]
+fn smoke_codex_mcp_add_uses_temp_home() {
+    let runtime = TempDir::new().expect("temp home");
+    let origin = assert_cmd::cargo::cargo_bin("origin");
+
+    let output = Command::new(origin)
+        .env("HOME", runtime.path())
+        .env("ORIGIN_HOST", "http://127.0.0.1:9")
+        .args(["mcp", "add", "codex"])
+        .output()
+        .expect("run origin mcp add codex");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let config = runtime.path().join(".codex/config.toml");
+    assert!(
+        config.exists(),
+        "expected Codex config at {}",
+        config.display()
+    );
+    let text = fs::read_to_string(config).expect("read Codex config");
+    assert!(text.contains("origin"), "{text}");
+    assert!(text.contains("origin-mcp"), "{text}");
+}

--- a/crates/origin-mcp/README.md
+++ b/crates/origin-mcp/README.md
@@ -6,7 +6,14 @@ Origin owns storage, search, embeddings, pages, and distill cycles. `origin-mcp`
 
 ## Install
 
-Most users should install through the root README. If you only need the MCP connector, add this to your MCP client config:
+Most users should install through the root README. After `npx -y @7xuanlu/origin setup`, use the product CLI to configure supported clients:
+
+```bash
+origin mcp add codex              # or: claude-code, cursor, claude-desktop, vscode, gemini
+origin mcp add cursor --dry-run   # preview before editing JSON config
+```
+
+If you only need the raw MCP connector config, add this to your MCP client:
 
 ```json
 {

--- a/crates/origin-mcp/README.md
+++ b/crates/origin-mcp/README.md
@@ -13,6 +13,8 @@ origin mcp add codex              # or: claude-code, cursor, claude-desktop, vsc
 origin mcp add cursor --dry-run   # preview before editing JSON config
 ```
 
+MCP-only setup gives agents tools for capture, recall, context, doctor, and page distillation. It does not install Claude Code slash skills like `/brief`, `/handoff`, `/distill`, or `/init`; use the Origin plugin for that workflow.
+
 If you only need the raw MCP connector config, add this to your MCP client:
 
 ```json
@@ -26,7 +28,7 @@ If you only need the raw MCP connector config, add this to your MCP client:
 }
 ```
 
-The npm wrapper currently installs a prebuilt macOS Apple Silicon binary from the Origin release. Use `cargo install origin-mcp` if you want to build from source on another supported Rust target.
+The npm wrapper currently installs a prebuilt macOS Apple Silicon binary from the Origin release. Other targets require building from source and are not advertised as supported setup targets yet.
 
 Or install a binary directly:
 

--- a/crates/origin-mcp/npm/package.json
+++ b/crates/origin-mcp/npm/package.json
@@ -38,6 +38,12 @@
   "cpu": [
     "arm64"
   ],
+  "files": [
+    "install.js",
+    "run.js",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/7xuanlu/origin",


### PR DESCRIPTION
## Summary
- add MCP-only setup helpers for Claude Code, Codex, Cursor, Claude Desktop, VS Code, and Gemini CLI
- harden MCP config generation around installed binaries, dry-run output, and non-destructive native client setup
- add distribution checks for plugin metadata, npm package allowlists, and release workflow packaging
- clarify README setup paths and keep docs-only README changes off the Rust CI path

## Test Plan
- cargo test -p origin
- git diff --check
- pre-commit clippy on changed crates