### PR TITLE
refactor: drop dead graph_observations filter + document eval cache TTL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,14 @@ export EVAL_BASELINES_DIR=$HOME/.cache/origin-eval
 
 Path must be writable and local (network mounts not recommended). When set, also chains `EVAL_ENRICHMENT_CACHE_DIR` default to the same dir unless explicitly overridden. Migration: `bash scripts/migrate-eval-cache.sh <source-baselines>`.
 
+### TTL policy
+
+Cache directories accumulate fast (1GB+ per full LoCoMo+LME run) and snapshots stay valid only as long as the fixture revision + embedder + provider stack remain unchanged. Rule of thumb:
+
+- **Active cache** (`~/.cache/origin-eval/`): purge whenever (a) `fixture_revision_hash` changes for the bench you're rerunning, (b) embedder weights swap, (c) LLM provider class swaps. Drop the affected `<task>/<fixture>.db` files; keep the JSONL judge cache if the judge model is unchanged.
+- **Archive caches** (`~/.cache/origin-eval.archive-YYYY-MM-DD/`): retain for 30 days after the matching baseline JSON ships to a PR. After that, delete unless the baseline is still actively cited in an open issue or recent release notes. Archives are recreated on demand by re-running the harness.
+- **Don't depend on archive contents for reproducibility** — baselines are reproduced by re-running with the same `ReportEnv` fields, not by replaying cached intermediates.
+
 ## Releasing (release-please)
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please). The workflow runs on every push to `main`.

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -339,12 +339,6 @@ pub async fn handle_chat_context(
         .filter(|r| r.score >= threshold)
         .collect();
 
-    let graph_observations: Vec<String> = filtered_search
-        .iter()
-        .filter(|r| r.source == "knowledge_graph")
-        .map(|r| format!("[{}] {}", r.title, r.content))
-        .collect();
-
     // Source IDs from search results — used to gate page relevance.
     // A page is only included if its source memories overlap with the
     // memories that search_memory returned for this query.
@@ -473,14 +467,6 @@ pub async fn handle_chat_context(
         sections.push(sec);
     }
 
-    if !graph_observations.is_empty() {
-        let mut sec = String::from("## Knowledge Graph\n");
-        for item in &graph_observations {
-            sec.push_str(&format!("- {}\n", item));
-        }
-        sections.push(sec);
-    }
-
     if !filtered_search.is_empty() {
         let mut sec = String::from("## Relevant Memories\n");
         for r in &filtered_search {
@@ -582,7 +568,7 @@ pub async fn handle_chat_context(
             pages: page_results,
             decisions,
             relevant_memories: filtered_search,
-            graph_context: graph_observations,
+            graph_context: Vec::new(),
         },
         took_ms,
         token_estimates,


### PR DESCRIPTION
## Summary

- `routes.rs:341` filtered `search_memory` output for `source=="knowledge_graph"`, but `db.rs:6950` strips those rows before returning. Filter always produced an empty `Vec`, feeding a never-firing UI section and a wire field that was already always empty in tests.
- `graph_context: Vec::new()` retained for wire backward compat with `origin-types` 0.6.x consumers (`origin-mcp` tests already assert empty arrays).
- Adds TTL guidance to `AGENTS.md` "Eval baselines cache" so future runs aren't blocked on stale archive directories.

## Test Plan

- [x] `cargo test -p origin-server --lib` — 54 passed, 0 failed
- [x] `cargo clippy -p origin-server --all-targets` — clean
- [x] Pre-commit hook passed (fmt + clippy on changed crates)
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)