### PR TITLE
chore(eval): forward-looking judge API surface (stamp_judge_model + structured parser)

### DIFF
--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -1204,3 +1204,11 @@ pub async fn judge_with_batch_api(
     );
     Ok(results)
 }
+
+/// Stamp the judge model id on a Report's env (no-op when env is None).
+/// Used by runners to record which judge produced the answer-quality metrics.
+pub fn stamp_judge_model(env: &mut Option<crate::eval::report::ReportEnv>, model: &str) {
+    if let Some(e) = env.as_mut() {
+        e.judge_model = Some(model.to_string());
+    }
+}

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -24,13 +24,7 @@ pub fn task_judge_prompt(
     ground_truth: &str,
     answer: &str,
 ) -> String {
-    let base = lme_anscheck_prompt(category, question, ground_truth, answer);
-    format!(
-        "{}\n\nRespond with a single JSON object on the final line:\n\
-         {{\"rubric_scores\": {{\"<criterion>\": 0.0_or_1.0, ...}}, \"verdict_reason\": \"<one sentence>\", \"verdict\": \"correct\" | \"incorrect\" | \"partial\"}}\n\n\
-         The rubric_scores keys must match the criteria listed above. Do not wrap the JSON in markdown fences. Do not add prose before or after the JSON object.",
-        base
-    )
+    lme_anscheck_prompt(category, question, ground_truth, answer)
 }
 
 // ===== LLM-as-Judge Types =====

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -3,7 +3,7 @@
 
 use crate::error::OriginError;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -1232,7 +1232,7 @@ pub enum JudgeVerdict {
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct StructuredJudgeOutput {
     #[serde(default)]
-    pub rubric_scores: std::collections::HashMap<String, f64>,
+    pub rubric_scores: BTreeMap<String, f64>,
     #[serde(default)]
     pub verdict_reason: String,
     pub verdict: JudgeVerdict,
@@ -1258,9 +1258,9 @@ pub fn parse_judge_output(raw: &str) -> Result<StructuredJudgeOutput, String> {
     }
     let normalized = trimmed.to_ascii_lowercase();
     let legacy = match normalized.as_str() {
-        s if s.starts_with("correct") => Some(JudgeVerdict::Correct),
-        s if s.starts_with("partial") => Some(JudgeVerdict::Partial),
-        s if s.starts_with("incorrect") => Some(JudgeVerdict::Incorrect),
+        "correct" => Some(JudgeVerdict::Correct),
+        "partial" => Some(JudgeVerdict::Partial),
+        "incorrect" => Some(JudgeVerdict::Incorrect),
         _ => None,
     };
     legacy
@@ -1310,5 +1310,32 @@ mod tests {
         let raw = "```json\n{\"rubric_scores\":{},\"verdict_reason\":\"x\",\"verdict\":\"incorrect\"}\n```";
         let parsed = parse_judge_output(raw).expect("fenced ok");
         assert_eq!(parsed.verdict, JudgeVerdict::Incorrect);
+    }
+
+    #[test]
+    fn parse_judge_output_legacy_partial() {
+        let parsed = parse_judge_output("partial").expect("legacy partial");
+        assert_eq!(parsed.verdict, JudgeVerdict::Partial);
+        assert!(parsed.rubric_scores.is_empty());
+    }
+
+    #[test]
+    fn parse_judge_output_rejects_empty_input() {
+        assert!(parse_judge_output("").is_err());
+        assert!(parse_judge_output("   \n  ").is_err());
+    }
+
+    #[test]
+    fn parse_judge_output_rejects_malformed_json() {
+        assert!(parse_judge_output("{").is_err());
+        assert!(parse_judge_output("{\"verdict\":}").is_err());
+    }
+
+    #[test]
+    fn parse_judge_output_legacy_rejects_substring_false_positives() {
+        // Regression for the starts_with -> exact-match fix.
+        assert!(parse_judge_output("corrects").is_err());
+        assert!(parse_judge_output("correctness").is_err());
+        assert!(parse_judge_output("correct then false").is_err());
     }
 }

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -24,7 +24,13 @@ pub fn task_judge_prompt(
     ground_truth: &str,
     answer: &str,
 ) -> String {
-    lme_anscheck_prompt(category, question, ground_truth, answer)
+    let base = lme_anscheck_prompt(category, question, ground_truth, answer);
+    format!(
+        "{}\n\nRespond with a single JSON object on the final line:\n\
+         {{\"rubric_scores\": {{\"<criterion>\": 0.0_or_1.0, ...}}, \"verdict_reason\": \"<one sentence>\", \"verdict\": \"correct\" | \"incorrect\" | \"partial\"}}\n\n\
+         The rubric_scores keys must match the criteria listed above. Do not wrap the JSON in markdown fences. Do not add prose before or after the JSON object.",
+        base
+    )
 }
 
 // ===== LLM-as-Judge Types =====
@@ -1210,5 +1216,99 @@ pub async fn judge_with_batch_api(
 pub fn stamp_judge_model(env: &mut Option<crate::eval::report::ReportEnv>, model: &str) {
     if let Some(e) = env.as_mut() {
         e.judge_model = Some(model.to_string());
+    }
+}
+
+// ===== Structured Judge Output =====
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum JudgeVerdict {
+    Correct,
+    Incorrect,
+    Partial,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct StructuredJudgeOutput {
+    #[serde(default)]
+    pub rubric_scores: std::collections::HashMap<String, f64>,
+    #[serde(default)]
+    pub verdict_reason: String,
+    pub verdict: JudgeVerdict,
+}
+
+/// Parse a judge response into a structured verdict.
+///
+/// Priority order:
+/// 1. Direct JSON object matching `StructuredJudgeOutput`.
+/// 2. Markdown-fenced JSON (```json ... ```).
+/// 3. Legacy bare string ("correct" / "incorrect" / "partial").
+///
+/// Anything else is an error — callers should treat that as a judge failure.
+pub fn parse_judge_output(raw: &str) -> Result<StructuredJudgeOutput, String> {
+    let trimmed = raw.trim();
+    if let Ok(s) = serde_json::from_str::<StructuredJudgeOutput>(trimmed) {
+        return Ok(s);
+    }
+    if let Some(fenced) = strip_json_fence(trimmed) {
+        if let Ok(s) = serde_json::from_str::<StructuredJudgeOutput>(fenced) {
+            return Ok(s);
+        }
+    }
+    let normalized = trimmed.to_ascii_lowercase();
+    let legacy = match normalized.as_str() {
+        s if s.starts_with("correct") => Some(JudgeVerdict::Correct),
+        s if s.starts_with("partial") => Some(JudgeVerdict::Partial),
+        s if s.starts_with("incorrect") => Some(JudgeVerdict::Incorrect),
+        _ => None,
+    };
+    legacy
+        .map(|v| StructuredJudgeOutput {
+            rubric_scores: Default::default(),
+            verdict_reason: String::new(),
+            verdict: v,
+        })
+        .ok_or_else(|| {
+            format!(
+                "unparseable judge output: {}",
+                trimmed.chars().take(80).collect::<String>()
+            )
+        })
+}
+
+fn strip_json_fence(s: &str) -> Option<&str> {
+    let s = s.strip_prefix("```json")?.trim_start();
+    s.strip_suffix("```").map(|inner| inner.trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_two_stage_judge_output_correct() {
+        let raw = r#"{
+            "rubric_scores": {"factual_match": 1.0, "covers_all_required_facts": 1.0},
+            "verdict_reason": "answer matches gold on every required fact",
+            "verdict": "correct"
+        }"#;
+        let parsed = parse_judge_output(raw).expect("valid JSON");
+        assert_eq!(parsed.verdict, JudgeVerdict::Correct);
+        assert_eq!(parsed.rubric_scores.get("factual_match"), Some(&1.0));
+    }
+
+    #[test]
+    fn parse_two_stage_judge_output_falls_back_to_legacy_string() {
+        let parsed = parse_judge_output("correct").expect("legacy ok");
+        assert_eq!(parsed.verdict, JudgeVerdict::Correct);
+        assert!(parsed.rubric_scores.is_empty());
+    }
+
+    #[test]
+    fn parse_two_stage_judge_output_extracts_fenced_json() {
+        let raw = "```json\n{\"rubric_scores\":{},\"verdict_reason\":\"x\",\"verdict\":\"incorrect\"}\n```";
+        let parsed = parse_judge_output(raw).expect("fenced ok");
+        assert_eq!(parsed.verdict, JudgeVerdict::Incorrect);
     }
 }

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1439,6 +1439,39 @@ mod tests {
     }
 
     #[test]
+    fn locomo_env_records_judge_model_when_batch_runs() {
+        let mut report = LocomoReport {
+            conversations: vec![],
+            aggregate_ndcg_at_10: 0.0,
+            aggregate_mrr: 0.0,
+            aggregate_recall_at_5: 0.0,
+            aggregate_hit_rate_at_1: 0.0,
+            total_questions: 0,
+            total_memories: 0,
+            per_category_aggregate: vec![],
+            qa_accuracy: None,
+            baseline: None,
+            env: None,
+        };
+        report.env = Some(crate::eval::report::ReportEnv {
+            fixture_revision: "deadbeef".into(),
+            embedder_model: "bge-base-en-v1.5-q".into(),
+            embedder_revision: "768d".into(),
+            retrieval_method: "search_memory".into(),
+            llm_provider_class: "on-device".into(),
+            llm_model: "qwen3-4b".into(),
+            judge_model: None,
+            origin_version: env!("CARGO_PKG_VERSION").into(),
+            eval_timestamp_unix: 0,
+        });
+        crate::eval::judge::stamp_judge_model(&mut report.env, "claude-haiku-4-5-20251001");
+        assert_eq!(
+            report.env.as_ref().and_then(|e| e.judge_model.clone()),
+            Some("claude-haiku-4-5-20251001".to_string())
+        );
+    }
+
+    #[test]
     fn test_to_terminal_with_baseline() {
         let report = LocomoReport {
             conversations: vec![],


### PR DESCRIPTION
## Summary

Lays two **forward-looking API surfaces** for a follow-up PR that re-architects the batch judge pipeline. Neither is wired into a production path in this PR.

**Why this scope:**

Plan B (`docs/superpowers/plans/2026-05-22-eval-semantic-gaps.md` — gitignored) targeted three Plan A follow-up gaps: `judge_model` always `None`, `embedder_revision` placeholder `"768d"`, free-form judge text. Tasks 2 and 3 collided with codebase realities:

- **Task 2 dropped:** the FastEmbed cache → HF-snapshot-hash mapping is a one-day chore better done when same-dim embedder swaps become a real comparability problem.
- **Task 3's prompt-suffix change was reverted** (`5b1f618d`) after an adversarial review caught that `task_judge_prompt`'s new JSON-output instruction contradicted the base "answer yes or no" body, and the downstream parser at `judge.rs:1186` (`lower.starts_with("yes")`) would silently score 0 for every tuple. The type machinery survives as a future-API; the prompt body is unchanged.

**What's actually shipped:**

1. **`stamp_judge_model(env, model)` helper** in `eval/judge.rs` — populates `ReportEnv.judge_model` on `LocomoReport` / `LongMemEvalReport`. Today, the runners that own those reports don't call the batch judge directly (judge runs in `eval_harness.rs` integration tests, results land in a separate `JudgedE2EReport`), so this is a forward hook for whenever the runner + judge pipelines share a session.
2. **`JudgeVerdict` enum + `StructuredJudgeOutput` struct + `parse_judge_output`** — 3-tier parser (direct JSON → markdown-fenced JSON → legacy exact-string fallback). Not yet wired into `judge_with_batch_api`. The future wiring requires either (a) reconciling the "yes/no" vs "correct/incorrect/partial" verdict vocabularies, or (b) dispatching different parsers per prompt builder. Out of this PR's scope.

## Test Plan

- [x] `cargo test -p origin-core --lib eval::judge` — 7/7 (3 original + 4 edge-case regression tests for the legacy-string false-positive fix)
- [x] `cargo test -p origin-core --lib eval::locomo` — all green incl. new `locomo_env_records_judge_model_when_batch_runs` contract test
- [x] `cargo clippy -p origin-core --all-targets` — clean
- [x] Pre-commit hook (fmt + clippy on changed crates) passed
- [x] Adversarial review of integrated impl run + blocker reverted before push

## Notes for reviewers

- The 4 commits in this branch will squash on merge. Title prefix is `chore:` so release-please does NOT bump version — this PR adds public API surface but does not change any production behavior, so a version bump would mislead changelog readers.
- Follow-up PR scope (queued, not blocking this one): wire `judge_with_batch_api` to call `parse_judge_output`, add `Yes`/`No` verdict variants to `JudgeVerdict`, and stamp `judge_model` from inside the wired flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)