### PR TITLE
fix(eval): restore app/eval/fixtures to monorepo for L6 CI canary

### DIFF
--- a/app/eval/fixtures/agent_coding_session.toml
+++ b/app/eval/fixtures/agent_coding_session.toml
@@ -1,0 +1,402 @@
+# Agent coding session — Claude Code storing decisions/prefs/bugs during a webapp project.
+# Tests single-agent retrieval across error handling, DB choice, testing, auth, and bugs.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: what error handling pattern did we decide on
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what error handling pattern did we decide on"
+
+[[cases.seeds]]
+id = "agent_coding_err_handling_decision"
+content = "Decided on a typed error enum (AppError) at the service layer, mapping to HTTP status codes in the handler layer. Using anyhow for internal errors that don't cross API boundaries, thiserror for public error types."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_coding_err_boundary"
+content = "Rule: errors that cross the HTTP boundary must implement Into<AppError> and carry a machine-readable error code string (e.g. 'validation.required_field'). Do not leak internal stack details in production responses."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_coding_err_logging"
+content = "Log all 5xx errors with tracing::error! including request_id span field. 4xx errors are logged at warn level. Client errors do not log the full body to avoid PII in logs."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "agent_coding_err_validation"
+content = "Validation errors return HTTP 422 with a JSON body containing a top-level 'errors' array. Each entry has 'field', 'code', and 'message'. The pattern was chosen to match the OpenAPI spec we agreed on."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — error vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_err_retry"
+content = "Retry logic for outbound HTTP calls uses exponential backoff with jitter: initial delay 100ms, max 3 retries, max delay 2s. Idempotent GET requests retry on 429 and 5xx; POST requests do not retry automatically."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_err_payment"
+content = "Known bug: Stripe webhook handler swallows the raw error from stripe-rs and returns 200 OK even on signature verification failure. Tracked as WEBAPP-412. Do not deploy payment webhooks to production until fixed."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_err_db"
+content = "libSQL returns SqliteFailure errors for constraint violations. The error code is in the extended_code field, not the primary code. Check for SQLITE_CONSTRAINT_UNIQUE (2067) to detect duplicate key violations."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_err_monitoring"
+content = "Sentry DSN configured via SENTRY_DSN env var. Only 5xx errors and panics are forwarded to Sentry. Configured to sample 10% of 429 responses to avoid quota burn during abuse events."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_err_test"
+content = "Integration tests use a shared test error type (TestError) that wraps anyhow. The test harness converts TestError to a human-readable assertion failure message."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_err_circuit"
+content = "No circuit breaker currently in place for the payment provider. Discussed using tower::limit but deferred to post-launch. Fallback is to return 503 after 3 consecutive gateway timeouts."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: which database did we pick and why
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "which database did we pick and why"
+
+[[cases.seeds]]
+id = "agent_coding_db_decision"
+content = "Chose PostgreSQL over MySQL for the primary store. Reasons: JSONB for flexible metadata columns, CTEs for recursive org-chart queries, strong Rust ecosystem (sqlx), and the team has prior Postgres ops experience."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_coding_db_schema_approach"
+content = "Using sqlx compile-time checked queries. Schema migrations managed by sqlx-migrate, stored in db/migrations/. Each migration is a pair: up.sql and down.sql. Migration files are named with a sequential prefix (0001_, 0002_, etc.)."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "agent_coding_db_cache"
+content = "Redis (via deadpool-redis) used for session tokens and short-lived rate-limit counters. Not for primary data. TTL on session keys is 24h. Redis connection pool size capped at 10 to stay within the managed plan's connection limit."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — database vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_db_pool"
+content = "SQLx connection pool configured with max_connections=20 in production, 5 in test environment. Pool acquire timeout is 3s. Connections idle for more than 600s are closed and removed."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_db_index"
+content = "Added composite index on (user_id, created_at DESC) to the events table after the profile page query showed 800ms p99 latency. Index brought it down to 12ms. Migration 0017 adds this index."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_db_backup"
+content = "Database backups run nightly via pg_dump to an S3 bucket. Retention is 30 days. RDS automated backups are also enabled with a 7-day window as a secondary recovery path."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_db_read_replica"
+content = "Read replicas not yet provisioned. Analytics queries currently run against the primary. Plan to add one read replica post-launch and route /api/reports/* queries through it."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_db_test"
+content = "Test suite spins up a real Postgres instance via Docker Compose (testcontainers-rs). Each test function gets an isolated schema created in a transaction that is rolled back on teardown."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_db_json"
+content = "JSONB columns used for the 'metadata' field on the resources table. Queries against metadata fields use the ->> operator and are not indexed. Acceptable given low query frequency."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# Query: what testing framework are we using
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what testing framework are we using"
+
+[[cases.seeds]]
+id = "agent_coding_test_framework"
+content = "Backend: Rust's built-in #[test] plus rstest for parameterized cases. No external test runner. Integration tests live in tests/ alongside the crate root and use testcontainers for Postgres and Redis."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_coding_test_frontend"
+content = "Frontend tests use Vitest with React Testing Library. Component tests cover user flows, not implementation details. MSW (Mock Service Worker) intercepts API calls in tests — no axios mocking."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_coding_test_coverage"
+content = "Coverage gate: 80% line coverage on the service layer enforced in CI via cargo-tarpaulin. Frontend coverage gate is 75% branch coverage via Vitest's built-in c8. Gate blocks PR merge if not met."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — testing vocabulary but wrong focus
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_test_load"
+content = "Load testing done with k6. Baseline target: 500 concurrent users, 95th percentile under 200ms for /api/search. Not yet integrated into CI — run manually before major releases."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_test_e2e"
+content = "E2E tests use Playwright. Only critical user paths covered (signup, login, checkout). Playwright tests run nightly in CI against staging, not on every PR due to flakiness on branch environments."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_test_contracts"
+content = "No contract tests between frontend and backend. The OpenAPI spec (openapi.yaml) is the contract. Both sides are checked against it in CI using spectral for linting and oasdiff for breaking-change detection."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_test_ci"
+content = "CI runs on GitHub Actions. Test job matrix: stable Rust + Node 20. PR checks run on push; nightly runs include full integration test suite and load tests against a staging stack."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_test_mock"
+content = "Database is not mocked in unit tests. We use the real Postgres with testcontainers and transaction rollback isolation. The decision was made to avoid mock drift after a bug that only appeared in production."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_test_snapshots"
+content = "Snapshot testing is used for API response shapes using insta (Rust). Snapshot files are committed to the repo and reviewed in PRs. Automatic snapshot acceptance is blocked to prevent silent regressions."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# Query: how does the authentication flow work
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how does the authentication flow work"
+
+[[cases.seeds]]
+id = "agent_coding_auth_flow"
+content = "Auth uses JWT with short-lived access tokens (15 min) and long-lived refresh tokens (30 days) stored as httpOnly Secure cookies. No token storage in localStorage. Refresh is automatic on 401 response."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_coding_auth_provider"
+content = "OAuth2 via Auth0 for social login (Google, GitHub). Own email+password flow for enterprise customers who cannot allow external auth. JWT signing key rotated via JWKS endpoint — no hardcoded secret."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_coding_auth_middleware"
+content = "Axum auth middleware extracts the Bearer token from Authorization header, validates against JWKS, and injects AuthContext into request extensions. Protected routes call auth_required() extractor."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "agent_coding_auth_roles"
+content = "RBAC: three roles — viewer, editor, admin. Role is embedded in the JWT claims as 'role'. Permission checks happen at the handler level, not middleware, so fine-grained resource checks can use DB context."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — auth vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_auth_session"
+content = "Session tokens for the admin panel use a separate session store (Redis). Admin sessions expire after 4 hours of inactivity, regardless of JWT validity. Admin login requires TOTP as a second factor."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_auth_api_key"
+content = "Machine-to-machine API keys are bearer tokens with prefix 'sk_'. Stored as bcrypt hashes in the api_keys table. Keys are scoped to specific routes via a JSON permissions array on the key record."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_auth_webhook"
+content = "Webhooks authenticated via HMAC-SHA256 signature in X-Signature header. Signature is computed over the raw request body. Verification uses constant-time comparison to prevent timing attacks."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_auth_cors"
+content = "CORS origin allowlist is loaded from the CORS_ORIGINS env var (comma-separated). Dev allows localhost:3000 and localhost:5173. Production allows only app.webapp.com and the mobile app deep-link scheme."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_auth_rate"
+content = "Login endpoint rate-limited to 10 attempts per 5 minutes per IP using the tower-governor middleware. Exceeded attempts return 429 with Retry-After header. Accounts are not locked on excess attempts."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_auth_audit"
+content = "Auth events (login, logout, token refresh, failed attempts) are written to the audit_log table with user_id, IP, user_agent, and timestamp. Audit logs are retained for 1 year and are append-only."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+
+# ─── CASE 5 ──────────────────────────────────────────────────────────────────
+# Query: what are the known bugs in the payment module
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are the known bugs in the payment module"
+
+[[cases.seeds]]
+id = "agent_coding_pay_bug_webhook"
+content = "WEBAPP-412: Stripe webhook handler returns 200 OK even on HMAC signature verification failure because the error is silently dropped in the match arm. Fix is to propagate the error as 400 Bad Request."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_coding_pay_bug_refund"
+content = "WEBAPP-389: Refund amounts exceeding the original charge are accepted without validation and passed to Stripe, which then rejects them. The check must be added before calling the Stripe client."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_coding_pay_bug_idempotency"
+content = "WEBAPP-401: Idempotency key generation uses UUID v4 and is not tied to the payment intent ID. Double-clicking the checkout button can submit two charges if the first request is slow. Fix: derive idempotency key from cart_id + user_id + amount."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — payment vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_pay_flow"
+content = "Payment flow: checkout creates a PaymentIntent on the backend, returns client_secret to the frontend, Stripe Elements mounts and handles card entry. Backend confirms via webhook — frontend never sees raw card data."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_pay_provider"
+content = "Using Stripe as the sole payment provider. Evaluated PayPal and Braintree; Stripe won on developer experience and Rust SDK quality. PayPal support requested by one enterprise customer, deferred to v2."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_pay_test"
+content = "Payment module integration tests use Stripe test mode with hardcoded test card numbers (4242... for success, 4000...0002 for decline). No real charges in CI. Test mode keys stored in .env.test."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_pay_retry"
+content = "Failed payment retry policy: 3 attempts over 7 days (days 1, 3, 7). Retry scheduling uses a background job queue (apalis with Postgres backend). Customers receive email notification before each retry."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_pay_currency"
+content = "Multi-currency support planned for Q3. Currently only USD. Currency conversion will be handled by the frontend using the Open Exchange Rates API; backend always stores amounts in USD cents."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_coding_neg_pay_invoice"
+content = "Invoice generation uses the printpdf crate. Invoice PDFs are stored in S3 and linked by URL in the invoices table. URLs are presigned with a 7-day expiry. Customers receive the URL via email on payment success."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"

--- a/app/eval/fixtures/agent_growing_corpus.toml
+++ b/app/eval/fixtures/agent_growing_corpus.toml
@@ -1,0 +1,1004 @@
+# Growing corpus scaling fixture — large seed sets allow subset testing at varying corpus sizes.
+# Each case has ~40 seeds (5-8 relevant + 30-35 filler) across diverse domains.
+# Use this fixture to measure NDCG@10 as corpus size scales from 10 to 120 seeds.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: what architecture decisions were made for the API layer
+# 6 relevant + 34 filler
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what architecture decisions were made for the API layer"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "gc_api_rest_decision"
+content = "Chose REST over GraphQL for the public API. GraphQL considered but rejected: adds client complexity, N+1 risks, and schema versioning overhead. REST with versioned URL prefixes (/v1/, /v2/) gives simpler evolution."
+memory_type = "decision"
+domain = "project:api"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "gc_api_versioning"
+content = "API versioning strategy: URL-path versioning (/v1/, /v2/). Header-based versioning considered and rejected — too invisible and harder to cache. Breaking changes get a new version; additive changes can land in the current version."
+memory_type = "decision"
+domain = "project:api"
+source_agent = "claude-desktop"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_api_gateway"
+content = "No API gateway in front of the service for now. AWS API Gateway adds latency and cost at current scale. Plan to add a gateway when multi-tenant rate limiting or external partner access is required."
+memory_type = "decision"
+domain = "project:api"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_api_pagination"
+content = "Pagination standard: cursor-based for all list endpoints using an opaque `cursor` field (base64-encoded row ID + sort key). Offset pagination not offered because it causes inconsistent results on concurrent writes."
+memory_type = "decision"
+domain = "project:api"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "gc_api_rate_limit"
+content = "Rate limiting: 1000 requests/minute per API key, 100/minute per IP for unauthenticated endpoints. Implemented with tower-governor in the Axum middleware stack. Exceeded limits return 429 with Retry-After header."
+memory_type = "fact"
+domain = "project:api"
+source_agent = "cursor"
+relevance = 2
+
+[[cases.seeds]]
+id = "gc_api_openapi"
+content = "OpenAPI 3.1 spec generated from code using utoipa macros on each handler. Spec is served at /openapi.json and /swagger-ui in development. Spec is linted with spectral in CI for breaking-change detection."
+memory_type = "fact"
+domain = "project:api"
+source_agent = "claude-code"
+relevance = 2
+
+# Filler — diverse domains and types, relevance 0
+
+[[cases.seeds]]
+id = "gc_f01"
+content = "Prefers espresso over drip coffee in the morning. Afternoon cutoff is 2pm to avoid disrupting sleep."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f02"
+content = "Weekly 1:1 with manager moved from Tuesday to Thursday. Duration is 30 minutes. Format is walking-meeting when weather permits."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f03"
+content = "Currently reading: The Pragmatic Programmer (re-read). Taking notes in Obsidian under /books/pragmatic-programmer."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f04"
+content = "Running 5K three times per week. Goal is a sub-25 minute 5K by June. Current PB is 27:42."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f05"
+content = "Switched to Zed editor for Rust development after VS Code became sluggish on large codebases. Vim bindings enabled. Still using VS Code for TypeScript."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f06"
+content = "Grocery shopping on Saturday mornings. Using Instacart for heavy items, local store for fresh produce. Monthly grocery budget: $400."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f07"
+content = "Obsidian vault structure: daily notes in /journal, project notes in /projects, book notes in /books. Templates for each note type. Synced via iCloud."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f08"
+content = "Home lab setup: Mac mini M4 running as a home server, TrueNAS Scale on a Beelink SER7, Ubiquiti UniFi network. Proxied via Cloudflare Tunnel for external access."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f09"
+content = "Frontend framework preference for side projects: SvelteKit. Lighter bundle than Next.js and simpler mental model. Avoid React for solo projects due to boilerplate overhead."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f10"
+content = "Dentist appointment reminder: checkup due in March. Last visit was September. Insurance covers 2 cleanings per year."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f11"
+content = "Team offsite scheduled for May 12-13 in Austin. Hotel booked at the Marriott downtown. Agenda planning starts April 28."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f12"
+content = "Q2 OKRs finalized: Ship v2 API with full OpenAPI spec, reach 50 paying customers, reduce p99 API latency below 300ms. OKRs approved by VP on March 1."
+memory_type = "goal"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f13"
+content = "Product roadmap for H1: authentication overhaul (March), API v2 (April), mobile app MVP (June). Roadmap presented to board on February 20."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f14"
+content = "New hire starting March 15: Sarah Chen, senior frontend engineer. Onboarding buddy is Marcus. First task: take over the dashboard rebuild."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f15"
+content = "Company all-hands is the first Friday of every month. Notes posted to Notion. Action items tracked in Linear with owner and due date."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f16"
+content = "Vendor evaluation for email delivery: Postmark vs Resend vs SendGrid. Resend won on developer experience and pricing. Monthly volume is < 50k emails, well within the Resend free tier."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f17"
+content = "Feature flag system: LaunchDarkly for production. Local development uses a TOML file in config/flags.toml that overrides server-side flag values. Flag reads are cached in memory with 60s TTL."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f18"
+content = "Logging library for the Node.js backend services: Pino. Structured JSON output, low overhead. Log correlation via x-request-id header propagated through the service mesh."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f19"
+content = "Onboarding flow split into 5 steps: account creation, workspace setup, invite teammates, connect integrations, first resource. Drop-off analysis shows step 4 (integrations) has 35% abandonment."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f20"
+content = "Customer support stack: Intercom for live chat, Linear for bug reports triaged from support. Support SLA: P1 (outage) 1 hour, P2 (degraded) 4 hours, P3 (feature request) 5 business days."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f21"
+content = "Billing handled by Stripe Billing. Subscription tiers: Starter ($49/mo), Growth ($149/mo), Enterprise (custom). Annual plans at 20% discount. Prorated upgrades handled automatically by Stripe."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f22"
+content = "Design system based on Radix UI primitives with Tailwind CSS utility classes. No CSS-in-JS. Design tokens (colors, spacing, typography) defined in tailwind.config.ts. Figma component library kept in sync manually."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f23"
+content = "Localization: English only at launch. i18n infrastructure (react-i18next) added proactively so copy is not hardcoded. Translation keys in en.json. Spanish and French planned for Q3."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f24"
+content = "Analytics: Posthog for product analytics (self-hosted on the home lab). No third-party analytics in production for GDPR compliance. Events: page_view, feature_used, subscription_upgraded, churn."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f25"
+content = "Side project: Rust CLI tool for batch image resizing. Used image crate and rayon for parallelism. Published on crates.io as imgbatch v0.1.0. Not maintained actively."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f26"
+content = "Podcast listening: Acquired, Hardcore History, Darknet Diaries, and the Rustacean Station. Listen during commute and runs. Prefer 1.25x speed for most shows."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f27"
+content = "Mechanical keyboard: Keychron Q3 with Gateron Blue switches. Profile: MT3. Noise complaints from family acknowledged. Switch to browns pending."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f28"
+content = "Sleep goal: 7.5 hours minimum. Wake time 6:30am fixed. Oura ring tracks HRV and readiness score. Low readiness (<70) means no hard workouts."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f29"
+content = "Vacation planned: 10 days in Japan, late September. Itinerary: Tokyo (4 days), Kyoto (3 days), Osaka (3 days). Flights booked, hotels not yet."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f30"
+content = "Home renovation: kitchen backsplash replacement approved. Contractor quote: $1,800 for labor, $400 for materials. Scheduled for the week of April 7."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f31"
+content = "Tax prep: documents gathered, waiting for brokerage 1099. CPA appointment on March 22. Expecting a refund based on Q4 estimated payments."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f32"
+content = "AWS cost optimization: Reserved instances for RDS (1-year term) saves $82/month vs on-demand. Committed April 10. Fargate Savings Plan under evaluation — need 3 more months of usage data."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f33"
+content = "Dependency audit run March 15: 2 moderate advisories (hyper 0.14.x), 0 high or critical. hyper upgrade to 0.14.28 resolves both. Scheduled for next PR sprint."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc_f34"
+content = "Legal: privacy policy and ToS reviewed by counsel on February 28. GDPR addendum added for EU customers. Cookie consent banner added to the marketing site. CCPA compliance verified."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: what user preferences were captured
+# 5 relevant + 35 filler (distinct filler IDs)
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what user preferences were captured"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "gc_pref_dark_mode"
+content = "Prefers dark mode across all applications. Light mode tolerated only in browser-based tools that don't support dark mode. System-level dark mode toggle is always on."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "gc_pref_lang"
+content = "Preferred programming language for new projects: Rust for performance-critical backend work, TypeScript for frontend and tooling. Avoid Python except for data science or ML scripts."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_pref_meeting"
+content = "Prefer async communication over meetings. If a meeting is necessary, keep it under 30 minutes with a written agenda. No recurring meetings without an explicit goal and owner."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_pref_work_hours"
+content = "Deep work block: 9am-12pm, no interruptions. Slack notifications muted during this block. Available for urgent issues via phone call only. Email and Slack checked at 1pm and 5pm."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "gc_pref_deploy"
+content = "Prefer weekly release cadence, Tuesdays only. No Friday deploys. Every release requires a rollback plan in the release doc. Post-deploy monitoring for 30 minutes before declaring the release stable."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 2
+
+# Filler — distinct IDs from case 1 filler
+
+[[cases.seeds]]
+id = "gc2_f01"
+content = "Migrated primary Postgres instance from 14 to 16 in the staging environment. No schema changes required. EXPLAIN ANALYZE on critical queries shows no regressions."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f02"
+content = "API key rotation policy: keys expire after 1 year. Users notified at 30 days, 7 days, and 1 day before expiry. Expired keys return 401 with a specific error code (api_key.expired)."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f03"
+content = "Webhook delivery retry policy: immediate first attempt, then 1min, 5min, 30min, 2h, 12h backoff. After 6 failed attempts the webhook subscription is marked inactive and the user is emailed."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f04"
+content = "Object storage: AWS S3 in us-east-1. Versioning enabled on the user-uploads bucket. Lifecycle policy: move to Glacier after 90 days, delete after 365 days. Pre-signed URLs expire after 15 minutes."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f05"
+content = "Email templates managed in Postmark template editor. Versioned by Postmark internally. Template IDs stored as constants in the mailer service. Approval required for production template changes."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f06"
+content = "Subscription upgrade path: user selects new tier, preview shows prorated charge, confirm triggers Stripe subscription update, webhook confirms and updates local DB. Downgrade queued for next billing cycle."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f07"
+content = "Search feature powered by Meilisearch. Full re-index on schema changes takes 2 minutes for 50k documents. Incremental indexing via change data capture from Postgres using Debezium."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f08"
+content = "Audit log retention: 2 years for compliance. Stored in a read-only Postgres schema (audit schema). Application role does not have DELETE privilege on audit schema tables."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f09"
+content = "SSO via SAML 2.0 supported for Enterprise tier customers. Using the samael crate for SAML parsing. SP metadata served at /sso/saml/metadata. Session created on successful assertion."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f10"
+content = "Data export: users can export all their data as a ZIP archive from the settings page. Export includes JSON for structured data and original files for uploads. Export job runs async, user emailed when ready."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f11"
+content = "Worked through Advent of Code 2024 in Rust, reaching day 21. Solutions published on GitHub. Used this to explore rayon for parallelism and pest for parsing. Stopped due to work deadline pressure."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f12"
+content = "Learning goal: complete the Stanford CS229 ML course on YouTube by end of Q2. Currently on week 4 (logistic regression). Taking notes in Obsidian, implementing exercises in Python."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f13"
+content = "Car: 2019 Honda CR-V. Scheduled maintenance due at 75k miles (current: 68k). Oil change done March 5. Tire rotation due same time as next oil change."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f14"
+content = "Mortgage refinanced in January. New rate: 6.1% (down from 6.8%). 30-year fixed. Monthly payment reduced by $130. Break-even on closing costs in 22 months."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f15"
+content = "Spotify playlists for coding: lo-fi beats for deep work, 80s synth for debugging, metal for deployments. Playlist links saved in Notion."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f16"
+content = "Flight booked: San Francisco to New York, April 22-26. Conference attendance (RustConf). Hotel: Marriott Times Square. Expensed via Concur, confirmation #RUS2024-4421."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f17"
+content = "Expense report for Q1 travel: $1,247. Submitted March 31. Approved by manager April 2. Reimbursement expected in the April 15 payroll."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f18"
+content = "401k contribution: 10% of gross salary, company matches 4%. Contribution increased from 8% in January after the raise. Target: max annual contribution ($23,000) by November."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f19"
+content = "Security training completed: OWASP Top 10, secure coding in Rust (internal course). Certificate valid until December 2025. Next required training: HIPAA compliance (not required unless healthcare customers signed)."
+memory_type = "fact"
+domain = "work"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f20"
+content = "Mentor session notes: mentoring two junior engineers. Monthly 1:1 format. Focus areas: career growth, system design thinking, and navigating ambiguity. Progress tracked in a shared Notion page."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f21"
+content = "Team size: 6 engineers (3 backend, 2 frontend, 1 full-stack). Two backend engineers are contractors on 6-month engagements. Planning to hire a DevOps engineer in Q2."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f22"
+content = "Performance review cycle: twice yearly, February and August. Last review rating: Exceeds Expectations. Feedback themes: strong system design, needs to improve documentation output."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f23"
+content = "Architecture review board (ARB) meets bi-weekly on Wednesdays at 2pm. Any change with cross-service impact requires ARB approval before implementation. Decision records stored in Confluence."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f24"
+content = "Bug triage happens every Monday at 10am. P1 bugs assigned immediately. P2 assigned to current sprint. P3 goes to the backlog. Triage attendees: EM, on-call engineer, and PM."
+memory_type = "fact"
+domain = "work"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f25"
+content = "Documentation: API reference auto-generated from OpenAPI spec and published to docs.company.io on every release. Internal architecture docs in Confluence. ADRs (Architecture Decision Records) in the repo under docs/adrs/."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f26"
+content = "CLI tool: origin-mcp (MIT licensed, separate repo). Provides MCP server protocol for AI agent integration. Talks to the origin-server daemon over HTTP. Published on npm and crates.io."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f27"
+content = "Libsql chosen for the memory database. Turso's SQLite fork with vector search (DiskANN), FTS5, and local-first design. Evaluated ChromaDB and Qdrant — libsql won for its SQLite compatibility and single-file deployment."
+memory_type = "decision"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f28"
+content = "FastEmbed model: BGE-Base-EN-v1.5-Q (768 dimensions). 512 token maximum. ONNX runtime via CoreML on Apple Silicon. Model weights downloaded on first launch from Hugging Face. Cached in .fastembed_cache/."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f29"
+content = "LLM for on-device inference: Qwen3-4B-Instruct-2507 via llama-cpp-2 with Metal GPU acceleration. Token generation rate: approximately 35 tokens/second on M3 Pro. Used for classification and quality assessment."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f30"
+content = "Tauri 2 desktop app wraps the daemon. App is a thin HTTP client — no business logic. All data operations go through the origin-server on port 7878. Sidecar mechanism for production builds only."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f31"
+content = "Dedup threshold set at 0.85 cosine similarity. Values below 0.80 cause false merges. Values above 0.90 miss near-duplicates. Threshold validated empirically on 500 memory pairs."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f32"
+content = "Refinery runs background enrichment every 30 minutes: entity extraction, dedup proposals, recap triggers, concept clustering. Each phase is idempotent and can be run independently."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f33"
+content = "MCP server provides 4 tools to AI agents: remember, recall, context, forget. Agent authentication via x-agent-name header. Trust level assigned per agent name in the agent registry."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f34"
+content = "Privacy model: all data stays local on the user's machine. No cloud sync by default. Cloudflare Tunnel is opt-in for remote access. No telemetry or analytics without explicit opt-in."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc2_f35"
+content = "Hybrid search: vector similarity (DiskANN) + FTS5 full-text search combined via Reciprocal Rank Fusion. RRF k parameter is 60. Domain boost multiplier is 1.5x when query mentions domain name."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# Query: what project goals and milestones exist
+# 7 relevant + 33 filler (mix of gc3_ and reused gc_/gc2_ IDs not already used)
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what project goals and milestones exist"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "gc_goal_launch"
+content = "Primary goal: public launch by April 30. Success criteria: Origin MCP listed on npm, README live on GitHub, first 50 external users onboarded via waitlist. Karpathy gist comment as primary acquisition channel."
+memory_type = "goal"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "gc_goal_q2_saas"
+content = "Q2 goals for the SaaS project: ship v2 API with OpenAPI spec (April), reach 50 paying customers (May), reduce p99 latency below 300ms (June). Reviewed with VP of Engineering March 1."
+memory_type = "goal"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_goal_personal_learn"
+content = "Learning goals for 2024: complete CS229 ML course (Q2), build and publish one Rust crate (Q3), read 12 technical books (1/month). Progress tracked in Obsidian journal weekly."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_goal_milestone_v1"
+content = "v0.1.0 milestone: basic memory store, hybrid search, MCP server, Tauri app. All items shipped by April 15 hardening commits. Next milestone is v0.2.0: Homebrew tap, release-please CI, public changelog."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "gc_goal_fitness"
+content = "Fitness goal: sub-25 minute 5K by June 30. Current PB is 27:42. Running plan: 3x/week with one tempo run. Supplementing with strength training 2x/week."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "gc_goal_eval"
+content = "Eval milestone: NDCG@10 above 0.80 on the LoCoMo benchmark for the base retrieval pipeline. Reranked pipeline target is 0.87. Baselines must be set before any retrieval changes merge to main."
+memory_type = "goal"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "gc_goal_saas_customers"
+content = "Customer acquisition milestone: 10 paying customers by end of March, 50 by end of Q2, 200 by end of year. Current CAC target is $200. LTV:CAC target ratio is 3:1."
+memory_type = "goal"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 2
+
+# Filler
+
+[[cases.seeds]]
+id = "gc3_f01"
+content = "Request ID middleware injects x-request-id header (UUID v4) on every incoming request and propagates it through all log entries and downstream service calls via tracing spans."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f02"
+content = "Health check endpoint /healthz returns 200 with JSON body including DB ping latency and Redis ping latency. Used by ECS task health check configuration. Timeout is 5 seconds."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f03"
+content = "Graceful shutdown: Axum server drains in-flight requests on SIGTERM with a 30-second deadline. Background jobs get a 60-second window before being force-killed."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f04"
+content = "Content Security Policy header configured to disallow inline scripts and restrict media-src to self. Report-only mode for 2 weeks before enforcement to catch violations before they break the UI."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f05"
+content = "CORS configured to allow credentials, restrict origins to the allowlist, and expose x-request-id in response headers. Preflight cache duration: 600 seconds."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f06"
+content = "New feature: bulk import endpoint /api/import accepts a ZIP file of JSON records. Processes async via the job queue. Progress reported via WebSocket. Batch size: 100 records per transaction."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f07"
+content = "Test environment refresh: weekly on Sunday midnight. Anonymizes production data clone. Personal data replaced with Faker-generated values. Email domain changed to example.com."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f08"
+content = "Security review scheduled for May 15 with external vendor (Cure53). Scope: authentication flows, API endpoints, and data encryption. Pre-engagement questionnaire due April 25."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f09"
+content = "Penetration testing budget: $15,000 for the initial engagement. Findings from the pentest will be triaged in a dedicated security sprint. P0/P1 findings block the launch."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f10"
+content = "ISO 27001 certification exploration: deferred to post-Series A. SOC 2 Type II is the nearer-term target. Readiness assessment scheduled for Q3. Internal audit first, then external auditor."
+memory_type = "fact"
+domain = "work"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f11"
+content = "Company values: ship fast and learn faster, default to transparency, own outcomes not just tasks, disagree and commit. Values refreshed at the February all-hands."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f12"
+content = "Office layout changed: engineering team now sits together on the second floor. Standing desks for all engineers. Quiet room on each floor for focus work. No assigned desks."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f13"
+content = "Intern program: 2 summer interns starting June 3. Both are rising juniors from CMU. Assigned mentors: one to backend, one to frontend. Projects TBD but scoped to 10-week deliverables."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f14"
+content = "Competing with Mem0, Zep, and Letta in the agent memory space. Origin differentiation: local-first, no cloud dependency, AGPL licensed, Tauri app for human curation. Mem0 is API-only SaaS."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f15"
+content = "Origin MCP npm package published under the @origin-ai org. Package name: @origin-ai/mcp. Initial release: 0.1.0. Listed on the MCP server directory maintained by Anthropic."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f16"
+content = "Entity extraction prompt uses few-shot examples with 5 entity/relation pairs. Extraction runs asynchronously post-ingest. Results written back to the knowledge graph entities and relations tables."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f17"
+content = "Concept clustering groups related memories into wiki-style prose entries using community detection on the knowledge graph. Orphan memories that don't cluster are grouped globally."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f18"
+content = "Profile narrative assembled from identity and preference memories. Editorial prose format, not bullet points. Regenerated by the refinery when source memories are updated. Served via /api/profile."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f19"
+content = "Working memory builder selects the most recently accessed and highest-confidence memories for the active session. Injected into agent context bundles. Window size: 20 memories maximum."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f20"
+content = "Tauri app identifier: com.origin.desktop. Main window starts invisible to prevent white flash. React calls show() + center() after mount. Traffic light position customized at (8, 16)."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f21"
+content = "Childhood in Portland, OR. Moved to San Francisco for first job after college. Currently in Austin, TX. Strong preference for mountain hiking over beach vacations."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f22"
+content = "Undergraduate degree in Computer Science from University of Washington. Graduated 2017. Capstone project was a distributed key-value store in Go."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f23"
+content = "First job: software engineer at a fintech startup (Plaid competitor). Worked on the bank data ingestion pipeline. Left after 2 years to join a series-A startup."
+memory_type = "identity"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f24"
+content = "Current role: Staff Software Engineer at a B2B SaaS company. Tech lead for the API platform team. Reports to VP of Engineering. 5 direct reports."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f25"
+content = "Family: married to Jordan, two kids (ages 4 and 7). Dog named Turing (a beagle). Living in a 3BR house in South Austin since 2021."
+memory_type = "identity"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f26"
+content = "Open source contributions: rust-analyzer (2 minor PRs), tokio (1 doc fix), axum (1 middleware example). Contributor badge on the tokio GitHub organization."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f27"
+content = "Conference talks given: RustConf 2023 (15-minute lightning talk on error handling patterns), Austin DevFest 2024 (30-minute talk on building local-first apps)."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f28"
+content = "Side project income: $240/month from imgbatch CLI tool (sponsorship via GitHub Sponsors). Not tracking hours spent — it's hobby income."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f29"
+content = "Homelab network: UniFi Dream Machine as the router, 4 UniFi access points (U6 Lite). VLANs for IoT, trusted devices, and the NAS. Tailscale for remote access as a Cloudflare Tunnel fallback."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f30"
+content = "Investment strategy: passive index funds (VTI, VXUS, BND) in a 70/20/10 split. No individual stocks except RSU grants from employer. Rebalanced annually in January."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f31"
+content = "Reading list for Q2: Project Hail Mary (Weir), The Staff Engineer's Path (Reilly), Programming Rust (3rd ed). One technical, one career, one fiction per quarter rule."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f32"
+content = "Weekly newsletter subscriptions: Bytes.dev (JS), This Week in Rust, The Pragmatic Engineer, TLDR Tech. Read on Sunday mornings. Archive older than 4 weeks without reading."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "gc3_f33"
+content = "GitHub account: @lucian. 147 public repos. Most-starred: imgbatch (312 stars), rust-error-patterns (88 stars). Pinned repos maintained. Profile README updated quarterly."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0

--- a/app/eval/fixtures/agent_identity_profile.toml
+++ b/app/eval/fixtures/agent_identity_profile.toml
@@ -1,0 +1,313 @@
+# Identity and profile fixture — tests retrieval from the profile memory tier.
+# Covers identity, preference, and goal memory types across 3 cases.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: who am I and what is my role
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "who am I and what is my role"
+
+[[cases.seeds]]
+id = "identity_name_role"
+content = "Name: Lucian. Current role: Staff Software Engineer and tech lead for the API platform team at a B2B SaaS company. 5 direct reports. Reports to VP of Engineering. 7 years of professional software engineering experience."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "identity_background"
+content = "Computer Science degree from University of Washington (2017). First role was at a fintech startup working on bank data ingestion pipelines. Moved to a series-A startup after 2 years. Joined current company 4 years ago."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "identity_location"
+content = "Based in Austin, Texas since 2021. Previously in San Francisco for 4 years after college. Grew up in Portland, Oregon. Prefers mountain environments over coastal."
+memory_type = "identity"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "identity_family"
+content = "Married to Jordan. Two kids, ages 4 and 7. Dog named Turing (beagle, age 3). Living in a 3-bedroom house in South Austin. Family is the primary non-work priority."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "identity_expertise"
+content = "Primary expertise: distributed systems, Rust backend development, and API design. Secondary strengths: system design, technical leadership, and developer tooling. Known within the company for deep debugging skills."
+memory_type = "identity"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 2
+
+[[cases.seeds]]
+id = "identity_open_source"
+content = "Open source contributor: rust-analyzer (2 minor PRs), tokio (1 doc fix), axum (1 middleware example). Published crates: imgbatch (image resizing CLI, 312 GitHub stars). GitHub: @lucian."
+memory_type = "identity"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — personal facts but not about identity/role
+
+[[cases.negative_seeds]]
+id = "identity_neg_project"
+content = "Current main project: Origin, a local-first AI memory layer. Building as a side project with potential to become a primary focus. Written in Rust with Tauri for the desktop UI and libSQL for storage."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "identity_neg_goals"
+content = "Professional goal for 2024: become a recognized voice in the Rust community. Tactics: publish 2 crates, give 2 conference talks, write 12 technical blog posts. Progress tracked in Obsidian."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "identity_neg_pref_tools"
+content = "Preferred coding tools: Zed editor for Rust, VS Code for TypeScript, Warp terminal, Raycast as launcher. All tools configured with Vim keybindings. Settings backed up in a dotfiles repo."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "identity_neg_routine"
+content = "Daily routine: wake 6:30am, journal 10 minutes, run or gym, deep work 9am-12pm (no meetings or Slack), lunch break 12-1pm, meetings and async work 1-5pm, family time from 5:30pm."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "identity_neg_finance"
+content = "Financial position: mortgage on South Austin house (6.1% 30-year fixed, refinanced January 2024), 401k at 10% contribution with 4% employer match, HSA maxed annually ($3,850). No consumer debt."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "identity_neg_work_style"
+content = "Work style: async-first, documentation-driven, TDD for all new features. Prefer written RFCs over verbal design discussions. Decisions logged as ADRs in the repo. Calendar protected for deep work blocks."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: what are my coding preferences
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are my coding preferences"
+
+[[cases.seeds]]
+id = "pref_lang_choice"
+content = "Preferred languages: Rust for performance-critical backend services and systems tools, TypeScript for frontend and build tooling. Avoid Python except for ML/data tasks. Go acceptable for simple CLI tools when Rust overhead isn't justified."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "pref_code_style"
+content = "Code style principles: functions under 40 lines, max 3 levels of nesting, no single-letter variable names outside iterators, descriptive names over short abbreviations. If it needs a comment to explain what it does, rename it."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "pref_error_handling"
+content = "Error handling preference in Rust: typed error enums (thiserror) for public API boundaries, anyhow for internal code. Never use unwrap() in production code except for genuinely impossible states. Always add context when propagating errors."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "pref_testing"
+content = "Testing approach: TDD for new features, write tests first before implementation. Test the behavior, not the implementation. Real dependencies over mocks where possible — use testcontainers for Postgres and Redis in integration tests."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 3
+
+[[cases.seeds]]
+id = "pref_comments"
+content = "Comments explain why, not what. Doc comments required on all public API items. Avoid commented-out code in committed files — use git stash or feature flags. TODOs must include a GitHub issue number."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "pref_deps"
+content = "Dependency selection: prefer crates with > 1000 GitHub stars, recent releases (< 12 months), and an active maintainer. Check crates.io download rank. Run cargo audit weekly. Never add a dep for < 10 lines of utility code."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 2
+
+[[cases.seeds]]
+id = "pref_git"
+content = "Git commit style: imperative mood, < 72 character subject line, blank separator, body explains why not what. Conventional commits format: feat, fix, refactor, docs, test, chore. Never commit with --no-verify unless pre-commit is known to be wrong."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — code-adjacent but not coding preferences
+
+[[cases.negative_seeds]]
+id = "pref_neg_project_stack"
+content = "Origin stack: Rust daemon (Axum on 7878), libSQL database, FastEmbed embeddings, Qwen3-4B LLM, Tauri 2 desktop app. React 19 frontend with TanStack Query 5 and Tailwind CSS 4."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "pref_neg_career"
+content = "Career goal: CTO or VP Engineering at a company of 50-200 engineers within 5 years. Developing executive presence and building the leadership skills required. Working with an external leadership coach."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "pref_neg_books"
+content = "Technical reading list Q2: Programming Rust 3rd ed (in progress), The Staff Engineer's Path (queued), Designing Data-Intensive Applications (reference). One technical book per quarter minimum."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "pref_neg_hardware"
+content = "Hardware: M3 Pro MacBook Pro 14-inch (primary), Mac mini M4 (home server). Keychron Q3 with Gateron Brown switches (switched from Blue after noise complaints). LG 34-inch ultrawide external monitor."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "pref_neg_communication"
+content = "Communication preferences: async over sync, written over verbal, long-form over bullet points. Response SLA: 4 hours during business hours for Slack, same day for email. Phone call for urgent issues only."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "pref_neg_work_hours"
+content = "Work schedule: deep work 9am-12pm (blocked on calendar, Slack muted). Meetings clustered in the afternoon. Finish by 5:30pm for family time. No work on weekends except production incidents."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# Query: what are my current project goals
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are my current project goals"
+
+[[cases.seeds]]
+id = "goal_origin_launch"
+content = "Primary goal: public launch of Origin by April 30. Success criteria: npm package published, README live on GitHub with the Karpathy gist comment strategy, first 50 external users onboarded from the waitlist."
+memory_type = "goal"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "goal_origin_eval"
+content = "Origin eval goal: NDCG@10 > 0.80 on LoCoMo benchmark for the base retrieval pipeline before any retrieval changes merge. Reranked pipeline target is 0.87. Token efficiency eval is the next milestone after retrieval quality."
+memory_type = "goal"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "goal_saas_revenue"
+content = "SaaS project Q2 goal: reach $60k ARR (from $28k in Q1). Primary lever: content marketing pipeline — 2 blog posts per week and 1 guest post per month. No paid ads yet — CAC via content is near zero."
+memory_type = "goal"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "goal_origin_v02"
+content = "Origin v0.2.0 milestone: Homebrew tap for easy Mac install, release-please CI for automated changelog, and a public-facing documentation site. Target: 6 weeks after the v0.1.0 launch."
+memory_type = "goal"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "goal_personal_learn"
+content = "Learning goals for 2024: complete CS229 ML course on YouTube (Q2 target), build and publish 1 Rust crate to crates.io (Q3), read 12 technical or career books (1/month). Progress tracked weekly in Obsidian."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "goal_personal_fitness"
+content = "Fitness goal: run a sub-25 minute 5K by June 30 (current PB: 27:42). Training plan: 3 runs per week with one tempo run, 2 strength sessions. Tracking mileage and pace in Garmin Connect."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 2
+
+# Hard negatives — related to projects/goals but answer different questions
+
+[[cases.negative_seeds]]
+id = "goal_neg_saas_backlog"
+content = "SaaS backlog items: SSO/SAML support (May, Enterprise requirement), mobile app MVP (June), multi-currency billing (Q3). Backlog maintained in Linear. Items without DRI and acceptance criteria are not scheduled."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "goal_neg_origin_completed"
+content = "Origin v0.1.0 completed: hybrid search (vector+FTS+RRF), knowledge graph (entities+relations), Tauri desktop app, MCP server integration, on-device LLM (Qwen3-4B), LoCoMo/LongMemEval eval harness."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "goal_neg_career"
+content = "Career trajectory: Staff Engineer currently, targeting Principal Engineer or VP Engineering within 3-5 years. Key development areas: executive presence, public speaking, and organizational design at scale."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "goal_neg_finance"
+content = "Financial goal: pay off the car loan by end of year (balance $8,200). After that, redirect that payment toward the brokerage account. Target net worth by age 40: $1.2M."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "goal_neg_team"
+content = "Team-building goal: hire a senior DevOps engineer by Q2 and a second frontend engineer by Q3. Recruiting pipeline opened in February. Target: 2 screened candidates per week from the job posting."
+memory_type = "goal"
+domain = "work"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "goal_neg_community"
+content = "Community goal: give 2 conference talks in 2024 (RustConf proposal submitted, Austin DevFest accepted). Write 12 technical blog posts on the TIL blog. Contribute to 3 open source projects beyond current PRs."
+memory_type = "goal"
+domain = "personal"
+source_agent = "claude-desktop"

--- a/app/eval/fixtures/agent_multi_tool.toml
+++ b/app/eval/fixtures/agent_multi_tool.toml
@@ -1,0 +1,449 @@
+# Multi-tool agent memories — tests cross-agent retrieval.
+# Memories arrive from claude-code, chatgpt, cursor, and claude-desktop across
+# coding sessions, design docs, and architectural discussions.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: what did I decide about the database schema
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what did I decide about the database schema"
+
+[[cases.seeds]]
+id = "agent_multi_db_schema_claude"
+content = "Decided to normalize users and accounts into separate tables with a one-to-many relationship. Users hold identity (email, name, auth); accounts hold billing context. This supports future multi-account per user without schema migration."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_multi_db_schema_chatgpt"
+content = "Schema decision: use soft deletes (deleted_at timestamp) rather than hard deletes on the users, accounts, and resources tables. Hard deletes cause FK cascade issues in audit trails. Confirmed this approach matches GDPR right-to-erasure — soft delete + periodic anonymization job."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_db_schema_cursor"
+content = "Added a jsonb 'settings' column to the accounts table instead of a separate account_settings table. Settings volume is low (< 30 keys), schema is user-defined, and embedding it avoids an extra join on every request."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_db_schema_desktop"
+content = "Enum types in Postgres for status fields (resource_status, subscription_status). Rationale: DB-level constraint catches invalid states that application code might miss. Enum extension requires a migration, but status values rarely change."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "agent_multi_db_schema_index"
+content = "Composite index on (account_id, created_at DESC) on the resources table. Query patterns are always scoped to one account and sorted by recency. Partial index on soft-deleted rows excluded to keep index size small."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 2
+
+# Hard negatives — database vocabulary but not schema decisions
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_pool"
+content = "SQLx pool configured with max_connections=15 and acquire_timeout=3s. Idle connections pruned after 600s. Pool size was reduced from 25 after profiling showed fewer than 8 concurrent DB operations at peak load."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_perf"
+content = "Slow query log shows the resource search endpoint hitting 350ms p99. The culprit is a sequential scan on the tags JSONB column. Need to add a GIN index on tags before launch."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_backup"
+content = "Automated backups via RDS point-in-time recovery, 7-day retention window. Manual pg_dump to S3 nightly as an additional layer. Restoration drill planned for the week before launch."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_migration"
+content = "Migration tooling: sqlx-cli with sqlx migrate run in CI before tests. Down migrations are written but not run in CI — they exist as a manual recovery option only. Each migration is reviewed in PRs."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_test"
+content = "Integration tests use testcontainers to spin up a real Postgres 16 instance per test run. Each test runs inside a transaction that is rolled back on teardown to maintain isolation."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_cache"
+content = "Redis used only for session tokens and short-term rate-limit counters. No DB query results are cached in Redis. The team agreed that cache invalidation complexity is not worth the latency gains at current scale."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_read"
+content = "Read replica added to staging environment. Analytics queries routed via DATABASE_REPLICA_URL env var. Primary handles all writes. Replica lag is acceptable for reporting use cases (< 1s observed)."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_audit"
+content = "Audit log table (audit_events) is append-only. Uses Postgres row-level security to block UPDATE and DELETE on the table. Populated by the application layer on every write to user, account, and resource tables."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_search"
+content = "Full-text search over resource names uses pg_trgm with a GIN index. Evaluated tsvector but trigram matching handles partial-word queries better for the short resource name field."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_db_partitioning"
+content = "No table partitioning at launch. Events table is the only candidate (expected 50M rows/year). Plan is to add range partitioning by month at 6 months post-launch if query times degrade."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: what are my coding style preferences
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are my coding style preferences"
+
+[[cases.seeds]]
+id = "agent_multi_style_rust_claude"
+content = "Prefer explicit error propagation over unwrap() in production code. Only use unwrap() in tests or for truly impossible states. Always use the ? operator and map_err() to add context to errors at boundaries."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_multi_style_fn_size"
+content = "Functions should fit on a screen (< 40 lines). If a function needs more than 3 levels of nesting, extract a helper. Prefer flat code over clever abstractions — readability beats cleverness."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_style_naming"
+content = "Naming conventions: use_snake_case for variables and functions, PascalCase for types and traits, SCREAMING_SNAKE_CASE for constants. Prefer descriptive names over short abbreviations. Never use single-letter variables outside of iterators."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_style_comments"
+content = "Comments explain why, not what. Function doc comments required on public API items. Avoid commented-out code in committed files — use git stash or a feature flag instead."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 2
+
+# Hard negatives — personal preferences but not coding style
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_editor"
+content = "Using VS Code with rust-analyzer and the GitLens extension. Vim keybindings enabled. Theme: Catppuccin Mocha. Font: JetBrains Mono 13pt. Line height 1.5. All editor settings stored in .vscode/settings.json in the repo."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_review"
+content = "Code review preference: always request changes rather than approving with comments if there are blocking issues. Leave nitpick comments prefixed with 'nit:' so the author knows they are not blocking. Review within 24 hours of request."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_meetings"
+content = "Prefer async written updates over synchronous meetings. If a meeting is necessary, require an agenda sent 24 hours in advance. No recurring meetings without an owner and explicit value statement."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_git"
+content = "Git commit style: imperative mood, under 72 chars subject line, blank line separator, body explains why not what. Conventional commits format required: feat, fix, refactor, docs, test, chore."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_work"
+content = "Deep work blocks from 9am-12pm, no meetings or Slack. Email checked twice: 1pm and 5pm. Async-first, response within 4 hours during business hours is the expected SLA."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_deploy"
+content = "Deploy preference: weekly release cadence on Tuesdays. No Friday deploys. All releases go through staging for 24h before production promotion. Rollback plan required in the release doc before promotion."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_infra"
+content = "Infrastructure as code preference: Terraform for all cloud resources. No click-ops in production AWS account. Resources not in Terraform are considered unmanaged and eligible for deletion."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_style_lib"
+content = "Library selection preference: prefer actively maintained libs with > 1000 GitHub stars and a recent release within 12 months. Avoid dependencies that haven't been updated in 2+ years. Check crates.io download rank for Rust."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# Query: what's the deployment strategy
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what's the deployment strategy"
+
+[[cases.seeds]]
+id = "agent_multi_deploy_strategy"
+content = "Deploying to AWS ECS Fargate. Docker image built in CI and pushed to ECR. ECS service updated via GitHub Actions deploy workflow. No EKS — Kubernetes overhead not justified at current scale."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_multi_deploy_blue_green"
+content = "Blue-green deployments configured via ECS deployment circuit breaker. New task definition spun up alongside existing; traffic shifted after health checks pass. Automatic rollback if error rate exceeds 5% in first 5 minutes."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_deploy_env"
+content = "Three environments: dev (auto-deployed on every main push), staging (manual promote from dev), production (manual promote from staging with release doc). Each environment has its own ECS cluster and RDS instance."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+
+[[cases.seeds]]
+id = "agent_multi_deploy_secrets"
+content = "Secrets injected at runtime via AWS Secrets Manager, not environment variables in task definitions. Application uses the AWS SDK to fetch secrets on startup. Rotation handled by Secrets Manager — no manual secret updates needed."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+relevance = 2
+
+# Hard negatives — infrastructure vocabulary but not deployment strategy
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_cdn"
+content = "Static assets served via CloudFront. Cache-Control: max-age=31536000 on hashed asset filenames. index.html gets no-cache. Invalidation triggered automatically by the frontend deploy job."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_dns"
+content = "DNS managed in Route 53. A records point to CloudFront (frontend) and ALB (API). Failover routing configured: secondary region (us-west-2) serves traffic if primary (us-east-1) health check fails."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_monitoring"
+content = "Monitoring stack: CloudWatch for infrastructure metrics, Datadog for APM traces. Alerts on p99 latency > 500ms, error rate > 1%, and ECS task count below 2. On-call rotation via PagerDuty."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_scaling"
+content = "ECS auto-scaling based on CPU utilization. Scale out at 70% average CPU across tasks, scale in at 30%. Min 2 tasks, max 10 tasks. Cooldown period 120s to prevent thrashing."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_cost"
+content = "Current AWS bill at $340/month. Fargate is 60% of cost. RDS is 30%. CloudFront + S3 is 10%. Cost optimization planned post-launch: reserved instances for RDS, Savings Plans for Fargate."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_local"
+content = "Local dev environment uses Docker Compose with Postgres, Redis, and localstack (for S3 and Secrets Manager emulation). Run docker compose up -d to start dependencies before cargo run."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_ci"
+content = "GitHub Actions CI pipeline: lint, format check, test, security audit (cargo audit), and build steps in parallel where independent. Total run time target < 8 minutes for PR feedback."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_region"
+content = "Primary region is us-east-1 (lowest latency for the majority of customers based on analytics). Disaster recovery region is us-west-2. RDS replication configured but failover is not yet automated."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_deploy_logging"
+content = "Application logs go to CloudWatch Logs. Log groups per service with 30-day retention. Structured JSON logging via the tracing crate with tracing-subscriber. Log level controlled by LOG_LEVEL env var."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# Query: what performance issues have been found
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what performance issues have been found"
+
+[[cases.seeds]]
+id = "agent_multi_perf_search_scan"
+content = "Profiled: resource search endpoint at 350ms p99 due to sequential scan on the JSONB tags column. No GIN index on tags. Needs index before launch. Estimated fix: add migration 0019 with CREATE INDEX CONCURRENTLY."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "agent_multi_perf_n_plus_one"
+content = "N+1 query detected on the dashboard endpoint. For each account in the list, a separate query fetches resource count. Fix: change to a single query with COUNT(*) GROUP BY account_id and join result. Tracked as SAAS-287."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_perf_cold_start"
+content = "ECS task cold start adds 8-12 seconds to initial request latency after a scale-out event. Root cause: SQLx connection pool does 15 health-check pings on startup. Mitigation: reduce min_connections from 15 to 3."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "agent_multi_perf_memory"
+content = "Memory leak identified in the file upload handler. The multipart stream buffer is not dropped until the request is fully processed, holding the file in memory even after it is written to S3. Fix is to use a streaming upload instead of buffering."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+relevance = 2
+
+[[cases.seeds]]
+id = "agent_multi_perf_cache_miss"
+content = "Permission check for each API request hits the DB to load the user's role. With 500 concurrent users, this is 500 DB queries per second just for auth. Fix: cache role in the JWT claims (already planned) or add a Redis read-through cache."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+
+# Hard negatives — performance vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_target"
+content = "Performance targets for launch: p50 < 50ms, p95 < 200ms, p99 < 500ms for API endpoints. Measured at the ALB level, excluding CDN cached responses. Targets are SLOs, not SLAs at this stage."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_load_test"
+content = "Load test with k6: 500 virtual users, 10-minute ramp-up, steady state for 30 minutes. All endpoints held p99 below 500ms except /api/export (1.2s p99). Export endpoint excluded from SLO."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_frontend"
+content = "Frontend Lighthouse score: 92 performance on desktop, 78 on mobile. Main drag is the initial JS bundle (420 KB gzipped). Need to code-split the settings page and the billing modal to reduce initial load."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_embedding"
+content = "BGE-Base-EN-v1.5-Q embedding model takes 8ms per 512-token input on Apple M3. FastEmbed batching reduces amortized cost to 2ms per document for batch sizes >= 16. Batch size 32 used in the ingest pipeline."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_build"
+content = "Rust release build takes 4m 30s on GitHub Actions runners (2-core, 7 GB RAM). Switched to cargo-nextest and split unit and integration tests into parallel jobs. Total CI time reduced from 14m to 8m."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_infra"
+content = "CPU utilization sits at 12% average across the 2-task ECS service under normal traffic. Headroom is comfortable. Auto-scaling threshold of 70% CPU gives ample time to provision new tasks before saturation."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_db_sizing"
+content = "RDS instance is db.t3.medium (2 vCPU, 4 GB RAM). At 40% CPU under load test with 500 users. Plan to upgrade to db.m5.large if the N+1 fix alone does not bring load down sufficiently."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_websocket"
+content = "WebSocket connections sit idle most of the time. Memory per connection is 64 KB overhead in the Axum WS handler. With 1000 concurrent WS connections that is 64 MB — well within available memory."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_serialization"
+content = "JSON serialization benchmarked with criterion. serde_json is the baseline. simd-json is 2.3x faster for large payloads (> 100 KB). Switched to simd-json for the /api/export endpoint only."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "agent_multi_neg_perf_profiling"
+content = "Profiling setup: cargo-flamegraph for CPU profiling, heaptrack for allocation profiling. Flamegraph showed 40% of CPU in the auth middleware on the JWKS validation path — caching the validated key set cut this to 3%."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"

--- a/app/eval/fixtures/agent_noisy_context.toml
+++ b/app/eval/fixtures/agent_noisy_context.toml
@@ -1,0 +1,854 @@
+# Noisy context — 20 relevant + 80 filler across 4 cases.
+# Tests signal extraction when the corpus is dominated by plausible but irrelevant memories.
+# Each case: 5 relevant seeds (relevance >= 2) + 20 filler seeds (relevance = 0).
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: how does the caching layer work
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how does the caching layer work"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "noisy_cache_strategy"
+content = "Caching layer uses Redis via deadpool-redis. Two cache namespaces: session: prefix for auth tokens (24h TTL) and rate: prefix for rate-limit counters (60s TTL). No application-level query result caching — DB is fast enough at current scale."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "noisy_cache_invalidation"
+content = "Cache invalidation strategy: write-through for session tokens (write to Redis and DB simultaneously). Rate-limit counters are Redis-only (no DB backing). No cache-aside pattern used — complexity not justified."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 3
+
+[[cases.seeds]]
+id = "noisy_cache_pool"
+content = "Redis connection pool: max 10 connections, idle timeout 300s. deadpool-redis configured with exponential backoff on connection failure. If Redis is unreachable, session reads fall through to DB, rate limiting is disabled."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_cache_hit_rate"
+content = "Session cache hit rate measured at 94% in production. The 6% miss rate is cold starts (new logins) and expired tokens. DB fallback for misses adds approximately 8ms compared to a cache hit."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_cache_eviction"
+content = "Redis maxmemory policy: allkeys-lru. Redis instance is 256 MB on the managed plan. At current session volume (< 5k active sessions), eviction pressure is negligible. Monitor if sessions exceed 50k."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 2
+
+# 20 filler seeds (relevance = 0, diverse topics)
+
+[[cases.seeds]]
+id = "noisy1_f01"
+content = "Stripe webhook handler must return 200 within 30 seconds or Stripe will retry. Processing is done asynchronously by pushing the event to the job queue immediately on receipt."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f02"
+content = "Preferred IDE is Zed for Rust, VS Code for TypeScript. Vim keybindings enabled in both. JetBrains Mono 13pt font. Catppuccin Mocha theme."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f03"
+content = "Team retrospective held every 2 weeks after the sprint review. Format: Start/Stop/Continue. Action items tracked in Linear. Facilitator rotates through the team."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f04"
+content = "User table has 120k rows in production. Account table has 45k rows. Resource table has 1.8M rows. These are approximate as of March 15 — fast-growing."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f05"
+content = "Error monitoring: Sentry with 10% sample rate on 429 responses, 100% on 500. Source maps uploaded on every deploy. Slack integration posts new error types to #alerts channel."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f06"
+content = "Learning Rust ownership model via Rustlings exercises. Completed chapters 1-8 of The Book. Lifetimes chapter taking the longest. Plan to finish by end of month."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f07"
+content = "Marketing site SEO: Lighthouse SEO score 95. Meta descriptions and OG tags for all landing pages. Blog posts indexed in Google Search Console. Sitemap submitted."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f08"
+content = "Physical health: blood pressure 118/76, cholesterol 185. Annual physical on March 10. Doctor recommended increasing cardio frequency. Currently at 3x/week."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f09"
+content = "Competitor analysis: Notion AI adds memory-like features via Q&A on workspace content. Not a direct competitor — Origin focuses on cross-tool agent memory, not document Q&A."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f10"
+content = "Cargo workspace linting: clippy pedantic enabled for all crates. clippy::nursery denied. clippy::cargo enabled. CI fails on any new warning. Existing suppressions tracked in a Notion doc for cleanup."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f11"
+content = "Open source release plan: Apache-2.0 for origin-types and origin-core, AGPL-3.0 for the Tauri app. Rationale: allow downstream tools to use the library crates without AGPL contamination."
+memory_type = "decision"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f12"
+content = "Vacation policy: 20 days PTO plus company holidays. Unlimited PTO not offered — data shows it leads to people taking less time off. Minimum 5 consecutive days off required per year."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f13"
+content = "GraphQL considered and rejected for the public API. N+1 query risk, schema versioning overhead, and additional client complexity were the deciding factors. REST with OpenAPI spec chosen instead."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f14"
+content = "GitHub Copilot subscription active. Used for boilerplate and test generation. Disabled for security-sensitive code (auth, crypto). Code review always required regardless of source."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f15"
+content = "Interview process: 30-min phone screen, 60-min technical discussion (no LeetCode), 2-hour pair programming on a realistic problem, 30-min culture fit with CEO. Total: 4 hours."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f16"
+content = "Embedding model BGE-Base-EN-v1.5-Q produces 768-dimensional dense vectors. 512 token maximum per chunk. Quantized ONNX model runs on CoreML for Apple Silicon acceleration."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f17"
+content = "Morning routine: wake 6:30am, 10 minutes journaling, 30-minute run or gym, shower, deep work block 9am. No phone or email before 9am."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f18"
+content = "Software subscription audit: cancelled Notion (migrated to Obsidian), kept Linear, Vercel, GitHub Pro, Figma. Monthly software spend reduced from $240 to $115."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f19"
+content = "Code review process: all PRs require at least one approval. Draft PRs can be opened for early feedback. Review within 24 hours expected. Auto-assign reviewers based on CODEOWNERS file."
+memory_type = "fact"
+domain = "work"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy1_f20"
+content = "RustConf 2024 talk proposal submitted: 'Local-first AI memory with Rust and libSQL'. Notification expected in 6 weeks. Preparing a demo of the Origin hybrid search pipeline."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: what CI/CD pipeline do we use
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what CI/CD pipeline do we use"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "noisy_ci_platform"
+content = "CI/CD platform is GitHub Actions. Workflows defined in .github/workflows/. Three main workflows: ci.yml (PR checks), deploy-staging.yml (main branch pushes), deploy-prod.yml (manual trigger with approval gate)."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "noisy_ci_jobs"
+content = "CI job structure: format check (cargo fmt --check, prettier), lint (clippy pedantic, eslint), test (unit + integration in matrix), security audit (cargo audit), and build (release binary). Jobs run in parallel where independent."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 3
+
+[[cases.seeds]]
+id = "noisy_ci_deploy"
+content = "Staging deploys automatically on main branch push. Production deploys require manual approval via GitHub Environments. Approval is gated on the 'prod-approvers' team (EM + CTO). One approval required."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_ci_time"
+content = "CI runtime target: < 8 minutes for PR checks. Achieved by: cargo-nextest for test parallelism, rust caching via Swatinem/rust-cache action, and splitting lint/test into parallel jobs. Current median is 6m 20s."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_ci_coverage"
+content = "Coverage gate in CI: cargo-tarpaulin for Rust (80% line coverage on service layer), vitest c8 for frontend (75% branch coverage). Gate runs on PR and blocks merge if not met. Coverage delta reported as a PR comment."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+
+# 20 filler seeds (diverse topics)
+
+[[cases.seeds]]
+id = "noisy2_f01"
+content = "Product roadmap Q2: API v2 (April), SSO/SAML (May), mobile app MVP (June). Roadmap items have assigned DRIs (directly responsible individuals) and acceptance criteria in Linear."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f02"
+content = "Origin's refinery runs dedup proposals, entity extraction, and recap triggers in a fixed phase sequence every 30 minutes. Each phase is idempotent to handle restarts safely."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f03"
+content = "Dog (Turing, beagle, age 3) needs flea prevention treatment monthly. Brand: NexGard. Next treatment: April 15. Vet contact: Austin Animal Clinic, (512) 555-0142."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f04"
+content = "Authentication uses JWT (15min access, 30-day refresh) with httpOnly Secure cookies. No localStorage for tokens. Auth0 for OAuth2 social login. Own email/password flow for enterprise."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f05"
+content = "Budget cycle: annual in November. Headcount requests submitted by October 1. Software subscription renewals evaluated in Q4. Engineering budget is $1.2M total including salaries."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f06"
+content = "Qwen3-4B-Instruct-2507 running on Metal GPU via llama-cpp-2. Dedicated std::thread for inference. Bridge pattern: capture Tokio runtime Handle at thread spawn for async DB write-back."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f07"
+content = "Meal planning done Sunday afternoon. 5 dinners planned, 2 nights flex (takeout or leftovers). Grocery list generated from the plan. Instacart delivery scheduled for Sunday evening."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f08"
+content = "API documentation hosted at docs.company.io. Generated from OpenAPI 3.1 spec via Redoc. Updated on every release automatically by the deploy workflow. Feedback button links to Canny."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f09"
+content = "Standing desk height: 41 inches for standing, 28 inches for sitting. Alternating every 45-60 minutes. Reminder set via TimerBar app. Ergotron LX arm for the ultrawide monitor."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f10"
+content = "Competitor Mem0 raised Series A in February. Valuation estimated at $60M. Focus: API-first agent memory for enterprise. Origin differentiates on local-first and human curation layer."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f11"
+content = "Payment module known bugs: WEBAPP-412 (webhook swallows HMAC verification error), WEBAPP-389 (refund over-charge not validated), WEBAPP-401 (idempotency key tied to UUID not cart_id)."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f12"
+content = "Podcast: Lex Fridman #421 with Andrej Karpathy on AI memory and cognition. Highly relevant to Origin's design. Key takeaway: external memory must be human-verifiable to build trust."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f13"
+content = "SQL safety rule: always use parameterized queries. Never interpolate user input into SQL strings. Reviewed in the OWASP secure coding training. This rule is non-negotiable in code review."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f14"
+content = "Company off-site in Austin, May 12-13. Engineering sessions: API v2 design (AM day 1), deployment automation (PM day 1), product roadmap review (AM day 2). Social dinner at Franklin BBQ on day 1."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f15"
+content = "Biometric data: Oura ring HRV average 62ms, readiness score average 78. Sleep score average 82. Readiness dips to < 65 on days after 2+ alcoholic drinks. Alcohol reduced to weekends only."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f16"
+content = "Rate limiting: 1000 requests/minute per API key. 100/minute for unauthenticated. Implemented with tower-governor. Header: X-RateLimit-Remaining and X-RateLimit-Reset returned on every response."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f17"
+content = "Side project: TIL (Today I Learned) blog. Built with Astro + MDX. Deployed to Cloudflare Pages. 47 posts published. Most popular: 'Rust ownership in 5 diagrams' (1.2k views)."
+memory_type = "fact"
+domain = "personal"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f18"
+content = "Dependency management rule: run cargo update monthly and review the diff. Security advisories checked weekly via cargo audit in CI. Deny crate used to enforce banned dependencies."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f19"
+content = "Home network upgrade: Upgraded to 2 Gbps fiber from 1 Gbps. ISP: AT&T. Router handles full 2 Gbps on the WAN side. Internal Wi-Fi 6E gives 1.8 Gbps on 6 GHz band in the office."
+memory_type = "fact"
+domain = "personal"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy2_f20"
+content = "TypeScript project convention: strict mode always on. No any types except in generated code. Zod for runtime validation of external data (API responses, env vars). Type assertions require a comment explaining why."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 0
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# Query: what are the API rate limits
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are the API rate limits"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "noisy_ratelimit_values"
+content = "API rate limits: 1000 requests/minute per authenticated API key. 100 requests/minute per IP for unauthenticated endpoints. Burst allowance of 50 extra requests per minute for burst-friendly endpoints (/api/search, /api/context)."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "noisy_ratelimit_impl"
+content = "Rate limiting implemented via tower-governor middleware in the Axum stack. Keyed on API key for authenticated requests, on X-Forwarded-For IP for unauthenticated. Response headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 3
+
+[[cases.seeds]]
+id = "noisy_ratelimit_exceeded"
+content = "Rate limit exceeded response: 429 Too Many Requests with JSON body containing 'error.code': 'rate_limit.exceeded' and 'Retry-After' header with seconds until the window resets."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_ratelimit_tier"
+content = "Rate limit tiers by subscription: Starter — 1000 req/min, Growth — 5000 req/min, Enterprise — unlimited (fair-use policy). Enterprise customers can request dedicated rate limit configurations."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_ratelimit_storage"
+content = "Rate limit counters stored in Redis with 60-second TTL. Sliding window algorithm with atomic INCR + EXPIRE operations. If Redis is unavailable, rate limiting is disabled and a fallback IP-based limit of 500 req/min applies."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+
+# 20 filler seeds
+
+[[cases.seeds]]
+id = "noisy3_f01"
+content = "RBAC system: viewer, editor, admin roles. Embedded in JWT claims. Permission checks in handlers using DB context for fine-grained resource ownership checks."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f02"
+content = "Hybrid search in Origin uses DiskANN vector search + FTS5 full-text search, combined via Reciprocal Rank Fusion. RRF k=60. Domain boost 1.5x when query mentions domain."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f03"
+content = "Grocery budget: $400/month. Tracking with YNAB. Eating out budget separate: $200/month. Current month at $380 grocery, $170 eating out. On track."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f04"
+content = "Linear setup: projects (not teams) for work isolation. Priorities: urgent, high, medium, low. SLA: urgent = same day, high = this sprint, medium = this quarter. Triage happens in Monday bug triage."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f05"
+content = "SQLx compile-time query checking enabled. All queries validated against a database schema snapshot (sqlx-data.json). Schema snapshot regenerated after each migration with cargo sqlx prepare."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f06"
+content = "English is primary language. Conversational Spanish. Learning Mandarin via Duolingo — 120-day streak. Goal: travel to Taiwan in 2025 and hold a basic conversation."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f07"
+content = "Documentation tooling: mdBook for internal developer docs, Redoc for external API docs, Confluence for company wiki. Each tool is the canonical source for its domain — no duplication."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f08"
+content = "Encryption at rest: RDS storage encrypted with AWS KMS. S3 bucket encryption with SSE-S3. Redis in-transit encryption enabled (TLS). No client-side encryption — data is plaintext in the application."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f09"
+content = "Tax-advantaged accounts: HSA ($3,850 annual contribution), 401k (10% + 4% employer match). HSA invested in the Fidelity HSA index fund options. Balance: $8,200 as of March."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f10"
+content = "Rust edition: 2024. Clippy pedantic on all crates. Deny unused_must_use, unused_variables, dead_code in CI. Zero unsafe blocks in origin-core — policy enforced via #![forbid(unsafe_code)]."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f11"
+content = "Feature flags: LaunchDarkly in production, local TOML file in dev. Flags used for gradual rollouts, kill switches, and A/B tests. Flag reads cached in memory with 60-second TTL to reduce API calls."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f12"
+content = "Coaching sessions: leadership coaching with external coach, bi-weekly. Focus: executive presence, difficult conversations, and scaling the team. Notes in a private Obsidian vault."
+memory_type = "fact"
+domain = "work"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f13"
+content = "Pagination standard: cursor-based for list endpoints. Opaque cursor = base64(row_id + sort_key). Page size default 20, max 100. No offset pagination offered."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f14"
+content = "Travel preferences: direct flights only for trips > 4 hours. Aisle seat. Lounge access via Amex Platinum. Hotel preference: Marriott (Bonvoy member, Gold status)."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f15"
+content = "Knowledge graph in Origin stores entities, relations, and observations. FK cascades propagate deletes. 2-hop traversal used to augment retrieval results with entity context."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f16"
+content = "Postmark for transactional email: welcome, password reset, billing receipts, webhook failure alerts. Template IDs are constants in the mailer crate. Template changes require PR approval."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f17"
+content = "Weekly newsletter: sent every Tuesday. Open rate: 34%. Click-through rate: 8%. List size: 2,800 subscribers. Managed in Resend. Unsubscribe rate: < 0.5%."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f18"
+content = "Work anniversary: April 3, 4 years at current company. Stock cliff was at year 1 (25%), now in monthly vesting. Refresher grant vesting started Q3 last year."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f19"
+content = "Rust async runtime: Tokio. Using #[tokio::main] macro. Worker threads set to num_cpus. Blocking operations use tokio::task::spawn_blocking. No async-std or smol."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy3_f20"
+content = "Sprint planning: 2 weeks sprints. Story points via Fibonacci (1, 2, 3, 5, 8, 13). Velocity average: 42 points/sprint. No carry-over allowed — re-estimate and re-prioritize."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# Query: how is user data encrypted
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how is user data encrypted"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "noisy_enc_at_rest"
+content = "Data at rest: RDS storage encrypted with AWS KMS (AES-256). S3 buckets use SSE-S3 (AES-256). Redis Elasticache encrypted at rest with AES-256. Encryption keys managed by AWS — no customer-managed keys at this stage."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "noisy_enc_in_transit"
+content = "Data in transit: TLS 1.2 minimum, TLS 1.3 preferred. ALB terminates TLS. Redis in-transit encryption enabled. All inter-service communication is internal VPC — no clear-text paths. Certificate managed by ACM."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 3
+
+[[cases.seeds]]
+id = "noisy_enc_passwords"
+content = "Passwords hashed with Argon2id (argon2 crate), memory=65536, iterations=3, parallelism=4. Salt is randomly generated per password. Bcrypt not used — Argon2id is the current recommended standard."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_enc_pii"
+content = "PII handling: email addresses and names are stored in plaintext in Postgres. No application-level field encryption at this stage. GDPR compliance via access controls and the right-to-erasure flow (soft delete + anonymization)."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 2
+
+[[cases.seeds]]
+id = "noisy_enc_keys"
+content = "API keys stored as bcrypt hashes (cost factor 12) in the api_keys table. The plaintext key is shown to the user once on creation and never stored. Key prefix (first 8 chars) stored in plaintext for identification."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+
+# 20 filler seeds
+
+[[cases.seeds]]
+id = "noisy4_f01"
+content = "Object storage: S3 us-east-1. Versioning enabled on user-uploads bucket. Lifecycle: Glacier after 90 days, delete after 365. Pre-signed URL expiry: 15 minutes."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f02"
+content = "Qwen3-4B-Instruct-2507 used for on-device classification, quality assessment, and reranking. Metal GPU on Apple Silicon. Fallback: degrade gracefully if Metal is unavailable."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f03"
+content = "Fitness goal check-in: weight 178 lbs (target 175). Body fat 17% (target 14%). Increasing protein intake to 180g/day. Adding a second strength session per week."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f04"
+content = "SAML 2.0 SSO for enterprise customers. SP metadata at /sso/saml/metadata. Session created on successful assertion validation. Using the samael crate for SAML XML parsing."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f05"
+content = "Sprint retrospective action items from March sprint: improve flaky test detection, add pre-commit hooks for formatting, and write runbook for payment webhook failure recovery."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f06"
+content = "Origin agent registry: x-agent-name header is the canonical agent identifier. Trust level (trusted, standard, untrusted) assigned per agent name. Trust gates write permissions and confidence ceilings."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f07"
+content = "Furniture: planning to replace the home office desk. Candidates: Uplift V2 Commercial (72x30), Flexispot E7 Pro (72x30). Budget: $800. Decision pending ergonomics review."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f08"
+content = "Multi-tenant architecture: all data partitioned by account_id. Row-level security not used — application layer enforces account scoping on all queries. Verified in integration tests."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f09"
+content = "Personal GitHub repository naming convention: kebab-case for all repos, no underscores. Public repos have a description and at least one topic tag. Stale repos archived, not deleted."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f10"
+content = "Data export for GDPR: /api/settings/export triggers async job, packages JSON + files into ZIP, emails presigned download link. Expires in 7 days. Only one pending export per user allowed."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f11"
+content = "DeepSeek-R1 evaluated as an alternative to Qwen3 for on-device inference. Rejected: 8B model exceeds the 4 GB memory budget for the origin-server daemon on base Mac configurations."
+memory_type = "decision"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f12"
+content = "Emergency contact: Jordan (spouse), mobile (512) 555-0188. Doctor: Austin Primary Care, (512) 555-0243. Pharmacy: CVS on Congress Ave."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f13"
+content = "WebSocket /ws/updates broadcasts memory store events, refinery completion, and quality gate rejections. Connected clients include the Tauri app and any MCP client subscribed to updates."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f14"
+content = "Q1 revenue: $28k ARR. Q2 target: $60k ARR. Primary growth lever: content marketing + word-of-mouth. Paid ads not yet evaluated. CAC from content is $0."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f15"
+content = "Book notes: The Pragmatic Programmer chapter 8 (Pragmatic Projects). Key insight: great teams have a project identity. Action: establish team name and associated rituals before the next offsite."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f16"
+content = "Database schema convention: all tables have id (UUID), created_at, and updated_at. updated_at managed by a trigger. No ON UPDATE CURRENT_TIMESTAMP in Postgres — trigger is more reliable."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f17"
+content = "Local dev environment: Docker Compose with Postgres 16, Redis 7, Localstack. Run docker compose up -d before cargo run. pg_admin available at localhost:5050 for DB inspection."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f18"
+content = "Reading: Raft consensus algorithm paper. Implementing a simplified Raft in Rust as a learning project. Not intended for production use — purely educational. Repository: github.com/lucian/raft-rs."
+memory_type = "fact"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f19"
+content = "Origin's access tracker records memory access counts and applies time decay. High-access memories receive a retrieval score boost. Decay rate: 0.1 per day for memories not accessed in 7 days."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 0
+
+[[cases.seeds]]
+id = "noisy4_f20"
+content = "Board meeting scheduled for April 28. Deck needs to be sent 72 hours in advance. Topics: Q1 actuals, Q2 plan, headcount ask, competitive landscape update. Presenter: CEO with EM for engineering slides."
+memory_type = "fact"
+domain = "work"
+source_agent = "chatgpt"
+relevance = 0

--- a/app/eval/fixtures/agent_temporal_updates.toml
+++ b/app/eval/fixtures/agent_temporal_updates.toml
@@ -1,0 +1,271 @@
+# Temporal updates — preferences and decisions that evolve via supersedes chains.
+# Tests whether recency scoring correctly ranks the newest decision above older ones.
+# Relevance grades favor the newest decision (3) over intermediate (2) over oldest (1).
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: what frontend framework do I prefer
+# React -> Vue -> Svelte evolution over 18 months
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what frontend framework do I prefer"
+
+[[cases.seeds]]
+id = "atemporal_fe_react"
+content = "Preferred frontend framework is React 16 with Redux for state management. Chosen for ecosystem maturity and hiring pool size. All new projects start from a custom CRA template."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-desktop"
+relevance = 1
+age_days = 540
+confirmed = true
+
+[[cases.seeds]]
+id = "atemporal_fe_vue"
+content = "Switched preferred framework to Vue 3 with Composition API. React's boilerplate overhead was slowing solo projects. Vue's SFC format and built-in reactivity feel more productive. Using Vite instead of webpack."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+relevance = 2
+age_days = 210
+supersedes = "atemporal_fe_react"
+confirmed = true
+
+[[cases.seeds]]
+id = "atemporal_fe_svelte"
+content = "Current preferred frontend framework is Svelte with SvelteKit for routing. Tried Vue for a year — preferred the compiler-based approach of Svelte. Zero-runtime overhead, ships less JavaScript. TypeScript support is excellent."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+relevance = 3
+age_days = 14
+supersedes = "atemporal_fe_vue"
+
+[[cases.seeds]]
+id = "atemporal_fe_svelte_perf"
+content = "SvelteKit chosen for the new marketing site. Lighthouse score 98 on mobile vs 82 with the previous React SSR setup. Bundle size reduced from 380 KB to 42 KB gzipped."
+memory_type = "fact"
+domain = "personal"
+source_agent = "cursor"
+relevance = 2
+age_days = 10
+
+# Hard negatives — frontend vocabulary but not framework preference
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_fe_react_perf"
+content = "React 19 concurrent mode reduced jank on the dashboard page from 120ms frame drops to under 16ms. The useTransition hook on the search input was the key fix. Upgrading React was the right call for this specific project."
+memory_type = "fact"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_fe_css"
+content = "CSS framework preference: Tailwind CSS v4 for all new projects. Avoided CSS-in-JS solutions after team velocity suffered with styled-components in 2022. Tailwind intellisense plugin is mandatory."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_fe_state"
+content = "State management decision for current project: Zustand over Redux Toolkit. Zustand's API surface is smaller and the devtools experience is good enough for current complexity. Redux reserved for truly global complex state."
+memory_type = "decision"
+domain = "project:webapp"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_fe_testing"
+content = "Frontend testing preference: component tests with Vitest and React Testing Library. Storybook interaction tests for design system components. Playwright for E2E on critical paths only."
+memory_type = "preference"
+domain = "personal"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_fe_build"
+content = "Build tooling preference: Vite for all new projects. Parcel tried and abandoned — plugin ecosystem is thin. Webpack only for projects that predate Vite adoption. esbuild for CLI tooling."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: what deployment target are we using
+# Heroku -> AWS -> self-hosted evolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what deployment target are we using"
+
+[[cases.seeds]]
+id = "atemporal_deploy_heroku"
+content = "Deployed to Heroku using the standard web dyno. Postgres add-on for the database, Redis add-on for caching. Automatic deploys from the main branch. Heroku Pipelines for staging promotion."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "chatgpt"
+relevance = 1
+age_days = 730
+confirmed = true
+
+[[cases.seeds]]
+id = "atemporal_deploy_aws"
+content = "Migrated from Heroku to AWS ECS Fargate after Heroku removed the free tier and quoted $240/month for equivalent capacity. AWS costs $85/month for the same workload. GitHub Actions handles the deploy workflow."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 2
+age_days = 300
+supersedes = "atemporal_deploy_heroku"
+confirmed = true
+
+[[cases.seeds]]
+id = "atemporal_deploy_selfhosted"
+content = "Moved production to self-hosted Hetzner bare metal (CX51, 16-core, 32 GB RAM). Monthly cost dropped from $85 to $22. Using Nomad for container orchestration. Decision driven by the need for local LLM inference on GPU."
+memory_type = "decision"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 3
+age_days = 7
+supersedes = "atemporal_deploy_aws"
+
+[[cases.seeds]]
+id = "atemporal_deploy_selfhosted_detail"
+content = "Self-hosted setup: Hetzner CX51 primary, CX21 secondary for failover. Nomad for scheduling, Consul for service discovery, Traefik as the ingress reverse proxy. All config in Terraform and Nomad job specs."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+relevance = 2
+age_days = 5
+
+[[cases.seeds]]
+id = "atemporal_deploy_aws_intermediate"
+content = "AWS deployment was on ECS Fargate with a db.t3.medium RDS Postgres instance. Blue-green deployment with ECS deployment circuit breaker. Auto-scaling based on CPU utilization threshold of 70%."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+relevance = 1
+age_days = 280
+
+# Hard negatives — deployment vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_deploy_ci"
+content = "CI pipeline: GitHub Actions with matrix builds for Rust stable and beta. Test job, lint job, and security audit (cargo audit) in parallel. Deploy job runs only on main branch pushes and has an approval gate."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_deploy_secrets"
+content = "Secret management: Vault by HashiCorp for all production secrets. Application fetches secrets at startup via Vault Agent sidecar. Automatic secret rotation configured for database credentials."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_deploy_monitoring"
+content = "Monitoring: Prometheus scraping all services every 15 seconds. Grafana dashboards for API latency, DB connection pool usage, and queue depth. PagerDuty alerts on p99 > 500ms for 5 consecutive minutes."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_deploy_cdn"
+content = "Frontend static assets served from Cloudflare CDN. Cache-Control: max-age=31536000 on hashed filenames. index.html is always cache-busted via Cloudflare cache purge on deploy. Edge functions not yet used."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-desktop"
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# Query: what logging approach was decided
+# Structured logging evolution: println -> env_logger -> tracing with structured fields
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what logging approach was decided"
+
+[[cases.seeds]]
+id = "atemporal_log_println"
+content = "Logging initially done with println! macros. No structured format, no log levels. Log output goes to stdout and is captured by the process supervisor. Acceptable for early prototype stage."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 1
+age_days = 600
+
+[[cases.seeds]]
+id = "atemporal_log_env_logger"
+content = "Replaced println! with env_logger. Added RUST_LOG environment variable support. Log levels (trace/debug/info/warn/error) now consistent. Filter default set to warn to reduce noise. Still not structured (text lines)."
+memory_type = "decision"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 2
+age_days = 320
+supersedes = "atemporal_log_println"
+confirmed = true
+
+[[cases.seeds]]
+id = "atemporal_log_tracing"
+content = "Migrated from env_logger to the tracing crate with tracing-subscriber. All logs now structured with span fields (request_id, module). JSON output format in production, pretty format in dev. Spans propagate through async boundaries correctly."
+memory_type = "decision"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 3
+age_days = 45
+supersedes = "atemporal_log_env_logger"
+confirmed = true
+
+[[cases.seeds]]
+id = "atemporal_log_tracing_filter"
+content = "Default log filter: warn. Enable info-level for specific modules by adding 'origin_core::db=info,origin_server=info' to the RUST_LOG value. Avoid global info in production — it generates 2 MB/minute under load."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"
+relevance = 2
+age_days = 30
+
+[[cases.seeds]]
+id = "atemporal_log_tracing_opentelemetry"
+content = "OpenTelemetry integration planned for v0.3.0. Will export traces to a self-hosted Tempo instance via OTLP gRPC. tracing-opentelemetry bridge crate will be used. Deferred because it requires the Hetzner server setup first."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-desktop"
+relevance = 1
+age_days = 15
+
+# Hard negatives — logging vocabulary but wrong topic
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_log_audit"
+content = "Audit trail for user actions: written to a dedicated audit_events table in Postgres. Not in the application log files. Audit events include user_id, action, resource_id, and timestamp. Append-only by DB policy."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_log_cloudwatch"
+content = "Application logs shipped to CloudWatch Logs via the Fluentd sidecar in the ECS task definition. Log group per service, 30-day retention. Metric filters on ERROR log events trigger CloudWatch alarms."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "claude-code"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_log_sentry"
+content = "Sentry configured for error tracking. Only 5xx errors and panics forwarded. Sample rate 10% on 429 responses. Source maps uploaded from the frontend build. Alert on new error types in production."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "cursor"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_log_access"
+content = "HTTP access logs in Combined Log Format written to /var/log/nginx/access.log. Logrotate configured: daily rotation, 30-day retention, compressed with gzip. Access logs parsed by GoAccess for real-time dashboards."
+memory_type = "fact"
+domain = "project:saas"
+source_agent = "chatgpt"
+
+[[cases.negative_seeds]]
+id = "atemporal_neg_log_debug"
+content = "Debug builds include full backtraces via RUST_BACKTRACE=1. In production, backtraces are captured only for panics and written to the panic log file. Production does not expose backtraces in HTTP error responses."
+memory_type = "fact"
+domain = "project:origin"
+source_agent = "claude-code"

--- a/app/eval/fixtures/basic_search.toml
+++ b/app/eval/fixtures/basic_search.toml
@@ -1,0 +1,110 @@
+# Basic search quality eval — seed fixtures
+# These test that the ranking pipeline correctly orders results by relevance.
+
+[[cases]]
+query = "memory deduplication threshold"
+
+[[cases.seeds]]
+id = "mem_dedup_decision"
+content = "Set dedup similarity threshold to 0.85 cosine. Values below 0.80 cause false merges, above 0.90 miss near-duplicates."
+memory_type = "decision"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_dedup_impl"
+content = "Post-ingest pipeline checks vector similarity. Matches above threshold queued as dedup_merge proposals for review."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "mem_unrelated_identity"
+content = "User prefers dark mode in all applications"
+memory_type = "preference"
+domain = "personal"
+
+# Hard negative: mentions dedup and threshold but is about frame comparison, not memory dedup
+[[cases.negative_seeds]]
+id = "mem_frame_dedup_threshold"
+content = "Frame deduplication uses a Hellinger distance threshold of 0.15 on downscaled 64x64 pixel frames. Duplicate frames are dropped before OCR to reduce pipeline load."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative: mentions similarity and threshold but is about quality gate novelty check
+[[cases.negative_seeds]]
+id = "mem_novelty_threshold"
+content = "The novelty check in the quality gate uses a 0.92 cosine similarity threshold. Near-duplicate memories above this threshold are rejected and logged in the rejected_memories table."
+memory_type = "fact"
+domain = "origin"
+
+[[cases]]
+query = "how does confidence scoring work"
+
+[[cases.seeds]]
+id = "mem_confidence_formula"
+content = "Effective confidence = base_confidence(tier) * trust_weight(trust_level) * low_quality_multiplier. Protected tier base is 0.90, standard 0.70, ephemeral 0.50."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_confidence_decay"
+content = "Confidence decays over time at tier-specific rates. Protected: 0.001/day, Standard: 0.01/day, Ephemeral: 0.05/day."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+[[cases.seeds]]
+id = "mem_tangential"
+content = "The refinery runs periodic sweeps to update confidence values and generate recaps."
+memory_type = "fact"
+domain = "origin"
+relevance = 1
+
+# Hard negative: mentions confidence but is about agent trust levels, not the scoring formula
+[[cases.negative_seeds]]
+id = "mem_confidence_trust_level"
+content = "Agent trust levels determine the maximum confidence an agent can assign: trusted agents cap at 0.95, standard at 0.80, and untrusted at 0.50. Trust is set per agent profile."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative: mentions scoring and tiers but is about retrieval ranking, not confidence computation
+[[cases.negative_seeds]]
+id = "mem_retrieval_scoring"
+content = "Retrieval scoring multiplies the RRF base score by recency decay, quality multiplier, and domain boost. The final score is normalized to a 0-1 range for consumer display."
+memory_type = "fact"
+domain = "origin"
+
+[[cases]]
+query = "hybrid search reciprocal rank fusion"
+
+[[cases.seeds]]
+id = "mem_rrf_impl"
+content = "Hybrid search combines vector similarity and FTS5 full-text search using Reciprocal Rank Fusion. RRF score = sum(1/(60+rank)) for each signal."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "mem_unrelated_recap"
+content = "Session recap: worked on UI styling for the memory page header"
+memory_type = "recap"
+domain = "origin"
+
+# Hard negative: mentions RRF and search but is about graph augmentation, not the core RRF fusion
+[[cases.negative_seeds]]
+id = "mem_graph_rrf"
+content = "Knowledge graph observations are merged into the search result set as a third RRF signal. Entity matches from 2-hop traversal receive a rank-based score that is added to the vector+FTS RRF total."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative: mentions search fusion but is about score normalization, not RRF mechanics
+[[cases.negative_seeds]]
+id = "mem_score_normalization"
+content = "After RRF fusion, the final result set is normalized so the top-scoring result has score 1.0 and all others are proportional fractions. This normalization runs after all boosts and penalties are applied."
+memory_type = "fact"
+domain = "origin"

--- a/app/eval/fixtures/contradiction_detection.toml
+++ b/app/eval/fixtures/contradiction_detection.toml
@@ -1,0 +1,87 @@
+# Contradiction detection — tests retrieval when conflicting memories exist.
+# Content is natural language. Structured fields enable field-level comparison.
+
+[[cases]]
+query = "preferred programming language for systems work"
+
+[[cases.seeds]]
+id = "mem_pref_rust"
+content = "I prefer Rust for systems programming because of memory safety guarantees"
+memory_type = "preference"
+domain = "engineering"
+relevance = 3
+confirmed = true
+structured_fields = '{"preference":"Rust","applies_when":"systems programming"}'
+
+# Older contradicting preference
+[[cases.seeds]]
+id = "mem_pref_python"
+content = "I prefer Python for systems programming because of rapid prototyping"
+memory_type = "preference"
+domain = "engineering"
+relevance = 1
+structured_fields = '{"preference":"Python","applies_when":"systems programming"}'
+
+[[cases.negative_seeds]]
+id = "mem_pref_unrelated"
+content = "I prefer Python for data analysis and machine learning work"
+memory_type = "preference"
+domain = "engineering"
+structured_fields = '{"preference":"Python","applies_when":"data analysis"}'
+
+# Hard negative: mentions language preference and systems work but is about C++ not a competing preference
+[[cases.negative_seeds]]
+id = "mem_pref_cpp"
+content = "I used C++ for systems programming at my previous job but found the build system and memory management overhead frustrating compared to modern alternatives"
+memory_type = "fact"
+domain = "engineering"
+
+# Hard negative: mentions Rust and programming preference but is about a library choice, not language preference
+[[cases.negative_seeds]]
+id = "mem_pref_rust_tokio"
+content = "I prefer using Tokio over async-std for async Rust because the ecosystem and documentation are more mature. Most Rust crates assume Tokio as the runtime."
+memory_type = "preference"
+domain = "engineering"
+
+
+[[cases]]
+query = "Origin launch status"
+
+[[cases.seeds]]
+id = "mem_goal_current"
+content = "The goal is to launch Origin publicly by April 2026, currently in progress with core features built"
+memory_type = "goal"
+domain = "origin"
+relevance = 3
+confirmed = true
+structured_fields = '{"objective":"launch Origin publicly","status":"in_progress","target_date":"2026-04"}'
+
+# Outdated status
+[[cases.seeds]]
+id = "mem_goal_old"
+content = "Planning to launch Origin publicly, still in early planning phase"
+memory_type = "goal"
+domain = "origin"
+relevance = 1
+structured_fields = '{"objective":"launch Origin publicly","status":"planning"}'
+
+[[cases.negative_seeds]]
+id = "mem_goal_other"
+content = "Need to publish origin-mcp to npm but blocked on distribution setup"
+memory_type = "goal"
+domain = "origin"
+structured_fields = '{"objective":"publish origin-mcp to npm","status":"blocked"}'
+
+# Hard negative: mentions Origin and launch but is about a feature launch, not the product launch
+[[cases.negative_seeds]]
+id = "mem_feature_launch"
+content = "The working context feature is planned for launch after the core memory pipeline stabilizes. It adds a hot tier for recently accessed memories with recency scoring."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative: mentions launch and status but is about a competitor's launch, not Origin
+[[cases.negative_seeds]]
+id = "mem_competitor_launch"
+content = "Mem0 launched their managed cloud platform in Q1 2026 with a free tier of 1000 memories. Their pricing starts at $99/month for the pro plan with unlimited storage."
+memory_type = "fact"
+domain = "market"

--- a/app/eval/fixtures/cross_project_bleed.toml
+++ b/app/eval/fixtures/cross_project_bleed.toml
@@ -1,0 +1,82 @@
+# Cross-project bleed — querying one project shouldn't surface another project's memories.
+# Pattern seen: querying "ruru" returned Origin UI decisions, and vice versa.
+
+[[cases]]
+query = "authentication flow for mobile app"
+domain = "projectA"
+
+[[cases.seeds]]
+id = "mem_auth_mobile"
+content = "Implemented Google Sign-In with SHA-1 fingerprint registration for production builds. Debug keystore uses a different signing key than EAS builds."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_auth_tokens"
+content = "Access tokens stored in secure storage with 24-hour expiry. Refresh tokens persist across app restarts."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Cross-project noise — same technical domain but different project
+[[cases.negative_seeds]]
+id = "mem_other_project_auth"
+content = "Added OAuth middleware to the admin dashboard. Session cookies expire after 30 minutes of inactivity."
+memory_type = "decision"
+domain = "projectB"
+
+[[cases.negative_seeds]]
+id = "mem_other_project_general"
+content = "Migrated the API gateway from Express to Fastify for better request throughput."
+memory_type = "decision"
+domain = "projectB"
+
+# Hard negative: same project auth topic but about token refresh edge cases, not the main flow
+[[cases.negative_seeds]]
+id = "mem_auth_refresh_edge"
+content = "Token refresh silently fails when the device clock is more than 5 minutes ahead of the server. The client catches 401 errors and forces re-authentication via the Google Sign-In prompt."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: same project auth topic but about deep linking, not the auth flow itself
+[[cases.negative_seeds]]
+id = "mem_auth_deeplink"
+content = "OAuth redirect URIs for mobile deep linking use the app scheme prefix. Universal links require an apple-app-site-association file hosted on the signing domain."
+memory_type = "fact"
+domain = "projectA"
+
+
+[[cases]]
+query = "database schema migration strategy"
+domain = "projectB"
+
+[[cases.seeds]]
+id = "mem_migration_strategy"
+content = "Using versioned migrations with PRAGMA user_version. Each migration checks the current version and applies changes incrementally."
+memory_type = "decision"
+domain = "projectB"
+relevance = 3
+confirmed = true
+
+# Should NOT appear — different project's DB decisions
+[[cases.negative_seeds]]
+id = "mem_other_db"
+content = "Switched from PostgreSQL to libSQL for local-first architecture. Vector columns use F32_BLOB with DiskANN indexing."
+memory_type = "decision"
+domain = "projectA"
+
+# Hard negative: mentions schema migration but is about data migration tooling, not the strategy
+[[cases.negative_seeds]]
+id = "mem_migration_tooling"
+content = "Evaluated Flyway and Liquibase for managing schema migrations. Both were rejected because the project uses SQLite-compatible PRAGMA-based versioning that does not need a separate migration framework."
+memory_type = "decision"
+domain = "projectB"
+
+# Hard negative: mentions migration and version but is about embedding model migration, not schema
+[[cases.negative_seeds]]
+id = "mem_embed_migration"
+content = "Migration 25 nullifies all embedding columns when the model changes. The crash-recovery loop on next startup detects NULL embeddings and re-embeds each row before accepting new writes."
+memory_type = "fact"
+domain = "projectB"

--- a/app/eval/fixtures/empty_set_precision.toml
+++ b/app/eval/fixtures/empty_set_precision.toml
@@ -1,0 +1,102 @@
+# Empty-set precision — queries where the DB has nothing relevant.
+# All seeds are distractors. The system should express low confidence.
+
+[[cases]]
+query = "best Italian restaurants near downtown"
+empty_set = true
+
+[[cases.negative_seeds]]
+id = "neg_cooking_pref"
+content = "User prefers cooking at home with fresh ingredients over eating out"
+memory_type = "preference"
+domain = "personal"
+
+[[cases.negative_seeds]]
+id = "neg_rome_trip"
+content = "Visited Rome in 2024, loved the Colosseum and Vatican architecture"
+memory_type = "fact"
+domain = "travel"
+
+[[cases]]
+query = "Alice's phone number"
+empty_set = true
+
+[[cases.negative_seeds]]
+id = "neg_alice_project"
+content = "Alice reviewed the PR for the authentication module refactor"
+memory_type = "fact"
+domain = "work"
+
+[[cases.negative_seeds]]
+id = "neg_contacts_pref"
+content = "User prefers Signal over iMessage for group chats"
+memory_type = "preference"
+domain = "personal"
+
+[[cases]]
+query = "kubernetes cluster autoscaling configuration"
+empty_set = true
+
+[[cases.negative_seeds]]
+id = "neg_docker_compose"
+content = "Development environment uses docker-compose with PostgreSQL and Redis containers"
+memory_type = "fact"
+domain = "work"
+
+[[cases.negative_seeds]]
+id = "neg_deploy_script"
+content = "Deploy script runs cargo build --release then copies binary to /opt/origin/bin"
+memory_type = "fact"
+domain = "origin"
+
+[[cases.negative_seeds]]
+id = "neg_ci_pipeline"
+content = "GitHub Actions CI runs cargo test and cargo clippy on every PR"
+memory_type = "fact"
+domain = "origin"
+
+# Near-miss: mentions scaling and cluster but is about database, not k8s
+[[cases.negative_seeds]]
+id = "neg_db_cluster"
+content = "Considered clustering the libSQL database across multiple nodes for horizontal scaling but rejected it because the local-first architecture requires single-node operation."
+memory_type = "decision"
+domain = "origin"
+
+# Near-miss: mentions autoscaling and configuration but is about a load balancer, not k8s
+[[cases.negative_seeds]]
+id = "neg_autoscale_lb"
+content = "The Axum HTTP server auto-adjusts its connection pool size based on request load. Configuration caps the pool at 128 connections with a 30-second idle timeout."
+memory_type = "fact"
+domain = "origin"
+
+[[cases]]
+query = "what happened at the March board meeting"
+empty_set = true
+
+[[cases.negative_seeds]]
+id = "neg_standup"
+content = "Daily standup moved to 10am starting next week per team vote"
+memory_type = "decision"
+domain = "work"
+
+[[cases.negative_seeds]]
+id = "neg_quarterly"
+content = "Q1 revenue exceeded projections by 12%, driven by enterprise tier upgrades"
+memory_type = "fact"
+domain = "work"
+
+[[cases]]
+query = "how to make sourdough bread starter"
+empty_set = true
+
+[[cases.negative_seeds]]
+id = "neg_baking_none"
+content = "User tracks macros: 2200 calories, 180g protein target per day"
+memory_type = "preference"
+domain = "health"
+
+[[cases.negative_seeds]]
+id = "neg_grocery"
+content = "Switched to weekly grocery delivery from Instacart to save time"
+memory_type = "decision"
+domain = "personal"

--- a/app/eval/fixtures/gen/.gitignore
+++ b/app/eval/fixtures/gen/.gitignore
@@ -1,0 +1,3 @@
+# Generated fixtures — regenerate with: cargo run --bin fixture-gen
+*
+!.gitignore

--- a/app/eval/fixtures/graph_augmented_retrieval.toml
+++ b/app/eval/fixtures/graph_augmented_retrieval.toml
@@ -1,0 +1,93 @@
+# Graph-augmented retrieval — tests that entity observations surface in search results.
+# Phase A of quality v2: search_memory now includes knowledge graph via RRF merge.
+# Graded observations count toward MRR/NDCG — this measures graph augmentation value.
+
+[[cases]]
+query = "Rust programming language features"
+
+[[cases.seeds]]
+id = "mem_rust_borrow"
+content = "Rust uses a borrow checker to enforce memory safety at compile time without a garbage collector"
+memory_type = "fact"
+domain = "engineering"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_rust_async"
+content = "Rust async/await is built on top of the Future trait and requires a runtime like Tokio"
+memory_type = "fact"
+domain = "engineering"
+relevance = 2
+
+[[cases.entities]]
+name = "Rust"
+entity_type = "technology"
+domain = "engineering"
+observations = [
+    { content = "Rust is a systems programming language focused on safety and performance", relevance = 2 },
+    { content = "Rust has a strong type system with ownership and borrowing", relevance = 2 },
+    { content = "Rust was originally developed by Mozilla Research", relevance = 1 },
+]
+
+[[cases.negative_seeds]]
+id = "mem_python_gc"
+content = "Python uses reference counting with a cycle-detecting garbage collector for memory management"
+memory_type = "fact"
+domain = "engineering"
+
+
+[[cases]]
+query = "libSQL database capabilities"
+
+[[cases.seeds]]
+id = "mem_libsql_vectors"
+content = "libSQL supports F32_BLOB vector columns with DiskANN indexing for approximate nearest neighbor search"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.entities]]
+name = "libSQL"
+entity_type = "technology"
+domain = "origin"
+observations = [
+    { content = "libSQL is Turso's fork of SQLite with vector search and replication support", relevance = 3 },
+    { content = "libSQL supports FTS5 full-text search with auto-sync triggers", relevance = 2 },
+    { content = "libSQL Connection is Send but not Sync, wrap in tokio Mutex", relevance = 1 },
+]
+
+[[cases.negative_seeds]]
+id = "mem_postgres_vectors"
+content = "PostgreSQL supports vector search via the pgvector extension with IVFFlat and HNSW indexes"
+memory_type = "fact"
+domain = "general"
+
+
+[[cases]]
+query = "who is Lucian"
+
+[[cases.seeds]]
+id = "mem_lucian_role"
+content = "Lucian is a full-stack developer specializing in Rust and TypeScript"
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.entities]]
+name = "Lucian"
+entity_type = "person"
+domain = "personal"
+observations = [
+    { content = "Lucian is the founder of Origin, a personal agent memory layer", relevance = 3 },
+    { content = "Lucian prefers dark mode in all editors and terminals", relevance = 1 },
+    { content = "Lucian is a software engineer based in the US", relevance = 2 },
+]
+
+[[cases.negative_seeds]]
+id = "mem_other_person"
+content = "Alice is a data scientist who works on recommendation systems using PyTorch"
+memory_type = "identity"
+domain = "personal"

--- a/app/eval/fixtures/hard_cross_agent_noise.toml
+++ b/app/eval/fixtures/hard_cross_agent_noise.toml
@@ -1,0 +1,171 @@
+# Cross-agent noise — same knowledge stored by different agents in different styles.
+# Tests that retrieval finds the most relevant version, not just any version.
+# Pattern: Claude Code writes terse technical facts, ChatGPT writes verbose explanations,
+# manual entries are informal notes.
+
+[[cases]]
+query = "what database does the project use"
+
+# Most relevant: terse, confirmed, technical — should rank first
+[[cases.seeds]]
+id = "hca_db_claude"
+content = "Project uses libSQL (Turso's SQLite fork) with F32_BLOB vector columns and DiskANN indexing. Single DB at ~/Library/Application Support/origin/memorydb/."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+source_agent = "claude-code"
+
+# Same fact, verbose explanatory style — should rank second
+[[cases.seeds]]
+id = "hca_db_chatgpt"
+content = "The project uses libSQL, which is Turso's fork of SQLite. This was chosen because it provides built-in vector support via F32_BLOB columns and DiskANN indexing for approximate nearest neighbor search, while keeping everything local. All data lives in a single database file stored at ~/Library/Application Support/origin/memorydb/, which simplifies backup and avoids the need for a separate server process."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+source_agent = "chatgpt"
+
+# Same fact, informal shorthand — should rank third
+[[cases.seeds]]
+id = "hca_db_manual"
+content = "db = libsql, local file, vectors built in. chose over postgres bc no server needed."
+memory_type = "fact"
+domain = "origin"
+relevance = 1
+source_agent = "manual"
+
+# Distractor: session tracking consolidation — adjacent topic, not the answer
+[[cases.negative_seeds]]
+id = "hca_db_noise_session"
+content = "Session tracking was consolidated into memory_db.rs to reduce the number of open database connections and simplify the connection lifecycle."
+memory_type = "fact"
+domain = "origin"
+source_agent = "claude-code"
+
+# Distractor: PostgreSQL rejection rationale — mentions DB choice but is about what was NOT chosen
+[[cases.negative_seeds]]
+id = "hca_db_noise_postgres"
+content = "PostgreSQL was rejected early in the architecture evaluation. Running a server process locally conflicts with the local-first, zero-dependency installation goal."
+memory_type = "decision"
+domain = "origin"
+source_agent = "chatgpt"
+
+# Distractor: LanceDB evaluation — another DB mentioned but not the chosen one
+[[cases.negative_seeds]]
+id = "hca_db_noise_lancedb"
+content = "Evaluated LanceDB as an alternative for vector storage. Rust bindings were immature at the time and it would have required a second database for document and graph data."
+memory_type = "decision"
+domain = "origin"
+source_agent = "claude-code"
+
+# Distractor: tokio Mutex wrapping — DB internals, not which DB is used
+[[cases.negative_seeds]]
+id = "hca_db_noise_mutex"
+content = "libsql::Connection is Send but not Sync. Wrapped in tokio::sync::Mutex inside AppState so it can be shared across async tasks without data races."
+memory_type = "fact"
+domain = "origin"
+source_agent = "claude-code"
+
+# Distractor: WAL mode — a DB configuration detail, not which DB
+[[cases.negative_seeds]]
+id = "hca_db_noise_wal"
+content = "WAL mode is enabled at connection time via PRAGMA journal_mode=WAL. This allows concurrent reads to proceed while a write transaction is open."
+memory_type = "fact"
+domain = "origin"
+source_agent = "manual"
+
+# Distractor: FK constraints — schema enforcement detail
+[[cases.negative_seeds]]
+id = "hca_db_noise_fk"
+content = "Foreign key enforcement is activated with PRAGMA foreign_keys=ON at every connection. The knowledge graph tables (entities, relations, observations) rely on FK cascades for cleanup."
+memory_type = "fact"
+domain = "origin"
+source_agent = "chatgpt"
+
+# Distractor: schema tables list — structural detail, not DB identity
+[[cases.negative_seeds]]
+id = "hca_db_noise_schema"
+content = "Database schema includes: memories (vectors + FTS), entities, relations, observations, agent_profiles, sessions. All in one file."
+memory_type = "fact"
+domain = "origin"
+source_agent = "manual"
+
+# Distractor: parameterized queries — SQL safety convention, not DB choice
+[[cases.negative_seeds]]
+id = "hca_db_noise_params"
+content = "All SQL queries use parameterized placeholders (?) to prevent injection. Never interpolate user input directly into query strings."
+memory_type = "decision"
+domain = "origin"
+source_agent = "claude-code"
+
+
+[[cases]]
+query = "user's preferred coding workflow"
+
+# Most relevant: terse, confirmed, direct — should rank first
+[[cases.seeds]]
+id = "hca_wf_claude"
+content = "User prefers strict TDD with separate agents for test writing vs implementation. Tests first, then implementation, always."
+memory_type = "preference"
+domain = "personal"
+relevance = 3
+confirmed = true
+source_agent = "claude-code"
+
+# Same fact, verbose explanatory style — should rank second
+[[cases.seeds]]
+id = "hca_wf_chatgpt"
+content = "The user follows a strict test-driven development methodology. Before any implementation begins, tests are written independently — typically by a dedicated AI agent focused solely on test design. A separate AI agent then writes the implementation code against those tests. This separation ensures that the test suite is not biased by knowledge of how the implementation will work, providing genuine independent verification."
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+source_agent = "chatgpt"
+
+# Same fact, informal shorthand — should rank third
+[[cases.seeds]]
+id = "hca_wf_manual"
+content = "tdd always. separate agents for tests vs code. never skip the test step."
+memory_type = "preference"
+domain = "personal"
+relevance = 1
+source_agent = "manual"
+
+# Distractor: language preferences — workflow-adjacent but not the coding workflow
+[[cases.negative_seeds]]
+id = "hca_wf_noise_lang"
+content = "User prefers Rust for backend systems and TypeScript for frontend. Avoids Python in production code."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"
+
+# Distractor: dark mode — a preference but entirely unrelated to coding workflow
+[[cases.negative_seeds]]
+id = "hca_wf_noise_darkmode"
+content = "User prefers dark mode in all development tools. VS Code, terminal, and browser devtools all configured with dark themes."
+memory_type = "preference"
+domain = "personal"
+source_agent = "manual"
+
+# Distractor: squash merge preference — git workflow, not coding workflow
+[[cases.negative_seeds]]
+id = "hca_wf_noise_squash"
+content = "User prefers squash merges for feature branches to keep main history linear. Conventional commit messages required for all commits."
+memory_type = "preference"
+domain = "personal"
+source_agent = "chatgpt"
+
+# Distractor: code review requirement — process step, not the core coding workflow
+[[cases.negative_seeds]]
+id = "hca_wf_noise_review"
+content = "Code review is required before merging. A code-reviewer agent is dispatched after implementation is complete; critical and important issues must be resolved before the PR merges."
+memory_type = "decision"
+domain = "personal"
+source_agent = "claude-code"
+
+# Distractor: git worktrees — tooling preference, not TDD workflow
+[[cases.negative_seeds]]
+id = "hca_wf_noise_worktree"
+content = "Always create a git worktree before writing code for a new feature. Worktree isolates the feature branch and allows parallel dev server instances."
+memory_type = "preference"
+domain = "personal"
+source_agent = "claude-code"

--- a/app/eval/fixtures/hard_distractor_density.toml
+++ b/app/eval/fixtures/hard_distractor_density.toml
@@ -1,0 +1,617 @@
+# Hard: Distractor density — 50 memories in one domain, find the 2-3 relevant ones.
+# Simulates a mature memory store. Target: NDCG@10 < 0.80 to differentiate model quality.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# Query: chunking strategy for code blocks
+# 3 relevant seeds + 47 distractors, all domain="origin"
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how does the chunking strategy handle code blocks"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "hd_chunking_code"
+content = "The code-aware chunker detects fenced code blocks and never splits them mid-block; the entire block is kept as a single chunk so embedding captures the full syntax context."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "hd_chunking_lang"
+content = "Chunker inspects the language tag on fenced code fences (e.g. ```rust, ```ts) and stores it as chunk metadata so downstream retrieval can filter by programming language."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+[[cases.seeds]]
+id = "hd_chunking_overlap"
+content = "Fixed-size chunking uses a 64-token overlap between adjacent chunks to preserve context across boundaries, but code blocks opt out of overlap to avoid duplicating import sections."
+memory_type = "fact"
+domain = "origin"
+relevance = 1
+
+# Distractors (relevance = 0)
+
+[[cases.seeds]]
+id = "hd_d01"
+content = "Vector search uses DiskANN indexing over F32_BLOB(768) columns in libSQL; approximate nearest-neighbour queries return top-k candidates before RRF re-ranking."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d02"
+content = "Full-text search is backed by an FTS5 virtual table (memories_fts) that is kept in sync with the memories table via SQLite triggers on insert, update, and delete."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d03"
+content = "Hybrid search combines vector similarity with FTS scores using Reciprocal Rank Fusion with a tunable rrf_k parameter; default is 60."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d04"
+content = "PII redaction runs before storage and replaces credit card numbers, SSNs, API keys, and email addresses with [REDACTED] placeholders."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d05"
+content = "The refinery runs background enrichment sweeps every 30 minutes: entity extraction, dedup proposals, and recap triggering are the three active phases."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d06"
+content = "Database migrations use PRAGMA user_version; each migration function checks the current version and applies changes incrementally up to the target version."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d07"
+content = "The toast window is a non-activating transparent overlay panel; it receives capture-event Tauri events and auto-dismisses after 4 seconds."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d08"
+content = "Quick-capture is a popup window triggered by the global hotkey; it lets users type a thought that is immediately stored as a memory without leaving their current app."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d09"
+content = "The Spotlight search window activates on Cmd+K and supports source filters, semantic search, and a working-memory panel showing the most recent captures."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d10"
+content = "Frontend server state is managed by TanStack React Query 5; all Tauri command responses are cached and invalidated on capture-event to keep the UI fresh."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d11"
+content = "MemoryCard components render summary as the primary text, falling back to content when summary is null; cards show memory_type as a badge and domain as a subtitle."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d12"
+content = "The Axum HTTP server listens on 127.0.0.1:7878 and also binds a Unix socket for same-machine tool integration; both surfaces share the same router."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d13"
+content = "Agent trust levels are enforced at write time: untrusted agents cannot set confirmed=true or relevance above 1 without human review."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d14"
+content = "The smart router deduplicates incoming trigger events using bigram Jaccard similarity with a 0.85 threshold before forwarding context bundles downstream."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d15"
+content = "AFK detection uses CGEventSource to poll idle time; captures are suppressed if the user has been idle for more than 60 seconds."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d16"
+content = "The focus sensor runs on a dedicated std::thread at 10 Hz, tracking cursor position with a 50-pixel radius and 2-second dwell threshold to determine the focused window."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d17"
+content = "The LLM formatter thread runs Qwen3-4B-Instruct-2507 via llama-cpp-2 on the Metal GPU; it captures a Tokio runtime Handle at spawn time for async DB write-back."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d18"
+content = "Persistent config is stored as JSON at ~/Library/Application Support/origin/config.json and is loaded at startup; hot-reload is not currently supported."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d19"
+content = "The file watcher uses the notify crate with a 2-second debounce; changed files are queued as RawDocuments for the two-pass capture pipeline."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d20"
+content = "WebSocket updates are served at /ws/updates on the Axum server; clients subscribe to receive real-time memory store and refinery phase completion events."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d21"
+content = "The /api/profile endpoint returns the user's identity fields including name, occupation observation, and preferred domains stored in the knowledge graph."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d22"
+content = "Spaces (projects) partition memories so that querying one project does not surface memories from another; domain acts as the partition key in hybrid search."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d23"
+content = "Stability tiers classify memories into ephemeral, working, and long-term based on confirmation status and recency; tiers influence retrieval weighting."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d24"
+content = "Confidence scores range from 0.0 to 1.0 and are assigned by the LLM classifier at store time; agent-written memories start at 0.7 unless explicitly overridden."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d25"
+content = "The quality gate rejects memories whose content fails minimum length, language detection, or information-density checks before they reach the embedding step."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d26"
+content = "Contradiction detection compares new memories against existing ones for the same entity; detected conflicts are flagged for human review rather than silently overwritten."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d27"
+content = "Distillation periodically collapses clusters of related memories into a single high-quality recap memory, reducing retrieval noise from redundant observations."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d28"
+content = "The supersede field records the ID of the earlier memory that a newer memory replaces; superseded memories are excluded from default search results."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d29"
+content = "Session tracking records the active session ID on each memory at write time so memories can be filtered or grouped by the conversation that produced them."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d30"
+content = "Tags are stored in a separate tag store and linked to memories by ID; the tag index enables fast filtering without adding columns to the memories table."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d31"
+content = "Apple Vision OCR is invoked per captured frame; results are passed through the OCR text cleanup pipeline before being assembled into a ContextBundle."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d32"
+content = "Frame comparison uses a 3-tier strategy: downscale to 64x64, perceptual hash, then Hellinger distance; frames below the similarity threshold are dropped without OCR."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d33"
+content = "Tauri commands are registered in lib.rs using the invoke_handler macro; there are approximately 92 commands covering search, memory CRUD, config, and capture control."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d34"
+content = "Frontend routing is hash-based: #/ loads the main window, #/toast loads the overlay, #/snip loads the selection overlay, and #/quick-capture loads the popup."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d35"
+content = "The memory detail page is the sole owner of edit actions; MemoryCard only shows fast hover toggles (confirm dot, delete) and delegates all other actions to the detail view."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d36"
+content = "Collapsed sidebar section state is persisted to localStorage with a 7-day TTL; stale entries are pruned on next load to avoid unbounded storage growth."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d37"
+content = "The processingStore uses the useSyncExternalStore pattern so capture progress state survives React component unmounts between navigation events."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d38"
+content = "Domain boost multiplies the base retrieval score by 1.5x when the search query explicitly mentions the memory's domain name, improving precision for project-scoped queries."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d39"
+content = "Recency decay reduces the effective score of memories older than 90 days by applying an exponential decay factor so stale information ranks below fresh observations."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d40"
+content = "FastEmbed caches model weights in .fastembed_cache/ at the repo root; on first run the 140 MB GTE-Base-EN-v1.5-Q model is downloaded and stored there."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d41"
+content = "Multi-row insert and delete loops are wrapped in explicit BEGIN/COMMIT transactions to ensure atomicity and improve write throughput on the libSQL connection."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d42"
+content = "WAL mode and foreign-key enforcement are set via PRAGMA at connection open time; FK cascades propagate deletes from entities to linked observations and relations."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d43"
+content = "Markdown-aware chunking preserves heading hierarchy so that each chunk inherits its parent headings as metadata, enabling section-level filtering during retrieval."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d44"
+content = "The knowledge graph stores entities, relations, and observations in separate tables with foreign-key cascades; 2-hop traversal is used to augment retrieval results."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d45"
+content = "Embedding model was upgraded from BGE-Small (384-dim) to GTE-Base-EN-v1.5-Q (768-dim) in migration 24; the larger model delivers +125% NDCG on combined benchmarks."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d46"
+content = "Source deduplication during retrieval removes candidates that share a source_id, then a content Jaccard pass removes near-duplicate text before final ranking."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd_d47"
+content = "The snip window is a full-screen transparent overlay used for region selection; the selected region coordinates are sent back to the router as a TriggerEvent payload."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# Query: what triggers a memory to be archived
+# 2 relevant seeds + 2 hard negatives + 30 distractors, all domain="origin"
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what triggers a memory to be archived"
+
+# Relevant seeds
+
+[[cases.seeds]]
+id = "hd2_archive_trigger"
+content = "A memory is automatically archived when its recency decay score drops below the archive threshold (default 0.05) and it has not been confirmed or accessed in the past 180 days."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "hd2_archive_decay"
+content = "Human confirmation resets the decay clock on a memory, preventing archival; memories confirmed by the user are exempt from automatic archival regardless of age."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+# Hard negatives — archive-adjacent but wrong concept
+
+[[cases.negative_seeds]]
+id = "hd2_neg_supersede"
+content = "When a memory is stored with replace mode, the previous memory with the same entity and attribute is marked superseded and hidden from default search results, but it is not archived — it remains queryable with include_superseded=true."
+memory_type = "fact"
+domain = "origin"
+
+[[cases.negative_seeds]]
+id = "hd2_neg_quality_gate"
+content = "The quality gate rejects low-density memories before they are ever stored; rejected candidates are written to a separate quality_rejects table for audit but never appear in the memories table."
+memory_type = "fact"
+domain = "origin"
+
+# Distractors (relevance = 0)
+
+[[cases.seeds]]
+id = "hd2_d01"
+content = "Vector search uses DiskANN indexing over F32_BLOB(768) columns; top-k candidates are retrieved before RRF re-ranking merges vector and FTS scores."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d02"
+content = "FTS5 virtual table memories_fts is kept in sync with the memories table via insert, update, and delete triggers registered at schema creation time."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d03"
+content = "Hybrid search blends vector and full-text scores using Reciprocal Rank Fusion; the rrf_k parameter is tunable via SearchScoringConfig without recompilation."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d04"
+content = "PII redaction applies regex patterns for credit cards, SSNs, API keys, and emails before any content reaches the embedding step or the database."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d05"
+content = "The refinery enrichment sweeps run every 30 minutes and cover entity extraction, dedup proposal generation, and recap triggering in a fixed phase sequence."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d06"
+content = "Database migrations use PRAGMA user_version for version tracking; each numbered migration function is idempotent and applied only when the current version is below target."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d07"
+content = "The toast window is a non-activating transparent overlay that displays capture notifications and auto-dismisses after 4 seconds without stealing window focus."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d08"
+content = "Quick-capture lets users store a thought via a popup without leaving their current app; the stored memory is immediately available in Spotlight search."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d09"
+content = "The smart router applies bigram Jaccard deduplication at a 0.85 threshold so near-identical OCR frames do not generate redundant memory candidates."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d10"
+content = "AFK detection suppresses captures when idle time exceeds 60 seconds, preventing empty or lock-screen frames from entering the pipeline."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d11"
+content = "The focus sensor polls cursor position at 10 Hz on a dedicated thread and records the front-most window after a 2-second dwell within a 50-pixel radius."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d12"
+content = "Qwen3-4B-Instruct-2507 runs on Metal GPU via llama-cpp-2 on a dedicated std::thread; the thread bridges back to Tokio for async memory write-back."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d13"
+content = "Config is persisted as JSON at ~/Library/Application Support/origin/config.json; feature toggles read from config are exposed as AtomicBool flags for lock-free reads."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d14"
+content = "The file watcher debounces filesystem events by 2 seconds using the notify crate before queuing changed files for the two-pass capture pipeline."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d15"
+content = "WebSocket /ws/updates broadcasts real-time events for memory stores, refinery phase completions, and quality gate rejections to connected clients."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d16"
+content = "Agent trust levels gate write permissions: untrusted agents cannot set confirmed=true or assign relevance above the trust-tier ceiling without human approval."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d17"
+content = "Stability tiers (ephemeral, working, long-term) are derived from confirmation status and recency; tier assignment influences retrieval weighting and display grouping."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d18"
+content = "Confidence scores are assigned by the LLM classifier at store time on a 0.0–1.0 scale; agent-written memories default to 0.7 unless explicitly overridden in the payload."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d19"
+content = "Contradiction detection flags semantic conflicts between new and existing memories for the same entity so humans can resolve them rather than silently overwrite."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d20"
+content = "Distillation collapses clusters of semantically similar memories into a single recap memory, reducing retrieval noise while preserving the most informative details."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d21"
+content = "Session tracking stamps each memory with the active session ID at write time so memories can later be filtered or grouped by the conversation that produced them."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d22"
+content = "Tags are stored in a side table and linked to memories by ID; the tag index supports fast multi-tag intersection queries without additional columns on the memories table."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d23"
+content = "Apple Vision OCR processes each captured frame and passes cleaned text through the OCR text cleanup pipeline before ContextBundle assembly."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d24"
+content = "Frame comparison applies a 3-tier strategy (downscale, perceptual hash, Hellinger distance) and drops frames below the similarity threshold before invoking OCR."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d25"
+content = "Domain boost applies a 1.5x multiplier to retrieval scores when the query explicitly names the memory domain, improving precision for project-scoped searches."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d26"
+content = "FastEmbed caches GTE-Base-EN-v1.5-Q model weights in .fastembed_cache/ at the repo root; the 140 MB weights are downloaded once on first startup."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d27"
+content = "Batch insert and delete operations are wrapped in explicit BEGIN/COMMIT transactions to ensure atomicity and avoid excessive per-row WAL entries."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d28"
+content = "The code-aware chunker preserves fenced code blocks as atomic units and stores the language tag from the fence as chunk metadata for language-filtered retrieval."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d29"
+content = "Markdown-aware chunking inherits parent heading hierarchy as metadata on each chunk, enabling section-level filtering without reprocessing the source document."
+memory_type = "fact"
+domain = "origin"
+relevance = 0
+
+[[cases.seeds]]
+id = "hd2_d30"
+content = "Source deduplication during retrieval removes candidates sharing a source_id, then a content Jaccard pass removes near-duplicate text before final RRF ranking."
+memory_type = "fact"
+domain = "origin"
+relevance = 0

--- a/app/eval/fixtures/hard_domain_boundary.toml
+++ b/app/eval/fixtures/hard_domain_boundary.toml
@@ -1,0 +1,131 @@
+# Domain boundary blur — technical content that exists in multiple projects.
+# Queries scoped to one domain, but the other domain has very similar content.
+# Tests that domain filtering + semantic search correctly isolate results.
+
+[[cases]]
+query = "error handling patterns in the API layer"
+domain = "projectA"
+
+[[cases.seeds]]
+id = "hdb_api_errors_a"
+memory_type = "fact"
+content = "API routes return structured error JSON with code, message, and optional detail fields. HTTP status codes follow REST conventions: 400 for validation, 404 for not found, 500 for internal."
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "hdb_error_types_a"
+memory_type = "fact"
+content = "Custom OriginError enum wraps VectorDb, Embedding, Generic, and IO variants. Axum's IntoResponse converts each variant to the appropriate HTTP status."
+domain = "projectA"
+relevance = 2
+confirmed = false
+
+[[cases.negative_seeds]]
+id = "hdb_api_errors_b"
+content = "API endpoints return JSON error responses with status, message, and trace_id. Standard HTTP codes: 400 for bad input, 401 for unauthorized, 500 for server errors."
+memory_type = "fact"
+domain = "projectB"
+
+[[cases.negative_seeds]]
+id = "hdb_error_types_b"
+content = "AppError enum covers Database, Auth, Validation, and NotFound variants. Each maps to a specific HTTP status code via the error handler middleware."
+memory_type = "fact"
+domain = "projectB"
+
+[[cases.seeds]]
+id = "hdb_rate_limiting_a"
+memory_type = "fact"
+content = "API rate limiting enforced at 100 requests per minute per client. Exceeded requests receive a 429 Too Many Requests response with a Retry-After header."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases.seeds]]
+id = "hdb_request_logging_a"
+memory_type = "fact"
+content = "All incoming API requests are logged with method, path, status code, and duration. Structured JSON logs emitted to stdout for downstream ingestion."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases.seeds]]
+id = "hdb_health_endpoint_a"
+memory_type = "fact"
+content = "The /api/health endpoint returns 200 OK with a JSON body containing version, uptime, and database connectivity status. Used by load balancers for liveness checks."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases.seeds]]
+id = "hdb_pagination_a"
+memory_type = "fact"
+content = "List endpoints support cursor-based pagination via a next_cursor field in the response envelope. Page size defaults to 20 and can be overridden up to 100 via the limit query parameter."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases.seeds]]
+id = "hdb_content_type_a"
+memory_type = "fact"
+content = "API endpoints validate the Content-Type header and reject non-JSON bodies with a 415 Unsupported Media Type response before parsing the request body."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases]]
+query = "how is state managed in the frontend"
+domain = "projectA"
+
+[[cases.seeds]]
+id = "hdb_state_a"
+memory_type = "fact"
+content = "Frontend state uses TanStack React Query for server state with automatic cache invalidation. Module-level stores with useSyncExternalStore for state that survives unmounts."
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "hdb_state_local_a"
+memory_type = "fact"
+content = "localStorage persists collapsed section state and sidebar toggle with 7-day TTL. QueryClient retains cache for 5 minutes before refetch."
+domain = "projectA"
+relevance = 2
+confirmed = false
+
+[[cases.negative_seeds]]
+id = "hdb_state_b"
+content = "React Query handles server state with staleTime of 30 seconds. Zustand stores manage client-side state with persist middleware writing to localStorage."
+memory_type = "fact"
+domain = "projectB"
+
+[[cases.negative_seeds]]
+id = "hdb_state_local_b"
+content = "User preferences stored in localStorage with JSON serialization. Redux Toolkit manages global UI state including sidebar, theme, and notification preferences."
+memory_type = "fact"
+domain = "projectB"
+
+[[cases.seeds]]
+id = "hdb_backend_state_a"
+memory_type = "fact"
+content = "Backend application state is held in Arc<RwLock<AppState>> managed by Tauri. Atomic flags (Arc<AtomicBool>) are used for feature toggles shared with sensor threads for lock-free reads."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases.seeds]]
+id = "hdb_processing_store_a"
+memory_type = "fact"
+content = "processingStore.ts uses the useSyncExternalStore pattern at module level so processing state survives React component unmounts between route navigations."
+domain = "projectA"
+relevance = 0
+confirmed = false
+
+[[cases.seeds]]
+id = "hdb_capture_heartbeat_a"
+memory_type = "fact"
+content = "captureHeartbeat.ts runs as a module-level singleton outside the React tree. It emits heartbeat ticks to indicate active capture sessions independent of component lifecycle."
+domain = "projectA"
+relevance = 0
+confirmed = false

--- a/app/eval/fixtures/hard_negative_vocabulary.toml
+++ b/app/eval/fixtures/hard_negative_vocabulary.toml
@@ -1,0 +1,98 @@
+# Hard negatives with high vocabulary overlap. Each negative shares key terms with the relevant
+# seed but answers a different question. Tests that the embedding model captures meaning, not
+# just word co-occurrence.
+
+# CASE 1: embedding generation
+# All seeds (relevant + negative) mention: embeddings, model, 768-dim, BGE-Base-Q.
+# The query asks HOW embeddings are generated. Negatives answer WHERE they are used (search),
+# WHEN they are rebuilt (migration), and HOW they are cached — not how they are produced.
+
+[[cases]]
+query = "how are embeddings generated for new memories"
+domain = "origin"
+
+# Relevance 3 — directly answers HOW generation works: thread, ONNX, prefix, 768-dim output.
+[[cases.seeds]]
+id = "hnv_embed_gen"
+content = "New memories are embedded on a dedicated std::thread using GTE-Base-EN-v1.5-Q (768-dim). The domain prefix is prepended to the raw content string before ONNX inference runs, producing a 768-dimensional F32 vector stored in the memories table."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+# Relevance 2 — explains the prefix step that is part of generation, one level of detail up.
+[[cases.seeds]]
+id = "hnv_embed_prefix"
+content = "A domain prefix such as [conversation] or [origin] is prepended to memory content before the GTE-Base-EN-v1.5-Q model encodes it. Ablation testing showed prefix-only embedding yields +1.9% NDCG over bare content on retrieval benchmarks."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+# Hard negative — same model and 768-dim vocabulary, but topic is SEARCH query embedding, not storage.
+[[cases.negative_seeds]]
+id = "hnv_neg_search"
+content = "Search queries are encoded with the same GTE-Base-EN-v1.5-Q model at query time, producing a 768-dim vector. Cosine distance is computed via DiskANN approximate nearest-neighbour index over the memories table."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative — same model and 768-dim vocabulary, but topic is MIGRATION recovery, not generation.
+[[cases.negative_seeds]]
+id = "hnv_neg_migration"
+content = "Migration 25 sets the embedding column to NULL for all rows in the memories table when the model changes. On next startup, the crash-recovery loop detects NULL 768-dim slots and re-embeds each row using GTE-Base-EN-v1.5-Q before accepting new writes."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative — same model and 768-dim vocabulary, but topic is CACHING, not generation.
+[[cases.negative_seeds]]
+id = "hnv_neg_cache"
+content = "An in-process LRU cache holds the 200 most recently computed 768-dim vectors produced by GTE-Base-EN-v1.5-Q. Cache hits skip ONNX inference entirely; misses fall through to the embedding thread."
+memory_type = "fact"
+domain = "origin"
+
+
+# CASE 2: quality gate rejection
+# All seeds (relevant + negative) mention: quality gate, reject/rejection, memory.
+# The query asks WHEN the gate rejects. Negatives answer what the gate ACCEPTS, what happens
+# to low-quality memories that are NOT rejected, and how rejection is surfaced to the user.
+
+[[cases]]
+query = "when does the quality gate reject a memory"
+domain = "origin"
+
+# Relevance 3 — directly answers the rejection conditions: short, URL-only, boilerplate.
+[[cases.seeds]]
+id = "hnv_gate_reject"
+content = "The quality gate rejects a memory and writes it to the rejected_memories table when it fails content checks: fewer than 10 words, URL-only content with no surrounding text, or matches a boilerplate pattern such as 'click here' or 'loading…'."
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+# Relevance 2 — explains the near-duplicate path to rejection, a second condition.
+[[cases.seeds]]
+id = "hnv_gate_novelty"
+content = "The quality gate rejects a memory as a near-duplicate when its embedding cosine similarity to an existing memory exceeds 0.92. The rejection record in rejected_memories logs the ID of the similar memory that caused the block."
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+# Hard negative — same vocabulary (quality gate, reject, memory), but answers what the gate ACCEPTS.
+[[cases.negative_seeds]]
+id = "hnv_neg_accept"
+content = "A memory passes the quality gate when it clears both the content check (at least 10 words, not URL-only, no boilerplate) and the novelty check (cosine similarity below 0.92 against all stored memories). Accepted memories enter the embedding pipeline."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative — same vocabulary, but answers what happens to LOW-QUALITY memories that are NOT rejected.
+[[cases.negative_seeds]]
+id = "hnv_neg_confidence"
+content = "Memories that the quality gate scores as low-quality but does not reject receive a 0.7x confidence multiplier at write time. They remain searchable but rank lower than confirmed or high-quality memories in retrieval scoring."
+memory_type = "fact"
+domain = "origin"
+
+# Hard negative — same vocabulary, but answers how rejection is SURFACED to the user, not when it occurs.
+[[cases.negative_seeds]]
+id = "hnv_neg_ui"
+content = "When the quality gate rejects a memory, a toast notification displays the reason (too short, duplicate, or boilerplate). The settings page exposes a toggle to disable content-length rejection for agents that store intentionally terse memories."
+memory_type = "fact"
+domain = "origin"

--- a/app/eval/fixtures/hard_temporal_decisions.toml
+++ b/app/eval/fixtures/hard_temporal_decisions.toml
@@ -1,0 +1,169 @@
+# Temporal decisions — multiple decisions on the same topic over time. The most recent decision
+# should rank highest, but older ones are still partially relevant. Tests that retrieval handles
+# temporal disambiguation.
+
+[[cases]]
+query = "which embedding model are we using"
+
+[[cases.seeds]]
+id = "htd_model_v1"
+content = "Chose BGE-Small-EN-v1.5 (384-dim) for embeddings. Fast inference, good quality for the initial version."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 1
+
+[[cases.seeds]]
+id = "htd_model_v2"
+content = "Upgraded embeddings from BGE-Small to GTE-Base-Q (768-dim). Doubles vector dimensions for better semantic capture. Migration 24 handles re-embedding."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 1
+
+[[cases.seeds]]
+id = "htd_model_v3"
+content = "Switched from GTE-Base-Q to BGE-Base-Q (768-dim, same dimensions). BGE-Base-Q scored +1.5% NDCG on LoCoMo and +75% on semantic disconnect. Same BAAI family as original."
+memory_type = "decision"
+domain = "origin"
+confirmed = true
+relevance = 3
+
+# Distractors — other technology decisions
+[[cases.seeds]]
+id = "htd_distractor_llm"
+content = "Chose Qwen3-4B-Instruct-2507 as the on-device LLM, running via llama-cpp-2 with Metal GPU acceleration."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_indexing"
+content = "Adopted DiskANN for approximate nearest-neighbor indexing over the memories table. Provides sub-millisecond retrieval at scale without a separate vector DB."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_rrf"
+content = "Using Reciprocal Rank Fusion (RRF) to combine vector similarity and FTS5 full-text search scores into a single hybrid ranking."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_libsql"
+content = "Selected libSQL (Turso's SQLite fork) as the single database for everything: vectors, knowledge graph, documents, and FTS."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_tauri"
+content = "Built the desktop shell with Tauri 2 targeting macOS-first. Avoids Electron's memory footprint while keeping a native system-tray experience."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_react"
+content = "Chose React 19 with TanStack React Query 5 for the frontend. Server state lives in React Query; cross-unmount state uses useSyncExternalStore module stores."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_pnpm"
+content = "Using pnpm as the package manager for the frontend monorepo. Faster installs and strict phantom-dependency prevention."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_prefix"
+content = "Settled on domain-only embedding prefix (e.g. '[origin]') rather than '[type | domain | agent]'. Autoresearch ablation showed +25% NDCG — type labels add noise."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+# Hard negative — different project's embedding decision
+[[cases.negative_seeds]]
+id = "htd_hard_neg_projectb"
+content = "Chose text-embedding-3-small from OpenAI for embeddings. Cost-effective at $0.02/million tokens; 1536-dim output truncated to 512 for storage efficiency."
+memory_type = "decision"
+domain = "projectB"
+
+[[cases]]
+query = "what is the current authentication approach"
+
+[[cases.seeds]]
+id = "htd_auth_v1"
+content = "No authentication initially — server binds to localhost only, so only local processes can reach it. Sufficient for single-user desktop use."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 1
+
+[[cases.seeds]]
+id = "htd_auth_v2"
+content = "Added bearer token authentication. Token generated on first launch and stored in config.json. Callers include it in the Authorization header."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 2
+
+[[cases.seeds]]
+id = "htd_auth_v3"
+content = "Now supports bearer tokens for MCP clients and session cookies for browser access. Tokens stored in config; cookies issued on first authenticated request and expire after 24 hours."
+memory_type = "decision"
+domain = "origin"
+confirmed = true
+relevance = 3
+
+# Distractors — auth-adjacent topics
+[[cases.seeds]]
+id = "htd_distractor_trust"
+content = "Agent trust levels (confirmed, inferred, speculative) gate which memory tiers are surfaced in context. Trust is per-source, not per-user."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_cors"
+content = "CORS is restricted to localhost origins on the Axum server. Remote browser extensions must proxy through a local relay to avoid cross-origin blocks."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_remote"
+content = "Remote access feature (PR #34) exposes the Axum HTTP API externally so ChatGPT and Claude can reach it. Integration testing underway."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+[[cases.seeds]]
+id = "htd_distractor_oauth"
+content = "OAuth gap: Claude.ai requires OAuth 2.0 for MCP connections, but origin-mcp only issues bearer tokens. Bridging this is a pending launch blocker."
+memory_type = "decision"
+domain = "origin"
+confirmed = false
+relevance = 0
+
+# Hard negative — different project's auth decision
+[[cases.negative_seeds]]
+id = "htd_hard_neg_projecta"
+content = "Implemented Google Sign-In for the mobile app using Firebase Auth. ID tokens are verified server-side; refresh tokens stored in the device keychain."
+memory_type = "decision"
+domain = "projectA"

--- a/app/eval/fixtures/identity_leakage.toml
+++ b/app/eval/fixtures/identity_leakage.toml
@@ -1,0 +1,80 @@
+# Identity leakage — personal identity memories should not appear in technical queries.
+# Pattern seen: querying "ruru hybrid search" returned name, employer, RSU details.
+
+[[cases]]
+query = "vector embedding model selection"
+
+[[cases.seeds]]
+id = "mem_embedding_choice"
+content = "Using AllMiniLM-L6-v2 with 384-dimensional embeddings via FastEmbed. Chosen for balance of quality and inference speed on-device."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_embedding_perf"
+content = "Embedding generation takes approximately 15ms per chunk on M-series GPU. Batch embedding of 100 chunks completes in under 2 seconds."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Identity memories that mention technical terms but are irrelevant
+[[cases.negative_seeds]]
+id = "mem_identity_employer"
+content = "Works as a senior engineer at a machine learning infrastructure company. Focuses on embedding pipelines and model serving."
+memory_type = "identity"
+domain = "personal"
+
+[[cases.negative_seeds]]
+id = "mem_identity_skills"
+content = "Experienced with PyTorch, ONNX runtime, and vector database systems. Previously worked on recommendation models."
+memory_type = "identity"
+domain = "personal"
+
+# Hard negative: mentions embedding model selection but is about a blog post read, not a project decision
+[[cases.negative_seeds]]
+id = "mem_embed_blog"
+content = "Read an article comparing MTEB leaderboard embeddings. GTE-Large outperforms all-MiniLM on retrieval tasks but is 4x slower. The author recommends MiniLM for latency-sensitive applications."
+memory_type = "fact"
+domain = "personal"
+
+# Hard negative: mentions vector model and dimensions but is about a course taken, not a selection decision
+[[cases.negative_seeds]]
+id = "mem_embed_course"
+content = "Completed a course on vector embeddings covering word2vec, GloVe, and transformer-based models. Key takeaway: 384-dim models offer the best quality-to-latency tradeoff for on-device inference."
+memory_type = "fact"
+domain = "personal"
+
+
+[[cases]]
+query = "API endpoint design patterns"
+
+[[cases.seeds]]
+id = "mem_api_patterns"
+content = "REST endpoints follow resource-based naming with /api prefix. Memory CRUD at /api/memory/store, /api/memory/search, /api/memory/delete. Health and status at /api/health."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+# Personal preference that mentions API but is irrelevant
+[[cases.negative_seeds]]
+id = "mem_pref_api"
+content = "Prefers RESTful APIs over GraphQL for simple CRUD applications. Uses OpenAPI specs for documentation."
+memory_type = "preference"
+domain = "personal"
+
+# Hard negative: mentions REST endpoints and API design but is about a different project's endpoints
+[[cases.negative_seeds]]
+id = "mem_api_other_project"
+content = "The analytics service exposes REST endpoints at /api/v2/events, /api/v2/metrics, and /api/v2/funnels. Rate limiting is enforced at 100 requests per minute per API key."
+memory_type = "fact"
+domain = "projectB"
+
+# Hard negative: mentions API patterns but is about WebSocket design, not REST endpoint patterns
+[[cases.negative_seeds]]
+id = "mem_api_websocket"
+content = "WebSocket API at /ws/updates uses a pub-sub pattern with topic subscriptions. Clients subscribe to memory.store, refinery.complete, and gate.reject event types via JSON messages."
+memory_type = "fact"
+domain = "projectA"

--- a/app/eval/fixtures/page_retrieval.toml
+++ b/app/eval/fixtures/page_retrieval.toml
@@ -1,0 +1,135 @@
+# Page retrieval — tests that distilled pages surface for knowledge-level queries.
+# These memories should cluster during distillation, producing pages that
+# answer broad "how does X work?" queries better than individual memories.
+
+[[cases]]
+query = "libSQL database architecture"
+domain = "origin"
+
+[[cases.seeds]]
+id = "mem_libsql_vector"
+content = "Origin stores 768-dimensional vectors in libSQL F32_BLOB columns with DiskANN indexing for approximate nearest neighbor search"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_libsql_fts"
+content = "Full-text search uses FTS5 virtual tables with auto-sync triggers on insert, update, and delete operations"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_libsql_conn"
+content = "libSQL Connection is Send but not Sync so Origin wraps it in tokio::sync::Mutex for safe concurrent access"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_libsql_single_db"
+content = "Origin uses a single libSQL database for memories, knowledge graph entities, relations, observations, and full-text search indexes"
+memory_type = "decision"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "neg_postgres_sharding"
+content = "PostgreSQL horizontal sharding distributes rows across multiple nodes using consistent hashing"
+memory_type = "fact"
+domain = "infrastructure"
+
+[[cases.negative_seeds]]
+id = "neg_redis_caching"
+content = "Redis provides in-memory key-value caching with TTL-based expiration and pub/sub messaging"
+memory_type = "fact"
+domain = "infrastructure"
+
+
+[[cases]]
+query = "memory retrieval pipeline"
+domain = "origin"
+
+[[cases.seeds]]
+id = "mem_hybrid_search"
+content = "Origin combines vector similarity search with FTS5 keyword matching using Reciprocal Rank Fusion with RRF_K parameter of 60"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_confirmation_boost"
+content = "Human-confirmed memories receive a 1.5x score boost during retrieval to prioritize curated knowledge"
+memory_type = "decision"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_recap_penalty"
+content = "Recap memories receive a 0.3x score penalty to prevent activity summaries from drowning out primary memories"
+memory_type = "decision"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_domain_prefix"
+content = "Embedding vectors are prefixed with [domain] tag to improve cross-domain retrieval separation"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "neg_elastic_bm25"
+content = "Elasticsearch uses BM25 scoring algorithm for relevance ranking in full-text search queries"
+memory_type = "fact"
+domain = "infrastructure"
+
+[[cases.negative_seeds]]
+id = "neg_pinecone_metadata"
+content = "Pinecone supports metadata filtering with namespace isolation for multi-tenant vector search"
+memory_type = "fact"
+domain = "infrastructure"
+
+
+[[cases]]
+query = "how does knowledge compilation work"
+domain = "origin"
+
+[[cases.seeds]]
+id = "mem_concept_compile"
+content = "Knowledge compilation clusters related memories by entity and domain then uses LLM to generate structured wiki-style concept pages"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_concept_fts"
+content = "Compiled concepts are indexed in FTS5 for fast full-text search on title, summary, and content fields"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_concept_source_ids"
+content = "Each concept tracks source_memory_ids linking back to the atomic memories that were compiled into it"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "neg_rag_chunking"
+content = "Retrieval augmented generation splits documents into fixed-size chunks with overlap for embedding"
+memory_type = "fact"
+domain = "ai"

--- a/app/eval/fixtures/quality_gate/duplicate_pollution.toml
+++ b/app/eval/fixtures/quality_gate/duplicate_pollution.toml
@@ -1,0 +1,243 @@
+# Quality gate duplicate-pollution tests — verify that near-duplicate memories
+# stored across multiple agent sessions don't crowd search results.
+# Seeds are the canonical versions; negative_seeds are the duplicates that
+# should have been rejected at ingest time (or de-ranked at retrieval time).
+
+# ── Case 1: preference — word-order and passive-voice variants ──────────────
+
+[[cases]]
+query = "preferred text editor"
+
+[[cases.seeds]]
+id = "mem_editor_pref"
+content = "User prefers VS Code as their primary text editor for all development work"
+memory_type = "preference"
+relevance = 3
+confirmed = true
+
+# Same fact, passive voice
+[[cases.negative_seeds]]
+id = "dup_editor_passive"
+content = "VS Code is preferred by the user for development work"
+memory_type = "preference"
+
+# Same fact, different word order
+[[cases.negative_seeds]]
+id = "dup_editor_reorder"
+content = "For all development work, VS Code is the user's preferred text editor"
+memory_type = "preference"
+
+# Same fact, agent-perspective framing
+[[cases.negative_seeds]]
+id = "dup_editor_agent_pov"
+content = "I learned that the user likes to use VS Code as their main editor"
+memory_type = "preference"
+
+# Same fact with unrelated noise appended
+[[cases.negative_seeds]]
+id = "dup_editor_noisy"
+content = "User prefers VS Code for development. Also mentioned the weather has been cold lately."
+memory_type = "preference"
+
+# Same fact, hedged past-tense form
+[[cases.negative_seeds]]
+id = "dup_editor_hedged"
+content = "The user has expressed a preference for VS Code when writing code"
+memory_type = "preference"
+
+
+# ── Case 2: decision — tense variants ──────────────────────────────────────
+
+[[cases]]
+query = "async runtime decision"
+
+[[cases.seeds]]
+id = "mem_tokio_decision"
+content = "Decided to use Tokio as the async runtime because it integrates natively with Tauri and the broader Rust ecosystem"
+memory_type = "decision"
+relevance = 3
+confirmed = true
+
+# Future-past tense
+[[cases.negative_seeds]]
+id = "dup_tokio_future_past"
+content = "We decided we would use Tokio for async because it works well with Tauri"
+memory_type = "decision"
+
+# Nominalised past
+[[cases.negative_seeds]]
+id = "dup_tokio_nominal"
+content = "The decision was to adopt Tokio as the async runtime given its Tauri compatibility"
+memory_type = "decision"
+
+# Present-tense statement of outcome
+[[cases.negative_seeds]]
+id = "dup_tokio_present"
+content = "Tokio is used as the async runtime, chosen for its tight integration with Tauri"
+memory_type = "decision"
+
+# Minimal restatement (detail stripped)
+[[cases.negative_seeds]]
+id = "dup_tokio_minimal"
+content = "Using Tokio for async in the Rust backend"
+memory_type = "decision"
+
+
+# ── Case 3: fact — level-of-detail variants ────────────────────────────────
+
+[[cases]]
+query = "programming language used for backend"
+
+[[cases.seeds]]
+id = "mem_rust_backend"
+content = "The backend is written in Rust using async Tokio, with Axum 0.8 for the HTTP layer and libSQL for storage"
+memory_type = "fact"
+relevance = 3
+confirmed = true
+
+# Coarse summary (less detail)
+[[cases.negative_seeds]]
+id = "dup_rust_coarse"
+content = "Backend uses Rust"
+memory_type = "fact"
+
+# Medium detail, no framework names
+[[cases.negative_seeds]]
+id = "dup_rust_medium"
+content = "The backend service is implemented in Rust with async support"
+memory_type = "fact"
+
+# Different framing, same core fact
+[[cases.negative_seeds]]
+id = "dup_rust_framing"
+content = "Rust powers the backend, handling HTTP requests and database operations asynchronously"
+memory_type = "fact"
+
+# Partial overlap — correct core but adds wrong/unrelated claim
+[[cases.negative_seeds]]
+id = "dup_rust_partial"
+content = "Backend is in Rust; frontend uses Vue.js and the app targets Linux primarily"
+memory_type = "fact"
+
+
+# ── Case 4: identity — pronoun and perspective shifts ──────────────────────
+
+[[cases]]
+query = "user's name"
+
+[[cases.seeds]]
+id = "mem_user_name"
+content = "The user's name is Lucian"
+memory_type = "identity"
+relevance = 3
+confirmed = true
+
+# Agent first-person
+[[cases.negative_seeds]]
+id = "dup_name_agent"
+content = "I was told the user goes by Lucian"
+memory_type = "identity"
+
+# Possessive reformulation
+[[cases.negative_seeds]]
+id = "dup_name_possessive"
+content = "Lucian is the name this user goes by"
+memory_type = "identity"
+
+# Greeting-style noise
+[[cases.negative_seeds]]
+id = "dup_name_greeting"
+content = "User introduced themselves as Lucian during our first session together"
+memory_type = "identity"
+
+# Embedded in longer sentence with irrelevant context
+[[cases.negative_seeds]]
+id = "dup_name_buried"
+content = "During onboarding the user confirmed their display name is Lucian and that notifications should go to their personal account"
+memory_type = "identity"
+
+
+# ── Case 5: preference — multi-session accumulation of the same UI pref ────
+
+[[cases]]
+query = "font size preference in code editor"
+
+[[cases.seeds]]
+id = "mem_font_size"
+content = "User sets editor font size to 14px and prefers JetBrains Mono as the coding font"
+memory_type = "preference"
+relevance = 3
+confirmed = true
+
+# Session 2 restatement
+[[cases.negative_seeds]]
+id = "dup_font_session2"
+content = "Coding font is JetBrains Mono at 14px in the editor"
+memory_type = "preference"
+
+# Session 3 — only font family mentioned
+[[cases.negative_seeds]]
+id = "dup_font_session3"
+content = "JetBrains Mono is the preferred programming font"
+memory_type = "preference"
+
+# Session 4 — inverted attribute order
+[[cases.negative_seeds]]
+id = "dup_font_session4"
+content = "Prefers 14px font size with JetBrains Mono for all code editing"
+memory_type = "preference"
+
+# Session 5 — agent-observation framing
+[[cases.negative_seeds]]
+id = "dup_font_session5"
+content = "I noticed the user consistently uses JetBrains Mono at 14 pixels across all their editor configs"
+memory_type = "preference"
+
+# Session 6 — partial with noise
+[[cases.negative_seeds]]
+id = "dup_font_session6"
+content = "Font: JetBrains Mono, size 14. User also asked about ligatures but no decision was made."
+memory_type = "preference"
+
+
+# ── Case 6: decision — architectural choice restated across agents ──────────
+
+[[cases]]
+query = "why libSQL was chosen over PostgreSQL"
+
+[[cases.seeds]]
+id = "mem_libsql_choice"
+content = "Chose libSQL over PostgreSQL because it runs embedded with no separate server, supports native vector search, FTS5, and knowledge graph in a single file"
+memory_type = "decision"
+relevance = 3
+confirmed = true
+
+# Second agent's shorter restatement
+[[cases.negative_seeds]]
+id = "dup_libsql_short"
+content = "libSQL was selected instead of PostgreSQL for its embedded vector and full-text search support"
+memory_type = "decision"
+
+# Third agent, present-state framing
+[[cases.negative_seeds]]
+id = "dup_libsql_present"
+content = "The project uses libSQL rather than PostgreSQL because it needs no separate database server process"
+memory_type = "decision"
+
+# Passive construction
+[[cases.negative_seeds]]
+id = "dup_libsql_passive"
+content = "PostgreSQL was ruled out in favour of libSQL due to the requirement for an embedded, serverless database"
+memory_type = "decision"
+
+# Different angle — focuses on single benefit
+[[cases.negative_seeds]]
+id = "dup_libsql_angle"
+content = "libSQL was picked because vector search is built in and the whole DB lives in one file"
+memory_type = "decision"
+
+# Partial overlap with extra unrelated claim
+[[cases.negative_seeds]]
+id = "dup_libsql_partial"
+content = "Using libSQL for the database, which supports vectors. Also considering Redis for caching later."
+memory_type = "decision"

--- a/app/eval/fixtures/quality_gate/noise_patterns.toml
+++ b/app/eval/fixtures/quality_gate/noise_patterns.toml
@@ -1,0 +1,56 @@
+# Quality gate noise pattern tests — verify gate rejects structural noise
+# while admitting legitimate memories.
+
+[[cases]]
+query = "what are the user's core preferences and technical stack decisions"
+
+# These should be REJECTED by the gate (negative_seeds = should not be in DB)
+[[cases.negative_seeds]]
+id = "noise_sys_prompt_1"
+content = "You are a helpful AI assistant. Your job is to answer questions accurately and concisely. Always be polite."
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_sys_prompt_2"
+content = "[INST] Always respond in JSON format. Never include personal opinions. Ensure all outputs are valid JSON. [/INST]"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_heartbeat_1"
+content = "heartbeat"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_timestamp_1"
+content = "2026-03-30T14:22:00Z ok"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_ack_1"
+content = "acknowledged"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_credential_1"
+content = "Set the API key to sk-abc123def456ghi789jkl012mno345pqr678stu901"
+memory_type = "fact"
+
+# These should be ADMITTED (positive seeds)
+[[cases.seeds]]
+id = "mem_real_pref"
+content = "User prefers dark mode for all code editors and terminal applications"
+memory_type = "preference"
+relevance = 3
+
+[[cases.seeds]]
+id = "mem_real_decision"
+content = "Decided to use libSQL instead of PostgreSQL because it supports embedded vector search natively without a separate service"
+memory_type = "decision"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_real_fact"
+content = "The Origin app uses Tauri 2 with a React 19 frontend and Rust backend running on macOS"
+memory_type = "fact"
+relevance = 2

--- a/app/eval/fixtures/quality_gate/noisy_db_retrieval.toml
+++ b/app/eval/fixtures/quality_gate/noisy_db_retrieval.toml
@@ -1,0 +1,342 @@
+# Noisy DB retrieval tests — verify that relevant memories surface above realistic
+# agent-generated noise in search results. Seeds are genuine useful memories;
+# negative_seeds are plausible-but-worthless content that should not rank highly.
+
+# Case 1: coding domain — editor preferences mixed with generic knowledge
+[[cases]]
+query = "what editor settings does the user prefer"
+
+[[cases.seeds]]
+id = "mem_editor_pref_1"
+content = "User prefers VS Code with Vim keybindings enabled, font size 14, and ligatures turned on"
+memory_type = "preference"
+domain = "coding"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_editor_pref_2"
+content = "User sets tab width to 2 spaces for TypeScript and JavaScript, 4 spaces for Rust and Python"
+memory_type = "preference"
+domain = "coding"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_generic_editor_1"
+content = "VS Code is a popular source code editor developed by Microsoft and released in 2015"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_editor_2"
+content = "Vim is a highly configurable text editor built to make creating and changing any kind of text very efficient"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_vague_editor_1"
+content = "Something about editor configuration and user settings"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_status_editor_1"
+content = "Currently updating VS Code settings file with new configuration values"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_meta_editor_1"
+content = "I just stored a memory about the user's VS Code preferences and font settings"
+memory_type = "fact"
+
+
+# Case 2: project domain — architecture decisions mixed with tool output noise
+[[cases]]
+query = "why did we choose libSQL over other databases"
+
+[[cases.seeds]]
+id = "mem_db_decision_1"
+content = "Chose libSQL over PostgreSQL and SQLite because it supports native vector search, FTS5, and knowledge graph in a single embedded file with no separate service required"
+memory_type = "decision"
+domain = "project"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_db_decision_2"
+content = "libSQL chosen over Qdrant and Weaviate for vector storage because on-device embedding keeps all data local — no cloud dependency"
+memory_type = "decision"
+domain = "project"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_tool_output_1"
+content = "cargo build output: Compiling libsql v0.9.29 (registry+https://github.com/rust-lang/crates.io-index) Finished release target in 47.3s"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_db_1"
+content = "SQLite is a C-language library that implements a small, fast, self-contained SQL database engine"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_db_2"
+content = "PostgreSQL is an advanced open-source relational database management system supporting ACID transactions"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_vague_db_1"
+content = "Something about databases and the storage layer decision"
+memory_type = "fact"
+
+
+# Case 3: personal domain — dietary preferences mixed with system prompt fragments
+[[cases]]
+query = "food allergies or dietary restrictions"
+
+[[cases.seeds]]
+id = "mem_diet_1"
+content = "User is lactose intolerant — avoid dairy in restaurant recommendations and meal suggestions"
+memory_type = "fact"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_diet_2"
+content = "User eats mostly Mediterranean diet — prefers fish and vegetables over red meat"
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_sysprompt_diet_1"
+content = "When the user asks about food, always check for dietary restrictions and suggest healthy alternatives that fit their lifestyle"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_sysprompt_diet_2"
+content = "You are a helpful assistant. Always be considerate of user dietary needs and food preferences when making recommendations"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_diet_1"
+content = "Lactose intolerance is a common digestive problem where the body is unable to digest lactose"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_dup_diet_1"
+content = "The user has lactose intolerance and cannot consume dairy products or milk-based foods"
+memory_type = "fact"
+
+
+# Case 4: coding domain — language preferences mixed with transient status updates
+[[cases]]
+query = "preferred programming languages and when to use each"
+
+[[cases.seeds]]
+id = "mem_lang_pref_1"
+content = "User prefers Rust for performance-critical backend work and TypeScript for all frontend and tooling code"
+memory_type = "preference"
+domain = "coding"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_lang_pref_2"
+content = "Python is the go-to for quick scripts and data analysis; user avoids it for long-running services due to GIL constraints"
+memory_type = "preference"
+domain = "coding"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_status_lang_1"
+content = "Currently debugging a TypeScript type error in the frontend authentication module"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_status_lang_2"
+content = "Just finished refactoring the Rust module and running cargo check to verify compilation"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_lang_1"
+content = "Python is a high-level general-purpose programming language known for its readability and simplicity"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_lang_2"
+content = "Rust is a systems programming language focused on safety, speed, and concurrency without a garbage collector"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_vague_lang_1"
+content = "Something about programming languages and when to use them in projects"
+memory_type = "fact"
+
+
+# Case 5: project domain — deployment preferences mixed with verbose tool output
+[[cases]]
+query = "how should the app be distributed to users"
+
+[[cases.seeds]]
+id = "mem_distrib_decision_1"
+content = "Origin will distribute via direct download from the website first, not the Mac App Store, to avoid sandboxing restrictions that break screen capture"
+memory_type = "decision"
+domain = "project"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_distrib_decision_2"
+content = "Code signing uses an Apple Developer ID certificate so Gatekeeper does not block installation on user machines"
+memory_type = "fact"
+domain = "project"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_tool_output_2"
+content = "tauri build output: bundling application, creating dmg, signing with Developer ID Application certificate, notarizing with Apple, stapling ticket completed successfully"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_tool_output_3"
+content = "gh release create v0.4.1 uploaded origin_0.4.1_aarch64.dmg 47.2MB upload complete status 200 OK"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_distrib_1"
+content = "The Mac App Store is Apple's digital distribution platform for macOS applications reviewed by Apple"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_meta_distrib_1"
+content = "I just saved a memory about the distribution strategy decision for the Origin application"
+memory_type = "fact"
+
+
+# Case 6: personal domain — work schedule mixed with near-duplicate noise
+[[cases]]
+query = "when does the user prefer to do focused work"
+
+[[cases.seeds]]
+id = "mem_schedule_1"
+content = "User does best focused coding work in the morning between 8am and noon — avoids scheduling meetings before lunch"
+memory_type = "preference"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_schedule_2"
+content = "User reserves Friday afternoons for exploratory work and reading — no sprint commitments on Friday after 2pm"
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_dup_schedule_1"
+content = "The user prefers to do focused deep work in the morning hours before noon each day"
+memory_type = "preference"
+
+[[cases.negative_seeds]]
+id = "noise_dup_schedule_2"
+content = "User's peak productivity hours are in the morning, from approximately 8 in the morning until midday"
+memory_type = "preference"
+
+[[cases.negative_seeds]]
+id = "noise_status_schedule_1"
+content = "Currently in a meeting, will be back to focused work in approximately 30 minutes"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_schedule_1"
+content = "Time blocking is a productivity technique where you schedule specific tasks into fixed time slots on your calendar"
+memory_type = "fact"
+
+
+# Case 7: architecture domain — API design decisions mixed with system prompt fragments
+[[cases]]
+query = "MCP server authentication approach"
+
+[[cases.seeds]]
+id = "mem_auth_decision_1"
+content = "origin-mcp uses bearer token authentication for HTTP transport — token stored in config.json at app startup"
+memory_type = "decision"
+domain = "architecture"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_auth_decision_2"
+content = "Claude.ai remote MCP requires OAuth 2.0 but origin-mcp only implements bearer tokens — this is the known auth gap blocking Claude.ai integration"
+memory_type = "fact"
+domain = "architecture"
+relevance = 3
+
+[[cases.negative_seeds]]
+id = "noise_sysprompt_auth_1"
+content = "Always validate authentication tokens before processing any request. Never expose credentials in logs or error messages."
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_auth_1"
+content = "OAuth 2.0 is an authorization framework that enables applications to obtain limited access to user accounts on HTTP services"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_auth_2"
+content = "Bearer tokens are a type of access token used in HTTP authentication where the token grants access to the bearer"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_vague_auth_1"
+content = "Something about authentication and how the MCP server handles access control"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_meta_auth_1"
+content = "I have stored a memory about the authentication design decision for the MCP server integration"
+memory_type = "fact"
+
+
+# Case 8: project domain — team process preferences mixed with verbose status noise
+[[cases]]
+query = "code review process and standards"
+
+[[cases.seeds]]
+id = "mem_review_pref_1"
+content = "All PRs require a code review agent pass before merge — critical and important issues must be fixed, style issues are optional"
+memory_type = "preference"
+domain = "project"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_review_pref_2"
+content = "Test coverage must stay above 90 percent — the pre-push git hook enforces this and blocks pushes that drop below the threshold"
+memory_type = "fact"
+domain = "project"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "noise_sysprompt_review_1"
+content = "When reviewing code, always check for security vulnerabilities, performance issues, and adherence to the project coding standards"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_status_review_1"
+content = "Currently reviewing pull request number 34 and checking the diff for any issues before approving"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_tool_output_4"
+content = "gh pr review 34 output: reviewed pull request adding 2 comments on 3 files changed 147 additions 52 deletions review submitted"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_generic_review_1"
+content = "Code review is a software quality assurance activity where one or more people check a program mainly by viewing and reading parts of its source code"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "noise_dup_review_1"
+content = "The user requires code reviews before merging any pull requests and all critical issues need to be resolved first"
+memory_type = "preference"

--- a/app/eval/fixtures/quality_gate/novelty_rejection.toml
+++ b/app/eval/fixtures/quality_gate/novelty_rejection.toml
@@ -1,0 +1,50 @@
+# Quality gate novelty tests — verify semantic duplicates are caught
+# while genuinely different memories about related topics are admitted.
+
+[[cases]]
+query = "dark mode preferences"
+
+# First memory (should be admitted and present in results)
+[[cases.seeds]]
+id = "mem_dark_original"
+content = "User prefers dark mode for all IDEs and terminal applications"
+memory_type = "preference"
+relevance = 3
+confirmed = true
+
+# Semantic duplicate (should be caught by novelty gate, not in DB)
+[[cases.negative_seeds]]
+id = "mem_dark_duplicate"
+content = "The user likes dark theme in code editors and terminals"
+memory_type = "preference"
+
+# Genuinely different memory about a related topic (should be admitted)
+[[cases.seeds]]
+id = "mem_theme_config"
+content = "VS Code theme is set to One Dark Pro. Terminal uses Dracula theme. Vim uses gruvbox colorscheme."
+memory_type = "fact"
+relevance = 2
+
+
+[[cases]]
+query = "database technology choices"
+
+[[cases.seeds]]
+id = "mem_db_decision"
+content = "Decided to use libSQL for the embedded database because it supports vectors, FTS5, and knowledge graph in a single file"
+memory_type = "decision"
+relevance = 3
+confirmed = true
+
+# Semantic duplicate of the decision above
+[[cases.negative_seeds]]
+id = "mem_db_duplicate"
+content = "We chose libSQL as our database since it has native vector support and full-text search built in"
+memory_type = "decision"
+
+# Different but related fact (should be admitted)
+[[cases.seeds]]
+id = "mem_db_config"
+content = "Database file is located at ~/Library/Application Support/origin/memorydb/origin_memory.db with DiskANN vector indexing enabled"
+memory_type = "fact"
+relevance = 2

--- a/app/eval/fixtures/quality_gate/realistic_agent_session.toml
+++ b/app/eval/fixtures/quality_gate/realistic_agent_session.toml
@@ -1,0 +1,212 @@
+# Quality gate realistic agent session tests — verify gate admits high-signal
+# memories from real agent workflows while rejecting low-value noise that agents
+# commonly write alongside genuine insights.
+
+# Session 1: Developer onboarding session
+# An agent walks a new developer through the Origin codebase architecture.
+
+[[cases]]
+query = "how does state management work in the Rust backend"
+
+# Useful memories the agent learned and stored
+[[cases.seeds]]
+id = "mem_onboard_state_arch"
+content = "AppState is wrapped in Arc<RwLock<AppState>> managed by Tauri; libsql::Connection is not Sync so it lives inside a tokio::sync::Mutex inside AppState"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_onboard_atomic_flags"
+content = "Feature toggle flags (capture_enabled, ambient_enabled) use Arc<AtomicBool> shared with sensor threads so hot-loop reads never need to acquire the AppState lock"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+
+[[cases.seeds]]
+id = "mem_onboard_setup_gotcha"
+content = "Calling tokio::runtime::Handle::current() inside Tauri's setup() closure panics — must use tauri::async_runtime::block_on(async { Handle::current() }) to capture the handle"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_onboard_llm_bridge"
+content = "The LLM formatter runs on a dedicated std::thread and uses a captured Tokio handle to call handle.block_on() for async DB writes from the GPU inference thread"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+# Junk the agent also stored — plausible-looking but zero retrieval value
+[[cases.negative_seeds]]
+id = "junk_onboard_greeting"
+content = "The developer said hello and asked where to start with the codebase"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_onboard_generic_rwlock"
+content = "RwLock allows multiple concurrent readers or a single exclusive writer, which is a common pattern for shared state in concurrent Rust programs"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_onboard_ack1"
+content = "Developer confirmed they understood the explanation of the thread model"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_onboard_sysprompt"
+content = "You are a helpful engineering assistant. Help the developer understand the codebase by explaining architecture decisions clearly and concisely."
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_onboard_obvious"
+content = "Rust is a systems programming language that emphasizes memory safety and performance without a garbage collector"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_onboard_restate"
+content = "The developer is new to the codebase and needs to understand how the backend is structured"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_onboard_generic_arc"
+content = "Arc enables shared ownership across threads by using atomic reference counting, which is thread-safe unlike Rc"
+memory_type = "fact"
+
+
+# Session 2: Debugging session
+# An agent helps debug a production issue where semantic search returns no results.
+
+[[cases]]
+query = "why did semantic search stop returning results"
+
+# Useful memories: root cause, fix, and lesson
+[[cases.seeds]]
+id = "mem_debug_root_cause"
+content = "libsql 0.9.29 broke vector_top_k result column naming — vt.distance no longer works; must use vector_distance_cos(chunks.embedding, ?) to compute similarity in the outer query"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_debug_fix"
+content = "Fixed semantic search by replacing vt.distance with vector_distance_cos() in the hybrid search query in memory_db.rs; all vector similarity scores now return correctly"
+memory_type = "fact"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_debug_lesson"
+content = "When upgrading libsql, test vector_top_k result column aliases first — the crate does not guarantee stable internal column names across minor versions"
+memory_type = "fact"
+domain = "origin"
+relevance = 2
+
+# Junk the agent stored during the debug session
+[[cases.negative_seeds]]
+id = "junk_debug_stacktrace"
+content = "thread 'tokio-runtime-worker' panicked at 'called Result::unwrap() on an Err value: LibsqlError { message: \"no such column: vt.distance\" }', app/src/memory_db.rs:412"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_debug_hypothesis1"
+content = "Initial hypothesis: the embedding dimension changed from 384 to 512 and stored vectors are incompatible with the new model — this turned out to be incorrect"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_debug_hypothesis2"
+content = "Considered that FTS5 triggers might be dropping rows during upsert, causing the chunks table to appear empty — ruled out after confirming row counts"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_debug_timestamp"
+content = "Issue first reported at 2026-03-24T09:15:00Z; root cause identified at 2026-03-24T11:42:00Z; fix deployed at 2026-03-24T12:08:00Z"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_debug_status_update"
+content = "Currently investigating the semantic search regression; narrowing down whether the issue is in the embedding pipeline or the vector similarity query"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_debug_generic_advice"
+content = "When debugging database query issues, it helps to isolate each clause of the query and verify intermediate results against known-good data"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_debug_restate"
+content = "The problem is that search_memory returns zero results even when the database contains chunks that should match the query"
+memory_type = "fact"
+
+
+# Session 3: Planning/design session
+# An agent helps design the ingest quality gate feature.
+
+[[cases]]
+query = "what is the quality gate and how should it filter memories"
+
+# Useful memories: requirements, architecture decisions, trade-off rationale
+[[cases.seeds]]
+id = "mem_plan_quality_gate_def"
+content = "The ingest quality gate is a pre-storage filter that rejects noise before it reaches MemoryDB — catches system prompt bleed, timestamp-only entries, semantic duplicates, and zero-information acknowledgments"
+memory_type = "decision"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_plan_two_stage"
+content = "Quality gate runs two stages: (1) rule-based fast rejection for structural noise patterns (regex, length, entropy), then (2) semantic novelty check via cosine similarity against recent embeddings to catch rephrased duplicates"
+memory_type = "decision"
+domain = "origin"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_plan_novelty_threshold"
+content = "Novelty threshold set at 0.85 cosine similarity — memories scoring above this against any existing chunk in the same domain within 7 days are rejected as duplicates; threshold chosen to match the existing bigram Jaccard dedup in the router"
+memory_type = "decision"
+domain = "origin"
+relevance = 3
+
+[[cases.seeds]]
+id = "mem_plan_no_llm_gate"
+content = "Decided against using an LLM call in the quality gate critical path — adds 200-800ms latency per memory write; rule-based + embedding similarity catches 90%+ of noise without blocking the ingest pipeline"
+memory_type = "decision"
+domain = "origin"
+relevance = 2
+
+# Junk from the planning session
+[[cases.negative_seeds]]
+id = "junk_plan_rejected_idea1"
+content = "Brainstormed using a small classifier model fine-tuned on labeled noise/signal pairs — rejected because it requires training data we don't have and adds a model dependency"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_plan_rejected_idea2"
+content = "Considered adding a human review queue for low-confidence memories — set aside for v2 since it adds friction to the zero-config experience"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_plan_meta"
+content = "Let me think through the requirements carefully before proposing an architecture for the quality gate feature"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_plan_restate_req"
+content = "The goal is to make sure that only high-quality, useful memories are stored in the database and that low-quality or duplicate content is filtered out"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_plan_generic_best_practice"
+content = "In general, input validation and filtering should happen as early as possible in a pipeline to avoid wasting compute on low-quality data downstream"
+memory_type = "fact"
+
+[[cases.negative_seeds]]
+id = "junk_plan_restate2"
+content = "The ingest quality gate should prevent junk memories from being stored so that search results stay relevant and the database does not grow unbounded with noise"
+memory_type = "fact"

--- a/app/eval/fixtures/realistic/realistic_multi_hop.toml
+++ b/app/eval/fixtures/realistic/realistic_multi_hop.toml
@@ -1,0 +1,953 @@
+# Realistic multi-hop retrieval — questions requiring information from 2-3 memories combined.
+# The answer to each query is not in any single memory; the reader must synthesize across seeds.
+# Difficulty: hard to medium across cases.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# "what tech stack is used for the main project"
+# Requires combining: Rust (server), React 19 (UI), libSQL (DB), Tauri 2 (shell)
+# No single memory says "tech stack" — each mentions one layer
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what tech stack is used for the main project"
+
+[[cases.seeds]]
+id = "rmh_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and the ability to do zero-cost FFI with macOS CoreGraphics. The compiled binary is roughly 35 MB."
+memory_type = "decision"
+domain = "work"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rmh_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state. Vite handles bundling and HMR during development."
+memory_type = "fact"
+domain = "work"
+relevance = 3
+
+[[cases.seeds]]
+id = "rmh_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index. No external database process to manage."
+memory_type = "decision"
+domain = "work"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rmh_proj_tauri"
+content = "Desktop shell is built with Tauri 2 to avoid the Electron memory overhead. The webview communicates with the native layer through IPC commands."
+memory_type = "decision"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rmh_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration. A dedicated thread handles the generation loop to avoid blocking the async runtime."
+memory_type = "fact"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model loaded through ONNX. Output vectors are 768-dimensional."
+memory_type = "fact"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback when Cursor's AI features are distracting during review work."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM. Secondary display is an LG UltraFine 5K."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score and adjusts workout intensity accordingly."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership, and a few smaller tools."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco. Has been there since mid-2023."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding. Switches to podcasts during commute walks."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_proj_testing"
+content = "Test suite covers both frontend (Vitest + React Testing Library) and Rust (cargo test). Pre-push hook enforces 90% coverage gate."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_proj_deploy"
+content = "App is distributed as a macOS .dmg built by Tauri's bundler. No CI/CD pipeline yet — builds are manual from the development machine."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed in a separate repository to encourage adoption."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack messages in batches. Keeps notifications off except for direct mentions."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration, started the eval framework."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_goal_launch"
+content = "Primary goal for April: get the product to three beta testers and collect qualitative feedback on the memory retrieval quality."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_pref_reading"
+content = "Reads mostly non-fiction — recently finished Thinking in Systems by Donella Meadows. Keeps a reading list in Notion."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture if it prevents accumulated tech debt."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_proj_pnpm"
+content = "Switched to pnpm early on for stricter dependency isolation and faster installs. Lockfile is committed to the repo."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh_fitness"
+content = "Goes to the gym four mornings a week — two upper body sessions and two lower body. Runs 5K on Saturdays at Dolores Park."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# "how does the user's work schedule affect their productivity preferences"
+# Requires combining: schedule habits + productivity setup + work style
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how does the user's work schedule affect their productivity preferences"
+
+[[cases.seeds]]
+id = "rmh2_schedule"
+content = "Most productive between 9 AM and 1 PM. Blocks that window for deep coding and pushes meetings to the afternoon when possible. Rarely works past 7 PM."
+memory_type = "preference"
+domain = "work"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rmh2_focus"
+content = "Uses the Pomodoro technique loosely — 50-minute focus blocks with 10-minute breaks. Keeps the phone in another room during morning coding sessions."
+memory_type = "preference"
+domain = "work"
+relevance = 3
+
+[[cases.seeds]]
+id = "rmh2_comms"
+content = "Prefers async communication. Checks email twice a day — once after morning standup, once before end of day. Slack notifications are batched."
+memory_type = "preference"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rmh2_caffeine"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM to protect sleep."
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.seeds]]
+id = "rmh2_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score and adjusts workout intensity accordingly."
+memory_type = "fact"
+domain = "health"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh2_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and CoreGraphics FFI."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_tauri"
+content = "Desktop shell is built with Tauri 2. Webview communicates through IPC commands."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback when Cursor's AI features are distracting."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding. Switches to podcasts during commute walks."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems by Donella Meadows."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_fitness"
+content = "Goes to the gym four mornings a week — two upper body and two lower body. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh2_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# "what are the user's dietary constraints for meal planning"
+# Requires combining: diet preference + allergy + cooking habits
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are the user's dietary constraints for meal planning"
+
+[[cases.seeds]]
+id = "rmh3_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rmh3_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+
+[[cases.seeds]]
+id = "rmh3_caffeine"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh3_recipe"
+content = "Favorite recipe right now is a Thai coconut curry with tofu. Uses red curry paste from Mae Ploy and tops with fresh basil from the farmers market."
+memory_type = "preference"
+domain = "food"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh3_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh3_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+# Near-miss: mentions food but different aspect
+[[cases.seeds]]
+id = "rmh3_grocery"
+content = "Does weekly grocery runs at Whole Foods on Sundays. Supplemented by farmers market pickups on Wednesday evenings when available."
+memory_type = "fact"
+domain = "food"
+relevance = 0
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# "what hardware and software does the user use for development"
+# Requires combining: OS/hardware + editor + dev tools
+# Hard because many tangentially related memories compete
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what hardware and software does the user use for development"
+
+[[cases.seeds]]
+id = "rmh4_hw"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM. Secondary display is an LG UltraFine 5K."
+memory_type = "fact"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rmh4_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback when Cursor's AI features are distracting during review work."
+memory_type = "preference"
+domain = "work"
+relevance = 3
+
+[[cases.seeds]]
+id = "rmh4_terminal"
+content = "Uses iTerm2 with zsh and Oh My Zsh. Has a custom theme based on Powerlevel10k with git status indicators."
+memory_type = "preference"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rmh4_tools"
+content = "Key dev tools: Linear for task tracking, Notion for documentation, Figma for design mockups, GitHub for code hosting."
+memory_type = "fact"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rmh4_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh4_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 5 ──────────────────────────────────────────────────────────────────
+# "how should I plan a dinner for the user"
+# Requires combining: diet + allergy + cooking preference + schedule
+# Hard: query is abstract, relevant memories are scattered across domains
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how should I plan a dinner for the user"
+
+[[cases.seeds]]
+id = "rmh5_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rmh5_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+
+[[cases.seeds]]
+id = "rmh5_recipe"
+content = "Favorite recipe right now is a Thai coconut curry with tofu. Uses red curry paste from Mae Ploy and tops with fresh basil from the farmers market."
+memory_type = "preference"
+domain = "food"
+relevance = 2
+
+[[cases.seeds]]
+id = "rmh5_schedule"
+content = "Most productive between 9 AM and 1 PM. Blocks that window for deep coding and pushes meetings to the afternoon. Rarely works past 7 PM."
+memory_type = "preference"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh5_caffeine"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 1
+
+[[cases.seeds]]
+id = "rmh5_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_testing"
+content = "Test suite covers both frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_grocery"
+content = "Does weekly grocery runs at Whole Foods on Sundays. Supplemented by farmers market pickups on Wednesday evenings."
+memory_type = "fact"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rmh5_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0

--- a/app/eval/fixtures/realistic/realistic_open_domain.toml
+++ b/app/eval/fixtures/realistic/realistic_open_domain.toml
@@ -1,0 +1,1046 @@
+# Realistic open-domain retrieval — broad questions where relevant memories are scattered
+# across domains and memory types. Tests the hardest retrieval category.
+# No single domain or memory type contains the full answer.
+# Difficulty: very hard to medium.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# "what kind of person is the user"
+# Extremely open — relevant memories scattered across identity, preferences, values.
+# Almost everything is somewhat relevant; grading requires judgment.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what kind of person is the user"
+
+[[cases.seeds]]
+id = "rod_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rod_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture if it prevents accumulated tech debt."
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rod_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019. Did an internship at Stripe the summer before senior year."
+memory_type = "identity"
+domain = "personal"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack messages in batches. Keeps notifications off except for direct mentions."
+memory_type = "preference"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod_pref_reading"
+content = "Reads mostly non-fiction — recently finished Thinking in Systems by Donella Meadows. Keeps a reading list in Notion."
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod_fitness"
+content = "Goes to the gym four mornings a week — two upper body sessions and two lower body. Runs 5K on Saturdays at Dolores Park when the weather is good."
+memory_type = "fact"
+domain = "health"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding. Switches to podcasts during commute walks."
+memory_type = "preference"
+domain = "personal"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod_travel_safari"
+content = "Took a trip to Tanzania in 2022 and did a safari in Serengeti. Saw elephants, lions, and a cheetah. Would love to go back."
+memory_type = "fact"
+domain = "travel"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and CoreGraphics FFI."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_tauri"
+content = "Desktop shell is built with Tauri 2 to avoid the Electron memory overhead."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration on a dedicated thread."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_deploy"
+content = "App is distributed as a macOS .dmg. No CI/CD pipeline yet."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_proj_pnpm"
+content = "Switched to pnpm for stricter dependency isolation and faster installs."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_recipe"
+content = "Favorite recipe: Thai coconut curry with tofu. Red curry paste from Mae Ploy."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod_grocery"
+content = "Does weekly grocery runs at Whole Foods on Sundays."
+memory_type = "fact"
+domain = "food"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# "what are the user's biggest concerns right now"
+# Open-domain — could be work deadlines, health, finances, personal life.
+# Relevant memories are goals, recaps, and blockers.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what are the user's biggest concerns right now"
+
+[[cases.seeds]]
+id = "rod2_goal_launch"
+content = "Primary goal for April: get the product to three beta testers and collect qualitative feedback on the memory retrieval quality."
+memory_type = "goal"
+domain = "work"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rod2_blocker_npm"
+content = "origin-mcp is not published to npm yet. The install wizard uses a local binary as a dev fallback, but real users need npm distribution."
+memory_type = "fact"
+domain = "work"
+relevance = 3
+
+[[cases.seeds]]
+id = "rod2_blocker_oauth"
+content = "OAuth gap: Claude.ai requires OAuth 2.0 for MCP connections, but origin-mcp only issues bearer tokens. Bridging this is a pending launch blocker."
+memory_type = "fact"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod2_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration, started the eval framework. No user testing yet."
+memory_type = "recap"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod2_finance_runway"
+content = "Current savings give about 8 months of runway before needing income. Not stressed yet but aware of the clock."
+memory_type = "fact"
+domain = "finance"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod2_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod2_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture if it prevents accumulated tech debt."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_license"
+content = "Main application is AGPL-3.0. MCP client is MIT-licensed."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod2_proj_pnpm"
+content = "Switched to pnpm for stricter dependency isolation."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# "summarize everything you know about the user's health"
+# Open-domain but scoped to health — requires finding health-related memories
+# across different domain labels (health, food, personal)
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "summarize everything you know about the user's health"
+
+[[cases.seeds]]
+id = "rod3_fitness"
+content = "Goes to the gym four mornings a week — two upper body sessions and two lower body. Runs 5K on Saturdays at Dolores Park when the weather is good."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rod3_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score and adjusts workout intensity accordingly."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+
+[[cases.seeds]]
+id = "rod3_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+
+[[cases.seeds]]
+id = "rod3_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod3_caffeine"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM to protect sleep."
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod3_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_testing"
+content = "Test suite covers both frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_proj_license"
+content = "Main application is AGPL-3.0."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+# Near-miss: mentions a body-related topic but not health status
+[[cases.seeds]]
+id = "rod3_ergonomics"
+content = "Switched to a standing desk in January. Alternates between standing and sitting every 45 minutes using a timer app."
+memory_type = "preference"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod3_recipe"
+content = "Favorite recipe: Thai coconut curry with tofu."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod3_grocery"
+content = "Does weekly grocery runs at Whole Foods on Sundays."
+memory_type = "fact"
+domain = "food"
+relevance = 0
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# "what motivates the user's technical decisions"
+# Open-domain question about decision-making philosophy.
+# Relevant memories are decisions + values + identity — widely scattered.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what motivates the user's technical decisions"
+
+[[cases.seeds]]
+id = "rod4_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture if it prevents accumulated tech debt."
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rod4_rust_decision"
+content = "Chose Rust for the server-side code because of memory safety guarantees and the ability to do zero-cost FFI with macOS CoreGraphics."
+memory_type = "decision"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod4_tauri_decision"
+content = "Desktop shell is built with Tauri 2 to avoid the Electron memory overhead. The webview communicates with the native layer through IPC commands."
+memory_type = "decision"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod4_db_decision"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index. No external database process to manage."
+memory_type = "decision"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod4_license_decision"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed in a separate repository to encourage adoption."
+memory_type = "decision"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod4_pnpm_decision"
+content = "Switched to pnpm early on for stricter dependency isolation and faster installs."
+memory_type = "decision"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod4_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_food_diet"
+content = "Mostly plant-based diet but not strict."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod4_proj_deploy"
+content = "App is distributed as a macOS .dmg. No CI/CD pipeline yet."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 5 ──────────────────────────────────────────────────────────────────
+# "what would make a good gift for the user"
+# Extremely open — requires synthesizing interests, hobbies, preferences.
+# Hard because no memory is directly about gifts.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what would make a good gift for the user"
+
+[[cases.seeds]]
+id = "rod5_reading"
+content = "Reads mostly non-fiction — recently finished Thinking in Systems by Donella Meadows. Keeps a reading list in Notion."
+memory_type = "preference"
+domain = "personal"
+relevance = 3
+
+[[cases.seeds]]
+id = "rod5_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod5_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding. Switches to podcasts during commute walks."
+memory_type = "preference"
+domain = "personal"
+relevance = 2
+
+[[cases.seeds]]
+id = "rod5_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays at Dolores Park."
+memory_type = "fact"
+domain = "health"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod5_travel"
+content = "Took a trip to Tanzania in 2022 and did a safari in Serengeti. Would love to go back."
+memory_type = "fact"
+domain = "travel"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod5_recipe"
+content = "Favorite recipe: Thai coconut curry with tofu. Uses red curry paste from Mae Ploy."
+memory_type = "preference"
+domain = "food"
+relevance = 1
+
+[[cases.seeds]]
+id = "rod5_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_rust"
+content = "Chose Rust for the server-side code."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_react"
+content = "The UI layer uses React 19."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_food_diet"
+content = "Mostly plant-based diet but not strict."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_pref_comms"
+content = "Prefers async communication."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_recap_week"
+content = "Week of March 24: shipped context composition PR."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_proj_testing"
+content = "Test suite covers both frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rod5_grocery"
+content = "Does weekly grocery runs at Whole Foods on Sundays."
+memory_type = "fact"
+domain = "food"
+relevance = 0

--- a/app/eval/fixtures/realistic/realistic_single_hop.toml
+++ b/app/eval/fixtures/realistic/realistic_single_hop.toml
@@ -1,0 +1,1184 @@
+# Realistic single-hop retrieval — direct questions where the answer lives in one memory
+# but is buried among 20-30 other plausible memories from the same user's life.
+# Vocabulary mismatch between queries and seeds is intentional.
+# Difficulty: varies from hard to easy across cases.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# "what language is the backend written in"
+# Answer says "Rust" and "server-side" — never says "language" or "backend"
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what language is the backend written in"
+
+[[cases.seeds]]
+id = "rsh_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and the ability to do zero-cost FFI with macOS CoreGraphics. The compiled binary is roughly 35 MB."
+memory_type = "decision"
+domain = "work"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rsh_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state. Vite handles bundling and HMR during development."
+memory_type = "fact"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rsh_proj_tauri"
+content = "Desktop shell is built with Tauri 2 to avoid the Electron memory overhead. The webview communicates with the native layer through IPC commands."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index. No external database process to manage."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration. A dedicated thread handles the generation loop to avoid blocking the async runtime."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model loaded through ONNX. Output vectors are 768-dimensional."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback when Cursor's AI features are distracting during review work."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM. Secondary display is an LG UltraFine 5K."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM. Avoids caffeine entirely after 5 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score and adjusts workout intensity accordingly."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership, and a few smaller tools."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco. Has been there since mid-2023."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding. Switches to podcasts during commute walks."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_proj_testing"
+content = "Test suite covers both frontend (Vitest + React Testing Library) and Rust (cargo test). Pre-push hook enforces 90% coverage gate."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_proj_deploy"
+content = "App is distributed as a macOS .dmg built by Tauri's bundler. No CI/CD pipeline yet — builds are manual from the development machine."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed in a separate repository to encourage adoption."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack messages in batches. Keeps notifications off except for direct mentions."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration, started the eval framework. No user testing yet."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_goal_launch"
+content = "Primary goal for April: get the product to three beta testers and collect qualitative feedback on the memory retrieval quality."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_pref_reading"
+content = "Reads mostly non-fiction — recently finished Thinking in Systems by Donella Meadows. Keeps a reading list in Notion."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture if it prevents accumulated tech debt."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# "does the user have any pets"
+# Empty-set case — no memory mentions pets. Noise includes animals in other contexts.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "does the user have any pets"
+empty_set = true
+
+[[cases.seeds]]
+id = "rsh2_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco. Has been there since mid-2023."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and CoreGraphics FFI."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack messages in batches."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems by Donella Meadows."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+# Near-miss: mentions an animal but not as a pet
+[[cases.seeds]]
+id = "rsh2_travel_safari"
+content = "Took a trip to Tanzania in 2022 and did a safari in Serengeti. Saw elephants, lions, and a cheetah. Would love to go back."
+memory_type = "fact"
+domain = "travel"
+relevance = 0
+
+# Near-miss: mentions animal-related content
+[[cases.seeds]]
+id = "rsh2_food_recipe"
+content = "Favorite recipe right now is a Thai coconut curry with tofu. Uses red curry paste from Mae Ploy and tops with fresh basil from the farmers market."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh2_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed in a separate repo."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# "where did the user go to school"
+# Answer uses "studied" and "university" — query says "go to school"
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "where did the user go to school"
+
+[[cases.seeds]]
+id = "rsh3_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019. Did an internship at Stripe the summer before senior year."
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rsh3_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company."
+memory_type = "identity"
+domain = "personal"
+relevance = 1
+
+[[cases.seeds]]
+id = "rsh3_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and CoreGraphics FFI."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_proj_tauri"
+content = "Desktop shell is built with Tauri 2 to avoid the Electron memory overhead."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration on a dedicated thread."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack messages in batches."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems by Donella Meadows."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+# Near-miss: mentions learning but not school
+[[cases.seeds]]
+id = "rsh3_learning"
+content = "Taking an online course on advanced Rust patterns through Jon Gjengset's Crust of Rust series. Plans to apply ownership patterns to the capture pipeline."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model loaded through ONNX."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh3_proj_testing"
+content = "Test suite covers both frontend (Vitest + React Testing Library) and Rust (cargo test). Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# "how much does the user exercise"
+# Answer says "gym four times a week" and "running" — query says "exercise"
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "how much does the user exercise"
+
+[[cases.seeds]]
+id = "rsh4_fitness"
+content = "Goes to the gym four mornings a week — two upper body sessions and two lower body. Runs 5K on Saturdays at Dolores Park when the weather is good."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rsh4_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score and adjusts workout intensity accordingly."
+memory_type = "fact"
+domain = "health"
+relevance = 2
+
+[[cases.seeds]]
+id = "rsh4_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically. Almonds and cashews are fine."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week. Cooks at home 4-5 nights."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack messages in batches."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh4_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 5 ──────────────────────────────────────────────────────────────────
+# "what does the user do for a living"
+# Answer says "indie developer" and "AI memory product" — query says "do for a living"
+# Hard because many work seeds exist but only one captures the occupation
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what does the user do for a living"
+
+[[cases.seeds]]
+id = "rsh5_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rsh5_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019. Did an internship at Stripe the summer before senior year."
+memory_type = "identity"
+domain = "personal"
+relevance = 1
+
+[[cases.seeds]]
+id = "rsh5_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and CoreGraphics FFI."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_proj_tauri"
+content = "Desktop shell is built with Tauri 2 to avoid the Electron memory overhead."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_travel_home"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_pref_comms"
+content = "Prefers async communication. Checks email twice a day and Slack in batches."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems by Donella Meadows."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh5_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays at Dolores Park."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+
+# ─── CASE 6 ──────────────────────────────────────────────────────────────────
+# "what package manager does the project use"
+# Hard: answer says "pnpm" — but there are seeds mentioning npm, cargo, etc.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what package manager does the project use"
+
+[[cases.seeds]]
+id = "rsh6_pnpm"
+content = "Switched to pnpm early on for stricter dependency isolation and faster installs. Lockfile is committed to the repo."
+memory_type = "decision"
+domain = "work"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "rsh6_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees and CoreGraphics FFI. The compiled binary is roughly 35 MB."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state. Vite handles bundling and HMR during development."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_tauri"
+content = "Desktop shell is built with Tauri 2. The webview communicates with the native layer through IPC commands."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration on a dedicated thread."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q, a quantized transformer model."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_testing"
+content = "Test suite covers both frontend (Vitest + React Testing Library) and Rust (cargo test)."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+# Near-miss: mentions cargo which is also a package manager
+[[cases.seeds]]
+id = "rsh6_proj_cargo"
+content = "Cargo workspace is configured at the repo root with a single member crate. Build cache is shared across git worktrees."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_license"
+content = "Main application is AGPL-3.0. The MCP client library is MIT-licensed."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_proj_deploy"
+content = "App is distributed as a macOS .dmg built by Tauri's bundler. No CI/CD pipeline yet."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh6_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 7 ──────────────────────────────────────────────────────────────────
+# "what's the user's email setup"
+# Hard: no memory directly says "email setup" — only communication preferences
+# mention email indirectly
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what's the user's email setup"
+
+[[cases.seeds]]
+id = "rsh7_comms"
+content = "Prefers async communication. Checks email twice a day — once after morning standup, once before end of day. Uses Apple Mail on the Mac and the Gmail app on iPhone."
+memory_type = "preference"
+domain = "work"
+relevance = 3
+
+[[cases.seeds]]
+id = "rsh7_notif"
+content = "Keeps notifications off except for direct mentions in Slack. Email notifications are batched, not real-time."
+memory_type = "preference"
+domain = "work"
+relevance = 2
+
+[[cases.seeds]]
+id = "rsh7_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_pref_editor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_food_diet"
+content = "Mostly plant-based diet but not strict. Eats fish once or twice a week."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_proj_db"
+content = "All data lives in a single libSQL instance — vectors, graph, documents, full-text index."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_pref_reading"
+content = "Reads mostly non-fiction. Recently finished Thinking in Systems."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_identity_values"
+content = "Values craftsmanship over speed. Willing to spend extra time on architecture."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_proj_testing"
+content = "Test suite covers both frontend and Rust. Pre-push hook enforces 90% coverage."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rsh7_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0

--- a/app/eval/fixtures/realistic/realistic_temporal.toml
+++ b/app/eval/fixtures/realistic/realistic_temporal.toml
@@ -1,0 +1,1194 @@
+# Realistic temporal retrieval — time-sensitive questions where outdated memories compete
+# with current ones. Uses age_days and supersedes to create update chains.
+# Difficulty: varies — stale info tests are harder than clear recency cases.
+
+# ─── CASE 1 ──────────────────────────────────────────────────────────────────
+# "what project is the user currently working on"
+# Career progression: consulting gig (180d ago) -> SaaS company (90d ago) -> indie product (now)
+# Hard because all three are "projects the user works on"
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what project is the user currently working on"
+
+[[cases.seeds]]
+id = "rt_project_consulting"
+content = "Doing freelance consulting for a fintech startup — building their data pipeline in Python. Two-month contract through end of Q3."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+age_days = 180
+
+[[cases.seeds]]
+id = "rt_project_saas"
+content = "Joined a mid-size SaaS company as a senior full-stack engineer. Working on their billing system migration from Stripe to a custom solution."
+memory_type = "fact"
+domain = "work"
+relevance = 1
+age_days = 90
+supersedes = "rt_project_consulting"
+
+[[cases.seeds]]
+id = "rt_project_current"
+content = "Left the SaaS job to go indie. Building a personal AI memory product — a local-first desktop app where agents write what they learn and humans curate."
+memory_type = "fact"
+domain = "work"
+relevance = 3
+confirmed = true
+age_days = 5
+supersedes = "rt_project_saas"
+
+[[cases.seeds]]
+id = "rt_goal_launch"
+content = "Primary goal for April: get the product to three beta testers and collect qualitative feedback on memory retrieval quality."
+memory_type = "goal"
+domain = "work"
+relevance = 2
+age_days = 3
+
+[[cases.seeds]]
+id = "rt_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock in the embedding migration, started the eval framework."
+memory_type = "recap"
+domain = "work"
+relevance = 1
+age_days = 10
+
+[[cases.seeds]]
+id = "rt_identity_role"
+content = "Solo indie developer working on a personal AI memory product. Previously spent four years at a mid-size SaaS company doing full-stack work."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_rust"
+content = "Chose Rust for the server-side code because of memory safety guarantees."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_react"
+content = "The UI layer uses React 19 with TanStack Query for server state."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max with 36 GB RAM."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_pref_coffee"
+content = "Drinks oat milk lattes in the morning and switches to green tea after 2 PM."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_health_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_health_allergy"
+content = "Has a mild tree nut allergy — walnuts and pecans specifically."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_pref_music"
+content = "Listens to lo-fi hip hop or ambient electronic while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_food_diet"
+content = "Mostly plant-based diet but not strict."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_pref_comms"
+content = "Prefers async communication. Checks email twice a day."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_fitness"
+content = "Goes to the gym four mornings a week. Runs 5K on Saturdays."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_pref_reading"
+content = "Reads mostly non-fiction."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_testing"
+content = "Test suite covers both frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 2 ──────────────────────────────────────────────────────────────────
+# "where does the user live"
+# Location progression: Portland (2y ago) -> Oakland (1y ago) -> SF Mission (now)
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "where does the user live"
+
+[[cases.seeds]]
+id = "rt2_home_portland"
+content = "Renting a studio in the Pearl District in Portland. Walking distance to Powell's Books and a handful of good coffee shops."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+age_days = 730
+
+[[cases.seeds]]
+id = "rt2_home_oakland"
+content = "Moved to a one-bedroom in Oakland near Lake Merritt. Shorter commute to the city for meetings and the food scene is surprisingly good."
+memory_type = "fact"
+domain = "personal"
+relevance = 1
+age_days = 365
+supersedes = "rt2_home_portland"
+
+[[cases.seeds]]
+id = "rt2_home_sf"
+content = "Lives in a one-bedroom apartment in the Mission District, San Francisco. Has been there since mid-2023."
+memory_type = "fact"
+domain = "personal"
+relevance = 3
+confirmed = true
+age_days = 5
+supersedes = "rt2_home_oakland"
+
+[[cases.seeds]]
+id = "rt2_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_proj_rust"
+content = "Chose Rust for the server-side code."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_proj_react"
+content = "The UI layer uses React 19."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_pref_coffee"
+content = "Drinks oat milk lattes in the morning."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_health_sleep"
+content = "Targets 7.5 hours of sleep."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_health_allergy"
+content = "Has a mild tree nut allergy."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_pref_music"
+content = "Listens to lo-fi hip hop while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_food_diet"
+content = "Mostly plant-based diet."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_pref_comms"
+content = "Prefers async communication."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_recap_week"
+content = "Week of March 24: shipped context composition PR."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_fitness"
+content = "Goes to the gym four mornings a week."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_pref_reading"
+content = "Reads mostly non-fiction."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+# Near-miss: mentions a place but not where they live
+[[cases.seeds]]
+id = "rt2_travel_safari"
+content = "Took a trip to Tanzania in 2022 and did a safari in Serengeti."
+memory_type = "fact"
+domain = "travel"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt2_proj_testing"
+content = "Test suite covers frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 3 ──────────────────────────────────────────────────────────────────
+# "what embedding model does the project use"
+# Tech progression: BGE-Small (60d) -> GTE-Base-Q (30d) -> BGE-Base-Q (5d)
+# Very hard: all three are embedding models with similar vocabulary
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what embedding model does the project use"
+
+[[cases.seeds]]
+id = "rt3_embed_v1"
+content = "Adopted BGE-Small-EN-v1.5 for initial embeddings. Produces 384-dimensional vectors with fast inference. Adequate for the early prototype stage."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+age_days = 60
+
+[[cases.seeds]]
+id = "rt3_embed_v2"
+content = "Upgraded from BGE-Small to GTE-Base-EN-v1.5-Q (768-dim). The quantized model doubles the vector dimensions for better semantic resolution. Migration 24 handles re-embedding existing rows."
+memory_type = "decision"
+domain = "work"
+relevance = 1
+age_days = 30
+supersedes = "rt3_embed_v1"
+
+[[cases.seeds]]
+id = "rt3_embed_v3"
+content = "Switched to BGE-Base-Q (768-dim, same dimensionality as GTE). Benchmark showed improvement on retrieval quality and semantic disconnect tests. Same BAAI model family as the original BGE-Small."
+memory_type = "decision"
+domain = "work"
+relevance = 3
+confirmed = true
+age_days = 5
+supersedes = "rt3_embed_v2"
+
+[[cases.seeds]]
+id = "rt3_embed_prefix"
+content = "Domain prefix such as [conversation] or [origin] is prepended before encoding. Ablation showed prefix-only embedding outperforms bare content."
+memory_type = "fact"
+domain = "work"
+relevance = 1
+
+[[cases.seeds]]
+id = "rt3_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_rust"
+content = "Chose Rust for the server-side code."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_react"
+content = "The UI layer uses React 19."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU acceleration."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_pref_coffee"
+content = "Drinks oat milk lattes in the morning."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_health_sleep"
+content = "Targets 7.5 hours of sleep."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_health_allergy"
+content = "Has a mild tree nut allergy."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_pref_music"
+content = "Listens to lo-fi hip hop while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_food_diet"
+content = "Mostly plant-based diet."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_pref_comms"
+content = "Prefers async communication."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_recap_week"
+content = "Week of March 24: shipped context composition PR, fixed a deadlock."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_fitness"
+content = "Goes to the gym four mornings a week."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_pref_reading"
+content = "Reads mostly non-fiction."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_testing"
+content = "Test suite covers frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt3_proj_license"
+content = "Main application is AGPL-3.0."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 4 ──────────────────────────────────────────────────────────────────
+# "what editor does the user prefer"
+# Tool progression: vim (120d) -> VS Code (60d) -> Cursor (5d)
+# Medium-hard: query says "prefer" but memories describe adoption/switching
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what editor does the user prefer"
+
+[[cases.seeds]]
+id = "rt4_editor_vim"
+content = "Still using neovim with a custom Lua config for all coding. Fast startup and the modal editing flow is second nature after five years."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+age_days = 120
+
+[[cases.seeds]]
+id = "rt4_editor_vscode"
+content = "Switched from neovim to VS Code. The extension ecosystem and integrated terminal won out over raw speed. Installed the Vim keybindings extension to keep muscle memory."
+memory_type = "preference"
+domain = "work"
+relevance = 1
+age_days = 60
+supersedes = "rt4_editor_vim"
+
+[[cases.seeds]]
+id = "rt4_editor_cursor"
+content = "Primarily uses Cursor as the code editor. VS Code as fallback when Cursor's AI features are distracting during review work."
+memory_type = "preference"
+domain = "work"
+relevance = 3
+confirmed = true
+age_days = 5
+supersedes = "rt4_editor_vscode"
+
+[[cases.seeds]]
+id = "rt4_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_rust"
+content = "Chose Rust for the server-side code."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_react"
+content = "The UI layer uses React 19."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_pref_os"
+content = "Runs macOS Sequoia on a 2023 MacBook Pro M3 Max."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_pref_coffee"
+content = "Drinks oat milk lattes in the morning."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_health_sleep"
+content = "Targets 7.5 hours of sleep."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_health_allergy"
+content = "Has a mild tree nut allergy."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_pref_music"
+content = "Listens to lo-fi hip hop while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_food_diet"
+content = "Mostly plant-based diet."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_pref_comms"
+content = "Prefers async communication."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_recap_week"
+content = "Week of March 24: shipped context composition PR."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_fitness"
+content = "Goes to the gym four mornings a week."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_pref_reading"
+content = "Reads mostly non-fiction."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+# Near-miss: mentions an IDE-like tool but for design
+[[cases.seeds]]
+id = "rt4_tools_figma"
+content = "Uses Figma for design mockups. Prefers designing directly in Figma rather than sketching on paper first."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt4_proj_testing"
+content = "Test suite covers frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 5 ──────────────────────────────────────────────────────────────────
+# "what's the user's current fitness routine"
+# Progression: yoga only (90d) -> added gym (45d) -> gym + running (5d)
+# Query says "current" — must rank freshest memory highest
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "what's the user's current fitness routine"
+
+[[cases.seeds]]
+id = "rt5_fitness_v1"
+content = "Doing yoga three times a week at a studio near the apartment. Also walking 20 minutes every morning before starting work."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+age_days = 90
+
+[[cases.seeds]]
+id = "rt5_fitness_v2"
+content = "Started going to a CrossFit gym. Three sessions a week on top of the yoga practice. Dropped the morning walks because the commute to the gym covers the distance."
+memory_type = "fact"
+domain = "health"
+relevance = 1
+age_days = 45
+supersedes = "rt5_fitness_v1"
+
+[[cases.seeds]]
+id = "rt5_fitness_v3"
+content = "Goes to the gym four mornings a week — two upper body sessions and two lower body. Runs 5K on Saturdays at Dolores Park when the weather is good. Dropped CrossFit because the class schedule was too rigid."
+memory_type = "fact"
+domain = "health"
+relevance = 3
+confirmed = true
+age_days = 5
+supersedes = "rt5_fitness_v2"
+
+[[cases.seeds]]
+id = "rt5_sleep"
+content = "Targets 7.5 hours of sleep. Uses a Whoop band to track recovery score and adjusts workout intensity accordingly."
+memory_type = "fact"
+domain = "health"
+relevance = 2
+
+[[cases.seeds]]
+id = "rt5_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_rust"
+content = "Chose Rust for the server-side code."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_react"
+content = "The UI layer uses React 19."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_pref_os"
+content = "Runs macOS Sequoia on a MacBook Pro M3 Max."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_pref_coffee"
+content = "Drinks oat milk lattes in the morning."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_health_allergy"
+content = "Has a mild tree nut allergy."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_finance_sub"
+content = "Monthly subscriptions total about $340."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_pref_music"
+content = "Listens to lo-fi hip hop while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_food_diet"
+content = "Mostly plant-based diet."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_pref_comms"
+content = "Prefers async communication."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_recap_week"
+content = "Week of March 24: shipped context composition PR."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_pref_reading"
+content = "Reads mostly non-fiction."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_testing"
+content = "Test suite covers frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt5_proj_llm"
+content = "On-device inference runs Qwen3-4B via Metal GPU."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+# Near-miss: mentions physical activity but different context
+[[cases.seeds]]
+id = "rt5_standing_desk"
+content = "Switched to a standing desk in January. Alternates between standing and sitting every 45 minutes."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+
+# ─── CASE 6 ──────────────────────────────────────────────────────────────────
+# "when did the user's financial situation last change"
+# Hard temporal — requires interpreting "last change" as the most recent financial event.
+# Progression: full-time salary (180d) -> consulting income (90d) -> indie (burn savings, 30d)
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[cases]]
+query = "when did the user's financial situation last change"
+
+[[cases.seeds]]
+id = "rt6_finance_salary"
+content = "Drawing a $145K annual salary as a senior full-stack engineer at the SaaS company. Benefits include health insurance and 401k matching."
+memory_type = "fact"
+domain = "finance"
+relevance = 0
+age_days = 180
+
+[[cases.seeds]]
+id = "rt6_finance_consulting"
+content = "Switched to freelance consulting at $180/hour. Working about 25 hours a week to maintain flexibility while exploring product ideas."
+memory_type = "fact"
+domain = "finance"
+relevance = 1
+age_days = 90
+supersedes = "rt6_finance_salary"
+
+[[cases.seeds]]
+id = "rt6_finance_indie"
+content = "No income stream currently — burning savings while building the product. Current savings give about 8 months of runway before needing income. Not stressed yet but aware of the clock."
+memory_type = "fact"
+domain = "finance"
+relevance = 3
+confirmed = true
+age_days = 30
+supersedes = "rt6_finance_consulting"
+
+[[cases.seeds]]
+id = "rt6_finance_sub"
+content = "Monthly subscriptions total about $340: Cursor Pro, Linear, Notion, Figma, iCloud+, gym membership, and a few smaller tools."
+memory_type = "fact"
+domain = "finance"
+relevance = 1
+
+[[cases.seeds]]
+id = "rt6_identity_role"
+content = "Solo indie developer working on a personal AI memory product."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_proj_rust"
+content = "Chose Rust for the server-side code."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_proj_react"
+content = "The UI layer uses React 19."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_proj_tauri"
+content = "Desktop shell is built with Tauri 2."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_proj_db"
+content = "All data lives in a single libSQL instance."
+memory_type = "decision"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_pref_editor"
+content = "Primarily uses Cursor as the code editor."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_pref_os"
+content = "Runs macOS Sequoia on a MacBook Pro M3 Max."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_pref_coffee"
+content = "Drinks oat milk lattes in the morning."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_health_sleep"
+content = "Targets 7.5 hours of sleep."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_health_allergy"
+content = "Has a mild tree nut allergy."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_travel_home"
+content = "Lives in the Mission District, San Francisco."
+memory_type = "fact"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_pref_music"
+content = "Listens to lo-fi hip hop while coding."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_food_diet"
+content = "Mostly plant-based diet."
+memory_type = "preference"
+domain = "food"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_pref_comms"
+content = "Prefers async communication."
+memory_type = "preference"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_recap_week"
+content = "Week of March 24: shipped context composition PR."
+memory_type = "recap"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_goal_launch"
+content = "Primary goal for April: get the product to three beta testers."
+memory_type = "goal"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_fitness"
+content = "Goes to the gym four mornings a week."
+memory_type = "fact"
+domain = "health"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_pref_reading"
+content = "Reads mostly non-fiction."
+memory_type = "preference"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_identity_values"
+content = "Values craftsmanship over speed."
+memory_type = "identity"
+domain = "personal"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_proj_testing"
+content = "Test suite covers frontend and Rust."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_proj_embed"
+content = "Embeddings are produced by GTE-Base-EN-v1.5-Q."
+memory_type = "fact"
+domain = "work"
+relevance = 0
+
+[[cases.seeds]]
+id = "rt6_edu"
+content = "Studied computer science at UC Berkeley, graduated in 2019."
+memory_type = "identity"
+domain = "personal"
+relevance = 0

--- a/app/eval/fixtures/recap_noise.toml
+++ b/app/eval/fixtures/recap_noise.toml
@@ -1,0 +1,82 @@
+# Recap noise — original memories should rank above their recap summaries.
+# Pattern seen: recap chunks with mid-sentence fragments flooding top results,
+# same fact appearing 3x (original + 2 recap mentions).
+
+[[cases]]
+query = "how to configure build profiles"
+
+[[cases.seeds]]
+id = "mem_build_original"
+content = "Added preview-playstore build profile with distribution set to store and buildType app-bundle. This produces a signed AAB that the Play Store accepts."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_build_detail"
+content = "The build profile system supports multiple configurations: preview for internal testing with APK distribution, preview-playstore for store distribution with AAB, and production for release builds."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Recap of the same content — should rank below originals
+[[cases.negative_seeds]]
+id = "mem_build_recap"
+content = "Session recap: configured build profiles, set up EAS submit automation, tested store distribution workflow."
+memory_type = "recap"
+domain = "projectA"
+
+# Hard negative: mentions build profiles but describes a different platform's build system
+[[cases.negative_seeds]]
+id = "mem_build_xcode"
+content = "Xcode build profiles support Debug and Release configurations out of the box. Custom build profiles can override signing identity, provisioning profile, and optimization level per scheme."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions build configuration but is about CI, not local build profiles
+[[cases.negative_seeds]]
+id = "mem_build_ci"
+content = "GitHub Actions CI workflow uses a build matrix with three profiles: debug for quick checks, release for integration tests, and production for deployment artifacts. Each profile sets different RUSTFLAGS."
+memory_type = "fact"
+domain = "projectA"
+
+
+[[cases]]
+query = "search ranking algorithm"
+
+[[cases.seeds]]
+id = "mem_ranking_impl"
+content = "Search scoring combines RRF base score with confidence, recency decay, quality multiplier, confirmation boost, and domain relevance. Final score is normalized to 0-1 range."
+memory_type = "fact"
+domain = "projectB"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_ranking_rrf"
+content = "Reciprocal Rank Fusion merges vector similarity and full-text search rankings. Score formula: sum of 1/(60+rank) for each retrieval signal."
+memory_type = "fact"
+domain = "projectB"
+relevance = 2
+
+# Recap that mentions ranking tangentially
+[[cases.negative_seeds]]
+id = "mem_ranking_recap"
+content = "Session recap: investigated search quality issues, compared score ranges, tested domain filtering. Scores improved from 0.007-0.014 to 0.38-1.0 range."
+memory_type = "recap"
+domain = "projectB"
+
+# Hard negative: mentions ranking algorithm but is about FTS ranking, not the full pipeline
+[[cases.negative_seeds]]
+id = "mem_fts_ranking"
+content = "FTS5 uses BM25 for internal ranking of full-text matches. The rank column returned by FTS5 is a negative number where values closer to zero indicate better matches."
+memory_type = "fact"
+domain = "projectB"
+
+# Hard negative: mentions search scoring but is about the tuning config, not the algorithm
+[[cases.negative_seeds]]
+id = "mem_scoring_config"
+content = "SearchScoringConfig exposes rrf_k, confirmation_boost, recap_penalty, and domain_boost as tunable parameters. Changes take effect on the next query without restart."
+memory_type = "fact"
+domain = "projectB"

--- a/app/eval/fixtures/relevance_gradient.toml
+++ b/app/eval/fixtures/relevance_gradient.toml
@@ -1,0 +1,94 @@
+# Relevance gradient — tests that ranking correctly orders by semantic closeness.
+# Pattern seen: all results scored 0.007-0.014 with no meaningful differentiation.
+
+[[cases]]
+query = "memory deduplication and merge strategy"
+
+[[cases.seeds]]
+id = "mem_dedup_core"
+content = "Deduplication uses cosine similarity with 0.85 threshold. Matches above threshold are queued as merge proposals for human review. Recaps excluded from dedup since they are expected to overlap with originals."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_dedup_postingest"
+content = "Post-ingest enrichment pipeline runs dedup check after every store. Vector similarity query finds candidates, then RRF scoring confirms the match before queuing."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+[[cases.seeds]]
+id = "mem_dedup_tangential"
+content = "The enrichment pipeline also handles entity auto-linking and recap triggers. These run in sequence after the dedup check."
+memory_type = "fact"
+domain = "projectA"
+relevance = 1
+
+# Noise that shares vocabulary but is semantically distant
+[[cases.negative_seeds]]
+id = "mem_git_merge"
+content = "Always create new git commits rather than amending existing ones. Resolve merge conflicts rather than discarding changes."
+memory_type = "preference"
+domain = "personal"
+
+# Hard negative: mentions dedup and merge but is about entity resolution, not memory dedup
+[[cases.negative_seeds]]
+id = "mem_entity_merge"
+content = "Entity resolution merges duplicate entity records that refer to the same real-world object. When two entities have cosine similarity above 0.90 and matching types, they are flagged for merge review."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions dedup and cosine similarity but is about search result dedup, not storage dedup
+[[cases.negative_seeds]]
+id = "mem_search_dedup"
+content = "Search result deduplication removes entries sharing a source_id, then a bigram Jaccard pass drops near-duplicate text with similarity above 0.5 before the final ranked list is returned."
+memory_type = "fact"
+domain = "projectA"
+
+
+[[cases]]
+query = "on-device language model inference"
+
+[[cases.seeds]]
+id = "mem_llm_setup"
+content = "Running Qwen3 4B parameter model via Metal GPU acceleration. Dedicated std::thread for inference to avoid blocking the Tokio runtime. Bridge pattern uses runtime Handle for async DB callbacks."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_llm_prompts"
+content = "LLM prompts loaded from PromptRegistry with TOML overrides at runtime. 17 prompt templates cover classification, quality assessment, reranking, entity extraction, and structured field extraction."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+[[cases.seeds]]
+id = "mem_llm_perf"
+content = "Inference timeout set to 10 seconds for reranking calls. Quality assessment runs asynchronously and does not block the store response."
+memory_type = "fact"
+domain = "projectA"
+relevance = 1
+
+[[cases.negative_seeds]]
+id = "mem_llm_noise"
+content = "Tokio uses a work-stealing scheduler with configurable thread count. Default is one thread per CPU core."
+memory_type = "fact"
+domain = "general"
+
+# Hard negative: mentions on-device LLM inference but is about model selection evaluation, not the running setup
+[[cases.negative_seeds]]
+id = "mem_llm_eval"
+content = "Evaluated Phi-3 Mini, Gemma 2B, and Qwen3 4B for on-device inference. Qwen3 won on quality per parameter but Phi-3 has 2x faster token generation on Metal. Decision was quality over speed."
+memory_type = "decision"
+domain = "projectA"
+
+# Hard negative: mentions language model and Metal GPU but is about embedding model, not the LLM formatter
+[[cases.negative_seeds]]
+id = "mem_embed_model_inference"
+content = "The GTE-Base-EN-v1.5-Q embedding model runs ONNX inference on a dedicated thread using CoreML acceleration on Apple Silicon. Each embedding takes approximately 8ms for a 512-token input."
+memory_type = "fact"
+domain = "projectA"

--- a/app/eval/fixtures/semantic_vs_keyword.toml
+++ b/app/eval/fixtures/semantic_vs_keyword.toml
@@ -1,0 +1,83 @@
+# Semantic vs keyword match — queries using different words than the stored content.
+# Tests that vector similarity catches semantic matches, not just exact keyword overlap.
+# Pattern seen: FTS-heavy ranking missed conceptually related memories that used different terminology.
+
+[[cases]]
+query = "how to prevent storing duplicate information"
+
+# Uses "dedup" and "similarity threshold" — different words than "duplicate" and "prevent"
+[[cases.seeds]]
+id = "mem_dedup_semantic"
+content = "Post-ingest dedup check compares new content against existing memories using cosine similarity. Threshold of 0.85 catches near-duplicates while avoiding false merges."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+# Uses "supersede" — another synonym for handling duplicates
+[[cases.seeds]]
+id = "mem_supersede"
+content = "When a newer memory supersedes an older one, the supersede mode determines behavior: archive keeps the old version with a 0.5x score penalty, replace removes it entirely."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "mem_keyword_trap"
+content = "Prevent PII from being stored by running content through the privacy redaction pipeline. Credit cards, SSNs, API keys, and email addresses are detected and masked."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions dedup and preventing storage but is about quality gate rejection, not duplicate handling
+[[cases.negative_seeds]]
+id = "mem_prevent_low_quality"
+content = "The quality gate prevents low-quality information from being stored by checking minimum word count, language detection, and information density before the embedding step runs."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions duplicate and storage but is about recap dedup, not general dedup
+[[cases.negative_seeds]]
+id = "mem_recap_dedup"
+content = "Recap deduplication removes redundant session summaries from search results by comparing bigram Jaccard similarity between recap and original content with a 0.5 threshold."
+memory_type = "fact"
+domain = "projectA"
+
+
+[[cases]]
+query = "making search results more relevant"
+
+# Mentions "scoring", "ranking", "quality" — not "relevant" or "search results"
+[[cases.seeds]]
+id = "mem_scoring_tuning"
+content = "Tiered retrieval scoring multiplies RRF base by confidence, recency decay, quality assessment, and confirmation boost. Each factor is configurable via TuningConfig."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_reranking"
+content = "Optional LLM reranking as a second pass: on-device model rates each result 0-10 for query relevance, then results are re-sorted. 10 second timeout with graceful fallback."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "mem_unrelated_search"
+content = "The spotlight search UI supports keyboard navigation with Cmd+K activation. Source filters narrow results by memory type."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions search quality but is about the eval harness measuring quality, not improving it
+[[cases.negative_seeds]]
+id = "mem_eval_quality"
+content = "Search quality is measured via NDCG@10 and MAP@5 on curated fixture cases. The eval harness seeds an ephemeral database per case and runs queries against it to compute metrics."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions relevance and results but is about displaying results, not ranking them
+[[cases.negative_seeds]]
+id = "mem_result_display"
+content = "Search results are displayed with relevance badges showing memory type and domain. The MemoryCard component renders summary text first, falling back to raw content when no summary exists."
+memory_type = "fact"
+domain = "projectA"

--- a/app/eval/fixtures/store_quality_agent_naming.toml
+++ b/app/eval/fixtures/store_quality_agent_naming.toml
@@ -1,0 +1,92 @@
+# Agent naming inconsistency — same agent stored under multiple names.
+# Real DB: "claude-code" (103), "refinery" (100), "claude" (51),
+# "Claude Code" (10), "Cursor" (2), "Claude Desktop" (2).
+# "claude-code" and "Claude Code" are the same agent with different casing.
+# This fragments source_agent filtering — querying agent="claude-code" misses "Claude Code" memories.
+
+[[cases]]
+query = "code review suggestions"
+# No domain filter — tests cross-agent ranking
+
+[[cases.seeds]]
+id = "mem_review_agent1"
+content = "Always run the full test suite before creating a PR. Coverage gate requires 90% on push to main. Pre-commit hooks run fast checks only."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_review_agent2"
+content = "Use conventional commit messages: feat, fix, refactor, test, docs, chore prefixes. Include scope in parentheses for multi-module repos."
+memory_type = "preference"
+domain = "projectA"
+relevance = 2
+
+# Auto-generated recap from refinery agent — should rank below human-curated
+[[cases.negative_seeds]]
+id = "mem_review_recap"
+content = "Session recap: reviewed PR #15, added test coverage for auth module, fixed linting errors in three files."
+memory_type = "recap"
+domain = "projectA"
+
+# Generic fact from untrusted source
+[[cases.negative_seeds]]
+id = "mem_review_untrusted"
+content = "Code review tools include GitHub pull requests, GitLab merge requests, and Gerrit. Most teams review within 24 hours."
+memory_type = "fact"
+domain = "general"
+
+# Hard negative: mentions code review but is about automated CI checks, not review suggestions
+[[cases.negative_seeds]]
+id = "mem_review_ci"
+content = "Pre-commit hooks run cargo fmt and cargo clippy on staged files. Push hooks run the full test suite with a 90% coverage gate. Both are configured via scripts/setup-hooks.sh."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions review suggestions but is about PR template, not the review process
+[[cases.negative_seeds]]
+id = "mem_review_template"
+content = "PR template includes a Summary section, a Test Plan checklist, and a Reviewer Notes field. The template is enforced by a GitHub Actions check that rejects PRs with empty sections."
+memory_type = "decision"
+domain = "projectA"
+
+
+[[cases]]
+query = "memory storage decisions"
+
+[[cases.seeds]]
+id = "mem_storage_decision"
+content = "Single libSQL database for everything: document chunks with vector columns, knowledge graph tables, full-text search via FTS5. One DB file simplifies backup and migration."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_storage_detail"
+content = "Chunks table uses F32_BLOB(384) for embeddings with DiskANN indexing on cosine metric. Max neighbors set to 32 for the vector index."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Refinery-generated consolidation — mentions storage but is a recap
+[[cases.negative_seeds]]
+id = "mem_storage_refinery"
+content = "Consolidation sweep: merged 3 overlapping facts about database schema. Source memories superseded with mode=archive."
+memory_type = "recap"
+domain = "projectA"
+
+# Hard negative: mentions memory storage but is about config storage, not the memory DB
+[[cases.negative_seeds]]
+id = "mem_storage_config"
+content = "Persistent configuration is stored as JSON at ~/Library/Application Support/origin/config.json. Feature toggles are read at startup and exposed as AtomicBool flags for lock-free access."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions storage decision but is about file watching, not DB storage
+[[cases.negative_seeds]]
+id = "mem_storage_files"
+content = "Watched files are stored on disk alongside their metadata in a sidecar JSON. The file watcher uses the notify crate with 2-second debounce to detect changes and queue re-indexing."
+memory_type = "decision"
+domain = "projectA"

--- a/app/eval/fixtures/store_quality_agent_trust.toml
+++ b/app/eval/fixtures/store_quality_agent_trust.toml
@@ -1,0 +1,56 @@
+# Agent trust levels — memories from high-trust agents should rank above untrusted.
+# Pattern from real DB: agent naming inconsistency ("claude-code" vs "Claude Code" vs "claude"),
+# and refinery-generated recaps (100 memories) ranking alongside human-curated content.
+
+[[cases]]
+query = "database connection pooling"
+
+# Human-confirmed memory from trusted agent
+[[cases.seeds]]
+id = "mem_db_confirmed"
+content = "libSQL Connection is Send but not Sync. Wrap in tokio::sync::Mutex for shared access from AppState. Single connection per app instance is sufficient for local-first usage."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+# Same topic from trusted agent, unconfirmed
+[[cases.seeds]]
+id = "mem_db_unconfirmed"
+content = "WAL mode enabled for concurrent reads during write operations. Foreign keys enforced via PRAGMA at connection time."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Auto-generated recap — lower trust, should rank below originals
+[[cases.negative_seeds]]
+id = "mem_db_recap_auto"
+content = "Session recap: investigated database connection issues, configured WAL mode, tested concurrent access patterns."
+memory_type = "recap"
+domain = "projectA"
+
+
+[[cases]]
+query = "configuration file format"
+
+[[cases.seeds]]
+id = "mem_config_toml"
+content = "Intelligence tuning parameters loaded from TOML at startup. File at ~/Library/Application Support/origin/intelligence.toml. Missing keys fall back to serde defaults — partial overrides work correctly."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_config_json"
+content = "User-facing config stored as JSON at ~/Library/Application Support/origin/config.json. Includes watch paths, feature toggles, skip list for privacy-sensitive apps."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Generic fact about config formats — not project-specific
+[[cases.negative_seeds]]
+id = "mem_config_generic"
+content = "TOML is preferred over YAML for configuration files due to explicit typing and no indentation sensitivity."
+memory_type = "fact"
+domain = "general"

--- a/app/eval/fixtures/store_quality_confidence_calibration.toml
+++ b/app/eval/fixtures/store_quality_confidence_calibration.toml
@@ -1,0 +1,65 @@
+# Confidence calibration — confirmed memories should outscore unconfirmed,
+# and high-quality should outscore low-quality.
+# Pattern from real DB: 7 confirmed memories have confidence < 0.5,
+# 247/276 memories have no quality assessment at all.
+
+[[cases]]
+query = "error handling best practices"
+
+# Confirmed, high-quality — should rank highest
+[[cases.seeds]]
+id = "mem_error_confirmed"
+content = "Use Result<T, OriginError> for all fallible operations. Map errors at module boundaries with .map_err(). Never use unwrap() in production code paths — only in tests and provably-safe contexts."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+quality = "high"
+
+# Unconfirmed but relevant — should rank second
+[[cases.seeds]]
+id = "mem_error_unconfirmed"
+content = "The OriginError enum has 13 variants covering VectorDb, Embedding, Indexer, Source, Io, Http, Json, Llm, Vision, Trigger, Router, AgentDisabled, and Generic."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Low-relevance tangential fact
+[[cases.seeds]]
+id = "mem_error_tangential"
+content = "Log filter defaults to warn level. Add modules explicitly for info-level logging with target filters."
+memory_type = "fact"
+domain = "projectA"
+relevance = 1
+
+# Different project's error handling — should not appear
+[[cases.negative_seeds]]
+id = "mem_error_other"
+content = "Express middleware catches unhandled promise rejections and returns a 500 status with a generic error message."
+memory_type = "fact"
+domain = "projectB"
+
+
+[[cases]]
+query = "window management and multi-window architecture"
+
+[[cases.seeds]]
+id = "mem_window_arch"
+content = "Four Tauri windows from a single webview, routed by URL hash: main for spotlight/memory/settings, toast for capture notifications, snip for region selection, quick-capture for thought input."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_window_toast"
+content = "Toast window is a transparent non-activating panel. It overlays without stealing focus from the user's current application."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+[[cases.negative_seeds]]
+id = "mem_window_generic"
+content = "Electron supports multiple BrowserWindow instances with separate renderer processes. Each window can load a different URL."
+memory_type = "fact"
+domain = "general"

--- a/app/eval/fixtures/store_quality_dedup_gap.toml
+++ b/app/eval/fixtures/store_quality_dedup_gap.toml
@@ -1,0 +1,58 @@
+# Dedup gap — near-duplicate content stored under different IDs.
+# Pattern from real DB: same PGroonga fact appeared 3x, Google Play setup stored twice.
+# Tests whether search surfaces the best version or floods with duplicates.
+
+[[cases]]
+query = "full-text search implementation"
+
+# Original fact
+[[cases.seeds]]
+id = "mem_fts_original"
+content = "Full-text search uses FTS5 virtual table (chunks_fts) with content and title columns. Auto-synced with chunks table via INSERT, UPDATE, and DELETE triggers."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+# Near-duplicate — slightly different wording, same information
+[[cases.seeds]]
+id = "mem_fts_neardup"
+content = "FTS5 virtual table chunks_fts indexes content and title fields. Triggers on the chunks table keep it synchronized on every insert, update, and delete."
+memory_type = "fact"
+domain = "projectA"
+relevance = 1
+
+# Recap mentioning FTS
+[[cases.negative_seeds]]
+id = "mem_fts_recap"
+content = "Session recap: added FTS5 indexing, created sync triggers, tested search with various query patterns."
+memory_type = "recap"
+domain = "projectA"
+
+
+[[cases]]
+query = "knowledge graph entity relationships"
+
+# Detailed original
+[[cases.seeds]]
+id = "mem_kg_original"
+content = "Knowledge graph uses three tables: entities (name, type, domain), relations (from_entity, to_entity, relation_type), and observations (entity_id, content, confidence). FK cascades handle cleanup on entity deletion."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+# Partial duplicate — subset of the same information
+[[cases.seeds]]
+id = "mem_kg_partial_dup"
+content = "Entities table stores name and type. Relations link entities with typed edges. Observations attach factual statements to entities with confidence scores."
+memory_type = "fact"
+domain = "projectA"
+relevance = 1
+
+# Different project's graph — should not appear
+[[cases.negative_seeds]]
+id = "mem_kg_other"
+content = "Neo4j graph database stores nodes with labels and properties. Cypher queries traverse relationships using MATCH patterns."
+memory_type = "fact"
+domain = "projectB"

--- a/app/eval/fixtures/store_quality_domain_consistency.toml
+++ b/app/eval/fixtures/store_quality_domain_consistency.toml
@@ -1,0 +1,47 @@
+# Domain consistency — semantically equivalent domains should not fragment search.
+# Pattern from real DB: "technology" (22), "engineering" (11), "development" (5),
+# "software-engineering" (3) all contain similar technical facts that should share one domain.
+
+[[cases]]
+query = "async programming patterns"
+domain = "technology"
+
+[[cases.seeds]]
+id = "mem_async_tech"
+content = "Async/await in Rust requires pinning futures that borrow across yield points. Use Box::pin for heap allocation or pin! macro for stack pinning."
+memory_type = "fact"
+domain = "technology"
+relevance = 3
+confirmed = true
+
+# Same kind of content but fragmented across synonym domains
+[[cases.negative_seeds]]
+id = "mem_async_eng"
+content = "Error handling in async Rust uses the ? operator with Result types. Map errors at boundary layers using .map_err() to maintain type consistency."
+memory_type = "fact"
+domain = "engineering"
+
+[[cases.negative_seeds]]
+id = "mem_async_dev"
+content = "Structured concurrency patterns group related async tasks. Use JoinSet to spawn and await multiple tasks with automatic cancellation on drop."
+memory_type = "fact"
+domain = "development"
+
+
+[[cases]]
+query = "type system design decisions"
+domain = "software-engineering"
+
+[[cases.seeds]]
+id = "mem_types_se"
+content = "Prefer newtype pattern over type aliases for domain types. A UserId(String) prevents accidentally passing a SessionId where a UserId is expected."
+memory_type = "decision"
+domain = "software-engineering"
+relevance = 3
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "mem_types_tech"
+content = "Rust enums with associated data replace the visitor pattern. Match exhaustiveness guarantees all variants are handled at compile time."
+memory_type = "fact"
+domain = "technology"

--- a/app/eval/fixtures/store_quality_missing_assessment.toml
+++ b/app/eval/fixtures/store_quality_missing_assessment.toml
@@ -1,0 +1,40 @@
+# Missing quality assessment — 247/276 memories (89.5%) have NULL quality.
+# Tests that unassessed memories rank below quality-assessed ones.
+# Pattern: most memories skip LLM quality assessment, so quality_mult defaults
+# to 0.9 (medium/NULL) instead of differentiating high (1.0) vs low (0.7).
+
+[[cases]]
+query = "state management architecture"
+
+# High-quality assessed memory — should rank highest (quality_mult=1.0)
+[[cases.seeds]]
+id = "mem_state_high_quality"
+content = "AppState uses Arc<RwLock<AppState>> managed by Tauri. Atomic flags (Arc<AtomicBool>) for feature toggles shared with sensor threads — lock-free reads from hot loops avoid contention."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+quality = "high"
+
+# Unassessed memory — quality NULL, gets default 0.9x multiplier
+[[cases.seeds]]
+id = "mem_state_no_quality"
+content = "Frontend uses TanStack React Query for server state. Module-level stores with useSyncExternalStore pattern for state that survives React unmounts."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Low-quality assessed — should rank lowest (quality_mult=0.7)
+[[cases.seeds]]
+id = "mem_state_low_quality"
+content = "State can also be stored in localStorage but this has size limits."
+memory_type = "fact"
+domain = "projectA"
+relevance = 1
+quality = "low"
+
+[[cases.negative_seeds]]
+id = "mem_state_noise"
+content = "React 19 introduced use() hook for reading promises and context in render."
+memory_type = "fact"
+domain = "general"

--- a/app/eval/fixtures/store_quality_recap_ratio.toml
+++ b/app/eval/fixtures/store_quality_recap_ratio.toml
@@ -1,0 +1,58 @@
+# Recap flooding — domains with high recap ratios dilute original content.
+# Pattern from real DB: "technology" domain is 95.5% recaps (21/22),
+# "homepage" is 88.9% recaps. Original content gets buried.
+
+[[cases]]
+query = "CSS grid layout patterns"
+
+# The one original memory in a recap-heavy domain
+[[cases.seeds]]
+id = "mem_css_original"
+content = "Use CSS Grid for 2D layouts and Flexbox for 1D. Grid template areas provide readable layout definitions. Auto-fit with minmax enables responsive grids without media queries."
+memory_type = "fact"
+domain = "frontend"
+relevance = 3
+confirmed = true
+
+# Recaps that mention CSS but are just session summaries
+[[cases.negative_seeds]]
+id = "mem_css_recap1"
+content = "Session recap: worked on responsive layout for the dashboard page, adjusted grid column widths, fixed mobile breakpoint issues."
+memory_type = "recap"
+domain = "frontend"
+
+[[cases.negative_seeds]]
+id = "mem_css_recap2"
+content = "Session recap: implemented dark mode theme, updated CSS variables, tested grid layout in both light and dark modes."
+memory_type = "recap"
+domain = "frontend"
+
+[[cases.negative_seeds]]
+id = "mem_css_recap3"
+content = "Session recap: refactored component styles to use Tailwind utility classes, removed custom CSS grid definitions in favor of Tailwind grid."
+memory_type = "recap"
+domain = "frontend"
+
+
+[[cases]]
+query = "image optimization strategy"
+
+[[cases.seeds]]
+id = "mem_img_decision"
+content = "Serve WebP with AVIF fallback for modern browsers. Lazy load below-fold images with loading=lazy. Use srcset for responsive sizes at 640w, 1024w, and 1920w breakpoints."
+memory_type = "decision"
+domain = "frontend"
+relevance = 3
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "mem_img_recap"
+content = "Session recap: optimized hero images, compressed PNG assets, added lazy loading to product gallery. Reduced page weight by 40%."
+memory_type = "recap"
+domain = "frontend"
+
+[[cases.negative_seeds]]
+id = "mem_img_recap2"
+content = "Session recap: migrated image pipeline to use sharp for server-side resizing. Generated WebP variants for all static assets."
+memory_type = "recap"
+domain = "frontend"

--- a/app/eval/fixtures/structured_content_quality.toml
+++ b/app/eval/fixtures/structured_content_quality.toml
@@ -1,0 +1,128 @@
+# Structured content quality — tests retrieval when structured_fields are present.
+# Content is natural language (as agents write it). Structured fields are the extracted sidecar.
+# The pipeline flattens structured_fields into content and keeps prose in source_text for embedding.
+
+[[cases]]
+query = "dark mode preference for editors"
+
+[[cases.seeds]]
+id = "mem_pref_dark"
+content = "I strongly prefer dark mode in all my editors and terminals"
+memory_type = "preference"
+domain = "tools"
+relevance = 3
+confirmed = true
+structured_fields = '{"preference":"dark mode","applies_when":"editors, terminals","strength":"strong"}'
+
+[[cases.seeds]]
+id = "mem_pref_vim"
+content = "I like using relative line numbers in vim for easier navigation"
+memory_type = "preference"
+domain = "tools"
+relevance = 1
+structured_fields = '{"preference":"relative line numbers","applies_when":"vim configuration"}'
+
+[[cases.negative_seeds]]
+id = "mem_pref_light"
+content = "I prefer light mode when reading long documents or articles"
+memory_type = "preference"
+domain = "tools"
+structured_fields = '{"preference":"light mode","applies_when":"reading documents","strength":"moderate"}'
+
+# Hard negative: mentions dark mode and editor preference but is about a specific theme, not the general preference
+[[cases.negative_seeds]]
+id = "mem_pref_theme"
+content = "Switched VS Code theme from One Dark Pro to Catppuccin Mocha because the contrast ratio is better for long coding sessions. Editor font is JetBrains Mono 14pt."
+memory_type = "preference"
+domain = "tools"
+
+# Hard negative: mentions editor terminal preference but is about keybindings, not visual mode
+[[cases.negative_seeds]]
+id = "mem_pref_keybindings"
+content = "I use vim keybindings in VS Code with the VSCodeVim extension. Terminal uses tmux with a custom prefix key set to Ctrl-A instead of the default Ctrl-B."
+memory_type = "preference"
+domain = "tools"
+
+
+[[cases]]
+query = "what decision was made about the database"
+
+[[cases.seeds]]
+id = "mem_dec_libsql"
+content = "I decided to use libSQL instead of SQLite because it supports vectors and FTS in a single database file"
+memory_type = "decision"
+domain = "origin"
+relevance = 3
+confirmed = true
+structured_fields = '{"decision":"use libSQL","context":"need unified DB with vector and FTS","alternatives_considered":"PostgreSQL, MongoDB, SQLite"}'
+
+[[cases.seeds]]
+id = "mem_dec_agpl"
+content = "Chose AGPL-3.0-only license for the origin app to protect the open source release"
+memory_type = "decision"
+domain = "origin"
+relevance = 2
+structured_fields = '{"decision":"AGPL-3.0-only for origin app","context":"licensing for open source release"}'
+
+[[cases.negative_seeds]]
+id = "mem_dec_unrelated"
+content = "Decided to use GraphQL for the mobile app API because it reduces over-fetching"
+memory_type = "decision"
+domain = "other_project"
+structured_fields = '{"decision":"use GraphQL","context":"API design for mobile app"}'
+
+# Hard negative: mentions database decision but is about the DB path, not which DB was chosen
+[[cases.negative_seeds]]
+id = "mem_dec_db_path"
+content = "Database file is stored at ~/Library/Application Support/origin/memorydb/origin_memory.db. This location was chosen because macOS sandboxing allows app-specific data under Application Support."
+memory_type = "decision"
+domain = "origin"
+
+# Hard negative: mentions database and decision but is about connection pooling, not DB selection
+[[cases.negative_seeds]]
+id = "mem_dec_conn_pool"
+content = "Decided against connection pooling because libSQL in WAL mode supports concurrent reads with a single writer. The tokio::sync::Mutex wrapper serializes writes without the overhead of a pool."
+memory_type = "decision"
+domain = "origin"
+
+
+[[cases]]
+query = "Lucian identity claims"
+
+[[cases.seeds]]
+id = "mem_id_rust"
+content = "I am a full-stack developer specializing in Rust and TypeScript"
+memory_type = "identity"
+domain = "personal"
+relevance = 3
+confirmed = true
+structured_fields = '{"claim":"full-stack developer specializing in Rust and TypeScript"}'
+
+[[cases.seeds]]
+id = "mem_id_founder"
+content = "I co-founded an S-Corp before joining Meta, with a US citizen co-founder holding majority ownership"
+memory_type = "identity"
+domain = "personal"
+relevance = 2
+structured_fields = '{"claim":"co-founded an S-Corp before joining Meta","evidence":"US citizen co-founder holds majority"}'
+
+[[cases.negative_seeds]]
+id = "mem_id_noise"
+content = "Experienced with cloud infrastructure and DevOps tooling across AWS and GCP"
+memory_type = "identity"
+domain = "personal"
+structured_fields = '{"claim":"experienced with cloud infrastructure and DevOps"}'
+
+# Hard negative: mentions identity and developer background but is about a team member, not the user
+[[cases.negative_seeds]]
+id = "mem_id_teammate"
+content = "Alice is a senior backend engineer on the team, specializing in distributed systems and database internals. She reviewed most of the memory pipeline PRs."
+memory_type = "fact"
+domain = "work"
+
+# Hard negative: mentions Lucian and developer claims but is about a conference talk, not identity
+[[cases.negative_seeds]]
+id = "mem_id_talk"
+content = "Submitted a talk proposal on building local-first AI memory systems with Rust and libSQL. Conference is in June 2026; acceptance notification pending."
+memory_type = "fact"
+domain = "personal"

--- a/app/eval/fixtures/temporal_ordering.toml
+++ b/app/eval/fixtures/temporal_ordering.toml
@@ -1,0 +1,118 @@
+# Temporal ordering — does recency scoring rank newer above older?
+
+[[cases]]
+query = "what database does the project use"
+
+[[cases.seeds]]
+id = "old_db_decision"
+content = "Chose PostgreSQL for the backend database due to strong ecosystem and JSONB support"
+memory_type = "decision"
+domain = "project"
+relevance = 1
+age_days = 90
+confirmed = true
+
+[[cases.seeds]]
+id = "new_db_decision"
+content = "Migrated from PostgreSQL to libSQL for embedded vector support and local-first architecture"
+memory_type = "decision"
+domain = "project"
+relevance = 3
+age_days = 5
+supersedes = "old_db_decision"
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "neg_unrelated_pref"
+content = "User prefers dark mode in all code editors"
+memory_type = "preference"
+domain = "personal"
+
+[[cases]]
+query = "deployment strategy for the API"
+
+[[cases.seeds]]
+id = "old_deploy"
+content = "API deployed to Heroku with automatic scaling and Postgres add-on"
+memory_type = "decision"
+domain = "work"
+relevance = 1
+age_days = 120
+confirmed = true
+
+[[cases.seeds]]
+id = "new_deploy"
+content = "Moved API deployment to Fly.io with edge regions in US-East and EU-West for lower latency"
+memory_type = "decision"
+domain = "work"
+relevance = 3
+age_days = 3
+supersedes = "old_deploy"
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "neg_ci_config"
+content = "GitHub Actions workflow runs tests on push to main"
+memory_type = "fact"
+domain = "work"
+
+[[cases]]
+query = "preferred frontend framework"
+
+[[cases.seeds]]
+id = "old_framework"
+content = "Using Vue 3 with Composition API for all frontend projects"
+memory_type = "preference"
+domain = "work"
+relevance = 1
+age_days = 180
+
+[[cases.seeds]]
+id = "new_framework"
+content = "Switched to React 19 with TanStack Query for better ecosystem support and hiring"
+memory_type = "preference"
+domain = "work"
+relevance = 3
+age_days = 10
+supersedes = "old_framework"
+
+[[cases.negative_seeds]]
+id = "neg_backend_pref"
+content = "Prefers Rust over Go for backend services due to memory safety guarantees"
+memory_type = "preference"
+domain = "work"
+
+[[cases]]
+query = "team communication tool"
+
+[[cases.seeds]]
+id = "stale_comms"
+content = "Team uses Slack for all async communication with dedicated channels per project"
+memory_type = "fact"
+domain = "work"
+relevance = 2
+age_days = 60
+
+[[cases.seeds]]
+id = "fresh_comms"
+content = "Team switched to Discord for async communication, using threads heavily for topic isolation"
+memory_type = "fact"
+domain = "work"
+relevance = 3
+age_days = 2
+supersedes = "stale_comms"
+
+[[cases.seeds]]
+id = "very_relevant_old"
+content = "Communication tooling evaluation: considered Slack, Discord, Teams, and Zulip before deciding"
+memory_type = "fact"
+domain = "work"
+relevance = 3
+age_days = 65
+confirmed = true
+
+[[cases.negative_seeds]]
+id = "neg_email_pref"
+content = "User checks personal email twice per day, morning and evening"
+memory_type = "preference"
+domain = "personal"

--- a/app/eval/fixtures/trivial_noise.toml
+++ b/app/eval/fixtures/trivial_noise.toml
@@ -1,0 +1,88 @@
+# Trivial noise — generic/low-value memories should rank below actionable ones.
+# Pattern seen: "Tokio work-stealing", "node_modules sizes" appearing alongside
+# actionable project decisions in search results.
+
+[[cases]]
+query = "async runtime configuration"
+
+[[cases.seeds]]
+id = "mem_async_decision"
+content = "Tauri manages the Tokio runtime. In setup() closure, Handle::current() panics — must use tauri::async_runtime::block_on(async { Handle::current() }) instead."
+memory_type = "decision"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_async_threading"
+content = "LLM inference runs on a dedicated std::thread to avoid blocking async tasks. The thread captures a tokio runtime Handle at spawn time for async DB callbacks via handle.block_on()."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Generic trivia that mentions async but has no actionable value
+[[cases.negative_seeds]]
+id = "mem_async_trivia"
+content = "Tokio uses a work-stealing scheduler. The default runtime is multi-threaded with one worker per CPU core."
+memory_type = "fact"
+domain = "general"
+
+[[cases.negative_seeds]]
+id = "mem_deps_trivia"
+content = "The node_modules directory is 847MB. pnpm uses content-addressable storage to share packages across projects."
+memory_type = "fact"
+domain = "general"
+
+# Hard negative: mentions async runtime and configuration but is about a different project's setup
+[[cases.negative_seeds]]
+id = "mem_async_other_project"
+content = "The web scraper configures a custom Tokio runtime with 4 worker threads and a 30-second task timeout. spawn_blocking handles CPU-intensive HTML parsing without starving the I/O reactor."
+memory_type = "fact"
+domain = "projectB"
+
+# Hard negative: mentions runtime Handle and threading but describes testing, not the actual setup
+[[cases.negative_seeds]]
+id = "mem_async_test_harness"
+content = "Integration tests create a separate Tokio runtime with current_thread flavor to avoid flaky behavior from shared state. The test harness captures Handle::current() in a once_cell for async assertions."
+memory_type = "fact"
+domain = "projectA"
+
+
+[[cases]]
+query = "privacy and data redaction"
+
+[[cases.seeds]]
+id = "mem_privacy_impl"
+content = "PII redaction pipeline detects credit card numbers, Social Security numbers, API keys, and email addresses. Patterns are applied before storage — redacted content uses [REDACTED] placeholders."
+memory_type = "fact"
+domain = "projectA"
+relevance = 3
+confirmed = true
+
+[[cases.seeds]]
+id = "mem_privacy_apps"
+content = "Private browsing detection skips capture from incognito windows. Skip list includes password managers, banking apps, and messaging apps."
+memory_type = "fact"
+domain = "projectA"
+relevance = 2
+
+# Generic privacy fact, not project-specific
+[[cases.negative_seeds]]
+id = "mem_privacy_generic"
+content = "GDPR requires data controllers to implement appropriate technical measures to protect personal data."
+memory_type = "fact"
+domain = "general"
+
+# Hard negative: mentions redaction and PII but is about audit logging, not the pipeline itself
+[[cases.negative_seeds]]
+id = "mem_privacy_audit"
+content = "Redacted PII events are written to the privacy_audit table with a hash of the original content, the redaction pattern that matched, and a timestamp. This audit trail enables compliance reporting without storing raw PII."
+memory_type = "fact"
+domain = "projectA"
+
+# Hard negative: mentions privacy and data protection but is about user preferences for data sharing
+[[cases.negative_seeds]]
+id = "mem_privacy_sharing"
+content = "User opted out of anonymous telemetry and crash reporting. Data sharing preference stored in config.json under privacy.telemetry_enabled=false. No data leaves the device."
+memory_type = "preference"
+domain = "projectA"


### PR DESCRIPTION
## Summary

- Vendored 41 TOML fixture scenarios (468K) from `7xuanlu/origin-app` into `app/eval/fixtures/`.
- Closes the post-Plan-A open thread: *"`app/eval/fixtures` extracted to origin-app repo — L6 CI canary artifact upload is plumbing-only until restored."*
- `eval::retrieval` ignored tests now find their fixture dir; the L6 canary `cargo nextest run -p origin-core --lib --run-ignored=only eval::retrieval` will produce real output instead of skip-all.

## Why re-vendor (not submodule)

- Same author owns both repos (Apache-2.0 daemon + AGPL-3.0 desktop).
- Fixtures are TOML test data — no third-party content, no AGPL license headers (verified).
- Submodules add contributor friction (`clone --recursive`, CI `submodules: true`).
- Trade-off: future fixture edits need two-way sync until origin-app drops its eval suite or the daemon takes over canonical authorship.

## Test Plan

- [x] `git status` shows `app/` is untracked (not gitignored) — fixtures will track cleanly
- [x] Local smoke: `cargo test -p origin-core --lib eval::retrieval::tests::test_run_quality_cost_eval_basic -- --ignored --nocapture` reaches the embedder init stage (fixture dir resolved, no "Skipping" message). HF download blocked by local sandbox but that's an environment limitation; GitHub runners have unrestricted egress.
- [x] Pre-commit hook (fmt + clippy) passed
- [ ] L6 CI canary on main runs `eval::retrieval` tests + uploads MTEB-schema artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)