### PR TITLE
feat(eval): page-distillation faithfulness benchmark (Plan C-D)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,10 @@ Cache directories accumulate fast (1GB+ per full LoCoMo+LME run) and snapshots s
 
 `app/eval/kg_fixtures/*.toml` hold hand-curated entity + relation ground-truth per source_text case. The `eval::kg_faithfulness` module's smoke test (`#[ignore]`d, runs in L6 main canary) extracts KG from each case and scores entity + relation precision/recall/F1 against the expected ground truth. No LLM judge in this bench — string-match faithfulness only. LLM-judge variant is a follow-up plan.
 
+### Page-distillation faithfulness bench
+
+`app/eval/page_fixtures/*.toml` hold hand-curated source memories + a distilled page body per case + an `expected_min_faithfulness` floor. The `eval::page_faithfulness` module's smoke test (`#[ignore]`d, runs in L6 main canary) splits each page body into sentences and scores what fraction of sentences have ≥ 50% content-token overlap with the union of source memories. Negative-control fixtures in `seed_hallucinations.toml` carry a high `expected_min` floor specifically to verify the scorer flags hallucinated pages. LLM-judge variant deferred.
+
 ## Releasing (release-please)
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please). The workflow runs on every push to `main`.

--- a/app/eval/page_fixtures/seed_decisions.toml
+++ b/app/eval/page_fixtures/seed_decisions.toml
@@ -1,0 +1,21 @@
+# app/eval/page_fixtures/seed_decisions.toml
+description = "Faithful distillations of decision-shaped memories."
+
+[[case]]
+id = "page_decision_001"
+source_memories = [
+    "Decided to use BGE-Base-EN-v1.5-Q as the embedding model.",
+    "BGE-Base produces 768-dimension quantized output.",
+    "BGE-Base runs well on M-series Macs with low latency.",
+]
+distilled_page_body = "The embedding model is BGE-Base-EN-v1.5-Q, producing 768-dimension quantized embeddings. BGE-Base runs efficiently on M-series Macs."
+expected_min_faithfulness = 0.85
+
+[[case]]
+id = "page_decision_002"
+source_memories = [
+    "Apache-2.0 was chosen for origin-core to allow downstream consumption.",
+    "The desktop app uses AGPL-3.0 to prevent closed-source forks.",
+]
+distilled_page_body = "Origin licenses origin-core under Apache-2.0 to permit downstream consumption. The desktop app uses AGPL-3.0 to prevent closed-source forks."
+expected_min_faithfulness = 0.85

--- a/app/eval/page_fixtures/seed_facts.toml
+++ b/app/eval/page_fixtures/seed_facts.toml
@@ -1,0 +1,22 @@
+# app/eval/page_fixtures/seed_facts.toml
+description = "Faithful distillations of technical fact memories. Should score high."
+
+[[case]]
+id = "page_rust_001"
+source_memories = [
+    "Rust is a systems programming language with memory safety guarantees.",
+    "Tokio is the most common async runtime in the Rust ecosystem.",
+    "Origin uses Rust for its daemon and CLI.",
+]
+distilled_page_body = "Rust is a systems programming language that guarantees memory safety. The Rust ecosystem provides Tokio as its dominant async runtime. Origin uses Rust for its daemon implementation."
+expected_min_faithfulness = 0.85
+
+[[case]]
+id = "page_libsql_001"
+source_memories = [
+    "Origin stores all data in a single libSQL database file.",
+    "libSQL supports vector columns via F32_BLOB type.",
+    "The chunks table uses a 768-dimension vector column for embeddings.",
+]
+distilled_page_body = "Origin persists data in a single libSQL database. Vector embeddings live in a 768-dimension F32_BLOB column on the chunks table."
+expected_min_faithfulness = 0.85

--- a/app/eval/page_fixtures/seed_hallucinations.toml
+++ b/app/eval/page_fixtures/seed_hallucinations.toml
@@ -1,0 +1,18 @@
+# app/eval/page_fixtures/seed_hallucinations.toml
+description = "Pages with extra claims not in source memories. The scorer SHOULD flag these as below threshold."
+
+[[case]]
+id = "page_halluc_001"
+source_memories = [
+    "Rust is a systems programming language.",
+]
+distilled_page_body = "Rust is a systems programming language. Rust was created by Mozilla. The first stable release was 1.0 in 2015."
+expected_min_faithfulness = 0.99
+
+[[case]]
+id = "page_halluc_002"
+source_memories = [
+    "Origin uses libSQL for storage.",
+]
+distilled_page_body = "Origin uses libSQL for storage. libSQL is a fork of SQLite maintained by Turso. The database file lives at a configurable path."
+expected_min_faithfulness = 0.99

--- a/crates/origin-core/src/eval/mod.rs
+++ b/crates/origin-core/src/eval/mod.rs
@@ -16,6 +16,7 @@ pub mod lifecycle;
 pub mod locomo;
 pub mod longmemeval;
 pub mod metrics;
+pub mod page_faithfulness;
 pub mod pipeline;
 pub mod report;
 pub mod retrieval;

--- a/crates/origin-core/src/eval/page_faithfulness.rs
+++ b/crates/origin-core/src/eval/page_faithfulness.rs
@@ -36,6 +36,26 @@ pub struct PageFaithfulnessReport {
     pub latency: Option<crate::eval::latency::LatencySummary>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct PageFixture {
+    pub description: String,
+    pub case: Vec<PageFixtureCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PageFixtureCase {
+    pub id: String,
+    pub source_memories: Vec<String>,
+    pub distilled_page_body: String,
+    pub expected_min_faithfulness: f64,
+}
+
+pub fn load_page_fixture(path: &std::path::Path) -> Result<PageFixture, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    toml::from_str(&content).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,5 +82,42 @@ mod tests {
             unfaithful_sentences: vec!["This is hallucinated.".to_string()],
         };
         assert!(c.meets_threshold());
+    }
+
+    #[test]
+    fn load_page_fixture_parses_minimal_toml() {
+        let toml_str = r#"
+            description = "smoke"
+
+            [[case]]
+            id = "c1"
+            source_memories = ["Rust is fast.", "Rust is safe."]
+            distilled_page_body = "Rust is fast and safe."
+            expected_min_faithfulness = 0.8
+        "#;
+        let f: PageFixture = toml::from_str(toml_str).expect("toml parses");
+        assert_eq!(f.case.len(), 1);
+        assert_eq!(f.case[0].source_memories.len(), 2);
+        assert!((f.case[0].expected_min_faithfulness - 0.8).abs() < 1e-9);
+    }
+
+    #[test]
+    fn load_page_fixture_from_path_reads_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.toml");
+        std::fs::write(
+            &path,
+            r#"
+            description = "file load"
+            [[case]]
+            id = "c1"
+            source_memories = ["x"]
+            distilled_page_body = "x"
+            expected_min_faithfulness = 0.5
+        "#,
+        )
+        .unwrap();
+        let f = load_page_fixture(&path).expect("loads");
+        assert_eq!(f.description, "file load");
     }
 }

--- a/crates/origin-core/src/eval/page_faithfulness.rs
+++ b/crates/origin-core/src/eval/page_faithfulness.rs
@@ -50,6 +50,52 @@ pub struct PageFixtureCase {
     pub expected_min_faithfulness: f64,
 }
 
+const STOPWORDS: &[&str] = &[
+    "with", "from", "that", "this", "these", "those", "have", "been", "will", "would", "could",
+    "should", "their", "there", "where", "when", "what", "which", "while", "about", "after",
+    "before", "between", "into", "over", "under", "very", "more", "most", "some", "such", "than",
+    "then", "they", "them", "your", "yours",
+];
+
+/// Split a page body into sentences. Uses regex on terminal punctuation
+/// followed by whitespace. Final sentence may not have trailing whitespace.
+pub fn split_sentences(body: &str) -> Vec<&str> {
+    let re = regex::Regex::new(r"(?m)[.!?]+\s+").expect("static regex");
+    re.split(body).filter(|s| !s.trim().is_empty()).collect()
+}
+
+/// Extract content-bearing tokens from a sentence: lowercase, length >= 4,
+/// excluding stopwords. Used for faithfulness overlap scoring.
+pub fn content_tokens(sentence: &str) -> Vec<String> {
+    sentence
+        .split(|c: char| !c.is_alphanumeric())
+        .map(|t| t.to_ascii_lowercase())
+        .filter(|t| t.len() >= 4 && !STOPWORDS.contains(&t.as_str()))
+        .collect()
+}
+
+/// Returns true if at least 50% of the sentence's content tokens appear
+/// as whole-word matches in the source text. Sentences with zero content
+/// tokens (pure punctuation / all stopwords) are vacuously faithful.
+pub fn score_sentence_faithful(sentence: &str, source: &str) -> bool {
+    let toks = content_tokens(sentence);
+    if toks.is_empty() {
+        return true;
+    }
+    let lo_source = source.to_ascii_lowercase();
+    let mut hits = 0usize;
+    for t in &toks {
+        let pattern = format!(r"\b{}\b", regex::escape(t));
+        let found = regex::Regex::new(&pattern)
+            .map(|re| re.is_match(&lo_source))
+            .unwrap_or_else(|_| lo_source.contains(t));
+        if found {
+            hits += 1;
+        }
+    }
+    hits * 2 >= toks.len() // >= 50%
+}
+
 pub fn load_page_fixture(path: &std::path::Path) -> Result<PageFixture, String> {
     let content = std::fs::read_to_string(path)
         .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
@@ -119,5 +165,41 @@ mod tests {
         .unwrap();
         let f = load_page_fixture(&path).expect("loads");
         assert_eq!(f.description, "file load");
+    }
+
+    #[test]
+    fn split_sentences_basic_punctuation() {
+        let body = "First sentence. Second sentence! Third question? Final.";
+        let s = split_sentences(body);
+        assert_eq!(s.len(), 4);
+    }
+
+    #[test]
+    fn content_tokens_strips_stopwords_and_short() {
+        let toks = content_tokens("This is a Rust programming language with memory safety.");
+        assert!(toks.contains(&"rust".to_string()));
+        assert!(toks.contains(&"programming".to_string()));
+        assert!(toks.contains(&"language".to_string()));
+        assert!(toks.contains(&"memory".to_string()));
+        assert!(toks.contains(&"safety".to_string()));
+        assert!(!toks.contains(&"this".to_string()));
+        assert!(!toks.contains(&"with".to_string()));
+        assert!(!toks.contains(&"is".to_string()));
+    }
+
+    #[test]
+    fn score_sentence_faithful_majority_overlap() {
+        let sentence = "Rust provides memory safety guarantees.";
+        let sources_all = ["Rust", "provides", "memory safety", "guarantees"].join(" ");
+        assert!(score_sentence_faithful(sentence, &sources_all));
+
+        let sources_one = "Rust is great".to_string();
+        assert!(!score_sentence_faithful(sentence, &sources_one));
+    }
+
+    #[test]
+    fn score_sentence_faithful_empty_sentence_is_faithful() {
+        assert!(score_sentence_faithful(".", "anything"));
+        assert!(score_sentence_faithful("a is the", "anything"));
     }
 }

--- a/crates/origin-core/src/eval/page_faithfulness.rs
+++ b/crates/origin-core/src/eval/page_faithfulness.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Page-distillation faithfulness benchmark — measures whether distilled
+//! pages introduce claims not grounded in their source memories.
+
+use serde::{Deserialize, Serialize};
+
+use crate::eval::report::ReportEnv;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PageCaseResult {
+    pub fixture_path: String,
+    pub case_id: String,
+    pub sentence_count: usize,
+    pub faithful_count: usize,
+    pub faithfulness: f64,
+    pub expected_min: f64,
+    pub unfaithful_sentences: Vec<String>,
+}
+
+impl PageCaseResult {
+    pub fn meets_threshold(&self) -> bool {
+        self.faithfulness >= self.expected_min
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PageFaithfulnessReport {
+    pub fixture_count: usize,
+    pub case_count: usize,
+    pub mean_faithfulness: f64,
+    pub below_threshold_count: usize,
+    pub per_case: Vec<PageCaseResult>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub env: Option<ReportEnv>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub latency: Option<crate::eval::latency::LatencySummary>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_faithfulness_report_default_is_empty() {
+        let r = PageFaithfulnessReport::default();
+        assert_eq!(r.fixture_count, 0);
+        assert_eq!(r.mean_faithfulness, 0.0);
+        assert_eq!(r.below_threshold_count, 0);
+        assert!(r.per_case.is_empty());
+        assert!(r.env.is_none());
+    }
+
+    #[test]
+    fn page_case_result_holds_per_fixture_data() {
+        let c = PageCaseResult {
+            fixture_path: "test.toml".to_string(),
+            case_id: "c1".to_string(),
+            sentence_count: 5,
+            faithful_count: 4,
+            faithfulness: 0.8,
+            expected_min: 0.7,
+            unfaithful_sentences: vec!["This is hallucinated.".to_string()],
+        };
+        assert!(c.meets_threshold());
+    }
+}

--- a/crates/origin-core/src/eval/page_faithfulness.rs
+++ b/crates/origin-core/src/eval/page_faithfulness.rs
@@ -102,6 +102,76 @@ pub fn load_page_fixture(path: &std::path::Path) -> Result<PageFixture, String> 
     toml::from_str(&content).map_err(|e| format!("failed to parse {}: {e}", path.display()))
 }
 
+pub fn score_case(fixture_path: &str, case: &PageFixtureCase) -> PageCaseResult {
+    let sources_joined = case.source_memories.join("\n");
+    let sentences = split_sentences(&case.distilled_page_body);
+    let total = sentences.len();
+    let mut faithful_count = 0usize;
+    let mut unfaithful_sentences: Vec<String> = Vec::new();
+    for s in &sentences {
+        if score_sentence_faithful(s, &sources_joined) {
+            faithful_count += 1;
+        } else {
+            unfaithful_sentences.push(s.trim().to_string());
+        }
+    }
+    let faithfulness = if total == 0 {
+        0.0
+    } else {
+        faithful_count as f64 / total as f64
+    };
+    PageCaseResult {
+        fixture_path: fixture_path.to_string(),
+        case_id: case.id.clone(),
+        sentence_count: total,
+        faithful_count,
+        faithfulness,
+        expected_min: case.expected_min_faithfulness,
+        unfaithful_sentences,
+    }
+}
+
+/// Run the full page-faithfulness benchmark over every fixture under `fixture_dir`.
+/// Skips gracefully if `fixture_dir` doesn't exist.
+pub fn run_page_faithfulness_eval(fixture_dir: &std::path::Path) -> PageFaithfulnessReport {
+    let mut report = PageFaithfulnessReport::default();
+    if !fixture_dir.exists() {
+        return report;
+    }
+    let fixtures: Vec<std::path::PathBuf> = std::fs::read_dir(fixture_dir)
+        .ok()
+        .map(|rd| {
+            rd.filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("toml"))
+                .collect()
+        })
+        .unwrap_or_default();
+    for path in &fixtures {
+        let fx = match load_page_fixture(path) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("[page_faith] skip {}: {}", path.display(), e);
+                continue;
+            }
+        };
+        report.fixture_count += 1;
+        let path_str = path.to_string_lossy().to_string();
+        for case in &fx.case {
+            let r = score_case(&path_str, case);
+            if !r.meets_threshold() {
+                report.below_threshold_count += 1;
+            }
+            report.per_case.push(r);
+            report.case_count += 1;
+        }
+    }
+    if !report.per_case.is_empty() {
+        let n = report.per_case.len() as f64;
+        report.mean_faithfulness = report.per_case.iter().map(|c| c.faithfulness).sum::<f64>() / n;
+    }
+    report
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -201,5 +271,41 @@ mod tests {
     fn score_sentence_faithful_empty_sentence_is_faithful() {
         assert!(score_sentence_faithful(".", "anything"));
         assert!(score_sentence_faithful("a is the", "anything"));
+    }
+
+    #[test]
+    fn score_case_perfectly_faithful_page_scores_1() {
+        let case = PageFixtureCase {
+            id: "c1".into(),
+            source_memories: vec![
+                "Rust is a systems programming language.".into(),
+                "Memory safety is provided by Rust.".into(),
+            ],
+            distilled_page_body: "Rust is a systems language. Memory safety is provided.".into(),
+            expected_min_faithfulness: 0.8,
+        };
+        let r = score_case("test.toml", &case);
+        assert!((r.faithfulness - 1.0).abs() < 1e-9);
+        assert_eq!(r.faithful_count, 2);
+        assert_eq!(r.sentence_count, 2);
+        assert!(r.unfaithful_sentences.is_empty());
+        assert!(r.meets_threshold());
+    }
+
+    #[test]
+    fn score_case_hallucinated_page_flags_unfaithful_sentences() {
+        let case = PageFixtureCase {
+            id: "c2".into(),
+            source_memories: vec!["Rust is a systems programming language.".into()],
+            distilled_page_body: "Rust is a systems language. Python is a scripting language."
+                .into(),
+            expected_min_faithfulness: 0.9,
+        };
+        let r = score_case("test.toml", &case);
+        assert!((r.faithfulness - 0.5).abs() < 1e-9);
+        assert_eq!(r.faithful_count, 1);
+        assert_eq!(r.unfaithful_sentences.len(), 1);
+        assert!(r.unfaithful_sentences[0].contains("Python"));
+        assert!(!r.meets_threshold());
     }
 }

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3930,3 +3930,33 @@ async fn run_kg_faithfulness_smoke() {
     let _ = fixture_dir;
     let _ = run_kg_faithfulness_eval;
 }
+
+#[tokio::test]
+#[ignore]
+async fn run_page_faithfulness_smoke() {
+    use origin_core::eval::page_faithfulness::run_page_faithfulness_eval;
+
+    let fixture_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("app/eval/page_fixtures");
+    if !fixture_dir.exists() {
+        eprintln!("SKIP: page_fixtures dir not found");
+        return;
+    }
+    let report = run_page_faithfulness_eval(&fixture_dir);
+    eprintln!("\n=== Page-Faithfulness ===");
+    eprintln!(
+        "Mean faithfulness: {:.3} across {} cases ({} below threshold)",
+        report.mean_faithfulness, report.case_count, report.below_threshold_count
+    );
+    for c in &report.per_case {
+        let marker = if c.meets_threshold() { "OK" } else { "FAIL" };
+        eprintln!(
+            "  [{}] {} {:.2} (expected >= {:.2})",
+            marker, c.case_id, c.faithfulness, c.expected_min
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Second half of Origin's concept-faithfulness differentiator. Plan C-B (PR #149) measured **extraction** faithfulness (does the KG extractor produce entities/relations grounded in source memories?). This PR measures **synthesis** faithfulness — does `synthesis/distill.rs`'s page output introduce claims not grounded in source memories?

**Implementation:**

- New module `crates/origin-core/src/eval/page_faithfulness.rs` (~310 LOC).
- Sentence-level scoring: split page body on `[.!?]+\s+`, content-tokens with stopword + length filter, ≥50% whole-word overlap against the union of source memories.
- `PageFaithfulnessReport` with `mean_faithfulness`, `below_threshold_count`, per-case breakdown, `ReportEnv` from Plan A.
- TOML fixtures at `app/eval/page_fixtures/`: each case has `source_memories[]` + `distilled_page_body` + `expected_min_faithfulness` floor.
- `#[ignore]`'d smoke test in `tests/eval_harness.rs` — **NOT a SKIP placeholder** (unlike C-B's). Runner is pure-function, no LLM, no DB. Smoke runs end-to-end as soon as fixtures land.
- 3 seed fixtures: `seed_facts.toml`, `seed_decisions.toml`, `seed_hallucinations.toml` (deliberate negative-control cases that the scorer SHOULD flag).

**Smoke verification (run during Task 5 + independently by adversarial reviewer):**

```
=== Page-Faithfulness ===
Mean faithfulness: 0.778 across 6 cases (2 below threshold)
  [OK]   page_rust_001      1.00 (>= 0.85)
  [OK]   page_libsql_001    1.00 (>= 0.85)
  [FAIL] page_halluc_001    0.33 (>= 0.99)
  [FAIL] page_halluc_002    0.33 (>= 0.99)
  [OK]   page_decision_001  1.00 (>= 0.85)
  [OK]   page_decision_002  1.00 (>= 0.85)
```

Negative-control fixtures correctly flagged — added Mozilla/Turso/release-year claims not in source memories drop the score below the 0.99 floor. Faithful fixtures all score 1.00.

**Scope cuts (deferred to follow-up):**

- **LLM-judge variant** that catches semantic equivalence string-match misses (mirrors C-B's C-C deferral).
- **End-to-end distill runner** that actually invokes `synthesis::distill::distill_one_cluster`. Needs DB seeding + on-device LLM + Metal GPU. The fixtures hand-author the page body so the bench measures the scorer not the distill engine.
- **Contradiction detection** — token overlap is high when "X is good" / "X is bad" share tokens; semantics are inverted. Acceptable limit for v1.
- **Recall measurement** — bench measures precision only (faithfulness). Whether the page omits critical claims is a separate metric.
- **Sentence splitter abbreviation handling** — "Dr. Smith decided." would false-split. Seed fixtures avoid abbreviations; document in AGENTS.md if it bites.

## Test Plan

- [x] `cargo test -p origin-core --lib eval::page_faithfulness` — 10/10 pass
- [x] `cargo clippy -p origin-core --all-targets` — clean
- [x] Pre-commit hook (fmt + clippy) passed on all 5 commits
- [x] Smoke test verified end-to-end with seed fixtures (output above, reproduced by adversarial reviewer)
- [x] Adversarial review run — READY_TO_MERGE verdict
- [ ] CI required checks pass
- [ ] L6 main canary picks up new bench (manual confirmation after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)