### PR TITLE
feat(eval): LLM judge for KG-faithfulness (Plan C-C)

### DIFF
--- a/crates/origin-core/src/eval/kg_faithfulness_llm.rs
+++ b/crates/origin-core/src/eval/kg_faithfulness_llm.rs
@@ -3,6 +3,64 @@
 
 use serde::{Deserialize, Serialize};
 
+pub fn build_entity_judge_prompt(source: &str, entity_name: &str, entity_type: &str) -> String {
+    format!(
+        "Source text:\n{}\n\n\
+         An extractor claimed the following entity is mentioned in (or paraphrased from) the source above:\n\
+         - Entity: \"{}\" (type: {})\n\n\
+         Verdict question: Is this entity faithful to the source — meaning the entity appears verbatim OR as a clear paraphrase/synonym of something in the source?\n\n\
+         Respond with a single JSON object: {{\"verdict\": \"faithful\" | \"hallucinated\" | \"partial\", \"reason\": \"<one short sentence>\"}}\n\
+         Do not wrap in markdown fences. Do not add prose before or after the JSON.",
+        source, entity_name, entity_type
+    )
+}
+
+pub fn build_relation_judge_prompt(
+    source: &str,
+    from: &str,
+    to: &str,
+    relation_type: &str,
+) -> String {
+    format!(
+        "Source text:\n{}\n\n\
+         An extractor claimed the following relation is mentioned in (or paraphrased from) the source above:\n\
+         - Relation: \"{}\" --{}--> \"{}\"\n\n\
+         Verdict question: Is this relation faithful to the source — meaning both endpoints are present (verbatim or paraphrase) AND the relation type matches a statement in the source?\n\n\
+         Respond with a single JSON object: {{\"verdict\": \"faithful\" | \"hallucinated\" | \"partial\", \"reason\": \"<one short sentence>\"}}\n\
+         Do not wrap in markdown fences. Do not add prose before or after the JSON.",
+        source, from, relation_type, to
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct JudgeResponseRaw {
+    verdict: KgJudgeVerdict,
+    #[serde(default)]
+    reason: String,
+}
+
+pub fn parse_judge_response(raw: &str) -> Result<(KgJudgeVerdict, String), String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("empty response".to_string());
+    }
+    let body = if let Some(after) = trimmed.strip_prefix("```json") {
+        after
+            .trim_start_matches('\n')
+            .trim_end_matches("```")
+            .trim()
+    } else {
+        trimmed
+    };
+    let parsed: JudgeResponseRaw = serde_json::from_str(body).map_err(|e| {
+        format!(
+            "parse failed: {e} (input: {})",
+            &trimmed.chars().take(80).collect::<String>()
+        )
+    })?;
+    Ok((parsed.verdict, parsed.reason))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum KgJudgeVerdict {
@@ -64,5 +122,45 @@ mod tests {
         assert_eq!(r.case_count, 0);
         assert_eq!(r.judge_model, "");
         assert!(r.per_case.is_empty());
+    }
+
+    #[test]
+    fn build_entity_judge_prompt_includes_source_and_entity() {
+        let p = build_entity_judge_prompt("Rust is fast.", "Rust", "language");
+        assert!(p.contains("Rust is fast."));
+        assert!(p.contains("Rust"));
+        assert!(p.contains("language"));
+        assert!(p.contains("faithful") || p.contains("verdict"));
+    }
+
+    #[test]
+    fn build_relation_judge_prompt_includes_triple_and_source() {
+        let p = build_relation_judge_prompt("Origin uses libSQL.", "Origin", "libSQL", "uses");
+        assert!(p.contains("Origin uses libSQL."));
+        assert!(p.contains("Origin"));
+        assert!(p.contains("libSQL"));
+        assert!(p.contains("uses"));
+    }
+
+    #[test]
+    fn parse_judge_response_accepts_direct_json() {
+        let raw = r#"{"verdict":"faithful","reason":"present verbatim"}"#;
+        let (v, r) = parse_judge_response(raw).expect("ok");
+        assert_eq!(v, KgJudgeVerdict::Faithful);
+        assert_eq!(r, "present verbatim");
+    }
+
+    #[test]
+    fn parse_judge_response_accepts_fenced_json() {
+        let raw = "```json\n{\"verdict\":\"hallucinated\",\"reason\":\"not in source\"}\n```";
+        let (v, _) = parse_judge_response(raw).expect("ok");
+        assert_eq!(v, KgJudgeVerdict::Hallucinated);
+    }
+
+    #[test]
+    fn parse_judge_response_rejects_malformed() {
+        assert!(parse_judge_response("not json").is_err());
+        assert!(parse_judge_response("").is_err());
+        assert!(parse_judge_response(r#"{"verdict":"bogus"}"#).is_err());
     }
 }

--- a/crates/origin-core/src/eval/kg_faithfulness_llm.rs
+++ b/crates/origin-core/src/eval/kg_faithfulness_llm.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+//! LLM-judge variant of the KG-faithfulness benchmark.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KgJudgeVerdict {
+    Faithful,
+    Hallucinated,
+    Partial,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KgJudgedEntity {
+    pub name: String,
+    pub verdict: KgJudgeVerdict,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KgJudgedRelation {
+    pub from: String,
+    pub to: String,
+    pub relation_type: String,
+    pub verdict: KgJudgeVerdict,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KgJudgedCase {
+    pub case_id: String,
+    pub entities: Vec<KgJudgedEntity>,
+    pub relations: Vec<KgJudgedRelation>,
+    pub entity_faithful_rate: f64,
+    pub relation_faithful_rate: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LlmJudgedKgReport {
+    pub case_count: usize,
+    pub judge_model: String,
+    pub mean_entity_faithful_rate: f64,
+    pub mean_relation_faithful_rate: f64,
+    pub per_case: Vec<KgJudgedCase>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kg_judge_verdict_serde_roundtrip() {
+        let v = KgJudgeVerdict::Hallucinated;
+        let j = serde_json::to_string(&v).unwrap();
+        assert_eq!(j, "\"hallucinated\"");
+        let parsed: KgJudgeVerdict = serde_json::from_str(&j).unwrap();
+        assert_eq!(parsed, KgJudgeVerdict::Hallucinated);
+    }
+
+    #[test]
+    fn llm_judged_kg_report_default() {
+        let r = LlmJudgedKgReport::default();
+        assert_eq!(r.case_count, 0);
+        assert_eq!(r.judge_model, "");
+        assert!(r.per_case.is_empty());
+    }
+}

--- a/crates/origin-core/src/eval/kg_faithfulness_llm.rs
+++ b/crates/origin-core/src/eval/kg_faithfulness_llm.rs
@@ -103,6 +103,101 @@ pub struct LlmJudgedKgReport {
     pub per_case: Vec<KgJudgedCase>,
 }
 
+/// Judge a single KgFixtureCase by submitting one batch request per entity
+/// and relation. Returns per-entity + per-relation verdicts plus aggregate
+/// faithful_rate per type. Costs ~$0.01-0.05 per case at typical sizes.
+///
+/// Requires ANTHROPIC_API_KEY env var. Honors EVAL_MAX_USD cost cap.
+pub async fn judge_kg_case_with_llm(
+    case: &crate::eval::kg_faithfulness::KgFixtureCase,
+    extracted: &crate::extract::KgExtractionResult,
+    judge_model: &str,
+) -> Result<KgJudgedCase, String> {
+    let api_key =
+        std::env::var("ANTHROPIC_API_KEY").map_err(|_| "ANTHROPIC_API_KEY required".to_string())?;
+    let client = reqwest::Client::new();
+
+    let mut requests: Vec<(String, String, Option<String>, usize)> = Vec::new();
+    for (i, e) in extracted.entities.iter().enumerate() {
+        let prompt = build_entity_judge_prompt(&case.source_text, &e.name, &e.entity_type);
+        requests.push((format!("e_{i}"), prompt, None, 200));
+    }
+    for (i, r) in extracted.relations.iter().enumerate() {
+        let prompt =
+            build_relation_judge_prompt(&case.source_text, &r.from, &r.to, &r.relation_type);
+        requests.push((format!("r_{i}"), prompt, None, 200));
+    }
+    if requests.is_empty() {
+        return Ok(KgJudgedCase {
+            case_id: case.id.clone(),
+            entities: vec![],
+            relations: vec![],
+            entity_faithful_rate: 0.0,
+            relation_faithful_rate: 0.0,
+        });
+    }
+
+    let batch_id =
+        crate::eval::anthropic::submit_batch(&client, &api_key, requests, judge_model, 0.50)
+            .await?;
+    let results_url = crate::eval::anthropic::poll_batch(&client, &api_key, &batch_id).await?;
+    let results =
+        crate::eval::anthropic::download_batch_results(&client, &api_key, &results_url).await?;
+
+    let mut judged_entities: Vec<KgJudgedEntity> = Vec::new();
+    let mut judged_relations: Vec<KgJudgedRelation> = Vec::new();
+
+    for (i, e) in extracted.entities.iter().enumerate() {
+        let raw = results.get(&format!("e_{i}")).cloned().unwrap_or_default();
+        let (verdict, reason) = parse_judge_response(&raw)
+            .unwrap_or((KgJudgeVerdict::Hallucinated, format!("parse failed: {raw}")));
+        judged_entities.push(KgJudgedEntity {
+            name: e.name.clone(),
+            verdict,
+            reason,
+        });
+    }
+    for (i, r) in extracted.relations.iter().enumerate() {
+        let raw = results.get(&format!("r_{i}")).cloned().unwrap_or_default();
+        let (verdict, reason) = parse_judge_response(&raw)
+            .unwrap_or((KgJudgeVerdict::Hallucinated, format!("parse failed: {raw}")));
+        judged_relations.push(KgJudgedRelation {
+            from: r.from.clone(),
+            to: r.to.clone(),
+            relation_type: r.relation_type.clone(),
+            verdict,
+            reason,
+        });
+    }
+
+    let entity_faithful_rate = if judged_entities.is_empty() {
+        0.0
+    } else {
+        let n = judged_entities
+            .iter()
+            .filter(|e| e.verdict == KgJudgeVerdict::Faithful)
+            .count();
+        n as f64 / judged_entities.len() as f64
+    };
+    let relation_faithful_rate = if judged_relations.is_empty() {
+        0.0
+    } else {
+        let n = judged_relations
+            .iter()
+            .filter(|r| r.verdict == KgJudgeVerdict::Faithful)
+            .count();
+        n as f64 / judged_relations.len() as f64
+    };
+
+    Ok(KgJudgedCase {
+        case_id: case.id.clone(),
+        entities: judged_entities,
+        relations: judged_relations,
+        entity_faithful_rate,
+        relation_faithful_rate,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/origin-core/src/eval/mod.rs
+++ b/crates/origin-core/src/eval/mod.rs
@@ -11,6 +11,7 @@ pub mod context_path;
 pub mod fixtures;
 pub mod gen;
 pub mod kg_faithfulness;
+pub mod kg_faithfulness_llm;
 pub mod latency;
 pub mod lifecycle;
 pub mod locomo;

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3960,3 +3960,71 @@ async fn run_page_faithfulness_smoke() {
         );
     }
 }
+
+#[tokio::test]
+#[ignore]
+async fn kg_faithfulness_llm_judge_smoke() {
+    if std::env::var("ANTHROPIC_API_KEY").is_err() {
+        eprintln!("SKIP: ANTHROPIC_API_KEY not set");
+        return;
+    }
+    if std::env::var("EVAL_RUN_LLM_JUDGE").as_deref() != Ok("1") {
+        eprintln!("SKIP: set EVAL_RUN_LLM_JUDGE=1 to actually fire the Batch API");
+        return;
+    }
+    use origin_core::eval::kg_faithfulness::{KgExpectedEntity, KgExpectedRelation, KgFixtureCase};
+    use origin_core::eval::kg_faithfulness_llm::judge_kg_case_with_llm;
+    use origin_core::extract::{ExtractedEntity, ExtractedRelation, KgExtractionResult};
+
+    let case = KgFixtureCase {
+        id: "smoke_001".into(),
+        source_text: "Rust is a systems programming language.".into(),
+        expected_entities: vec![KgExpectedEntity {
+            name: "Rust".into(),
+            kind: "language".into(),
+        }],
+        expected_relations: vec![],
+    };
+    let extracted = KgExtractionResult {
+        index: 0,
+        entities: vec![
+            ExtractedEntity {
+                name: "Rust".into(),
+                entity_type: "language".into(),
+            },
+            ExtractedEntity {
+                name: "Python".into(),
+                entity_type: "language".into(),
+            },
+        ],
+        observations: vec![],
+        relations: vec![ExtractedRelation {
+            from: "Rust".into(),
+            to: "systems programming".into(),
+            relation_type: "is_a".into(),
+            confidence: None,
+            explanation: None,
+        }],
+    };
+    let judged = judge_kg_case_with_llm(&case, &extracted, "claude-haiku-4-5-20251001")
+        .await
+        .expect("judge call");
+    eprintln!("\n=== KG-Faith LLM Judge ===");
+    eprintln!("Case: {}", judged.case_id);
+    eprintln!("Entity faithful rate: {:.2}", judged.entity_faithful_rate);
+    for e in &judged.entities {
+        eprintln!("  [{}] {:?} :: {}", e.name, e.verdict, e.reason);
+    }
+    eprintln!(
+        "Relation faithful rate: {:.2}",
+        judged.relation_faithful_rate
+    );
+    for r in &judged.relations {
+        eprintln!(
+            "  [{} --{}-> {}] {:?} :: {}",
+            r.from, r.relation_type, r.to, r.verdict, r.reason
+        );
+    }
+    assert!(judged.entities.iter().any(|e| e.name == "Rust"));
+    assert!(judged.entities.iter().any(|e| e.name == "Python"));
+}

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3972,7 +3972,7 @@ async fn kg_faithfulness_llm_judge_smoke() {
         eprintln!("SKIP: set EVAL_RUN_LLM_JUDGE=1 to actually fire the Batch API");
         return;
     }
-    use origin_core::eval::kg_faithfulness::{KgExpectedEntity, KgExpectedRelation, KgFixtureCase};
+    use origin_core::eval::kg_faithfulness::{KgExpectedEntity, KgFixtureCase};
     use origin_core::eval::kg_faithfulness_llm::judge_kg_case_with_llm;
     use origin_core::extract::{ExtractedEntity, ExtractedRelation, KgExtractionResult};
 


### PR DESCRIPTION
## Summary

Optional LLM-judge variant of the KG-faithfulness scorer (PR #149's string-match bench). Uses Anthropic Batch API (Haiku). Defense-in-depth gated — neither `ANTHROPIC_API_KEY` alone NOR `EVAL_RUN_LLM_JUDGE=1` alone fires the API. Both required.

**Implementation:**

- New module `crates/origin-core/src/eval/kg_faithfulness_llm.rs` (~230 LOC).
- `KgJudgeVerdict` enum (Faithful / Hallucinated / Partial).
- `build_entity_judge_prompt` + `build_relation_judge_prompt` — structured prompts asking for `{verdict, reason}` JSON.
- `parse_judge_response` — direct JSON + fenced JSON variants, malformed input returns error.
- `judge_kg_case_with_llm(case, extracted, judge_model)` — batches per-entity + per-relation requests through `eval::anthropic::submit_batch` (cost cap $0.50, ~$0.06 typical), polls + downloads, returns `KgJudgedCase` with per-item verdicts + faithful_rate.
- `#[ignore]`'d smoke test in `tests/eval_harness.rs` double-gated by `ANTHROPIC_API_KEY` + `EVAL_RUN_LLM_JUDGE=1`.

**What this catches:** semantic equivalence the string-match bench (PR #149) misses. Example: source says "Rust" + extractor produces "Rust language" — string-match could miss the second one; LLM judge marks it Faithful.

**Defense-in-depth:**

- `judge_kg_case_with_llm` reads `ANTHROPIC_API_KEY` from env (no logging of key).
- `submit_batch` honors `EVAL_MAX_USD` env cap (added in Plan A).
- Per-call `cost_cap_usd = 0.50` (well under typical EVAL_MAX_USD).
- Smoke test requires BOTH env vars to actually fire.
- Adversarial review: zero `eprintln!` of api_key, both gates fire before any Batch call.

**Known limitation (deferred):** Malformed Batch responses default to `KgJudgeVerdict::Hallucinated` with `reason = "parse failed: ..."`. Conflates "LLM said hallucinated" with "response unparseable" — biases the headline metric slightly toward unfaithful. Acceptable for v1 (judge model is deterministic at temp=0 + prompt mandates strict JSON). When this becomes a baseline-reporting harness, add `KgJudgeVerdict::ParseError` variant or exclude unparseable from denominator.

## Test Plan

- [x] `cargo test -p origin-core --lib eval::kg_faithfulness_llm` — 7/7 pass
- [x] `cargo clippy -p origin-core --all-targets` — clean (after unused-import fix in 6a3db32f)
- [x] Pre-commit hook passed all 4 commits
- [x] Smoke test NOT run during dev (would burn ~$0.06 API spend)
- [x] Adversarial review run — READY_TO_MERGE after import fix
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)