### PR TITLE
docs: scope-cut note for page-distillation faithfulness bench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ Cache directories accumulate fast (1GB+ per full LoCoMo+LME run) and snapshots s
 
 `app/eval/page_fixtures/*.toml` hold hand-curated source memories + a distilled page body per case + an `expected_min_faithfulness` floor. The `eval::page_faithfulness` module's smoke test (`#[ignore]`d, runs in L6 main canary) splits each page body into sentences and scores what fraction of sentences have ≥ 50% content-token overlap with the union of source memories. Negative-control fixtures in `seed_hallucinations.toml` carry a high `expected_min` floor specifically to verify the scorer flags hallucinated pages. LLM-judge variant deferred.
 
+**Scope limits.** Token-overlap is lexical, not semantic. Paraphrased faithful claims may fail the 50% floor and hallucinated claims with high keyword overlap may pass. Sentence-level granularity only (no multi-sentence claim composition). Acceptable for the smoke-test floor; a real faithfulness gate needs the LLM-judge variant tracked under C-D-LLM.
+
 ## Releasing (release-please)
 
 Releases are automated via [release-please](https://github.com/googleapis/release-please). The workflow runs on every push to `main`.


### PR DESCRIPTION
## Summary

Adds a one-paragraph scope-limits note to the C-D page-distillation faithfulness bench in AGENTS.md. Token-overlap is lexical not semantic, so paraphrased faithful claims may fail and hallucinated claims with high keyword overlap may pass. Sentence-level granularity only. Acceptable as smoke-test floor, not a real faithfulness gate. Mirrors C-B doc style.

Closes the last of 4 Plan A carry-over items. The other 3 verified resolved/deferred in session:
- judge_model None: correct as-is (8 retrieval-only runners legitimately have no judge; judge stamps via judge.rs:949 in JudgedE2EReport).
- _with_gate env=None: already populated (locomo.rs:1118, longmemeval.rs:1027).
- embedder_revision "768d": deferred per Plan B (FastEmbed -> HF-snapshot mapping not a real comparability problem yet).

## Test plan

- [x] docs-only, no code paths touched
- [ ] CI green (fmt/lint/test skip per docs-only convention)