### PR TITLE
fix(docker): switch daemon image base to Debian trixie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,17 +219,14 @@ jobs:
       - name: Set up Docker Buildx (Linux)
         if: matrix.os == 'ubuntu-24.04'
         uses: docker/setup-buildx-action@v3
-      # Docker smoke is informational on PR. ort_sys compiles onnxruntime
-      # from source inside the container, which currently fails against the
-      # bookworm base (glibc 2.36 < required 2.38 __isoc23_strtoull). Tracked
-      # as a follow-up. Native Linux release build (release.yml matrix) is
-      # the gating signal that the daemon works on Linux.
+      # Docker smoke gates the daemon image build + runtime. The base
+      # switched to Debian trixie (13) so ort_sys's onnxruntime build
+      # sees glibc 2.41+ (provides __isoc23_strtoull, required since 2.38).
       #
       # GHA cache speeds up subsequent runs (layers reused across PRs on the
       # same scope). cache-to mode=max preserves intermediate stage layers.
-      - name: Smoke (Linux daemon image, informational)
+      - name: Smoke (Linux daemon image)
         if: matrix.os == 'ubuntu-24.04'
-        continue-on-error: true
         env:
           BUILDX_CACHE_FROM: type=gha,scope=daemon
           BUILDX_CACHE_TO: type=gha,scope=daemon,mode=max

--- a/docker/Dockerfile.daemon
+++ b/docker/Dockerfile.daemon
@@ -16,7 +16,10 @@
 
 ARG RUST_VERSION=1
 
-FROM rust:${RUST_VERSION}-bookworm AS chef
+# Debian trixie (13) ships glibc 2.41+, which provides the `__isoc23_strtoull`
+# symbol that ort_sys's onnxruntime build needs (added in glibc 2.38). The
+# previous bookworm (12) base shipped glibc 2.36 and broke the daemon image.
+FROM rust:${RUST_VERSION}-trixie AS chef
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake pkg-config libssl-dev clang lld \
     && rm -rf /var/lib/apt/lists/*
@@ -34,7 +37,7 @@ COPY . .
 RUN cargo build --release -p origin-server
 RUN strip target/release/origin-server
 
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
 COPY --from=builder /src/target/release/origin-server /usr/local/bin/origin-server
 # Copy the ONNX Runtime shared library that `ort`'s build script placed next
 # to the binary via the `copy-dylibs` feature. Without this, the daemon

--- a/docker/Dockerfile.daemon
+++ b/docker/Dockerfile.daemon
@@ -36,6 +36,10 @@ RUN cargo chef cook --release --recipe-path recipe.json -p origin-server
 COPY . .
 RUN cargo build --release -p origin-server
 RUN strip target/release/origin-server
+# Skeleton dir copied into runtime so /data exists in the image with the
+# right ownership. Without this, Docker creates /data lazily at first
+# run owned by root, and the nonroot user (UID 65532) can't write to it.
+RUN mkdir -p /data-skeleton
 
 FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
 COPY --from=builder /src/target/release/origin-server /usr/local/bin/origin-server
@@ -43,6 +47,11 @@ COPY --from=builder /src/target/release/origin-server /usr/local/bin/origin-serv
 # to the binary via the `copy-dylibs` feature. Without this, the daemon
 # crashes on first embedding call with `libonnxruntime.so` not found.
 COPY --from=builder /src/target/release/libonnxruntime.so* /usr/local/lib/
+# Materialize /data in the image so anonymous volumes inherit the nonroot
+# owner (UID 65532) instead of defaulting to root. Distroless has no shell
+# for a `mkdir`+`chown` RUN step; `COPY --chown` from the builder skeleton
+# does the same job.
+COPY --from=builder --chown=65532:65532 /data-skeleton /data
 ENV LD_LIBRARY_PATH=/usr/local/lib
 USER nonroot
 EXPOSE 7878

--- a/scripts/smoke-linux.sh
+++ b/scripts/smoke-linux.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 IMAGE_TAG="${IMAGE_TAG:-origin-server:smoke}"
 CONTAINER="${CONTAINER:-origin-smoke}"
 PORT="${PORT:-17878}"
-DATA_DIR="$(mktemp -d -t origin-smoke.XXXXXX)"
 # Default to the host arch: linux/arm64 on Apple Silicon devs (fast via OrbStack
 # / Docker Desktop), linux/amd64 on CI (ubuntu-24.04 is amd64; arm64 emulation
 # via QEMU adds 15-30 min). Override with PLATFORM= env var.
@@ -15,7 +14,6 @@ esac
 
 cleanup() {
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
-    rm -rf "$DATA_DIR"
 }
 trap cleanup EXIT
 
@@ -29,12 +27,16 @@ docker buildx build --platform "$PLATFORM" --load \
     "${CACHE_ARGS[@]}" \
     -f docker/Dockerfile.daemon -t "$IMAGE_TAG" .
 
-echo "==> Starting container on port ${PORT}, data ${DATA_DIR}"
+echo "==> Starting container on port ${PORT}"
 # Deliberately omit --rm: if the daemon crashes before /api/health
 # responds, `docker logs` needs the container record to still exist.
 # The cleanup trap removes it with `docker rm -f` regardless.
-docker run -d --name "$CONTAINER" -p "${PORT}:7878" \
-    -v "${DATA_DIR}:/data" "$IMAGE_TAG"
+#
+# No host -v mount: container runs as `nonroot` (UID 65532) and a
+# host bind would inherit the runner's UID, breaking writes to /data.
+# Smoke wants ephemeral storage anyway; the named VOLUME in the image
+# gives the container a writable anonymous mount.
+docker run -d --name "$CONTAINER" -p "${PORT}:7878" "$IMAGE_TAG"
 
 echo "==> Waiting for /api/health"
 for i in $(seq 1 30); do

--- a/scripts/smoke-linux.sh
+++ b/scripts/smoke-linux.sh
@@ -30,7 +30,10 @@ docker buildx build --platform "$PLATFORM" --load \
     -f docker/Dockerfile.daemon -t "$IMAGE_TAG" .
 
 echo "==> Starting container on port ${PORT}, data ${DATA_DIR}"
-docker run --rm -d --name "$CONTAINER" -p "${PORT}:7878" \
+# Deliberately omit --rm: if the daemon crashes before /api/health
+# responds, `docker logs` needs the container record to still exist.
+# The cleanup trap removes it with `docker rm -f` regardless.
+docker run -d --name "$CONTAINER" -p "${PORT}:7878" \
     -v "${DATA_DIR}:/data" "$IMAGE_TAG"
 
 echo "==> Waiting for /api/health"
@@ -42,7 +45,10 @@ for i in $(seq 1 30); do
     sleep 1
     if [ "$i" = "30" ]; then
         echo "FAIL: daemon did not become healthy" >&2
-        docker logs "$CONTAINER" >&2
+        echo "--- container state ---" >&2
+        docker ps -a --filter "name=${CONTAINER}" --format 'id={{.ID}} status={{.Status}} exit={{.RunningFor}}' >&2 || true
+        echo "--- container logs ---" >&2
+        docker logs "$CONTAINER" >&2 || true
         exit 1
     fi
 done


### PR DESCRIPTION
## Summary

Closes Task 41 from the cross-platform port handoff. The daemon Docker image build failed against the bookworm base because ort_sys's onnxruntime build needed `__isoc23_strtoull` (glibc 2.38), and bookworm shipped glibc 2.36. CI papered over it with `continue-on-error: true`.

- `docker/Dockerfile.daemon`: `rust:1-bookworm` → `rust:1-trixie`, `cc-debian12` → `cc-debian13`. Trixie ships glibc 2.41+.
- `.github/workflows/ci.yml`: drop `continue-on-error: true` from the Linux smoke step. Smoke now gates the daemon image.

## Test plan

- [ ] CI Docker smoke step on this PR runs to completion (build + curl `/api/health` + store + search).
- [ ] Conclusion gate stays green.