### PR TITLE
feat(cli): origin space subcommands + doctor resolver state (Plan C)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ No cloud sync or telemetry by default. Local models and Anthropic keys are opt-i
 - **Explicit spaces**: tag memories, pages, and recalls with `space=work | personal | client-X` so a day-job capture never bleeds into a side-project brief. Auto-detected from the current repo or workspace when no space is set; overridable always.
 - **Local artifacts**: Markdown pages live in `~/.origin/pages/`, session logs and project status live under `~/.origin/sessions/`, and `~/.origin/` keeps local git history you can inspect, revert, or symlink into Obsidian.
 
+### Multi-bucket workflows
+
+Memories belong to a **space** — a bucket like `origin`, `career`, or
+`ideas`. Set the active bucket per shell:
+
+    ORIGIN_SPACE=career claude
+
+Or declaratively via `~/.origin/spaces.toml` (see
+`plugin/examples/spaces.toml`). To manage spaces from the CLI:
+
+    origin space list
+    origin space add ideas --default
+    origin space show ideas
+    origin space move scratch career
+
+`origin doctor` prints the current resolver state so you can see exactly
+which layer chose the active space.
+
 ---
 
 ## Evaluation

--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -167,6 +167,18 @@ origin agents show claude-code
 origin agents edit claude-code --trust trusted --enabled true
 ```
 
+### `origin space <list|add|default|move|show>`
+
+Manage memory spaces (buckets).
+
+```bash
+origin space list
+origin space add ideas --default
+origin space show career
+origin space default work
+origin space move scratch career
+```
+
 ## Output formats
 
 - `--format auto` (default): table on TTY, JSON when piped.

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -204,6 +204,21 @@ impl OriginClient {
             .context("parsing /api/agents/{name} response")
     }
 
+    /// GET /api/spaces — list all spaces.
+    pub async fn list_spaces(&self) -> Result<Vec<origin_types::Space>> {
+        let url = format!("{}/api/spaces", self.base_url);
+        let resp = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("GET {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        resp.json().await.context("parsing /api/spaces response")
+    }
+
     /// PUT /api/agents/{name} — update an agent's metadata.
     pub async fn update_agent(&self, name: &str, req: UpdateAgentRequest) -> Result<AgentResponse> {
         let url = format!("{}/api/agents/{}", self.base_url, name);

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -234,6 +234,15 @@ impl OriginClient {
         Ok(json["affected"].as_u64().unwrap_or(0) as usize)
     }
 
+    /// GET /api/spaces — fetch a single space by name (filters from list).
+    pub async fn get_space(&self, name: &str) -> Result<origin_types::Space> {
+        let spaces = self.list_spaces().await?;
+        spaces
+            .into_iter()
+            .find(|s| s.name == name)
+            .ok_or_else(|| anyhow::anyhow!("space '{}' not found", name))
+    }
+
     /// GET /api/spaces — list all spaces.
     pub async fn list_spaces(&self) -> Result<Vec<origin_types::Space>> {
         let url = format!("{}/api/spaces", self.base_url);

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -218,6 +218,22 @@ impl OriginClient {
         Ok(())
     }
 
+    /// POST /api/spaces/{from}/move-to/{to} — bulk reassign memories from one space to another.
+    pub async fn move_space(&self, from: &str, to: &str) -> Result<usize> {
+        let url = format!("{}/api/spaces/{}/move-to/{}", self.base_url, from, to);
+        let resp = self
+            .http
+            .post(&url)
+            .send()
+            .await
+            .with_context(|| format!("POST {} failed", url))?;
+        let resp = resp
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        let json: serde_json::Value = resp.json().await.context("parsing move-to response")?;
+        Ok(json["affected"].as_u64().unwrap_or(0) as usize)
+    }
+
     /// GET /api/spaces — list all spaces.
     pub async fn list_spaces(&self) -> Result<Vec<origin_types::Space>> {
         let url = format!("{}/api/spaces", self.base_url);

--- a/crates/origin-cli/src/client.rs
+++ b/crates/origin-cli/src/client.rs
@@ -204,6 +204,20 @@ impl OriginClient {
             .context("parsing /api/agents/{name} response")
     }
 
+    /// POST /api/spaces — register a new space.
+    pub async fn create_space(&self, name: &str) -> Result<()> {
+        let url = format!("{}/api/spaces", self.base_url);
+        self.http
+            .post(&url)
+            .json(&serde_json::json!({"name": name}))
+            .send()
+            .await
+            .with_context(|| format!("POST {} failed", url))?
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {}", url))?;
+        Ok(())
+    }
+
     /// GET /api/spaces — list all spaces.
     pub async fn list_spaces(&self) -> Result<Vec<origin_types::Space>> {
         let url = format!("{}/api/spaces", self.base_url);

--- a/crates/origin-cli/src/commands/mod.rs
+++ b/crates/origin-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod recall;
 pub mod search;
 pub mod service;
 pub mod setup;
+pub mod space;
 pub mod status;
 pub mod store;
 

--- a/crates/origin-cli/src/commands/setup.rs
+++ b/crates/origin-cli/src/commands/setup.rs
@@ -147,6 +147,9 @@ pub async fn run_doctor() -> anyhow::Result<()> {
         println!("  Or:  origin key set anthropic");
     }
 
+    let cwd = std::env::current_dir()?;
+    print_space_resolution(&cwd);
+
     Ok(())
 }
 
@@ -391,6 +394,59 @@ async fn delete(path: &str) -> anyhow::Result<()> {
         return Err(anyhow::anyhow!("HTTP {}", resp.status()));
     }
     Ok(())
+}
+
+fn print_space_resolution(cwd: &std::path::Path) {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let _ = writeln!(out, "\n--- Space resolution ---");
+
+    let env = std::env::var("ORIGIN_SPACE").ok().filter(|s| !s.is_empty());
+    let _ = writeln!(
+        out,
+        "ORIGIN_SPACE env:      {}",
+        env.as_deref().unwrap_or("(unset)")
+    );
+
+    let cfg = dirs::home_dir().map(|h| h.join(".origin/spaces.toml"));
+    let cfg_exists = cfg.as_ref().map(|p| p.exists()).unwrap_or(false);
+    let _ = writeln!(
+        out,
+        "~/.origin/spaces.toml: {}",
+        if cfg_exists { "present" } else { "missing" }
+    );
+
+    let _ = writeln!(out, "cwd:                   {}", cwd.display());
+
+    let plugin_resolver = std::env::var("CLAUDE_PLUGIN_ROOT")
+        .ok()
+        .map(|p| format!("{}/bin/resolve-space.sh", p));
+    if let Some(p) = plugin_resolver {
+        if std::path::Path::new(&p).exists() {
+            let _ = writeln!(out, "Plugin resolver:       {}", p);
+            let output = std::process::Command::new(&p)
+                .arg("--cwd")
+                .arg(cwd)
+                .output();
+            if let Ok(o) = output {
+                let s = String::from_utf8_lossy(&o.stdout);
+                let s = s.trim().replace('\t', " (from ");
+                let s = if s.contains(" (from ") {
+                    format!("{})", s)
+                } else {
+                    s.to_string()
+                };
+                let _ = writeln!(out, "Resolved:              {}", s);
+            }
+        } else {
+            let _ = writeln!(out, "Plugin resolver:       not found at {}", p);
+        }
+    } else {
+        let _ = writeln!(
+            out,
+            "Plugin resolver:       CLAUDE_PLUGIN_ROOT not set (running outside Claude Code)"
+        );
+    }
 }
 
 fn prompt_line(prompt: &str) -> anyhow::Result<String> {

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -7,6 +7,38 @@ use clap::Subcommand;
 use crate::client::OriginClient;
 use crate::output::OutputFormat;
 
+fn set_default_in_toml(name: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    let home =
+        std::env::var("HOME").map_err(|_| anyhow::anyhow!("HOME environment variable not set"))?;
+    let path = std::path::PathBuf::from(home).join(".origin/spaces.toml");
+    std::fs::create_dir_all(path.parent().unwrap())?;
+
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    let mut found = false;
+    let mut new_body = String::with_capacity(existing.len() + 32);
+    for line in existing.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("default") && trimmed.contains('=') {
+            new_body.push_str(&format!("default = \"{}\"\n", name));
+            found = true;
+        } else {
+            new_body.push_str(line);
+            new_body.push('\n');
+        }
+    }
+    if !found {
+        if !new_body.is_empty() && !new_body.ends_with("\n\n") {
+            new_body.push('\n');
+        }
+        new_body.push_str(&format!("default = \"{}\"\n", name));
+    }
+
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(new_body.as_bytes())?;
+    Ok(())
+}
+
 fn read_default_from_toml() -> Option<String> {
     let home = std::env::var("HOME").ok()?;
     let path = std::path::PathBuf::from(home).join(".origin/spaces.toml");
@@ -104,8 +136,24 @@ async fn list(client: &OriginClient, format: OutputFormat, quiet: bool) -> Resul
     }
     Ok(())
 }
-async fn add(_c: &OriginClient, _f: OutputFormat, _q: bool, _n: &str, _d: bool) -> Result<()> {
-    todo!("Task 3")
+async fn add(
+    client: &OriginClient,
+    _format: OutputFormat,
+    quiet: bool,
+    name: &str,
+    set_default: bool,
+) -> Result<()> {
+    client.create_space(name).await?;
+    if set_default {
+        set_default_in_toml(name)?;
+    }
+    if !quiet {
+        println!("Registered space '{}'.", name);
+        if set_default {
+            println!("Set '{}' as the default in ~/.origin/spaces.toml.", name);
+        }
+    }
+    Ok(())
 }
 async fn default_cmd(
     _c: &OriginClient,

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -156,12 +156,32 @@ async fn add(
     Ok(())
 }
 async fn default_cmd(
-    _c: &OriginClient,
-    _f: OutputFormat,
-    _q: bool,
-    _n: Option<&str>,
+    _client: &OriginClient,
+    _format: OutputFormat,
+    quiet: bool,
+    name: Option<&str>,
 ) -> Result<()> {
-    todo!("Task 4")
+    match name {
+        Some(n) => {
+            set_default_in_toml(n)?;
+            if !quiet {
+                println!("Set default space to '{}' in ~/.origin/spaces.toml.", n);
+            }
+        }
+        None => match read_default_from_toml() {
+            Some(n) => {
+                if !quiet {
+                    println!("{}", n);
+                }
+            }
+            None => {
+                if !quiet {
+                    println!("(no default space set; resolver layer-6 fallback is \"personal\")");
+                }
+            }
+        },
+    }
+    Ok(())
 }
 async fn move_cmd(
     _c: &OriginClient,

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -143,13 +143,32 @@ async fn add(
     name: &str,
     set_default: bool,
 ) -> Result<()> {
-    client.create_space(name).await?;
+    match client.create_space(name).await {
+        Ok(()) => {
+            if !quiet {
+                println!("Registered space '{}'.", name);
+            }
+        }
+        Err(e) => {
+            // Best-effort detection of "already exists" via error string match.
+            // The daemon currently returns 500 on UNIQUE constraint failure;
+            // surface as a non-fatal warning so the --default flow can proceed.
+            let s = e.to_string().to_lowercase();
+            let already_exists = s.contains("unique constraint")
+                || s.contains("already exists")
+                || s.contains("duplicate");
+            if already_exists {
+                if !quiet {
+                    println!("Space '{}' already registered (no-op).", name);
+                }
+            } else {
+                return Err(e);
+            }
+        }
+    }
     if set_default {
         set_default_in_toml(name)?;
-    }
-    if !quiet {
-        println!("Registered space '{}'.", name);
-        if set_default {
+        if !quiet {
             println!("Set '{}' as the default in ~/.origin/spaces.toml.", name);
         }
     }

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -7,6 +7,25 @@ use clap::Subcommand;
 use crate::client::OriginClient;
 use crate::output::OutputFormat;
 
+fn read_default_from_toml() -> Option<String> {
+    let home = std::env::var("HOME").ok()?;
+    let path = std::path::PathBuf::from(home).join(".origin/spaces.toml");
+    let body = std::fs::read_to_string(&path).ok()?;
+    for line in body.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("default") {
+            let rest = rest.trim_start();
+            if let Some(rest) = rest.strip_prefix('=') {
+                let val = rest.trim().trim_matches('"').to_string();
+                if !val.is_empty() {
+                    return Some(val);
+                }
+            }
+        }
+    }
+    None
+}
+
 #[derive(Subcommand)]
 pub enum SpaceCmd {
     /// List all registered spaces.
@@ -53,8 +72,37 @@ pub async fn run(
     }
 }
 
-async fn list(_c: &OriginClient, _f: OutputFormat, _q: bool) -> Result<()> {
-    todo!("Task 2")
+async fn list(client: &OriginClient, format: OutputFormat, quiet: bool) -> Result<()> {
+    let spaces = client.list_spaces().await?;
+    let default = read_default_from_toml();
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => crate::output::print_json(&spaces)?,
+        OutputFormat::Table => {
+            if spaces.is_empty() {
+                println!("(no spaces registered)");
+                return Ok(());
+            }
+            println!(
+                "{:<20} {:<10} {:<10} {:<8}",
+                "NAME", "MEMORIES", "ENTITIES", "DEFAULT?"
+            );
+            for s in &spaces {
+                let is_default = default.as_deref() == Some(s.name.as_str());
+                println!(
+                    "{:<20} {:<10} {:<10} {:<8}",
+                    s.name,
+                    s.memory_count,
+                    s.entity_count,
+                    if is_default { "yes" } else { "" }
+                );
+            }
+        }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
 }
 async fn add(_c: &OriginClient, _f: OutputFormat, _q: bool, _n: &str, _d: bool) -> Result<()> {
     todo!("Task 3")

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -196,6 +196,29 @@ async fn move_cmd(
     }
     Ok(())
 }
-async fn show(_c: &OriginClient, _f: OutputFormat, _q: bool, _n: &str) -> Result<()> {
-    todo!("Task 6")
+async fn show(client: &OriginClient, format: OutputFormat, quiet: bool, name: &str) -> Result<()> {
+    let space = client.get_space(name).await?;
+    let default = read_default_from_toml();
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        OutputFormat::Json => crate::output::print_json(&space)?,
+        OutputFormat::Table => {
+            println!("Name:           {}", space.name);
+            if let Some(desc) = &space.description {
+                println!("Description:    {}", desc);
+            }
+            println!("Memory count:   {}", space.memory_count);
+            println!("Entity count:   {}", space.entity_count);
+            if space.starred {
+                println!("Starred:        yes");
+            }
+            if default.as_deref() == Some(space.name.as_str()) {
+                println!("Default:        yes (~/.origin/spaces.toml)");
+            }
+        }
+        OutputFormat::Auto => unreachable!("Auto resolved by main before dispatch"),
+    }
+    Ok(())
 }

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `origin space list/add/default/move/show` — manage memory spaces.
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::client::OriginClient;
+use crate::output::OutputFormat;
+
+#[derive(Subcommand)]
+pub enum SpaceCmd {
+    /// List all registered spaces.
+    List,
+    /// Register a new space.
+    Add {
+        /// Space name (e.g. "career", "health", "ideas").
+        name: String,
+        /// Also set this space as the default.
+        #[arg(long)]
+        default: bool,
+    },
+    /// Get or set the default space.
+    Default {
+        /// Space name to set as default. Omit to print the current default.
+        name: Option<String>,
+    },
+    /// Bulk-reassign all memories from one space to another.
+    Move {
+        /// Source space.
+        from: String,
+        /// Destination space.
+        to: String,
+    },
+    /// Show detail for a space — memory count, page count, last activity.
+    Show {
+        /// Space name.
+        name: String,
+    },
+}
+
+pub async fn run(
+    client: &OriginClient,
+    format: OutputFormat,
+    quiet: bool,
+    cmd: SpaceCmd,
+) -> Result<()> {
+    match cmd {
+        SpaceCmd::List => list(client, format, quiet).await,
+        SpaceCmd::Add { name, default } => add(client, format, quiet, &name, default).await,
+        SpaceCmd::Default { name } => default_cmd(client, format, quiet, name.as_deref()).await,
+        SpaceCmd::Move { from, to } => move_cmd(client, format, quiet, &from, &to).await,
+        SpaceCmd::Show { name } => show(client, format, quiet, &name).await,
+    }
+}
+
+async fn list(_c: &OriginClient, _f: OutputFormat, _q: bool) -> Result<()> {
+    todo!("Task 2")
+}
+async fn add(_c: &OriginClient, _f: OutputFormat, _q: bool, _n: &str, _d: bool) -> Result<()> {
+    todo!("Task 3")
+}
+async fn default_cmd(
+    _c: &OriginClient,
+    _f: OutputFormat,
+    _q: bool,
+    _n: Option<&str>,
+) -> Result<()> {
+    todo!("Task 4")
+}
+async fn move_cmd(
+    _c: &OriginClient,
+    _f: OutputFormat,
+    _q: bool,
+    _f2: &str,
+    _t: &str,
+) -> Result<()> {
+    todo!("Task 5")
+}
+async fn show(_c: &OriginClient, _f: OutputFormat, _q: bool, _n: &str) -> Result<()> {
+    todo!("Task 6")
+}

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -184,13 +184,17 @@ async fn default_cmd(
     Ok(())
 }
 async fn move_cmd(
-    _c: &OriginClient,
-    _f: OutputFormat,
-    _q: bool,
-    _f2: &str,
-    _t: &str,
+    client: &OriginClient,
+    _format: OutputFormat,
+    quiet: bool,
+    from: &str,
+    to: &str,
 ) -> Result<()> {
-    todo!("Task 5")
+    let n = client.move_space(from, to).await?;
+    if !quiet {
+        println!("Moved {} memories from '{}' to '{}'.", n, from, to);
+    }
+    Ok(())
 }
 async fn show(_c: &OriginClient, _f: OutputFormat, _q: bool, _n: &str) -> Result<()> {
     todo!("Task 6")

--- a/crates/origin-cli/src/commands/space.rs
+++ b/crates/origin-cli/src/commands/space.rs
@@ -82,7 +82,7 @@ pub enum SpaceCmd {
         /// Destination space.
         to: String,
     },
-    /// Show detail for a space — memory count, page count, last activity.
+    /// Show detail for a space — name, description, memory count, entity count, default + starred flags.
     Show {
         /// Space name.
         name: String,

--- a/crates/origin-cli/src/main.rs
+++ b/crates/origin-cli/src/main.rs
@@ -100,6 +100,11 @@ enum Commands {
         #[command(subcommand)]
         cmd: commands::agents::AgentsCmd,
     },
+    /// Manage memory spaces (list, add, default, move, show).
+    Space {
+        #[command(subcommand)]
+        cmd: commands::space::SpaceCmd,
+    },
 }
 
 #[tokio::main]
@@ -145,6 +150,7 @@ async fn main() -> anyhow::Result<()> {
             commands::list::run(&client, format, cli.quiet, limit, memory_type).await?
         }
         Commands::Agents { cmd } => commands::agents::run(&client, format, cli.quiet, cmd).await?,
+        Commands::Space { cmd } => commands::space::run(&client, format, cli.quiet, cmd).await?,
     }
     Ok(())
 }

--- a/crates/origin-cli/tests/space_cli.rs
+++ b/crates/origin-cli/tests/space_cli.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration tests for `origin space` subcommands.
+//!
+//! Decision: toml-only approach (no throwaway daemon).
+//! Spawning a process-level daemon requires port management, wait-for-ready
+//! polling, and drop-based cleanup — well over 30 lines of scaffolding with no
+//! existing harness in origin-cli tests.  The unit tests in `origin-core` and
+//! the origin-server HTTP integration tests already cover the server-side space
+//! logic.  These tests cover the CLI surface that does NOT require a live
+//! daemon: argument parsing (--help flags) and the toml-backed `space default`
+//! round-trip.
+
+use assert_cmd::Command;
+use std::fs;
+
+fn cli() -> Command {
+    Command::cargo_bin("origin").expect("origin binary built")
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing — all `space` subcommands must accept --help
+// ---------------------------------------------------------------------------
+
+#[test]
+fn space_subcommands_help_exits_zero() {
+    for args in [
+        &["space", "--help"][..],
+        &["space", "list", "--help"][..],
+        &["space", "add", "--help"][..],
+        &["space", "default", "--help"][..],
+        &["space", "move", "--help"][..],
+        &["space", "show", "--help"][..],
+    ] {
+        cli().args(args).assert().success();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// `space default` toml round-trip — no daemon required
+// ---------------------------------------------------------------------------
+
+#[test]
+fn space_default_set_and_read_back() {
+    let tmp = tempfile::tempdir().expect("mktempdir");
+
+    // Set the default.
+    cli()
+        .env("HOME", tmp.path())
+        .args(["space", "default", "work"])
+        .assert()
+        .success();
+
+    // Read it back — output should be exactly "work".
+    cli()
+        .env("HOME", tmp.path())
+        .args(["space", "default"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("work"));
+}
+
+#[test]
+fn space_default_toml_file_written_correctly() {
+    let tmp = tempfile::tempdir().expect("mktempdir");
+
+    cli()
+        .env("HOME", tmp.path())
+        .args(["space", "default", "personal"])
+        .assert()
+        .success();
+
+    let toml_path = tmp.path().join(".origin/spaces.toml");
+    let content = fs::read_to_string(&toml_path).expect("spaces.toml should exist");
+    assert!(
+        content.contains("default = \"personal\""),
+        "toml content: {}",
+        content
+    );
+}
+
+#[test]
+fn space_default_overwrite_existing_entry() {
+    let tmp = tempfile::tempdir().expect("mktempdir");
+
+    // First write.
+    cli()
+        .env("HOME", tmp.path())
+        .args(["space", "default", "first"])
+        .assert()
+        .success();
+
+    // Overwrite.
+    cli()
+        .env("HOME", tmp.path())
+        .args(["space", "default", "second"])
+        .assert()
+        .success();
+
+    // Only the new value survives.
+    let toml_path = tmp.path().join(".origin/spaces.toml");
+    let content = fs::read_to_string(&toml_path).expect("spaces.toml should exist");
+    assert!(
+        content.contains("default = \"second\""),
+        "expected 'second' in toml: {}",
+        content
+    );
+    assert!(
+        !content.contains("default = \"first\""),
+        "unexpected stale 'first' in toml: {}",
+        content
+    );
+}
+
+#[test]
+fn space_default_no_default_set_prints_fallback_message() {
+    let tmp = tempfile::tempdir().expect("mktempdir");
+
+    // No default has been set — CLI should print the fallback note.
+    cli()
+        .env("HOME", tmp.path())
+        .args(["space", "default"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("personal"));
+}

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -5244,12 +5244,24 @@ impl MemoryDB {
 
     /// Bulk-reassign all memories and entities from `from` space to `to` space.
     /// Returns the number of memory rows (chunks) updated.
+    /// Auto-creates the destination space if it is not already registered.
     pub async fn reassign_memories_space(
         &self,
         from: &str,
         to: &str,
     ) -> Result<usize, OriginError> {
         let conn = self.conn.lock().await;
+
+        // Auto-create destination space if not registered yet.
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().timestamp() as f64;
+        conn.execute(
+            "INSERT OR IGNORE INTO spaces (id, name, description, suggested, sort_order, created_at, updated_at)
+             SELECT ?1, ?2, NULL, 0, COALESCE(MAX(sort_order), -1) + 1, ?3, ?3 FROM spaces",
+            libsql::params![id, to, now],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("reassign auto-create-dest: {}", e)))?;
 
         conn.execute("BEGIN", ())
             .await
@@ -30079,5 +30091,34 @@ pub(crate) mod tests {
         let row2 = rows2.next().await.unwrap().expect("count row");
         let foo_count: i64 = row2.get(0).unwrap();
         assert_eq!(foo_count, 0, "foo should have 0 memories after move");
+    }
+
+    #[tokio::test]
+    async fn reassign_memories_space_auto_creates_dest() {
+        let (db, _td) = test_db().await;
+
+        // Only create the source space — destination "baz" does not exist yet.
+        db.create_space("src", None, false).await.unwrap();
+
+        let doc = make_memory_doc(
+            "mem_autocreate_1",
+            "Memory in src.",
+            "knowledge",
+            "src",
+            "agent",
+        );
+        db.upsert_documents(vec![doc]).await.unwrap();
+
+        // Move without pre-creating "baz".
+        let affected = db.reassign_memories_space("src", "baz").await.unwrap();
+        assert!(affected >= 1, "expected >= 1 row updated, got {}", affected);
+
+        // "baz" must now appear in list_spaces.
+        let spaces = db.list_spaces().await.unwrap();
+        assert!(
+            spaces.iter().any(|s| s.name == "baz"),
+            "destination space 'baz' should be registered after move, got: {:?}",
+            spaces.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -5242,6 +5242,52 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Bulk-reassign all memories and entities from `from` space to `to` space.
+    /// Returns the number of memory rows (chunks) updated.
+    pub async fn reassign_memories_space(
+        &self,
+        from: &str,
+        to: &str,
+    ) -> Result<usize, OriginError> {
+        let conn = self.conn.lock().await;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("reassign_memories_space begin: {}", e)))?;
+
+        let txn_result = async {
+            let updated = conn
+                .execute(
+                    "UPDATE memories SET space = ?1 WHERE space = ?2",
+                    libsql::params![to, from],
+                )
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("reassign memories: {}", e)))?;
+
+            conn.execute(
+                "UPDATE entities SET space = ?1 WHERE space = ?2",
+                libsql::params![to, from],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("reassign entities: {}", e)))?;
+
+            conn.execute("COMMIT", ()).await.map_err(|e| {
+                OriginError::VectorDb(format!("reassign_memories_space commit: {}", e))
+            })?;
+
+            Ok::<usize, OriginError>(updated as usize)
+        }
+        .await;
+
+        match txn_result {
+            Ok(n) => Ok(n),
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
     pub async fn confirm_space(&self, name: &str) -> Result<(), OriginError> {
         let conn = self.conn.lock().await;
         let now = chrono::Utc::now().timestamp() as f64;
@@ -29979,5 +30025,59 @@ pub(crate) mod tests {
             rows.next().await.unwrap().is_some(),
             "document_tags table must exist after migration 51 replay"
         );
+    }
+
+    #[tokio::test]
+    async fn reassign_memories_space_works() {
+        let (db, _td) = test_db().await;
+
+        db.create_space("foo", None, false).await.unwrap();
+        db.create_space("bar", None, false).await.unwrap();
+
+        let doc1 = make_memory_doc(
+            "mem_move_1",
+            "First memory in foo.",
+            "knowledge",
+            "foo",
+            "agent",
+        );
+        let doc2 = make_memory_doc(
+            "mem_move_2",
+            "Second memory in foo.",
+            "knowledge",
+            "foo",
+            "agent",
+        );
+        db.upsert_documents(vec![doc1]).await.unwrap();
+        db.upsert_documents(vec![doc2]).await.unwrap();
+
+        let affected = db.reassign_memories_space("foo", "bar").await.unwrap();
+        assert!(
+            affected >= 2,
+            "expected >= 2 rows updated, got {}",
+            affected
+        );
+
+        // Verify via a direct count query.
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT COUNT(*) FROM memories WHERE space = 'bar'", ())
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().expect("count row");
+        let bar_count: i64 = row.get(0).unwrap();
+        assert!(
+            bar_count >= 2,
+            "expected >= 2 memories in bar, got {}",
+            bar_count
+        );
+
+        let mut rows2 = conn
+            .query("SELECT COUNT(*) FROM memories WHERE space = 'foo'", ())
+            .await
+            .unwrap();
+        let row2 = rows2.next().await.unwrap().expect("count row");
+        let foo_count: i64 = row2.get(0).unwrap();
+        assert_eq!(foo_count, 0, "foo should have 0 memories after move");
     }
 }

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1789,6 +1789,21 @@ pub async fn handle_delete_space(
     Ok(Json(serde_json::json!({"deleted": name})))
 }
 
+pub async fn handle_move_space(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path((from, to)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    let affected = db
+        .reassign_memories_space(&from, &to)
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    Ok(Json(serde_json::json!({"affected": affected})))
+}
+
 // ===== Nurture Cards =====
 
 #[derive(Debug, Deserialize)]

--- a/crates/origin-server/src/router.rs
+++ b/crates/origin-server/src/router.rs
@@ -184,6 +184,10 @@ pub fn build_router(state: SharedState) -> Router {
             "/api/spaces/{name}",
             put(memory_routes::handle_update_space).delete(memory_routes::handle_delete_space),
         )
+        .route(
+            "/api/spaces/{from}/move-to/{to}",
+            post(memory_routes::handle_move_space),
+        )
         // Pages (legacy SQL tables still named "concepts" — see db.rs)
         .route(
             "/api/pages",


### PR DESCRIPTION
## Summary

Ships Plan C of the space UX gap design: `origin space {list, add, default, move, show}` CLI subcommands + a `--- Space resolution ---` section in `origin doctor` so users can debug "why did my memory land in X". Adds one new daemon endpoint (`POST /api/spaces/{from}/move-to/{to}`) backed by a transactional bulk-reassign in `MemoryDB`.

**CLI surface (mirrors `aws --profile` / `kubectl config` ergonomics):**

```
origin space list                      # enumerate spaces, mark default from ~/.origin/spaces.toml
origin space add <name> [--default]    # register a new space (idempotent on duplicate)
origin space default [<name>]          # get or set default via ~/.origin/spaces.toml (NOT daemon)
origin space move <from> <to>          # bulk-reassign memories + entities; auto-creates <to>
origin space show <name>               # detail view
origin doctor                          # now includes "--- Space resolution ---" block
```

**Default lives in plugin toml, not daemon** — per Spec D7. The `default` subcommand reads/writes `~/.origin/spaces.toml` directly. CLI tests use HOME-isolation tmpdir to avoid polluting real home.

## Files

**`crates/origin-cli/`:**
- New: `src/commands/space.rs` — clap `SpaceCmd` enum + 5 subcommand handlers + toml helpers (`read_default_from_toml`, `set_default_in_toml`).
- Modified: `src/commands/mod.rs`, `src/main.rs` — wire `Space` variant into the parent `Commands` enum.
- Modified: `src/client.rs` — 3 new methods (`list_spaces`, `create_space`, `get_space`, `move_space`).
- Modified: `src/commands/setup.rs` — `print_space_resolution(cwd)` helper called from `run_doctor`. Reports env, toml presence, cwd, plugin resolver path + output.
- New: `tests/space_cli.rs` — 5 daemon-free integration tests covering `--help` surface + toml round-trip + overwrite + missing-default fallback.

**`crates/origin-server/`:**
- Modified: `src/router.rs` — registers `POST /api/spaces/{from}/move-to/{to}`.
- Modified: `src/memory_routes.rs` — `handle_move_space` extracts `Path((from, to))`, clones `Arc<MemoryDB>`, calls core.

**`crates/origin-core/`:**
- Modified: `src/db.rs` — `MemoryDB::reassign_memories_space(from, to) -> usize` runs `INSERT OR IGNORE` for destination + `UPDATE chunks SET space` + `UPDATE entities SET space` inside `BEGIN/COMMIT`. Returns affected chunks count.
- Unit tests: `reassign_memories_space_works` (basic round-trip) + `reassign_memories_space_auto_creates_dest` (auto-create destination).

**Root + CLI README:** documents `origin space` subcommands + a Multi-bucket workflows section.

## Test coverage

- `cargo test -p origin --test space_cli` — 5/5 (CLI surface + toml round-trip)
- `cargo test -p origin-core --lib reassign_memories_space` — 2/2 (basic + auto-create-dest)
- `cargo build -p origin -p origin-server -p origin-core` — clean

## Spec + Plan

- Spec: `docs/superpowers/specs/2026-05-23-space-ux-gap-design.md` (gitignored, local)
- Plan C: `docs/superpowers/plans/2026-05-23-space-plan-c-cli.md` (gitignored, local)

Decisions D6 (CLI subcommands), D7 (default in plugin toml), D8 (warn-and-create, partial) implemented. Acceptance criteria AC5, AC6, AC9 fully satisfied. AC7 partially satisfied — memories + entities reassigned; pages table + GC of source space deferred (see Deferred section).

## Adversarial review applied

A fresh-eye reviewer ran before this PR opened. Findings: 0 Critical + 5 Important.

**Fixed before PR (3 of 5):**

- `origin space add <existing>` was returning HTTP 500 on duplicate UNIQUE constraint, blocking the `--default` upgrade path. CLI now treats "already exists" as a non-fatal warning and continues to apply `--default`. Commit `74f89312` (post-rebase: `74f89312`).
- `origin space show` doc-comment promised "page count, last activity" — fields the wire type doesn't expose. Truncated help text to match actual rendered fields. Commit `ec6e19a4`.
- `origin space move <from> <to>` left memories with `space=<to>` but never registered `<to>` in the spaces table. `reassign_memories_space` now auto-creates the destination via `INSERT OR IGNORE` before the UPDATEs (uses the already-held connection lock to avoid deadlock). Plus added unit test. Commit `6988b814`.

**Deferred (2 of 5) — documented for follow-up:**

- **`reassign_memories_space` does not touch `pages` table.** Migration 50 added `pages.space`, but the column is *also* used as a categorical tag (e.g. `pages.space='recap'` per `db.rs:16136-16137` comment). Blindly UPDATE-ing would relabel recap-type pages. Needs an audit to distinguish real spaces from categorical tags before the page-reassign can be added safely.
- **Source space GC after move.** Spec AC7 says "old space becomes empty (and is GC'd if registration was implicit)". `reassign_memories_space` doesn't remove the now-empty source. Deferred — needs `suggested=1` check + page-reassign first.

Both deferrals are tracked for a future patch in the same v0.7.x cycle.

## Test plan

- [x] `cargo test -p origin --test space_cli` — 5/5
- [x] `cargo test -p origin-core --lib reassign` — 2/2
- [x] `cargo build -p origin -p origin-server -p origin-core` — clean
- [x] `origin doctor` shows `--- Space resolution ---` block (env, toml, cwd, plugin resolver)
- [ ] Manual end-to-end (after merge, against real daemon):
  - [ ] `origin space list` enumerates spaces, marks default-from-toml correctly
  - [ ] `origin space add ideas --default` registers + sets default; second invocation prints "already registered (no-op)" but still updates default
  - [ ] `origin space move foo bar` bulk-reassigns; `origin space list` shows `bar` auto-created with the moved counts
  - [ ] `ORIGIN_SPACE=ideas origin doctor` shows `ORIGIN_SPACE env: ideas`

## Depends on / paired with

- Plan A (PR #153) — plugin-side resolver chain. C complements A by giving users CLI-level discoverability of the spaces A's resolver targets.
- Plan B (PR #156) — daemon + MCP schema gating. C is independent of B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)