### PR TITLE
feat(cli): implement Windows install via schtasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,35 +237,59 @@ jobs:
         run: |
           cargo build --release -p origin-server
           ./scripts/smoke-windows.ps1
-      # `origin install` on Windows currently exits non-zero with guidance
-      # toward manual run / Task Scheduler. Verify the contract: install
-      # MUST fail with a clear message, not crash, not register a broken
-      # service. Follow-up: implement Windows Service Control Protocol via
-      # the windows-service crate so sc.exe start no longer times out.
-      - name: E2E origin install contract (Windows; expects clean error)
+      # `origin install` on Windows registers a per-user Task Scheduler
+      # ONLOGON entry via schtasks.exe and triggers it immediately. We
+      # verify the full round-trip: install registers the task, daemon
+      # binds /api/health, uninstall removes the task.
+      - name: E2E origin install round-trip (Windows; schtasks)
         if: matrix.os == 'windows-2022'
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          cargo build -p origin
-          $out = & target\debug\origin.exe install 2>&1
-          $code = $LASTEXITCODE
-          Write-Host "exit code: $code"
-          Write-Host "output: $out"
-          if ($code -eq 0) { throw "install unexpectedly succeeded on Windows" }
-          if ("$out" -notmatch "not yet supported on Windows") {
-            throw "install did not surface the documented Windows guidance"
+          cargo build -p origin -p origin-server
+          $installOut = & target\debug\origin.exe install 2>&1
+          $installCode = $LASTEXITCODE
+          Write-Host "install exit=$installCode out=$installOut"
+          if ($installCode -ne 0) { throw "install failed: $installOut" }
+
+          # schtasks /query must report the task as present.
+          & schtasks.exe /query /tn OriginServer | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "schtasks did not register OriginServer" }
+
+          # /run launched the daemon as a separate process. Poll /api/health.
+          $healthy = $false
+          for ($i = 0; $i -lt 30; $i++) {
+            try {
+              $r = Invoke-WebRequest -Uri "http://127.0.0.1:7878/api/health" -UseBasicParsing -TimeoutSec 1
+              if ($r.StatusCode -eq 200) { $healthy = $true; break }
+            } catch { }
+            Start-Sleep -Seconds 1
           }
-          # Confirm no stale sc.exe service entry left behind.
-          $svc = & sc.exe query com.origin.server 2>&1
-          $svcExit = $LASTEXITCODE
-          if ($svcExit -eq 0) {
-            & sc.exe delete com.origin.server | Out-Null
-            throw "install must not register a service before erroring; cleaned up stale entry"
+          if (-not $healthy) {
+            & schtasks.exe /query /tn OriginServer /fo LIST /v
+            throw "daemon did not respond on /api/health after schtasks /run"
           }
-          Write-Host "    Windows install error-contract PASS"
-          # sc.exe query returns 1060 when service not found; that leaks as the
-          # script's exit code under $ErrorActionPreference=Stop. Reset.
+          Write-Host "    daemon healthy under scheduled task"
+
+          $uninstallOut = & target\debug\origin.exe uninstall 2>&1
+          $uninstallCode = $LASTEXITCODE
+          Write-Host "uninstall exit=$uninstallCode out=$uninstallOut"
+          if ($uninstallCode -ne 0) { throw "uninstall failed: $uninstallOut" }
+
+          # Task must be gone; /query returns 1 with stderr "not found".
+          & schtasks.exe /query /tn OriginServer 2>&1 | Out-Null
+          if ($LASTEXITCODE -eq 0) {
+            & schtasks.exe /delete /tn OriginServer /f | Out-Null
+            throw "uninstall did not remove the scheduled task"
+          }
+
+          # Best-effort: kill any leftover origin-server.exe so the next step
+          # is not blocked on port 7878.
+          Get-Process -Name origin-server -ErrorAction SilentlyContinue |
+            Stop-Process -Force -ErrorAction SilentlyContinue
+
+          Write-Host "    Windows install round-trip PASS"
+          # schtasks /query exit 1 leaks under $ErrorActionPreference=Stop.
           $global:LASTEXITCODE = 0
           exit 0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,9 @@ Origin runs on macOS (arm64, x86_64), Linux (x86_64, aarch64; musl), and Windows
 |---|---|---|
 | macOS | `~/Library/Application Support/origin/` | launchd via `~/Library/LaunchAgents/com.origin.server.plist` (user-level) |
 | Linux | `~/.local/share/origin/` (or `$XDG_DATA_HOME/origin`) | systemd user unit at `~/.config/systemd/user/origin-server.service` (qualifier dropped per `ServiceLabel::to_script_name()`). Enable lingering with `loginctl enable-linger` if you want the service alive after logout. |
-| Windows | `%LOCALAPPDATA%\origin\` | `origin install` is **not supported on Windows in v1**. origin-server is a plain console app and does not speak the Windows Service Control Protocol; sc.exe times out at 30s. Run the daemon manually (`Start-Process .\origin-server.exe -WindowStyle Hidden`) or register a per-user Task Scheduler task with `schtasks /create /sc onlogon`. Tracked follow-up: implement service control via the `windows-service` crate. |
+| Windows | `%LOCALAPPDATA%\origin\` | Per-user Task Scheduler ONLOGON task registered via `schtasks.exe /create /tn OriginServer /sc ONLOGON /tr <exe> /f`. `origin install` short-circuits before service-manager and drives schtasks directly (origin-server is a plain console app and would otherwise time out at 30s under sc.exe + the Windows Service Control Protocol). `origin uninstall` calls `schtasks /delete /tn OriginServer /f`. |
 
-`origin install` / `origin uninstall` work on macOS + Linux. On Windows both commands exit non-zero with guidance toward manual run or Task Scheduler.
+`origin install` / `origin uninstall` work on macOS, Linux, and Windows. macOS + Linux go through the `service-manager` crate (launchd / systemd-user); Windows takes the schtasks path described above so the daemon does not need a service dispatcher.
 
 ### llama-cpp-2 backend
 

--- a/crates/origin-cli/src/commands/service.rs
+++ b/crates/origin-cli/src/commands/service.rs
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Cross-platform service registration for the Origin daemon.
 //!
-//! Wraps the `service-manager` crate to register `origin-server` with the
-//! host's native service manager (launchd, systemd-user, Windows SCM via winsw).
+//! - macOS: launchd LaunchAgent via the `service-manager` crate.
+//! - Linux: systemd --user unit via the `service-manager` crate.
+//! - Windows: per-user ONLOGON Task Scheduler entry via `schtasks.exe`.
+//!   We bypass `service-manager`'s `ScServiceManager` because origin-server
+//!   is a plain console app and does not implement the Windows Service
+//!   Control Protocol (`sc start` would time out at 30s with error 1053).
 
 use anyhow::{Context, Result};
 use service_manager::{
@@ -15,20 +19,43 @@ use crate::client::origin_host_from_env;
 
 pub const SERVICE_LABEL: &str = "com.origin.server";
 
+/// Windows Task Scheduler does not love dots in task names. The macOS launchd
+/// and systemd-user paths still use the canonical reverse-DNS `SERVICE_LABEL`.
+#[cfg(target_os = "windows")]
+pub const WINDOWS_TASK_NAME: &str = "OriginServer";
+
 fn label() -> Result<ServiceLabel> {
     SERVICE_LABEL.parse().context("invalid service label")
 }
 
+#[cfg(target_os = "windows")]
+fn run_schtasks(args: &[&str], action: &str) -> Result<std::process::Output> {
+    let output = std::process::Command::new("schtasks.exe")
+        .args(args)
+        .output()
+        .with_context(|| format!("spawn schtasks.exe ({action})"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        anyhow::bail!(
+            "schtasks.exe {} failed (exit {}): {}{}",
+            action,
+            output.status.code().unwrap_or(-1),
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!("\nstdout: {}", stdout.trim())
+            }
+        );
+    }
+    Ok(output)
+}
+
 fn manager() -> Result<Box<dyn ServiceManager>> {
-    // Windows note: `<dyn ServiceManager>::native()` returns `ScServiceManager`
-    // (sc.exe) on Windows. sc.exe requires Administrator privileges. We do NOT
-    // try to use winsw: service-manager 0.11's WinSwServiceManager invokes
-    // `winsw install <name>.xml` which winsw v2 does not understand (v2 expects
-    // rename-pattern config next to its executable). Users on Windows need to
-    // run `origin install` from an elevated terminal.
+    // macOS + Linux only. Windows install/uninstall short-circuit before
+    // calling this and drive schtasks.exe directly (see install/uninstall).
     let mut m = <dyn ServiceManager>::native().context("detect native service manager")?;
-    // launchd and systemd-user both support user-level. Windows sc.exe does not
-    // and silently keeps system-level after this call. macOS + Linux benefit.
     let _ = m.set_level(ServiceLevel::User);
     Ok(m)
 }
@@ -158,22 +185,34 @@ fn build_launchd_plist(
 pub fn install() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
-        // origin-server is a plain console app; it does not speak the Windows
-        // Service Control Protocol (no SetServiceStatus / control handler).
-        // sc.exe install succeeds but `sc start` times out at 30s (error 1053:
-        // "service did not respond"). Until origin-server is wrapped with the
-        // `windows-service` crate or via Task Scheduler, the `install`
-        // subcommand is not supported on Windows.
-        anyhow::bail!(
-            "`origin install` is not yet supported on Windows.\n\
-             Run the daemon manually instead:\n\
-             \n  Set-Location <install-dir>\n  $env:ORIGIN_BIND_ADDR = \"127.0.0.1:7878\"\n  Start-Process .\\origin-server.exe -WindowStyle Hidden\n\
-             \n\
-             To auto-start at logon, register a per-user Task Scheduler task:\n\
-             \n  schtasks /create /tn OriginServer /sc onlogon /tr \"<install-dir>\\origin-server.exe\"\n\
-             \n\
-             Tracked: cross-platform Windows service support."
+        // origin-server is a plain console app and does not speak the Windows
+        // Service Control Protocol, so sc.exe install + start would time out
+        // at 30s with error 1053. Use Task Scheduler instead: register a
+        // per-user ONLOGON task and trigger it immediately. Matches the
+        // user-scope semantics of launchd LaunchAgent (macOS) and
+        // systemd --user (Linux), without needing a service dispatcher in
+        // origin-server.
+        let program = current_server_path()?;
+        let program_str = program.to_string_lossy();
+        run_schtasks(
+            &[
+                "/create",
+                "/tn",
+                WINDOWS_TASK_NAME,
+                "/sc",
+                "ONLOGON",
+                "/tr",
+                &program_str,
+                "/f",
+            ],
+            "create scheduled task",
+        )?;
+        run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
+        println!(
+            "Installed and started Windows scheduled task '{}' (origin-server).",
+            WINDOWS_TASK_NAME
         );
+        return Ok(());
     }
 
     #[cfg_attr(target_os = "windows", allow(unreachable_code))]
@@ -240,13 +279,20 @@ pub fn install() -> Result<()> {
 pub fn uninstall() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
-        // `origin install` is gated off on Windows; `uninstall` is a no-op for
-        // the matching reason. If a previous build left a stale sc.exe entry,
-        // remove it manually: `sc.exe delete com.origin.server`.
-        anyhow::bail!(
-            "`origin uninstall` is not yet supported on Windows. \
-             If a stale service exists: sc.exe delete com.origin.server"
+        // /end returns nonzero if the task is not currently running; that
+        // is not an error worth surfacing, so swallow the exit code.
+        let _ = std::process::Command::new("schtasks.exe")
+            .args(["/end", "/tn", WINDOWS_TASK_NAME])
+            .output();
+        run_schtasks(
+            &["/delete", "/tn", WINDOWS_TASK_NAME, "/f"],
+            "delete scheduled task",
+        )?;
+        println!(
+            "Uninstalled Windows scheduled task '{}'.",
+            WINDOWS_TASK_NAME
         );
+        return Ok(());
     }
 
     #[cfg_attr(target_os = "windows", allow(unreachable_code))]
@@ -264,11 +310,10 @@ pub fn uninstall() -> Result<()> {
 pub fn is_installed() -> bool {
     #[cfg(target_os = "windows")]
     {
-        // `sc.exe query <label>` exits 0 when the service is registered with
-        // the Windows Service Control Manager, 1060 when it is not. We don't
-        // need admin rights for a read-only query.
-        std::process::Command::new("sc.exe")
-            .args(["query", SERVICE_LABEL])
+        // `schtasks /query /tn <name>` exits 0 when the task exists, 1 when
+        // it does not. No admin rights needed for the read-only query.
+        std::process::Command::new("schtasks.exe")
+            .args(["/query", "/tn", WINDOWS_TASK_NAME])
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
@@ -283,9 +328,15 @@ pub async fn print_status() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
         if is_installed() {
-            println!("Service: {} (registered with sc.exe)", SERVICE_LABEL);
+            println!(
+                "Service: scheduled task '{}' (registered)",
+                WINDOWS_TASK_NAME
+            );
         } else {
-            println!("Service: {} (not installed)", SERVICE_LABEL);
+            println!(
+                "Service: scheduled task '{}' (not installed)",
+                WINDOWS_TASK_NAME
+            );
         }
     }
     #[cfg(not(target_os = "windows"))]

--- a/crates/origin-cli/src/commands/service.rs
+++ b/crates/origin-cli/src/commands/service.rs
@@ -68,8 +68,8 @@ fn manager() -> Result<Box<dyn ServiceManager>> {
 /// - Linux (systemd-user): `<config_dir>/systemd/user/<script_name>.service`
 ///   (`ServiceLabel::to_script_name()` joins org+app with `-` and DROPS the
 ///   qualifier, so `com.origin.server` becomes `origin-server.service`).
-/// - Windows (sc.exe): no on-disk unit file. Service state lives in the
-///   Windows registry — see `is_installed()` for the probe.
+/// - Windows: no on-disk unit file. The scheduled task lives in the Task
+///   Scheduler database — see `is_installed()` for the schtasks-based probe.
 #[cfg(not(target_os = "windows"))]
 pub fn service_unit_path() -> Result<PathBuf> {
     #[cfg(target_os = "macos")]

--- a/crates/origin-server/README.md
+++ b/crates/origin-server/README.md
@@ -10,7 +10,7 @@ Most users install Origin through the [Claude Code plugin](../../plugin/.claude-
 npx -y @7xuanlu/origin setup
 ```
 
-The installer downloads `origin`, `origin-server`, and `origin-mcp` into `~/.origin/bin/`. Cross-platform: macOS (arm64, x64), Linux (x64, arm64; glibc), Windows (x64). The `origin` CLI owns setup and service management; `origin-server` is the daemon binary the host's service manager runs (launchd on macOS, systemd-user on Linux; Windows runs the binary manually for now).
+The installer downloads `origin`, `origin-server`, and `origin-mcp` into `~/.origin/bin/`. Cross-platform: macOS (arm64, x64), Linux (x64, arm64; glibc), Windows (x64). The `origin` CLI owns setup and service management; `origin-server` is the daemon binary the host's service manager runs (launchd on macOS, systemd-user on Linux, Task Scheduler ONLOGON task on Windows).
 
 ## Setup modes
 
@@ -42,12 +42,12 @@ The libSQL store lives under the platform data directory (`dirs::data_local_dir(
 ## Service Commands
 
 ```bash
-origin install      # register with the host service manager (launchd / systemd-user)
+origin install      # register with the host service manager (launchd / systemd-user / schtasks)
 origin uninstall    # remove from the service manager
 origin status       # service + runtime status
 ```
 
-On Windows `origin install` currently exits non-zero with guidance toward manual run (`Start-Process .\origin-server.exe`) or Task Scheduler. Tracked follow-up.
+On Windows the install path uses `schtasks.exe` to register a per-user `OriginServer` ONLOGON task and triggers it immediately. origin-server stays a plain console app — no Windows Service Control Protocol dispatcher is needed.
 
 The daemon listens on `127.0.0.1:7878`. MCP clients, the Claude Code plugin, and local tools call that local API.
 


### PR DESCRIPTION
## Summary

Closes Task 43 from the cross-platform port handoff. PR #150 shipped \`origin install\` on Windows as a documented hard error because origin-server does not implement the Windows Service Control Protocol — sc.exe install + start times out at 30s with error 1053.

Wrap origin-server with the \`windows-service\` crate adds ~200 LOC of dispatcher boilerplate. Use Task Scheduler instead.

### Changes

- \`service.rs\`: Windows branches of \`install\`, \`uninstall\`, \`is_installed\`, and \`print_status\` drive \`schtasks.exe\` directly. macOS + Linux paths untouched.
  - \`/create /tn OriginServer /sc ONLOGON /tr <exe> /f\` + \`/run\` for install.
  - \`/delete /tn OriginServer /f\` (preceded by \`/end\` best-effort) for uninstall.
  - \`/query /tn OriginServer\` for is_installed probe.
- \`ci.yml\`: flip the Windows install step from error-contract to a real round-trip — install, \`schtasks /query\` exists, \`/api/health\` probe, uninstall, \`/query\` reports missing, kill any leftover daemon.
- \`AGENTS.md\` + \`origin-server/README.md\`: refresh Windows install language.

### Tradeoffs

- ONLOGON tasks fire on user logon, not at system boot. Acceptable for a personal memory layer; macOS LaunchAgent and systemd --user have the same scope.
- No origin-server source change — keeps the daemon a portable console app.

## Test plan

- [ ] CI \`test (windows-2022)\` runs the install/uninstall round-trip + \`/api/health\` probe.
- [ ] macOS launchd path still works (rebased on top of #158 + #161).
- [ ] Linux systemd-user E2E still passes.