### PR TITLE
fix(ci): release.yml — publish-crates correctness + add origin CLI to Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,16 @@ jobs:
           tar -czf dist/origin-mcp-darwin-arm64.tar.gz origin-mcp
           rm origin-mcp
 
+      # Per-binary archive for the origin CLI consumed by the Homebrew tap
+      # formula. Darwin-arm64 only — matches the origin-mcp tap pattern.
+      - name: Package origin CLI tarball for Homebrew (darwin-arm64 only)
+        if: matrix.target == 'aarch64-apple-darwin'
+        shell: bash
+        run: |
+          cp "target/${{ matrix.target }}/release/origin" origin
+          tar -czf dist/origin-darwin-arm64.tar.gz origin
+          rm origin
+
       - name: Upload archives to release
         uses: softprops/action-gh-release@v2
         with:
@@ -240,12 +250,14 @@ jobs:
           append_body: false
           fail_on_unmatched_files: true
 
-      - name: Upload origin-mcp artifact for Homebrew job
+      - name: Upload Homebrew artifacts (origin + origin-mcp)
         if: matrix.target == 'aarch64-apple-darwin'
         uses: actions/upload-artifact@v4
         with:
-          name: origin-mcp-artifacts
-          path: dist/origin-mcp-darwin-arm64.tar.gz
+          name: homebrew-artifacts
+          path: |
+            dist/origin-darwin-arm64.tar.gz
+            dist/origin-mcp-darwin-arm64.tar.gz
 
   docker:
     name: Build & Push Docker Image
@@ -404,14 +416,15 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: origin-mcp-artifacts
+          name: homebrew-artifacts
           merge-multiple: true
-      - name: Compute checksums and update formula
+      - name: Compute checksums and update formulae
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${RELEASE_TAG#v}"
-          SHA_DARWIN_ARM64=$(sha256sum origin-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
+          SHA_MCP_DARWIN_ARM64=$(sha256sum origin-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
+          SHA_CLI_DARWIN_ARM64=$(sha256sum origin-darwin-arm64.tar.gz | cut -d' ' -f1)
 
           git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git tap
           mkdir -p tap/Formula
@@ -445,14 +458,47 @@ jobs:
           FORMULA
 
           sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" tap/Formula/origin-mcp.rb
-          sed -i "s/SHA_PLACEHOLDER/${SHA_DARWIN_ARM64}/g" tap/Formula/origin-mcp.rb
+          sed -i "s/SHA_PLACEHOLDER/${SHA_MCP_DARWIN_ARM64}/g" tap/Formula/origin-mcp.rb
+
+          cat > tap/Formula/origin.rb << 'FORMULA'
+          class Origin < Formula
+            desc "Origin CLI — local-first memory + knowledge layer for AI agents"
+            homepage "https://github.com/7xuanlu/origin"
+            version "VERSION_PLACEHOLDER"
+            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/origin-darwin-arm64.tar.gz"
+            sha256 "SHA_PLACEHOLDER"
+            license "Apache-2.0"
+
+            livecheck do
+              url :homepage
+              strategy :github_latest
+            end
+
+            on_macos do
+              depends_on arch: :arm64
+            end
+
+            def install
+              bin.install "origin"
+            end
+
+            test do
+              assert_match "origin", shell_output("#{bin}/origin --help")
+            end
+          end
+          FORMULA
+
+          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" tap/Formula/origin.rb
+          sed -i "s/SHA_PLACEHOLDER/${SHA_CLI_DARWIN_ARM64}/g" tap/Formula/origin.rb
 
           cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/origin-mcp.rb
-          git commit -m "origin-mcp ${VERSION}"
+          git add Formula/origin-mcp.rb Formula/origin.rb
+          git commit -m "origin + origin-mcp ${VERSION}"
           git push origin HEAD:main
 
       - name: Verify formula syntax
-        run: ruby -c tap/Formula/origin-mcp.rb
+        run: |
+          ruby -c tap/Formula/origin-mcp.rb
+          ruby -c tap/Formula/origin.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,37 +295,60 @@ jobs:
         # runs. Real origin-mcp publish happens after origin-types is indexed.
         run: cargo publish -p origin-types --dry-run
 
-      - name: Check if origin-types changed since last tag
-        id: check-types
+      - name: Resolve workspace version
+        id: version
         run: |
-          PREV_TAG=$(git tag --sort=-version:refname | grep '^v' | sed -n '2p')
-          if [ -z "$PREV_TAG" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            CHANGED=$(git diff --name-only "$PREV_TAG" HEAD -- crates/origin-types/)
-            if [ -n "$CHANGED" ]; then echo "changed=true" >> "$GITHUB_OUTPUT"; else echo "changed=false" >> "$GITHUB_OUTPUT"; fi
-          fi
+          VERSION=$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)".*/\1/')
+          echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Workspace version: $VERSION"
 
       - name: Publish origin-types to crates.io
-        if: steps.check-types.outputs.changed == 'true' && env.CARGO_REGISTRY_TOKEN != ''
-        run: cargo publish -p origin-types || echo "Already published, skipping"
+        # Always attempt when the version is not yet on crates.io.
+        # Prior logic gated on "files changed since last tag" which silently
+        # skipped publish when only the workspace version bumped without
+        # origin-types code changes. v0.6.1 hit this: origin-types code was
+        # stable so publish skipped, then origin-mcp 0.6.1 publish failed
+        # because its `origin-types = "^0.6.1"` dep was unreachable. Both
+        # crates stayed at 0.6.0 while the release job exited SUCCESS because
+        # the trailing `|| echo "Already published, skipping"` masked it.
+        # Registry check is the source of truth.
+        if: env.CARGO_REGISTRY_TOKEN != ''
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          if curl -sf "https://crates.io/api/v1/crates/origin-types/${VERSION}" >/dev/null; then
+            echo "origin-types ${VERSION} already on crates.io, skipping publish"
+          else
+            cargo publish -p origin-types
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: Wait for origin-types to be available on crates.io
-        if: steps.check-types.outputs.changed == 'true'
         run: |
-          VERSION=$(grep -E '^version = ' Cargo.toml | head -1 | sed -E 's/version = "([^"]+)".*/\1/')
+          VERSION="${{ steps.version.outputs.value }}"
           for i in $(seq 1 30); do
             if curl -sf "https://crates.io/api/v1/crates/origin-types/${VERSION}" >/dev/null; then
-              echo "origin-types ${VERSION} available"; break
+              echo "origin-types ${VERSION} available"; exit 0
             fi
             echo "Waiting for crates.io to index origin-types ${VERSION}... ($i/30)"
             sleep 10
           done
+          echo "ERROR: origin-types ${VERSION} not visible on crates.io after 5 min"
+          exit 1
 
       - name: Publish origin-mcp to crates.io
-        run: cargo publish -p origin-mcp || echo "Already published, skipping"
+        # Same registry-check pattern. Real errors from cargo publish now
+        # propagate — the prior `|| echo "Already published, skipping"`
+        # swallowed dependency-resolution errors and marked the job SUCCESS
+        # while uploading nothing.
+        if: env.CARGO_REGISTRY_TOKEN != ''
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          if curl -sf "https://crates.io/api/v1/crates/origin-mcp/${VERSION}" >/dev/null; then
+            echo "origin-mcp ${VERSION} already on crates.io, skipping publish"
+          else
+            cargo publish -p origin-mcp
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
Two bundled fixes to `.github/workflows/release.yml`. Both surfaced during v0.6.1 release-artifact validation. Single PR because both touch the same file with small, independent diffs.

---

## Fix 1: publish-crates actually publishes when version bumps

### Problem

crates.io has been silently stuck at **origin-types 0.6.0** + **origin-mcp 0.6.0** since the v0.6.1 tag shipped on 2026-05-16. The release.yml publish-crates job exits SUCCESS every time, but never uploads. Will recur on v0.7.0 (release-please PR #140 currently open) unless fixed first.

### Root cause

Two bugs:

**Bug A** — `check-types.changed=false` gates out publish. The prior `git diff --name-only "$PREV_TAG" HEAD -- crates/origin-types/` returns empty when only the workspace `Cargo.toml` version bumps (release-please updates the root manifest, not files inside `crates/origin-types/`). Publish skipped silently.

**Bug B** — `cargo publish -p origin-mcp || echo "Already published, skipping"` swallows every non-zero exit, not just dupes. When origin-mcp 0.6.1 tried to resolve `origin-types = "^0.6.1"` from a crates.io that still only knew about 0.6.0 (because Bug A), `cargo publish` errored with `failed to select a version for the requirement` — but the `||` trap converted that to the misleading "Already published, skipping" success log.

### Fix

Replace the file-diff gate with a registry check. Always attempt publish when the bumped workspace version isn't on crates.io; skip cleanly when it already is. Real `cargo publish` errors propagate.

```yaml
- name: Publish origin-types to crates.io
  if: env.CARGO_REGISTRY_TOKEN != ''
  run: |
    VERSION="${{ steps.version.outputs.value }}"
    if curl -sf "https://crates.io/api/v1/crates/origin-types/${VERSION}" >/dev/null; then
      echo "origin-types ${VERSION} already on crates.io, skipping publish"
    else
      cargo publish -p origin-types
    fi
```

The `Wait for origin-types` step also now exits 1 on timeout (previously silently continued).

---

## Fix 2: add origin CLI to Homebrew tap

### Problem

`brew install 7xuanlu/tap/origin-mcp` works but `brew install 7xuanlu/tap/origin` does not — the tap only contains `Formula/origin-mcp.rb`. CLI users have to download the raw binary from the GitHub release page manually.

### Fix

- Build `origin-darwin-arm64.tar.gz` alongside the existing `origin-mcp-darwin-arm64.tar.gz` on the aarch64-apple-darwin matrix leg.
- Upload both under a single `homebrew-artifacts` artifact name (replaces the prior `origin-mcp-artifacts`-only).
- `update-homebrew` job writes both `Formula/origin-mcp.rb` (existing pattern, unchanged) and the new `Formula/origin.rb` to the homebrew-tap repo on every release.

---

## Verification

Validated v0.6.1 release artifacts to find Bug 1:

- GH release v0.6.1: aarch64-darwin binaries only (expected, pre-cross-platform)
- `release.yml` v0.6.1 run #25951129376: all 4 jobs SUCCESS
- `Publish crates.io` step log shows `cargo publish -p origin-mcp` failed with the dependency-resolution error, then `||` trapped it
- `curl https://crates.io/api/v1/crates/origin-types` confirms latest is 0.6.0
- `curl https://crates.io/api/v1/crates/origin-mcp` confirms latest is 0.6.0
- npm + Homebrew `origin-mcp.rb` both at 0.6.1 — those paths work
- `curl https://api.github.com/repos/7xuanlu/homebrew-tap/contents/Formula` returns only `origin-mcp.rb` — confirms no CLI formula exists today

## Why this matters now

Release-please PR #140 is open and will cut v0.7.0 once merged. Without this PR, v0.7.0 ships with: (a) crates.io stuck at 0.6.0, (b) no `brew install origin` path. Merge this first, then merge #140 to get a clean 0.7.0 across all channels.

## Test plan

- [x] yamllint clean
- [x] Pre-commit hook passed
- [ ] Manual after merge: next release.yml run actually executes `cargo publish` for both crates and uploads both Homebrew formulae
- [ ] Verify `cargo add origin-types` resolves 0.7.0 after v0.7.0 ships
- [ ] Verify `brew install 7xuanlu/tap/origin` works after v0.7.0 ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)