### PR TITLE
fix(ci): refresh Cargo.lock for 0.7.0 workspace bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,7 +3070,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "origin"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3090,7 +3090,7 @@ dependencies = [
 
 [[package]]
 name = "origin-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "origin-mcp"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3162,7 +3162,7 @@ dependencies = [
 
 [[package]]
 name = "origin-server"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3190,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "origin-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "serde",


### PR DESCRIPTION
## Summary

The v0.7.0 release pipeline (\`release.yml\` run 26367496434) failed at the very first job (\"Create GitHub Release\") with:

\`\`\`
ERROR: Cargo.lock drift — origin is not 0.7.0
\`\`\`

release-please updates \`Cargo.toml\` workspace versions when it cuts the release PR but does NOT run \`cargo update --workspace\`. \`Cargo.lock\`'s workspace member entries stay at the previous version (0.6.1), so \`scripts/validate-versions.sh\` correctly bails before the publish steps run.

Refresh \`Cargo.lock\` so the workspace members match \`Cargo.toml\`. 5-line diff.

## Follow-up (post-merge)

The v0.7.0 tag (currently at \`341203f0\`) points at the broken commit. After this lands on main we need either:
- **Move the tag** to the lock-fix commit and let \`release.yml\` retry (destructive tag-move, version stays 0.7.0).
- **Cut v0.7.1** with this fix-only patch and treat 0.7.0 as a non-release (release-please will pick this commit's \`fix:\` prefix and bump).

Decision pending on the retag.

## Test plan

- [x] \`cargo update --workspace\` locally — picks up the 5 workspace members → 0.7.0.
- [x] \`RELEASE_TAG=v0.7.0 bash scripts/validate-versions.sh\` → \`All versions consistent: 0.7.0\`.
- [ ] CI on this PR runs to green (it's not under release-tag context, so validate-versions.sh skips; standard fmt/lint/test should pass).