### PR TITLE
fix(ci): close 4 multi-target gaps in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,13 +145,35 @@ jobs:
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
 
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+      # rust-toolchain.toml pins the workspace to 1.95.0. The previous
+      # `@stable` install installed targets against the stable channel and
+      # cargo ran with 1.95.0 (per rust-toolchain.toml override), so
+      # `--target x86_64-apple-darwin` failed with `can't find crate for core`
+      # — the target was added to the wrong toolchain. Pin explicitly to
+      # mirror ci.yml.
+      - name: Install Rust 1.95.0 with matrix target
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
         with:
+          toolchain: 1.95.0
           targets: ${{ matrix.target }}
+
+      # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
+      # time and does not bundle SQLite on Windows. Mirrors ci.yml's test
+      # step. GitHub `windows-2022` runner ships vcpkg preinstalled.
+      - name: Install sqlite3 (Windows only)
+        if: matrix.os == 'windows-2022'
+        shell: pwsh
+        run: |
+          vcpkg install sqlite3:x64-windows-static-md
+          "LIB=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md\lib;$env:LIB" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          # Per-target cache key so the macos-14 jobs don't share state
+          # between aarch64 and x86_64 (otherwise the first job's target/
+          # contents pollute the second).
+          shared-key: release-${{ matrix.target }}
 
       - name: Install cross
         if: matrix.use_cross == true
@@ -161,8 +183,16 @@ jobs:
         if: matrix.use_cross != true
         run: cargo build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
+      # OPENSSL_VENDORED tells openssl-sys to build OpenSSL from source
+      # inside the cross container, which doesn't ship libssl-dev. The dep
+      # is pulled transitively through fastembed → hf-hub → native-tls →
+      # openssl-sys. Cross.toml's `[build.env] passthrough` forwards the
+      # env var into the container.
       - name: Build (cross)
         if: matrix.use_cross == true
+        env:
+          OPENSSL_VENDORED: "1"
+          OPENSSL_STATIC: "1"
         run: cross build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
       - name: Smoke (native)

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,13 @@
+# Configuration for the `cross` cross-compilation tool used by the release
+# pipeline's Linux build jobs (`x86_64-unknown-linux-gnu`,
+# `aarch64-unknown-linux-gnu`).
+#
+# Pass OPENSSL_* env vars through to the cross container so openssl-sys can
+# build OpenSSL from source. The container does not ship `libssl-dev`, and
+# `openssl-sys` is pulled transitively via fastembed → hf-hub → native-tls.
+
+[build.env]
+passthrough = [
+    "OPENSSL_VENDORED",
+    "OPENSSL_STATIC",
+]


### PR DESCRIPTION
## Summary

PR #150 introduced the 5-target release matrix but only `aarch64-apple-darwin` worked end-to-end. CI doesn't exercise release.yml, so the other 4 targets first ran on the v0.7.0 tag push and all failed. Each failure has its own root cause:

1. **x86_64-apple-darwin:** \`can't find crate for core\`. \`@stable\` added the target to the stable toolchain, but cargo runs 1.95.0 per \`rust-toolchain.toml\`. → pin \`toolchain: 1.95.0\` (mirror ci.yml).
2. **x86_64-pc-windows-msvc:** \`LNK1181 sqlite3.lib\`. libsql 0.9 doesn't bundle SQLite on Windows. → install \`sqlite3:x64-windows-static-md\` via vcpkg + prepend \`LIB\` (mirror ci.yml).
3. **{x86_64,aarch64}-unknown-linux-gnu:** \`openssl-sys\` build fails — pulled transitively via fastembed → hf-hub → native-tls → openssl-sys. cross container has no libssl-dev. → \`OPENSSL_VENDORED=1\` + \`OPENSSL_STATIC=1\`, new \`Cross.toml\` passes the env through.

Also: per-target Swatinem cache \`shared-key: release-\${{ matrix.target }}\` so the two macos-14 jobs don't fight over \`target/\`.

## Validation plan

CI here only runs the normal workspace lint/test (release.yml isn't triggered by PRs). After this merges:

- [ ] \`gh workflow run release.yml --field tag=v0.7.0\` — re-run release against the existing v0.7.0 tag (already at \`1a80083f\` post-#165). No third retag needed.
- [ ] All 5 matrix targets green.
- [ ] Docker push, Homebrew, crates.io, npm jobs run + succeed.