### PR TITLE
docs(seo): add Learn more section linking README to useorigin.app cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,29 @@ Build details for the daemon, MCP server, CLI, and core crates live in the crate
 
 ---
 
+## Learn more
+
+Longer-form writing on AI work memory and how Origin compares lives at [useorigin.app/learn](https://useorigin.app/learn):
+
+**Concepts**
+- [What is AI work memory?](https://useorigin.app/learn/ai-work-memory) — the shape of the problem Origin solves
+- [MCP memory server](https://useorigin.app/learn/mcp-memory-server) — how Origin exposes memory through the Model Context Protocol
+- [Local-first AI memory](https://useorigin.app/learn/local-first-ai-memory) — data, privacy, and control
+- [Markdown + local index](https://useorigin.app/learn/markdown-local-index-ai-memory) — the storage model
+- [AI agent handoff loop](https://useorigin.app/learn/ai-agent-handoff-loop) — session-end discipline that prevents context loss
+
+**Comparisons**
+- [Origin vs Basic Memory](https://useorigin.app/learn/origin-vs-basic-memory) — Markdown knowledge base vs AI work-session memory
+- [Origin vs claude-mem](https://useorigin.app/learn/origin-vs-claude-mem) — observer-style Claude Code memory vs MCP-first cross-tool memory
+- [Origin vs Superlocal Memory](https://useorigin.app/learn/origin-vs-superlocal-memory) — includes the honest LoCoMo benchmark concession
+
+**Docs**
+- [Get started](https://useorigin.app/docs/get-started) — install + verify the first local memory loop
+- [Daily workflow](https://useorigin.app/docs/daily-workflow) — capture, handoff, distill
+- [MCP clients](https://useorigin.app/docs/mcp-clients) — connect Claude Code, Cursor, Codex, Claude Desktop, Gemini CLI
+
+---
+
 ## What Origin is NOT
 
 - **Not a Life OS.** No habits, calendar, journal, or life-management modules. Origin scopes to AI work artifacts only. If you want a full personal OS, look at [PAI](https://github.com/danielmiessler/PAI).


### PR DESCRIPTION
## Summary

GitHub README visitors had no direct link to the website's longer-form content. Added a "Learn more" section before "What Origin is NOT" with curated links to:

- **5 concept articles**: AI work memory, MCP memory server, local-first AI memory, Markdown + local index, AI agent handoff loop
- **3 comparisons**: vs Basic Memory, vs claude-mem, vs Superlocal Memory (third notes the honest LoCoMo benchmark concession)
- **3 doc entry points**: get-started, daily-workflow, mcp-clients

## Why

Cross-domain link from \`github.com/7xuanlu/origin\` README into \`useorigin.app\` distributes link authority both ways and gives developers a clear path from the project surface they discover (GitHub) to the longer-form context (the website).

Pairs with the recent autonomous SEO run on \`7xuanlu/origin-website\` (PR #10-#36 there) which strengthened the inbound side: every Learn/Docs page now has tailored OG images, schema.org graph, IndexNow auto-ping, RSS, llms.txt, and a sitewide footer that links back into the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)