### PR TITLE
docs(seo): add Links section to every crate README cross-referencing useorigin.app

### DIFF
--- a/crates/origin-cli/README.md
+++ b/crates/origin-cli/README.md
@@ -186,6 +186,14 @@ origin space move scratch career
 - `--format table`: human-readable table.
 - `--quiet` / `-q`: suppress success output (errors still go to stderr).
 
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/docs/get-started](https://useorigin.app/docs/get-started) — install + verify the first memory loop
+- [useorigin.app/docs/commands](https://useorigin.app/docs/commands) — Claude Code commands and MCP tools reference
+- [useorigin.app/docs/troubleshooting](https://useorigin.app/docs/troubleshooting) — common failure modes
+- [github.com/7xuanlu/origin](https://github.com/7xuanlu/origin) — source
+
 ## License
 
 Apache-2.0. See top-level LICENSE.

--- a/crates/origin-core/README.md
+++ b/crates/origin-core/README.md
@@ -43,6 +43,13 @@ See [CLAUDE.md](../../CLAUDE.md) for lower-level invariants and locking rules.
 
 Evaluation docs live in [docs/eval](../../docs/eval/README.md). Slow GPU/API benchmarks are manual and should not run in normal CI.
 
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/learn/local-first-ai-memory](https://useorigin.app/learn/local-first-ai-memory) — storage model explained
+- [useorigin.app/learn/markdown-local-index-ai-memory](https://useorigin.app/learn/markdown-local-index-ai-memory) — why Markdown + libSQL together
+- [github.com/7xuanlu/origin](https://github.com/7xuanlu/origin) — source
+
 ## License
 
 Apache-2.0.

--- a/crates/origin-mcp/README.md
+++ b/crates/origin-mcp/README.md
@@ -91,6 +91,14 @@ The MCP server ships tool instructions that tell agents to capture durable state
 
 See [`src/tools.rs`](src/tools.rs) for the full instructions.
 
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/learn/mcp-memory-server](https://useorigin.app/learn/mcp-memory-server) — concept article on Origin as an MCP memory server
+- [useorigin.app/docs/mcp-clients](https://useorigin.app/docs/mcp-clients) — connect Claude Code, Cursor, Codex, Claude Desktop, Gemini CLI
+- [npm: origin-mcp](https://www.npmjs.com/package/origin-mcp) — standalone npm package
+- [github.com/7xuanlu/origin](https://github.com/7xuanlu/origin) — source
+
 ## License
 
 Apache-2.0.

--- a/crates/origin-server/README.md
+++ b/crates/origin-server/README.md
@@ -78,6 +78,13 @@ First build on macOS takes several minutes while `llama.cpp` compiles for Metal.
 
 See [CLAUDE.md](../../CLAUDE.md) for the full route and module map.
 
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/docs/get-started](https://useorigin.app/docs/get-started) — install + verify the first memory loop
+- [useorigin.app/docs/mcp-clients](https://useorigin.app/docs/mcp-clients) — connect Claude Code, Cursor, Codex, Claude Desktop, Gemini CLI
+- [github.com/7xuanlu/origin](https://github.com/7xuanlu/origin) — source
+
 ## License
 
 Apache-2.0.

--- a/crates/origin-types/README.md
+++ b/crates/origin-types/README.md
@@ -10,7 +10,14 @@ This crate defines the HTTP API request/response types and core enums used by:
 
 ## Stability
 
-Pre-1.0 — expect minor version bumps to include breaking changes, per Rust 0.x convention. Types marked `#[doc(hidden)]` are not part of the stability contract and may change without a version bump.
+Pre-1.0. Expect minor version bumps to include breaking changes, per Rust 0.x convention. Types marked `#[doc(hidden)]` are not part of the stability contract and may change without a version bump.
+
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/docs](https://useorigin.app/docs) — install + daily workflow
+- [origin-mcp on crates.io](https://crates.io/crates/origin-mcp) — sibling crate
+- [github.com/7xuanlu/origin](https://github.com/7xuanlu/origin) — source
 
 ## License
 


### PR DESCRIPTION
## Summary

The five crate READMEs (origin-types, origin-core, origin-server, origin-cli, origin-mcp) had zero links to useorigin.app. Each now ends with a short Links section before License, curated to the crate's audience:

- **origin-types**: project home, docs, sibling origin-mcp on crates.io, GitHub source
- **origin-core**: project home, local-first-ai-memory + markdown-local-index concept articles, source
- **origin-server**: project home, get-started, mcp-clients, source
- **origin-cli**: project home, get-started, commands reference, troubleshooting, source
- **origin-mcp**: project home, mcp-memory-server concept, mcp-clients setup, npm package, source

Surfaces affected:
- crates.io visitors on origin-types + origin-mcp (their READMEs are the public crate descriptions)
- GitHub visitors browsing per-crate paths
- AI agents fetching READMEs for project context

Pairs with PR #171 (top-level README "Learn more" cross-link section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)