### PR TITLE
fix(deps): vendored OpenSSL for cross-Linux + portable build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,29 +179,14 @@ jobs:
         if: matrix.use_cross == true
         run: cargo install cross --locked
 
-      # workflow_dispatch can target a tag from before Cross.toml landed.
-      # Write it inline. cross runs pre-build commands inside the target
-      # container as root, so we install libssl-dev (openssl-sys needs the
-      # system headers — it's pulled transitively via fastembed → hf-hub →
-      # native-tls). `OPENSSL_VENDORED` is a CARGO FEATURE not an env var,
-      # so the previous env-only attempt did nothing.
-      - name: Write Cross.toml (pre-build libssl-dev)
-        if: matrix.use_cross == true
-        shell: bash
-        run: |
-          cat > Cross.toml <<'EOF'
-          [target.x86_64-unknown-linux-gnu]
-          pre-build = [
-              "apt-get update && apt-get install --assume-yes libssl-dev pkg-config",
-          ]
-
-          [target.aarch64-unknown-linux-gnu]
-          pre-build = [
-              "dpkg --add-architecture arm64",
-              "apt-get update && apt-get install --assume-yes libssl-dev:arm64 pkg-config",
-          ]
-          EOF
-          cat Cross.toml
+      # No pre-build openssl install. The cross 0.2.5 container ships
+      # OpenSSL 1.0.2 (Ubuntu 16.04 base), which openssl-sys 0.9.x rejects
+      # as too old. Worse, when openssl-sys finds *any* system OpenSSL it
+      # short-circuits BEFORE checking the `vendored` cargo feature — so a
+      # `pre-build apt-get install libssl-dev` actively breaks the build.
+      # Workspace Cargo.toml's vendored feature (origin-server pulls
+      # `openssl = { workspace = true }`) compiles OpenSSL 3.x from source
+      # via `openssl-src`, so no container packages are needed.
 
       - name: Build (native)
         if: matrix.use_cross != true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3067,7 @@ checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3172,6 +3182,7 @@ dependencies = [
  "futures",
  "hyper 1.9.0",
  "hyper-util",
+ "openssl",
  "origin-core",
  "origin-types",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,14 @@ log = "0.4"
 
 # HTTP
 reqwest = { version = "0.12", features = ["json"] }
+# OpenSSL vendored: builds OpenSSL from source instead of linking the system
+# library. Required because fastembed → hf-hub → native-tls → openssl-sys is
+# transitive, and the `cross` Linux build container's system OpenSSL is too
+# old (the openssl-sys 0.9.x build script wants 1.1.0+/3.x or LibreSSL 3.5+).
+# Adding it as a direct workspace dep with the `vendored` feature engages
+# cargo's feature unification — every transitive consumer of openssl-sys gets
+# the vendored build. ~30s extra build time per target; universal portability.
+openssl = { version = "0.10", features = ["vendored"] }
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }

--- a/crates/origin-cli/tests/distribution.rs
+++ b/crates/origin-cli/tests/distribution.rs
@@ -150,7 +150,9 @@ fn release_workflow_publishes_cli_and_mcp_npm_packages() {
         "cp README.md crates/origin-mcp/npm/README.md",
         "cp README.md crates/origin-cli/npm/README.md",
         "origin-darwin-arm64",
-        "origin-darwin-x64",
+        // origin-darwin-x64 dropped in v0.7.0 (PR #168) — ort has no
+        // prebuilt for x86_64-apple-darwin. Re-add when ONNX builds from
+        // source or ort-tract becomes viable.
         "origin-linux-arm64",
         "origin-linux-x64",
         "origin-windows-x64",

--- a/crates/origin-server/Cargo.toml
+++ b/crates/origin-server/Cargo.toml
@@ -37,6 +37,12 @@ uuid = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 futures = { workspace = true }
 sha2 = "0.10"
+# Direct dep with `vendored` feature so cargo's feature unification turns on
+# `openssl-sys/vendored` everywhere the dep is pulled transitively (fastembed
+# → hf-hub → native-tls → openssl-sys). Builds OpenSSL from source — required
+# for the cross-compile Linux build whose container's system OpenSSL is too
+# old. No code in origin-server actually calls `openssl` directly.
+openssl = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary

cross 0.2.5's Linux container has a system OpenSSL too old for openssl-sys 0.9.x. Installing libssl-dev didn't help (wrong version, not missing).

Switch to vendored OpenSSL: openssl-sys builds OpenSSL from source as part of the build, no system dep, no version matrix to chase.

- Workspace Cargo.toml: declare \`openssl = { version = "0.10", features = ["vendored"] }\`.
- origin-server pulls it as direct dep (engages cargo feature unification — every transitive consumer of openssl-sys gets \`vendored\`).
- Cargo.lock adds \`openssl-src v300.6.0+3.6.2\` (the bundled OpenSSL source).

After this lands, v0.7.0 tag must be moved forward to include the new Cargo.toml + Cargo.lock so workflow_dispatch checkout sees them.

## Test plan

- [x] \`cargo check -p origin-server\` builds clean locally with vendored.
- [x] \`scripts/validate-versions.sh\` still passes.
- [ ] CI on this PR (fmt/lint/test on 3 OSes).
- [ ] After merge + tag-move: \`gh workflow run release.yml --field tag=v0.7.0\`.