### PR TITLE
docs(seo): add Links sections to sub-READMEs cross-referencing useorigin.app

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -24,3 +24,8 @@ python3 scripts/update-readme-eval.py
 
 - LongMemEval uses `Recall@5`, `MRR`, and `NDCG@10` as headline fields.
 - Keep `notes` concise, e.g. "pending reproducibility pass" or run metadata.
+
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app#benchmarks](https://useorigin.app/#benchmarks) — the public benchmark table sourced from this workflow

--- a/plugin/.claude-plugin/README.md
+++ b/plugin/.claude-plugin/README.md
@@ -114,6 +114,13 @@ The actual skill instructions live in [`../skills`](../skills):
 - `handoff`: capture end-of-session decisions, lessons, gotchas, and open threads
 - `debrief`: alias for `handoff` (brief/debrief symmetry)
 
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/learn/claude-code-memory](https://useorigin.app/learn/claude-code-memory) — Claude Code memory concept article
+- [useorigin.app/docs/daily-workflow](https://useorigin.app/docs/daily-workflow) — the brief/capture/recall/handoff loop
+- [useorigin.app/docs/get-started](https://useorigin.app/docs/get-started) — install + verify
+
 ## License
 
 Apache-2.0.

--- a/plugin/skills/README.md
+++ b/plugin/skills/README.md
@@ -60,3 +60,10 @@ On the first space-aware skill call of a session, the skill prints one
 line so the user can confirm the active bucket:
 
     Resolved space: <name> (from <layer>)
+
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/docs/commands](https://useorigin.app/docs/commands) — full Claude Code commands and MCP tools reference
+- [useorigin.app/docs/daily-workflow](https://useorigin.app/docs/daily-workflow) — brief/capture/recall/handoff loop
+- [useorigin.app/learn/claude-code-memory](https://useorigin.app/learn/claude-code-memory) — Claude Code memory concept article


### PR DESCRIPTION
## Summary

Three sub-READMEs that get GitHub traffic but had no link to the website:

- **plugin/.claude-plugin/README.md**: links to project home, claude-code-memory concept, daily-workflow doc, get-started. The plugin README is what Claude Code marketplace visitors see first.
- **plugin/skills/README.md**: links to project home, commands reference, daily-workflow, claude-code-memory. This README is the canonical list for /brief, /capture, /recall, /handoff, /distill consumers.
- **docs/eval/README.md**: links to project home + homepage benchmark section so eval-workflow readers can see how the numbers are surfaced publicly.

Pairs with PR #171 (top-level README) and PR #172 (five crate READMEs). The daemon repo now distributes discovery into useorigin.app from every visited surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)