### PR TITLE
docs(seo): fix CONTRIBUTING + SECURITY drift to v0.7.x + cross-platform; add useorigin.app links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This repo holds the daemon (`origin-server`), the CLI (`origin`), the MCP server
 
 ## Development Setup
 
-**Requirements:** macOS Apple Silicon (M1+), [Xcode Command Line Tools](https://developer.apple.com/xcode/resources/), [Rust](https://rustup.rs/) (stable).
+**Requirements:** macOS (arm64 + x64), Linux (x86_64 + arm64; glibc), or Windows (x86_64); platform build tools ([Xcode Command Line Tools](https://developer.apple.com/xcode/resources/) on macOS, MSVC Build Tools on Windows, gcc + make on Linux); [Rust](https://rustup.rs/) (stable).
 
 ```bash
 git clone https://github.com/7xuanlu/origin.git
@@ -96,3 +96,9 @@ These conventions keep the codebase consistent. See `CLAUDE.md` for the full lis
 This repo is Apache-2.0: `crates/origin-types`, `crates/origin-core`, `crates/origin-server`, `crates/origin-cli`, `crates/origin-mcp`, and the Claude Code plugin files. The desktop app in [origin-app](https://github.com/7xuanlu/origin-app) is AGPL-3.0-only.
 
 By contributing, you agree that your changes will be licensed under the license that applies to the files you modify.
+
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/docs/get-started](https://useorigin.app/docs/get-started) — install + verify the local memory loop before opening a PR
+- [useorigin.app/docs/daily-workflow](https://useorigin.app/docs/daily-workflow) — the workflow your changes will fit into

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,4 +29,10 @@ We are especially interested in:
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
+| 0.7.x   | Yes       |
+| < 0.7.0 | Best-effort |
+
+## Links
+
+- [useorigin.app](https://useorigin.app) — project home
+- [useorigin.app/.well-known/security.txt](https://useorigin.app/.well-known/security.txt) — machine-readable security contact per RFC 9116


### PR DESCRIPTION
## Summary

**CONTRIBUTING.md**:
- Drift fix: dev requirement was "macOS Apple Silicon (M1+)" only, predates Windows install (PR #162) and Linux support. Now matches README cross-platform spec.
- Added Links section pointing to useorigin.app/docs.

**SECURITY.md**:
- Drift fix: "Supported Versions" listed only 0.1.x. Current is 0.7.0. Updated to "0.7.x: Yes / < 0.7.0: Best-effort".
- Added Links to useorigin.app and /.well-known/security.txt (the machine-readable RFC 9116 file shipped on the website earlier today).

Same drift pattern as the website homepage benchmark + "macOS Apple Silicon" callouts caught in earlier autonomous-run PRs. Governance files lag README updates because they get less foot traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)