### PR TITLE
fix(deps): declare openssl-sys directly with vendored feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
  "futures",
  "hyper 1.9.0",
  "hyper-util",
- "openssl",
+ "openssl-sys",
  "origin-core",
  "origin-types",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,12 +419,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,16 +1000,6 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
-name = "der"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
-dependencies = [
- "pem-rfc7468",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -3297,15 +3281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "pem-rfc7468"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5307,15 +5282,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
- "der",
  "log",
- "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-root-certs",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5579,15 +5553,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,14 +44,14 @@ log = "0.4"
 
 # HTTP
 reqwest = { version = "0.12", features = ["json"] }
-# OpenSSL vendored: builds OpenSSL from source instead of linking the system
-# library. Required because fastembed → hf-hub → native-tls → openssl-sys is
-# transitive, and the `cross` Linux build container's system OpenSSL is too
-# old (the openssl-sys 0.9.x build script wants 1.1.0+/3.x or LibreSSL 3.5+).
-# Adding it as a direct workspace dep with the `vendored` feature engages
-# cargo's feature unification — every transitive consumer of openssl-sys gets
-# the vendored build. ~30s extra build time per target; universal portability.
-openssl = { version = "0.10", features = ["vendored"] }
+# OpenSSL vendored: build OpenSSL from source instead of linking the
+# system library. Required because fastembed → hf-hub → native-tls →
+# openssl-sys is transitive, and the `cross` Linux build container's
+# system OpenSSL is too old (1.0.2 from Ubuntu 16.04 base). Declare
+# `openssl-sys` DIRECTLY with the `vendored` feature — the previous
+# attempt routed through the `openssl` wrapper crate and the feature
+# did not propagate to openssl-sys inside cross's container resolver.
+openssl-sys = { version = "0.9", features = ["vendored"] }
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,16 +42,15 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "tracing-log"] }
 log = "0.4"
 
-# HTTP
-reqwest = { version = "0.12", features = ["json"] }
-# OpenSSL vendored: build OpenSSL from source instead of linking the
-# system library. Required because fastembed → hf-hub → native-tls →
-# openssl-sys is transitive, and the `cross` Linux build container's
-# system OpenSSL is too old (1.0.2 from Ubuntu 16.04 base). Declare
-# `openssl-sys` DIRECTLY with the `vendored` feature — the previous
-# attempt routed through the `openssl` wrapper crate and the feature
-# did not propagate to openssl-sys inside cross's container resolver.
-openssl-sys = { version = "0.9", features = ["vendored"] }
+# HTTP — explicit rustls-tls everywhere. Default features pull native-tls,
+# which on Linux drags openssl-sys → system OpenSSL. cross-rs's container
+# ships an OpenSSL too old for openssl-sys 0.9.x, and vendored feature
+# propagation through transitive deps proved unreliable (see PR #173/#179
+# attempts). Dropping native-tls from the dep graph entirely removes
+# openssl-sys, which removes the whole problem. Per cross-rs issue #510
+# (Aug 2021): "look through your Cargo.lock for OpenSSL deps and switch
+# them to Rustls instead. Once that's done, everything should build."
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 axum = { version = "0.8", features = ["ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace", "timeout"] }
@@ -62,7 +61,25 @@ hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 libsql = { version = "0.9", default-features = false, features = ["core", "replication"] }
 
 # Embeddings & LLM
-fastembed = "5"
+# fastembed defaults are: hf-hub, hf-hub-native-tls, image-models,
+# ort-download-binaries-native-tls. Swap both TLS features to the rustls
+# variants to keep native-tls (and its openssl-sys transitive) out of the
+# dep graph. Keep `hf-hub` + `image-models` so the public surface stays
+# identical.
+fastembed = { version = "5", default-features = false, features = [
+    "hf-hub",
+    "hf-hub-rustls-tls",
+    "image-models",
+    "ort-download-binaries-rustls-tls",
+] }
+
+# openssl-sys vendored — belt + suspenders. Even with fastembed swapped to
+# rustls features, hf-hub still drags native-tls into the dep graph via
+# Cargo feature unification (its `default-tls` feature is enabled by the
+# parent `reqwest` default features upstream). Declaring openssl-sys
+# directly with `vendored` forces it to compile OpenSSL from source so
+# the cross-rs Linux container's stale system OpenSSL is irrelevant.
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 # Utilities
 regex = "1"

--- a/crates/origin-server/Cargo.toml
+++ b/crates/origin-server/Cargo.toml
@@ -37,10 +37,10 @@ uuid = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 futures = { workspace = true }
 sha2 = "0.10"
-# Direct openssl-sys dep (workspace declares it with `vendored` feature).
-# Going through the `openssl` wrapper crate did not propagate vendored to
-# openssl-sys inside cross's container resolver. Forcing the direct dep
-# guarantees the feature lands on openssl-sys itself.
+# Pulls openssl-sys with the vendored feature (declared at workspace level).
+# origin-server doesn't call openssl_sys directly, but the dep needs to land
+# in at least one workspace-member's tree for cargo feature unification to
+# apply the vendored feature to every transitive consumer.
 openssl-sys = { workspace = true }
 
 [dev-dependencies]

--- a/crates/origin-server/Cargo.toml
+++ b/crates/origin-server/Cargo.toml
@@ -37,12 +37,11 @@ uuid = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 futures = { workspace = true }
 sha2 = "0.10"
-# Direct dep with `vendored` feature so cargo's feature unification turns on
-# `openssl-sys/vendored` everywhere the dep is pulled transitively (fastembed
-# → hf-hub → native-tls → openssl-sys). Builds OpenSSL from source — required
-# for the cross-compile Linux build whose container's system OpenSSL is too
-# old. No code in origin-server actually calls `openssl` directly.
-openssl = { workspace = true }
+# Direct openssl-sys dep (workspace declares it with `vendored` feature).
+# Going through the `openssl` wrapper crate did not propagate vendored to
+# openssl-sys inside cross's container resolver. Forcing the direct dep
+# guarantees the feature lands on openssl-sys itself.
+openssl-sys = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## Summary

PR #173 routed vendored through the \`openssl\` wrapper crate. cargo tree -e features locally confirmed openssl-sys feature \"vendored\" was resolved, yet cross's container build kept running openssl-sys's pkg-config probe and failing.

Declare openssl-sys directly in the workspace, pull into origin-server with workspace=true. Feature lands on the crate with the build script — no wrapper-crate routing.

## Risk

Untested on cross until merge + dispatch. Researching cross + openssl-sys + vendored official docs in parallel before holding the merge.