### PR TITLE
perf(ci): cache + sccache + thin LTO + zigbuild for ~50% CI speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
           # *.rlib. Shared key loses because lint writes first and test then
           # gets a partial cache + recompiles from scratch.
           shared-key: clippy
+          # Cache the full crates.io registry. Cold cache pulls thousands of
+          # small files otherwise; cached restore is ~2-3min faster.
+          cache-all-crates: "true"
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Verify origin-mcp uses path dep for origin-types
         run: |
@@ -113,14 +116,22 @@ jobs:
       # Drop debuginfo from test artifacts. CI has no debugger attached and the
       # build cache stays warm via rust-cache. Trims linker time + cache size.
       CARGO_PROFILE_TEST_DEBUG: "0"
+      # sccache wraps rustc and caches compile outputs to GHA, including
+      # C/C++ from build scripts (ring, openssl-src, llama-cpp-sys). Bigger
+      # win than rust-cache alone on cold cache.
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
         with:
           toolchain: 1.95.0
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: test
+          cache-all-crates: "true"
       # Windows needs sqlite3.lib for libsql linking (libsql does not bundle
       # SQLite on Windows). vcpkg ships sqlite3 prebuilt; one-shot install
       # before any cargo step.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,12 @@ jobs:
           toolchain: 1.95.0
           targets: ${{ matrix.target }}
 
+      # sccache caches rustc + build-script outputs to GHA. Big win on the
+      # C/C++-heavy crates we pull (openssl-src, ring, llama-cpp-sys).
+      - name: Set up sccache
+        if: matrix.use_cross != true
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
       # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
       # time and does not bundle SQLite on Windows. Mirrors ci.yml's test
       # step. GitHub `windows-2022` runner ships vcpkg preinstalled.
@@ -174,27 +180,34 @@ jobs:
           # between aarch64 and x86_64 (otherwise the first job's target/
           # contents pollute the second).
           shared-key: release-${{ matrix.target }}
+          cache-all-crates: "true"
 
-      - name: Install cross
+      # cargo-zigbuild replaces `cross` for Linux targets. No Docker
+      # container — uses Zig as the cross C/C++ compiler. ~3-5min faster
+      # per Linux job (no image pull, no apt-get inside container) and
+      # avoids the cross-0.2.5 Ubuntu-16.04-OpenSSL trap entirely.
+      - name: Install Zig + cargo-zigbuild
         if: matrix.use_cross == true
-        run: cargo install cross --locked
-
-      # No pre-build openssl install. The cross 0.2.5 container ships
-      # OpenSSL 1.0.2 (Ubuntu 16.04 base), which openssl-sys 0.9.x rejects
-      # as too old. Worse, when openssl-sys finds *any* system OpenSSL it
-      # short-circuits BEFORE checking the `vendored` cargo feature — so a
-      # `pre-build apt-get install libssl-dev` actively breaks the build.
-      # Workspace Cargo.toml's vendored feature (origin-server pulls
-      # `openssl = { workspace = true }`) compiles OpenSSL 3.x from source
-      # via `openssl-src`, so no container packages are needed.
+        uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2
+        with:
+          version: 0.13.0
+      - name: Install cargo-zigbuild
+        if: matrix.use_cross == true
+        run: cargo install cargo-zigbuild --locked
 
       - name: Build (native)
         if: matrix.use_cross != true
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         run: cargo build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
-      - name: Build (cross)
+      - name: Build (cross via zigbuild)
         if: matrix.use_cross == true
-        run: cross build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
+        run: cargo zigbuild --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
       - name: Smoke (native)
         if: matrix.use_cross != true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,15 @@ serde_yaml = "0.9"
 sysinfo = "0.33"
 image = "0.25"
 toml = "0.8"
+
+# Release profile tuned for CI throughput. Default is `codegen-units = 1`
+# + no `lto`, optimized for runtime perf at the cost of long link times.
+# Origin's bottleneck is build time, not the last 5% of release-binary
+# perf. `codegen-units = 16` lets rustc fan out across cores; `lto =
+# "thin"` keeps the LTO pass cheap but still inlines hot paths. Net:
+# ~30-50% off link time on Linux/Windows, binary ~5-10% larger.
+[profile.release]
+codegen-units = 16
+lto = "thin"
+strip = "debuginfo"
+incremental = false


### PR DESCRIPTION
## Summary

Targeted at the 30-min Linux/Windows tail observed during the v0.7.0 release iteration. Expected total CI: 15-20 min (down from ~30).

Four levers, all community-proven for cross-platform Rust release matrices:

| Change | Where | Expected saving |
|---|---|---|
| 1. \`cache-all-crates: "true"\` on Swatinem rust-cache | ci.yml + release.yml | 2-3 min on cold-cache restore |
| 2. \`mozilla-actions/sccache-action\` + \`RUSTC_WRAPPER=sccache\` | ci.yml test + release.yml native + cross | 5-8 min on cold compile (C/C++ deps: ring, openssl-src, llama-cpp-sys) |
| 3. \`[profile.release]\` \`codegen-units=16\`, \`lto=\"thin\"\`, \`strip=\"debuginfo\"\` | Cargo.toml | 30-50% off link time |
| 4. \`cargo-zigbuild\` replaces \`cross\` for Linux targets | release.yml | 3-5 min off Linux jobs (no Docker container) |

Plus: zigbuild dodges the entire cross-0.2.5 Ubuntu-16.04-OpenSSL chain that consumed several PRs during v0.7.0.

## Tradeoffs

- Release binary 5-10% larger (codegen-units + thin LTO instead of fat).
- One new action dep (sccache-action) and one new tool (cargo-zigbuild + zig).
- Cross-platform cross-compile semantics with zigbuild are simpler but not identical to cross — needs validation that QEMU smoke step still works.

## Test plan

- [ ] CI on this PR runs to green (validates Swatinem cache + sccache wiring).
- [ ] Manual release.yml workflow_dispatch against v0.7.0 (or v0.7.1 if cut) to validate cargo-zigbuild + sccache + thin LTO release builds.