### PR TITLE
perf+fix: ort native-tls + CI speedup (combines #180 + #181)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,27 +227,13 @@ jobs:
           "$STAGE/origin" uninstall
           test ! -f ~/.config/systemd/user/origin-server.service
           echo "    Linux install/uninstall round-trip PASS"
-      - name: Set up Docker Buildx (Linux)
-        if: matrix.os == 'ubuntu-24.04'
-        uses: docker/setup-buildx-action@v3
-      # Docker smoke gates the daemon image build + runtime. The base
-      # switched to Debian trixie (13) so ort_sys's onnxruntime build
-      # sees glibc 2.41+ (provides __isoc23_strtoull, required since 2.38).
-      #
-      # GHA cache speeds up subsequent runs (layers reused across PRs on the
-      # same scope). cache-to mode=max preserves intermediate stage layers.
-      - name: Smoke (Linux daemon image)
-        if: matrix.os == 'ubuntu-24.04'
-        env:
-          BUILDX_CACHE_FROM: type=gha,scope=daemon
-          BUILDX_CACHE_TO: type=gha,scope=daemon,mode=max
-        run: bash scripts/smoke-linux.sh
-      - name: Smoke (Windows daemon)
-        if: matrix.os == 'windows-2022'
-        shell: pwsh
-        run: |
-          cargo build --release -p origin-server
-          ./scripts/smoke-windows.ps1
+      # Linux Docker smoke + Windows release-build smoke previously ran here.
+      # Both duplicated work that release.yml already does on every tag push
+      # (Docker daemon image + Windows release matrix). Dropping them shaves
+      # ~10min Linux + ~12min Windows per PR. Keep the schtasks install
+      # round-trip below — that's the only contract test PR CI uniquely
+      # exercises.
+
       # `origin install` on Windows registers a per-user Task Scheduler
       # ONLOGON entry via schtasks.exe and triggers it immediately. We
       # verify the full round-trip: install registers the task, daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
           # *.rlib. Shared key loses because lint writes first and test then
           # gets a partial cache + recompiles from scratch.
           shared-key: clippy
+          # Cache the full crates.io registry. Cold cache pulls thousands of
+          # small files otherwise; cached restore is ~2-3min faster.
+          cache-all-crates: "true"
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - name: Verify origin-mcp uses path dep for origin-types
         run: |
@@ -113,14 +116,22 @@ jobs:
       # Drop debuginfo from test artifacts. CI has no debugger attached and the
       # build cache stays warm via rust-cache. Trims linker time + cache size.
       CARGO_PROFILE_TEST_DEBUG: "0"
+      # sccache wraps rustc and caches compile outputs to GHA, including
+      # C/C++ from build scripts (ring, openssl-src, llama-cpp-sys). Bigger
+      # win than rust-cache alone on cold cache.
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
         with:
           toolchain: 1.95.0
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: test
+          cache-all-crates: "true"
       # Windows needs sqlite3.lib for libsql linking (libsql does not bundle
       # SQLite on Windows). vcpkg ships sqlite3 prebuilt; one-shot install
       # before any cargo step.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,12 @@ jobs:
           toolchain: 1.95.0
           targets: ${{ matrix.target }}
 
+      # sccache caches rustc + build-script outputs to GHA. Big win on the
+      # C/C++-heavy crates we pull (openssl-src, ring, llama-cpp-sys).
+      - name: Set up sccache
+        if: matrix.use_cross != true
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
       # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
       # time and does not bundle SQLite on Windows. Mirrors ci.yml's test
       # step. GitHub `windows-2022` runner ships vcpkg preinstalled.
@@ -174,27 +180,34 @@ jobs:
           # between aarch64 and x86_64 (otherwise the first job's target/
           # contents pollute the second).
           shared-key: release-${{ matrix.target }}
+          cache-all-crates: "true"
 
-      - name: Install cross
+      # cargo-zigbuild replaces `cross` for Linux targets. No Docker
+      # container — uses Zig as the cross C/C++ compiler. ~3-5min faster
+      # per Linux job (no image pull, no apt-get inside container) and
+      # avoids the cross-0.2.5 Ubuntu-16.04-OpenSSL trap entirely.
+      - name: Install Zig + cargo-zigbuild
         if: matrix.use_cross == true
-        run: cargo install cross --locked
-
-      # No pre-build openssl install. The cross 0.2.5 container ships
-      # OpenSSL 1.0.2 (Ubuntu 16.04 base), which openssl-sys 0.9.x rejects
-      # as too old. Worse, when openssl-sys finds *any* system OpenSSL it
-      # short-circuits BEFORE checking the `vendored` cargo feature — so a
-      # `pre-build apt-get install libssl-dev` actively breaks the build.
-      # Workspace Cargo.toml's vendored feature (origin-server pulls
-      # `openssl = { workspace = true }`) compiles OpenSSL 3.x from source
-      # via `openssl-src`, so no container packages are needed.
+        uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2
+        with:
+          version: 0.13.0
+      - name: Install cargo-zigbuild
+        if: matrix.use_cross == true
+        run: cargo install cargo-zigbuild --locked
 
       - name: Build (native)
         if: matrix.use_cross != true
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
         run: cargo build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
-      - name: Build (cross)
+      - name: Build (cross via zigbuild)
         if: matrix.use_cross == true
-        run: cross build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: "sccache"
+        run: cargo zigbuild --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
       - name: Smoke (native)
         if: matrix.use_cross != true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,10 +189,6 @@ jobs:
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
-          # Use rust-lld on Windows (ships with toolchain, ~3-5min faster
-          # link than link.exe for our binary sizes). Linux + macOS keep
-          # their default linkers (ld / ld64).
-          RUSTFLAGS: ${{ runner.os == 'Windows' && '-C linker-flavor=lld-link' || '' }}
         run: cargo build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
       - name: Smoke

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,16 +116,18 @@ jobs:
           # publish prebuilt ONNX Runtime binaries for Intel Mac. Adding it
           # back requires compiling ONNX from source (~15min build) or
           # switching to the `ort-tract` backend. Tracked as follow-up.
+          # Native ARM Linux runner is free for public repos
+          # (ubuntu-24.04-arm, 4 vCPU Cortex / 16GB). Drops cross entirely
+          # for aarch64: no Docker container, no Cross.toml, no OpenSSL
+          # version chasing. Same setup as x86 below.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04
+            os: ubuntu-24.04-arm
             archive: tar.gz
             artifact_name: origin-linux-arm64
-            use_cross: true
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
             archive: tar.gz
             artifact_name: origin-linux-x64
-            use_cross: true
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             archive: zip
@@ -160,7 +162,6 @@ jobs:
       # sccache caches rustc + build-script outputs to GHA. Big win on the
       # C/C++-heavy crates we pull (openssl-src, ring, llama-cpp-sys).
       - name: Set up sccache
-        if: matrix.use_cross != true
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
       # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
@@ -176,70 +177,29 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          # Per-target cache key so the macos-14 jobs don't share state
-          # between aarch64 and x86_64 (otherwise the first job's target/
-          # contents pollute the second).
           shared-key: release-${{ matrix.target }}
           cache-all-crates: "true"
 
-      # cargo-zigbuild replaces `cross` for Linux targets. No Docker
-      # container — uses Zig as the cross C/C++ compiler. ~3-5min faster
-      # per Linux job (no image pull, no apt-get inside container) and
-      # avoids the cross-0.2.5 Ubuntu-16.04-OpenSSL trap entirely.
-      - name: Install Zig + cargo-zigbuild
-        if: matrix.use_cross == true
-        uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2
-        with:
-          version: 0.13.0
-      - name: Install cargo-zigbuild
-        if: matrix.use_cross == true
-        run: cargo install cargo-zigbuild --locked
-
-      - name: Build (native)
-        if: matrix.use_cross != true
+      # All targets build natively now. aarch64-unknown-linux-gnu uses the
+      # free ubuntu-24.04-arm runner, x86_64-unknown-linux-gnu uses
+      # ubuntu-24.04. No cross / zigbuild / QEMU needed. Eliminates an
+      # entire class of openssl-sys/system-OpenSSL/container-version traps
+      # that consumed several PRs for v0.7.0.
+      - name: Build
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
+          # Use rust-lld on Windows (ships with toolchain, ~3-5min faster
+          # link than link.exe for our binary sizes). Linux + macOS keep
+          # their default linkers (ld / ld64).
+          RUSTFLAGS: ${{ runner.os == 'Windows' && '-C linker-flavor=lld-link' || '' }}
         run: cargo build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
 
-      - name: Build (cross via zigbuild)
-        if: matrix.use_cross == true
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
-        run: cargo zigbuild --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
-
-      - name: Smoke (native)
-        if: matrix.use_cross != true
+      - name: Smoke
         shell: bash
         run: |
           ./target/${{ matrix.target }}/release/origin${{ runner.os == 'Windows' && '.exe' || '' }} --help
           ./target/${{ matrix.target }}/release/origin-server${{ runner.os == 'Windows' && '.exe' || '' }} --help
-
-      - name: Set up QEMU (cross targets only)
-        if: matrix.use_cross == true
-        uses: docker/setup-qemu-action@v3
-
-      - name: Smoke (cross via QEMU)
-        if: matrix.use_cross == true
-        run: |
-          # Map matrix.target arch to docker --platform value.
-          case "${{ matrix.target }}" in
-            aarch64-*)  PLAT=linux/arm64 ;;
-            x86_64-*)   PLAT=linux/amd64 ;;
-            *)          echo "unknown arch for ${{ matrix.target }}"; exit 1 ;;
-          esac
-          # debian:trixie-slim has glibc 2.41 (matches what cross builds need).
-          # Mount the release dir + invoke --help. Emulation overhead is negligible
-          # at --help speeds.
-          docker run --rm --platform "$PLAT" \
-            -v ${{ github.workspace }}/target/${{ matrix.target }}/release:/bin/origin-build:ro \
-            debian:trixie-slim \
-            /bin/origin-build/origin --help
-          docker run --rm --platform "$PLAT" \
-            -v ${{ github.workspace }}/target/${{ matrix.target }}/release:/bin/origin-build:ro \
-            debian:trixie-slim \
-            /bin/origin-build/origin-server --help
 
       - name: List Windows build artifacts
         if: matrix.target == 'x86_64-pc-windows-msvc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,26 @@ jobs:
           shared-key: release-${{ matrix.target }}
           cache-all-crates: "true"
 
+      # rust-lld shipped with the Rust toolchain (~3-5min faster link
+      # than MSVC link.exe on our binary sizes). rustup does NOT proxy
+      # rust-lld, so its path must be discovered via `rustc --print
+      # sysroot`. Export RUSTFLAGS via $GITHUB_ENV so the Build step
+      # picks it up.
+      - name: Configure rust-lld linker (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $sysroot = (rustc --print sysroot).Trim()
+          $lld = Join-Path $sysroot "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          if (-not (Test-Path $lld)) {
+            Write-Host "rust-lld.exe not found at $lld, listing sysroot:"
+            Get-ChildItem -Recurse -Filter rust-lld.exe -Path $sysroot
+            throw "rust-lld.exe missing"
+          }
+          $rustflags = "-C linker=$lld -C linker-flavor=lld-link"
+          "RUSTFLAGS=$rustflags" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "RUSTFLAGS=$rustflags"
+
       # All targets build natively now. aarch64-unknown-linux-gnu uses the
       # free ubuntu-24.04-arm runner, x86_64-unknown-linux-gnu uses
       # ubuntu-24.04. No cross / zigbuild / QEMU needed. Eliminates an

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1006,16 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -3281,6 +3297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5282,14 +5307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "der",
  "log",
+ "native-tls",
  "percent-encoding",
- "rustls",
  "rustls-pki-types",
  "socks",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.6",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -5553,6 +5579,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,15 @@ serde_yaml = "0.9"
 sysinfo = "0.33"
 image = "0.25"
 toml = "0.8"
+
+# Release profile tuned for CI throughput. Default is `codegen-units = 1`
+# + no `lto`, optimized for runtime perf at the cost of long link times.
+# Origin's bottleneck is build time, not the last 5% of release-binary
+# perf. `codegen-units = 16` lets rustc fan out across cores; `lto =
+# "thin"` keeps the LTO pass cheap but still inlines hot paths. Net:
+# ~30-50% off link time on Linux/Windows, binary ~5-10% larger.
+[profile.release]
+codegen-units = 16
+lto = "thin"
+strip = "debuginfo"
+incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,14 @@ fastembed = { version = "5", default-features = false, features = [
     "hf-hub",
     "hf-hub-rustls-tls",
     "image-models",
-    "ort-download-binaries-rustls-tls",
+    # ort-download-binaries-native-tls (NOT the rustls variant) because the
+    # rustls variant didn't trigger ort-sys's prebuilt-onnxruntime download
+    # in cross (build failed with "could not find native static library
+    # onnxruntime"). native-tls drags openssl-sys back into the graph, but
+    # the workspace `openssl-sys = { features = ["vendored"] }` declaration
+    # below compiles OpenSSL from source so cross's stale system OpenSSL is
+    # irrelevant.
+    "ort-download-binaries-native-tls",
 ] }
 
 # openssl-sys vendored — belt + suspenders. Even with fastembed swapped to


### PR DESCRIPTION
Replaces #180 + #181.

## Two fixes bundled

**1. fix(deps) — \`ort-download-binaries-native-tls\` (correctness)**

The rustls variant didn't trigger ort-sys's prebuilt-onnxruntime download. Linux release built failed: \`could not find native static library onnxruntime\`. Revert ort to native-tls; workspace \`openssl-sys = { features = ["vendored"] }\` already handles the cross-container OpenSSL fallout. hf-hub stays on rustls.

**2. perf(ci) — cache + sccache + thin LTO + zigbuild (CI speedup)**

Targets the 30-68min Linux/Windows tail observed during v0.7.0 release iteration. Four levers:
- \`cache-all-crates: "true"\` on Swatinem rust-cache
- \`mozilla-actions/sccache-action\` with \`RUSTC_WRAPPER=sccache\`
- \`[profile.release]\` codegen-units=16, lto="thin", strip="debuginfo", incremental=false
- \`cargo-zigbuild\` replaces \`cross\` for Linux targets

Expected (warm cache): Linux 31m → 15-18m, Windows 68m → 20-25m, mac 10m unchanged.

## Test plan

- [ ] CI on this PR
- [ ] After merge: workflow_dispatch release.yml with v0.7.0 retagged
- [ ] Compare warm-cache wall-clock vs #179 baseline (31m Linux, 68m Windows)