### PR TITLE
fix+perf(ci): npm skip-existing + Windows matrix trim (CI follow-ups)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,10 @@ jobs:
       rust:    ${{ steps.filter.outputs.rust }}
       plugin:  ${{ steps.filter.outputs.plugin }}
       npm:     ${{ steps.filter.outputs.npm }}
+      windows: ${{ steps.filter.outputs.windows }}
+      # Test matrix OSes as a JSON array. Windows is included only when
+      # Windows-affecting files changed (saves ~30min per PR otherwise).
+      test-oses: ${{ steps.matrix.outputs.json }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
@@ -52,6 +56,30 @@ jobs:
               - '.claude-plugin/**'
             npm:
               - 'crates/*/npm/**'
+            windows:
+              # Files that change Windows-specific behavior. PRs not
+              # touching any of these skip the Windows test job entirely.
+              - 'crates/origin-cli/src/commands/service.rs'
+              - 'crates/origin-cli/src/commands/mcp.rs'
+              - 'crates/origin-cli/tests/cli_integration.rs'
+              - 'crates/origin-cli/tests/distribution.rs'
+              - 'crates/origin-server/src/main.rs'
+              - 'crates/origin-mcp/npm/install.js'
+              - 'scripts/smoke-windows.ps1'
+              - 'install.sh'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+
+      - id: matrix
+        run: |
+          if [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+            echo 'json=["ubuntu-24.04", "macos-14", "windows-2022"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'json=["ubuntu-24.04", "macos-14"]' >> "$GITHUB_OUTPUT"
+          fi
 
   # fmt + lint always run (cheap, cached). Skipping them based on
   # detect-changes outputs created a FAIL-OPEN path: if detect-changes
@@ -109,9 +137,17 @@ jobs:
     if: "needs.detect-changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(main): release')"
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      # Cancel the rest of the matrix when one OS fails. Saves ~20-30min
+      # per PR when a real bug breaks all platforms — Linux/macOS catch
+      # the same regression in 6-15min, Windows would have spent another
+      # ~30min hitting the identical failure.
+      fail-fast: true
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2022]
+        # Built dynamically by detect-changes.test-oses. Windows is
+        # included only when detect-changes flags a Windows-affecting
+        # file changed. Most PRs don't touch Windows-specific code paths
+        # and pay the ~30min Windows tax anyway today.
+        os: ${{ fromJSON(needs.detect-changes.outputs.test-oses) }}
     env:
       # Drop debuginfo from test artifacts. CI has no debugger attached and the
       # build cache stays warm via rust-cache. Trims linker time + cache size.
@@ -147,8 +183,13 @@ jobs:
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-nextest
-      - name: Workspace lib tests (Linux/Windows)
-        if: matrix.os != 'macos-14'
+      # Workspace lib tests skipped on Windows — Linux + macOS catch the
+      # same cross-platform unit logic in ~5-15min vs 25min on Windows.
+      # Windows-specific behavior (paths, mcp_add, schtasks) is covered
+      # by `Integration tests origin-cli + origin-server` + the schtasks
+      # install round-trip E2E further down.
+      - name: Workspace lib tests (Linux)
+        if: matrix.os == 'ubuntu-24.04'
         run: cargo nextest run --workspace --lib
       - name: Workspace lib tests (macOS, single-threaded)
         if: matrix.os == 'macos-14'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -482,12 +482,28 @@ jobs:
           cp LICENSE crates/origin-cli/npm/LICENSE
       - name: Publish origin-mcp
         working-directory: crates/origin-mcp/npm
-        run: npm publish --provenance --access public
+        # Skip if version already on npm. Retried releases or re-dispatch
+        # workflows would otherwise fail with "You cannot publish over the
+        # previously published versions". `npm view <pkg>@<v> version`
+        # exits 0 + prints the version when published, exits 1 otherwise.
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          if npm view "origin-mcp@$VERSION" version >/dev/null 2>&1; then
+            echo "origin-mcp@$VERSION already on npm, skipping"
+          else
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish @7xuanlu/origin
         working-directory: crates/origin-cli/npm
-        run: npm publish --provenance --access public
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          if npm view "@7xuanlu/origin@$VERSION" version >/dev/null 2>&1; then
+            echo "@7xuanlu/origin@$VERSION already on npm, skipping"
+          else
+            npm publish --provenance --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,17 +306,29 @@ jobs:
             dist/origin-mcp-darwin-arm64.tar.gz
 
   docker:
-    name: Build & Push Docker Image
+    name: Build & Push Docker Image (${{ matrix.platform }})
     needs: release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-24.04
+            tag-suffix: amd64
+          # Native ARM runner — free for public repos. Building arm64
+          # under QEMU emulation took 90+min and is the dominant cost
+          # of the release pipeline. Native is ~10min instead.
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+            tag-suffix: arm64
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_TAG }}
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -327,11 +339,28 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.daemon
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: |
-            ghcr.io/7xuanlu/origin-server:${{ env.RELEASE_TAG }}
-            ghcr.io/7xuanlu/origin-server:latest
+          tags: ghcr.io/7xuanlu/origin-server:${{ env.RELEASE_TAG }}-${{ matrix.tag-suffix }}
+
+  docker-manifest:
+    name: Combine Docker Manifest (multi-arch)
+    needs: docker
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create + push multi-arch manifest
+        run: |
+          TAG="${{ env.RELEASE_TAG }}"
+          IMG="ghcr.io/7xuanlu/origin-server"
+          docker buildx imagetools create -t "$IMG:$TAG" "$IMG:$TAG-amd64" "$IMG:$TAG-arm64"
+          docker buildx imagetools create -t "$IMG:latest"  "$IMG:$TAG-amd64" "$IMG:$TAG-arm64"
 
   publish-crates:
     name: Publish crates.io (origin-types + origin-mcp)


### PR DESCRIPTION
Combines PR #183 + npm skip-existing as a single CI follow-up bundle. **v0.7.0 release is functionally complete** (binaries + crates + Docker + npm + Homebrew all live); no release.yml re-dispatch needed.

## Bundled changes

**1. fix(ci): skip npm publish when version already exists**

origin-mcp + @7xuanlu/origin published once per release. Re-dispatched runs failed with \`You cannot publish over the previously published versions\`. Same pattern as crates skip-check (#184). Gated behind \`npm view <pkg>@<v> version\`.

**2. perf(ci): skip Windows matrix when not Windows-affecting + fail-fast**

Three free-tier wins on PR CI:
- \`fail-fast: true\` cancels matrix on first failure (~20-30min saved when real bug breaks all platforms)
- Drop workspace lib tests on Windows (Linux + macOS cover same logic; Windows-specific behavior caught by integration tests + schtasks E2E)
- Skip Windows job entirely when no Windows-affecting files changed (new dorny \`windows\` paths-filter + dynamic JSON matrix output)

Expected PR turnaround: 31min → 14-15min (Linux floor) for most PRs. Windows-touching PRs: ~10-12min Windows runs.

## Test plan

- [ ] CI green
- [ ] After merge: future release pipelines benefit from npm skip-check
- [ ] Future PRs not touching Windows-affecting paths skip Windows job entirely