### PR TITLE
feat(eval+server): foundations P0b — comparable hash + path layout + daemon port discovery

### DIFF
--- a/crates/origin-core/src/eval/report.rs
+++ b/crates/origin-core/src/eval/report.rs
@@ -231,6 +231,33 @@ pub fn comparable_env_hash(env: &ReportEnv) -> String {
     hex.chars().take(8).collect()
 }
 
+/// Encode the on-disk path for a baseline given an env stamp.
+///
+/// Layout: `<root>/<layer_dir>/<task>/<variant>__<comparable_hash>.json`
+///
+/// E.g.: `~/.cache/origin-eval/baselines/l1_db/locomo/base__a1b2c3d4.json`
+///
+/// Panics if env.layer / env.task / env.variant are None — these are required
+/// for any baseline that ships through `save_full_report`.
+pub fn encode_baseline_path(root: &std::path::Path, env: &ReportEnv) -> std::path::PathBuf {
+    let layer = env
+        .layer
+        .expect("encode_baseline_path: env.layer must be Some")
+        .as_path_component();
+    let task = env
+        .task
+        .as_deref()
+        .expect("encode_baseline_path: env.task must be Some");
+    let variant = env
+        .variant
+        .as_deref()
+        .expect("encode_baseline_path: env.variant must be Some");
+    let hash = comparable_env_hash(env);
+    root.join(layer)
+        .join(task)
+        .join(format!("{}__{}.json", variant, hash))
+}
+
 /// Encode retrieval variant + provider + fixture-hash into a baseline filename.
 /// Shared by EvalReport, LocomoReport, and LongMemEvalReport.
 /// Falls back to `base + ".json"` when `env` is None (back-compat).
@@ -571,5 +598,35 @@ mod tests {
         let parsed2: BenchmarkHistoryEntry = serde_json::from_str(lines[1]).unwrap();
         assert_eq!(parsed2.benchmark, "locomo");
         assert_eq!(parsed2.git_sha, "def5678");
+    }
+
+    #[test]
+    fn encode_baseline_path_layout() {
+        let env = sample_env(EvalLayer::L1Db, "base");
+        let path = encode_baseline_path(std::path::Path::new("/tmp/baselines"), &env);
+        let comparable = comparable_env_hash(&env);
+        let expected = format!("/tmp/baselines/l1_db/locomo/base__{}.json", comparable);
+        assert_eq!(path.to_string_lossy(), expected);
+    }
+
+    #[test]
+    fn encode_baseline_path_all_layers_distinct() {
+        let base = std::path::Path::new("/tmp");
+        let p1 = encode_baseline_path(base, &sample_env(EvalLayer::L1Db, "base"));
+        let p2 = encode_baseline_path(base, &sample_env(EvalLayer::L2Http, "base"));
+        let p3 = encode_baseline_path(base, &sample_env(EvalLayer::L3Mcp, "base"));
+        assert_ne!(p1, p2);
+        assert_ne!(p2, p3);
+        assert_ne!(p1, p3);
+    }
+
+    #[test]
+    fn encode_baseline_path_all_variants_distinct() {
+        let base = std::path::Path::new("/tmp");
+        let p_base = encode_baseline_path(base, &sample_env(EvalLayer::L1Db, "base"));
+        let p_rerank = encode_baseline_path(base, &sample_env(EvalLayer::L1Db, "reranked"));
+        let p_aq = encode_baseline_path(base, &sample_env(EvalLayer::L1Db, "answer_quality"));
+        assert_ne!(p_base, p_rerank);
+        assert_ne!(p_rerank, p_aq);
     }
 }

--- a/crates/origin-core/src/eval/report.rs
+++ b/crates/origin-core/src/eval/report.rs
@@ -202,6 +202,11 @@ pub struct CaseResult {
 /// run_id, timestamp, costs, latency fields. These vary across runs of
 /// the same eval setup, so cross-run comparison of metrics requires the
 /// COMPARABLE subset to match.
+///
+/// **Contract:** any modification to this function's input set (adding,
+/// removing, reordering, or changing the encoding of any field) MUST bump
+/// `default_schema_version()` so old vs new baselines hash distinctly and
+/// don't appear comparable.
 pub fn comparable_env_hash(env: &ReportEnv) -> String {
     use sha2::{Digest, Sha256};
     let mut h = Sha256::new();

--- a/crates/origin-core/src/eval/report.rs
+++ b/crates/origin-core/src/eval/report.rs
@@ -192,6 +192,45 @@ pub struct CaseResult {
     pub neg_above_relevant: usize,
 }
 
+/// Hash the subset of `ReportEnv` fields that determine baseline comparability.
+///
+/// Includes: fixture_revision, embedder_revision, llm_provider_class,
+/// llm_model, mcp_schema_hash, skill_prompt_hash, schema_version,
+/// schema_db_version, similarity_fn_name.
+///
+/// Excludes: layer (path component), variant (path component), n_runs,
+/// run_id, timestamp, costs, latency fields. These vary across runs of
+/// the same eval setup, so cross-run comparison of metrics requires the
+/// COMPARABLE subset to match.
+pub fn comparable_env_hash(env: &ReportEnv) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(env.fixture_revision.as_bytes());
+    h.update(b"|");
+    h.update(env.embedder_revision.as_bytes());
+    h.update(b"|");
+    h.update(env.llm_provider_class.as_bytes());
+    h.update(b"|");
+    h.update(env.llm_model.as_bytes());
+    h.update(b"|");
+    h.update(env.mcp_schema_hash.as_deref().unwrap_or("").as_bytes());
+    h.update(b"|");
+    h.update(env.skill_prompt_hash.as_deref().unwrap_or("").as_bytes());
+    h.update(b"|");
+    h.update(env.schema_version.to_string().as_bytes());
+    h.update(b"|");
+    h.update(
+        env.schema_db_version
+            .map(|v| v.to_string())
+            .unwrap_or_default()
+            .as_bytes(),
+    );
+    h.update(b"|");
+    h.update(env.similarity_fn_name.as_bytes());
+    let hex = format!("{:x}", h.finalize());
+    hex.chars().take(8).collect()
+}
+
 /// Encode retrieval variant + provider + fixture-hash into a baseline filename.
 /// Shared by EvalReport, LocomoReport, and LongMemEvalReport.
 /// Falls back to `base + ".json"` when `env` is None (back-compat).
@@ -392,6 +431,60 @@ pub struct CategoryBaseline {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eval::EvalLayer;
+
+    fn sample_env(layer: EvalLayer, variant: &str) -> ReportEnv {
+        ReportEnv {
+            layer: Some(layer),
+            task: Some("locomo".to_string()),
+            variant: Some(variant.to_string()),
+            fixture_revision: "fixture_aaaa".to_string(),
+            embedder_revision: "BGE-Base-EN-v1.5-Q".to_string(),
+            llm_provider_class: "on-device".to_string(),
+            llm_model: "qwen3-4b".to_string(),
+            mcp_schema_hash: None,
+            skill_prompt_hash: None,
+            schema_version: 1,
+            schema_db_version: Some(46),
+            similarity_fn_name: "cosine".to_string(),
+            ..ReportEnv::default()
+        }
+    }
+
+    #[test]
+    fn comparable_hash_excludes_layer_and_variant() {
+        // L1 base vs L2 base: same comparable fields → same hash across layers.
+        let h1 = comparable_env_hash(&sample_env(EvalLayer::L1Db, "base"));
+        let h2 = comparable_env_hash(&sample_env(EvalLayer::L2Http, "base"));
+        assert_eq!(h1, h2, "same comparable fields → same hash across layers");
+
+        // base vs reranked at L1: also same hash (variant excluded).
+        let h3 = comparable_env_hash(&sample_env(EvalLayer::L1Db, "reranked"));
+        assert_eq!(h1, h3, "variant should not affect comparable hash");
+    }
+
+    #[test]
+    fn comparable_hash_changes_when_fixture_changes() {
+        let e1 = sample_env(EvalLayer::L1Db, "base");
+        let mut e2 = sample_env(EvalLayer::L1Db, "base");
+        e2.fixture_revision = "different_fixture".to_string();
+        assert_ne!(comparable_env_hash(&e1), comparable_env_hash(&e2));
+    }
+
+    #[test]
+    fn comparable_hash_changes_when_schema_version_bumps() {
+        let e1 = sample_env(EvalLayer::L1Db, "base");
+        let mut e2 = sample_env(EvalLayer::L1Db, "base");
+        e2.schema_version = 2;
+        assert_ne!(comparable_env_hash(&e1), comparable_env_hash(&e2));
+    }
+
+    #[test]
+    fn comparable_hash_stable_across_calls() {
+        let e = sample_env(EvalLayer::L1Db, "base");
+        assert_eq!(comparable_env_hash(&e), comparable_env_hash(&e));
+        assert_eq!(comparable_env_hash(&e).len(), 8, "expected sha256[..8]");
+    }
 
     #[test]
     fn test_baseline_save_load_roundtrip() {

--- a/crates/origin-core/tests/eval_report_paths.rs
+++ b/crates/origin-core/tests/eval_report_paths.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+#![cfg(feature = "eval-harness")]
+//! Path-layout collision tests across all (layer × task × variant) combinations.
+
+use origin_core::eval::report::{comparable_env_hash, encode_baseline_path, ReportEnv};
+use origin_core::eval::EvalLayer;
+
+fn env(layer: EvalLayer, task: &str, variant: &str) -> ReportEnv {
+    ReportEnv {
+        layer: Some(layer),
+        task: Some(task.to_string()),
+        variant: Some(variant.to_string()),
+        fixture_revision: "fix".to_string(),
+        embedder_revision: "emb".to_string(),
+        llm_provider_class: "on-device".to_string(),
+        llm_model: "qwen3-4b".to_string(),
+        schema_version: 1,
+        schema_db_version: Some(46),
+        similarity_fn_name: "cosine".to_string(),
+        ..ReportEnv::default()
+    }
+}
+
+#[test]
+fn full_combination_grid_has_no_collisions() {
+    let root = std::path::Path::new("/tmp/baselines");
+    let layers = [EvalLayer::L1Db, EvalLayer::L2Http, EvalLayer::L3Mcp];
+    let tasks = ["locomo", "longmemeval"];
+    let variants = ["base", "reranked", "answer_quality"];
+
+    let mut seen = std::collections::HashSet::new();
+    for layer in layers {
+        for task in tasks {
+            for variant in variants {
+                let p = encode_baseline_path(root, &env(layer, task, variant));
+                assert!(seen.insert(p.clone()), "duplicate path: {:?}", p);
+            }
+        }
+    }
+    // 3 × 2 × 3 = 18 distinct paths.
+    assert_eq!(seen.len(), 18);
+}
+
+#[test]
+fn cross_layer_same_hash_when_comparable_fields_equal() {
+    let e1 = env(EvalLayer::L1Db, "locomo", "base");
+    let e2 = env(EvalLayer::L2Http, "locomo", "base");
+    assert_eq!(comparable_env_hash(&e1), comparable_env_hash(&e2));
+}

--- a/crates/origin-server/src/main.rs
+++ b/crates/origin-server/src/main.rs
@@ -539,10 +539,7 @@ async fn run_daemon() -> anyhow::Result<()> {
     // Bind
     let addr = resolve_bind_addr(port);
     let listener = match tokio::net::TcpListener::bind(&addr).await {
-        Ok(l) => {
-            tracing::info!("Listening on http://{}", addr);
-            l
-        }
+        Ok(l) => l,
         Err(e) => {
             // Check if existing daemon is healthy
             tracing::warn!("Failed to bind {}: {}", addr, e);
@@ -579,6 +576,7 @@ async fn run_daemon() -> anyhow::Result<()> {
     // Advertise the bound port before accepting requests.
     // `addr` may be `127.0.0.1:0`; `local_addr()` gives the real ephemeral port.
     let local_addr = listener.local_addr()?;
+    tracing::info!("Listening on http://{}", local_addr);
 
     // Eval harness reads this stdout line to discover the bound port even when
     // ORIGIN_BIND_ADDR=127.0.0.1:0. Format MUST stay stable — see

--- a/crates/origin-server/src/main.rs
+++ b/crates/origin-server/src/main.rs
@@ -576,6 +576,26 @@ async fn run_daemon() -> anyhow::Result<()> {
         }
     };
 
+    // Advertise the bound port before accepting requests.
+    // `addr` may be `127.0.0.1:0`; `local_addr()` gives the real ephemeral port.
+    let local_addr = listener.local_addr()?;
+
+    // Eval harness reads this stdout line to discover the bound port even when
+    // ORIGIN_BIND_ADDR=127.0.0.1:0. Format MUST stay stable — see
+    // crates/origin-core/src/eval/http_harness.rs in the P2 plan.
+    println!("ORIGIN_LISTENING_ON={}", local_addr);
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    // Alternate signal: write the port to a file if ORIGIN_PORT_FILE is set.
+    // Eval harness uses this when stdout is captured by tracing-appender.
+    if let Ok(port_file) = std::env::var("ORIGIN_PORT_FILE") {
+        if let Err(e) = std::fs::write(&port_file, local_addr.port().to_string()) {
+            tracing::error!("failed to write ORIGIN_PORT_FILE={}: {}", port_file, e);
+            return Err(anyhow::anyhow!("ORIGIN_PORT_FILE write failed: {}", e));
+        }
+    }
+
     // Serve
     axum::serve(listener, app).await?;
 

--- a/crates/origin-server/tests/port_discovery.rs
+++ b/crates/origin-server/tests/port_discovery.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration test: spawn origin-server with ORIGIN_BIND_ADDR=127.0.0.1:0 and verify
+//! both port-discovery channels (stdout printline + ORIGIN_PORT_FILE) work.
+
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_origin-server"))
+}
+
+#[test]
+fn port_discovery_via_stdout() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut child = Command::new(binary_path())
+        .env("ORIGIN_BIND_ADDR", "127.0.0.1:0")
+        .env("ORIGIN_DATA_DIR", tmp.path())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn origin-server");
+
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let mut reader = BufReader::new(stdout);
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut line = String::new();
+    loop {
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("timed out waiting for ORIGIN_LISTENING_ON line");
+        }
+        line.clear();
+        if reader.read_line(&mut line).unwrap() == 0 {
+            let _ = child.kill();
+            panic!("daemon stdout closed before announcing port");
+        }
+        if line.starts_with("ORIGIN_LISTENING_ON=") {
+            let addr = line
+                .trim_end()
+                .strip_prefix("ORIGIN_LISTENING_ON=")
+                .unwrap();
+            assert!(addr.starts_with("127.0.0.1:"), "bad addr: {}", addr);
+            let port_str = addr.split(':').next_back().unwrap();
+            let _port: u16 = port_str.parse().expect("port number");
+            break;
+        }
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn port_discovery_via_port_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let port_file = tmp.path().join("port");
+    let mut child = Command::new(binary_path())
+        .env("ORIGIN_BIND_ADDR", "127.0.0.1:0")
+        .env("ORIGIN_DATA_DIR", tmp.path().join("data"))
+        .env("ORIGIN_PORT_FILE", &port_file)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn origin-server");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("timed out waiting for ORIGIN_PORT_FILE");
+        }
+        if let Ok(contents) = std::fs::read_to_string(&port_file) {
+            let _port: u16 = contents.trim().parse().expect("valid port in file");
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary

Phase 0b of the eval-foundations refactor. **Additive only**; no behavior change to the HTTP API.

Builds on P0a (PR #178, merged as 46a9703a).

### What changed

- **`comparable_env_hash(env: &ReportEnv) -> String`** in `eval/report.rs` — sha256[..8] over the comparable subset of `ReportEnv` fields: fixture_revision, embedder_revision, llm_provider_class, llm_model, mcp_schema_hash (or empty), skill_prompt_hash (or empty), schema_version, schema_db_version (or empty), similarity_fn_name. **Excludes** layer, variant, task, n_runs, run_id, timestamp, cost/latency fields. Hash contract documented inline — any field-set change must bump `default_schema_version()`.
- **`encode_baseline_path(root, env) -> PathBuf`** in `eval/report.rs` — layered path `<root>/<layer_dir>/<task>/<variant>__<hash>.json`. Panics with named-field message if `env.layer/task/variant` is None (precondition for `save_full_report` callers in P0c).
- **Daemon port advertisement** in `origin-server/src/main.rs`:
  - `println!("ORIGIN_LISTENING_ON={}", local_addr)` after bind, before serve.
  - Optional `ORIGIN_PORT_FILE` env writes resolved port; hard-fails on write error (no silent swallow).
  - Existing `tracing::info!("Listening on http://{}", local_addr)` updated to use resolved `local_addr` instead of bind `addr` (otherwise it prints `127.0.0.1:0` under ephemeral-port mode).
- **Integration tests**:
  - `crates/origin-core/tests/eval_report_paths.rs` — full (layer × task × variant) collision grid (18 distinct paths from 3×2×3) + cross-layer hash parity.
  - `crates/origin-server/tests/port_discovery.rs` — spawn `origin-server` via `env!("CARGO_BIN_EXE_origin-server")`, verify both stdout printline and `ORIGIN_PORT_FILE` channels work with 30s timeout + cleanup.

### Adversarial review (5 findings, 2 fixed pre-merge)

- IMPORTANT: tracing log line was printing `:0` under ephemeral mode while new stdout printline showed resolved port — fixed in 845f7d55 (single Listening log line now uses `local_addr`).
- IMPORTANT: `comparable_env_hash` hash-input contract was implicit — fixed in 845f7d55 (doc-comment explicitly states "any modification MUST bump `default_schema_version()`").
- NIT: `std::fs::write(ORIGIN_PORT_FILE)` not atomic — acceptable for 5-byte port number on local disk; harness retries via `read_to_string().ok()`.
- NIT: inside-function `use std::io::Write` — stylistic mismatch with rest of `main.rs` top-level imports.
- P2 RISK: cross-layer comparable-hash parity depends on L2 runner constructing `ReportEnv.embedder_revision` literal-identical to L1. P2 plan will add a `canonical_embedder_revision()` helper.

### Test plan

- [x] `cargo clippy --workspace --all-targets --features origin-core/eval-harness -- -D warnings` → clean
- [x] `cargo test --workspace --features origin-core/eval-harness` → 1160 lib tests pass; 4 new integration tests pass (2 path-layout, 2 port-discovery); pre-existing `eval::retrieval::tests::test_multi_turn_eval` network failure unchanged
- [x] Manual smoke: `ORIGIN_BIND_ADDR=127.0.0.1:0 ./target/debug/origin-server` shows single `Listening on http://127.0.0.1:<resolved-port>` line + matching `ORIGIN_LISTENING_ON=` stdout
- [x] `ORIGIN_PORT_FILE` write contains resolved port

### Follow-ups for P0c+

- `comparable_env_hash` will be consumed by `save_full_report` (P0c) for filename construction
- `encode_baseline_path` will be the canonical save path used by P1 baseline regeneration
- `ORIGIN_LISTENING_ON` + `ORIGIN_PORT_FILE` will be consumed by P2 `http_harness.rs::DaemonHandle::spawn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)