### PR TITLE
fix(ci): rename Homebrew origin CLI tarball + add release archive smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,13 +279,39 @@ jobs:
 
       # Per-binary archive for the origin CLI consumed by the Homebrew tap
       # formula. Darwin-arm64 only — matches the origin-mcp tap pattern.
+      # Filename intentionally distinct from the multi-binary release tarball
+      # `origin-darwin-arm64.tar.gz` to avoid clobbering it in `dist/`.
       - name: Package origin CLI tarball for Homebrew (darwin-arm64 only)
         if: matrix.target == 'aarch64-apple-darwin'
         shell: bash
         run: |
           cp "target/${{ matrix.target }}/release/origin" origin
-          tar -czf dist/origin-darwin-arm64.tar.gz origin
+          tar -czf dist/origin-cli-darwin-arm64.tar.gz origin
           rm origin
+
+      # Smoke test: verify the multi-binary release archive contains all three
+      # binaries before upload. Catches regressions like a same-named Homebrew
+      # tarball clobbering the install.sh-consumed archive (v0.7.0 bug).
+      - name: Verify release archive contains origin, origin-server, origin-mcp
+        shell: bash
+        run: |
+          set -e
+          if [ "${{ matrix.archive }}" = "tar.gz" ]; then
+            contents=$(tar -tzf "dist/${{ matrix.artifact_name }}.tar.gz")
+            suffix=""
+          else
+            contents=$(unzip -l "dist/${{ matrix.artifact_name }}.zip" | awk '{print $NF}')
+            suffix=".exe"
+          fi
+          for bin in origin origin-server origin-mcp; do
+            if ! printf '%s\n' "$contents" | grep -qE "(^|/)${bin}${suffix}$"; then
+              echo "ERROR: dist/${{ matrix.artifact_name }}.${{ matrix.archive }} missing ${bin}${suffix}"
+              echo "--- archive contents ---"
+              printf '%s\n' "$contents"
+              exit 1
+            fi
+          done
+          echo "OK: archive contains origin, origin-server, origin-mcp"
 
       - name: Upload archives to release
         uses: softprops/action-gh-release@v2
@@ -302,7 +328,7 @@ jobs:
         with:
           name: homebrew-artifacts
           path: |
-            dist/origin-darwin-arm64.tar.gz
+            dist/origin-cli-darwin-arm64.tar.gz
             dist/origin-mcp-darwin-arm64.tar.gz
 
   docker:


### PR DESCRIPTION
## Summary

- darwin-arm64 release pipeline had two packaging steps writing `dist/origin-darwin-arm64.tar.gz`. The Homebrew CLI tarball step (added in #163) clobbers the multi-binary release tarball, so v0.7.0 install.sh fails with `Archive origin-darwin-arm64.tar.gz missing expected binary: origin-server`.
- Rename the Homebrew CLI tarball to `origin-cli-darwin-arm64.tar.gz` (no formula references the old name yet — homebrew-tap only has `origin-mcp.rb`).
- Add a post-package smoke test that opens the multi-binary archive and verifies `origin`, `origin-server`, `origin-mcp` are all present before the upload step. Catches this regression class on every release.

## Root cause

```
darwin-arm64 release job, dist/ writes in order:
  step 266: tar dist/origin-darwin-arm64.tar.gz       ◄── origin + origin-server + origin-mcp
  step 277: tar dist/origin-mcp-darwin-arm64.tar.gz   ◄── origin-mcp only
  step 287: tar dist/origin-darwin-arm64.tar.gz       ◄── origin only (Homebrew CLI)  ✗ CLOBBERS step 266
```

`softprops/action-gh-release@v2` then uploads the clobbered (single-binary) tarball to the release page. install.sh's binary-presence loop (`for bin in origin origin-server origin-mcp`) bails at `origin-server`.

Linux/Windows tarballs unaffected — the Homebrew step is gated on `matrix.target == 'aarch64-apple-darwin'`.

## Test plan

- [ ] Merge this PR.
- [ ] Re-run release workflow against `v0.7.0`: `gh workflow run release.yml -f tag=v0.7.0 --repo 7xuanlu/origin`.
- [ ] Confirm `origin-darwin-arm64.tar.gz` on the v0.7.0 release page contains all three binaries (`tar -tzf` shows `origin`, `origin-server`, `origin-mcp`).
- [ ] Confirm `origin-cli-darwin-arm64.tar.gz` is uploaded as a separate asset.
- [ ] Confirm Homebrew artifact upload (`actions/upload-artifact@v4`) references the new filename.
- [ ] Confirm smoke-test step runs on all three platforms (darwin-arm64, linux-x64/arm64, windows-x64) and passes.
- [ ] End-to-end: `curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/v0.7.0/install.sh | bash` on a clean machine succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)