### PR TITLE
fix(plugin): MCP runner prefers ~/.origin/bin/origin-mcp over npx

### DIFF
--- a/plugin/bin/origin-mcp-runner.sh
+++ b/plugin/bin/origin-mcp-runner.sh
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 # Dispatch the origin MCP server.
 #
-# Default path: pull the published origin-mcp from npm via npx. This is what
-# end users get after installing the plugin.
-#
-# Dev paths (checked in order):
+# Resolution order (most specific first):
 #   1. Sibling file `bin/origin-mcp.local` next to this script — typically a
 #      symlink to a locally-built origin-mcp binary. Filesystem-based so it
 #      survives plugin reloads that don't re-read settings.json env.
 #   2. ORIGIN_MCP_DEV_BIN env var — secondary, kept for shells that already
 #      export it. Requires Claude Code to inherit the var at startup.
-#
-# Either path means plugin changes to the MCP tool shape can be tested
-# without publishing to npm first.
+#   3. ~/.origin/bin/origin-mcp — the path install.sh places binaries at.
+#      Preferred over npx because (a) it's already on disk so MCP host
+#      handshake is instant, and (b) it sidesteps the EPERM class of npx
+#      failures when ~/.npm/_cacache contains root-owned files left over
+#      from older npm versions (npx exits before responding to initialize,
+#      MCP host then waits 30s and times out).
+#   4. npx -y origin-mcp@^0.7.0 — fallback for users who installed the
+#      plugin without running install.sh.
 
 # Don't enable `set -u` here: if Claude Code (or any MCP host) invokes the
 # script through a shell that doesn't populate BASH_SOURCE, `set -u` halts
@@ -26,6 +28,11 @@ fi
 
 if [ -n "${ORIGIN_MCP_DEV_BIN:-}" ] && [ -x "${ORIGIN_MCP_DEV_BIN}" ]; then
   exec "${ORIGIN_MCP_DEV_BIN}" "$@"
+fi
+
+installed_bin="${HOME}/.origin/bin/origin-mcp"
+if [ -x "${installed_bin}" ]; then
+  exec "${installed_bin}" "$@"
 fi
 
 exec npx -y origin-mcp@^0.7.0 "$@"


### PR DESCRIPTION
## Symptom

Claude Code MCP host fails to connect to the origin MCP server with:

```
Failed to reconnect to plugin:origin:origin: MCP server "plugin:origin:origin" connection timed out after 30000ms
```

## Root cause

`plugin/bin/origin-mcp-runner.sh` falls back to `exec npx -y origin-mcp@^0.7.0` when no dev override is set. If `~/.npm/_cacache` contains root-owned files (a recurring class of issue from older npm versions that npm itself prints `Your cache folder contains root-owned files...` for), npx exits with EPERM before it can write its tmp file. From the MCP host's perspective the spawned process disappears immediately without responding to the `initialize` JSON-RPC, so the host waits the full 30s and times out.

The user has install.sh installed and a healthy origin-mcp binary at `~/.origin/bin/origin-mcp` — the runner just never looked there.

## Fix

New resolution order in the runner (most specific first):

1. `${plugin}/bin/origin-mcp.local` — dev override symlink (unchanged)
2. `$ORIGIN_MCP_DEV_BIN` — dev override env var (unchanged)
3. **`~/.origin/bin/origin-mcp` — install.sh's standard path (new)**
4. `npx -y origin-mcp@^0.7.0` — fallback for users without install.sh

## Why this is the right shape

- Anyone who already ran the v0.7.0 installer gets a 0-network-call MCP launch.
- `npx` stays as the safety net for plugin-only installs (no install.sh).
- Same upgrade path: install.sh refreshes `~/.origin/bin/origin-mcp` on every run.
- No change to dev override semantics — the two existing overrides still win.

## Test plan

- [ ] Verify locally: drop a symlink at `~/.origin/bin/origin-mcp`, run the runner with an `initialize` payload, confirm it responds without invoking npx.
- [ ] Verify fallback: remove `~/.origin/bin/origin-mcp`, run the runner, confirm it still works via npx (assuming clean npm cache).
- [ ] After merge: in a session where origin MCP previously timed out, restart Claude Code and confirm `plugin:origin:origin` connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)