### PR TITLE
docs: refresh eval snapshot for cross-reranker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@
 
 **Your next AI session should pick up the context you built, not lose it in chat history.**
 
-Origin gives your daily AI workflow one local home: memory your agents can recall, wiki pages you can read, and source-backed context that captures, distills, and versions decisions, lessons, and project context across chats, projects, and time.
+Origin gives AI work one local home: decisions, lessons, gotchas, and project context are captured in flow, distilled into source-backed wiki pages, and brought back as retrieval context across chats, projects, and time.
 
-Your agent reads searchable memory, graph context, and hybrid retrieval. You read Markdown artifacts under `~/.origin/`. Same store, two surfaces.
+Agents query the same store through atomic memories, distilled pages, graph context, and hybrid retrieval. You read the Markdown artifacts under `~/.origin/`. Same source-backed store, two surfaces.
 
 [![Watch the Origin demo](./docs/assets/demo-preview.gif)](https://youtu.be/k37gjWVPHwI)
 
@@ -37,24 +37,15 @@ Your agent reads searchable memory, graph context, and hybrid retrieval. You rea
 
 ## What makes Origin distinct
 
-1. **Composition, not just storage.** Memories distill into pages. Sessions track workflow. An entity graph links people, projects, tools, and relations. Recall pulls vector hits, FTS hits, and graph neighbors together. Keyword search alone misses the connections. ~30 MCP tools across one daemon, not 100+ skills bolted on.
-2. **Real git versioning.** Every memory write is a `git commit` in `~/.origin/.git/`. Inspect with `git log`. Revert with `git checkout`. Branch and blame as needed.
-  ```text
-   $ cd ~/.origin && git log --oneline -5
+1. **Composition, not just storage.** Origin does not stop at chat-memory snippets. Captures cluster into source-backed wiki pages, and those pages feed retrieval alongside atomic memories, FTS, vectors, and graph neighbors.
+2. **Review before trust.** Low-confidence captures and contradictions surface for review when they happen, instead of silently entering context. Supersession chains and protected-memory conflicts stay visible.
+3. **Mandatory, refreshable provenance.** Wiki pages cite source memory IDs, carry `stale_reasons` and `revision_state`, and refresh through `/distill` or opt-in self-evolving background cycles when you add a local model or API key. The daemon refuses unsourced pages instead of letting hallucinated summaries enter the store.
+4. **Real git versioning.** Memory, page, and session writes commit into `~/.origin/.git/`, so you can inspect, diff, revert, branch, or symlink the Markdown artifacts into Obsidian.
+   ```text
    a1b2c3d page: embedding-retrieval refreshed (4 sources)
    9f8e7d6 session: handoff embedding-work
-   5a4b3c2 capture: fact mem_def456
-   8d7c6b5 capture: decision mem_abc123
-   3e2f1a0 init: origin v0.6.1
-  ```
-3. **Mandatory, refreshable provenance.** Wiki pages cite source memory IDs. The daemon rejects pages with empty `source_memory_ids` (HTTP 422). Pages aren't write-once: each carries `stale_reasons` and `revision_state`. `/distill` re-runs and background cycles refresh them as new memories arrive, without losing the citation chain.
-  ```bash
-   $ curl -X POST http://127.0.0.1:7878/pages \
-       -d '{"title":"X","content":"Y","source_memory_ids":[]}'
-   HTTP/1.1 422 Unprocessable Entity
-   {"error":"source_memory_ids cannot be empty"}
-  ```
-4. **Auditable memory.** Low-confidence captures and contradictions surface for review when they happen, instead of silently entering context. Supersession chains and protected-memory conflicts stay visible. Audit when you want, trust the defaults when you don't.
+   5a4b3c2 capture: decision mem_abc123
+   ```
 
 ---
 
@@ -147,15 +138,17 @@ which layer chose the active space.
 
 ## Evaluation
 
-**Hybrid retrieval, transparent eval.** BGE-Base-EN-v1.5-Q + FTS5 + Reciprocal Rank Fusion. Recall@5 = 88% on LongMemEval (oracle, 500 Q), 67% on LoCoMo. ~168 tokens per recall query. Eval harness at [`crates/origin-core/src/eval/`](crates/origin-core/src/eval/). Run it yourself.
+**Hybrid retrieval, transparent eval.** BGE-Base-EN-v1.5-Q + FTS5 + Reciprocal Rank Fusion; local BGE-Reranker-V2-M3 cross-encoder rerank is the latest shipped path when enabled. The table below is retrieval-only, not end-to-end answer quality. ~168 tokens per recall query. Eval harness at [`crates/origin-core/src/eval/`](crates/origin-core/src/eval/). Run it yourself.
 
 Update workflow in [docs/eval](docs/eval/README.md).
 
 
-| Benchmark                   | Recall@5 | MRR   | NDCG@10 |
-| --------------------------- | -------- | ----- | ------- |
-| LongMemEval (oracle, 500 Q) | 88.0%    | 74.2% | 79.0%   |
-| LoCoMo (locomo10)           | 67.3%    | 58.9% | 64.0%   |
+<!-- EVAL_SNAPSHOT_START -->
+| Benchmark | Recall@5 | MRR | NDCG@10 |
+|---|---:|---:|---:|
+| LongMemEval (oracle, 500 Q) | 93.6% | 0.857 | 0.883 |
+| LoCoMo (locomo10) | 70.0% | 0.647 | 0.684 |
+<!-- EVAL_SNAPSHOT_END -->
 
 
 ---

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -22,8 +22,10 @@ python3 scripts/update-readme-eval.py
 
 ## Notes
 
-- LongMemEval uses `Recall@5`, `MRR`, and `NDCG@10` as headline fields.
-- Keep `notes` concise, e.g. "pending reproducibility pass" or run metadata.
+- LongMemEval and LoCoMo use `Recall@5`, `MRR`, and `NDCG@10` as headline fields.
+- Current README numbers are retrieval-only, single-run local snapshots unless a reproducibility pass is explicitly documented.
+- Name the retrieval mode once in surrounding prose when all rows use the same mode.
+- Keep `notes` in the metrics JSON for maintainer-facing caveats and run metadata; the root README does not render them.
 
 ## Links
 

--- a/docs/eval/readme_metrics.example.json
+++ b/docs/eval/readme_metrics.example.json
@@ -1,11 +1,19 @@
 {
-  "updated_at": "2026-04-13",
+  "updated_at": "2026-05-25",
   "benchmarks": {
     "longmemeval": {
-      "recall_at_5": 0.88,
-      "mrr": null,
-      "ndcg_at_10": null,
-      "notes": "Local baseline, pending reproducibility pass"
+      "label": "LongMemEval (oracle, 500 Q)",
+      "recall_at_5": 0.936,
+      "mrr": 0.857,
+      "ndcg_at_10": 0.883,
+      "notes": "single-run local snapshot"
+    },
+    "locomo": {
+      "label": "LoCoMo (locomo10)",
+      "recall_at_5": 0.7,
+      "mrr": 0.647,
+      "ndcg_at_10": 0.684,
+      "notes": "single-run local snapshot"
     }
   }
 }

--- a/scripts/update-readme-eval.py
+++ b/scripts/update-readme-eval.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python3
 """Update README benchmark snapshot from local gitignored JSON.
 
-Source (gitignored): app/eval/baselines/readme_metrics.json
+Source (gitignored): ${EVAL_BASELINES_DIR:-~/.cache/origin-eval}/readme_metrics.json
 Target: README.md block between EVAL_SNAPSHOT_START / EVAL_SNAPSHOT_END
 """
 
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
-METRICS = ROOT / "app" / "eval" / "baselines" / "readme_metrics.json"
+BASELINES_DIR = Path(
+    os.environ.get("EVAL_BASELINES_DIR", str(Path.home() / ".cache" / "origin-eval"))
+).expanduser()
+METRICS = BASELINES_DIR / "readme_metrics.json"
 START = "<!-- EVAL_SNAPSHOT_START -->"
 END = "<!-- EVAL_SNAPSHOT_END -->"
 
@@ -30,36 +34,37 @@ def score(v: float | None) -> str:
     return f"{v:.3f}"
 
 
-def build_table(data: dict) -> str:
-    rows = data.get("benchmarks", {})
-    longmem = rows.get("longmemeval", {})
-    locomo = rows.get("locomo_plus", {})
-    life = rows.get("lifebench", {})
+def benchmark_rows(data: dict) -> list[dict]:
+    benchmarks = data.get("benchmarks", {})
+    known = [
+        ("longmemeval", "LongMemEval (oracle, 500 Q)"),
+        ("locomo", "LoCoMo (locomo10)"),
+        ("locomo_plus", "LoCoMo-Plus"),
+        ("lifebench", "LifeBench"),
+    ]
 
+    rows = []
+    for key, fallback_label in known:
+        if key not in benchmarks:
+            continue
+        row = dict(benchmarks[key])
+        row.setdefault("label", fallback_label)
+        rows.append(row)
+    return rows
+
+
+def build_table(data: dict) -> str:
     lines = [
         START,
-        "| Benchmark | Recall@5 | MRR | NDCG@10 | Notes |",
-        "|---|---:|---:|---:|---|",
-        (
-            f"| LongMemEval | **{pct(longmem.get('recall_at_5'))}** | "
-            f"{score(longmem.get('mrr'))} | {score(longmem.get('ndcg_at_10'))} | "
-            f"{longmem.get('notes', '-')}"
-            " |"
-        ),
-        (
-            f"| LoCoMo-Plus | {pct(locomo.get('recall_at_5'))} | "
-            f"{score(locomo.get('mrr'))} | {score(locomo.get('ndcg_at_10'))} | "
-            f"{locomo.get('notes', '-')}"
-            " |"
-        ),
-        (
-            f"| LifeBench | {pct(life.get('recall_at_5'))} | "
-            f"{score(life.get('mrr'))} | {score(life.get('ndcg_at_10'))} | "
-            f"{life.get('notes', '-')}"
-            " |"
-        ),
-        END,
+        "| Benchmark | Recall@5 | MRR | NDCG@10 |",
+        "|---|---:|---:|---:|",
     ]
+    for row in benchmark_rows(data):
+        lines.append(
+            f"| {row['label']} | {pct(row.get('recall_at_5'))} | {score(row.get('mrr'))} | "
+            f"{score(row.get('ndcg_at_10'))} |"
+        )
+    lines.append(END)
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- refresh README eval snapshot with shipped cross-reranker numbers
- clarify memory-to-wiki retrieval positioning in intro and distinct section
- keep single-run caveat in eval docs instead of the main README table

## Test Plan
- python3 scripts/update-readme-eval.py
- python3 -B -m py_compile scripts/update-readme-eval.py
- git diff --check