### PR TITLE
fix(retrieval): page-channel as 4th RRF stream in search_memory_with_reranker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,10 @@ export EVAL_BASELINES_DIR=$HOME/.cache/origin-eval
 
 Path must be writable and local (network mounts not recommended). When set, also chains `EVAL_ENRICHMENT_CACHE_DIR` default to the same dir unless explicitly overridden. Migration: `bash scripts/migrate-eval-cache.sh <source-baselines>`.
 
+### Cached scenario DBs (page-channel + retrieval-only evals)
+
+The PR-B page-channel runners reuse the fullpipeline_*.db seeded DBs without re-ingesting. They live at `~/.cache/origin-eval/scenario_seeded/{locomo_v1,lme_v1}/origin_memory.db`. Repopulate via `bash scripts/seed-scenario-dbs.sh` from the repo root. The `cached_scenario_db_check.rs` integration test (L7 manual) verifies migration replay against current schema; it auto-resolves the root from `SCENARIO_DB_ROOT > EVAL_BASELINES_DIR/scenario_seeded > ~/.cache/origin-eval/scenario_seeded/`.
+
 ### Eval pre-flight subset
 
 Set `EVAL_LOCOMO_LIMIT=N` (or `EVAL_LME_LIMIT=N`) to truncate the fixture and run a small-subset eval (~30min) before committing to full 3h runs. Useful for verifying direction on new retrieval variants. Applies to every `run_locomo_eval*` / `run_longmemeval_eval*` variant. Unset (the default) runs the full fixture unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,7 @@ Origin runs across several layers. The split is driven by three questions: **(1)
 | **L5 coverage on PR** | `cargo llvm-cov` on origin-core + origin-server only | GitHub (`coverage.yml`) | Every PR | ~10min | **No (informational)** |
 | **L6 main canary** | Embedding-only eval (`cargo test -p origin-core --lib eval::retrieval -- --ignored`) | GitHub (`ci.yml`) | Push to `main` | ~10min | No (post-merge) |
 | **L7 manual local** | `bash scripts/coverage.sh` (HTML coverage), GPU eval suite (`cargo test -- --ignored`), Anthropic batch judge (`ANTHROPIC_API_KEY=... cargo test ...`) | Your laptop | On demand | minutes-hours | No |
-| **L8 pre-release** | Full eval suite vs saved baseline. Record deltas in vault/memory **never git** (Apache-2.0 public-repo rule for daemon; treat numbers as private until you have signed-off baselines) | Your laptop | Per release | hours | Soft gate |
+| **L8 pre-release** | Full eval suite vs saved baseline. Commit a **curated, env-stamped snapshot** of headline numbers to a results doc/README (single-run tagged "scaffold"; headline claims need N≥3 + stddev). Raw per-run baselines + history series stay gitignored. See "Commit policy" under Eval Citation Discipline. | Your laptop | Per release | hours | Soft gate |
 
 ### What does NOT run in CI and why
 
@@ -375,6 +375,7 @@ Numbers from `~/.cache/origin-eval/baselines/` carry guardrails that MUST be hon
 - **Receipt-only rule (extends cost-receipt).** Regression thresholds, latency claims, accuracy improvements must have a measured-stddev or N≥3-run backing. No "improved X%" or "regressed Y%" without `compare-baselines` output AND multi-run inputs.
 - **Per-case visibility.** Aggregate accuracy claims must include per-case breakdown when available. Headline-only numbers hide regressions (LoCoMo adversarial-cat-5 contamination is the canonical trap; see `feature/eval-semantic-gaps` discussion).
 - **Layer attribution.** Public numbers must specify L1 / L2 / L3 / L4. No cross-layer averages without explicit weighting.
+- **Commit policy — snapshot, not history.** Metric *values* MAY be committed to git as a **curated, env-stamped snapshot** (the current headline numbers) in a results doc or README section, overwritten per release. Each committed value carries its methodology inline (model, dataset, run count, repro command); single-run results are tagged "scaffold" and headline/external claims still require the Single-run + Receipt-only gates above (N≥3 + stddev). Do **not** commit a per-run *history series* — that is what the gitignored `append_history` file is for. Raw per-run baseline JSONs under `~/.cache/origin-eval/baselines/` stay **gitignored** (artifacts, reproduced by re-running, not source). The repo is Apache-2.0; the older blanket "never commit numbers to git" rule is retired in favor of this snapshot policy.
 
 ### Crate boundaries
 - **origin-core must have NO tauri or axum dependencies.** Verify with `grep -rn "use tauri\|use axum" crates/origin-core/src/` — expect zero hits. Any event emission goes through the `EventEmitter` trait.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,8 @@ Path must be writable and local (network mounts not recommended). When set, also
 
 The PR-B page-channel runners reuse the fullpipeline_*.db seeded DBs without re-ingesting. They live at `~/.cache/origin-eval/scenario_seeded/{locomo_v1,lme_v1}/origin_memory.db`. Repopulate via `bash scripts/seed-scenario-dbs.sh` from the repo root. The `cached_scenario_db_check.rs` integration test (L7 manual) verifies migration replay against current schema; it auto-resolves the root from `SCENARIO_DB_ROOT > EVAL_BASELINES_DIR/scenario_seeded > ~/.cache/origin-eval/scenario_seeded/`.
 
+For full eval discipline (fixture management, baseline layout, env vars, seed scripts, pre-flight checklist, runner conventions), see `app/eval/AGENTS.md` and `crates/origin-core/src/eval/AGENTS.md`. The subdir AGENTS.md files apply per the agents.md hierarchical-instruction convention when an agent is working under those subtrees.
+
 ### Eval pre-flight subset
 
 Set `EVAL_LOCOMO_LIMIT=N` (or `EVAL_LME_LIMIT=N`) to truncate the fixture and run a small-subset eval (~30min) before committing to full 3h runs. Useful for verifying direction on new retrieval variants. Applies to every `run_locomo_eval*` / `run_longmemeval_eval*` variant. Unset (the default) runs the full fixture unchanged.

--- a/app/eval/AGENTS.md
+++ b/app/eval/AGENTS.md
@@ -1,0 +1,188 @@
+# app/eval — Eval Discipline
+
+Applies to agents working under `app/eval/`. Read alongside root `AGENTS.md`, which takes precedence on any topic not covered here.
+
+---
+
+## data/ — fixture management
+
+**`app/eval/data/` is not committed.** It is shown as an untracked directory in `git status`. `.gitignore` only excludes `app/eval/data/longmemeval_*.json` by pattern; `locomo10.json` has no explicit gitignore rule but is also not tracked. Neither file ships in the repo. Every worktree must populate its own copy.
+
+### What each file is
+
+| File | Benchmark | Size | Source |
+|---|---|---|---|
+| `locomo10.json` | LoCoMo (10-conv subset) | ~5MB | https://github.com/snap-research/locomo |
+| `longmemeval_oracle.json` | LongMemEval oracle split | ~15MB | https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned |
+
+### How to populate a new worktree
+
+Option A: copy from a sibling worktree that already has the files:
+
+```bash
+find . -name "locomo10.json" -not -path "*/target/*"
+# then:
+cp /path/to/found/locomo10.json app/eval/data/locomo10.json
+```
+
+Option B: download from source:
+
+```bash
+mkdir -p app/eval/data
+# LoCoMo — obtain locomo10.json from the snap-research/locomo repo (see README there)
+# LongMemEval oracle:
+curl -sL 'https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_oracle.json' \
+  -o app/eval/data/longmemeval_oracle.json
+```
+
+No import script exists in this repo for the LoCoMo 10-conv subset. If one is added, reference it here.
+
+### What silently SKIPs when a fixture is missing
+
+Tests that call `eval_root().join("data/<fixture>.json")` print "SKIP" and return early if the file is absent. They do not fail — they silently produce no metrics. This is the bug that triggered this doc.
+
+Tests that depend on `locomo10.json`:
+- `test_locomo_benchmark`
+- `test_locomo_gate_comparison`
+- `save_locomo_baseline`
+- `save_locomo_reranked_baseline`
+- `save_locomo_expanded_baseline`
+- `save_locomo_cross_rerank_baseline`
+- `save_locomo_v2_with_pages_baseline`
+- `benchmark_locomo_pipeline`
+- `benchmark_context_path`
+- `generate_e2e_context_tuples_locomo`
+- `generate_e2e_context_tuples_locomo_api`
+- `judge_e2e_context_locomo` (and variants)
+- `generate_fullpipeline_locomo`
+- `smoke_per_scenario_locomo` (and `_cli`, `_cli_batched`)
+
+Tests that depend on `longmemeval_oracle.json`:
+- `test_longmemeval_benchmark`
+- `test_longmemeval_gate_comparison`
+- `save_longmemeval_baseline`
+- `save_longmemeval_reranked_baseline`
+- `save_longmemeval_expanded_baseline`
+- `save_longmemeval_cross_rerank_baseline`
+- `save_longmemeval_v2_with_pages_baseline`
+- `benchmark_longmemeval_pipeline`
+- `benchmark_context_path_longmemeval`
+- `generate_e2e_context_tuples_longmemeval`
+- `generate_fullpipeline_lme`
+- `smoke_per_scenario_lme`
+- `judge_fullpipeline_lme` (and `_cli`)
+
+---
+
+## baselines/ — artifact layout
+
+`app/eval/baselines/` is gitignored. Two parallel artifact paths exist:
+
+### Legacy path (single-file format)
+
+```
+app/eval/baselines/<benchmark>__<retrieval_method>__<hash>.json
+```
+
+Used by README citations and external references. Written by `report.save_baseline(&baseline_path)`. The `save_locomo_v2_with_pages_baseline` and `save_longmemeval_v2_with_pages_baseline` tests branch the filename suffix on `ORIGIN_DISABLE_PAGE_CHANNEL`:
+- page-channel ON: `...__with_pages.json`
+- page-channel OFF: `...__no_pages.json`
+
+### Layered path (P0b schema, for compare-baselines)
+
+```
+~/.cache/origin-eval/baselines/l1_db/<task>/<variant_tag>__<comparable_hash>.json
+```
+
+Written by `save_full_report` via the `save_layered` helper in `eval_harness.rs`. Used by `compare-baselines`. The `comparable_hash` is a SHA-256[..8] over a fixed subset of `ReportEnv` fields (fixture revision, embedder revision, LLM provider class, LLM model, mcp_schema_hash, skill_prompt_hash, schema_version, schema_db_version, similarity_fn). The `variant_tag` string (not flags) is the load-bearing differentiator because `flags` is not yet included in the hash (Task #30).
+
+### Dual-write convention
+
+New PR-B tests call `save_baseline` for the legacy path AND `save_layered` for the layered path. Older tests (`save_locomo_baseline`, `save_longmemeval_baseline`, etc.) call `save_layered` too, via the same pattern.
+
+---
+
+## environment variables
+
+| Variable | Purpose | Default | Consumed by |
+|---|---|---|---|
+| `SCENARIO_DB_ROOT` | Override root for cached scenario DBs | (auto-resolve) | `resolve_scenario_db_root_from_harness`, `cached_scenario_db_check.rs` |
+| `EVAL_BASELINES_DIR` | Root of the `~/.cache/origin-eval` cache | `$HOME/.cache/origin-eval` | `baselines_root()`, `resolve_scenario_db_root_from_harness` |
+| `EVAL_LOCOMO_LIMIT` | Truncate LoCoMo fixture to N samples | full fixture (10 conversations) | all `run_locomo_eval*` variants |
+| `EVAL_LME_LIMIT` | Truncate LME fixture to N samples | full fixture | all `run_longmemeval_eval*` variants |
+| `LOCOMO_LIMIT_CONVS` | (fullpipeline only) Limit to first N conversations | full fixture | `generate_fullpipeline_locomo` in `answer_quality.rs` |
+| `EVAL_SCENARIO_CONCURRENCY` | Parallel scenario seeding (fullpipeline) | 1 | `generate_fullpipeline_locomo`, `generate_fullpipeline_lme` in `answer_quality.rs` |
+| `EVAL_MAX_USD` | Cost cap for API-batch judge runs | none | `wall_clock.rs` watchdog |
+| `EVAL_ALLOW_WIPE` | Allow `clear_all_for_eval` to wipe DB | unset (refuses) | `open_or_seed_scenario_db` stale-cache recovery |
+| `ORIGIN_DISABLE_PAGE_CHANNEL` | Skip page-channel in `search_memory_with_reranker` | unset (page-channel ON) | `db.rs:search_memory_with_reranker`, `locomo.rs:run_locomo_eval_cross_rerank_from_db`, `longmemeval.rs:run_longmemeval_eval_cross_rerank_from_db`, suffix branching in `eval_harness.rs` |
+| `ORIGIN_EVAL_ROOT` | Override `eval_root()` in test harness | `app/eval/` | `eval_root()` in `eval_harness.rs` |
+
+---
+
+## seed scripts and cached-DB workflow
+
+### seed-scenario-dbs.sh
+
+`scripts/seed-scenario-dbs.sh` copies `origin_memory.db` from the canonical fullpipeline DBs to the scenario_seeded layout:
+
+```
+~/.cache/origin-eval/scenario_seeded/locomo_v1/origin_memory.db
+~/.cache/origin-eval/scenario_seeded/lme_v1/origin_memory.db
+```
+
+Run from the repo root:
+
+```bash
+bash scripts/seed-scenario-dbs.sh
+```
+
+Sources: `~/.cache/origin-eval/fullpipeline_locomo_tuples.db/origin_memory.db` and `~/.cache/origin-eval/fullpipeline_lme_tuples.db/origin_memory.db`. If those originals do not exist, run the fullpipeline harness first (`generate_fullpipeline_locomo` / `generate_fullpipeline_lme`).
+
+### cached_scenario_db_check.rs
+
+`crates/origin-core/tests/cached_scenario_db_check.rs` (L7 manual, `--ignored`) opens each scenario DB via `MemoryDB::new`, which replays migrations idempotently, then prints table counts and 3 sample pages per DB. Root resolution: `SCENARIO_DB_ROOT > EVAL_BASELINES_DIR/scenario_seeded > ~/.cache/origin-eval/scenario_seeded/`.
+
+Run with:
+
+```bash
+cargo test -p origin-core --test cached_scenario_db_check -- --ignored --nocapture
+```
+
+---
+
+## eval citation discipline
+
+For the full citation rules (single-run rule, schema-version rule, receipt-only rule, per-case visibility, layer attribution), see the **"### Eval Citation Discipline"** section in root `AGENTS.md`. Do not cite external-facing numbers without satisfying those rules.
+
+---
+
+## pre-flight checklist
+
+Before running any eval test:
+
+```
+- [ ] app/eval/data/locomo10.json present — if missing, populate via sibling worktree cp or source download
+- [ ] app/eval/data/longmemeval_oracle.json present — if missing, download via curl (see above)
+- [ ] Cached scenario DBs present at ~/.cache/origin-eval/scenario_seeded/{locomo_v1,lme_v1}/origin_memory.db — if missing, run: bash scripts/seed-scenario-dbs.sh
+- [ ] Branch is clean: git status --short shows only intentional changes
+- [ ] Limit chosen: EVAL_LOCOMO_LIMIT=2 for ~1min wiring smoke; EVAL_LOCOMO_LIMIT=20 for ~30min subset; unset for full fixture
+- [ ] For A/B comparison runs: identical env except the ONE variable being tested
+```
+
+---
+
+## subset eval methodology (PR-B page-channel)
+
+Page-channel impact is measured by running the same test twice:
+
+```bash
+# page-channel ON (default):
+cargo test -p origin-core --test eval_harness save_locomo_v2_with_pages_baseline -- --ignored --nocapture
+
+# page-channel OFF:
+ORIGIN_DISABLE_PAGE_CHANNEL=1 cargo test -p origin-core --test eval_harness save_locomo_v2_with_pages_baseline -- --ignored --nocapture
+```
+
+The cached consolidated scenario DB introduces cross-conversation noise compared to the per-conversation ephemeral DB used by `save_locomo_cross_rerank_baseline`. So numbers from `save_locomo_v2_with_pages_baseline` are NOT directly comparable to the published 0.684 LoCoMo bar. They are comparable to the OFF variant of the same runner (`ORIGIN_DISABLE_PAGE_CHANNEL=1`).
+
+The `variant_tag` field (`cross_rerank_v2_pages` vs `cross_rerank_v2_no_pages`) is the load-bearing differentiator on the layered baseline path, because `comparable_env_hash` does not yet hash `flags` (pending Task #30).

--- a/app/eval/AGENTS.md
+++ b/app/eval/AGENTS.md
@@ -1,10 +1,10 @@
-# app/eval — Eval Discipline
+# app/eval - Eval Discipline
 
 Applies to agents working under `app/eval/`. Read alongside root `AGENTS.md`, which takes precedence on any topic not covered here.
 
 ---
 
-## data/ — fixture management
+## data/ - fixture management
 
 **`app/eval/data/` is not committed.** It is shown as an untracked directory in `git status`. `.gitignore` only excludes `app/eval/data/longmemeval_*.json` by pattern; `locomo10.json` has no explicit gitignore rule but is also not tracked. Neither file ships in the repo. Every worktree must populate its own copy.
 
@@ -29,7 +29,7 @@ Option B: download from source:
 
 ```bash
 mkdir -p app/eval/data
-# LoCoMo — obtain locomo10.json from the snap-research/locomo repo (see README there)
+# LoCoMo: obtain locomo10.json from the snap-research/locomo repo (see README there)
 # LongMemEval oracle:
 curl -sL 'https://huggingface.co/datasets/xiaowu0162/longmemeval-cleaned/resolve/main/longmemeval_oracle.json' \
   -o app/eval/data/longmemeval_oracle.json
@@ -39,7 +39,7 @@ No import script exists in this repo for the LoCoMo 10-conv subset. If one is ad
 
 ### What silently SKIPs when a fixture is missing
 
-Tests that call `eval_root().join("data/<fixture>.json")` print "SKIP" and return early if the file is absent. They do not fail — they silently produce no metrics. This is the bug that triggered this doc.
+Tests that call `eval_root().join("data/<fixture>.json")` print "SKIP" and return early if the file is absent. They do not fail: they silently produce no metrics. This is the bug that triggered this doc.
 
 Tests that depend on `locomo10.json`:
 - `test_locomo_benchmark`
@@ -72,9 +72,17 @@ Tests that depend on `longmemeval_oracle.json`:
 - `smoke_per_scenario_lme`
 - `judge_fullpipeline_lme` (and `_cli`)
 
+### Sibling fixture trees
+
+Three sibling subdirs live alongside `data/` and are tracked in git:
+
+- `app/eval/kg_fixtures/*.toml` - hand-curated entity + relation ground-truth, consumed by `eval::kg_faithfulness`. See root `AGENTS.md` "KG-faithfulness bench".
+- `app/eval/page_fixtures/*.toml` - hand-curated source memories + distilled page bodies, consumed by `eval::page_faithfulness`. See root `AGENTS.md` "Page-distillation faithfulness bench".
+- `app/eval/fixtures/*.toml` - 41 LoCoMo/LME fixtures vendored from `7xuanlu/origin-app` (PR #148). Used by `eval_harness.rs` integration tests.
+
 ---
 
-## baselines/ — artifact layout
+## baselines/ - artifact layout
 
 `app/eval/baselines/` is gitignored. Two parallel artifact paths exist:
 
@@ -94,11 +102,13 @@ Used by README citations and external references. Written by `report.save_baseli
 ~/.cache/origin-eval/baselines/l1_db/<task>/<variant_tag>__<comparable_hash>.json
 ```
 
-Written by `save_full_report` via the `save_layered` helper in `eval_harness.rs`. Used by `compare-baselines`. The `comparable_hash` is a SHA-256[..8] over a fixed subset of `ReportEnv` fields (fixture revision, embedder revision, LLM provider class, LLM model, mcp_schema_hash, skill_prompt_hash, schema_version, schema_db_version, similarity_fn). The `variant_tag` string (not flags) is the load-bearing differentiator because `flags` is not yet included in the hash (Task #30).
+Written by `save_full_report` via the `save_layered` helper in `eval_harness.rs`. Used by `compare-baselines`. The `comparable_hash` is a SHA-256[..8] over a fixed subset of `ReportEnv` fields (fixture revision, embedder revision, LLM provider class, LLM model, mcp_schema_hash, skill_prompt_hash, schema_version, schema_db_version, similarity_fn_name). The `variant_tag` string (not flags) is the load-bearing differentiator because `flags` is not yet included in the hash (Task #30).
 
 ### Dual-write convention
 
 New PR-B tests call `save_baseline` for the legacy path AND `save_layered` for the layered path. Older tests (`save_locomo_baseline`, `save_longmemeval_baseline`, etc.) call `save_layered` too, via the same pattern.
+
+Exception: `save_locomo_cross_rerank_baseline` and `save_longmemeval_cross_rerank_baseline` write legacy-only by design. This protects the pre-PR-B 0.684/0.883 disk artifacts as a stable reference (see Task 5 plan). New `__with_pages` variants dual-write.
 
 ---
 
@@ -112,7 +122,8 @@ New PR-B tests call `save_baseline` for the legacy path AND `save_layered` for t
 | `EVAL_LME_LIMIT` | Truncate LME fixture to N samples | full fixture | all `run_longmemeval_eval*` variants |
 | `LOCOMO_LIMIT_CONVS` | (fullpipeline only) Limit to first N conversations | full fixture | `generate_fullpipeline_locomo` in `answer_quality.rs` |
 | `EVAL_SCENARIO_CONCURRENCY` | Parallel scenario seeding (fullpipeline) | 1 | `generate_fullpipeline_locomo`, `generate_fullpipeline_lme` in `answer_quality.rs` |
-| `EVAL_MAX_USD` | Cost cap for API-batch judge runs | none | `wall_clock.rs` watchdog |
+| `EVAL_MAX_USD` | Cost cap for API-batch judge runs (pre-flight and per-batch) | none | `anthropic.rs` (`parse_eval_max_usd`, `submit_batch`, `estimate_batch_cost`) |
+| `EVAL_MAX_WALL_SECS` | Wall-clock timeout for eval runs | 14400 (4h) | `wall_clock.rs` watchdog |
 | `EVAL_ALLOW_WIPE` | Allow `clear_all_for_eval` to wipe DB | unset (refuses) | `open_or_seed_scenario_db` stale-cache recovery |
 | `ORIGIN_DISABLE_PAGE_CHANNEL` | Skip page-channel in `search_memory_with_reranker` | unset (page-channel ON) | `db.rs:search_memory_with_reranker`, `locomo.rs:run_locomo_eval_cross_rerank_from_db`, `longmemeval.rs:run_longmemeval_eval_cross_rerank_from_db`, suffix branching in `eval_harness.rs` |
 | `ORIGIN_EVAL_ROOT` | Override `eval_root()` in test harness | `app/eval/` | `eval_root()` in `eval_harness.rs` |
@@ -161,9 +172,9 @@ For the full citation rules (single-run rule, schema-version rule, receipt-only 
 Before running any eval test:
 
 ```
-- [ ] app/eval/data/locomo10.json present — if missing, populate via sibling worktree cp or source download
-- [ ] app/eval/data/longmemeval_oracle.json present — if missing, download via curl (see above)
-- [ ] Cached scenario DBs present at ~/.cache/origin-eval/scenario_seeded/{locomo_v1,lme_v1}/origin_memory.db — if missing, run: bash scripts/seed-scenario-dbs.sh
+- [ ] app/eval/data/locomo10.json present. If missing, populate via sibling worktree cp or source download
+- [ ] app/eval/data/longmemeval_oracle.json present. If missing, download via curl (see above)
+- [ ] Cached scenario DBs present at ~/.cache/origin-eval/scenario_seeded/{locomo_v1,lme_v1}/origin_memory.db. If missing, run: bash scripts/seed-scenario-dbs.sh
 - [ ] Branch is clean: git status --short shows only intentional changes
 - [ ] Limit chosen: EVAL_LOCOMO_LIMIT=2 for ~1min wiring smoke; EVAL_LOCOMO_LIMIT=20 for ~30min subset; unset for full fixture
 - [ ] For A/B comparison runs: identical env except the ONE variable being tested

--- a/app/eval/AGENTS.md
+++ b/app/eval/AGENTS.md
@@ -92,9 +92,9 @@ Three sibling subdirs live alongside `data/` and are tracked in git:
 app/eval/baselines/<benchmark>__<retrieval_method>__<hash>.json
 ```
 
-Used by README citations and external references. Written by `report.save_baseline(&baseline_path)`. The `save_locomo_v2_with_pages_baseline` and `save_longmemeval_v2_with_pages_baseline` tests branch the filename suffix on `ORIGIN_DISABLE_PAGE_CHANNEL`:
-- page-channel ON: `...__with_pages.json`
-- page-channel OFF: `...__no_pages.json`
+Used by README citations and external references. Written by `report.save_baseline(&baseline_path)`. The `save_locomo_v2_with_pages_baseline` and `save_longmemeval_v2_with_pages_baseline` tests branch the filename suffix on `ORIGIN_ENABLE_PAGE_CHANNEL`:
+- page-channel ON (`ORIGIN_ENABLE_PAGE_CHANNEL=1`): `...__with_pages.json`
+- page-channel OFF (default, unset): `...__no_pages.json`
 
 ### Layered path (P0b schema, for compare-baselines)
 
@@ -125,7 +125,7 @@ Exception: `save_locomo_cross_rerank_baseline` and `save_longmemeval_cross_reran
 | `EVAL_MAX_USD` | Cost cap for API-batch judge runs (pre-flight and per-batch) | none | `anthropic.rs` (`parse_eval_max_usd`, `submit_batch`, `estimate_batch_cost`) |
 | `EVAL_MAX_WALL_SECS` | Wall-clock timeout for eval runs | 14400 (4h) | `wall_clock.rs` watchdog |
 | `EVAL_ALLOW_WIPE` | Allow `clear_all_for_eval` to wipe DB | unset (refuses) | `open_or_seed_scenario_db` stale-cache recovery |
-| `ORIGIN_DISABLE_PAGE_CHANNEL` | Skip page-channel in `search_memory_with_reranker` | unset (page-channel ON) | `db.rs:search_memory_with_reranker`, `locomo.rs:run_locomo_eval_cross_rerank_from_db`, `longmemeval.rs:run_longmemeval_eval_cross_rerank_from_db`, suffix branching in `eval_harness.rs` |
+| `ORIGIN_ENABLE_PAGE_CHANNEL` | Enable page-channel in `search_memory_with_reranker` | unset (page-channel OFF) | `db.rs:search_memory_with_reranker`, `locomo.rs:run_locomo_eval_cross_rerank_from_db`, `longmemeval.rs:run_longmemeval_eval_cross_rerank_from_db`, suffix branching in `eval_harness.rs` |
 | `ORIGIN_EVAL_ROOT` | Override `eval_root()` in test harness | `app/eval/` | `eval_root()` in `eval_harness.rs` |
 
 ---
@@ -187,13 +187,13 @@ Before running any eval test:
 Page-channel impact is measured by running the same test twice:
 
 ```bash
-# page-channel ON (default):
-cargo test -p origin-core --test eval_harness save_locomo_v2_with_pages_baseline -- --ignored --nocapture
+# page-channel ON (opt-in):
+ORIGIN_ENABLE_PAGE_CHANNEL=1 cargo test -p origin-core --test eval_harness save_locomo_v2_with_pages_baseline -- --ignored --nocapture
 
-# page-channel OFF:
-ORIGIN_DISABLE_PAGE_CHANNEL=1 cargo test -p origin-core --test eval_harness save_locomo_v2_with_pages_baseline -- --ignored --nocapture
+# page-channel OFF (default):
+cargo test -p origin-core --test eval_harness save_locomo_v2_with_pages_baseline -- --ignored --nocapture
 ```
 
-The cached consolidated scenario DB introduces cross-conversation noise compared to the per-conversation ephemeral DB used by `save_locomo_cross_rerank_baseline`. So numbers from `save_locomo_v2_with_pages_baseline` are NOT directly comparable to the published 0.684 LoCoMo bar. They are comparable to the OFF variant of the same runner (`ORIGIN_DISABLE_PAGE_CHANNEL=1`).
+The cached consolidated scenario DB introduces cross-conversation noise compared to the per-conversation ephemeral DB used by `save_locomo_cross_rerank_baseline`. So numbers from `save_locomo_v2_with_pages_baseline` are NOT directly comparable to the published 0.684 LoCoMo bar. They are comparable to the OFF variant of the same runner (page-channel unset/default).
 
 The `variant_tag` field (`cross_rerank_v2_pages` vs `cross_rerank_v2_no_pages`) is the load-bearing differentiator on the layered baseline path, because `comparable_env_hash` does not yet hash `flags` (pending Task #30).

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -8071,6 +8071,13 @@ impl MemoryDB {
     /// RRF mass `1/(60+rank)` on top. Carrying `relevance_score` would double-add
     /// at different scales and warp ranking. `raw_score` retains the page's
     /// internal vec+FTS RRF score for diagnostics only.
+    ///
+    /// **Recency caveat**: `page.last_modified` is parsed from RFC3339; on parse
+    /// failure, `last_modified=0` (1970-01-01). Page-channel rows MUST stay out of
+    /// recency-based scoring paths (`signals::recency_decay` etc.) or a malformed
+    /// timestamp silently demotes the page to maximum decay. Current consumer
+    /// (PR-B Task 3 two-stage RRF merge) does not route page rows through recency,
+    /// so this is documented as an invariant rather than enforced at the type level.
     // consumed by search_memory_with_reranker in PR-B Task 3
     #[allow(dead_code)]
     fn search_result_from_page(page: Page) -> SearchResult {
@@ -31648,6 +31655,21 @@ pub(crate) mod tests {
         assert!(
             r.last_modified > 0,
             "RFC3339 string should parse to non-zero Unix ts"
+        );
+        // Tighten per code-quality review: protect every non-Option mapping.
+        assert_eq!(r.source_id, "page_x", "source_id should equal page.id");
+        assert_eq!(r.title, "T", "title should pass through unchanged");
+        assert_eq!(r.content, "body", "content should pass through unchanged");
+        assert_eq!(
+            r.summary.as_deref(),
+            Some("s"),
+            "summary should pass through"
+        );
+        assert_eq!(r.version, 3, "version should pass through unchanged");
+        assert_eq!(
+            r.space.as_deref(),
+            Some("work"),
+            "space should pass through"
         );
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -8060,6 +8060,60 @@ impl MemoryDB {
         Ok(results)
     }
 
+    /// Convert a `Page` to a `SearchResult` so the page-channel can join the
+    /// memory RRF pool. Pages bypass per-memory modulators (they're pre-distilled
+    /// wiki summaries with their own quality signal). `source` is tagged `"page"`
+    /// so downstream filters / loggers can distinguish.
+    ///
+    /// IMPORTANT: `score` is intentionally set to `0.0` (not `page.relevance_score`).
+    /// The page-channel topology mirrors `augment_with_graph` (db.rs:7619-7629):
+    /// memory results SEED the merged score_map; page rows contribute only the
+    /// RRF mass `1/(60+rank)` on top. Carrying `relevance_score` would double-add
+    /// at different scales and warp ranking. `raw_score` retains the page's
+    /// internal vec+FTS RRF score for diagnostics only.
+    // consumed by search_memory_with_reranker in PR-B Task 3
+    #[allow(dead_code)]
+    fn search_result_from_page(page: Page) -> SearchResult {
+        let last_modified = chrono::DateTime::parse_from_rfc3339(&page.last_modified)
+            .map(|dt| dt.timestamp())
+            .unwrap_or(0);
+        SearchResult {
+            id: page.id.clone(),
+            content: page.content,
+            source: "page".to_string(),
+            source_id: page.id,
+            title: page.title,
+            url: None,
+            chunk_index: 0,
+            last_modified,
+            score: 0.0,
+            chunk_type: None,
+            language: None,
+            semantic_unit: None,
+            memory_type: None,
+            space: page.space,
+            source_agent: None,
+            confidence: None,
+            confirmed: None,
+            stability: None,
+            supersedes: None,
+            summary: page.summary,
+            entity_id: page.entity_id,
+            entity_name: None,
+            quality: None,
+            is_archived: false,
+            is_recap: false,
+            structured_fields: None,
+            retrieval_cue: None,
+            source_text: None,
+            raw_score: page.relevance_score,
+            version: page.version,
+            pending_revision: false,
+            merged_from: None,
+            last_delta_summary: None,
+        }
+    }
+
     /// Insert an eval signal (fire-and-forget, INSERT OR IGNORE for dedup).
     #[allow(clippy::too_many_arguments)]
     pub async fn insert_eval_signal(
@@ -31551,5 +31605,49 @@ pub(crate) mod tests {
             .await
             .expect("sweep");
         assert_eq!(processed, 5, "should process all 5 rows across batches");
+    }
+
+    // ── search_result_from_page tests ────────────────────────────────────────
+
+    #[test]
+    fn from_page_tags_source_and_zeroes_score() {
+        let page = Page {
+            id: "page_x".into(),
+            title: "T".into(),
+            summary: Some("s".into()),
+            content: "body".into(),
+            entity_id: Some("ent_a".into()),
+            space: Some("work".into()),
+            source_memory_ids: vec![],
+            version: 3,
+            status: "active".into(),
+            created_at: "2026-05-01T00:00:00Z".into(),
+            last_compiled: "2026-05-01T00:00:00Z".into(),
+            last_modified: "2026-05-20T12:34:56Z".into(),
+            sources_updated_count: 0,
+            stale_reason: None,
+            user_edited: false,
+            relevance_score: 0.42,
+            last_edited_by: None,
+            last_edited_at: None,
+            last_delta_summary: None,
+            changelog: None,
+        };
+        let r = MemoryDB::search_result_from_page(page);
+        assert_eq!(r.source, "page");
+        assert_eq!(r.id, "page_x");
+        assert_eq!(
+            r.score, 0.0,
+            "fusion-channel rows must start at 0.0; RRF mass is added in the merge loop"
+        );
+        assert_eq!(
+            r.raw_score, 0.42,
+            "raw_score preserves page.relevance_score for diagnostics"
+        );
+        assert_eq!(r.entity_id.as_deref(), Some("ent_a"));
+        assert!(
+            r.last_modified > 0,
+            "RFC3339 string should parse to non-zero Unix ts"
+        );
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7521,7 +7521,29 @@ impl MemoryDB {
             }
         }
 
+        // Page-channel append semantics (iter2, addresses Phase 2 regression).
+        //
+        // Page rows mechanically can't earn ground-truth credit in retrieval
+        // metrics (relevant_ids are memory source_ids; page_* ids never
+        // appear). When pages competed with memories inside the CE rerank
+        // top-N, they displaced relevant memories and dropped NDCG@10 by
+        // up to 1.92pt on LME. Iter2 separates: rerank memories vs pages
+        // jointly above for ordering quality, then PARTITION the result so
+        // memories fill the top `limit` slots and pages ride along as
+        // supplementary context in positions [limit, limit + page_count).
+        //
+        // Net effect on eval: neutral (eval reads positions 0..limit,
+        // sees only memories). Net effect on production: page surface
+        // available to callers reading beyond `limit` for bonus context.
+        // No wire-shape break: SearchResult.source distinguishes "page"
+        // from "memory" rows for any consumer that wants to filter.
+        let (page_results, mem_results): (Vec<_>, Vec<_>) =
+            results.into_iter().partition(|r| r.source == "page");
+        let mut results = mem_results;
         results.truncate(limit);
+        // Append top-K pages after the memory limit. K = configured pool
+        // size (already capped upstream by page_channel_limit()).
+        results.extend(page_results);
         Ok(results)
     }
 

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7364,12 +7364,23 @@ impl MemoryDB {
         Ok(results)
     }
 
-    /// Max pages fetched per query in the page-channel.
-    /// Hardcoded (no tuning struct change) per design philosophy — surgical scope.
-    /// Override at runtime via env: `ORIGIN_DISABLE_PAGE_CHANNEL=1` skips the
-    /// page-channel entirely (used by bar-setting baseline tests to avoid
+    /// Default page-channel pool size. Phase 2 eval at LIMIT=10 showed
+    /// regression (LoCoMo -0.71pt NDCG@10, LME -1.92pt NDCG@10) caused by
+    /// page rows displacing specific-event memory hits in CE rerank. Reduced
+    /// to 3 for the iteration cycle. Override at runtime with
+    /// `ORIGIN_PAGE_CHANNEL_LIMIT=<N>`. `ORIGIN_DISABLE_PAGE_CHANNEL=1` skips
+    /// the channel entirely (used by bar-setting baseline tests to avoid
     /// overwriting pre-PR-B headline numbers — see comparable_hash follow-up).
-    const PAGE_CHANNEL_LIMIT: usize = 10;
+    const PAGE_CHANNEL_LIMIT_DEFAULT: usize = 3;
+
+    /// Resolve the page-channel pool size at call time. Env override lets
+    /// the eval harness sweep tuning values without recompile.
+    fn page_channel_limit() -> usize {
+        std::env::var("ORIGIN_PAGE_CHANNEL_LIMIT")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(Self::PAGE_CHANNEL_LIMIT_DEFAULT)
+    }
 
     /// Hybrid search with reranker-trait reranking.
     ///
@@ -7426,7 +7437,7 @@ impl MemoryDB {
         } else {
             // Log-and-degrade on page-channel failure (mirrors augment_with_graph's
             // silent fallback pattern at db.rs:7605-7608).
-            self.search_pages(query, Self::PAGE_CHANNEL_LIMIT, None)
+            self.search_pages(query, Self::page_channel_limit(), None)
                 .await
                 .unwrap_or_default()
         };

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -407,6 +407,25 @@ pub fn compute_rerank_fetch_pool(
     limit.saturating_mul(multiplier).max(floor).max(limit)
 }
 
+/// True iff `ORIGIN_DISABLE_PAGE_CHANNEL` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive).
+///
+/// Used by [`MemoryDB::search_memory_with_reranker`] to skip the page-channel
+/// branch and by the eval harness (locomo + longmemeval) to tag baseline
+/// JSON artifacts with their page-ON/OFF variant. All five call sites MUST
+/// share this helper so a `ORIGIN_DISABLE_PAGE_CHANNEL=0` setting can't
+/// disagree between production and eval (which would make baseline filenames
+/// lie about their contents — see AGENTS.md Eval Citation Discipline).
+///
+/// Truthy-only parse (not `is_ok()`): callers can clear the channel by
+/// setting the var to `0` or `false` without `unsetenv`.
+pub fn page_channel_disabled() -> bool {
+    std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 /// Bigram Jaccard similarity between two strings (0.0–1.0).
 /// Used for content-based deduplication in search results.
 fn bigram_jaccard(a: &str, b: &str) -> f64 {
@@ -7417,7 +7436,7 @@ impl MemoryDB {
             std::env::var("RERANK_POOL_MULTIPLIER").ok().as_deref(),
             std::env::var("RERANK_POOL_FLOOR").ok().as_deref(),
         );
-        let page_channel_disabled = std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok();
+        let page_channel_disabled = page_channel_disabled();
 
         let memory_results = self
             .search_memory(
@@ -7437,9 +7456,58 @@ impl MemoryDB {
         } else {
             // Log-and-degrade on page-channel failure (mirrors augment_with_graph's
             // silent fallback pattern at db.rs:7605-7608).
-            self.search_pages(query, Self::page_channel_limit(), None)
+            match self
+                .search_pages(query, Self::page_channel_limit(), None)
                 .await
-                .unwrap_or_default()
+            {
+                Ok(pages) => pages,
+                Err(e) => {
+                    log::warn!("[memory_db] page channel degraded: {e}; continuing memory-only");
+                    Vec::new()
+                }
+            }
+        };
+
+        // Space/filter passthrough guard (BEFORE RRF entry — post-merge filtering
+        // would corrupt ranking because the page would have already contributed
+        // RRF mass to a memory before being removed; "ghost signal" problem).
+        //
+        // `search_pages` doesn't natively honor `memory_type`/`space`/`source_agent`
+        // filters because pages don't carry those fields (pages store category in
+        // their own `space` column, used for `page_type` filtering). Instead we
+        // gate pages by `page_sources` overlap with the memory result set: a page
+        // surfaces iff ≥1 of its source memories survived the memory-side filter.
+        //
+        // Without this gate, a `space="work"`-scoped recall could leak pages from
+        // `space="personal"` whose only sources are personal memories — cross-
+        // workspace information disclosure (HIGH per 2026-05-28 adversarial review).
+        let filters_active = memory_type.is_some() || space.is_some() || source_agent.is_some();
+        let page_results: Vec<Page> = if filters_active && !page_results.is_empty() {
+            let allowed_memory_ids: std::collections::HashSet<String> =
+                memory_results.iter().map(|r| r.source_id.clone()).collect();
+            let mut filtered = Vec::with_capacity(page_results.len());
+            for page in page_results {
+                let sources = match self.get_page_sources(&page.id).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        log::warn!(
+                            "[memory_db] page_sources lookup failed for {}: {e}; \
+                             dropping page from filtered set",
+                            page.id
+                        );
+                        continue;
+                    }
+                };
+                if sources
+                    .iter()
+                    .any(|s| allowed_memory_ids.contains(&s.memory_source_id))
+                {
+                    filtered.push(page);
+                }
+            }
+            filtered
+        } else {
+            page_results
         };
 
         // Two-stage RRF merge — mirrors augment_with_graph (db.rs:7619-7644).
@@ -31829,5 +31897,78 @@ pub(crate) mod tests {
             "ORIGIN_DISABLE_PAGE_CHANNEL=1: expected zero source=page hits, got {:?}",
             hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
         );
+    }
+
+    /// Regression guard for the truthy-parse fix (2026-05-28 adversarial
+    /// review). The pre-fix `is_ok()` check disabled the channel on ANY
+    /// non-empty value, including `0`. After the fix, `0` (falsy) MUST
+    /// keep the channel enabled — same shape as default-on.
+    #[tokio::test]
+    async fn page_channel_disabled_treats_zero_as_enabled() {
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        db.insert_page(
+            "page_truthy_zero",
+            "truthy zero title",
+            Some("truthy zero summary"),
+            "truthy zero body content",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let hits = temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("0"))], async {
+            db.search_memory_with_reranker("truthy zero", 10, None, None, None, None)
+                .await
+                .unwrap()
+        })
+        .await;
+        assert!(
+            hits.iter().any(|r| r.source == "page"),
+            "ORIGIN_DISABLE_PAGE_CHANNEL=0 must be a no-op (channel stays on), \
+             but got zero source=page hits: {:?}",
+            hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
+        );
+    }
+
+    /// Truthy-parse coverage for synonyms: `true` and `YES` should both
+    /// disable the channel, matching the documented contract on
+    /// `page_channel_disabled()`.
+    #[tokio::test]
+    async fn page_channel_disabled_accepts_truthy_synonyms() {
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        db.insert_page(
+            "page_truthy_syn",
+            "truthy syn title",
+            Some("truthy syn summary"),
+            "truthy syn body content",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        for value in ["true", "YES", "True"] {
+            let hits =
+                temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some(value))], async {
+                    db.search_memory_with_reranker("truthy syn", 10, None, None, None, None)
+                        .await
+                        .unwrap()
+                })
+                .await;
+            assert!(
+                hits.iter().all(|r| r.source != "page"),
+                "ORIGIN_DISABLE_PAGE_CHANNEL={value}: expected zero page hits, got {:?}",
+                hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
+            );
+        }
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -16563,7 +16563,7 @@ impl MemoryDB {
         let mut vector_results: Vec<(String, f64, Page)> = Vec::new();
         let vec_sql = format!(
             "SELECT {}, vector_distance_cos(c.embedding, vector32(?1)) AS dist \
-             FROM vector_top_k('idx_concepts_embedding', vector32(?1), ?2) AS vt \
+             FROM vector_top_k('idx_pages_embedding', vector32(?1), ?2) AS vt \
              JOIN pages c ON c.rowid = vt.id \
              WHERE c.status = 'active'{type_clause}",
             concept_select,
@@ -25505,6 +25505,41 @@ pub(crate) mod tests {
         assert!(
             !all_results.is_empty(),
             "expected at least 1 page without filter"
+        );
+    }
+
+    // Regression test: search_pages must use idx_pages_embedding (migration 46
+    // renamed the index from idx_concepts_embedding). Without the fix the
+    // vector_top_k call errors silently and falls through to FTS-only; the
+    // query below has zero keyword overlap with the page so only the vector
+    // channel can produce a hit.
+    #[tokio::test]
+    async fn search_pages_uses_idx_pages_embedding_not_concepts() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_rrf_t1",
+            "Origin daemon retrieval",
+            Some("The daemon exposes hybrid memory search over HTTP"),
+            "Origin daemon serves hybrid search combining vector similarity and full-text ranking.",
+            None,
+            Some("architecture"),
+            &["m1"],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        // Query uses semantically related but lexically disjoint terms so FTS
+        // cannot rescue a vector failure.
+        let hits = db
+            .search_pages("server-side retrieval pipeline", 5, None)
+            .await
+            .unwrap();
+        assert!(
+            !hits.is_empty(),
+            "expected non-empty hits with correct vector index; \
+             empty result indicates vector path failed (idx_concepts_embedding stale reference)"
         );
     }
 

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7364,6 +7364,13 @@ impl MemoryDB {
         Ok(results)
     }
 
+    /// Max pages fetched per query in the page-channel.
+    /// Hardcoded (no tuning struct change) per design philosophy — surgical scope.
+    /// Override at runtime via env: `ORIGIN_DISABLE_PAGE_CHANNEL=1` skips the
+    /// page-channel entirely (used by bar-setting baseline tests to avoid
+    /// overwriting pre-PR-B headline numbers — see comparable_hash follow-up).
+    const PAGE_CHANNEL_LIMIT: usize = 10;
+
     /// Hybrid search with reranker-trait reranking.
     ///
     /// Equivalent to `search_memory_reranked` but takes a [`Reranker`] trait
@@ -7377,6 +7384,12 @@ impl MemoryDB {
     /// The reranker trait method is sync (fastembed is CPU work). This wrapper
     /// dispatches it via `tokio::task::spawn_blocking` so the tokio runtime
     /// stays free.
+    ///
+    /// Page-channel: pages are injected as a 4th RRF stream between the memory
+    /// pool and the CE rerank step. Memory `r.score` seeds the merged score_map;
+    /// page rows contribute only `1/(60+rank)` RRF mass on top (mirrors
+    /// `augment_with_graph` at db.rs:7619-7644). Disable with
+    /// `ORIGIN_DISABLE_PAGE_CHANNEL=1`.
     pub async fn search_memory_with_reranker(
         &self,
         query: &str,
@@ -7393,7 +7406,9 @@ impl MemoryDB {
             std::env::var("RERANK_POOL_MULTIPLIER").ok().as_deref(),
             std::env::var("RERANK_POOL_FLOOR").ok().as_deref(),
         );
-        let mut results = self
+        let page_channel_disabled = std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok();
+
+        let memory_results = self
             .search_memory(
                 query,
                 fetch_pool,
@@ -7406,6 +7421,51 @@ impl MemoryDB {
             )
             .await?;
 
+        let page_results: Vec<Page> = if page_channel_disabled {
+            Vec::new()
+        } else {
+            // Log-and-degrade on page-channel failure (mirrors augment_with_graph's
+            // silent fallback pattern at db.rs:7605-7608).
+            self.search_pages(query, Self::PAGE_CHANNEL_LIMIT, None)
+                .await
+                .unwrap_or_default()
+        };
+
+        // Two-stage RRF merge — mirrors augment_with_graph (db.rs:7619-7644).
+        // Memory r.score SEEDS the merged score_map; page rows contribute only
+        // 1/(60+rank) RRF mass on top. `search_result_from_page` zeros page
+        // score so this addition doesn't double-add at incompatible scales.
+        let mut score_map: HashMap<String, f32> = memory_results
+            .iter()
+            .map(|r| (r.id.clone(), r.score))
+            .collect();
+        let mut result_map: HashMap<String, SearchResult> = memory_results
+            .into_iter()
+            .map(|r| (r.id.clone(), r))
+            .collect();
+
+        for (rank, page) in page_results.into_iter().enumerate() {
+            let rrf_score = 1.0 / (60.0 + rank as f32);
+            let r = Self::search_result_from_page(page);
+            *score_map.entry(r.id.clone()).or_default() += rrf_score;
+            result_map.entry(r.id.clone()).or_insert(r);
+        }
+
+        let mut results: Vec<SearchResult> = result_map
+            .into_values()
+            .map(|mut r| {
+                r.score = *score_map.get(&r.id).unwrap_or(&0.0);
+                r
+            })
+            .collect();
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.source_id.cmp(&b.source_id))
+        });
+
+        // CE rerank — unchanged from prior body, now operates on the merged pool.
         if let Some(reranker) = reranker {
             if results.len() > 1 {
                 let candidates: Vec<(String, String)> = results
@@ -7435,8 +7495,7 @@ impl MemoryDB {
                 };
 
                 if !scored.is_empty() {
-                    let score_map: std::collections::HashMap<String, f32> =
-                        scored.into_iter().collect();
+                    let score_map: HashMap<String, f32> = scored.into_iter().collect();
                     for r in &mut results {
                         if let Some(&s) = score_map.get(&r.id) {
                             r.score = s;
@@ -8078,8 +8137,7 @@ impl MemoryDB {
     /// timestamp silently demotes the page to maximum decay. Current consumer
     /// (PR-B Task 3 two-stage RRF merge) does not route page rows through recency,
     /// so this is documented as an invariant rather than enforced at the type level.
-    // consumed by search_memory_with_reranker in PR-B Task 3
-    #[allow(dead_code)]
+    // consumed by search_memory_with_reranker (page-channel RRF, PR-B Task 3)
     fn search_result_from_page(page: Page) -> SearchResult {
         let last_modified = chrono::DateTime::parse_from_rfc3339(&page.last_modified)
             .map(|dt| dt.timestamp())
@@ -31670,6 +31728,73 @@ pub(crate) mod tests {
             r.space.as_deref(),
             Some("work"),
             "space should pass through"
+        );
+    }
+
+    // ── page-channel RRF integration tests ───────────────────────────────────
+
+    #[tokio::test]
+    async fn search_with_reranker_includes_pages_by_default() {
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        // Seed a page — insert_page generates a real embedding so search_pages can find it.
+        db.insert_page(
+            "page_t1",
+            "Pages topic title about retrieval",
+            Some("pages topic summary about retrieval"),
+            "pages topic body about retrieval systems",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let hits =
+            temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", None::<&str>)], async {
+                db.search_memory_with_reranker("pages topic retrieval", 10, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert!(
+            hits.iter().any(|r| r.source == "page"),
+            "page-channel default-ON: expected at least one source=page hit, got {} results sources={:?}",
+            hits.len(),
+            hits.iter().map(|r| &r.source).collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn search_with_reranker_excludes_pages_when_env_disables() {
+        let (db, _tmp) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        db.insert_page(
+            "page_t2",
+            "Pages disabled title",
+            Some("pages disabled summary"),
+            "pages disabled body content",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let hits = temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("1"))], async {
+            db.search_memory_with_reranker("pages disabled", 10, None, None, None, None)
+                .await
+                .unwrap()
+        })
+        .await;
+        assert!(
+            hits.iter().all(|r| r.source != "page"),
+            "ORIGIN_DISABLE_PAGE_CHANNEL=1: expected zero source=page hits, got {:?}",
+            hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
         );
     }
 }

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -407,20 +407,21 @@ pub fn compute_rerank_fetch_pool(
     limit.saturating_mul(multiplier).max(floor).max(limit)
 }
 
-/// True iff `ORIGIN_DISABLE_PAGE_CHANNEL` is set to a truthy value
-/// (`1`, `true`, or `yes`, case-insensitive).
+/// True iff `ORIGIN_ENABLE_PAGE_CHANNEL` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive). The page-channel is OPT-IN:
+/// unset or a falsey value (`0`/`false`/`no`/"") leaves it disabled.
 ///
-/// Used by [`MemoryDB::search_memory_with_reranker`] to skip the page-channel
+/// Used by [`MemoryDB::search_memory_with_reranker`] to gate the page-channel
 /// branch and by the eval harness (locomo + longmemeval) to tag baseline
 /// JSON artifacts with their page-ON/OFF variant. All five call sites MUST
-/// share this helper so a `ORIGIN_DISABLE_PAGE_CHANNEL=0` setting can't
+/// share this helper so an `ORIGIN_ENABLE_PAGE_CHANNEL` setting can't
 /// disagree between production and eval (which would make baseline filenames
 /// lie about their contents — see AGENTS.md Eval Citation Discipline).
 ///
-/// Truthy-only parse (not `is_ok()`): callers can clear the channel by
-/// setting the var to `0` or `false` without `unsetenv`.
-pub fn page_channel_disabled() -> bool {
-    std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL")
+/// Truthy-only parse (not `is_ok()`): operators enable the channel by setting
+/// the var to a truthy value; any other value or unset = disabled.
+pub fn page_channel_enabled() -> bool {
+    std::env::var("ORIGIN_ENABLE_PAGE_CHANNEL")
         .ok()
         .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
         .unwrap_or(false)
@@ -7387,9 +7388,9 @@ impl MemoryDB {
     /// regression (LoCoMo -0.71pt NDCG@10, LME -1.92pt NDCG@10) caused by
     /// page rows displacing specific-event memory hits in CE rerank. Reduced
     /// to 3 for the iteration cycle. Override at runtime with
-    /// `ORIGIN_PAGE_CHANNEL_LIMIT=<N>`. `ORIGIN_DISABLE_PAGE_CHANNEL=1` skips
-    /// the channel entirely (used by bar-setting baseline tests to avoid
-    /// overwriting pre-PR-B headline numbers — see comparable_hash follow-up).
+    /// `ORIGIN_PAGE_CHANNEL_LIMIT=<N>`. The channel is opt-in; set
+    /// `ORIGIN_ENABLE_PAGE_CHANNEL=1` to enable (used by page-channel eval
+    /// tests — see comparable_hash follow-up).
     const PAGE_CHANNEL_LIMIT_DEFAULT: usize = 3;
 
     /// Resolve the page-channel pool size at call time. Env override lets
@@ -7418,8 +7419,8 @@ impl MemoryDB {
     /// Page-channel: pages are injected as a 4th RRF stream between the memory
     /// pool and the CE rerank step. Memory `r.score` seeds the merged score_map;
     /// page rows contribute only `1/(60+rank)` RRF mass on top (mirrors
-    /// `augment_with_graph` at db.rs:7619-7644). Disable with
-    /// `ORIGIN_DISABLE_PAGE_CHANNEL=1`.
+    /// `augment_with_graph` at db.rs:7619-7644). Enable with
+    /// `ORIGIN_ENABLE_PAGE_CHANNEL=1` (opt-in, default OFF).
     pub async fn search_memory_with_reranker(
         &self,
         query: &str,
@@ -7436,7 +7437,7 @@ impl MemoryDB {
             std::env::var("RERANK_POOL_MULTIPLIER").ok().as_deref(),
             std::env::var("RERANK_POOL_FLOOR").ok().as_deref(),
         );
-        let page_channel_disabled = page_channel_disabled();
+        let page_channel_enabled = page_channel_enabled();
 
         let memory_results = self
             .search_memory(
@@ -7451,9 +7452,7 @@ impl MemoryDB {
             )
             .await?;
 
-        let page_results: Vec<Page> = if page_channel_disabled {
-            Vec::new()
-        } else {
+        let page_results: Vec<Page> = if page_channel_enabled {
             // Log-and-degrade on page-channel failure (mirrors augment_with_graph's
             // silent fallback pattern at db.rs:7605-7608).
             match self
@@ -7466,6 +7465,8 @@ impl MemoryDB {
                     Vec::new()
                 }
             }
+        } else {
+            Vec::new()
         };
 
         // Space/filter passthrough guard (BEFORE RRF entry — post-merge filtering
@@ -31832,10 +31833,10 @@ pub(crate) mod tests {
         );
     }
 
-    // ── page-channel RRF integration tests ───────────────────────────────────
+    // ── page-channel RRF integration tests ────────────────────────────────────
 
     #[tokio::test]
-    async fn search_with_reranker_includes_pages_by_default() {
+    async fn search_with_reranker_includes_pages_when_env_enables() {
         let (db, _tmp) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
 
@@ -31853,23 +31854,22 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        let hits =
-            temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", None::<&str>)], async {
-                db.search_memory_with_reranker("pages topic retrieval", 10, None, None, None, None)
-                    .await
-                    .unwrap()
-            })
-            .await;
+        let hits = temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", Some("1"))], async {
+            db.search_memory_with_reranker("pages topic retrieval", 10, None, None, None, None)
+                .await
+                .unwrap()
+        })
+        .await;
         assert!(
             hits.iter().any(|r| r.source == "page"),
-            "page-channel default-ON: expected at least one source=page hit, got {} results sources={:?}",
+            "ORIGIN_ENABLE_PAGE_CHANNEL=1: expected at least one source=page hit, got {} results sources={:?}",
             hits.len(),
             hits.iter().map(|r| &r.source).collect::<Vec<_>>()
         );
     }
 
     #[tokio::test]
-    async fn search_with_reranker_excludes_pages_when_env_disables() {
+    async fn search_with_reranker_excludes_pages_by_default() {
         let (db, _tmp) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
 
@@ -31886,25 +31886,24 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        let hits = temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("1"))], async {
-            db.search_memory_with_reranker("pages disabled", 10, None, None, None, None)
-                .await
-                .unwrap()
-        })
-        .await;
+        let hits =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", None::<&str>)], async {
+                db.search_memory_with_reranker("pages disabled", 10, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
         assert!(
             hits.iter().all(|r| r.source != "page"),
-            "ORIGIN_DISABLE_PAGE_CHANNEL=1: expected zero source=page hits, got {:?}",
+            "page-channel default-OFF: expected zero source=page hits, got {:?}",
             hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
         );
     }
 
-    /// Regression guard for the truthy-parse fix (2026-05-28 adversarial
-    /// review). The pre-fix `is_ok()` check disabled the channel on ANY
-    /// non-empty value, including `0`. After the fix, `0` (falsy) MUST
-    /// keep the channel enabled — same shape as default-on.
+    /// Regression guard: `0` and unset are both falsy for the opt-in var,
+    /// so the channel stays disabled in either case.
     #[tokio::test]
-    async fn page_channel_disabled_treats_zero_as_enabled() {
+    async fn page_channel_enabled_treats_zero_and_unset_as_disabled() {
         let (db, _tmp) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
 
@@ -31921,25 +31920,24 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        let hits = temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("0"))], async {
+        let hits = temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", Some("0"))], async {
             db.search_memory_with_reranker("truthy zero", 10, None, None, None, None)
                 .await
                 .unwrap()
         })
         .await;
         assert!(
-            hits.iter().any(|r| r.source == "page"),
-            "ORIGIN_DISABLE_PAGE_CHANNEL=0 must be a no-op (channel stays on), \
-             but got zero source=page hits: {:?}",
+            hits.iter().all(|r| r.source != "page"),
+            "ORIGIN_ENABLE_PAGE_CHANNEL=0 must keep channel disabled,              but got page hits: {:?}",
             hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
         );
     }
 
-    /// Truthy-parse coverage for synonyms: `true` and `YES` should both
-    /// disable the channel, matching the documented contract on
-    /// `page_channel_disabled()`.
+    /// Truthy-parse coverage for synonyms: `true`, `YES`, and `True` should all
+    /// enable the channel, matching the documented contract on
+    /// `page_channel_enabled()`.
     #[tokio::test]
-    async fn page_channel_disabled_accepts_truthy_synonyms() {
+    async fn page_channel_enabled_accepts_truthy_synonyms() {
         let (db, _tmp) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
 
@@ -31958,15 +31956,15 @@ pub(crate) mod tests {
 
         for value in ["true", "YES", "True"] {
             let hits =
-                temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some(value))], async {
+                temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", Some(value))], async {
                     db.search_memory_with_reranker("truthy syn", 10, None, None, None, None)
                         .await
                         .unwrap()
                 })
                 .await;
             assert!(
-                hits.iter().all(|r| r.source != "page"),
-                "ORIGIN_DISABLE_PAGE_CHANNEL={value}: expected zero page hits, got {:?}",
+                hits.iter().any(|r| r.source == "page"),
+                "ORIGIN_ENABLE_PAGE_CHANNEL={value}: expected page hits, got {:?}",
                 hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
             );
         }

--- a/crates/origin-core/src/eval/AGENTS.md
+++ b/crates/origin-core/src/eval/AGENTS.md
@@ -1,0 +1,150 @@
+# crates/origin-core/src/eval — Rust runner conventions
+
+Applies to agents working under `crates/origin-core/src/eval/`. Read alongside root `AGENTS.md` and `app/eval/AGENTS.md` for fixture + artifact context.
+
+---
+
+## runner shapes
+
+Two runner families exist. Choose based on what question you are answering.
+
+### Ephemeral-per-conversation runners
+
+Create a `tempdir` + `MemoryDB::new` + upsert observations per conversation. Each conversation gets a fresh isolated DB. No page distillation runs because pages are a background task that requires a full enrichment pipeline.
+
+Examples: `run_locomo_eval`, `run_locomo_eval_cross_rerank`, `run_locomo_eval_expanded`, and their LME equivalents.
+
+Use when: measuring the published baseline bar, or any retrieval-only benchmark where pages should not be a factor.
+
+### From-cached-DB runners (PR-B)
+
+Accept a pre-seeded `&MemoryDB` for a consolidated scenario DB that already contains memories, KG entities, and distilled pages. Skips ingest entirely. The DB was seeded once via the fullpipeline harness.
+
+Examples: `run_locomo_eval_cross_rerank_from_db`, `run_longmemeval_eval_cross_rerank_from_db`.
+
+Use when: measuring page-channel impact, or any question that requires pages to already exist in the DB.
+
+Tradeoff: consolidated DB introduces cross-conversation noise because all conversations share one DB. Results are comparable to the OFF variant of the same runner, not to the ephemeral-per-conversation bar.
+
+---
+
+## source_id conventions
+
+Source IDs must match exactly between the seeder and the evaluator. A mismatch produces silent zero NDCG with no error.
+
+### LoCoMo
+
+```rust
+source_id: format!("locomo_{}_obs_{}", sample.sample_id, i)
+```
+
+Used in: ephemeral runner seed paths and the fullpipeline harness. The `run_locomo_eval_cross_rerank_from_db` runner re-derives this mapping from the fixture file, so the cached DB must have been seeded with the same format.
+
+### LongMemEval
+
+```rust
+// Use the helper, not a hand-rolled format!:
+memory_source_id(question_id, session_idx, turn_idx)
+// defined at longmemeval.rs:165-167
+```
+
+The helper exists precisely so the format is defined once. Do not inline an equivalent `format!` call elsewhere.
+
+---
+
+## build_*_env stamping
+
+`build_locomo_env` and `build_lme_env` produce a `ReportEnv` struct that stamps every baseline. Key fields:
+
+- `variant`: the `variant_tag` string. This is the load-bearing differentiator for the layered baseline path because `comparable_env_hash` does not yet include `flags` (pending Task #30).
+- `flags`: human-readable `Vec<String>` with `"key=value"` entries. Populated for audit but not yet wired into hashing. Always populate it.
+- `is_single_run`: always `true` for single-run tests. Any baseline with `is_single_run = true` must not be cited externally (see root AGENTS.md Eval Citation Discipline).
+
+### When adding a new A/B variant
+
+1. Branch `variant_tag` on the distinguishing env var. Pattern from `locomo.rs`:
+
+```rust
+let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+    "off"
+} else {
+    "on"
+};
+let variant_tag = if page_channel_state == "off" {
+    "cross_rerank_v2_no_pages"
+} else {
+    "cross_rerank_v2_pages"
+};
+```
+
+2. Push the state into `flags`:
+
+```rust
+env_stamp.flags.push(format!("page_channel={}", page_channel_state));
+env_stamp.flags.push("scenario_db=consolidated".to_string());
+```
+
+3. Mirror the filename suffix in `eval_harness.rs` (legacy path). The harness branches `__with_pages` vs `__no_pages` on `ORIGIN_DISABLE_PAGE_CHANNEL`.
+
+---
+
+## filename suffix on legacy path
+
+`eval_harness.rs` branches the `app/eval/baselines/` filename suffix on `ORIGIN_DISABLE_PAGE_CHANNEL`:
+
+```rust
+let suffix = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+    "__no_pages"
+} else {
+    "__with_pages"
+};
+```
+
+When adding a new A/B variant driven by a different env var, add an analogous suffix branch so page-ON and page-OFF artifacts don't overwrite each other at the legacy path.
+
+---
+
+## smoke vs full run sizing
+
+| `EVAL_*_LIMIT` | Time | Use case |
+|---|---|---|
+| `2` | ~1 min | Wiring smoke: verify the test reaches the eval loop and saves a baseline |
+| `20` | ~30 min | Subset eval: direction check for A/B comparison |
+| unset | ~30 min-3h | Full fixture: for results worth citing |
+
+Reranker first-run downloads ~600MB. Account for that on cold caches.
+
+---
+
+## pages_count sanity assertion (PR-B convention)
+
+When using a cached scenario DB, assert that pages exist BEFORE the eval loop. The PR-B runners do this:
+
+```rust
+let pages_count = db.count_active_pages().await.expect("count_active_pages failed");
+assert!(
+    pages_count > 0,
+    "cached scenario DB has 0 active pages at {} — run scripts/seed-scenario-dbs.sh ...",
+    db_dir.display()
+);
+```
+
+Without this assertion, a corrupt or empty page table silently produces page-OFF metrics stamped with the page-ON variant tag. The mislabeling would contaminate any external citation.
+
+---
+
+## ephemeral vs cached: decision table
+
+| Question | Runner shape | DB |
+|---|---|---|
+| What is the baseline NDCG for retrieval-only? | ephemeral-per-conv | tempdir |
+| Does page-channel improve NDCG? | from-cached-DB, run twice (ON/OFF) | scenario_seeded |
+| Does a new retrieval signal help? | ephemeral-per-conv (no pages needed) | tempdir |
+| Does distillation quality affect retrieval? | from-cached-DB (pages already distilled) | scenario_seeded |
+
+---
+
+## cross-reference
+
+- Fixture population, env vars, seed scripts, baseline layout: see `app/eval/AGENTS.md`.
+- Citation rules (single-run, schema-version, receipt-only): see root `AGENTS.md` "Eval Citation Discipline".

--- a/crates/origin-core/src/eval/AGENTS.md
+++ b/crates/origin-core/src/eval/AGENTS.md
@@ -116,20 +116,22 @@ Reranker first-run downloads ~600MB. Account for that on cold caches.
 
 ---
 
-## pages_count sanity assertion (PR-B convention)
+## pages_count sanity gate (PR-B convention)
 
-When using a cached scenario DB, assert that pages exist BEFORE the eval loop. The PR-B runners do this:
+When using a cached scenario DB, check that pages exist BEFORE the eval loop. The PR-B runners SKIP with a clear message when the table is empty:
 
 ```rust
 let pages_count = db.count_active_pages().await.expect("count_active_pages failed");
-assert!(
-    pages_count > 0,
-    "cached scenario DB has 0 active pages at {} - run scripts/seed-scenario-dbs.sh ...",
-    db_dir.display()
-);
+if pages_count == 0 {
+    println!(
+        "SKIP: cached scenario DB has 0 active pages at {}. Run scripts/seed-scenario-dbs.sh from the repo root then verify with cached_scenario_db_compat_check.",
+        db_dir.display()
+    );
+    return;
+}
 ```
 
-Without this assertion, a corrupt or empty page table silently produces page-OFF metrics stamped with the page-ON variant tag. The mislabeling would contaminate any external citation.
+SKIP semantics (rather than panic) match the surrounding fixture-missing branches so a contributor without seeded DBs gets actionable output instead of a thread panic. Without this gate, a corrupt or empty page table silently produces page-OFF metrics stamped with the page-ON variant tag. The mislabeling would contaminate any external citation.
 
 ---
 

--- a/crates/origin-core/src/eval/AGENTS.md
+++ b/crates/origin-core/src/eval/AGENTS.md
@@ -1,4 +1,4 @@
-# crates/origin-core/src/eval — Rust runner conventions
+# crates/origin-core/src/eval - Rust runner conventions
 
 Applies to agents working under `crates/origin-core/src/eval/`. Read alongside root `AGENTS.md` and `app/eval/AGENTS.md` for fixture + artifact context.
 
@@ -124,7 +124,7 @@ When using a cached scenario DB, assert that pages exist BEFORE the eval loop. T
 let pages_count = db.count_active_pages().await.expect("count_active_pages failed");
 assert!(
     pages_count > 0,
-    "cached scenario DB has 0 active pages at {} — run scripts/seed-scenario-dbs.sh ...",
+    "cached scenario DB has 0 active pages at {} - run scripts/seed-scenario-dbs.sh ...",
     db_dir.display()
 );
 ```

--- a/crates/origin-core/src/eval/AGENTS.md
+++ b/crates/origin-core/src/eval/AGENTS.md
@@ -65,15 +65,15 @@ The helper exists precisely so the format is defined once. Do not inline an equi
 1. Branch `variant_tag` on the distinguishing env var. Pattern from `locomo.rs`:
 
 ```rust
-let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
-    "off"
-} else {
+let page_channel_state = if crate::db::page_channel_enabled() {
     "on"
-};
-let variant_tag = if page_channel_state == "off" {
-    "cross_rerank_v2_no_pages"
 } else {
+    "off"
+};
+let variant_tag = if page_channel_state == "on" {
     "cross_rerank_v2_pages"
+} else {
+    "cross_rerank_v2_no_pages"
 };
 ```
 
@@ -84,19 +84,19 @@ env_stamp.flags.push(format!("page_channel={}", page_channel_state));
 env_stamp.flags.push("scenario_db=consolidated".to_string());
 ```
 
-3. Mirror the filename suffix in `eval_harness.rs` (legacy path). The harness branches `__with_pages` vs `__no_pages` on `ORIGIN_DISABLE_PAGE_CHANNEL`.
+3. Mirror the filename suffix in `eval_harness.rs` (legacy path). The harness branches `__with_pages` vs `__no_pages` on `ORIGIN_ENABLE_PAGE_CHANNEL` (opt-in, default OFF).
 
 ---
 
 ## filename suffix on legacy path
 
-`eval_harness.rs` branches the `app/eval/baselines/` filename suffix on `ORIGIN_DISABLE_PAGE_CHANNEL`:
+`eval_harness.rs` branches the `app/eval/baselines/` filename suffix on `ORIGIN_ENABLE_PAGE_CHANNEL`:
 
 ```rust
-let suffix = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
-    "__no_pages"
-} else {
+let suffix = if origin_core::db::page_channel_enabled() {
     "__with_pages"
+} else {
+    "__no_pages"
 };
 ```
 

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1157,7 +1157,7 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
 
     // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
     // produce distinct baseline filenames (comparable_hash uses the variant string).
-    let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+    let page_channel_state = if crate::db::page_channel_disabled() {
         "off"
     } else {
         "on"

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1029,6 +1029,156 @@ pub async fn run_locomo_eval_cross_rerank(
 }
 
 // ---------------------------------------------------------------------------
+// Cross-encoder rerank runner against a pre-seeded consolidated DB (PR-B)
+// ---------------------------------------------------------------------------
+
+/// Like `run_locomo_eval_cross_rerank`, but scores against a PRE-SEEDED
+/// consolidated scenario DB (no per-conversation ephemeral DB, no ingest).
+/// Used by PR-B's page-channel eval to surface distilled pages that the
+/// fullpipeline harness wrote into the cache.
+///
+/// `db` MUST already contain memories with `source_id` formatted as
+/// `locomo_<sample_id>_obs_<i>` (matches both the in-tree fullpipeline
+/// seed path and the ephemeral seed in `run_locomo_eval_cross_rerank`).
+/// Page-channel ON/OFF is controlled by the caller via the
+/// `ORIGIN_DISABLE_PAGE_CHANNEL` env var (read inside
+/// `search_memory_with_reranker`).
+pub async fn run_locomo_eval_cross_rerank_from_db(
+    db: &MemoryDB,
+    path: &Path,
+    reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
+) -> Result<LocomoReport, OriginError> {
+    let mut samples = load_locomo(path)?;
+    apply_locomo_limit(&mut samples);
+    let mut conversations = Vec::new();
+    // (category, ndcg_5, ndcg_10, mrr, recall_5, hit_rate_1)
+    let mut all_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_observations(sample);
+
+        // Re-derive the source_id mapping — matches the fullpipeline seed path.
+        let dia_to_source: HashMap<String, String> = memories
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                (
+                    m.dia_id.clone(),
+                    format!("locomo_{}_obs_{}", sample.sample_id, i),
+                )
+            })
+            .collect();
+
+        let mut conv_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
+
+        for qa in &sample.qa {
+            if qa.category == 5 {
+                continue;
+            }
+
+            let results = db
+                .search_memory_with_reranker(
+                    &qa.question,
+                    10,
+                    None,
+                    None,
+                    None,
+                    Some(reranker.clone()),
+                )
+                .await?;
+
+            let relevant_ids: HashSet<String> = qa
+                .evidence
+                .iter()
+                .filter_map(|did| dia_to_source.get(did).cloned())
+                .collect();
+
+            if relevant_ids.is_empty() {
+                continue;
+            }
+
+            let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+
+            let grades: HashMap<&str, u8> = result_ids
+                .iter()
+                .map(|id| (*id, if relevant_ids.contains(*id) { 1 } else { 0 }))
+                .collect();
+
+            let relevant_set: HashSet<&str> = relevant_ids.iter().map(|s| s.as_str()).collect();
+
+            let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+            let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+            let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+            let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+            let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+
+            conv_scores.push((qa.category, ndcg_5, ndcg_10, mrr_val, recall_5, hr_1));
+            all_scores.push((qa.category, ndcg_5, ndcg_10, mrr_val, recall_5, hr_1));
+            per_case.push(build_locomo_case_result(
+                &qa.question,
+                qa.category,
+                ndcg_5,
+                ndcg_10,
+                mrr_val,
+                recall_5,
+                hr_1,
+            ));
+        }
+
+        let per_cat = aggregate_by_category(&conv_scores);
+        let n = conv_scores.len();
+        conversations.push(LocomoConversationResult {
+            sample_id: sample.sample_id.clone(),
+            memories_seeded: memories.len(),
+            questions_evaluated: n,
+            overall_ndcg_at_10: avg_field(&conv_scores, |s| s.2),
+            overall_mrr: avg_field(&conv_scores, |s| s.3),
+            overall_recall_at_5: avg_field(&conv_scores, |s| s.4),
+            per_category: per_cat,
+        });
+    }
+
+    let per_cat_agg = aggregate_by_category(&all_scores);
+    let mut report = LocomoReport {
+        conversations,
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories: samples.iter().map(|s| extract_observations(s).len()).sum(),
+        per_category_aggregate: per_cat_agg,
+        qa_accuracy: None,
+        baseline: None,
+        env: None,
+        per_case,
+    };
+
+    // Stamp env.flags to record page_channel state (purely informational
+    // until comparable_hash includes flags — future task).
+    let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+        "off"
+    } else {
+        "on"
+    };
+    let mut env_stamp = build_locomo_env(
+        "cross_rerank_v2_pages",
+        path,
+        "search_memory_with_reranker",
+        "cross-encoder",
+        &format!("cross-encoder:{}", reranker.model_id()),
+        None,
+    );
+    env_stamp
+        .flags
+        .push(format!("page_channel={}", page_channel_state));
+    env_stamp.flags.push("scenario_db=consolidated".to_string());
+    report.env = Some(env_stamp);
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
 // Expanded benchmark runner -- same as run_locomo_eval but uses search_memory_expanded
 // ---------------------------------------------------------------------------
 

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1064,6 +1064,8 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
     // (category, ndcg_5, ndcg_10, mrr, recall_5, hit_rate_1)
     let mut all_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
     let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
+    let mut cov_blind_acc: Vec<f64> = Vec::new();
+    let mut cov_expanded_acc: Vec<f64> = Vec::new();
 
     for sample in &samples {
         let memories = extract_observations(sample);
@@ -1134,6 +1136,47 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
                 recall_5,
                 hr_1,
             ));
+
+            // Source-expanded coverage recall (page provenance, eval-only).
+            // Pages contribute the memory source ids they were distilled from;
+            // memories contribute their own id. Set-based + deduped so a gold
+            // id counts once (no double-count). Reads the full result bundle
+            // (memories in [0..limit] + appended pages) — pages ride after the
+            // limit by the iter2 partition.
+            let page_src_owned: Vec<(String, Vec<String>)> = {
+                let mut v = Vec::new();
+                for r in &results {
+                    if r.source == "page" {
+                        let srcs: Vec<String> = db
+                            .get_page_sources(&r.source_id)
+                            .await
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|ps| ps.memory_source_id)
+                            .collect();
+                        v.push((r.source_id.clone(), srcs));
+                    }
+                }
+                v
+            };
+            let page_sources_map: HashMap<&str, Vec<&str>> = page_src_owned
+                .iter()
+                .map(|(pid, srcs)| (pid.as_str(), srcs.iter().map(|s| s.as_str()).collect()))
+                .collect();
+            let units: Vec<(&str, &str)> = results
+                .iter()
+                .map(|r| (r.source.as_str(), r.source_id.as_str()))
+                .collect();
+            let cov_blind = metrics::coverage_recall(
+                &metrics::build_coverage_set(&units, &HashMap::new()),
+                &relevant_set,
+            );
+            let cov_expanded = metrics::coverage_recall(
+                &metrics::build_coverage_set(&units, &page_sources_map),
+                &relevant_set,
+            );
+            cov_blind_acc.push(cov_blind);
+            cov_expanded_acc.push(cov_expanded);
         }
 
         let per_cat = aggregate_by_category(&conv_scores);
@@ -1150,6 +1193,14 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
     }
 
     let per_cat_agg = aggregate_by_category(&all_scores);
+    let coverage = if cov_blind_acc.is_empty() {
+        None
+    } else {
+        Some(crate::eval::report::CoverageRecall {
+            blind: cov_blind_acc.iter().sum::<f64>() / cov_blind_acc.len() as f64,
+            expanded: cov_expanded_acc.iter().sum::<f64>() / cov_expanded_acc.len() as f64,
+        })
+    };
     let mut report = LocomoReport {
         conversations,
         aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
@@ -1163,7 +1214,7 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
         baseline: None,
         env: None,
         per_case,
-        coverage: None,
+        coverage,
     };
 
     // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -361,6 +361,15 @@ impl LocomoReport {
             self.aggregate_hit_rate_at_1
         ));
 
+        if let Some(ref cov) = self.coverage {
+            out.push_str(&format!(
+                "  Coverage recall (set-based, page-source-expanded):\n    blind:    {:.4}\n    expanded: {:.4}\n    delta:    {:+.4}  <- page contribution\n",
+                cov.blind,
+                cov.expanded,
+                cov.expanded - cov.blind
+            ));
+        }
+
         if let Some(ref b) = self.baseline {
             out.push_str("\nBaseline comparison:\n");
             let delta = |name: &str, old: f64, new: f64| -> String {
@@ -2148,5 +2157,37 @@ mod tests {
         let mut samples = mock_samples(5);
         apply_limit_from_env(&mut samples, var, "locomo", "conversations");
         assert_eq!(samples.len(), 5, "unset env var must leave samples intact");
+    }
+
+    #[test]
+    fn to_terminal_prints_coverage_delta_when_present() {
+        let mut report = LocomoReport {
+            conversations: vec![],
+            aggregate_ndcg_at_10: 0.0,
+            aggregate_mrr: 0.0,
+            aggregate_recall_at_5: 0.0,
+            aggregate_hit_rate_at_1: 0.0,
+            total_questions: 0,
+            total_memories: 0,
+            per_category_aggregate: vec![],
+            qa_accuracy: None,
+            baseline: None,
+            env: None,
+            per_case: vec![],
+            coverage: Some(crate::eval::report::CoverageRecall {
+                blind: 0.40,
+                expanded: 0.55,
+            }),
+        };
+        let out = report.to_terminal();
+        assert!(
+            out.contains("Coverage recall"),
+            "missing coverage header:\n{out}"
+        );
+        assert!(out.contains("0.4000"), "missing blind:\n{out}");
+        assert!(out.contains("0.5500"), "missing expanded:\n{out}");
+        assert!(out.contains("+0.1500"), "missing delta:\n{out}");
+        report.coverage = None;
+        assert!(!report.to_terminal().contains("Coverage recall"));
     }
 }

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1060,7 +1060,7 @@ pub async fn run_locomo_eval_cross_rerank(
 /// `locomo_<sample_id>_obs_<i>` (matches both the in-tree fullpipeline
 /// seed path and the ephemeral seed in `run_locomo_eval_cross_rerank`).
 /// Page-channel ON/OFF is controlled by the caller via the
-/// `ORIGIN_DISABLE_PAGE_CHANNEL` env var (read inside
+/// `ORIGIN_ENABLE_PAGE_CHANNEL` env var (read inside
 /// `search_memory_with_reranker`).
 pub async fn run_locomo_eval_cross_rerank_from_db(
     db: &MemoryDB,
@@ -1226,12 +1226,12 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
         coverage,
     };
 
-    // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
+    // Branch variant_tag on ORIGIN_ENABLE_PAGE_CHANNEL so page-ON and page-OFF
     // produce distinct baseline filenames (comparable_hash uses the variant string).
-    let page_channel_state = if crate::db::page_channel_disabled() {
-        "off"
-    } else {
+    let page_channel_state = if crate::db::page_channel_enabled() {
         "on"
+    } else {
+        "off"
     };
     let variant_tag = if page_channel_state == "off" {
         "cross_rerank_v2_no_pages"

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -278,6 +278,8 @@ pub struct LocomoBaseline {
     pub recall_at_5: f64,
     pub hit_rate_at_1: f64,
     pub per_category: Vec<crate::eval::report::CategoryBaseline>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<crate::eval::report::CoverageRecall>,
 }
 
 /// Per-category results
@@ -329,6 +331,10 @@ pub struct LocomoReport {
     /// Populated by each runner variant; empty by default for back-compat.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub per_case: Vec<crate::eval::report::CaseResult>,
+    /// Source-expanded coverage recall (page-channel `_from_db` runner only;
+    /// None elsewhere). See [`crate::eval::report::CoverageRecall`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<crate::eval::report::CoverageRecall>,
 }
 
 impl LocomoReport {
@@ -438,6 +444,7 @@ impl LocomoReport {
             recall_at_5: self.aggregate_recall_at_5,
             hit_rate_at_1: self.aggregate_hit_rate_at_1,
             per_category,
+            coverage: self.coverage.clone(),
         };
         let json = serde_json::to_string_pretty(&baseline).map_err(std::io::Error::other)?;
         std::fs::write(path, json)
@@ -716,6 +723,7 @@ pub async fn run_locomo_eval(path: &Path) -> Result<LocomoReport, OriginError> {
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_locomo_env(
         "base",
@@ -863,6 +871,7 @@ pub async fn run_locomo_eval_reranked(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_locomo_env(
         "reranked",
@@ -1016,6 +1025,7 @@ pub async fn run_locomo_eval_cross_rerank(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_locomo_env(
         "cross_rerank",
@@ -1153,6 +1163,7 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
 
     // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
@@ -1318,6 +1329,7 @@ pub async fn run_locomo_eval_expanded(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_locomo_env(
         "expanded",
@@ -1640,6 +1652,7 @@ pub async fn run_locomo_eval_with_gate(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_locomo_env(
         "gated",
@@ -1943,6 +1956,7 @@ mod tests {
             baseline: None,
             env: None,
             per_case: vec![],
+            coverage: None,
         };
 
         report.save_baseline(&path).unwrap();
@@ -1976,6 +1990,7 @@ mod tests {
             baseline: None,
             env: None,
             per_case: vec![],
+            coverage: None,
         };
         report.env = Some(crate::eval::report::ReportEnv {
             fixture_revision: "deadbeef".into(),
@@ -2028,9 +2043,11 @@ mod tests {
                     mrr: 0.410,
                     recall_at_5: 0.380,
                 }],
+                coverage: None,
             }),
             env: None,
             per_case: vec![],
+            coverage: None,
         };
 
         let text = report.to_terminal();

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1155,15 +1155,20 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
         per_case,
     };
 
-    // Stamp env.flags to record page_channel state (purely informational
-    // until comparable_hash includes flags — future task).
+    // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
+    // produce distinct baseline filenames (comparable_hash uses the variant string).
     let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
         "off"
     } else {
         "on"
     };
+    let variant_tag = if page_channel_state == "off" {
+        "cross_rerank_v2_no_pages"
+    } else {
+        "cross_rerank_v2_pages"
+    };
     let mut env_stamp = build_locomo_env(
-        "cross_rerank_v2_pages",
+        variant_tag,
         path,
         "search_memory_with_reranker",
         "cross-encoder",

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1085,15 +1085,20 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
         per_case,
     };
 
-    // Stamp env.flags to record page_channel state (purely informational
-    // until comparable_hash includes flags — future task).
+    // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
+    // produce distinct baseline filenames (comparable_hash uses the variant string).
     let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
         "off"
     } else {
         "on"
     };
+    let variant_tag = if page_channel_state == "off" {
+        "cross_rerank_v2_no_pages"
+    } else {
+        "cross_rerank_v2_pages"
+    };
     let mut env_stamp = build_lme_env(
-        "cross_rerank_v2_pages",
+        variant_tag,
         path,
         "search_memory_with_reranker",
         "cross-encoder",

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -974,6 +974,141 @@ pub async fn run_longmemeval_eval_cross_rerank(
 }
 
 // ---------------------------------------------------------------------------
+// Cross-encoder rerank runner against a pre-seeded consolidated DB (PR-B)
+// ---------------------------------------------------------------------------
+
+/// Like `run_longmemeval_eval_cross_rerank`, but scores against a PRE-SEEDED
+/// consolidated scenario DB (no per-question ephemeral DB, no ingest).
+/// Used by PR-B's page-channel eval to surface distilled pages that the
+/// fullpipeline harness wrote into the cache.
+///
+/// `db` MUST already contain memories with `source_id` formatted as
+/// `lme_<question_id>_<session_idx>_t<turn_idx>` (matches the
+/// `memory_source_id` function used by the LME ephemeral seed path and
+/// the fullpipeline harness).
+/// Page-channel ON/OFF is controlled by the caller via the
+/// `ORIGIN_DISABLE_PAGE_CHANNEL` env var (read inside
+/// `search_memory_with_reranker`).
+pub async fn run_longmemeval_eval_cross_rerank_from_db(
+    db: &MemoryDB,
+    path: &Path,
+    reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
+) -> Result<LongMemEvalReport, OriginError> {
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    // (question_type, ndcg_5, ndcg_10, mrr, recall_5, hit_rate_1)
+    let mut all_scores: Vec<(String, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
+    let mut total_memories: usize = 0;
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        total_memories += memories.len();
+
+        // Build relevance judgments: has_answer turns are relevant.
+        // source_id format matches both the ephemeral seed and fullpipeline harness.
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        let results = db
+            .search_memory_with_reranker(
+                &sample.question,
+                10,
+                None,
+                None,
+                None,
+                Some(reranker.clone()),
+            )
+            .await?;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| {
+                (
+                    *id,
+                    if relevant_source_ids.contains(*id) {
+                        1
+                    } else {
+                        0
+                    },
+                )
+            })
+            .collect();
+
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+        let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+        let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+        let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+        let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+
+        all_scores.push((
+            sample.question_type.clone(),
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+        per_case.push(build_lme_case_result(
+            &sample.question,
+            &sample.question_type,
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+    }
+
+    let per_category = aggregate_by_category(&all_scores);
+    let mut report = LongMemEvalReport {
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories,
+        per_category,
+        baseline: None,
+        env: None,
+        per_case,
+    };
+
+    // Stamp env.flags to record page_channel state (purely informational
+    // until comparable_hash includes flags — future task).
+    let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+        "off"
+    } else {
+        "on"
+    };
+    let mut env_stamp = build_lme_env(
+        "cross_rerank_v2_pages",
+        path,
+        "search_memory_with_reranker",
+        "cross-encoder",
+        &format!("cross-encoder:{}", reranker.model_id()),
+        None,
+    );
+    env_stamp
+        .flags
+        .push(format!("page_channel={}", page_channel_state));
+    env_stamp.flags.push("scenario_db=consolidated".to_string());
+    report.env = Some(env_stamp);
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
 // Expanded benchmark runner -- same as run_longmemeval_eval but uses search_memory_expanded
 // ---------------------------------------------------------------------------
 

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1010,6 +1010,8 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
     let mut all_scores: Vec<(String, f64, f64, f64, f64, f64)> = Vec::new();
     let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
     let mut total_memories: usize = 0;
+    let mut cov_blind_acc: Vec<f64> = Vec::new();
+    let mut cov_expanded_acc: Vec<f64> = Vec::new();
 
     for sample in &samples {
         let memories = extract_memories(sample);
@@ -1079,9 +1081,58 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
             recall_5,
             hr_1,
         ));
+
+        // Source-expanded coverage recall (page provenance, eval-only).
+        // Pages contribute the memory source ids they were distilled from;
+        // memories contribute their own id. Set-based + deduped so a gold
+        // id counts once (no double-count). Reads the full result bundle
+        // (memories in [0..limit] + appended pages) — pages ride after the
+        // limit by the iter2 partition.
+        let page_src_owned: Vec<(String, Vec<String>)> = {
+            let mut v = Vec::new();
+            for r in &results {
+                if r.source == "page" {
+                    let srcs: Vec<String> = db
+                        .get_page_sources(&r.source_id)
+                        .await
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|ps| ps.memory_source_id)
+                        .collect();
+                    v.push((r.source_id.clone(), srcs));
+                }
+            }
+            v
+        };
+        let page_sources_map: HashMap<&str, Vec<&str>> = page_src_owned
+            .iter()
+            .map(|(pid, srcs)| (pid.as_str(), srcs.iter().map(|s| s.as_str()).collect()))
+            .collect();
+        let units: Vec<(&str, &str)> = results
+            .iter()
+            .map(|r| (r.source.as_str(), r.source_id.as_str()))
+            .collect();
+        let cov_blind = metrics::coverage_recall(
+            &metrics::build_coverage_set(&units, &HashMap::new()),
+            &relevant_set,
+        );
+        let cov_expanded = metrics::coverage_recall(
+            &metrics::build_coverage_set(&units, &page_sources_map),
+            &relevant_set,
+        );
+        cov_blind_acc.push(cov_blind);
+        cov_expanded_acc.push(cov_expanded);
     }
 
     let per_category = aggregate_by_category(&all_scores);
+    let coverage = if cov_blind_acc.is_empty() {
+        None
+    } else {
+        Some(crate::eval::report::CoverageRecall {
+            blind: cov_blind_acc.iter().sum::<f64>() / cov_blind_acc.len() as f64,
+            expanded: cov_expanded_acc.iter().sum::<f64>() / cov_expanded_acc.len() as f64,
+        })
+    };
     let mut report = LongMemEvalReport {
         aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
         aggregate_mrr: avg_field(&all_scores, |s| s.3),
@@ -1093,7 +1144,7 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
         baseline: None,
         env: None,
         per_case,
-        coverage: None,
+        coverage,
     };
 
     // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1006,7 +1006,7 @@ pub async fn run_longmemeval_eval_cross_rerank(
 /// `memory_source_id` function used by the LME ephemeral seed path and
 /// the fullpipeline harness).
 /// Page-channel ON/OFF is controlled by the caller via the
-/// `ORIGIN_DISABLE_PAGE_CHANNEL` env var (read inside
+/// `ORIGIN_ENABLE_PAGE_CHANNEL` env var (read inside
 /// `search_memory_with_reranker`).
 pub async fn run_longmemeval_eval_cross_rerank_from_db(
     db: &MemoryDB,
@@ -1156,12 +1156,12 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
         coverage,
     };
 
-    // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
+    // Branch variant_tag on ORIGIN_ENABLE_PAGE_CHANNEL so page-ON and page-OFF
     // produce distinct baseline filenames (comparable_hash uses the variant string).
-    let page_channel_state = if crate::db::page_channel_disabled() {
-        "off"
-    } else {
+    let page_channel_state = if crate::db::page_channel_enabled() {
         "on"
+    } else {
+        "off"
     };
     let variant_tag = if page_channel_state == "off" {
         "cross_rerank_v2_no_pages"

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -362,6 +362,15 @@ impl LongMemEvalReport {
             self.aggregate_hit_rate_at_1
         ));
 
+        if let Some(ref cov) = self.coverage {
+            out.push_str(&format!(
+                "  Coverage recall (set-based, page-source-expanded):\n    blind:    {:.4}\n    expanded: {:.4}\n    delta:    {:+.4}  <- page contribution\n",
+                cov.blind,
+                cov.expanded,
+                cov.expanded - cov.blind
+            ));
+        }
+
         if let Some(ref b) = self.baseline {
             out.push_str("\nBaseline comparison:\n");
             let delta = |name: &str, old: f64, new: f64| -> String {

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -293,6 +293,8 @@ pub struct LongMemEvalBaseline {
     pub recall_at_5: f64,
     pub hit_rate_at_1: f64,
     pub per_category: Vec<crate::eval::report::CategoryBaseline>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<crate::eval::report::CoverageRecall>,
 }
 
 /// Per-category results.
@@ -328,6 +330,10 @@ pub struct LongMemEvalReport {
     /// Populated by each runner variant; empty by default for back-compat.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub per_case: Vec<crate::eval::report::CaseResult>,
+    /// Source-expanded coverage recall (page-channel `_from_db` runner only;
+    /// None elsewhere). See [`crate::eval::report::CoverageRecall`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<crate::eval::report::CoverageRecall>,
 }
 
 impl LongMemEvalReport {
@@ -429,6 +435,7 @@ impl LongMemEvalReport {
             recall_at_5: self.aggregate_recall_at_5,
             hit_rate_at_1: self.aggregate_hit_rate_at_1,
             per_category,
+            coverage: self.coverage.clone(),
         };
         let json = serde_json::to_string_pretty(&baseline).map_err(std::io::Error::other)?;
         std::fs::write(path, json)
@@ -691,6 +698,7 @@ pub async fn run_longmemeval_eval(path: &Path) -> Result<LongMemEvalReport, Orig
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_lme_env(
         "base",
@@ -824,6 +832,7 @@ pub async fn run_longmemeval_eval_reranked(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_lme_env(
         "reranked",
@@ -961,6 +970,7 @@ pub async fn run_longmemeval_eval_cross_rerank(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_lme_env(
         "cross_rerank",
@@ -1083,6 +1093,7 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
 
     // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
@@ -1234,6 +1245,7 @@ pub async fn run_longmemeval_eval_expanded(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_lme_env(
         "expanded",
@@ -1512,6 +1524,7 @@ pub async fn run_longmemeval_eval_with_gate(
         baseline: None,
         env: None,
         per_case,
+        coverage: None,
     };
     report.env = Some(build_lme_env(
         "gated",
@@ -1833,6 +1846,7 @@ mod tests {
             baseline: None,
             env: None,
             per_case: vec![],
+            coverage: None,
         };
         let text = report.to_terminal();
         assert!(text.contains("LongMemEval Benchmark"));
@@ -1878,6 +1892,7 @@ mod tests {
             baseline: None,
             env: None,
             per_case: vec![],
+            coverage: None,
         };
 
         report.save_baseline(&path).unwrap();
@@ -1926,9 +1941,11 @@ mod tests {
                     mrr: 0.550,
                     recall_at_5: 0.650,
                 }],
+                coverage: None,
             }),
             env: None,
             per_case: vec![],
+            coverage: None,
         };
 
         let text = report.to_terminal();

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1087,7 +1087,7 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
 
     // Branch variant_tag on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF
     // produce distinct baseline filenames (comparable_hash uses the variant string).
-    let page_channel_state = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+    let page_channel_state = if crate::db::page_channel_disabled() {
         "off"
     } else {
         "on"

--- a/crates/origin-core/src/eval/metrics.rs
+++ b/crates/origin-core/src/eval/metrics.rs
@@ -110,6 +110,63 @@ pub fn hit_rate_at_k(ranked_ids: &[&str], relevant_ids: &HashSet<&str>, k: usize
     }
 }
 
+/// Source-coverage set for set-based recall over a retrieved bundle.
+///
+/// Each retrieved unit contributes the source-memory ids it "covers": a
+/// `"page"` unit expands to its `page_sources` ids (provenance expansion,
+/// the HippoRAG / LongMemEval key-value pattern), and every other unit
+/// contributes its own id. The result is a set, so a gold id is covered at
+/// most once no matter how many units point to it — that is what structurally
+/// prevents the double-count a positional metric would suffer when a
+/// page-expanded id is also retrieved directly at another rank.
+///
+/// `units` is `(source_tag, source_id)` per retrieved result. `page_sources`
+/// maps a page id to the memory source ids it was distilled from; a page id
+/// absent from the map (or with no sources) contributes only its own id,
+/// which will not match memory-keyed ground truth.
+pub fn build_coverage_set(
+    units: &[(&str, &str)],
+    page_sources: &HashMap<&str, Vec<&str>>,
+) -> HashSet<String> {
+    let mut covered = HashSet::new();
+    for (source, id) in units {
+        if *source == "page" {
+            match page_sources.get(id) {
+                Some(srcs) if !srcs.is_empty() => {
+                    for s in srcs {
+                        covered.insert((*s).to_string());
+                    }
+                }
+                _ => {
+                    covered.insert((*id).to_string());
+                }
+            }
+        } else {
+            covered.insert((*id).to_string());
+        }
+    }
+    covered
+}
+
+/// Set-based coverage recall: fraction of `relevant` ids present in `covered`.
+///
+/// Position-independent and dedup-safe (both args are sets), unlike
+/// [`recall_at_k`]. This is the metric pages move honestly — a page is
+/// credited via the source ids it brings into `covered`, never as its own id.
+/// Returns 0.0 when `relevant` is empty.
+pub fn coverage_recall(covered: &HashSet<String>, relevant: &HashSet<&str>) -> f64 {
+    if relevant.is_empty() {
+        return 0.0;
+    }
+    let mut found = 0usize;
+    for id in relevant {
+        if covered.contains(*id) {
+            found += 1;
+        }
+    }
+    found as f64 / relevant.len() as f64
+}
+
 /// Negative leakage — count of negative IDs that appear in top-K results.
 pub fn negative_leakage(ranked_ids: &[&str], negative_ids: &HashSet<&str>, k: usize) -> usize {
     let k = k.min(ranked_ids.len());
@@ -468,5 +525,71 @@ mod tests {
         let archived: HashSet<&str> = HashSet::new();
         let results: Vec<(&str, Vec<&str>)> = vec![];
         assert_eq!(archive_leakage(&archived, &results), 0.0);
+    }
+
+    fn sset(ids: &[&str]) -> HashSet<String> {
+        ids.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn coverage_set_memory_only() {
+        let units = vec![("memory", "m1"), ("memory", "m2")];
+        let ps: HashMap<&str, Vec<&str>> = HashMap::new();
+        assert_eq!(build_coverage_set(&units, &ps), sset(&["m1", "m2"]));
+    }
+
+    #[test]
+    fn coverage_set_page_expands_to_sources_not_own_id() {
+        let units = vec![("memory", "m1"), ("page", "p1")];
+        let mut ps = HashMap::new();
+        ps.insert("p1", vec!["m2", "m3"]);
+        assert_eq!(build_coverage_set(&units, &ps), sset(&["m1", "m2", "m3"]));
+    }
+
+    #[test]
+    fn coverage_set_dedup_no_double_count() {
+        let units = vec![("memory", "m2"), ("page", "p1")];
+        let mut ps = HashMap::new();
+        ps.insert("p1", vec!["m2", "m3"]);
+        let cov = build_coverage_set(&units, &ps);
+        assert_eq!(cov, sset(&["m2", "m3"]));
+        assert_eq!(cov.len(), 2, "m2 counted once, not twice");
+    }
+
+    #[test]
+    fn coverage_set_page_without_sources_falls_back_to_own_id() {
+        let units = vec![("page", "p1")];
+        let ps: HashMap<&str, Vec<&str>> = HashMap::new();
+        let cov = build_coverage_set(&units, &ps);
+        assert_eq!(cov, sset(&["p1"]));
+    }
+
+    #[test]
+    fn coverage_recall_empty_relevant_is_zero() {
+        assert_eq!(coverage_recall(&sset(&["m1"]), &HashSet::new()), 0.0);
+    }
+
+    #[test]
+    fn coverage_recall_full_and_partial() {
+        let cov = sset(&["m1", "m2", "m3"]);
+        let rel_full: HashSet<&str> = ["m1", "m2"].into_iter().collect();
+        assert_eq!(coverage_recall(&cov, &rel_full), 1.0);
+        let rel_partial: HashSet<&str> = ["m1", "mX"].into_iter().collect();
+        assert_eq!(coverage_recall(&cov, &rel_partial), 0.5);
+    }
+
+    #[test]
+    fn coverage_recall_page_expansion_lifts_over_blind() {
+        let units = vec![("memory", "m1"), ("page", "p1")];
+        let mut ps = HashMap::new();
+        ps.insert("p1", vec!["m2", "m3"]);
+        let blind = build_coverage_set(&units, &HashMap::new());
+        let expanded = build_coverage_set(&units, &ps);
+        let rel: HashSet<&str> = ["m1", "m2", "m3"].into_iter().collect();
+        let cb = coverage_recall(&blind, &rel);
+        let ce = coverage_recall(&expanded, &rel);
+        assert!((cb - 1.0 / 3.0).abs() < 1e-9, "blind = 1/3, got {cb}");
+        assert!((ce - 1.0).abs() < 1e-9, "expanded = 1.0, got {ce}");
+        assert!(ce > cb, "page expansion must lift coverage");
     }
 }

--- a/crates/origin-core/src/eval/report.rs
+++ b/crates/origin-core/src/eval/report.rs
@@ -208,6 +208,22 @@ pub struct CaseResult {
     pub category: Option<String>,
 }
 
+/// Source-expanded coverage recall for the page-channel eval (task #45).
+///
+/// `blind` is set-based recall over memory results only (a retrieved page
+/// contributes only its own `page_*` id, which never matches memory-keyed
+/// ground truth). `expanded` is recall after expanding each retrieved page to
+/// the memory source ids it was distilled from (provenance expansion). The
+/// `expanded - blind` delta is the honest "pages help" signal. Both are
+/// dedup-safe set metrics — a gold id is credited once regardless of how many
+/// units point to it, so a page-expanded id also retrieved directly cannot
+/// inflate the score.
+#[derive(Debug, Clone, Serialize, serde::Deserialize)]
+pub struct CoverageRecall {
+    pub blind: f64,
+    pub expanded: f64,
+}
+
 /// Hash the subset of `ReportEnv` fields that determine baseline comparability.
 ///
 /// Includes: fixture_revision, embedder_revision, llm_provider_class,

--- a/crates/origin-core/tests/cached_scenario_db_check.rs
+++ b/crates/origin-core/tests/cached_scenario_db_check.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+//! PR-B Step 1: compat verify cached scenario DBs.
+//!
+//! Opens copies of the May-23 fullpipeline scenario DBs via `MemoryDB::new`,
+//! which runs migrations 44..=54 idempotently. Then opens a separate libSQL
+//! connection to report user_version, table counts, and 3 sample pages per DB.
+//!
+//! Operate on COPIES (set via `SCENARIO_DB_ROOT`), never on the canonical
+//! `~/.cache/origin-eval/fullpipeline_*.db/` originals.
+//!
+//! Skipped unless `--ignored` is passed. Resolves the scenario DB root in this order:
+//!   1. `SCENARIO_DB_ROOT` env var (highest priority — used by CI / cross-machine).
+//!   2. `${EVAL_BASELINES_DIR}/scenario_seeded` (existing eval cache convention).
+//!   3. `~/.cache/origin-eval/scenario_seeded/` (canonical default; seed via
+//!      `scripts/seed-scenario-dbs.sh`).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use origin_core::db::MemoryDB;
+use origin_core::events::NoopEmitter;
+
+/// Resolve the scenario DB root with sensible fallback:
+/// 1. `SCENARIO_DB_ROOT` env override (highest priority).
+/// 2. `EVAL_BASELINES_DIR` (chains the existing eval cache convention) + `scenario_seeded`.
+/// 3. `~/.cache/origin-eval/scenario_seeded/` (canonical default; matches the
+///    fullpipeline_*.db cache layout documented in AGENTS.md).
+fn resolve_scenario_db_root() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("SCENARIO_DB_ROOT") {
+        return std::path::PathBuf::from(p);
+    }
+    if let Ok(p) = std::env::var("EVAL_BASELINES_DIR") {
+        return std::path::PathBuf::from(p).join("scenario_seeded");
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home)
+        .join(".cache")
+        .join("origin-eval")
+        .join("scenario_seeded")
+}
+
+async fn dump_counts(dir: &Path, label: &str) {
+    let db_file = dir.join("origin_memory.db");
+    let db = libsql::Builder::new_local(db_file.to_str().unwrap())
+        .build()
+        .await
+        .expect("libsql open for counts");
+    let conn = db.connect().expect("libsql connect for counts");
+
+    let mut rows = conn.query("PRAGMA user_version", ()).await.unwrap();
+    let version: i64 = rows
+        .next()
+        .await
+        .unwrap()
+        .map(|r| r.get::<i64>(0).unwrap_or(-1))
+        .unwrap_or(-1);
+    drop(rows);
+
+    let tables = [
+        "pages",
+        "page_sources",
+        "memories",
+        "entities",
+        "relations",
+        "memory_entities",
+    ];
+
+    println!("=== {} ===", label);
+    println!("user_version: {}", version);
+    for t in &tables {
+        let q = format!("SELECT COUNT(*) FROM {}", t);
+        let n = match conn.query(&q, ()).await {
+            Ok(mut rs) => rs
+                .next()
+                .await
+                .ok()
+                .flatten()
+                .and_then(|r| r.get::<i64>(0).ok())
+                .unwrap_or(-1),
+            Err(_) => -1,
+        };
+        println!("  {:<18} {}", t, n);
+    }
+
+    // Sample 3 pages.
+    let mut sample = conn
+        .query(
+            "SELECT id, title, length(content) AS content_len, \
+                  (SELECT COUNT(*) FROM page_sources ps WHERE ps.page_id = p.id) AS source_count \
+             FROM pages p ORDER BY RANDOM() LIMIT 3",
+            (),
+        )
+        .await
+        .unwrap();
+    println!("  sample pages:");
+    while let Some(row) = sample.next().await.unwrap() {
+        let id: String = row.get(0).unwrap_or_default();
+        let title: String = row.get(1).unwrap_or_default();
+        let content_len: i64 = row.get(2).unwrap_or(-1);
+        let src_count: i64 = row.get(3).unwrap_or(-1);
+        println!(
+            "    id={} title={:?} content_len={} sources={}",
+            id, title, content_len, src_count
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore = "needs SCENARIO_DB_ROOT pointing at copies of cached scenario DBs (PR-B Step 1)"]
+async fn cached_scenario_db_compat_check() {
+    let root = resolve_scenario_db_root();
+
+    for sub in &["locomo_v1", "lme_v1"] {
+        let dir = root.join(sub);
+        assert!(
+            dir.join("origin_memory.db").exists(),
+            "missing {}/origin_memory.db -- run scripts/seed-scenario-dbs.sh from the repo root to repopulate the cache",
+            dir.display()
+        );
+
+        let start = std::time::Instant::now();
+        {
+            let _db = MemoryDB::new(&dir, Arc::new(NoopEmitter))
+                .await
+                .expect("MemoryDB::new (runs migrations)");
+        }
+        let elapsed = start.elapsed();
+        println!(
+            "\n[{}] MemoryDB::new (migrations) replay: {:?}",
+            sub, elapsed
+        );
+
+        dump_counts(&dir, sub).await;
+    }
+}

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -534,15 +534,15 @@ async fn save_locomo_expanded_baseline() {
 // Cross-encoder rerank variants — fastembed TextRerank (BGERerankerV2M3) in
 // place of the LLM reranker. First run downloads ~600MB of model weights.
 //
-// ORIGIN_DISABLE_PAGE_CHANNEL=1 is forced here so the pre-PR-B 0.684 / 0.883
-// disk artifacts stay reproducible regardless of the page-channel default.
+// ORIGIN_ENABLE_PAGE_CHANNEL is forced to None (unset) here so the pre-PR-B
+// 0.684 / 0.883 disk artifacts stay reproducible regardless of the caller env.
 // The ephemeral per-conversation DBs these tests build today have zero
 // distilled pages, so page-channel is a no-op for them with or without the
 // wrap. The wrap makes the intent explicit at the source.
 #[tokio::test]
 #[ignore]
 async fn save_locomo_cross_rerank_baseline() {
-    temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("1"))], async {
+    temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", None::<&str>)], async {
         let path = eval_root().join("data/locomo10.json");
         if !path.exists() {
             println!("SKIP: locomo10.json not found");
@@ -565,7 +565,7 @@ async fn save_locomo_cross_rerank_baseline() {
 #[tokio::test]
 #[ignore]
 async fn save_longmemeval_cross_rerank_baseline() {
-    temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("1"))], async {
+    temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", None::<&str>)], async {
         let path = eval_root().join("data/longmemeval_oracle.json");
         if !path.exists() {
             println!("SKIP: longmemeval_oracle.json not found");
@@ -641,7 +641,7 @@ fn resolve_scenario_db_root_from_harness() -> std::path::PathBuf {
 /// Uses the pre-seeded consolidated scenario DB at
 /// `${SCENARIO_DB_ROOT or ~/.cache/origin-eval/scenario_seeded}/locomo_v1/origin_memory.db`
 /// — skips ingest entirely. Page-channel ON by default; set
-/// `ORIGIN_DISABLE_PAGE_CHANNEL=1` to measure the OFF variant.
+/// `ORIGIN_ENABLE_PAGE_CHANNEL=1` to measure the ON variant. Page-channel is OFF by default.
 ///
 /// Filename suffix `__with_pages` distinguishes from the per-conversation
 /// `cross_rerank__*__pool_baseline.json` headline (which uses ephemeral DBs
@@ -699,13 +699,13 @@ async fn save_locomo_v2_with_pages_baseline() {
     let baselines_dir = eval_root().join("baselines");
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let mut filename = report.baseline_filename("locomo");
-    // Branch suffix on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
+    // Branch suffix on ORIGIN_ENABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
     // don't collide at the legacy app/eval/baselines/ path. Truthy parse via
     // shared helper so suffix matches what the production code path actually did.
-    let suffix = if origin_core::db::page_channel_disabled() {
-        "__no_pages"
-    } else {
+    let suffix = if origin_core::db::page_channel_enabled() {
         "__with_pages"
+    } else {
+        "__no_pages"
     };
     if let Some(stripped) = filename.strip_suffix(".json") {
         filename = format!("{}{}.json", stripped, suffix);
@@ -726,7 +726,7 @@ async fn save_locomo_v2_with_pages_baseline() {
 /// Uses the pre-seeded consolidated scenario DB at
 /// `${SCENARIO_DB_ROOT or ~/.cache/origin-eval/scenario_seeded}/lme_v1/origin_memory.db`
 /// — skips ingest entirely. Page-channel ON by default; set
-/// `ORIGIN_DISABLE_PAGE_CHANNEL=1` to measure the OFF variant.
+/// `ORIGIN_ENABLE_PAGE_CHANNEL=1` to measure the ON variant. Page-channel is OFF by default.
 ///
 /// Filename suffix `__with_pages` distinguishes from the per-question
 /// `cross_rerank__*__pool_baseline.json` headline.
@@ -784,13 +784,13 @@ async fn save_longmemeval_v2_with_pages_baseline() {
     let baselines_dir = eval_root().join("baselines");
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let mut filename = report.baseline_filename("longmemeval");
-    // Branch suffix on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
+    // Branch suffix on ORIGIN_ENABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
     // don't collide at the legacy app/eval/baselines/ path. Truthy parse via
     // shared helper so suffix matches what the production code path actually did.
-    let suffix = if origin_core::db::page_channel_disabled() {
-        "__no_pages"
-    } else {
+    let suffix = if origin_core::db::page_channel_enabled() {
         "__with_pages"
+    } else {
+        "__no_pages"
     };
     if let Some(stripped) = filename.strip_suffix(".json") {
         filename = format!("{}{}.json", stripped, suffix);

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -534,11 +534,11 @@ async fn save_locomo_expanded_baseline() {
 // Cross-encoder rerank variants — fastembed TextRerank (BGERerankerV2M3) in
 // place of the LLM reranker. First run downloads ~600MB of model weights.
 //
-// ORIGIN_DISABLE_PAGE_CHANNEL=1 is forced here to preserve the pre-PR-B
-// 0.684 / 0.883 disk artifacts. These tests use ephemeral per-conversation
-// DBs with no distilled pages so page-channel was already a no-op for them,
-// but the explicit wrap future-proofs against any ephemeral DB change that
-// gains pages.
+// ORIGIN_DISABLE_PAGE_CHANNEL=1 is forced here so the pre-PR-B 0.684 / 0.883
+// disk artifacts stay reproducible regardless of the page-channel default.
+// The ephemeral per-conversation DBs these tests build today have zero
+// distilled pages, so page-channel is a no-op for them with or without the
+// wrap. The wrap makes the intent explicit at the source.
 #[tokio::test]
 #[ignore]
 async fn save_locomo_cross_rerank_baseline() {
@@ -664,17 +664,22 @@ async fn save_locomo_v2_with_pages_baseline() {
     .await
     .expect("open locomo_v1 scenario DB");
 
-    // Sanity: cached scenario DB must have distilled pages for page-channel to be measurable.
-    // An empty pages table silently produces page-OFF metrics stamped as page-ON.
+    // Sanity: cached scenario DB must have distilled pages for page-channel
+    // to be measurable. An empty pages table silently produces page-OFF
+    // metrics stamped as page-ON. SKIP semantics match the fixture-missing
+    // branch below so contributors without seeded DBs get a clear message
+    // instead of a thread panic.
     let pages_count = db
         .count_active_pages()
         .await
         .expect("count_active_pages failed");
-    assert!(
-        pages_count > 0,
-        "cached scenario DB has 0 active pages at {} — run scripts/seed-scenario-dbs.sh and verify with cached_scenario_db_compat_check",
-        db_dir.display()
-    );
+    if pages_count == 0 {
+        println!(
+            "SKIP: cached scenario DB has 0 active pages at {}. Run scripts/seed-scenario-dbs.sh from the repo root then verify with cached_scenario_db_compat_check.",
+            db_dir.display()
+        );
+        return;
+    }
     println!("Pages in scenario DB: {}", pages_count);
 
     let fixture = eval_root().join("data/locomo10.json");
@@ -742,17 +747,22 @@ async fn save_longmemeval_v2_with_pages_baseline() {
     .await
     .expect("open lme_v1 scenario DB");
 
-    // Sanity: cached scenario DB must have distilled pages for page-channel to be measurable.
-    // An empty pages table silently produces page-OFF metrics stamped as page-ON.
+    // Sanity: cached scenario DB must have distilled pages for page-channel
+    // to be measurable. An empty pages table silently produces page-OFF
+    // metrics stamped as page-ON. SKIP semantics match the fixture-missing
+    // branch below so contributors without seeded DBs get a clear message
+    // instead of a thread panic.
     let pages_count = db
         .count_active_pages()
         .await
         .expect("count_active_pages failed");
-    assert!(
-        pages_count > 0,
-        "cached scenario DB has 0 active pages at {} — run scripts/seed-scenario-dbs.sh and verify with cached_scenario_db_compat_check",
-        db_dir.display()
-    );
+    if pages_count == 0 {
+        println!(
+            "SKIP: cached scenario DB has 0 active pages at {}. Run scripts/seed-scenario-dbs.sh from the repo root then verify with cached_scenario_db_compat_check.",
+            db_dir.display()
+        );
+        return;
+    }
     println!("Pages in scenario DB: {}", pages_count);
 
     let fixture = eval_root().join("data/longmemeval_oracle.json");

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -664,6 +664,19 @@ async fn save_locomo_v2_with_pages_baseline() {
     .await
     .expect("open locomo_v1 scenario DB");
 
+    // Sanity: cached scenario DB must have distilled pages for page-channel to be measurable.
+    // An empty pages table silently produces page-OFF metrics stamped as page-ON.
+    let pages_count = db
+        .count_active_pages()
+        .await
+        .expect("count_active_pages failed");
+    assert!(
+        pages_count > 0,
+        "cached scenario DB has 0 active pages at {} — run scripts/seed-scenario-dbs.sh and verify with cached_scenario_db_compat_check",
+        db_dir.display()
+    );
+    println!("Pages in scenario DB: {}", pages_count);
+
     let fixture = eval_root().join("data/locomo10.json");
     if !fixture.exists() {
         println!("SKIP: locomo10.json not found");
@@ -681,11 +694,17 @@ async fn save_locomo_v2_with_pages_baseline() {
     let baselines_dir = eval_root().join("baselines");
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let mut filename = report.baseline_filename("locomo");
-    // Insert __with_pages before the .json extension so cmp tools see the variant.
-    if let Some(stripped) = filename.strip_suffix(".json") {
-        filename = format!("{}__with_pages.json", stripped);
+    // Branch suffix on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
+    // don't collide at the legacy app/eval/baselines/ path.
+    let suffix = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+        "__no_pages"
     } else {
-        filename = format!("{}__with_pages", filename);
+        "__with_pages"
+    };
+    if let Some(stripped) = filename.strip_suffix(".json") {
+        filename = format!("{}{}.json", stripped, suffix);
+    } else {
+        filename = format!("{}{}", filename, suffix);
     }
     let baseline_path = baselines_dir.join(filename);
     report.save_baseline(&baseline_path).unwrap();
@@ -723,6 +742,19 @@ async fn save_longmemeval_v2_with_pages_baseline() {
     .await
     .expect("open lme_v1 scenario DB");
 
+    // Sanity: cached scenario DB must have distilled pages for page-channel to be measurable.
+    // An empty pages table silently produces page-OFF metrics stamped as page-ON.
+    let pages_count = db
+        .count_active_pages()
+        .await
+        .expect("count_active_pages failed");
+    assert!(
+        pages_count > 0,
+        "cached scenario DB has 0 active pages at {} — run scripts/seed-scenario-dbs.sh and verify with cached_scenario_db_compat_check",
+        db_dir.display()
+    );
+    println!("Pages in scenario DB: {}", pages_count);
+
     let fixture = eval_root().join("data/longmemeval_oracle.json");
     if !fixture.exists() {
         println!("SKIP: longmemeval_oracle.json not found");
@@ -741,11 +773,17 @@ async fn save_longmemeval_v2_with_pages_baseline() {
     let baselines_dir = eval_root().join("baselines");
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let mut filename = report.baseline_filename("longmemeval");
-    // Insert __with_pages before the .json extension so cmp tools see the variant.
-    if let Some(stripped) = filename.strip_suffix(".json") {
-        filename = format!("{}__with_pages.json", stripped);
+    // Branch suffix on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
+    // don't collide at the legacy app/eval/baselines/ path.
+    let suffix = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+        "__no_pages"
     } else {
-        filename = format!("{}__with_pages", filename);
+        "__with_pages"
+    };
+    if let Some(stripped) = filename.strip_suffix(".json") {
+        filename = format!("{}{}.json", stripped, suffix);
+    } else {
+        filename = format!("{}{}", filename, suffix);
     }
     let baseline_path = baselines_dir.join(filename);
     report.save_baseline(&baseline_path).unwrap();

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -533,47 +533,60 @@ async fn save_locomo_expanded_baseline() {
 
 // Cross-encoder rerank variants — fastembed TextRerank (BGERerankerV2M3) in
 // place of the LLM reranker. First run downloads ~600MB of model weights.
+//
+// ORIGIN_DISABLE_PAGE_CHANNEL=1 is forced here to preserve the pre-PR-B
+// 0.684 / 0.883 disk artifacts. These tests use ephemeral per-conversation
+// DBs with no distilled pages so page-channel was already a no-op for them,
+// but the explicit wrap future-proofs against any ephemeral DB change that
+// gains pages.
 #[tokio::test]
 #[ignore]
 async fn save_locomo_cross_rerank_baseline() {
-    let path = eval_root().join("data/locomo10.json");
-    if !path.exists() {
-        println!("SKIP: locomo10.json not found");
-        return;
-    }
-    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
-        .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
-    let report = origin_core::eval::locomo::run_locomo_eval_cross_rerank(&path, reranker)
-        .await
-        .unwrap();
-    let baselines_dir = eval_root().join("baselines");
-    std::fs::create_dir_all(&baselines_dir).unwrap();
-    let baseline_path = baselines_dir.join(report.baseline_filename("locomo"));
-    report.save_baseline(&baseline_path).unwrap();
-    println!("Saved LoCoMo cross-rerank baseline to {:?}", baseline_path);
+    temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("1"))], async {
+        let path = eval_root().join("data/locomo10.json");
+        if !path.exists() {
+            println!("SKIP: locomo10.json not found");
+            return;
+        }
+        let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+            .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+        let report = origin_core::eval::locomo::run_locomo_eval_cross_rerank(&path, reranker)
+            .await
+            .unwrap();
+        let baselines_dir = eval_root().join("baselines");
+        std::fs::create_dir_all(&baselines_dir).unwrap();
+        let baseline_path = baselines_dir.join(report.baseline_filename("locomo"));
+        report.save_baseline(&baseline_path).unwrap();
+        println!("Saved LoCoMo cross-rerank baseline to {:?}", baseline_path);
+    })
+    .await;
 }
 
 #[tokio::test]
 #[ignore]
 async fn save_longmemeval_cross_rerank_baseline() {
-    let path = eval_root().join("data/longmemeval_oracle.json");
-    if !path.exists() {
-        println!("SKIP: longmemeval_oracle.json not found");
-        return;
-    }
-    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
-        .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
-    let report = origin_core::eval::longmemeval::run_longmemeval_eval_cross_rerank(&path, reranker)
-        .await
-        .unwrap();
-    let baselines_dir = eval_root().join("baselines");
-    std::fs::create_dir_all(&baselines_dir).unwrap();
-    let baseline_path = baselines_dir.join(report.baseline_filename("longmemeval"));
-    report.save_baseline(&baseline_path).unwrap();
-    println!(
-        "Saved LongMemEval cross-rerank baseline to {:?}",
-        baseline_path
-    );
+    temp_env::async_with_vars([("ORIGIN_DISABLE_PAGE_CHANNEL", Some("1"))], async {
+        let path = eval_root().join("data/longmemeval_oracle.json");
+        if !path.exists() {
+            println!("SKIP: longmemeval_oracle.json not found");
+            return;
+        }
+        let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+            .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+        let report =
+            origin_core::eval::longmemeval::run_longmemeval_eval_cross_rerank(&path, reranker)
+                .await
+                .unwrap();
+        let baselines_dir = eval_root().join("baselines");
+        std::fs::create_dir_all(&baselines_dir).unwrap();
+        let baseline_path = baselines_dir.join(report.baseline_filename("longmemeval"));
+        report.save_baseline(&baseline_path).unwrap();
+        println!(
+            "Saved LongMemEval cross-rerank baseline to {:?}",
+            baseline_path
+        );
+    })
+    .await;
 }
 
 #[tokio::test]
@@ -596,6 +609,153 @@ async fn save_longmemeval_expanded_baseline() {
     let baseline_path = baselines_dir.join(report.baseline_filename("longmemeval"));
     report.save_baseline(&baseline_path).unwrap();
     println!("Saved LongMemEval expanded baseline to {:?}", baseline_path);
+    save_layered(&report, |r| r.to_eval_report());
+}
+
+// ---------------------------------------------------------------------------
+// PR-B page-channel with-pages baseline runners
+// ---------------------------------------------------------------------------
+
+/// Resolve the root directory for cached scenario DBs.
+///
+/// Resolution order (highest priority first):
+/// 1. `SCENARIO_DB_ROOT` env var
+/// 2. `${EVAL_BASELINES_DIR}/scenario_seeded`
+/// 3. `~/.cache/origin-eval/scenario_seeded/` (canonical default)
+fn resolve_scenario_db_root_from_harness() -> std::path::PathBuf {
+    if let Ok(p) = std::env::var("SCENARIO_DB_ROOT") {
+        return std::path::PathBuf::from(p);
+    }
+    if let Ok(p) = std::env::var("EVAL_BASELINES_DIR") {
+        return std::path::PathBuf::from(p).join("scenario_seeded");
+    }
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home)
+        .join(".cache")
+        .join("origin-eval")
+        .join("scenario_seeded")
+}
+
+/// PR-B page-channel ON baseline (LoCoMo).
+///
+/// Uses the pre-seeded consolidated scenario DB at
+/// `${SCENARIO_DB_ROOT or ~/.cache/origin-eval/scenario_seeded}/locomo_v1/origin_memory.db`
+/// — skips ingest entirely. Page-channel ON by default; set
+/// `ORIGIN_DISABLE_PAGE_CHANNEL=1` to measure the OFF variant.
+///
+/// Filename suffix `__with_pages` distinguishes from the per-conversation
+/// `cross_rerank__*__pool_baseline.json` headline (which uses ephemeral DBs
+/// and is preserved as the 0.684 bar).
+#[tokio::test]
+#[ignore = "needs Metal GPU + cached scenario DB (run scripts/seed-scenario-dbs.sh)"]
+async fn save_locomo_v2_with_pages_baseline() {
+    let scenario_root = resolve_scenario_db_root_from_harness();
+    let db_dir = scenario_root.join("locomo_v1");
+    assert!(
+        db_dir.join("origin_memory.db").exists(),
+        "missing {}/origin_memory.db — run scripts/seed-scenario-dbs.sh",
+        db_dir.display()
+    );
+
+    let db = origin_core::db::MemoryDB::new(
+        &db_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open locomo_v1 scenario DB");
+
+    let fixture = eval_root().join("data/locomo10.json");
+    if !fixture.exists() {
+        println!("SKIP: locomo10.json not found");
+        return;
+    }
+
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+        .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+
+    let report =
+        origin_core::eval::locomo::run_locomo_eval_cross_rerank_from_db(&db, &fixture, reranker)
+            .await
+            .unwrap();
+
+    let baselines_dir = eval_root().join("baselines");
+    std::fs::create_dir_all(&baselines_dir).unwrap();
+    let mut filename = report.baseline_filename("locomo");
+    // Insert __with_pages before the .json extension so cmp tools see the variant.
+    if let Some(stripped) = filename.strip_suffix(".json") {
+        filename = format!("{}__with_pages.json", stripped);
+    } else {
+        filename = format!("{}__with_pages", filename);
+    }
+    let baseline_path = baselines_dir.join(filename);
+    report.save_baseline(&baseline_path).unwrap();
+    println!("Saved LoCoMo v2 with-pages baseline to {:?}", baseline_path);
+    println!("  NDCG@10:  {:.4}", report.aggregate_ndcg_at_10);
+    println!("  Recall@5: {:.4}", report.aggregate_recall_at_5);
+    println!("  MRR:      {:.4}", report.aggregate_mrr);
+    save_layered(&report, |r| r.to_eval_report());
+}
+
+/// PR-B page-channel ON baseline (LongMemEval).
+///
+/// Uses the pre-seeded consolidated scenario DB at
+/// `${SCENARIO_DB_ROOT or ~/.cache/origin-eval/scenario_seeded}/lme_v1/origin_memory.db`
+/// — skips ingest entirely. Page-channel ON by default; set
+/// `ORIGIN_DISABLE_PAGE_CHANNEL=1` to measure the OFF variant.
+///
+/// Filename suffix `__with_pages` distinguishes from the per-question
+/// `cross_rerank__*__pool_baseline.json` headline.
+#[tokio::test]
+#[ignore = "needs Metal GPU + cached scenario DB (run scripts/seed-scenario-dbs.sh)"]
+async fn save_longmemeval_v2_with_pages_baseline() {
+    let scenario_root = resolve_scenario_db_root_from_harness();
+    let db_dir = scenario_root.join("lme_v1");
+    assert!(
+        db_dir.join("origin_memory.db").exists(),
+        "missing {}/origin_memory.db — run scripts/seed-scenario-dbs.sh",
+        db_dir.display()
+    );
+
+    let db = origin_core::db::MemoryDB::new(
+        &db_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open lme_v1 scenario DB");
+
+    let fixture = eval_root().join("data/longmemeval_oracle.json");
+    if !fixture.exists() {
+        println!("SKIP: longmemeval_oracle.json not found");
+        return;
+    }
+
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+        .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+
+    let report = origin_core::eval::longmemeval::run_longmemeval_eval_cross_rerank_from_db(
+        &db, &fixture, reranker,
+    )
+    .await
+    .unwrap();
+
+    let baselines_dir = eval_root().join("baselines");
+    std::fs::create_dir_all(&baselines_dir).unwrap();
+    let mut filename = report.baseline_filename("longmemeval");
+    // Insert __with_pages before the .json extension so cmp tools see the variant.
+    if let Some(stripped) = filename.strip_suffix(".json") {
+        filename = format!("{}__with_pages.json", stripped);
+    } else {
+        filename = format!("{}__with_pages", filename);
+    }
+    let baseline_path = baselines_dir.join(filename);
+    report.save_baseline(&baseline_path).unwrap();
+    println!(
+        "Saved LongMemEval v2 with-pages baseline to {:?}",
+        baseline_path
+    );
+    println!("  NDCG@10:  {:.4}", report.aggregate_ndcg_at_10);
+    println!("  Recall@5: {:.4}", report.aggregate_recall_at_5);
+    println!("  MRR:      {:.4}", report.aggregate_mrr);
     save_layered(&report, |r| r.to_eval_report());
 }
 

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -700,8 +700,9 @@ async fn save_locomo_v2_with_pages_baseline() {
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let mut filename = report.baseline_filename("locomo");
     // Branch suffix on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
-    // don't collide at the legacy app/eval/baselines/ path.
-    let suffix = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+    // don't collide at the legacy app/eval/baselines/ path. Truthy parse via
+    // shared helper so suffix matches what the production code path actually did.
+    let suffix = if origin_core::db::page_channel_disabled() {
         "__no_pages"
     } else {
         "__with_pages"
@@ -784,8 +785,9 @@ async fn save_longmemeval_v2_with_pages_baseline() {
     std::fs::create_dir_all(&baselines_dir).unwrap();
     let mut filename = report.baseline_filename("longmemeval");
     // Branch suffix on ORIGIN_DISABLE_PAGE_CHANNEL so page-ON and page-OFF artifacts
-    // don't collide at the legacy app/eval/baselines/ path.
-    let suffix = if std::env::var("ORIGIN_DISABLE_PAGE_CHANNEL").is_ok() {
+    // don't collide at the legacy app/eval/baselines/ path. Truthy parse via
+    // shared helper so suffix matches what the production code path actually did.
+    let suffix = if origin_core::db::page_channel_disabled() {
         "__no_pages"
     } else {
         "__with_pages"

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1088,12 +1088,21 @@ pub async fn handle_search_memory(
         }
     };
 
-    let source_ids: Vec<String> = results.iter().map(|r| r.source_id.clone()).collect();
+    // Filter to memory rows ONLY before access_log + agent_activity. Page-channel
+    // (PR-B) returns `source="page"` rows whose `source_id` (`page_*`) is NOT a
+    // valid memory id; persisting those into `access_log` or `agent_activity`
+    // breaks downstream analytics that resolve ids against the `memories` table
+    // (e.g. /api/retrievals/recent). See 2026-05-28 adversarial review.
+    let memory_source_ids: Vec<String> = results
+        .iter()
+        .filter(|r| r.source == "memory")
+        .map(|r| r.source_id.clone())
+        .collect();
     {
         let s = state.read().await;
-        s.access_tracker.record_accesses(&source_ids);
+        s.access_tracker.record_accesses(&memory_source_ids);
         if let Some(db) = s.db.as_ref() {
-            if let Err(e) = db.log_accesses(&source_ids).await {
+            if let Err(e) = db.log_accesses(&memory_source_ids).await {
                 tracing::warn!("Failed to log accesses: {}", e);
             }
         }
@@ -1112,7 +1121,13 @@ pub async fn handle_search_memory(
         let detail = format!("found {} results", results.len());
         if let Some(db) = s.db.as_ref() {
             if let Err(e) = db
-                .log_agent_activity(&agent, "search", &source_ids, Some(&req.query), &detail)
+                .log_agent_activity(
+                    &agent,
+                    "search",
+                    &memory_source_ids,
+                    Some(&req.query),
+                    &detail,
+                )
                 .await
             {
                 tracing::warn!("Failed to log agent activity: {}", e);

--- a/scripts/seed-scenario-dbs.sh
+++ b/scripts/seed-scenario-dbs.sh
@@ -6,7 +6,7 @@
 # PR-B page-channel eval runners
 # (`save_locomo_v2_with_pages_baseline` / `save_longmemeval_v2_with_pages_baseline`).
 #
-# Idempotent. Skips files that already exist (cp -n) so reruns are cheap.
+# Idempotent. Skips files that already exist so reruns are cheap.
 # Honors EVAL_BASELINES_DIR override; defaults to $HOME/.cache/origin-eval.
 set -euo pipefail
 
@@ -27,8 +27,8 @@ if [ ! -f "$LME_SRC" ]; then
     exit 1
 fi
 
-cp -n "$LOCOMO_SRC" "$CACHE/locomo_v1/origin_memory.db" || true
-cp -n "$LME_SRC" "$CACHE/lme_v1/origin_memory.db" || true
+[ -f "$CACHE/locomo_v1/origin_memory.db" ] || cp "$LOCOMO_SRC" "$CACHE/locomo_v1/origin_memory.db"
+[ -f "$CACHE/lme_v1/origin_memory.db" ] || cp "$LME_SRC" "$CACHE/lme_v1/origin_memory.db"
 
 echo "Seeded scenario DBs at $CACHE"
 ls -la "$CACHE/locomo_v1/origin_memory.db" "$CACHE/lme_v1/origin_memory.db"

--- a/scripts/seed-scenario-dbs.sh
+++ b/scripts/seed-scenario-dbs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Repopulate ~/.cache/origin-eval/scenario_seeded/ from canonical
+# fullpipeline_*.db.
+#
+# Used by `crates/origin-core/tests/cached_scenario_db_check.rs` and the
+# PR-B page-channel eval runners
+# (`save_locomo_v2_with_pages_baseline` / `save_longmemeval_v2_with_pages_baseline`).
+#
+# Idempotent. Skips files that already exist (cp -n) so reruns are cheap.
+# Honors EVAL_BASELINES_DIR override; defaults to $HOME/.cache/origin-eval.
+set -euo pipefail
+
+CACHE="${EVAL_BASELINES_DIR:-$HOME/.cache/origin-eval}/scenario_seeded"
+LOCOMO_SRC="${EVAL_BASELINES_DIR:-$HOME/.cache/origin-eval}/fullpipeline_locomo_tuples.db/origin_memory.db"
+LME_SRC="${EVAL_BASELINES_DIR:-$HOME/.cache/origin-eval}/fullpipeline_lme_tuples.db/origin_memory.db"
+
+mkdir -p "$CACHE/locomo_v1" "$CACHE/lme_v1"
+
+if [ ! -f "$LOCOMO_SRC" ]; then
+    echo "missing LoCoMo source: $LOCOMO_SRC" >&2
+    echo "expected the canonical fullpipeline cache; rerun the LoCoMo fullpipeline harness or symlink the source" >&2
+    exit 1
+fi
+if [ ! -f "$LME_SRC" ]; then
+    echo "missing LME source: $LME_SRC" >&2
+    echo "expected the canonical fullpipeline cache; rerun the LME fullpipeline harness or symlink the source" >&2
+    exit 1
+fi
+
+cp -n "$LOCOMO_SRC" "$CACHE/locomo_v1/origin_memory.db" || true
+cp -n "$LME_SRC" "$CACHE/lme_v1/origin_memory.db" || true
+
+echo "Seeded scenario DBs at $CACHE"
+ls -la "$CACHE/locomo_v1/origin_memory.db" "$CACHE/lme_v1/origin_memory.db"


### PR DESCRIPTION
## Summary

Wire `search_pages` (vector + FTS, internally RRF-fused) as a parallel 4th channel into `search_memory_with_reranker`. Memory pool seeds the merged score_map with its existing `r.score`; page-channel rows contribute only `1/(60+rank)` RRF mass on top. Topology mirrors `augment_with_graph` (db.rs:7619-7644) exactly. Pages bypass per-memory modulators (they are pre-distilled wiki summaries with their own quality signal).

Gated by opt-in env var `ORIGIN_ENABLE_PAGE_CHANNEL=1`. Default behavior: page-channel OFF (opt-in; see Update below).

## Hidden bug fixed

`search_pages` at db.rs:16566 referenced `idx_concepts_embedding`, dropped by migration 46 (renamed to `idx_pages_embedding`). The libSQL vector path silently fell back to FTS-only since m46 shipped. One-line fix at db.rs:16566. Pre-existing regression test at db.rs:25517 verified red pre-fix, green post-fix.

## Why

Pre-distilled pages bypass hub-saturation that bit Plan B composite (closed PR #200). 12-system primary-source survey + Mem0's April 2026 graph-deletion confirm surfacing consolidated content as a parallel RRF stream is the standard lift. Two-stage RRF (memory pool then page-channel) preserves the 0.684 / 0.883 winning topology while adding a precision channel.

## Adversarial caveats (final review)

Final adversarial review on the integrated impl flagged five items the PR body must surface explicitly:

1. **Production hot-path cost.** Every reranked search now pays an extra `search_pages` call (DiskANN vec_top_k + 2 FTS queries on the pages table, serialized on the same conn lock). On DBs with thousands of pages this is non-trivial. The only opt-out today is the daemon-wide `ORIGIN_ENABLE_PAGE_CHANNEL=1` env var. A per-request `include_pages` flag on `SearchMemoryRequest` is a sensible follow-up — see Follow-ups below.
2. **CE rerank pool grows by up to PAGE_CHANNEL_LIMIT=10 candidates.** With default `RERANK_POOL_MULTIPLIER=3` + `limit=10` the CE input expands from ~30 to ~40 — about 33% more forward passes per query. Acceptable per-eval cost; flag for latency telemetry post-merge.
3. **Eval methodology discipline.** `save_locomo_v2_with_pages_baseline` and the LME equivalent open a CONSOLIDATED scenario DB (all conversations + distilled pages + post-ingest enrichment in one namespace). The pre-PR-B published bar (LoCoMo 0.684 / LME 0.883) used per-conversation EPHEMERAL DBs. These two setups are NOT directly comparable. The lift claim must be measured ON-vs-OFF on the SAME consolidated DB, not against the per-conv bar. Cross-DB headlines are forbidden in any external citation.
4. **`source=\"page\"` wire shape.** `SearchResult.source` is a plain `String` (memory.rs:11), so adding the new variant is backward-compatible across MCP wrappers and downstream consumers. Page rows have `last_modified` derived from RFC3339 string; on parse failure it falls back to 0 (= 1970-01-01). Doc-comment on `search_result_from_page` (db.rs) calls out the invariant: page rows MUST stay out of `signals::recency_decay` paths. Frontend / MCP consumers rendering `last_modified` should handle zero / pre-1990 dates as \"unknown\".
5. **Version bump intent.** The squash-merge title prefix `feat:` triggers release-please to bump 0.7.x → 0.8.0. That is intentional: page-channel is a user-visible retrieval feature.

## Eval discipline alongside the impl

Two new subdir AGENTS.md files localize the eval discipline that PR-B Task 5 exercised:
- `app/eval/AGENTS.md`: data/ fixture management, baselines/ layout, env-var table, seed scripts, pre-flight checklist, subset eval methodology.
- `crates/origin-core/src/eval/AGENTS.md`: Rust runner conventions, ephemeral vs cached DB choice, `source_id` formats, `build_*_env` variant_tag rules.

Triggered because Task 5 surfaced a real gap: `app/eval/data/locomo10.json` is untracked and was missing in the PR-B worktree. Future contributors get the discipline in-place.

## Receipts (smoke)

LIMIT=2 LoCoMo page-ON smoke (controller machine, Metal GPU):
- NDCG@10: 0.6532
- Recall@5: 0.6632
- MRR: 0.6114
- Files emitted: `app/eval/baselines/locomo__with_reranker__cross-encoder__79fa87e90f040813__with_pages.json` (legacy) and `~/.cache/origin-eval/baselines/l1_db/locomo/cross_rerank_v2_pages__4b8e3ff0.json` (layered, variant_tag differentiates ON / OFF).

Per the methodology discipline above, 0.6532 is NOT comparable to the per-conv published 0.684. The number gates wiring correctness, not the lift claim. Phase 2 LIMIT=20 ON-vs-OFF runs (LoCoMo + LME) produce the comparable receipts.

## Follow-ups

- `comparable_hash` should include `env.flags` (Task #30, Plan A leftover) so the layered path differentiates by `flags` instead of relying on the `variant_tag` workaround.
- `SearchMemoryRequest.include_pages` per-call opt-out flag (response to adversarial B1) so callers can disable the page-channel per-request, not just daemon-wide.
- Phase 2 eval: LoCoMo + LME × page-ON / page-OFF at LIMIT=20, retrieval-only metrics, compare deltas. To be run post-push.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p origin-core --lib` 1251 passed, 0 failed, 15 ignored
- [x] LoCoMo page-ON smoke at LIMIT=2 produces both legacy + layered artifacts
- [ ] LoCoMo page-OFF smoke at LIMIT=2 (variant_tag differentiation check)
- [ ] LME page-ON + page-OFF LIMIT=2 smoke
- [ ] Phase 2: LIMIT=20 LoCoMo + LME × ON / OFF, compare-baselines output
- [ ] Latency telemetry on production hot-path post-merge (per adversarial item 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Update — opt-in default, safety fixups, coverage metric (post-review)

**Default flipped to opt-in** (`0fdedcd4`). Page-channel is now OFF by default; enable with `ORIGIN_ENABLE_PAGE_CHANNEL=1` (replaces opt-out `ORIGIN_DISABLE_PAGE_CHANNEL`). Conservative default for a new, latency-adding, answer-quality-unproven channel (community norm; matches Mem0's opt-in graph). Promote to default-on after answer-quality validation.

**Page-channel safety fixups** (`61511d9d`):
- space/filter passthrough to `search_pages` — page rows gated by source overlap with the filtered memory set (no cross-space/type leak)
- `page_*` ids excluded from access-log + agent-activity recording
- `log::warn!` + degrade on `search_pages` error (no silent drop)
- truthy env parse

**Source-expanded coverage metric** (`e4878cfd`..`0e614435`):
Page rows score 0 on NDCG by construction (`page_*` ids never match memory-keyed ground truth) and the partition keeps them out of the ranked top-N, so NDCG stays neutral. To measure the channel honestly, added a SET-based `coverage_recall` that credits a retrieved page via the memory source ids it expands to (`get_page_sources`) — the HippoRAG / LongMemEval provenance-expansion pattern. Reports `blind` (memory-only) vs `expanded` (page-source-expanded); `delta` = page contribution. Additive, eval-only, dedup-safe. Three adversarial review passes, 1261 lib tests green.

**Measured page-source coverage lift** (single-run, N=20 subset; *scaffold, not a headline claim*; cached scenario DB; cross-encoder rerank):

| bench | coverage blind | coverage expanded | delta |
|---|---|---|---|
| LoCoMo | 0.743 | 0.921 | **+0.178** |
| LongMemEval | 0.658 | 0.700 | **+0.042** |

Positive on both; larger on LoCoMo (dialogue/multi-hop), matching prior context-path findings. Full multi-run (N>=3 + stddev) required before any headline/external claim.
