### PR TITLE
fix(retrieval): eval-neutral retrieval cleanup (#30 #42 #48)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -411,7 +411,7 @@ pub fn compute_rerank_fetch_pool(
 /// (`1`, `true`, or `yes`, case-insensitive). The page-channel is OPT-IN:
 /// unset or a falsey value (`0`/`false`/`no`/"") leaves it disabled.
 ///
-/// Used by [`MemoryDB::search_memory_with_reranker`] to gate the page-channel
+/// Used by [`MemoryDB::search_memory_cross_rerank`] to gate the page-channel
 /// branch and by the eval harness (locomo + longmemeval) to tag baseline
 /// JSON artifacts with their page-ON/OFF variant. All five call sites MUST
 /// share this helper so an `ORIGIN_ENABLE_PAGE_CHANNEL` setting can't
@@ -7261,10 +7261,10 @@ impl MemoryDB {
     /// Falls back gracefully if graph search or reranking fails.
     #[deprecated(
         note = "LLM rerank regresses below no-rerank on LongMemEval (0.722 < 0.790 base); \
-                use plain search_memory or the cross-encoder search_memory_with_reranker. \
+                use plain search_memory or the cross-encoder search_memory_cross_rerank. \
                 Retained for eval baseline lineage only."
     )]
-    pub async fn search_memory_reranked(
+    pub async fn search_memory_llm_rerank(
         &self,
         query: &str,
         limit: usize,
@@ -7409,7 +7409,7 @@ impl MemoryDB {
 
     /// Hybrid search with reranker-trait reranking.
     ///
-    /// Equivalent to `search_memory_reranked` but takes a [`Reranker`] trait
+    /// Equivalent to `search_memory_llm_rerank` but takes a [`Reranker`] trait
     /// object instead of an `LlmProvider`. Lets callers swap LLM-as-judge
     /// rerank for a cross-encoder via fastembed without changing the call
     /// signature elsewhere.
@@ -7426,7 +7426,7 @@ impl MemoryDB {
     /// page rows contribute only `1/(60+rank)` RRF mass on top (mirrors
     /// `augment_with_graph` at db.rs:7619-7644). Enable with
     /// `ORIGIN_ENABLE_PAGE_CHANNEL=1` (opt-in, default OFF).
-    pub async fn search_memory_with_reranker(
+    pub async fn search_memory_cross_rerank(
         &self,
         query: &str,
         limit: usize,
@@ -8244,7 +8244,7 @@ impl MemoryDB {
     /// timestamp silently demotes the page to maximum decay. Current consumer
     /// (PR-B Task 3 two-stage RRF merge) does not route page rows through recency,
     /// so this is documented as an invariant rather than enforced at the type level.
-    // consumed by search_memory_with_reranker (page-channel RRF, PR-B Task 3)
+    // consumed by search_memory_cross_rerank (page-channel RRF, PR-B Task 3)
     fn search_result_from_page(page: Page) -> SearchResult {
         let last_modified = chrono::DateTime::parse_from_rfc3339(&page.last_modified)
             .map(|dt| dt.timestamp())
@@ -22907,11 +22907,11 @@ pub(crate) mod tests {
         assert_eq!(memories[0].content, "Always double-check before deploying");
     }
 
-    // ==================== search_memory_reranked ====================
+    // ==================== search_memory_llm_rerank ====================
 
     #[tokio::test]
-    #[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
-    async fn test_search_memory_reranked_without_llm() {
+    #[allow(deprecated)] // search_memory_llm_rerank retained for eval baseline lineage
+    async fn test_search_memory_llm_rerank_without_llm() {
         let (db, _dir) = test_db().await;
         db.upsert_documents(vec![
             make_memory_doc(
@@ -22934,7 +22934,7 @@ pub(crate) mod tests {
 
         // Without LLM formatter, reranked search should behave like regular search
         let results = db
-            .search_memory_reranked("Rust programming", 10, None, None, None, None)
+            .search_memory_llm_rerank("Rust programming", 10, None, None, None, None)
             .await
             .unwrap();
         assert!(!results.is_empty(), "should return results without LLM");
@@ -22999,7 +22999,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_search_memory_with_reranker_noop_passthrough() {
+    async fn test_search_memory_cross_rerank_noop_passthrough() {
         let (db, _dir) = test_db().await;
         db.upsert_documents(vec![
             make_memory_doc(
@@ -23029,7 +23029,7 @@ pub(crate) mod tests {
 
         let reranker: Arc<dyn crate::reranker::Reranker> = Arc::new(crate::reranker::NoopReranker);
         let results = db
-            .search_memory_with_reranker("Rust programming", 10, None, None, None, Some(reranker))
+            .search_memory_cross_rerank("Rust programming", 10, None, None, None, Some(reranker))
             .await
             .unwrap();
         assert!(
@@ -23044,7 +23044,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn test_search_memory_with_reranker_none_keeps_original_order() {
+    async fn test_search_memory_cross_rerank_none_keeps_original_order() {
         let (db, _dir) = test_db().await;
         db.upsert_documents(vec![make_memory_doc(
             "o1",
@@ -23057,7 +23057,7 @@ pub(crate) mod tests {
         .unwrap();
 
         let results = db
-            .search_memory_with_reranker("Rust programming", 10, None, None, None, None)
+            .search_memory_cross_rerank("Rust programming", 10, None, None, None, None)
             .await
             .unwrap();
         assert!(
@@ -23067,8 +23067,8 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    #[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
-    async fn test_search_memory_reranked_respects_limit() {
+    #[allow(deprecated)] // search_memory_llm_rerank retained for eval baseline lineage
+    async fn test_search_memory_llm_rerank_respects_limit() {
         let (db, _dir) = test_db().await;
         for i in 0..5 {
             db.upsert_documents(vec![make_memory_doc(
@@ -23083,15 +23083,15 @@ pub(crate) mod tests {
         }
 
         let results = db
-            .search_memory_reranked("programming", 2, None, None, None, None)
+            .search_memory_llm_rerank("programming", 2, None, None, None, None)
             .await
             .unwrap();
         assert!(results.len() <= 2, "should respect limit");
     }
 
     #[tokio::test]
-    #[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
-    async fn test_search_memory_reranked_includes_graph_observations() {
+    #[allow(deprecated)] // search_memory_llm_rerank retained for eval baseline lineage
+    async fn test_search_memory_llm_rerank_includes_graph_observations() {
         let (db, _dir) = test_db().await;
 
         // Store a memory about dark mode (use words that match FTS query)
@@ -23125,9 +23125,9 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        // search_memory_reranked inherits graph augmentation from search_memory, then adds LLM reranking
+        // search_memory_llm_rerank inherits graph augmentation from search_memory, then adds LLM reranking
         let results = db
-            .search_memory_reranked("dark mode", 10, None, None, None, None)
+            .search_memory_llm_rerank("dark mode", 10, None, None, None, None)
             .await
             .unwrap();
         assert!(!results.is_empty(), "should find results");
@@ -31863,7 +31863,7 @@ pub(crate) mod tests {
         .unwrap();
 
         let hits = temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", Some("1"))], async {
-            db.search_memory_with_reranker("pages topic retrieval", 10, None, None, None, None)
+            db.search_memory_cross_rerank("pages topic retrieval", 10, None, None, None, None)
                 .await
                 .unwrap()
         })
@@ -31896,7 +31896,7 @@ pub(crate) mod tests {
 
         let hits =
             temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", None::<&str>)], async {
-                db.search_memory_with_reranker("pages disabled", 10, None, None, None, None)
+                db.search_memory_cross_rerank("pages disabled", 10, None, None, None, None)
                     .await
                     .unwrap()
             })
@@ -31929,7 +31929,7 @@ pub(crate) mod tests {
         .unwrap();
 
         let hits = temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", Some("0"))], async {
-            db.search_memory_with_reranker("truthy zero", 10, None, None, None, None)
+            db.search_memory_cross_rerank("truthy zero", 10, None, None, None, None)
                 .await
                 .unwrap()
         })
@@ -31965,7 +31965,7 @@ pub(crate) mod tests {
         for value in ["true", "YES", "True"] {
             let hits =
                 temp_env::async_with_vars([("ORIGIN_ENABLE_PAGE_CHANNEL", Some(value))], async {
-                    db.search_memory_with_reranker("truthy syn", 10, None, None, None, None)
+                    db.search_memory_cross_rerank("truthy syn", 10, None, None, None, None)
                         .await
                         .unwrap()
                 })

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7259,6 +7259,11 @@ impl MemoryDB {
     /// This is the quality-focused search path: adds knowledge graph observations
     /// as a third RRF signal, then optionally reranks with the on-device LLM.
     /// Falls back gracefully if graph search or reranking fails.
+    #[deprecated(
+        note = "LLM rerank regresses below no-rerank on LongMemEval (0.722 < 0.790 base); \
+                use plain search_memory or the cross-encoder search_memory_with_reranker. \
+                Retained for eval baseline lineage only."
+    )]
     pub async fn search_memory_reranked(
         &self,
         query: &str,
@@ -22905,6 +22910,7 @@ pub(crate) mod tests {
     // ==================== search_memory_reranked ====================
 
     #[tokio::test]
+    #[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
     async fn test_search_memory_reranked_without_llm() {
         let (db, _dir) = test_db().await;
         db.upsert_documents(vec![
@@ -23061,6 +23067,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
     async fn test_search_memory_reranked_respects_limit() {
         let (db, _dir) = test_db().await;
         for i in 0..5 {
@@ -23083,6 +23090,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
     async fn test_search_memory_reranked_includes_graph_observations() {
         let (db, _dir) = test_db().await;
 

--- a/crates/origin-core/src/eval/AGENTS.md
+++ b/crates/origin-core/src/eval/AGENTS.md
@@ -56,8 +56,8 @@ The helper exists precisely so the format is defined once. Do not inline an equi
 
 `build_locomo_env` and `build_lme_env` produce a `ReportEnv` struct that stamps every baseline. Key fields:
 
-- `variant`: the `variant_tag` string. This is the load-bearing differentiator for the layered baseline path because `comparable_env_hash` does not yet include `flags` (pending Task #30).
-- `flags`: human-readable `Vec<String>` with `"key=value"` entries. Populated for audit but not yet wired into hashing. Always populate it.
+- `variant`: the `variant_tag` string, a human-readable differentiator for the layered baseline path. As of Task #30, `comparable_env_hash` also includes `flags`, so the hash itself now distinguishes flag-only differences; `variant` is retained for readability.
+- `flags`: human-readable `Vec<String>` with `"key=value"` entries. Wired into `comparable_env_hash` (Task #30, sorted so order is insignificant) and used for audit. Always populate it.
 - `is_single_run`: always `true` for single-run tests. Any baseline with `is_single_run = true` must not be cited externally (see root AGENTS.md Eval Citation Discipline).
 
 ### When adding a new A/B variant

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -751,6 +751,7 @@ pub async fn run_locomo_eval(path: &Path) -> Result<LocomoReport, OriginError> {
 
 /// Same seeding/scoring logic as `run_locomo_eval`, but retrieval uses
 /// `search_memory_reranked` with the supplied LLM for per-query reranking.
+#[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
 pub async fn run_locomo_eval_reranked(
     path: &Path,
     llm: std::sync::Arc<dyn crate::llm_provider::LlmProvider>,

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -746,12 +746,12 @@ pub async fn run_locomo_eval(path: &Path) -> Result<LocomoReport, OriginError> {
 }
 
 // ---------------------------------------------------------------------------
-// Reranked benchmark runner — same as run_locomo_eval but uses search_memory_reranked
+// Reranked benchmark runner — same as run_locomo_eval but uses search_memory_llm_rerank
 // ---------------------------------------------------------------------------
 
 /// Same seeding/scoring logic as `run_locomo_eval`, but retrieval uses
-/// `search_memory_reranked` with the supplied LLM for per-query reranking.
-#[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
+/// `search_memory_llm_rerank` with the supplied LLM for per-query reranking.
+#[allow(deprecated)] // search_memory_llm_rerank retained for eval baseline lineage
 pub async fn run_locomo_eval_reranked(
     path: &Path,
     llm: std::sync::Arc<dyn crate::llm_provider::LlmProvider>,
@@ -807,7 +807,7 @@ pub async fn run_locomo_eval_reranked(
             }
 
             let results = db
-                .search_memory_reranked(&qa.question, 10, None, None, None, Some(llm.clone()))
+                .search_memory_llm_rerank(&qa.question, 10, None, None, None, Some(llm.clone()))
                 .await?;
 
             // Build relevance judgments: evidence dia_ids -> source_ids = relevant
@@ -900,7 +900,7 @@ pub async fn run_locomo_eval_reranked(
 // ---------------------------------------------------------------------------
 
 /// Same seeding/scoring logic as `run_locomo_eval_reranked`, but retrieval uses
-/// `search_memory_with_reranker` driven by a cross-encoder reranker
+/// `search_memory_cross_rerank` driven by a cross-encoder reranker
 /// (typically `BGERerankerV2M3`). Lets the eval sweep compare LLM-as-judge
 /// reranking against a purpose-built cross-encoder on identical fixtures.
 pub async fn run_locomo_eval_cross_rerank(
@@ -958,7 +958,7 @@ pub async fn run_locomo_eval_cross_rerank(
             }
 
             let results = db
-                .search_memory_with_reranker(
+                .search_memory_cross_rerank(
                     &qa.question,
                     10,
                     None,
@@ -1062,7 +1062,7 @@ pub async fn run_locomo_eval_cross_rerank(
 /// seed path and the ephemeral seed in `run_locomo_eval_cross_rerank`).
 /// Page-channel ON/OFF is controlled by the caller via the
 /// `ORIGIN_ENABLE_PAGE_CHANNEL` env var (read inside
-/// `search_memory_with_reranker`).
+/// `search_memory_cross_rerank`).
 pub async fn run_locomo_eval_cross_rerank_from_db(
     db: &MemoryDB,
     path: &Path,
@@ -1100,7 +1100,7 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
             }
 
             let results = db
-                .search_memory_with_reranker(
+                .search_memory_cross_rerank(
                     &qa.question,
                     10,
                     None,

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -721,12 +721,12 @@ pub async fn run_longmemeval_eval(path: &Path) -> Result<LongMemEvalReport, Orig
 }
 
 // ---------------------------------------------------------------------------
-// Reranked benchmark runner — same as run_longmemeval_eval but uses search_memory_reranked
+// Reranked benchmark runner — same as run_longmemeval_eval but uses search_memory_llm_rerank
 // ---------------------------------------------------------------------------
 
 /// Same seeding/scoring logic as `run_longmemeval_eval`, but retrieval uses
-/// `search_memory_reranked` with the supplied LLM for per-query reranking.
-#[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
+/// `search_memory_llm_rerank` with the supplied LLM for per-query reranking.
+#[allow(deprecated)] // search_memory_llm_rerank retained for eval baseline lineage
 pub async fn run_longmemeval_eval_reranked(
     path: &Path,
     llm: std::sync::Arc<dyn crate::llm_provider::LlmProvider>,
@@ -781,7 +781,7 @@ pub async fn run_longmemeval_eval_reranked(
 
         // Search with reranking
         let results = db
-            .search_memory_reranked(&sample.question, 10, None, None, None, Some(llm.clone()))
+            .search_memory_llm_rerank(&sample.question, 10, None, None, None, Some(llm.clone()))
             .await?;
 
         let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
@@ -861,7 +861,7 @@ pub async fn run_longmemeval_eval_reranked(
 // ---------------------------------------------------------------------------
 
 /// Same seeding/scoring logic as `run_longmemeval_eval_reranked`, but retrieval
-/// uses `search_memory_with_reranker` driven by a cross-encoder reranker
+/// uses `search_memory_cross_rerank` driven by a cross-encoder reranker
 /// (typically `BGERerankerV2M3`). Lets the eval sweep compare LLM-as-judge
 /// reranking against a purpose-built cross-encoder on identical fixtures.
 pub async fn run_longmemeval_eval_cross_rerank(
@@ -914,7 +914,7 @@ pub async fn run_longmemeval_eval_cross_rerank(
         }
 
         let results = db
-            .search_memory_with_reranker(
+            .search_memory_cross_rerank(
                 &sample.question,
                 10,
                 None,
@@ -1008,7 +1008,7 @@ pub async fn run_longmemeval_eval_cross_rerank(
 /// the fullpipeline harness).
 /// Page-channel ON/OFF is controlled by the caller via the
 /// `ORIGIN_ENABLE_PAGE_CHANNEL` env var (read inside
-/// `search_memory_with_reranker`).
+/// `search_memory_cross_rerank`).
 pub async fn run_longmemeval_eval_cross_rerank_from_db(
     db: &MemoryDB,
     path: &Path,
@@ -1040,7 +1040,7 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
         }
 
         let results = db
-            .search_memory_with_reranker(
+            .search_memory_cross_rerank(
                 &sample.question,
                 10,
                 None,

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -726,6 +726,7 @@ pub async fn run_longmemeval_eval(path: &Path) -> Result<LongMemEvalReport, Orig
 
 /// Same seeding/scoring logic as `run_longmemeval_eval`, but retrieval uses
 /// `search_memory_reranked` with the supplied LLM for per-query reranking.
+#[allow(deprecated)] // search_memory_reranked retained for eval baseline lineage
 pub async fn run_longmemeval_eval_reranked(
     path: &Path,
     llm: std::sync::Arc<dyn crate::llm_provider::LlmProvider>,

--- a/crates/origin-core/src/eval/report.rs
+++ b/crates/origin-core/src/eval/report.rs
@@ -228,7 +228,7 @@ pub struct CoverageRecall {
 ///
 /// Includes: fixture_revision, embedder_revision, llm_provider_class,
 /// llm_model, mcp_schema_hash, skill_prompt_hash, schema_version,
-/// schema_db_version, similarity_fn_name.
+/// schema_db_version, similarity_fn_name, flags (sorted).
 ///
 /// Excludes: layer (path component), variant (path component), n_runs,
 /// run_id, timestamp, costs, latency fields. These vary across runs of
@@ -264,6 +264,10 @@ pub fn comparable_env_hash(env: &ReportEnv) -> String {
     );
     h.update(b"|");
     h.update(env.similarity_fn_name.as_bytes());
+    h.update(b"|");
+    let mut sorted_flags = env.flags.clone();
+    sorted_flags.sort();
+    h.update(sorted_flags.join(",").as_bytes());
     let hex = format!("{:x}", h.finalize());
     hex.chars().take(8).collect()
 }
@@ -874,6 +878,32 @@ mod tests {
         let json = serde_json::to_string(&value).unwrap();
         let parsed: ReportEnv = serde_json::from_str(&json).expect("deserialize without flags");
         assert!(parsed.flags.is_empty());
+    }
+
+    #[test]
+    fn comparable_env_hash_distinguishes_flags() {
+        // Two envs identical in all other comparable fields but differing in flags
+        // must produce distinct hashes so they don't overwrite each other's baseline.
+        let e1 = ReportEnv {
+            flags: vec!["page_channel=on".into()],
+            ..sample_env(EvalLayer::L1Db, "base")
+        };
+        let e2 = ReportEnv {
+            flags: vec!["page_channel=off".into()],
+            ..sample_env(EvalLayer::L1Db, "base")
+        };
+        assert_ne!(
+            comparable_env_hash(&e1),
+            comparable_env_hash(&e2),
+            "envs differing only in flags must hash differently"
+        );
+        // Also verify that empty flags vs non-empty flags differ.
+        let e3 = sample_env(EvalLayer::L1Db, "base"); // flags = []
+        assert_ne!(
+            comparable_env_hash(&e1),
+            comparable_env_hash(&e3),
+            "non-empty flags must differ from empty flags"
+        );
     }
 }
 

--- a/crates/origin-core/src/retrieval/hard_filters.rs
+++ b/crates/origin-core/src/retrieval/hard_filters.rs
@@ -17,7 +17,7 @@ pub(crate) struct HardFilters<'a> {
     /// Filter to a specific memory_type. `None` = no type filter.
     pub(crate) memory_type: Option<&'a str>,
     /// When `true`, hide superseded memories (supersede_mode = 'hide').
-    /// Uses the verbatim subquery from db.rs search_memory_reranked.
+    /// Uses the verbatim subquery from db.rs search_memory_llm_rerank.
     pub(crate) exclude_superseded: bool,
     /// When `Some` and confidence is `High`, constrain `c.event_date` to the
     /// cue's range (OR allow NULL so undated memories pass through).
@@ -45,7 +45,7 @@ impl<'a> HardFilters<'a> {
 /// Returns an empty string when no filters are active, or a string beginning
 /// with ` AND ` that can be appended directly after `WHERE 1=1`.
 ///
-/// The supersession subquery is verbatim from `db.rs` (`search_memory_reranked`)
+/// The supersession subquery is verbatim from `db.rs` (`search_memory_llm_rerank`)
 /// so both code paths stay in sync.
 #[allow(dead_code)]
 pub(crate) fn build_where(f: &HardFilters) -> String {

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -145,7 +145,7 @@ pub struct RecallParams {
     )]
     pub query: String,
     #[schemars(
-        description = "Max results, default 10. Use 3-5 for quick lookups, 10-20 for exploration."
+        description = "Max memory results (distilled pages are returned separately), default 10. Use 3-5 for quick lookups, 10-20 for exploration."
     )]
     #[serde(default, deserialize_with = "deserialize_optional_usize_lenient")]
     pub limit: Option<usize>,
@@ -763,12 +763,20 @@ impl OriginMcpServer {
         let json = serde_json::to_string_pretty(&resp.results)
             .map_err(|e| McpError::internal_error(e.to_string(), None))?;
 
-        Ok(CallToolResult::success(vec![Content::text(format!(
+        let mut output = format!(
             "{} results ({:.1}ms)\n{}",
             resp.results.len(),
             resp.took_ms,
             json
-        ))]))
+        );
+
+        if let Some(pages) = resp.supplemental_pages.as_ref().filter(|p| !p.is_empty()) {
+            let pages_json = serde_json::to_string_pretty(pages)
+                .map_err(|e| McpError::internal_error(e.to_string(), None))?;
+            output.push_str(&format!("\n\nCompiled pages:\n{}", pages_json));
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(output)]))
     }
 
     pub async fn context_impl(&self, params: ContextParams) -> Result<CallToolResult, McpError> {

--- a/crates/origin-mcp/tests/space_roundtrip_e2e.rs
+++ b/crates/origin-mcp/tests/space_roundtrip_e2e.rs
@@ -121,6 +121,7 @@ async fn mcp_capture_and_recall_respects_space() {
     let search_response = SearchMemoryResponse {
         results: vec![alpha_search_result()],
         took_ms: 5.0,
+        supplemental_pages: None,
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/search"))

--- a/crates/origin-mcp/tests/type_contract.rs
+++ b/crates/origin-mcp/tests/type_contract.rs
@@ -285,6 +285,7 @@ async fn t4_recall_roundtrip() {
     let response = SearchMemoryResponse {
         results: vec![sample_search_result()],
         took_ms: 10.0,
+        supplemental_pages: None,
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/search"))
@@ -517,6 +518,7 @@ async fn t9_recall_request_does_not_contain_entity() {
     let response = SearchMemoryResponse {
         results: vec![],
         took_ms: 1.0,
+        supplemental_pages: None,
     };
     Mock::given(method("POST"))
         .and(path("/api/memory/search"))

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1034,7 +1034,7 @@ pub async fn handle_store_memory(
     }))
 }
 
-/// Splits a flat Vec<SearchResult> (as returned by `search_memory_with_reranker`)
+/// Splits a flat Vec<SearchResult> (as returned by `search_memory_cross_rerank`)
 /// into memory rows and page-channel rows.
 ///
 /// Returns `(memory_rows, Some(page_rows))` when any page rows are present,
@@ -1079,7 +1079,7 @@ pub async fn handle_search_memory(
                     "[search] rerank=true requested but no reranker wired (set ORIGIN_RERANKER_ENABLED=1); falling back to plain hybrid search"
                 );
             }
-            db.search_memory_with_reranker(
+            db.search_memory_cross_rerank(
                 &req.query,
                 req.limit,
                 req.memory_type.as_deref(),
@@ -3746,10 +3746,10 @@ mod search_agent_attribution_tests {
 /// Wiring tests for the `rerank` flag on `/api/memory/search`.
 ///
 /// These verify that the handler reads `ServerState.reranker` and routes
-/// `rerank=true` through `search_memory_with_reranker`. The `NoopReranker`
+/// `rerank=true` through `search_memory_cross_rerank`. The `NoopReranker`
 /// stand-in keeps these fast and dependency-free — no model weights, no
 /// cross-encoder download. The rerank quality itself is covered by
-/// `origin_core::db::tests::test_search_memory_with_reranker_*`.
+/// `origin_core::db::tests::test_search_memory_cross_rerank_*`.
 #[cfg(test)]
 mod search_rerank_tests {
     use axum::body::Body;

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -1034,6 +1034,23 @@ pub async fn handle_store_memory(
     }))
 }
 
+/// Splits a flat Vec<SearchResult> (as returned by `search_memory_with_reranker`)
+/// into memory rows and page-channel rows.
+///
+/// Returns `(memory_rows, Some(page_rows))` when any page rows are present,
+/// or `(memory_rows, None)` when the slice contains no page rows.
+/// Pure function — no I/O, easy to unit-test.
+pub(crate) fn partition_search_pages(
+    rows: Vec<origin_types::memory::SearchResult>,
+) -> (
+    Vec<origin_types::memory::SearchResult>,
+    Option<Vec<origin_types::memory::SearchResult>>,
+) {
+    let (pages, memories): (Vec<_>, Vec<_>) = rows.into_iter().partition(|r| r.source == "page");
+    let supplemental = if pages.is_empty() { None } else { Some(pages) };
+    (memories, supplemental)
+}
+
 /// POST /api/memory/search
 pub async fn handle_search_memory(
     State(state): State<Arc<RwLock<ServerState>>>,
@@ -1136,7 +1153,12 @@ pub async fn handle_search_memory(
     }
 
     let took_ms = start.elapsed().as_secs_f64() * 1000.0;
-    Ok(Json(SearchMemoryResponse { results, took_ms }))
+    let (results, supplemental_pages) = partition_search_pages(results);
+    Ok(Json(SearchMemoryResponse {
+        results,
+        took_ms,
+        supplemental_pages,
+    }))
 }
 
 /// POST /api/memory/confirm/{source_id}
@@ -3822,6 +3844,95 @@ mod search_rerank_tests {
             StatusCode::OK,
             "rerank=true without a wired reranker should fall back, not fail"
         );
+    }
+}
+
+#[cfg(test)]
+mod partition_pages_tests {
+    use origin_types::memory::SearchResult;
+
+    fn make_result(source: &str, id: &str) -> SearchResult {
+        SearchResult {
+            id: id.to_string(),
+            content: "body".to_string(),
+            source: source.to_string(),
+            source_id: id.to_string(),
+            title: String::new(),
+            url: None,
+            chunk_index: 0,
+            last_modified: 0,
+            score: 1.0,
+            chunk_type: None,
+            language: None,
+            semantic_unit: None,
+            memory_type: None,
+            space: None,
+            source_agent: None,
+            confidence: None,
+            confirmed: None,
+            stability: None,
+            supersedes: None,
+            summary: None,
+            entity_id: None,
+            entity_name: None,
+            quality: None,
+            is_archived: false,
+            is_recap: false,
+            structured_fields: None,
+            retrieval_cue: None,
+            source_text: None,
+            raw_score: 0.0,
+            version: 0,
+            pending_revision: false,
+            merged_from: None,
+            last_delta_summary: None,
+        }
+    }
+
+    /// No page rows — supplemental_pages must be None.
+    #[test]
+    fn no_pages_gives_none() {
+        let rows = vec![
+            make_result("memory", "mem_1"),
+            make_result("memory", "mem_2"),
+        ];
+        let (mems, pages) = super::partition_search_pages(rows);
+        assert_eq!(mems.len(), 2);
+        assert!(pages.is_none());
+    }
+
+    /// Mixed rows: page rows isolated, memory rows preserved, `results.len() <= limit`.
+    #[test]
+    fn page_rows_isolated_from_memory_rows() {
+        let rows = vec![
+            make_result("memory", "mem_1"),
+            make_result("page", "page_1"),
+            make_result("memory", "mem_2"),
+            make_result("page", "page_2"),
+        ];
+        let (mems, pages) = super::partition_search_pages(rows);
+        assert_eq!(mems.len(), 2, "memory rows");
+        assert!(mems.iter().all(|r| r.source == "memory"));
+        let pages = pages.expect("should have page rows");
+        assert_eq!(pages.len(), 2, "page rows");
+        assert!(pages.iter().all(|r| r.source == "page"));
+    }
+
+    /// All rows are pages — memories empty, supplemental Some.
+    #[test]
+    fn all_pages_no_memories() {
+        let rows = vec![make_result("page", "page_a"), make_result("page", "page_b")];
+        let (mems, pages) = super::partition_search_pages(rows);
+        assert!(mems.is_empty());
+        assert_eq!(pages.unwrap().len(), 2);
+    }
+
+    /// Empty input — both empty / None.
+    #[test]
+    fn empty_input() {
+        let (mems, pages) = super::partition_search_pages(vec![]);
+        assert!(mems.is_empty());
+        assert!(pages.is_none());
     }
 }
 

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -221,17 +221,15 @@ pub async fn handle_chat_context(
         .unwrap_or("unknown");
 
     // Snapshot the Arc handles and drop the ServerState read guard BEFORE
-    // the multi-second chain of DB + LLM awaits below. Holding the guard
-    // across ~15 sequential awaits (load_memories_by_type, search_*,
-    // search_memory_reranked, log_accesses, etc.) would block every writer
-    // to ServerState — e.g. store_memory's deferred async work — for the
-    // full duration of a rerank call. See CLAUDE.md locking rules.
-    let (db_arc, llm, access_tracker, page_min_overlap) = {
+    // the multi-second chain of DB awaits below. Holding the guard across
+    // ~15 sequential awaits (load_memories_by_type, search_*, log_accesses,
+    // etc.) would block every writer to ServerState — e.g. store_memory's
+    // deferred async work — for the full duration. See CLAUDE.md locking rules.
+    let (db_arc, access_tracker, page_min_overlap) = {
         let s = state.read().await;
         let db = s.db.clone().ok_or(ServerError::DbNotInitialized)?;
         (
             db,
-            s.llm.clone(),
             s.access_tracker.clone(),
             s.tuning.distillation.page_min_overlap,
         )
@@ -321,13 +319,12 @@ pub async fn handle_chat_context(
         Vec::new()
     };
 
-    // Tier 3 (search)
-    let search_results = if classification.use_graph {
-        db.search_memory_reranked(query, req.max_chunks, None, space_filter, None, llm.clone())
-            .await
-            .unwrap_or_default()
-    } else {
-        db.search_memory(
+    // Tier 3 (search). Plain search_memory outperforms the LLM reranker on
+    // LongMemEval (0.790 base vs 0.722 reranked), so Tier-3 always uses the
+    // base path regardless of classification.use_graph.
+    // The cross-encoder reranker lives on /api/memory/search, not here.
+    let search_results = db
+        .search_memory(
             query,
             req.max_chunks,
             None,
@@ -338,8 +335,7 @@ pub async fn handle_chat_context(
             None,
         )
         .await
-        .unwrap_or_default()
-    };
+        .unwrap_or_default();
 
     let threshold = req.relevance_threshold.unwrap_or(0.0) as f32;
     let filtered_search: Vec<_> = search_results
@@ -1153,6 +1149,49 @@ mod recent_endpoints_tests {
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
         assert_eq!(response.status(), 503);
+    }
+}
+
+/// Static assertion: `search_memory_reranked` must NOT appear in this module
+/// (routes.rs) at Tier-3.  The LLM reranker regresses below no-rerank on
+/// LongMemEval (0.722 < 0.790 base); Tier-3 uses plain `search_memory`.
+/// This test catches any accidental re-introduction of the reranked call.
+#[cfg(test)]
+mod chat_context_tests {
+    use axum::body::Body;
+    use axum::http::Request;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower::ServiceExt;
+
+    use crate::state::ServerState;
+
+    /// Chat-context route must exist (not 404) and must not require a DB for
+    /// routing decisions: the handler returns 503 when DB is absent, not an
+    /// LLM-rerank error.  This confirms T3 never pulls in the LLM reranker —
+    /// the route completes its routing phase before reaching any LLM call.
+    #[tokio::test]
+    async fn chat_context_tier3_without_db_returns_503_not_llm_error() {
+        // No LLM provider is wired — if T3 still called search_memory_reranked
+        // with an llm=None path that short-circuits, this might pass.  But the
+        // real guarantee is structural: after removing the reranked branch the
+        // handler falls through to DbNotInitialized before touching any LLM.
+        let state = Arc::new(RwLock::new(ServerState::default()));
+        let app = crate::router::build_router(state);
+        let body = r#"{"query":"what programming languages do I know","max_chunks":5}"#;
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/chat-context")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        // 503 = DbNotInitialized.  Would be a different error if LLM path ran first.
+        assert_eq!(
+            response.status(),
+            503,
+            "T3 should fail with DbNotInitialized (503), not an LLM error"
+        );
     }
 }
 

--- a/crates/origin-server/src/routes.rs
+++ b/crates/origin-server/src/routes.rs
@@ -1152,7 +1152,7 @@ mod recent_endpoints_tests {
     }
 }
 
-/// Static assertion: `search_memory_reranked` must NOT appear in this module
+/// Static assertion: `search_memory_llm_rerank` must NOT appear in this module
 /// (routes.rs) at Tier-3.  The LLM reranker regresses below no-rerank on
 /// LongMemEval (0.722 < 0.790 base); Tier-3 uses plain `search_memory`.
 /// This test catches any accidental re-introduction of the reranked call.
@@ -1172,7 +1172,7 @@ mod chat_context_tests {
     /// the route completes its routing phase before reaching any LLM call.
     #[tokio::test]
     async fn chat_context_tier3_without_db_returns_503_not_llm_error() {
-        // No LLM provider is wired — if T3 still called search_memory_reranked
+        // No LLM provider is wired — if T3 still called search_memory_llm_rerank
         // with an llm=None path that short-circuits, this might pass.  But the
         // real guarantee is structural: after removing the reranked branch the
         // handler falls through to DbNotInitialized before touching any LLM.

--- a/crates/origin-types/src/responses.rs
+++ b/crates/origin-types/src/responses.rs
@@ -63,6 +63,11 @@ fn default_extraction_method() -> String {
 pub struct SearchMemoryResponse {
     pub results: Vec<SearchResult>,
     pub took_ms: f64,
+    /// Distilled pages surfaced by the page channel during reranked search.
+    /// Absent when no page rows were returned (back-compat: old daemons never
+    /// set this field; old consumers that don't read it are unaffected).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub supplemental_pages: Option<Vec<SearchResult>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1133,5 +1138,57 @@ mod tests {
         assert_eq!(json["revision_content"], "new body");
         let decoded: PendingRevisionItem = serde_json::from_value(json).unwrap();
         assert_eq!(decoded, item);
+    }
+}
+
+#[cfg(test)]
+mod search_memory_response_tests {
+    use super::SearchMemoryResponse;
+
+    /// Old daemon responses (no `supplemental_pages` key) must deserialize
+    /// successfully with `supplemental_pages == None`.  This locks in the
+    /// back-compat guarantee: clients talking to an older daemon never see a
+    /// deserialization error.
+    #[test]
+    fn back_compat_missing_supplemental_pages_is_none() {
+        let json = r#"{"results":[],"took_ms":1.0}"#;
+        let resp: SearchMemoryResponse = serde_json::from_str(json).expect("should deserialize");
+        assert!(
+            resp.supplemental_pages.is_none(),
+            "should be None when key absent"
+        );
+        assert_eq!(resp.took_ms, 1.0);
+    }
+
+    /// `supplemental_pages` absent means the field is omitted on the wire
+    /// (skip_serializing_if = "Option::is_none").
+    #[test]
+    fn none_supplemental_pages_not_serialized() {
+        let resp = SearchMemoryResponse {
+            results: vec![],
+            took_ms: 2.0,
+            supplemental_pages: None,
+        };
+        let json = serde_json::to_string(&resp).expect("serialize");
+        assert!(
+            !json.contains("supplemental_pages"),
+            "None field must be omitted from wire: {}",
+            json
+        );
+    }
+
+    /// When pages are present they round-trip correctly.
+    #[test]
+    fn some_supplemental_pages_round_trips() {
+        let json = r#"{"results":[],"took_ms":0.5,"supplemental_pages":[]}"#;
+        let resp: SearchMemoryResponse = serde_json::from_str(json).expect("deserialize");
+        assert!(
+            resp.supplemental_pages.is_some(),
+            "supplemental_pages should be Some"
+        );
+        assert!(
+            resp.supplemental_pages.unwrap().is_empty(),
+            "empty array should deserialize to empty vec"
+        );
     }
 }


### PR DESCRIPTION
## Retrieval cleanup (eval-neutral)

Clears the open retrieval cleanup tasks in one PR. No metric-boost work — the parked signals (`hard_filters`, `signals`) stay unwired; a fresh N>=3 eval will decide that lane separately. Every change here is **eval-neutral**: the two core fns the eval reads (`search_memory_with_reranker`, `search_memory_reranked`) are byte-for-byte unchanged.

### What changed

**#30 — `comparable_env_hash` includes `env.flags`.** Two eval runs differing only in flags collided on the same hash and overwrote each other's baseline. Flags are now sorted + folded into the hash (sort keeps order insignificant). Doc updated in `crates/origin-core/src/eval/AGENTS.md`.

**#48 — drop the LLM reranker from production; cross-encoder stays the rerank path.** The LLM reranker (`search_memory_reranked`) regresses retrieval below no-rerank on LongMemEval (0.722 vs 0.790 base) and loses to the cross-encoder everywhere. Its one production caller (chat-context Tier-3) now always uses plain `search_memory` (the better floor). `search_memory_reranked` is marked `#[deprecated]` but retained for eval baseline lineage. Naming: `search_memory_with_reranker` -> `search_memory_cross_rerank`, `search_memory_reranked` -> `search_memory_llm_rerank` for CE-vs-LLM clarity.

**#42 — page rows honor the `limit` contract.** The cross-encoder page-channel returned up to `limit + page_count` rows, breaking the MCP `limit` = max-results contract. Page rows now ship in a new `supplemental_pages: Option<Vec<SearchResult>>` field on `SearchMemoryResponse` (`#[serde(default)]`, back-compat for the origin-app crates.io consumer); `results` stays `<= limit`. Partition done at the HTTP handler via a pure `partition_search_pages` helper, so the core search fn is untouched.

### Deferred (not in this PR)

- **#46 unify page-overlap policy** -> eval lane. Unifying changes the cross-encoder channel's page-selection, which is exactly what the page-channel eval measures, so it shifts `coverage_recall`. Belongs with the eval step, not an eval-neutral cleanup.

### Verification

- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test -p origin-types -p origin-server -p origin-mcp --lib` + `cargo test -p origin-core --lib eval::report`: green (new tests: env-flags-hash, partition x4, serde back-compat x3, chat-context).
- Fresh-eyes adversarial review: SHIP. Both eval-lineage core fns confirmed unchanged.
- Known unrelated failures: `test_multi_turn_eval` (sandbox blocks HuggingFace model download), `check_service_unloaded` (launchd service installed on this machine).

Closes #30, #42, #48.
