### PR TITLE
fix(retrieval): query decomposition into independent subqueries

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -7428,6 +7428,19 @@ impl MemoryDB {
             .unwrap_or(Self::PAGE_CHANNEL_LIMIT_DEFAULT)
     }
 
+    /// Max subqueries (including the original) for `search_memory_decomposed`.
+    /// Env override `ORIGIN_QUERY_DECOMP_MAX_SUBQUERIES` lets the eval harness
+    /// sweep the cap without recompile. Default 4 matches Cognee's CoT max_iter.
+    const QUERY_DECOMP_MAX_DEFAULT: usize = 4;
+
+    fn query_decomp_max_subqueries() -> usize {
+        std::env::var("ORIGIN_QUERY_DECOMP_MAX_SUBQUERIES")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .filter(|&n| n >= 1)
+            .unwrap_or(Self::QUERY_DECOMP_MAX_DEFAULT)
+    }
+
     /// Hybrid search with reranker-trait reranking.
     ///
     /// Equivalent to `search_memory_llm_rerank` but takes a [`Reranker`] trait
@@ -7775,6 +7788,98 @@ impl MemoryDB {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
 
+        merged.truncate(limit);
+        Ok(merged)
+    }
+
+    /// Hybrid search with LLM query *decomposition* BEFORE search.
+    ///
+    /// Splits a compositional query into independent factual subqueries
+    /// (`retrieval::decompose`), runs `search_memory` per subquery, and RRF-merges
+    /// the pools. Unlike `search_memory_expanded` (paraphrases of one clause), each
+    /// stream is a DISTINCT clause, so a memory satisfying clause B is not drowned
+    /// by vocabulary variants of clause A. The original full query is always the
+    /// first stream, so the worst case degrades to a plain single-query search.
+    /// Graceful degradation: no LLM / parse failure / all-subquery-search failure
+    /// falls back to `search_memory(query, ...)`.
+    pub async fn search_memory_decomposed(
+        &self,
+        query: &str,
+        limit: usize,
+        memory_type: Option<&str>,
+        space: Option<&str>,
+        source_agent: Option<&str>,
+        llm: Option<Arc<dyn crate::llm_provider::LlmProvider>>,
+    ) -> Result<Vec<SearchResult>, OriginError> {
+        let queries = crate::retrieval::decompose::decompose_query(
+            llm.as_ref(),
+            query,
+            Self::query_decomp_max_subqueries(),
+        )
+        .await;
+
+        let fetch_pool = limit * 2;
+        let mut all_ranked: Vec<Vec<SearchResult>> = Vec::with_capacity(queries.len());
+        for q in &queries {
+            match self
+                .search_memory(
+                    q,
+                    fetch_pool,
+                    memory_type,
+                    space,
+                    source_agent,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+            {
+                Ok(results) => all_ranked.push(results),
+                Err(e) => {
+                    log::warn!("[memory_db] decompose search failed for subquery '{q}': {e}");
+                }
+            }
+        }
+
+        // If every subquery search failed, fall back to a plain search.
+        if all_ranked.is_empty() {
+            return self
+                .search_memory(
+                    query,
+                    limit,
+                    memory_type,
+                    space,
+                    source_agent,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+        }
+
+        // RRF merge — each subquery contributes one equal-weight stream.
+        let mut score_map: HashMap<String, f32> = HashMap::new();
+        let mut result_map: HashMap<String, SearchResult> = HashMap::new();
+        for ranked in all_ranked {
+            for (rank, result) in ranked.into_iter().enumerate() {
+                let rrf_score = 1.0 / (60.0 + rank as f32);
+                *score_map.entry(result.id.clone()).or_default() += rrf_score;
+                result_map.entry(result.id.clone()).or_insert(result);
+            }
+        }
+
+        let mut merged: Vec<SearchResult> = result_map
+            .into_values()
+            .map(|mut r| {
+                r.score = *score_map.get(&r.id).unwrap_or(&0.0);
+                r
+            })
+            .collect();
+        merged.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         merged.truncate(limit);
         Ok(merged)
     }

--- a/crates/origin-core/src/retrieval/decompose.rs
+++ b/crates/origin-core/src/retrieval/decompose.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Query decomposition: split a compositional query into independent factual
+//! subqueries so each clause's evidence is retrieved separately, then RRF-merged.
+//!
+//! Distinct from query *expansion* (`search_memory_expanded`), which rewrites the
+//! whole query into paraphrases. Decomposition splits "which projects did Alice
+//! work on after joining Acme" into independent clauses whose facts live in
+//! different memories — the multi-hop case a single embedding starves.
+
+use crate::llm_provider::{LlmProvider, LlmRequest};
+use std::sync::Arc;
+
+const DECOMP_SYSTEM_PROMPT: &str = "Split this question into the minimal set of INDEPENDENT factual subqueries needed to answer it. If the question is atomic, return a single-element array. Output ONLY a JSON array of strings.";
+
+/// Parse the LLM output (expected: a JSON array of strings) into a subquery list,
+/// always prefixed with the original query so the worst case degrades to a plain
+/// single-query search. Pure + synchronous so the parse contract is unit-tested
+/// in isolation.
+///
+/// - empty / malformed / no-array output -> just `[original]`
+/// - caps the returned list at `cap` total (including the original)
+/// - drops subqueries that exactly match the original (case-insensitive) or are blank
+pub(crate) fn parse_subqueries(output: &str, original: &str, cap: usize) -> Vec<String> {
+    let mut out = vec![original.to_string()];
+    let room = cap.saturating_sub(1);
+    if room == 0 {
+        return out;
+    }
+    let (Some(si), Some(ei)) = (output.find('['), output.rfind(']')) else {
+        log::warn!("[decompose] no JSON array in output");
+        return out;
+    };
+    if ei <= si {
+        return out;
+    }
+    match serde_json::from_str::<Vec<String>>(&output[si..=ei]) {
+        Ok(subs) if !subs.is_empty() => {
+            for s in subs {
+                // out always holds the original first, so out.len() - 1 == subs added.
+                if out.len() > room {
+                    break;
+                }
+                let t = s.trim();
+                if !t.is_empty() && !t.eq_ignore_ascii_case(original) {
+                    out.push(t.to_string());
+                }
+            }
+        }
+        Ok(_) => log::warn!("[decompose] empty subquery array"),
+        Err(e) => log::warn!("[decompose] JSON parse failed: {e}"),
+    }
+    out
+}
+
+/// Decompose `query` into independent subqueries via the LLM. Returns just the
+/// original query when no LLM is available or the call errors/times out
+/// (graceful degradation — same contract as `search_memory_expanded`).
+pub(crate) async fn decompose_query(
+    llm: Option<&Arc<dyn LlmProvider>>,
+    query: &str,
+    cap: usize,
+) -> Vec<String> {
+    let Some(llm) = llm else {
+        return vec![query.to_string()];
+    };
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        llm.generate(LlmRequest {
+            system_prompt: Some(DECOMP_SYSTEM_PROMPT.into()),
+            user_prompt: query.to_string(),
+            max_tokens: 256,
+            temperature: 0.2,
+            label: Some("query_decompose".into()),
+            timeout_secs: None,
+        }),
+    )
+    .await;
+    match result {
+        Ok(Ok(output)) => parse_subqueries(&output, query, cap),
+        Ok(Err(e)) => {
+            log::warn!("[decompose] LLM failed: {e}");
+            vec![query.to_string()]
+        }
+        // Timeout arm: identical degradation to the error arm. Not unit-tested
+        // (simulating a >10s elapse in a unit test is impractical); mirrors
+        // search_memory_expanded which leaves the same arm untested.
+        Err(_) => {
+            log::warn!("[decompose] timed out");
+            vec![query.to_string()]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm_provider::{LlmBackend, LlmError};
+    use async_trait::async_trait;
+
+    struct MockLlm {
+        response: Result<String, ()>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for MockLlm {
+        async fn generate(&self, _req: LlmRequest) -> Result<String, LlmError> {
+            self.response
+                .clone()
+                .map_err(|_| LlmError::InferenceFailed("mock".into()))
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn name(&self) -> &str {
+            "mock"
+        }
+        fn backend(&self) -> LlmBackend {
+            LlmBackend::OnDevice
+        }
+    }
+
+    fn arc(resp: Result<&str, ()>) -> Arc<dyn LlmProvider> {
+        Arc::new(MockLlm {
+            response: resp.map(|s| s.to_string()),
+        })
+    }
+
+    #[test]
+    fn parse_subqueries_clean() {
+        let v = parse_subqueries(r#"["a","b"]"#, "orig", 4);
+        assert_eq!(v, vec!["orig", "a", "b"]);
+    }
+
+    #[test]
+    fn parse_subqueries_with_noise() {
+        let v = parse_subqueries(r#"sure: ["a"] done"#, "orig", 4);
+        assert_eq!(v, vec!["orig", "a"]);
+    }
+
+    #[test]
+    fn parse_subqueries_empty_array() {
+        // silent-zero guard: empty array must degrade to original only.
+        let v = parse_subqueries("[]", "orig", 4);
+        assert_eq!(v, vec!["orig"]);
+    }
+
+    #[test]
+    fn parse_subqueries_malformed() {
+        // PR #147 silent-zero class: malformed JSON must not panic, degrade to original.
+        let v = parse_subqueries("[not valid json", "orig", 4);
+        assert_eq!(v, vec!["orig"]);
+    }
+
+    #[test]
+    fn parse_subqueries_no_array() {
+        let v = parse_subqueries("no brackets here", "orig", 4);
+        assert_eq!(v, vec!["orig"]);
+    }
+
+    #[test]
+    fn parse_subqueries_caps_total() {
+        // cap=2 -> original + at most 1 subquery.
+        let v = parse_subqueries(r#"["a","b","c"]"#, "orig", 2);
+        assert_eq!(v, vec!["orig", "a"]);
+    }
+
+    #[test]
+    fn parse_subqueries_dedups_original() {
+        let v = parse_subqueries(r#"["orig","b"]"#, "orig", 4);
+        assert_eq!(v, vec!["orig", "b"]);
+    }
+
+    #[test]
+    fn parse_subqueries_skips_blank() {
+        let v = parse_subqueries(r#"["  ","b"]"#, "orig", 4);
+        assert_eq!(v, vec!["orig", "b"]);
+    }
+
+    #[tokio::test]
+    async fn decompose_query_none_llm_returns_original() {
+        let v = decompose_query(None, "q", 4).await;
+        assert_eq!(v, vec!["q"]);
+    }
+
+    #[tokio::test]
+    async fn decompose_query_happy_path() {
+        let llm = arc(Ok(r#"["clause one","clause two"]"#));
+        let v = decompose_query(Some(&llm), "orig", 4).await;
+        assert_eq!(v, vec!["orig", "clause one", "clause two"]);
+    }
+
+    #[tokio::test]
+    async fn decompose_query_llm_error_returns_original() {
+        let llm = arc(Err(()));
+        let v = decompose_query(Some(&llm), "orig", 4).await;
+        assert_eq!(v, vec!["orig"]);
+    }
+}

--- a/crates/origin-core/src/retrieval/mod.rs
+++ b/crates/origin-core/src/retrieval/mod.rs
@@ -5,5 +5,6 @@
 //! Moved out of `composite/` in PR-A so the legacy retrieval path can use
 //! these helpers without importing the composite scoring orchestrator.
 
+pub(crate) mod decompose;
 pub(crate) mod hard_filters;
 pub(crate) mod signals;


### PR DESCRIPTION
## What

`MemoryDB::search_memory_decomposed` + `retrieval::decompose`: split a compositional query into **independent factual subqueries** via the LLM, run `search_memory` per subquery, and RRF-merge the pools.

Distinct from `search_memory_expanded` (which paraphrases ONE clause) — each stream here is a **different clause**, so a memory satisfying clause B isn't drowned by vocabulary variants of clause A. Targets the multi-hop / temporal questions a single embedding starves (LoCoMo multi-hop ~37%, temporal ~2%).

## How

- `retrieval::decompose::parse_subqueries` (pure) + `decompose_query` (async LLM).
- The original full query is **always** the first stream → worst case degrades to a plain `search_memory`. No-LLM / parse-fail / timeout / all-subquery-fail all fall back to the original (silent-zero-regression guard, PR #147/#203 class).
- Capped at `ORIGIN_QUERY_DECOMP_MAX_SUBQUERIES` (default 4, Cognee CoT max_iter).

## Scope

This PR ships the **method + pure logic + unit tests** only. Per the T1 plan, production wiring (behind `ORIGIN_ENABLE_QUERY_DECOMP`, feeding the cross-encoder reranker) and the `_decomposed` eval runners are **follow-up PRs**. The decomposition decision is agent-delegated primary + cloud-LLM fallback, never on-device 4B.

## Tests (TDD, written first)

11 new unit tests: parse (clean / noisy / empty / malformed / no-array / cap / dedup-original / blank-skip) + decompose (none-llm / happy / llm-error → all degrade to original). Timeout arm intentionally untested (impractical to simulate; identical to error arm, documented inline).

## Adversarial review

feature-dev:code-reviewer → **SHIP**, no blockers. Confirmed: RRF-merge + fallback faithful to `search_memory_expanded`; `output[si..=ei]` slice UTF-8-safe (`[`/`]` are ASCII); all degradation arms return `[original]`, no panic paths.

## Design intent / gap

T1 of the retrieval gap roadmap. `eval/report.rs` McNemar already documents a `decomposed` arm. No measured deltas — N≥3 per-category eval before any headline (hypothesis: lift on multi-hop, neutral/slight-negative on single-hop from the extra LLM hop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)