### PR TITLE
chore(eval): dual-bench graph-gate A/B + search_memory from_db runners

### DIFF
--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1256,6 +1256,150 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
 }
 
 // ---------------------------------------------------------------------------
+/// Retrieval eval over a pre-seeded DB using the base `search_memory` path
+/// (vector + FTS + RRF + graph augmentation) — the path the graph gate
+/// (`ORIGIN_ENABLE_GRAPH_GATE`) acts on. Mirrors `run_locomo_eval_cross_rerank_from_db`
+/// but without the cross-encoder/page channel, so the only LLM-free retrieval
+/// signal under test is the graph augmentation + its gate. Used for the T3
+/// graph-gate A/B experiment.
+pub async fn run_locomo_eval_from_db(
+    db: &MemoryDB,
+    path: &Path,
+) -> Result<LocomoReport, OriginError> {
+    let mut samples = load_locomo(path)?;
+    apply_locomo_limit(&mut samples);
+    let mut conversations = Vec::new();
+    let mut all_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut cov_acc: Vec<f64> = Vec::new();
+    let gate_on = crate::db::graph_gate_enabled();
+    let (mut gate_skipped, mut gate_total) = (0usize, 0usize);
+
+    for sample in &samples {
+        let memories = extract_observations(sample);
+        let dia_to_source: HashMap<String, String> = memories
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                (
+                    m.dia_id.clone(),
+                    format!("locomo_{}_obs_{}", sample.sample_id, i),
+                )
+            })
+            .collect();
+
+        let mut conv_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
+        for qa in &sample.qa {
+            if qa.category == 5 {
+                continue;
+            }
+            gate_total += 1;
+            if gate_on && !crate::retrieval::signals::query_warrants_graph(&qa.question) {
+                gate_skipped += 1;
+            }
+            let results = db
+                .search_memory(&qa.question, 10, None, None, None, None, None, None)
+                .await?;
+
+            let relevant_ids: HashSet<String> = qa
+                .evidence
+                .iter()
+                .filter_map(|did| dia_to_source.get(did).cloned())
+                .collect();
+            if relevant_ids.is_empty() {
+                continue;
+            }
+            let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+            let grades: HashMap<&str, u8> = result_ids
+                .iter()
+                .map(|id| (*id, if relevant_ids.contains(*id) { 1 } else { 0 }))
+                .collect();
+            let relevant_set: HashSet<&str> = relevant_ids.iter().map(|s| s.as_str()).collect();
+
+            let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+            let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+            let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+            let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+            let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+
+            conv_scores.push((qa.category, ndcg_5, ndcg_10, mrr_val, recall_5, hr_1));
+            all_scores.push((qa.category, ndcg_5, ndcg_10, mrr_val, recall_5, hr_1));
+
+            let units: Vec<(&str, &str)> = results
+                .iter()
+                .map(|r| (r.source.as_str(), r.source_id.as_str()))
+                .collect();
+            cov_acc.push(metrics::coverage_recall(
+                &metrics::build_coverage_set(&units, &HashMap::new()),
+                &relevant_set,
+            ));
+        }
+
+        let per_cat = aggregate_by_category(&conv_scores);
+        let n = conv_scores.len();
+        conversations.push(LocomoConversationResult {
+            sample_id: sample.sample_id.clone(),
+            memories_seeded: memories.len(),
+            questions_evaluated: n,
+            overall_ndcg_at_10: avg_field(&conv_scores, |s| s.2),
+            overall_mrr: avg_field(&conv_scores, |s| s.3),
+            overall_recall_at_5: avg_field(&conv_scores, |s| s.4),
+            per_category: per_cat,
+        });
+    }
+
+    if gate_on {
+        eprintln!(
+            "[locomo] graph-gate skipped {gate_skipped}/{gate_total} queries ({:.1}%)",
+            100.0 * gate_skipped as f64 / gate_total.max(1) as f64
+        );
+    }
+    let per_cat_agg = aggregate_by_category(&all_scores);
+    let coverage = if cov_acc.is_empty() {
+        None
+    } else {
+        Some(crate::eval::report::CoverageRecall {
+            blind: cov_acc.iter().sum::<f64>() / cov_acc.len() as f64,
+            expanded: cov_acc.iter().sum::<f64>() / cov_acc.len() as f64,
+        })
+    };
+    let mut report = LocomoReport {
+        conversations,
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories: samples.iter().map(|s| extract_observations(s).len()).sum(),
+        per_category_aggregate: per_cat_agg,
+        qa_accuracy: None,
+        baseline: None,
+        env: None,
+        per_case: Vec::new(),
+        coverage,
+    };
+    let graph_gate = if crate::db::graph_gate_enabled() {
+        "on"
+    } else {
+        "off"
+    };
+    let mut env_stamp = build_locomo_env(
+        if graph_gate == "off" {
+            "search_memory_gate_off"
+        } else {
+            "search_memory_gate_on"
+        },
+        path,
+        "search_memory",
+        "none",
+        "none",
+        None,
+    );
+    env_stamp.flags.push(format!("graph_gate={graph_gate}"));
+    env_stamp.flags.push("scenario_db=consolidated".to_string());
+    report.env = Some(env_stamp);
+    Ok(report)
+}
+
 // Expanded benchmark runner -- same as run_locomo_eval but uses search_memory_expanded
 // ---------------------------------------------------------------------------
 

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1185,6 +1185,121 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
     Ok(report)
 }
 
+/// Retrieval eval over a pre-seeded DB using the base `search_memory` path
+/// (vector + FTS + RRF + graph augmentation) — the path the graph gate acts on.
+/// Mirrors `run_longmemeval_eval_cross_rerank_from_db` minus the cross-encoder/
+/// page channel. Reports the graph-gate skip rate (queries that bypass graph)
+/// when `ORIGIN_ENABLE_GRAPH_GATE` is on. Used for the T3 graph-gate A/B.
+pub async fn run_longmemeval_eval_from_db(
+    db: &MemoryDB,
+    path: &Path,
+) -> Result<LongMemEvalReport, OriginError> {
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut all_scores: Vec<(String, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut total_memories: usize = 0;
+    let mut cov_acc: Vec<f64> = Vec::new();
+    let gate_on = crate::db::graph_gate_enabled();
+    let (mut gate_skipped, mut gate_total) = (0usize, 0usize);
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        total_memories += memories.len();
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        gate_total += 1;
+        if gate_on && !crate::retrieval::signals::query_warrants_graph(&sample.question) {
+            gate_skipped += 1;
+        }
+        let results = db
+            .search_memory(&sample.question, 10, None, None, None, None, None, None)
+            .await?;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| (*id, u8::from(relevant_source_ids.contains(*id))))
+            .collect();
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+        let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+        let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+        let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+        let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+        all_scores.push((
+            sample.question_type.clone(),
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+
+        let units: Vec<(&str, &str)> = results
+            .iter()
+            .map(|r| (r.source.as_str(), r.source_id.as_str()))
+            .collect();
+        cov_acc.push(metrics::coverage_recall(
+            &metrics::build_coverage_set(&units, &HashMap::new()),
+            &relevant_set,
+        ));
+    }
+    if gate_on {
+        eprintln!(
+            "[lme] graph-gate skipped {gate_skipped}/{gate_total} queries ({:.1}%)",
+            100.0 * gate_skipped as f64 / gate_total.max(1) as f64
+        );
+    }
+
+    let per_category = aggregate_by_category(&all_scores);
+    let coverage = if cov_acc.is_empty() {
+        None
+    } else {
+        Some(crate::eval::report::CoverageRecall {
+            blind: cov_acc.iter().sum::<f64>() / cov_acc.len() as f64,
+            expanded: cov_acc.iter().sum::<f64>() / cov_acc.len() as f64,
+        })
+    };
+    let mut report = LongMemEvalReport {
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories,
+        per_category,
+        baseline: None,
+        env: None,
+        per_case: Vec::new(),
+        coverage,
+    };
+    let graph_gate = if gate_on { "on" } else { "off" };
+    let mut env_stamp = build_lme_env(
+        if gate_on {
+            "search_memory_gate_on"
+        } else {
+            "search_memory_gate_off"
+        },
+        path,
+        "search_memory",
+        "none",
+        "none",
+        None,
+    );
+    env_stamp.flags.push(format!("graph_gate={graph_gate}"));
+    env_stamp.flags.push("scenario_db=consolidated".to_string());
+    report.env = Some(env_stamp);
+    Ok(report)
+}
+
 // ---------------------------------------------------------------------------
 // Expanded benchmark runner -- same as run_longmemeval_eval but uses search_memory_expanded
 // ---------------------------------------------------------------------------

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -636,6 +636,145 @@ fn resolve_scenario_db_root_from_harness() -> std::path::PathBuf {
         .join("scenario_seeded")
 }
 
+/// T3 graph-gate A/B experiment (retrieval-only, no GPU LLM, no judge).
+/// Runs the base `search_memory` path over the cached LoCoMo scenario DB with
+/// `ORIGIN_ENABLE_GRAPH_GATE` OFF (graph always on) vs ON (gated), and prints
+/// the retrieval-metric deltas. Single-run = scaffold/direction only.
+#[tokio::test]
+#[ignore = "needs cached scenario DB (run scripts/seed-scenario-dbs.sh); retrieval-only, no GPU"]
+async fn graph_gate_ab_locomo() {
+    use origin_core::eval::locomo::run_locomo_eval_from_db;
+
+    let db_dir = resolve_scenario_db_root_from_harness().join("locomo_v1");
+    if !db_dir.join("origin_memory.db").exists() {
+        println!("SKIP: no seeded DB at {}", db_dir.display());
+        return;
+    }
+    let fixture = eval_root().join("data/locomo10.json");
+    if !fixture.exists() {
+        println!("SKIP: locomo10.json not found");
+        return;
+    }
+    let db = origin_core::db::MemoryDB::new(
+        &db_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open locomo_v1 scenario DB");
+
+    let off = temp_env::async_with_vars(
+        [("ORIGIN_ENABLE_GRAPH_GATE", None::<&str>)],
+        run_locomo_eval_from_db(&db, &fixture),
+    )
+    .await
+    .expect("gate-off eval");
+    let on = temp_env::async_with_vars(
+        [("ORIGIN_ENABLE_GRAPH_GATE", Some("1"))],
+        run_locomo_eval_from_db(&db, &fixture),
+    )
+    .await
+    .expect("gate-on eval");
+
+    let cov = |r: &origin_core::eval::locomo::LocomoReport| {
+        r.coverage.as_ref().map(|c| c.blind).unwrap_or(0.0)
+    };
+    println!("=== T3 GRAPH-GATE A/B (LoCoMo, search_memory path, retrieval-only) ===");
+    println!("questions evaluated: {}", off.total_questions);
+    println!(
+        "GATE OFF (graph always): ndcg@10={:.4} recall@5={:.4} mrr={:.4} hit@1={:.4} cov={:.4}",
+        off.aggregate_ndcg_at_10,
+        off.aggregate_recall_at_5,
+        off.aggregate_mrr,
+        off.aggregate_hit_rate_at_1,
+        cov(&off)
+    );
+    println!(
+        "GATE ON  (gated):        ndcg@10={:.4} recall@5={:.4} mrr={:.4} hit@1={:.4} cov={:.4}",
+        on.aggregate_ndcg_at_10,
+        on.aggregate_recall_at_5,
+        on.aggregate_mrr,
+        on.aggregate_hit_rate_at_1,
+        cov(&on)
+    );
+    println!(
+        "DELTA (on-off):          ndcg@10={:+.4} recall@5={:+.4} mrr={:+.4} hit@1={:+.4} cov={:+.4}",
+        on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+        on.aggregate_recall_at_5 - off.aggregate_recall_at_5,
+        on.aggregate_mrr - off.aggregate_mrr,
+        on.aggregate_hit_rate_at_1 - off.aggregate_hit_rate_at_1,
+        cov(&on) - cov(&off)
+    );
+}
+
+/// T3 graph-gate A/B experiment on LongMemEval (retrieval-only, no GPU LLM).
+/// Dual-bench companion to `graph_gate_ab_locomo` so T3 is validated on BOTH
+/// metrics, not a partial view.
+#[tokio::test]
+#[ignore = "needs cached scenario DB (run scripts/seed-scenario-dbs.sh); retrieval-only, no GPU"]
+async fn graph_gate_ab_lme() {
+    use origin_core::eval::longmemeval::run_longmemeval_eval_from_db;
+
+    let db_dir = resolve_scenario_db_root_from_harness().join("lme_v1");
+    if !db_dir.join("origin_memory.db").exists() {
+        println!("SKIP: no seeded LME DB at {}", db_dir.display());
+        return;
+    }
+    let fixture = eval_root().join("data/longmemeval_oracle.json");
+    if !fixture.exists() {
+        println!("SKIP: longmemeval_oracle.json not found");
+        return;
+    }
+    let db = origin_core::db::MemoryDB::new(
+        &db_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open lme_v1 scenario DB");
+
+    let off = temp_env::async_with_vars(
+        [("ORIGIN_ENABLE_GRAPH_GATE", None::<&str>)],
+        run_longmemeval_eval_from_db(&db, &fixture),
+    )
+    .await
+    .expect("gate-off eval");
+    let on = temp_env::async_with_vars(
+        [("ORIGIN_ENABLE_GRAPH_GATE", Some("1"))],
+        run_longmemeval_eval_from_db(&db, &fixture),
+    )
+    .await
+    .expect("gate-on eval");
+
+    let cov = |r: &origin_core::eval::longmemeval::LongMemEvalReport| {
+        r.coverage.as_ref().map(|c| c.blind).unwrap_or(0.0)
+    };
+    println!("=== T3 GRAPH-GATE A/B (LongMemEval, search_memory path, retrieval-only) ===");
+    println!("questions evaluated: {}", off.total_questions);
+    println!(
+        "GATE OFF (graph always): ndcg@10={:.4} recall@5={:.4} mrr={:.4} hit@1={:.4} cov={:.4}",
+        off.aggregate_ndcg_at_10,
+        off.aggregate_recall_at_5,
+        off.aggregate_mrr,
+        off.aggregate_hit_rate_at_1,
+        cov(&off)
+    );
+    println!(
+        "GATE ON  (gated):        ndcg@10={:.4} recall@5={:.4} mrr={:.4} hit@1={:.4} cov={:.4}",
+        on.aggregate_ndcg_at_10,
+        on.aggregate_recall_at_5,
+        on.aggregate_mrr,
+        on.aggregate_hit_rate_at_1,
+        cov(&on)
+    );
+    println!(
+        "DELTA (on-off):          ndcg@10={:+.4} recall@5={:+.4} mrr={:+.4} hit@1={:+.4} cov={:+.4}",
+        on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+        on.aggregate_recall_at_5 - off.aggregate_recall_at_5,
+        on.aggregate_mrr - off.aggregate_mrr,
+        on.aggregate_hit_rate_at_1 - off.aggregate_hit_rate_at_1,
+        cov(&on) - cov(&off)
+    );
+}
+
 /// PR-B page-channel ON baseline (LoCoMo).
 ///
 /// Uses the pre-seeded consolidated scenario DB at


### PR DESCRIPTION
## What

Eval infrastructure so retrieval features can be validated on **both** LoCoMo and LongMemEval (not a partial single-bench view).

- `run_locomo_eval_from_db` + `run_longmemeval_eval_from_db`: base `search_memory` path (vector + FTS + RRF + graph augmentation), retrieval-only — **no GPU LLM, no paid judge** — run over the cached `scenario_seeded` DBs without re-ingest.
- Both report a **graph-gate skip rate** (the metric that actually captures T3's effect; NDCG can't).
- `graph_gate_ab_locomo` + `graph_gate_ab_lme` `#[ignore]` harness tests: A/B `ORIGIN_ENABLE_GRAPH_GATE` OFF vs ON.

## Why

The cross-encoder eval path (`search_memory_cross_rerank`) has no `augment_with_graph`, so it can't measure the T3 graph gate. T3 lives in `search_memory`; these runners exercise that path.

## Measured (single-run scaffold — NOT citable; N≥3 for headline)

| Bench | Q | skip rate | ΔNDCG@10 | Δrecall@5 | Δcov |
|---|---|---|---|---|---|
| LoCoMo | 625 | 0.7% | +0.0000 | +0.0000 | +0.0000 |
| LME | 30 | 23.3% | +0.0000 | +0.0000 | +0.0000 |

T3 is **retrieval-neutral on both benches** (no regression) and skips the graph hop on ~23% of LME queries at **zero quality cost** — the cost win, invisible on entity-rich LoCoMo. Dual-bench was essential: LoCoMo alone read as a no-op.

## Scope

Eval-only (`src/eval/` + `tests/`, behind `eval-harness` feature). No production behavior change. `chore(eval)` → no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)