### PR TITLE
fix(retrieval): opt-in FTS recall hardening (ORIGIN_ENABLE_FTS_HARDENING)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -6640,6 +6640,11 @@ impl MemoryDB {
         // --- FTS search ---
         let mut fts_results: Vec<SearchResult> = Vec::new();
         {
+            use crate::retrieval::fts_query::{
+                build_relaxed_or, fts_length_exceeded, fts_recall_hardening_enabled,
+                sanitize_fts_query, stopwords,
+            };
+
             // Renumber placeholders: ?1 = query, ?2 = fetch_limit, ?3.. = filters.
             let mut fts_where_parts: Vec<String> = Vec::new();
             let mut param_idx = 3usize;
@@ -6678,23 +6683,47 @@ impl MemoryDB {
                 supersedes_exclusion, fts_extra
             );
 
-            let mut params: Vec<libsql::Value> = vec![
-                libsql::Value::Text(query.to_string()),
-                libsql::Value::Integer(fetch_limit),
-            ];
-            params.extend(filter_values.clone());
+            // Build the list of FTS queries to try. Flag OFF: the legacy single
+            // AND query (search() never had an OR fallback). Flag ON: sanitized
+            // AND + eligibility-gated relaxed-OR; overlong queries (>128 tokens)
+            // skip the FTS block so RRF degrades to vector-only by construction.
+            let fts_queries: Vec<String> = if fts_recall_hardening_enabled() {
+                if fts_length_exceeded(query, 128) {
+                    vec![] // skip FTS; vector-only path
+                } else {
+                    let mut v = vec![sanitize_fts_query(query)];
+                    if let Some(or) = build_relaxed_or(query, stopwords()) {
+                        v.push(or);
+                    }
+                    v
+                }
+            } else {
+                // Flag OFF: exact legacy path (byte-identical)
+                vec![query.to_string()]
+            };
 
-            match conn.query(&fts_sql, params).await {
-                Ok(mut rows) => {
-                    while let Ok(Some(row)) = rows.next().await {
-                        let rank: f64 = row.get(30).unwrap_or(0.0);
-                        if let Ok(result) = Self::row_to_search_result(&row, rank as f32) {
-                            fts_results.push(result);
+            for fts_query in &fts_queries {
+                let mut params: Vec<libsql::Value> = vec![
+                    libsql::Value::Text(fts_query.clone()),
+                    libsql::Value::Integer(fetch_limit),
+                ];
+                params.extend(filter_values.clone());
+
+                match conn.query(&fts_sql, params).await {
+                    Ok(mut rows) => {
+                        while let Ok(Some(row)) = rows.next().await {
+                            let rank: f64 = row.get(30).unwrap_or(0.0);
+                            if let Ok(result) = Self::row_to_search_result(&row, rank as f32) {
+                                fts_results.push(result);
+                            }
                         }
                     }
+                    Err(e) => {
+                        log::warn!("[memory_db] FTS search failed: {}", e);
+                    }
                 }
-                Err(e) => {
-                    log::warn!("[memory_db] FTS search failed: {}", e);
+                if !fts_results.is_empty() {
+                    break; // AND matched; skip relaxed-OR fallback
                 }
             }
         }
@@ -6933,7 +6962,28 @@ impl MemoryDB {
             // Try AND matching first (implicit FTS5 default), fall back to OR
             // if no results. OR matching broadens recall for multi-word queries
             // where no single document contains all terms.
-            let fts_queries = vec![query.to_string(), Self::fts_or_query(query)];
+            //
+            // When hardening is enabled: sanitize to neutralize FTS5 operators;
+            // skip the FTS block entirely for overlong queries (>128 tokens) so
+            // RRF degrades to vector-only by construction.
+            use crate::retrieval::fts_query::{
+                build_relaxed_or, fts_length_exceeded, fts_recall_hardening_enabled,
+                sanitize_fts_query, stopwords,
+            };
+            let fts_queries: Vec<String> = if fts_recall_hardening_enabled() {
+                if fts_length_exceeded(query, 128) {
+                    vec![] // skip FTS; vector-only path
+                } else {
+                    let mut v = vec![sanitize_fts_query(query)];
+                    if let Some(or) = build_relaxed_or(query, stopwords()) {
+                        v.push(or);
+                    }
+                    v
+                }
+            } else {
+                // Flag OFF: exact legacy path (byte-identical)
+                vec![query.to_string(), Self::fts_or_query(query)]
+            };
 
             for fts_query in &fts_queries {
                 let mut params: Vec<libsql::Value> = vec![
@@ -8068,8 +8118,27 @@ impl MemoryDB {
             space_clause
         );
 
-        // AND match first, fall back to OR for multi-word queries
-        let fts_queries = vec![query.to_string(), Self::fts_or_query(query)];
+        // AND match first, fall back to OR for multi-word queries.
+        // When hardening is enabled: sanitize query + eligibility-gated relaxed-OR;
+        // skip entirely for overlong queries (>128 tokens).
+        use crate::retrieval::fts_query::{
+            build_relaxed_or, fts_length_exceeded, fts_recall_hardening_enabled,
+            sanitize_fts_query, stopwords,
+        };
+        let fts_queries: Vec<String> = if fts_recall_hardening_enabled() {
+            if fts_length_exceeded(query, 128) {
+                vec![] // skip FTS; return empty (eval-only path, vector not available here)
+            } else {
+                let mut v = vec![sanitize_fts_query(query)];
+                if let Some(or) = build_relaxed_or(query, stopwords()) {
+                    v.push(or);
+                }
+                v
+            }
+        } else {
+            // Flag OFF: exact legacy path (byte-identical)
+            vec![query.to_string(), Self::fts_or_query(query)]
+        };
         let mut results: Vec<SearchResult> = Vec::new();
 
         for fts_query in &fts_queries {
@@ -16960,7 +17029,22 @@ impl MemoryDB {
              ORDER BY rank LIMIT ?2",
             concept_select,
         );
-        let fts_queries = vec![query.to_string(), Self::fts_or_query(query)];
+        // search_pages: sanitize-only when hardening enabled (no relaxed-OR for pages).
+        use crate::retrieval::fts_query::{
+            fts_length_exceeded, fts_recall_hardening_enabled, sanitize_fts_query,
+        };
+        let fts_queries: Vec<String> = if fts_recall_hardening_enabled() {
+            if fts_length_exceeded(query, 128) {
+                vec![] // skip FTS; vector-only path
+            } else {
+                // Sanitize-only: a relaxed-OR fallback here would re-introduce the
+                // unsanitized operator-error the hardening exists to remove.
+                vec![sanitize_fts_query(query)]
+            }
+        } else {
+            // Flag OFF: exact legacy path (byte-identical)
+            vec![query.to_string(), Self::fts_or_query(query)]
+        };
         for fts_q in &fts_queries {
             let fts_result = if let Some(pt) = page_type {
                 conn.query(
@@ -32102,5 +32186,198 @@ pub(crate) mod tests {
                 hits.iter().map(|r| (&r.id, &r.source)).collect::<Vec<_>>()
             );
         }
+    }
+
+    // ── T12: FTS recall hardening integration tests ──────────────────────────
+
+    /// Regression guard: with hardening OFF (default), the behavior of
+    /// `search_memory` must be byte-identical to pre-T12 — a clean query
+    /// ("rust programming") still surfaces the seeded memory.
+    #[tokio::test]
+    async fn fts_hardening_off_preserves_exact_current_behavior() {
+        let (db, _tmp) = test_db().await;
+        db.upsert_documents(vec![make_memory_doc(
+            "m_rust_prog",
+            "rust programming language systems memory safety",
+            "fact",
+            "work",
+            "claude-code",
+        )])
+        .await
+        .unwrap();
+
+        // Unset flag → legacy path
+        let results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_FTS_HARDENING", None::<&str>)], async {
+                db.search_memory("rust programming", 10, None, None, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert!(
+            !results.is_empty(),
+            "flag-OFF: search_memory must return results for clean query"
+        );
+        assert!(
+            results.iter().any(|r| r.content.contains("rust")),
+            "flag-OFF: seeded rust memory must appear; got {:?}",
+            results.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+
+        // Flag ON must also surface the same hit (no regression)
+        let results_on =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_FTS_HARDENING", Some("1"))], async {
+                db.search_memory("rust programming", 10, None, None, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert!(
+            results_on.iter().any(|r| r.content.contains("rust")),
+            "flag-ON: clean query must still surface the seeded memory (silent-zero guard); got {:?}",
+            results_on.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+    }
+
+    /// With hardening ON, a query containing special FTS5 chars (parens) must
+    /// return Ok results without surfacing an FTS error, and the FTS channel
+    /// contributes hits containing the rare lexical token.
+    #[tokio::test]
+    async fn fts_hardening_on_handles_special_char_query_without_error() {
+        let (db, _tmp) = test_db().await;
+        // Seed a memory with a rare, highly-distinctive token
+        db.upsert_documents(vec![make_memory_doc(
+            "m_libsql_unique",
+            "libsqlXYZ7 database (libSQL) engine backend storage",
+            "fact",
+            "work",
+            "claude-code",
+        )])
+        .await
+        .unwrap();
+
+        // This query contains parens — FTS5 would normally error on it
+        let query = "the libsqlXYZ7 (libSQL)";
+
+        // Flag OFF: FTS branch errors, returns Ok but FTS may contribute 0 rows
+        let _results_off =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_FTS_HARDENING", None::<&str>)], async {
+                db.search_memory(query, 10, None, None, None, None, None, None)
+                    .await
+                    .unwrap() // must not panic/error regardless
+            })
+            .await;
+
+        // Flag ON: sanitize_fts_query neutralizes parens, FTS channel fires
+        let results_on =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_FTS_HARDENING", Some("1"))], async {
+                db.search_memory(query, 10, None, None, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        // The rare token "libsqlXYZ7" is distinctive enough that the seeded
+        // memory must appear via FTS (and/or vector)
+        assert!(
+            results_on.iter().any(|r| r.content.contains("libsqlXYZ7")),
+            "flag-ON: special-char query must surface the seeded memory; got {:?}",
+            results_on.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+    }
+
+    /// With hardening ON, an overlong query (>128 tokens) must succeed (Ok)
+    /// and return non-empty results via the vector-only path; no panic or error.
+    #[tokio::test]
+    async fn fts_hardening_on_skips_fts_for_overlong_query() {
+        let (db, _tmp) = test_db().await;
+        db.upsert_documents(vec![make_memory_doc(
+            "m_overlong",
+            "overlong query graceful degradation vector fallback memory",
+            "fact",
+            "work",
+            "claude-code",
+        )])
+        .await
+        .unwrap();
+
+        // Build a >128-token query; include the rare token at position 0 so
+        // vector similarity can still find it even without FTS.
+        let mut tokens: Vec<String> = vec!["overlong".to_string()];
+        for i in 0..130 {
+            tokens.push(format!("padding{i}"));
+        }
+        let long_query = tokens.join(" ");
+        assert!(
+            long_query.split_whitespace().count() > 128,
+            "test setup: query must exceed 128 tokens"
+        );
+
+        let result =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_FTS_HARDENING", Some("1"))], async {
+                db.search_memory(&long_query, 10, None, None, None, None, None, None)
+                    .await
+            })
+            .await;
+        assert!(
+            result.is_ok(),
+            "overlong query must not error; got {:?}",
+            result
+        );
+        // Vector path should still find the seeded memory
+        let hits = result.unwrap();
+        assert!(
+            hits.iter().any(|r| r.content.contains("overlong")),
+            "overlong query: vector path must surface the seeded memory; got {:?}",
+            hits.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+    }
+
+    /// With hardening ON, a mostly-stopword query does NOT flood results via
+    /// OR-joined stopwords. The relaxed-OR eligibility gate (<2 content
+    /// survivors → None) prevents stopword-noise OR matches.
+    #[tokio::test]
+    async fn fts_hardening_relaxed_or_is_eligibility_gated() {
+        let (db, _tmp) = test_db().await;
+        // Seed one memory with a rare token
+        db.upsert_documents(vec![make_memory_doc(
+            "m_rare_xylophone",
+            "xylophoneZZZ9 instrument music wooden percussion",
+            "fact",
+            "work",
+            "claude-code",
+        )])
+        .await
+        .unwrap();
+        // Seed a bunch of other memories to act as potential false positives
+        for i in 0..5 {
+            db.upsert_documents(vec![make_memory_doc(
+                &format!("m_noise_{i}"),
+                &format!("noise memory number {i} unrelated content filler"),
+                "fact",
+                "work",
+                "claude-code",
+            )])
+            .await
+            .unwrap();
+        }
+
+        // "what is the xylophoneZZZ9" — what/is/the are stopwords; only one
+        // content token survives → relaxed-OR must NOT fire (None), so no
+        // stopword-OR flood; the rare memory surfaces via AND match or vector.
+        let query = "what is the xylophoneZZZ9";
+
+        let results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_FTS_HARDENING", Some("1"))], async {
+                db.search_memory(query, 10, None, None, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        // The rare memory should rank at or near the top
+        assert!(
+            results.iter().any(|r| r.content.contains("xylophoneZZZ9")),
+            "eligibility-gated OR: rare token memory must surface; got {:?}",
+            results.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/origin-core/src/retrieval/fts_query.rs
+++ b/crates/origin-core/src/retrieval/fts_query.rs
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: Apache-2.0
+//! FTS5 query hardening helpers.
+//!
+//! Sanitizes user queries before passing them to the `memories_fts MATCH ?1`
+//! clause, preventing FTS5 syntax errors from silently zeroing the FTS channel.
+//!
+//! All functions are pure (no I/O, no async, no DB). Flag gate lives here so
+//! all call sites share the same env-var logic.
+
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+/// FTS5 operator characters that trigger a syntax error when unquoted.
+/// `+` and `-` are phrase operators; `*` is a prefix wildcard;
+/// `(` `)` group subexpressions; `:` selects a column; `^` boosts a token;
+/// `"` is a phrase delimiter; `{` `}` `[` `]` `~` `\` are reserved.
+const FTS5_SPECIAL_CHARS: &[char] = &[
+    '"', '*', '(', ')', ':', '^', '+', '-', '{', '}', '[', ']', '~', '\\',
+];
+
+/// Bare-keyword tokens that FTS5 interprets as operators.
+const FTS5_KEYWORDS: &[&str] = &["AND", "OR", "NOT", "NEAR"];
+
+/// ~40 common English stopwords used for relaxed-OR eligibility gating.
+static STOPWORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+    [
+        "a", "an", "the", "and", "or", "not", "in", "on", "at", "to", "of", "for", "with", "by",
+        "from", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had", "do",
+        "does", "did", "will", "would", "could", "should", "may", "might", "shall", "it", "its",
+        "this", "that", "as", "up", "if", "so", "but", "what", "which", "who", "how", "when",
+        "where", "why", "near",
+    ]
+    .iter()
+    .copied()
+    .collect()
+});
+
+/// Returns the global stopword set for use in [`build_relaxed_or`].
+pub fn stopwords() -> &'static HashSet<&'static str> {
+    &STOPWORDS
+}
+
+/// Returns `true` iff `ORIGIN_ENABLE_FTS_HARDENING` is set to a truthy value
+/// (`"1"`, `"true"`, or `"yes"`, case-insensitive). Any other value or unset
+/// leaves hardening disabled (byte-identical to pre-T12 behavior).
+pub fn fts_recall_hardening_enabled() -> bool {
+    std::env::var("ORIGIN_ENABLE_FTS_HARDENING")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+/// Sanitize a raw user query for safe use in an FTS5 `MATCH` expression.
+///
+/// Each whitespace-delimited token is examined. A token is "unsafe" when it
+/// contains any FTS5-significant character (`"`, `*`, `(`, `)`, `:`, `^`,
+/// `+`, `-`, `{`, `}`, `[`, `]`, `~`, `\\`) OR is a bare FTS5 keyword
+/// (`AND`, `OR`, `NOT`, `NEAR`) case-sensitively. Unsafe tokens are wrapped
+/// in double-quotes after escaping interior `"` as `""`, making FTS5 treat
+/// the entire token as a literal phrase.
+///
+/// Safe tokens are emitted as-is. Tokens are joined with a single space,
+/// preserving the implicit AND-matching default.
+///
+/// Iterates via `chars()` — never byte-slices — for UTF-8 safety per AGENTS.md.
+pub fn sanitize_fts_query(raw: &str) -> String {
+    if raw.is_empty() {
+        return String::new();
+    }
+
+    raw.split_whitespace()
+        .map(|token| {
+            let needs_quoting = token.chars().any(|c| FTS5_SPECIAL_CHARS.contains(&c))
+                || FTS5_KEYWORDS.contains(&token);
+            if needs_quoting {
+                // Escape interior double-quotes by doubling them, then wrap.
+                let escaped: String = token
+                    .chars()
+                    .flat_map(|c| if c == '"' { vec!['"', '"'] } else { vec![c] })
+                    .collect();
+                format!("\"{}\"", escaped)
+            } else {
+                token.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Count whitespace-delimited tokens in `raw`.
+pub fn query_token_count(raw: &str) -> usize {
+    raw.split_whitespace().count()
+}
+
+/// Returns `true` when the query exceeds `max` tokens — i.e. the FTS branch
+/// should be skipped entirely to avoid pathologically large MATCH expressions.
+pub fn fts_length_exceeded(raw: &str, max: usize) -> bool {
+    query_token_count(raw) > max
+}
+
+/// Build a relaxed OR query from `raw`, dropping stopwords and
+/// gating on having at least two survivors before firing.
+///
+/// Steps:
+/// 1. Split on whitespace.
+/// 2. Drop tokens whose lowercase form appears in `stopwords`.
+/// 3. If fewer than 2 survivors remain → `None` (OR is meaningless or empty).
+/// 4. Sanitize each survivor via [`sanitize_fts_query`] (so `C++` becomes
+///    `"C++"` in the OR list, not a bare operator).
+/// 5. Join with ` OR ` → `Some(string)`.
+pub fn build_relaxed_or(raw: &str, stopwords: &HashSet<&str>) -> Option<String> {
+    let survivors: Vec<&str> = raw
+        .split_whitespace()
+        .filter(|t| !stopwords.contains(t.to_lowercase().as_str()))
+        .collect();
+
+    if survivors.len() < 2 {
+        return None;
+    }
+
+    let parts: Vec<String> = survivors.into_iter().map(sanitize_fts_query).collect();
+
+    Some(parts.join(" OR "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── sanitize_fts_query ──────────────────────────────────────────────────
+
+    #[test]
+    fn sanitize_clean_query_unchanged() {
+        assert_eq!(sanitize_fts_query("hello world"), "hello world");
+    }
+
+    #[test]
+    fn sanitize_plus_token_quoted() {
+        // "C++" contains a `+` character — must be quoted
+        let out = sanitize_fts_query("C++ project");
+        assert!(
+            out.contains("\"C++\""),
+            "C++ token should be double-quoted; got: {out}"
+        );
+    }
+
+    #[test]
+    fn sanitize_interior_quote_doubled() {
+        // token `"big"` contains double-quotes: interior must be escaped as `""`
+        let out = sanitize_fts_query(r#"what's the "big" plan"#);
+        // The `"big"` token should appear as `"""big"""` in output
+        // (outer wrap + doubled interior quotes)
+        assert!(
+            out.contains(r#""""big""""#),
+            "Interior quotes must be doubled and token wrapped; got: {out}"
+        );
+    }
+
+    #[test]
+    fn sanitize_bare_booleans_quoted() {
+        let out = sanitize_fts_query("a AND b OR c NOT d");
+        // AND / OR / NOT must NOT appear as bare tokens (they must be quoted)
+        let tokens: Vec<&str> = out.split_whitespace().collect();
+        for tok in &["AND", "OR", "NOT"] {
+            assert!(
+                !tokens.contains(tok),
+                "Bare keyword {tok} must not survive sanitization; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_star_paren_colon_caret() {
+        for (input, bad_char) in [
+            ("foo*", '*'),
+            ("(bar)", '('),
+            ("baz:qux", ':'),
+            ("^lead", '^'),
+        ] {
+            let out = sanitize_fts_query(input);
+            // The bad char should be inside a quoted phrase, not bare
+            // Verify the token is quoted (starts and ends with `"`)
+            // and bad_char still appears inside (not dropped)
+            let token = out.split_whitespace().next().unwrap_or("");
+            assert!(
+                token.starts_with('"') && token.ends_with('"'),
+                "Token with `{bad_char}` must be quoted; input={input:?} out={out:?}"
+            );
+            assert!(
+                out.contains(bad_char),
+                "Bad char must be preserved (not dropped); input={input:?} out={out:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn sanitize_empty_in_empty_out() {
+        assert_eq!(sanitize_fts_query(""), "");
+    }
+
+    #[test]
+    fn sanitize_injection_or_neutralized() {
+        // An injection attempt using a bare double-quote followed by OR
+        let out = sanitize_fts_query("\" OR 1=1 --");
+        // The `"` token should be quoted/escaped, and OR must not be bare
+        let tokens: Vec<&str> = out.split_whitespace().collect();
+        assert!(
+            !tokens.contains(&"OR"),
+            "Bare OR must not survive injection attempt; got: {out}"
+        );
+    }
+
+    #[test]
+    fn sanitize_utf8_no_panic() {
+        // Non-ASCII code points: must not byte-slice, must not panic
+        let out = sanitize_fts_query("café ☕ naïve");
+        // No special FTS chars in these tokens → returned as-is
+        assert!(out.contains("café"), "café should be preserved; got: {out}");
+        assert!(out.contains("☕"), "☕ should be preserved; got: {out}");
+        assert!(
+            out.contains("naïve"),
+            "naïve should be preserved; got: {out}"
+        );
+    }
+
+    // ── query_token_count ──────────────────────────────────────────────────
+
+    #[test]
+    fn token_count_three_words() {
+        assert_eq!(query_token_count("one two three"), 3);
+    }
+
+    #[test]
+    fn token_count_empty() {
+        assert_eq!(query_token_count(""), 0);
+    }
+
+    // ── fts_length_exceeded ────────────────────────────────────────────────
+
+    #[test]
+    fn length_not_exceeded_small_query() {
+        assert!(!fts_length_exceeded("a b c", 128));
+    }
+
+    #[test]
+    fn length_exceeded_129_tokens() {
+        let q: String = (0..129)
+            .map(|i| format!("tok{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(fts_length_exceeded(&q, 128));
+    }
+
+    #[test]
+    fn length_boundary_exactly_128_tokens() {
+        let q: String = (0..128)
+            .map(|i| format!("tok{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        // Exactly 128 tokens: NOT exceeded (strictly greater than)
+        assert!(!fts_length_exceeded(&q, 128));
+    }
+
+    // ── build_relaxed_or ──────────────────────────────────────────────────
+
+    #[test]
+    fn relaxed_or_all_content_tokens_survive() {
+        let sw = stopwords();
+        let out = build_relaxed_or("vector embedding model", sw);
+        assert_eq!(
+            out.as_deref(),
+            Some("vector OR embedding OR model"),
+            "No stopwords -> all tokens survive"
+        );
+    }
+
+    #[test]
+    fn relaxed_or_single_survivor_returns_none() {
+        // "what is the" are all stopwords; only "plan" survives -> <2 survivors -> None
+        let sw = stopwords();
+        let out = build_relaxed_or("what is the plan", sw);
+        assert_eq!(out, None, "Only 1 survivor must return None");
+    }
+
+    #[test]
+    fn relaxed_or_two_survivors_returns_some() {
+        // "the" is a stopword; "database" and "schema" survive
+        let sw = stopwords();
+        let out = build_relaxed_or("the database schema", sw);
+        assert_eq!(
+            out.as_deref(),
+            Some("database OR schema"),
+            "2 survivors should return Some"
+        );
+    }
+
+    #[test]
+    fn relaxed_or_all_stopwords_returns_none() {
+        let sw = stopwords();
+        let out = build_relaxed_or("the of a an", sw);
+        assert_eq!(out, None, "All stopwords must return None");
+    }
+
+    #[test]
+    fn relaxed_or_single_token_returns_none() {
+        let sw = stopwords();
+        let out = build_relaxed_or("singleword", sw);
+        assert_eq!(out, None, "Single token has no OR semantics");
+    }
+
+    #[test]
+    fn relaxed_or_sanitizes_survivors() {
+        // "foo*" contains a special char; it must be quoted in the OR output.
+        // "AND" lowercases to "and" which IS a stopword, so it gets dropped.
+        // Survivors: "foo*" and "bar" → "foo*" must be sanitized to "\"foo*\"".
+        let sw = stopwords();
+        let out = build_relaxed_or("foo* AND bar", sw);
+        let s = out.expect("foo* and bar should yield two survivors");
+        assert!(
+            s.contains("\"foo*\""),
+            "foo* survivor must be sanitized to \"foo*\"; got: {s}"
+        );
+        // "bar" has no special chars → emitted as-is
+        assert!(
+            s.contains("bar"),
+            "bar survivor should appear in OR output; got: {s}"
+        );
+    }
+
+    // ── fts_recall_hardening_enabled ────────────────────────────────────────
+
+    #[test]
+    fn hardening_enabled_truthy_values() {
+        for val in ["1", "true", "yes", "TRUE", "YES", "True"] {
+            temp_env::with_var("ORIGIN_ENABLE_FTS_HARDENING", Some(val), || {
+                assert!(
+                    fts_recall_hardening_enabled(),
+                    "Expected enabled for value={val:?}"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn hardening_disabled_for_falsy_and_unset() {
+        for val in [Some("0"), Some("false"), Some("garbage"), None] {
+            temp_env::with_var("ORIGIN_ENABLE_FTS_HARDENING", val, || {
+                assert!(
+                    !fts_recall_hardening_enabled(),
+                    "Expected disabled for value={val:?}"
+                );
+            });
+        }
+    }
+}

--- a/crates/origin-core/src/retrieval/mod.rs
+++ b/crates/origin-core/src/retrieval/mod.rs
@@ -6,5 +6,6 @@
 //! these helpers without importing the composite scoring orchestrator.
 
 pub(crate) mod decompose;
+pub(crate) mod fts_query;
 pub(crate) mod hard_filters;
 pub(crate) mod signals;

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -706,6 +706,83 @@ async fn graph_gate_ab_locomo() {
     );
 }
 
+/// T12 FTS-hardening A/B on BOTH benches (retrieval-only). Hardening only changes
+/// special-char/overlong queries (absent from clean LoCoMo/LME), so the expected
+/// result is delta about 0 — this confirms no-regression on clean-query benchmarks.
+#[tokio::test]
+#[ignore = "needs cached scenario DBs; retrieval-only, no GPU"]
+async fn fts_hardening_ab_dualbench() {
+    use origin_core::eval::locomo::run_locomo_eval_from_db;
+    use origin_core::eval::longmemeval::run_longmemeval_eval_from_db;
+    let root = resolve_scenario_db_root_from_harness();
+
+    let lo_dir = root.join("locomo_v1");
+    if lo_dir.join("origin_memory.db").exists() {
+        let fx = eval_root().join("data/locomo10.json");
+        if fx.exists() {
+            let db = origin_core::db::MemoryDB::new(
+                &lo_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .unwrap();
+            let off = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_FTS_HARDENING", None::<&str>)],
+                run_locomo_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            let on = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_FTS_HARDENING", Some("1"))],
+                run_locomo_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            println!(
+                "[FTS A/B LoCoMo] q={} ndcg@10 off={:.4} on={:.4} d={:+.4} | recall@5 d={:+.4}",
+                off.total_questions,
+                off.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+                on.aggregate_recall_at_5 - off.aggregate_recall_at_5
+            );
+        }
+    }
+
+    let lme_dir = root.join("lme_v1");
+    if lme_dir.join("origin_memory.db").exists() {
+        let fx = eval_root().join("data/longmemeval_oracle.json");
+        if fx.exists() {
+            let db = origin_core::db::MemoryDB::new(
+                &lme_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .unwrap();
+            let off = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_FTS_HARDENING", None::<&str>)],
+                run_longmemeval_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            let on = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_FTS_HARDENING", Some("1"))],
+                run_longmemeval_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            println!(
+                "[FTS A/B LME] q={} ndcg@10 off={:.4} on={:.4} d={:+.4} | recall@5 d={:+.4}",
+                off.total_questions,
+                off.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+                on.aggregate_recall_at_5 - off.aggregate_recall_at_5
+            );
+        }
+    }
+}
+
 /// T3 graph-gate A/B experiment on LongMemEval (retrieval-only, no GPU LLM).
 /// Dual-bench companion to `graph_gate_ab_locomo` so T3 is validated on BOTH
 /// metrics, not a partial view.


### PR DESCRIPTION
## What

FTS5 queries with special chars (`"` `*` `(` `)` `:` `^` `+` or bare AND/OR/NOT/NEAR) raise an FTS5 error that's swallowed → the FTS channel silently contributes 0 rows → query degrades to vector-only (a real recall hole). Behind opt-in `ORIGIN_ENABLE_FTS_HARDENING` (default OFF = byte-identical).

When ON: sanitize tokens (quote+escape, neutralizing operators), eligibility-gated relaxed-OR (≥2 non-stopword survivors), and a 128-token length gate that skips FTS (vector-only) instead of erroring.

## How

New pure `retrieval::fts_query` module (`sanitize_fts_query`, `query_token_count`, `fts_length_exceeded`, `build_relaxed_or`, `fts_recall_hardening_enabled`), routed through `search` / `search_memory` / `fts_only_search` (flag-gated) + `search_pages` (sanitize-only). `topic_match_title_fts` untouched (ingest-time helper). UTF-8 safe (`chars()`, no byte-slicing); graceful-degrade arms preserved.

## Tests + review

21 unit + 4 integration tests (TDD-first). Adversarial review caught + fixed a **blocker**: `search_pages` flag-ON still appended the *unsanitized* `fts_or_query` (would re-error on special chars, contradicting its sanitize-only intent) → dropped. Plus a misleading `search()` comment → corrected.

**Follow-up (noted):** integration coverage for the `search` / `fts_only_search` / `search_pages` sites under flag-ON (all route through the exhaustively-unit-tested helper; `search_memory` is integration-covered). Low risk; deferred to keep this PR surgical.

## Dual-bench A/B (single-run scaffold, subset — not citable; N≥3 for headline)

| Bench | Q | ΔNDCG@10 | Δrecall@5 |
|---|---|---|---|
| LoCoMo | 625 | −0.0001 | +0.0000 |
| LME | 30 | −0.0116 | +0.0111 |

No meaningful regression on either clean-query benchmark. The hardening's value is special-char/overlong-query correctness (absent from these benchmarks; covered by the unit/integration tests). T12 of the retrieval gap roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)