### PR TITLE
fix(retrieval): wire query-side temporal filter, opt-in (ORIGIN_ENABLE_TEMPORAL_FILTER)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -442,6 +442,24 @@ pub fn graph_gate_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// True iff `ORIGIN_ENABLE_TEMPORAL_FILTER` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive). The temporal filter is OPT-IN:
+/// unset or a falsey value leaves it disabled (dark by default).
+///
+/// When enabled, [`MemoryDB::search_memory_temporal`] will extract a temporal
+/// cue from the query via [`crate::temporal_query::extract_cue`] and, if the
+/// cue has `High` confidence, inject a parameterized `event_date BETWEEN ? AND ?
+/// OR event_date IS NULL` clause into the search filter cascade.
+///
+/// All call sites MUST share this helper so the env var cannot disagree between
+/// production and eval.
+pub fn temporal_filter_enabled() -> bool {
+    std::env::var("ORIGIN_ENABLE_TEMPORAL_FILTER")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 /// True iff `ORIGIN_MAGNITUDE_FUSION` is set to a truthy value
 /// (`1`, `true`, or `yes`, case-insensitive). OPT-IN: when unset or falsey,
 /// `search_memory`'s FTS channel keeps the legacy rank-only RRF term
@@ -6855,6 +6873,8 @@ impl MemoryDB {
     }
 
     /// Hybrid search (vector + FTS + RRF) with memory-specific filters.
+    ///
+    /// For query-side temporal filtering, use [`search_memory_temporal`] instead.
     #[allow(clippy::too_many_arguments)]
     pub async fn search_memory(
         &self,
@@ -6863,6 +6883,35 @@ impl MemoryDB {
         memory_type: Option<&str>,
         space: Option<&str>,
         source_agent: Option<&str>,
+        confirmation_boost: Option<f32>,
+        recap_penalty: Option<f32>,
+        scoring: Option<&crate::tuning::SearchScoringConfig>,
+    ) -> Result<Vec<SearchResult>, OriginError> {
+        self.search_memory_with_cue(
+            query,
+            limit,
+            memory_type,
+            space,
+            source_agent,
+            None, // temporal_cue: None -> no temporal hard filter
+            confirmation_boost,
+            recap_penalty,
+            scoring,
+        )
+        .await
+    }
+
+    /// Inner search implementation shared by `search_memory` and `search_memory_temporal`.
+    /// The `temporal_cue` argument injects a parameterized event_date filter when `Some`.
+    #[allow(clippy::too_many_arguments)]
+    async fn search_memory_with_cue(
+        &self,
+        query: &str,
+        limit: usize,
+        memory_type: Option<&str>,
+        space: Option<&str>,
+        source_agent: Option<&str>,
+        temporal_cue: Option<crate::temporal_query::DateRange>,
         confirmation_boost: Option<f32>,
         recap_penalty: Option<f32>,
         scoring: Option<&crate::tuning::SearchScoringConfig>,
@@ -6919,6 +6968,18 @@ impl MemoryDB {
         if let Some(sa) = source_agent {
             filter_conditions.push("c.source_agent = ?".to_string());
             filter_values.push(libsql::Value::Text(sa.to_string()));
+        }
+
+        // Temporal hard-filter (T4a): inject as parameterized ? placeholders.
+        // `temporal_cue` is `Some(DateRange)` only when the caller has already
+        // verified High confidence (see `search_memory_temporal`). Low-confidence
+        // cues are filtered out upstream; this block is unconditional when Some.
+        // OR event_date IS NULL is load-bearing: undated memories are never filtered out.
+        if let Some(cue) = temporal_cue {
+            filter_conditions
+                .push("(c.event_date BETWEEN ? AND ? OR c.event_date IS NULL)".to_string());
+            filter_values.push(libsql::Value::Integer(cue.start));
+            filter_values.push(libsql::Value::Integer(cue.end));
         }
 
         // Supersedes exclusion: only hide memories superseded with mode='hide'.
@@ -7424,6 +7485,83 @@ impl MemoryDB {
         }
 
         Ok(final_results)
+    }
+    /// Hybrid search with query-side temporal cue wiring (T4a).
+    ///
+    /// Wraps [`search_memory_with_cue`] with an optional temporal hard-filter:
+    ///
+    /// - `ORIGIN_ENABLE_TEMPORAL_FILTER` unset/falsey -> delegates to plain
+    ///   [`search_memory`] (byte-identical, dark by default).
+    /// - Query has no temporal pattern -> plain delegation (cue = None).
+    /// - Cue has `Low` confidence (e.g. "last week" at week boundary) ->
+    ///   plain delegation (no hard filter; soft-scoring reserved for future work).
+    /// - Cue has `High` confidence -> injects a parameterized
+    ///   `(event_date BETWEEN ? AND ? OR event_date IS NULL)` into the filter
+    ///   cascade.
+    ///
+    /// **Clock injection**: the `now` parameter is mandatory. Never call
+    /// `Utc::now()` inside this function (ensures deterministic tests and
+    /// reproducible eval runs).
+    ///
+    /// # LoCoMo note
+    /// LoCoMo has no reliable absolute dates (only session_num), so a LoCoMo
+    /// temporal eval runner is not provided. Temporal evaluation on LoCoMo
+    /// requires synthetic date assignment, which risks fabricating the signal.
+    ///
+    /// # Tuning params not yet exposed
+    /// `confirmation_boost`, `recap_penalty`, and `scoring` are intentionally
+    /// hardcoded to `None` on BOTH the flag-on and flag-off delegation paths
+    /// (sufficient for the eval-only caller today). The future routes/MCP wiring
+    /// task MUST thread these through from the caller — otherwise temporal search
+    /// would silently rank differently from non-temporal `search_memory` whenever
+    /// a caller passes custom tuning.
+    pub async fn search_memory_temporal(
+        &self,
+        query: &str,
+        limit: usize,
+        memory_type: Option<&str>,
+        space: Option<&str>,
+        source_agent: Option<&str>,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<SearchResult>, OriginError> {
+        // Gate: flag off -> plain search (byte-identical to search_memory)
+        if !temporal_filter_enabled() {
+            return self
+                .search_memory(
+                    query,
+                    limit,
+                    memory_type,
+                    space,
+                    source_agent,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+        }
+
+        // Extract temporal cue. None or Low confidence -> degrade to plain search.
+        use crate::temporal_query::{extract_cue, CueConfidence};
+        let high_conf_cue = extract_cue(query, now).and_then(|c| {
+            if c.confidence == CueConfidence::High {
+                Some(c.range)
+            } else {
+                None // Low confidence: no hard filter (soft-scoring is future work)
+            }
+        });
+
+        self.search_memory_with_cue(
+            query,
+            limit,
+            memory_type,
+            space,
+            source_agent,
+            high_conf_cue,
+            None, // confirmation_boost
+            None, // recap_penalty
+            None, // scoring
+        )
+        .await
     }
 
     /// Hybrid search with graph augmentation and optional LLM reranking.
@@ -32881,6 +33019,279 @@ pub(crate) mod tests {
             "flag ON: confirmed memory must still outrank equal-base unconfirmed \
              (multiplier stack intact); confirmed={confirmed_score} \
              unconfirmed={unconfirmed_score}"
+        );
+    }
+
+    // ==================== T4a: search_memory_temporal ====================
+
+    /// Helper: seed a memory with a specific event_date (Unix seconds) via direct SQL.
+    async fn seed_memory_with_event_date(
+        db: &MemoryDB,
+        source_id: &str,
+        content: &str,
+        event_date: Option<i64>,
+    ) {
+        let docs = vec![RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: format!("mem-{source_id}"),
+            content: content.to_string(),
+            last_modified: 0,
+            memory_type: Some("fact".to_string()),
+            space: Some("test".to_string()),
+            source_agent: Some("test-agent".to_string()),
+            ..Default::default()
+        }];
+        db.upsert_documents(docs).await.unwrap();
+        if let Some(ts) = event_date {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "UPDATE memories SET event_date = ? WHERE source_id = ?",
+                libsql::params![ts, source_id],
+            )
+            .await
+            .unwrap();
+        }
+    }
+
+    /// [T4a] seed 3 memories w/ identical text but distinct event_date;
+    /// 'yesterday' cue + fixed `now`; assert in-range AND NULL returned, out-of-range excluded.
+    #[tokio::test]
+    async fn test_temporal_scoped_search_filters_by_event_date() {
+        let (db, _dir) = test_db().await;
+        // Fixed "now" = 2026-05-27T12:00:00Z
+        // "yesterday" window: 2026-05-26 00:00:00Z .. 2026-05-26 23:59:59Z
+        // Inside:  2026-05-26T06:00:00Z = 1_779_775_200
+        // Outside: 2026-05-24T06:00:00Z = 1_779_602_400
+        let now: chrono::DateTime<chrono::Utc> = "2026-05-27T12:00:00Z".parse().unwrap();
+        // Use distinct content to avoid near-duplicate dedup (Jaccard > 0.92).
+        // All still match the temporal query text.
+        seed_memory_with_event_date(
+            &db,
+            "mem_in_range",
+            "yesterday we decided to use database retrieval indexing approach A",
+            Some(1_779_775_200),
+        )
+        .await;
+        seed_memory_with_event_date(
+            &db,
+            "mem_out_range",
+            "yesterday we considered switching the database retrieval strategy B",
+            Some(1_779_602_400),
+        )
+        .await;
+        seed_memory_with_event_date(
+            &db,
+            "mem_null_date",
+            "yesterday the database retrieval evaluation results were reviewed C",
+            None,
+        )
+        .await;
+
+        let results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_TEMPORAL_FILTER", Some("1"))], async {
+                db.search_memory_temporal(
+                    "what database decision did I make yesterday",
+                    10,
+                    None,
+                    None,
+                    None,
+                    now,
+                )
+                .await
+                .unwrap()
+            })
+            .await;
+
+        let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            ids.contains(&"mem_in_range"),
+            "in-range memory must be returned; got {ids:?}"
+        );
+        assert!(
+            ids.contains(&"mem_null_date"),
+            "NULL-date memory must be returned (OR IS NULL clause); got {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"mem_out_range"),
+            "out-of-range memory must be excluded; got {ids:?}"
+        );
+    }
+
+    /// [T4a] Non-temporal query -> results identical to plain search_memory.
+    #[tokio::test]
+    async fn test_temporal_scoped_search_no_cue_is_noop() {
+        let (db, _dir) = test_db().await;
+        let now: chrono::DateTime<chrono::Utc> = "2026-05-27T12:00:00Z".parse().unwrap();
+        // DISTINCT content so near-duplicate dedup (Jaccard > 0.92) does NOT collapse
+        // them — both must survive into results for the no-op comparison to be meaningful.
+        seed_memory_with_event_date(
+            &db,
+            "noop_mem_a",
+            "database retrieval system architecture postgres",
+            Some(1_779_775_200),
+        )
+        .await;
+        seed_memory_with_event_date(
+            &db,
+            "noop_mem_b",
+            "database storage engine indexing libsql",
+            Some(1_779_602_400),
+        )
+        .await;
+
+        let temporal_results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_TEMPORAL_FILTER", Some("1"))], async {
+                db.search_memory_temporal("what database did I pick", 10, None, None, None, now)
+                    .await
+                    .unwrap()
+            })
+            .await;
+
+        let plain_results = db
+            .search_memory(
+                "what database did I pick",
+                10,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let temporal_ids: Vec<&str> = temporal_results
+            .iter()
+            .map(|r| r.source_id.as_str())
+            .collect();
+        let plain_ids: Vec<&str> = plain_results.iter().map(|r| r.source_id.as_str()).collect();
+
+        // Both distinct memories must survive (guards against the temporal path
+        // wrongly dropping them, which a hollow assert_eq! of two 1-element lists
+        // would not catch).
+        assert!(
+            temporal_ids.len() >= 2,
+            "both distinct memories must survive into results; got {temporal_ids:?}"
+        );
+        assert!(
+            temporal_ids.contains(&"noop_mem_a") && temporal_ids.contains(&"noop_mem_b"),
+            "both noop_mem_a and noop_mem_b must appear; got {temporal_ids:?}"
+        );
+
+        assert_eq!(
+            temporal_ids, plain_ids,
+            "no-cue temporal search must return identical result order as plain search_memory"
+        );
+    }
+
+    /// [T4a] Low-confidence cue -> out-of-range NOT excluded (no hard filter on Low).
+    #[tokio::test]
+    async fn test_temporal_scoped_low_confidence_cue_not_hard_filtered() {
+        use chrono::{Datelike, Weekday};
+        let (db, _dir) = test_db().await;
+        // "last week" at Sunday 23:59 is Low confidence per temporal_query.rs week-boundary logic
+        let now: chrono::DateTime<chrono::Utc> = "2026-05-31T23:59:00Z".parse().unwrap();
+        assert_eq!(
+            now.weekday(),
+            Weekday::Sun,
+            "fixture requires now=Sunday for Low-confidence last-week cue"
+        );
+        let text = "last week sprint planning meeting";
+        // event_date clearly outside any plausible "last week" window (>30 days before now)
+        seed_memory_with_event_date(&db, "low_conf_out", text, Some(1_746_057_600)).await;
+
+        let results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_TEMPORAL_FILTER", Some("1"))], async {
+                db.search_memory_temporal(
+                    "what happened last week in sprint planning",
+                    10,
+                    None,
+                    None,
+                    None,
+                    now,
+                )
+                .await
+                .unwrap()
+            })
+            .await;
+
+        let ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            ids.contains(&"low_conf_out"),
+            "Low-confidence cue must NOT exclude out-of-range memory; got {ids:?}"
+        );
+    }
+
+    /// [T4a] Flag unset -> out-of-range returned; flag set -> excluded.
+    #[tokio::test]
+    async fn test_temporal_scoped_search_disabled_by_default_flag() {
+        let (db, _dir) = test_db().await;
+        let now: chrono::DateTime<chrono::Utc> = "2026-05-27T12:00:00Z".parse().unwrap();
+        let text = "yesterday architecture decision database";
+        // Outside "yesterday" window (2026-05-24T06:00:00Z = 2 days out)
+        seed_memory_with_event_date(&db, "flag_out", text, Some(1_779_602_400)).await;
+
+        // Flag unset -> filter off -> out-of-range memory returned
+        let off_results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_TEMPORAL_FILTER", None::<&str>)], async {
+                db.search_memory_temporal(
+                    "what database architecture did I decide yesterday",
+                    10,
+                    None,
+                    None,
+                    None,
+                    now,
+                )
+                .await
+                .unwrap()
+            })
+            .await;
+        let off_ids: Vec<&str> = off_results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            off_ids.contains(&"flag_out"),
+            "TEMPORAL_FILTER unset -> no filter; out-of-range must be returned; got {off_ids:?}"
+        );
+
+        // Flag set -> filter on -> out-of-range memory excluded
+        let on_results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_TEMPORAL_FILTER", Some("1"))], async {
+                db.search_memory_temporal(
+                    "what database architecture did I decide yesterday",
+                    10,
+                    None,
+                    None,
+                    None,
+                    now,
+                )
+                .await
+                .unwrap()
+            })
+            .await;
+        let on_ids: Vec<&str> = on_results.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            !on_ids.contains(&"flag_out"),
+            "TEMPORAL_FILTER=1 -> out-of-range must be excluded; got {on_ids:?}"
+        );
+    }
+
+    /// [T4a] Empty DB + temporal query -> Ok(vec![]), no panic.
+    #[tokio::test]
+    async fn test_temporal_scoped_search_graceful_on_empty_db() {
+        let (db, _dir) = test_db().await;
+        let now: chrono::DateTime<chrono::Utc> = "2026-05-27T12:00:00Z".parse().unwrap();
+
+        let results =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_TEMPORAL_FILTER", Some("1"))], async {
+                db.search_memory_temporal("what happened yesterday", 10, None, None, None, now)
+                    .await
+            })
+            .await;
+        assert!(results.is_ok(), "empty DB must return Ok; got {results:?}");
+        assert!(
+            results.unwrap().is_empty(),
+            "empty DB must return empty vec"
         );
     }
 }

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1447,6 +1447,188 @@ pub async fn run_longmemeval_eval_expanded(
 }
 
 // ---------------------------------------------------------------------------
+// T4a eval runner — temporal filter with haystack_dates event_date seeding
+// ---------------------------------------------------------------------------
+
+/// Parse LongMemEval date string "YYYY/MM/DD (DDD) HH:MM" to a UTC DateTime.
+///
+/// Returns `None` on malformed input so the runner degrades gracefully.
+fn parse_lme_date(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    // Format: "2023/04/10 (Mon) 23:07"
+    // We strip the weekday parenthetical and parse the rest.
+    let s = s.trim();
+    // Find the part before " (" and after ") "
+    let without_weekday = if let (Some(a), Some(b)) = (s.find(" ("), s.rfind(") ")) {
+        format!("{} {}", &s[..a], &s[b + 2..])
+    } else {
+        s.to_string()
+    };
+    // without_weekday is now "YYYY/MM/DD HH:MM"
+    chrono::NaiveDateTime::parse_from_str(&without_weekday, "%Y/%m/%d %H:%M")
+        .ok()
+        .map(|dt| chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(dt, chrono::Utc))
+}
+
+/// LongMemEval temporal eval runner (T4a).
+///
+/// Clones `run_longmemeval_eval_expanded` but adds two T4a-specific steps:
+///
+/// 1. **Event-date seeding**: after `upsert_documents`, each seeded memory is
+///    stamped with the Unix timestamp of its session's `haystack_dates` entry
+///    via a direct `UPDATE memories SET event_date=? WHERE source_id=?` on the
+///    connection. Without this, every `event_date` is NULL and the temporal
+///    hard-filter is a guaranteed no-op (all memories pass the `OR IS NULL`
+///    branch).
+///
+/// 2. **Temporal search**: calls `search_memory_temporal` with
+///    `now = parse(sample.question_date)` — NOT `Utc::now()` — so the cue
+///    window aligns with the fixture clock.
+///
+/// # LoCoMo note
+/// LoCoMo has no reliable absolute dates (only session_num), so a LoCoMo
+/// temporal runner is not provided. Temporal eval on LoCoMo would require
+/// synthetic date assignment, which risks fabricating the measured signal.
+///
+/// # Citation discipline
+/// First runs are single-run scaffolds (`is_single_run = true`). Do NOT cite
+/// accuracy numbers without N>=3 + stddev per AGENTS.md Eval Citation Discipline.
+#[allow(dead_code)] // L7 manual, GPU-requiring eval; not wired to CI
+pub async fn run_longmemeval_eval_temporal(path: &Path) -> Result<LongMemEvalReport, OriginError> {
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut all_scores: Vec<(String, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
+    let mut total_memories: usize = 0;
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+
+        // Create ephemeral DB for this question
+        let tmp = tempfile::tempdir().map_err(|e| OriginError::Generic(format!("tempdir: {e}")))?;
+        let db = MemoryDB::new(tmp.path(), std::sync::Arc::new(crate::events::NoopEmitter)).await?;
+
+        // Seed all extracted memories (same as run_longmemeval_eval_expanded)
+        let docs: Vec<RawDocument> = memories
+            .iter()
+            .map(|mem| {
+                let memory_type = match sample.question_type.as_str() {
+                    "single-session-preference" => "preference",
+                    _ => "fact",
+                };
+                RawDocument {
+                    content: mem.content.clone(),
+                    source_id: memory_source_id(&mem.question_id, mem.session_idx, mem.turn_idx),
+                    source: "memory".to_string(),
+                    title: format!("{} session {}", mem.role, mem.session_idx),
+                    memory_type: Some(memory_type.to_string()),
+                    space: Some("conversation".to_string()),
+                    last_modified: chrono::Utc::now().timestamp(),
+                    ..Default::default()
+                }
+            })
+            .collect();
+        total_memories += docs.len();
+        db.upsert_documents(docs).await?;
+
+        // T4a: stamp event_date from haystack_dates (parallel to sessions/memories).
+        // Without this, every event_date is NULL and the temporal filter is a no-op.
+        {
+            let conn = db.conn.lock().await;
+            for mem in &memories {
+                // haystack_dates is parallel to haystack_session_ids
+                // (one date per session, indexed by session_idx)
+                if let Some(date_str) = sample.haystack_dates.get(mem.session_idx) {
+                    if let Some(ts) = parse_lme_date(date_str).map(|d| d.timestamp()) {
+                        let sid = memory_source_id(&mem.question_id, mem.session_idx, mem.turn_idx);
+                        let _ = conn
+                            .execute(
+                                "UPDATE memories SET event_date = ? WHERE source_id = ?",
+                                libsql::params![ts, sid.as_str()],
+                            )
+                            .await;
+                    }
+                }
+            }
+        }
+
+        // Build relevance judgments
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        // T4a: parse question_date as `now` so the cue window aligns with fixture clock.
+        // Fall back to Utc::now() only if the date is unparseable (degraded mode).
+        let now = parse_lme_date(&sample.question_date).unwrap_or_else(chrono::Utc::now);
+
+        // T4a: use search_memory_temporal with ORIGIN_ENABLE_TEMPORAL_FILTER=1
+        let results = db
+            .search_memory_temporal(&sample.question, 10, None, None, None, now)
+            .await?;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| (*id, u8::from(relevant_source_ids.contains(*id))))
+            .collect();
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+        let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+        let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+        let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+        let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+
+        all_scores.push((
+            sample.question_type.clone(),
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+        per_case.push(build_lme_case_result(
+            &sample.question,
+            &sample.question_type,
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+    }
+
+    let per_category = aggregate_by_category(&all_scores);
+    let mut report = LongMemEvalReport {
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories,
+        per_category,
+        baseline: None,
+        env: None,
+        per_case,
+        coverage: None,
+    };
+    report.env = Some(build_lme_env(
+        "temporal",
+        path,
+        "search_memory_temporal",
+        "none", // no LLM provider (no query expansion)
+        "none",
+        None,
+    ));
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
 // Gated benchmark runner — clean / noisy / gated comparison
 // ---------------------------------------------------------------------------
 

--- a/crates/origin-core/src/temporal_query.rs
+++ b/crates/origin-core/src/temporal_query.rs
@@ -5,9 +5,8 @@
 //! This module ships the yesterday/today/tomorrow patterns; Tasks 7-8 add
 //! week/month/year, weekday, N-ago, quarter, and since patterns.
 //
-// The module is pub(crate) for Plan A. Plan B promotes it and wires extract_cue
-// into the composite scorer; until then the query-side helpers are stubs.
-#![allow(dead_code)]
+// `extract_cue` is wired into `db::search_memory_temporal` (T4a).
+// `extract_cue_for_content` is called from migration 55 backfill.
 
 use chrono::{DateTime, Datelike, Duration, NaiveDate, TimeZone, Utc, Weekday};
 use regex::Regex;

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -4696,3 +4696,113 @@ async fn smoke_tool_use_judge_returns_structured_verdict() {
         "Paris->France obvious-correct judgment should be 1"
     );
 }
+
+/// T4a temporal-filter A/B on LongMemEval (retrieval-only, no GPU LLM, no judge).
+///
+/// The runner `run_longmemeval_eval_temporal` self-seeds a fresh ephemeral DB per
+/// question from the fixture, stamps `event_date` from `haystack_dates`, then
+/// retrieves via `search_memory_temporal(.., now=question_date)`.
+///
+/// `ORIGIN_ENABLE_TEMPORAL_FILTER` controls whether the hard temporal filter
+/// activates on High-confidence temporal cues. This A/B measures:
+///   OFF (None)  -- temporal search path with filter disabled (plain search)
+///   ON  ("1")   -- temporal search path with hard filter enabled
+///
+/// Respects `EVAL_LME_LIMIT` for fast iteration (e.g. EVAL_LME_LIMIT=30).
+/// Single-run scaffold -- N>=3 for any headline per AGENTS.md Eval Citation Discipline.
+#[tokio::test]
+#[ignore = "self-seeds from fixture; retrieval-only, no GPU; set ORIGIN_EVAL_ROOT + EVAL_LME_LIMIT"]
+async fn temporal_filter_ab_lme() {
+    use origin_core::eval::longmemeval::run_longmemeval_eval_temporal;
+
+    let fixture = eval_root().join("data/longmemeval_oracle.json");
+    if !fixture.exists() {
+        println!(
+            "SKIP: longmemeval_oracle.json not found at {}",
+            fixture.display()
+        );
+        return;
+    }
+
+    println!(
+        "=== T4a TEMPORAL-FILTER A/B (LongMemEval, search_memory_temporal, retrieval-only) ==="
+    );
+    println!("fixture: {}", fixture.display());
+
+    let off = temp_env::async_with_vars(
+        [("ORIGIN_ENABLE_TEMPORAL_FILTER", None::<&str>)],
+        run_longmemeval_eval_temporal(&fixture),
+    )
+    .await
+    .expect("temporal eval OFF failed");
+
+    let on = temp_env::async_with_vars(
+        [("ORIGIN_ENABLE_TEMPORAL_FILTER", Some("1"))],
+        run_longmemeval_eval_temporal(&fixture),
+    )
+    .await
+    .expect("temporal eval ON failed");
+
+    println!("questions evaluated: {}", off.total_questions);
+    println!(
+        "FILTER OFF: ndcg@10={:.4} recall@5={:.4} mrr={:.4} hit@1={:.4}",
+        off.aggregate_ndcg_at_10,
+        off.aggregate_recall_at_5,
+        off.aggregate_mrr,
+        off.aggregate_hit_rate_at_1,
+    );
+    println!(
+        "FILTER ON:  ndcg@10={:.4} recall@5={:.4} mrr={:.4} hit@1={:.4}",
+        on.aggregate_ndcg_at_10,
+        on.aggregate_recall_at_5,
+        on.aggregate_mrr,
+        on.aggregate_hit_rate_at_1,
+    );
+    println!(
+        "DELTA (on-off): ndcg@10={:+.4} recall@5={:+.4} mrr={:+.4} hit@1={:+.4}",
+        on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+        on.aggregate_recall_at_5 - off.aggregate_recall_at_5,
+        on.aggregate_mrr - off.aggregate_mrr,
+        on.aggregate_hit_rate_at_1 - off.aggregate_hit_rate_at_1,
+    );
+
+    // Per-category breakdown -- print temporal-reasoning bucket specifically
+    println!("\n--- Per-category breakdown (OFF) ---");
+    for cat in &off.per_category {
+        println!(
+            "  {:30} n={:3}  ndcg@10={:.4}  recall@5={:.4}  mrr={:.4}",
+            cat.question_type, cat.count, cat.ndcg_at_10, cat.recall_at_5, cat.mrr
+        );
+    }
+    println!("--- Per-category breakdown (ON) ---");
+    for cat in &on.per_category {
+        println!(
+            "  {:30} n={:3}  ndcg@10={:.4}  recall@5={:.4}  mrr={:.4}",
+            cat.question_type, cat.count, cat.ndcg_at_10, cat.recall_at_5, cat.mrr
+        );
+    }
+
+    // Targeted temporal-reasoning delta
+    let tr_off = off
+        .per_category
+        .iter()
+        .find(|c| c.question_type == "temporal-reasoning");
+    let tr_on = on
+        .per_category
+        .iter()
+        .find(|c| c.question_type == "temporal-reasoning");
+    match (tr_off, tr_on) {
+        (Some(o), Some(n)) => {
+            println!(
+                "\n>>> temporal-reasoning bucket (n={}): ndcg@10 OFF={:.4} ON={:.4} d={:+.4} | recall@5 OFF={:.4} ON={:.4} d={:+.4} | mrr OFF={:.4} ON={:.4} d={:+.4}",
+                o.count,
+                o.ndcg_at_10, n.ndcg_at_10, n.ndcg_at_10 - o.ndcg_at_10,
+                o.recall_at_5, n.recall_at_5, n.recall_at_5 - o.recall_at_5,
+                o.mrr, n.mrr, n.mrr - o.mrr,
+            );
+        }
+        _ => {
+            println!("\n>>> temporal-reasoning bucket: not present in per_category (may be absent at this EVAL_LME_LIMIT)");
+        }
+    }
+}


### PR DESCRIPTION
## What

Wires Origin's fully-built-but-DEAD query-side temporal filter behind opt-in `ORIGIN_ENABLE_TEMPORAL_FILTER` (default OFF). `extract_cue` (temporal_query.rs, was `#![allow(dead_code)]`) parses "yesterday"/"last week" into a date window; the `event_date` column + `idx_memories_entity_event` are live; nothing called them. New `search_memory_temporal(query, .., now)` threads `(event_date BETWEEN ? AND ? OR event_date IS NULL)` (parameterized) into search when a **High-confidence** cue is present, else delegates to plain search. Clock injected as a param (deterministic). `search_memory` body factored into a private `search_memory_with_cue` helper — public signature unchanged, confirmed byte-identical in review.

T4a only — T4b (k-hop entity traversal) is a separate follow-up per the plan's split recommendation.

## ⚠️ Eval result: the HARD filter regresses — do NOT enable yet

LME temporal A/B (retrieval-only, `run_longmemeval_eval_temporal`, event_date post-seeded from haystack_dates, N=30 scaffold):

| Metric | filter OFF | filter ON | Δ |
|---|---|---|---|
| ndcg@10 | 0.8053 | 0.7720 | **−0.0333** |
| recall@5 | 0.8389 | 0.8056 | **−0.0333** |
| mrr | 0.7972 | 0.7639 | **−0.0333** |

Uniform −0.0333 = exactly **1 of 30 questions** going hit→miss: the hard temporal exclude drops a relevant memory whose `event_date` is outside the parsed window. **Hard-filtering is the wrong mechanism for temporal** — it can exclude the answer. (LoCoMo can't measure temporal — no absolute dates; documented.)

## Why merge anyway

Default OFF = zero production impact. The wiring (cue extraction + parameterized clause + LME temporal runner + 5 deterministic unit tests + review-confirmed byte-identical refactor) is correct and reusable. **Follow-up (tracked): replace the hard filter with a SOFT temporal-proximity boost** (`signals::temporal_proximity` already exists — Gaussian in-window boost that lifts dated matches WITHOUT excluding out-of-window answers). Do NOT flip the default ON without that rework + a full N≥3 run.

## Tests
5 temporal unit tests (in-window kept / out excluded / NULL kept / flag-off no-op / low-confidence no-op; no-op test asserts both memories survive). Review: no blocker; the ~300-line search_memory→search_memory_with_cue extraction verified byte-identical (placeholder numbering + OR-IS-NULL parenthesization checked). clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)