### PR TITLE
fix(retrieval): opt-in wide-pool-seeded graph expansion (ORIGIN_ENABLE_GRAPH_SEED)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -442,6 +442,20 @@ pub fn graph_gate_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// True iff `ORIGIN_ENABLE_GRAPH_SEED` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive). T9 wide-pool-seeded graph expansion.
+/// OPT-IN: unset or falsey leaves `augment_with_graph` using the existing
+/// query-anchor seed (byte-identical to pre-T9). When enabled, the seeded variant
+/// seeds from the wide candidate pool entity provenance + k-hop BFS.
+/// Controls: `ORIGIN_GRAPH_HOP_DEPTH` (default 1), `ORIGIN_GRAPH_SEED_TOP_K` (default 10),
+/// `ORIGIN_GRAPH_FRONTIER_CAP` (default 64).
+pub fn graph_seed_enabled() -> bool {
+    std::env::var("ORIGIN_ENABLE_GRAPH_SEED")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 /// True iff `ORIGIN_ENABLE_TEMPORAL_FILTER` is set to a truthy value
 /// (`1`, `true`, or `yes`, case-insensitive). The temporal filter is OPT-IN:
 /// unset or a falsey value leaves it disabled (dark by default).
@@ -7308,13 +7322,45 @@ impl MemoryDB {
 
         // --- Graph augmentation (knowledge graph as third RRF signal) ---
         // Drop the conn lock first — augment_with_graph acquires it internally.
+        //
+        // T9: harvest (entity_id, rank) from the WIDE pre-truncate pool BEFORE dropping
+        // the lock (final_results here is the limit*3 scored pool). rank = enumeration
+        // index. Used by augment_with_graph_seeded when ORIGIN_ENABLE_GRAPH_SEED=1.
+        let pool_entity_ids: Vec<String> = final_results
+            .iter()
+            .filter_map(|r| r.entity_id.clone())
+            .collect();
         drop(conn);
         // Graph gate (ORIGIN_ENABLE_GRAPH_GATE, opt-in): when enabled, skip the
         // graph hop for queries that warrant no traversal (no relational/temporal
         // phrasing, no entity anchor). When the gate is off, always augment —
         // behavior is byte-identical to before this gate existed.
         if !graph_gate_enabled() || crate::retrieval::signals::query_warrants_graph(query) {
-            final_results = self.augment_with_graph(query, final_results, limit).await?;
+            // T9: pool-seeded variant (ORIGIN_ENABLE_GRAPH_SEED, opt-in, default OFF).
+            // When ON + pool has entity ids: seed BFS from pool provenance instead of
+            // a fresh query-anchored search_entities_by_vector call.
+            // Graceful log-and-degrade: on Err, warn + fall back to query-anchor.
+            if graph_seed_enabled() && !pool_entity_ids.is_empty() {
+                let seeded_result = self
+                    .augment_with_graph_seeded(query, final_results, &pool_entity_ids, limit)
+                    .await;
+                match seeded_result {
+                    Ok(augmented) => {
+                        final_results = augmented;
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[search_memory] T9 seeded graph augmentation failed: {}; falling back to query-anchor",
+                            e
+                        );
+                        // final_results was moved; augment_with_graph with empty results
+                        // so score boosts still flow (query-anchor picks up entities).
+                        final_results = self.augment_with_graph(query, vec![], limit).await?;
+                    }
+                }
+            } else {
+                final_results = self.augment_with_graph(query, final_results, limit).await?;
+            }
         }
 
         // Deduplicate: keep only the best-scoring chunk per source document.
@@ -8202,6 +8248,193 @@ impl MemoryDB {
             results.into_iter().map(|r| (r.id.clone(), r)).collect();
 
         // Merge graph observations as third RRF signal
+        for (rank, result) in graph_results.into_iter().enumerate() {
+            let rrf_score = 1.0 / (60.0 + rank as f32);
+            *score_map.entry(result.id.clone()).or_default() += rrf_score;
+            result_map.entry(result.id.clone()).or_insert(result);
+        }
+
+        let mut merged: Vec<SearchResult> = result_map
+            .into_values()
+            .map(|mut r| {
+                r.score = *score_map.get(&r.id).unwrap_or(&0.0);
+                r
+            })
+            .collect();
+        merged.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.source_id.cmp(&b.source_id))
+        });
+        Ok(merged)
+    }
+
+    // ---------------------------------------------------------------------------
+    // T9: k-hop BFS entity expansion
+    // ---------------------------------------------------------------------------
+
+    /// BFS over the entity-relation graph up to `depth` hops from `seed_ids`.
+    ///
+    /// depth=0 or empty seeds → returns deduped seeds only.
+    /// Each hop follows relations in BOTH directions (`from_entity` and `to_entity`)
+    /// mirroring the bidirectional UNION-ALL at the single-entity get_entity_detail.
+    /// Expansion is bounded by `frontier_cap`: once `visited.len() >= frontier_cap`,
+    /// the frontier is sorted (deterministic) and truncated before breaking.
+    ///
+    /// Single conn lock is held across the bounded BFS loop (depth ≤ 3, small).
+    /// No non-libsql `.await` is called inside the lock.
+    async fn expand_entities_khop(
+        &self,
+        seed_ids: &[String],
+        depth: usize,
+        frontier_cap: usize,
+    ) -> Result<Vec<String>, OriginError> {
+        if seed_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut visited: std::collections::HashSet<String> = seed_ids.iter().cloned().collect();
+
+        if depth == 0 {
+            let mut out: Vec<String> = visited.into_iter().collect();
+            out.sort();
+            return Ok(out);
+        }
+
+        let conn = self.conn.lock().await;
+        let mut frontier: Vec<String> = seed_ids.to_vec();
+
+        for _hop in 0..depth {
+            if frontier.is_empty() {
+                break;
+            }
+
+            // Build parameterised IN clause for the current frontier
+            let placeholders: Vec<String> =
+                (1..=frontier.len()).map(|i| format!("?{}", i)).collect();
+            let ph = placeholders.join(",");
+
+            // Bidirectional: outgoing (from_entity IN frontier) + incoming (to_entity IN frontier)
+            let sql = format!(
+                "SELECT to_entity FROM relations WHERE from_entity IN ({ph})
+                 UNION
+                 SELECT from_entity FROM relations WHERE to_entity IN ({ph})",
+                ph = ph
+            );
+
+            let params: Vec<libsql::Value> = frontier
+                .iter()
+                .map(|id| libsql::Value::Text(id.clone()))
+                .collect();
+
+            let mut rows = conn
+                .query(&sql, libsql::params_from_iter(params))
+                .await
+                .map_err(|e| OriginError::VectorDb(format!("expand_entities_khop: {}", e)))?;
+
+            let mut next_frontier: Vec<String> = Vec::new();
+            while let Ok(Some(row)) = rows.next().await {
+                let eid: String = row.get(0).unwrap_or_default();
+                if !eid.is_empty() && !visited.contains(&eid) {
+                    visited.insert(eid.clone());
+                    next_frontier.push(eid);
+                    if visited.len() >= frontier_cap {
+                        break;
+                    }
+                }
+            }
+
+            if visited.len() >= frontier_cap {
+                // Sort for determinism before truncating
+                let mut all: Vec<String> = visited.into_iter().collect();
+                all.sort();
+                all.truncate(frontier_cap);
+                return Ok(all);
+            }
+
+            frontier = next_frontier;
+        }
+
+        drop(conn);
+
+        let mut out: Vec<String> = visited.into_iter().collect();
+        out.sort();
+        Ok(out)
+    }
+
+    // ---------------------------------------------------------------------------
+    // T9: pool-seeded RRF augmentation
+    // ---------------------------------------------------------------------------
+
+    /// Wide-pool-seeded graph augmentation. Seeds graph BFS from `seed_entity_ids`
+    /// (the candidate pool's entity provenance) instead of a fresh query-anchored
+    /// `search_entities_by_vector(query, 5)` call.
+    ///
+    /// If `seed_entity_ids` is empty, delegates to [`Self::augment_with_graph`]
+    /// (query-anchor fallback, never-worse-than-today guarantee).
+    ///
+    /// BFS depth and cap are read from env: `ORIGIN_GRAPH_HOP_DEPTH` (default 1),
+    /// `ORIGIN_GRAPH_SEED_TOP_K` (default 10), `ORIGIN_GRAPH_FRONTIER_CAP` (default 64).
+    ///
+    /// RRF merge is byte-identical to `augment_with_graph`: seed score_map from
+    /// existing results, then += 1/(60+rank) per graph row via `entry().or_default()` +
+    /// `or_insert` (no double-count guard matches db.rs `augment_with_graph` verbatim).
+    pub async fn augment_with_graph_seeded(
+        &self,
+        query: &str,
+        results: Vec<SearchResult>,
+        seed_entity_ids: &[String],
+        limit: usize,
+    ) -> Result<Vec<SearchResult>, OriginError> {
+        // Empty seeds → fall back to existing query-anchor path
+        if seed_entity_ids.is_empty() {
+            return self.augment_with_graph(query, results, limit).await;
+        }
+
+        // Read tuning env vars
+        let depth = crate::retrieval::signals::parse_hop_depth(
+            std::env::var("ORIGIN_GRAPH_HOP_DEPTH").ok().as_deref(),
+        );
+        let top_k = crate::retrieval::signals::parse_seed_top_k(
+            std::env::var("ORIGIN_GRAPH_SEED_TOP_K").ok().as_deref(),
+        );
+        let frontier_cap = crate::retrieval::signals::parse_frontier_cap(
+            std::env::var("ORIGIN_GRAPH_FRONTIER_CAP").ok().as_deref(),
+        );
+
+        // Build (entity_id, rank) pairs from the provided seed list (already ranked)
+        let pool_pairs: Vec<(String, usize)> = seed_entity_ids
+            .iter()
+            .enumerate()
+            .map(|(rank, id)| (id.clone(), rank))
+            .collect();
+        let seeds = crate::retrieval::signals::seed_entities_by_rank(&pool_pairs, top_k);
+
+        // BFS to expand seed set
+        let expanded = match self.expand_entities_khop(&seeds, depth, frontier_cap).await {
+            Ok(ids) => ids,
+            Err(e) => {
+                log::warn!(
+                    "[augment_seeded] expand_entities_khop failed: {}; using raw seeds",
+                    e
+                );
+                seeds
+            }
+        };
+
+        // Fetch observations for expanded entity set
+        let graph_results = match self.get_observations_for_entities(&expanded, limit).await {
+            Ok(r) if !r.is_empty() => r,
+            _ => return Ok(results),
+        };
+
+        // RRF merge (verbatim from augment_with_graph — preserves byte-identical semantics)
+        let mut score_map: HashMap<String, f32> =
+            results.iter().map(|r| (r.id.clone(), r.score)).collect();
+        let mut result_map: HashMap<String, SearchResult> =
+            results.into_iter().map(|r| (r.id.clone(), r)).collect();
+
         for (rank, result) in graph_results.into_iter().enumerate() {
             let rrf_score = 1.0 / (60.0 + rank as f32);
             *score_map.entry(result.id.clone()).or_default() += rrf_score;
@@ -24988,6 +25221,284 @@ pub(crate) mod tests {
             .unwrap();
         assert!(!augmented.is_empty(), "should include graph observations");
         assert!(augmented.iter().any(|r| r.source == "knowledge_graph"));
+    }
+    // ==================== T9: wide-pool-seeded graph expansion ====================
+
+    /// Verify expand_entities_khop depth=1 gives neighbors, depth=0 gives seeds only.
+    #[tokio::test]
+    async fn test_expand_entities_khop_depth1_is_neighbor_parity() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .store_entity("E1", "thing", None, None, None)
+            .await
+            .unwrap();
+        let e2 = db
+            .store_entity("E2", "thing", None, None, None)
+            .await
+            .unwrap();
+        db.create_relation(&e1, &e2, "related_to", None, None, None, None)
+            .await
+            .unwrap();
+
+        let depth0 = db
+            .expand_entities_khop(std::slice::from_ref(&e1), 0, 64)
+            .await
+            .unwrap();
+        assert_eq!(depth0, vec![e1.clone()], "depth=0 returns seeds unchanged");
+
+        let depth1 = db
+            .expand_entities_khop(std::slice::from_ref(&e1), 1, 64)
+            .await
+            .unwrap();
+        let mut d1 = depth1.clone();
+        d1.sort();
+        let mut expected = vec![e1.clone(), e2.clone()];
+        expected.sort();
+        assert_eq!(d1, expected, "depth=1 should reach E2 via relation");
+    }
+
+    /// Verify two-hop BFS reaches E3 at depth=2 but NOT at depth=1.
+    #[tokio::test]
+    async fn test_expand_entities_khop_depth2_reaches_two_hop() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .store_entity("ChainA", "thing", None, None, None)
+            .await
+            .unwrap();
+        let e2 = db
+            .store_entity("ChainB", "thing", None, None, None)
+            .await
+            .unwrap();
+        let e3 = db
+            .store_entity("ChainC", "thing", None, None, None)
+            .await
+            .unwrap();
+        db.create_relation(&e1, &e2, "related_to", None, None, None, None)
+            .await
+            .unwrap();
+        db.create_relation(&e2, &e3, "related_to", None, None, None, None)
+            .await
+            .unwrap();
+
+        let depth1 = db
+            .expand_entities_khop(std::slice::from_ref(&e1), 1, 64)
+            .await
+            .unwrap();
+        assert!(depth1.contains(&e1), "depth=1 must include seed");
+        assert!(depth1.contains(&e2), "depth=1 must include e2");
+        assert!(
+            !depth1.contains(&e3),
+            "depth=1 must NOT include e3 (two hops away)"
+        );
+
+        let depth2 = db
+            .expand_entities_khop(std::slice::from_ref(&e1), 2, 64)
+            .await
+            .unwrap();
+        assert!(depth2.contains(&e3), "depth=2 must reach e3");
+    }
+
+    /// Verify BFS is bidirectional (follows both from→to and to→from relations).
+    #[tokio::test]
+    async fn test_expand_entities_khop_bidirectional() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .store_entity("BiA", "thing", None, None, None)
+            .await
+            .unwrap();
+        let e2 = db
+            .store_entity("BiB", "thing", None, None, None)
+            .await
+            .unwrap();
+        // relation stored from e2 → e1 (reversed)
+        db.create_relation(&e2, &e1, "related_to", None, None, None, None)
+            .await
+            .unwrap();
+
+        let result = db
+            .expand_entities_khop(std::slice::from_ref(&e1), 1, 64)
+            .await
+            .unwrap();
+        assert!(
+            result.contains(&e2),
+            "must follow incoming relation (bidirectional)"
+        );
+    }
+
+    /// Verify empty seed returns empty.
+    #[tokio::test]
+    async fn test_expand_entities_khop_empty_seed_returns_empty() {
+        let (db, _dir) = test_db().await;
+        let result = db.expand_entities_khop(&[], 1, 64).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    /// Verify frontier_cap bounds fan-out on a star graph.
+    #[tokio::test]
+    async fn test_expand_entities_khop_respects_frontier_cap() {
+        let (db, _dir) = test_db().await;
+        let center = db
+            .store_entity("StarCenter", "thing", None, None, None)
+            .await
+            .unwrap();
+        // Create 30 leaf entities and connect them to center
+        for i in 0..30 {
+            let leaf = db
+                .store_entity(&format!("Leaf{}", i), "thing", None, None, None)
+                .await
+                .unwrap();
+            db.create_relation(&center, &leaf, "related_to", None, None, None, None)
+                .await
+                .unwrap();
+        }
+        let result = db
+            .expand_entities_khop(std::slice::from_ref(&center), 1, 16)
+            .await
+            .unwrap();
+        assert!(
+            result.len() <= 17,
+            "frontier_cap=16 => at most 17 entities (center + 16 leaves)"
+        );
+    }
+
+    /// Empty seeds → augment_with_graph_seeded delegates to query-anchor (fallback guarantee).
+    #[tokio::test]
+    async fn test_augment_seeded_falls_back_to_query_anchor_on_empty_seeds() {
+        let (db, _dir) = test_db().await;
+        let eid = db
+            .store_entity("Rust", "technology", None, None, None)
+            .await
+            .unwrap();
+        db.add_observation(&eid, "Rust is memory-safe", Some("test"), None)
+            .await
+            .unwrap();
+
+        let results: Vec<SearchResult> = vec![];
+        // With empty seed_entity_ids, must delegate to augment_with_graph (query-anchor)
+        let seeded = db
+            .augment_with_graph_seeded("Rust programming", results.clone(), &[], 10)
+            .await
+            .unwrap();
+        let unseeded = db
+            .augment_with_graph("Rust programming", results, 10)
+            .await
+            .unwrap();
+
+        // Both should return the same KG observation (Rust entity found by vector search)
+        assert_eq!(
+            seeded.len(),
+            unseeded.len(),
+            "empty seeds must match query-anchor output"
+        );
+    }
+
+    /// Pool-seeded variant picks up entity from pool provenance, not query anchor.
+    #[tokio::test]
+    async fn test_augment_seeded_uses_pool_provenance_when_present() {
+        let (db, _dir) = test_db().await;
+        // E_rust: in pool, has observation
+        let e_rust = db
+            .store_entity("RustLang", "technology", None, None, None)
+            .await
+            .unwrap();
+        db.add_observation(
+            &e_rust,
+            "RustLang observation via pool seed",
+            Some("test"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Call with explicit seed [e_rust] — skip the query-anchor search entirely
+        let results: Vec<SearchResult> = vec![];
+        let augmented = db
+            .augment_with_graph_seeded(
+                "unrelated query text xyz",
+                results,
+                std::slice::from_ref(&e_rust),
+                10,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            augmented.iter().any(|r| r.source == "knowledge_graph"),
+            "should surface RustLang observation from pool seed"
+        );
+    }
+
+    /// RRF no double-count: observation already in pool gets merged score, not doubled.
+    #[tokio::test]
+    async fn test_seeded_rrf_no_double_count() {
+        let (db, _dir) = test_db().await;
+        let eid = db
+            .store_entity("RrfCheck", "thing", None, None, None)
+            .await
+            .unwrap();
+        db.add_observation(
+            &eid,
+            "observation content for rrf check",
+            Some("test"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Add the observation as a result in the initial pool too
+        let obs_results = db
+            .get_observations_for_entities(std::slice::from_ref(&eid), 10)
+            .await
+            .unwrap();
+        assert!(!obs_results.is_empty());
+
+        // Run seeded with seeds = [eid]
+        let augmented = db
+            .augment_with_graph_seeded("any query", obs_results, &[eid], 10)
+            .await
+            .unwrap();
+        // Each observation id appears exactly once
+        let ids: Vec<&str> = augmented.iter().map(|r| r.id.as_str()).collect();
+        let unique: std::collections::HashSet<&str> = ids.iter().cloned().collect();
+        assert_eq!(
+            ids.len(),
+            unique.len(),
+            "no duplicate observation ids after RRF merge"
+        );
+    }
+
+    /// Dark-ship: with ORIGIN_ENABLE_GRAPH_SEED unset, search_memory is byte-identical.
+    #[tokio::test]
+    async fn test_search_memory_seeded_flag_off_is_identical() {
+        let (db, _dir) = test_db().await;
+        let doc = crate::sources::RawDocument {
+            source: "memory".into(),
+            source_id: "seed_dark_test_1".into(),
+            title: "Rust programming language".into(),
+            content: "Rust is a systems programming language".into(),
+            last_modified: chrono::Utc::now().timestamp(),
+            memory_type: Some("fact".into()),
+            ..Default::default()
+        };
+        db.upsert_documents(vec![doc]).await.unwrap();
+        let eid = db
+            .store_entity("Rust", "technology", None, None, None)
+            .await
+            .unwrap();
+        db.add_observation(&eid, "Rust has no GC", Some("test"), None)
+            .await
+            .unwrap();
+
+        // With flag OFF, output must be identical to pre-T9 path
+        std::env::remove_var("ORIGIN_ENABLE_GRAPH_SEED");
+        let results = db
+            .search_memory("Rust programming", 10, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            results.iter().all(|r| r.source != "knowledge_graph"),
+            "KG rows must be stripped"
+        );
     }
 
     // ==================== search_memory graph augmentation ====================

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1248,6 +1248,18 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
     if magfusion_state == "on" {
         variant_tag.push_str("_magfusion");
     }
+    // T9: append __graph_seed_d{depth} suffix when ORIGIN_ENABLE_GRAPH_SEED is on.
+    let graph_seed_depth = if crate::db::graph_seed_enabled() {
+        let depth = crate::retrieval::signals::parse_hop_depth(
+            std::env::var("ORIGIN_GRAPH_HOP_DEPTH").ok().as_deref(),
+        );
+        Some(depth)
+    } else {
+        None
+    };
+    if let Some(depth) = graph_seed_depth {
+        variant_tag.push_str(&format!("__graph_seed_d{}", depth));
+    }
     let mut env_stamp = build_locomo_env(
         &variant_tag,
         path,
@@ -1262,6 +1274,11 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
     env_stamp
         .flags
         .push(format!("magnitude_fusion={}", magfusion_state));
+    if let Some(depth) = graph_seed_depth {
+        env_stamp.flags.push(format!("graph_seed=on_d{}", depth));
+    } else {
+        env_stamp.flags.push("graph_seed=off".to_string());
+    }
     env_stamp.flags.push("scenario_db=consolidated".to_string());
     report.env = Some(env_stamp);
     Ok(report)

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1178,6 +1178,18 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
     if magfusion_state == "on" {
         variant_tag.push_str("_magfusion");
     }
+    // T9: append __graph_seed_d{depth} suffix when ORIGIN_ENABLE_GRAPH_SEED is on.
+    let graph_seed_depth = if crate::db::graph_seed_enabled() {
+        let depth = crate::retrieval::signals::parse_hop_depth(
+            std::env::var("ORIGIN_GRAPH_HOP_DEPTH").ok().as_deref(),
+        );
+        Some(depth)
+    } else {
+        None
+    };
+    if let Some(depth) = graph_seed_depth {
+        variant_tag.push_str(&format!("__graph_seed_d{}", depth));
+    }
     let mut env_stamp = build_lme_env(
         &variant_tag,
         path,
@@ -1192,6 +1204,11 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
     env_stamp
         .flags
         .push(format!("magnitude_fusion={}", magfusion_state));
+    if let Some(depth) = graph_seed_depth {
+        env_stamp.flags.push(format!("graph_seed=on_d{}", depth));
+    } else {
+        env_stamp.flags.push("graph_seed=off".to_string());
+    }
     env_stamp.flags.push("scenario_db=consolidated".to_string());
     report.env = Some(env_stamp);
     Ok(report)

--- a/crates/origin-core/src/retrieval/signals.rs
+++ b/crates/origin-core/src/retrieval/signals.rs
@@ -52,6 +52,72 @@ pub(crate) fn temporal_proximity(query_date: i64, event_date: Option<i64>, sigma
     }
 }
 
+// ---------------------------------------------------------------------------
+// T9 — Wide-pool-seeded graph expansion helpers
+// ---------------------------------------------------------------------------
+
+/// Parse `ORIGIN_GRAPH_HOP_DEPTH` → usize in [0, 3]. Default 1 on unset or parse failure.
+pub(crate) fn parse_hop_depth(val: Option<&str>) -> usize {
+    let raw = match val {
+        Some(s) => s,
+        None => return 1,
+    };
+    match raw.trim().parse::<isize>() {
+        Ok(n) if n >= 0 => (n as usize).min(3),
+        _ => 1,
+    }
+}
+
+/// Parse `ORIGIN_GRAPH_SEED_TOP_K` → usize in [1, 50]. Default 10 on unset or parse failure.
+pub(crate) fn parse_seed_top_k(val: Option<&str>) -> usize {
+    let raw = match val {
+        Some(s) => s,
+        None => return 10,
+    };
+    match raw.trim().parse::<isize>() {
+        Ok(n) if n >= 1 => (n as usize).min(50),
+        _ => 10,
+    }
+}
+
+/// Parse `ORIGIN_GRAPH_FRONTIER_CAP` → usize in [1, 512]. Default 64 on unset or parse failure.
+pub(crate) fn parse_frontier_cap(val: Option<&str>) -> usize {
+    let raw = match val {
+        Some(s) => s,
+        None => return 64,
+    };
+    match raw.trim().parse::<isize>() {
+        Ok(n) if n >= 1 => (n as usize).min(512),
+        _ => 64,
+    }
+}
+
+/// Dedup entity IDs by best (lowest) rank, sort ascending by rank, truncate to `top_k`.
+///
+/// Input: `(entity_id, rank)` pairs from the wide pool (rank = enumeration index).
+/// Multiple entries for the same entity keep only the lowest rank (best position).
+/// Empty pool → empty result (no panic).
+pub(crate) fn seed_entities_by_rank(pool: &[(String, usize)], top_k: usize) -> Vec<String> {
+    if pool.is_empty() || top_k == 0 {
+        return Vec::new();
+    }
+    // dedup by best (lowest) rank
+    let mut best: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for (id, rank) in pool {
+        let entry = best.entry(id.as_str()).or_insert(*rank);
+        if *rank < *entry {
+            *entry = *rank;
+        }
+    }
+    let mut sorted: Vec<(&str, usize)> = best.into_iter().collect();
+    sorted.sort_by_key(|(_, rank)| *rank);
+    sorted
+        .into_iter()
+        .take(top_k)
+        .map(|(id, _)| id.to_string())
+        .collect()
+}
+
 /// Capitalized words that commonly start a query but are NOT entity anchors
 /// (question words, articles, pronouns, common verbs). Compared lowercased.
 const NON_ENTITY_CAP_WORDS: &[&str] = &[
@@ -220,5 +286,81 @@ mod tests {
     #[test]
     fn entity_anchor_false_on_all_lowercase() {
         assert!(!query_has_entity_anchor("what is the database password"));
+    }
+
+    // ---------------------------------------------------------------------------
+    // T9 pure-helper tests (no DB needed)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn graph_seed_top_k_ranks_by_carrier_rank() {
+        let pool = vec![
+            ("a".to_string(), 5usize),
+            ("b".to_string(), 1usize),
+            ("a".to_string(), 0usize),
+            ("c".to_string(), 3usize),
+        ];
+        let result = seed_entities_by_rank(&pool, 2);
+        assert_eq!(result, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn graph_seed_top_k_empty_pool_is_empty() {
+        assert!(seed_entities_by_rank(&[], 10).is_empty());
+    }
+
+    #[test]
+    fn graph_seed_top_k_truncates_to_k() {
+        let pool: Vec<(String, usize)> = (0..20).map(|i| (format!("e{}", i), i)).collect();
+        let result = seed_entities_by_rank(&pool, 5);
+        assert_eq!(result.len(), 5);
+        assert_eq!(result[0], "e0");
+        assert_eq!(result[4], "e4");
+    }
+
+    #[test]
+    fn graph_hop_depth_parse_clamps() {
+        assert_eq!(parse_hop_depth(None), 1);
+        assert_eq!(parse_hop_depth(Some("0")), 0);
+        assert_eq!(parse_hop_depth(Some("2")), 2);
+        assert_eq!(parse_hop_depth(Some("3")), 3);
+        assert_eq!(parse_hop_depth(Some("99")), 3);
+        assert_eq!(parse_hop_depth(Some("-1")), 1);
+        assert_eq!(parse_hop_depth(Some("abc")), 1);
+    }
+
+    #[test]
+    fn graph_frontier_cap_parse_defaults() {
+        assert_eq!(parse_frontier_cap(None), 64);
+        assert_eq!(parse_frontier_cap(Some("16")), 16);
+        assert_eq!(parse_frontier_cap(Some("999")), 512);
+        assert_eq!(parse_frontier_cap(Some("0")), 64);
+        assert_eq!(parse_frontier_cap(Some("bad")), 64);
+    }
+
+    #[test]
+    fn graph_seed_top_k_parse_defaults() {
+        assert_eq!(parse_seed_top_k(None), 10);
+        assert_eq!(parse_seed_top_k(Some("5")), 5);
+        assert_eq!(parse_seed_top_k(Some("100")), 50);
+        assert_eq!(parse_seed_top_k(Some("0")), 10);
+        assert_eq!(parse_seed_top_k(Some("bad")), 10);
+    }
+
+    #[test]
+    fn graph_seed_enabled_truthy_table() {
+        for val in &["1", "true", "yes"] {
+            std::env::set_var("ORIGIN_ENABLE_GRAPH_SEED", val);
+            assert!(crate::db::graph_seed_enabled(), "expected true for {val}");
+        }
+        for val in &["0", "false", ""] {
+            std::env::set_var("ORIGIN_ENABLE_GRAPH_SEED", val);
+            assert!(!crate::db::graph_seed_enabled(), "expected false for {val}");
+        }
+        std::env::remove_var("ORIGIN_ENABLE_GRAPH_SEED");
+        assert!(
+            !crate::db::graph_seed_enabled(),
+            "expected false when unset"
+        );
     }
 }

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -785,6 +785,110 @@ async fn magnitude_fusion_ab_dualbench() {
     }
 }
 
+/// T9 wide-pool-seeded graph-expansion A/B on BOTH benches (retrieval-only).
+/// Measurement vehicle is coverage_recall (NDCG is neutral-by-construction —
+/// KG observation rows are stripped from user output, only the RRF boost survives,
+/// so reordering of the surviving chunks is the only NDCG signal). The graph-seed
+/// expands the entity set used for the KG-RRF boost, which can pull more source
+/// chunks into coverage. Toggles `ORIGIN_ENABLE_GRAPH_SEED` OFF vs ON over the
+/// cached scenario DBs. Single-run scaffold — N≥3 for any headline claim.
+#[tokio::test]
+#[ignore = "needs cached scenario DBs; retrieval-only, no GPU"]
+async fn graph_seed_ab_dualbench() {
+    use origin_core::eval::locomo::run_locomo_eval_from_db;
+    use origin_core::eval::longmemeval::run_longmemeval_eval_from_db;
+    let root = resolve_scenario_db_root_from_harness();
+
+    // coverage_recall blind field (the T9 measurement vehicle)
+    let lo_cov = |r: &origin_core::eval::locomo::LocomoReport| {
+        r.coverage.as_ref().map(|c| c.blind).unwrap_or(0.0)
+    };
+    let lme_cov = |r: &origin_core::eval::longmemeval::LongMemEvalReport| {
+        r.coverage.as_ref().map(|c| c.blind).unwrap_or(0.0)
+    };
+
+    let lo_dir = root.join("locomo_v1");
+    if lo_dir.join("origin_memory.db").exists() {
+        let fx = eval_root().join("data/locomo10.json");
+        if fx.exists() {
+            let db = origin_core::db::MemoryDB::new(
+                &lo_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .unwrap();
+            let off = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_GRAPH_SEED", None::<&str>)],
+                run_locomo_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            let on = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_GRAPH_SEED", Some("1"))],
+                run_locomo_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            println!(
+                "[GRAPH-SEED A/B LoCoMo] q={} | cov_blind off={:.4} on={:.4} d={:+.4} | ndcg@10 off={:.4} on={:.4} d={:+.4}",
+                off.total_questions,
+                lo_cov(&off),
+                lo_cov(&on),
+                lo_cov(&on) - lo_cov(&off),
+                off.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+            );
+        } else {
+            println!("SKIP LoCoMo: locomo10.json not found at {}", fx.display());
+        }
+    } else {
+        println!("SKIP LoCoMo: no seeded DB at {}", lo_dir.display());
+    }
+
+    let lme_dir = root.join("lme_v1");
+    if lme_dir.join("origin_memory.db").exists() {
+        let fx = eval_root().join("data/longmemeval_oracle.json");
+        if fx.exists() {
+            let db = origin_core::db::MemoryDB::new(
+                &lme_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .unwrap();
+            let off = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_GRAPH_SEED", None::<&str>)],
+                run_longmemeval_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            let on = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_GRAPH_SEED", Some("1"))],
+                run_longmemeval_eval_from_db(&db, &fx),
+            )
+            .await
+            .unwrap();
+            println!(
+                "[GRAPH-SEED A/B LME] q={} | cov_blind off={:.4} on={:.4} d={:+.4} | ndcg@10 off={:.4} on={:.4} d={:+.4}",
+                off.total_questions,
+                lme_cov(&off),
+                lme_cov(&on),
+                lme_cov(&on) - lme_cov(&off),
+                off.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+            );
+        } else {
+            println!(
+                "SKIP LME: longmemeval_oracle.json not found at {}",
+                fx.display()
+            );
+        }
+    } else {
+        println!("SKIP LME: no seeded DB at {}", lme_dir.display());
+    }
+}
+
 /// T12 FTS-hardening A/B on BOTH benches (retrieval-only). Hardening only changes
 /// special-char/overlong queries (absent from clean LoCoMo/LME), so the expected
 /// result is delta about 0 — this confirms no-regression on clean-query benchmarks.


### PR DESCRIPTION
## What

`augment_with_graph` seeded its expansion from a fresh query-anchored `search_entities_by_vector(query,5)` — discarding the candidate pool's own entity provenance, single-hop only. Behind opt-in `ORIGIN_ENABLE_GRAPH_SEED` (default OFF = byte-identical): seed from the **wide pre-truncate pool** (`limit*3`, each row's `entity_id`), k-hop BFS over relations (parameterized, depth/frontier bounded), RRF-merge observations. **Composes with T3's graph gate** (gate decides IF graph runs; seed decides HOW). Graceful log-and-degrade to query-anchored augment on error.

## Dual-bench A/B — coverage_recall (T9's measurement vehicle; NDCG neutral-by-construction, KG rows stripped)

| Bench | Q | Δcoverage_recall | Δndcg@10 |
|---|---|---|---|
| LoCoMo | 625 | +0.0000 | +0.0000 |
| **LME** | 30 | **+0.0278** | +0.0038 |

Improves LME coverage (wider pool-seeded BFS surfaces more answer-bearing observations), neutral on LoCoMo (its wide pool reaches the same observation set as the query-anchor — verified not an empty-graph artifact: LoCoMo DB has 1604 entities / 2819 relations). Single-run scaffold, N≥3 for headline.

## Review

Adversarial review: **SHIP**, no blockers. Verified flag-OFF byte-identity, lock-across-await (no non-libsql await under the conn lock; lock dropped before the seeded call), parameterized `IN(?,…)` BFS (no injection), deterministic frontier cap, verbatim RRF (no double-count), wide-pre-truncate-pool harvest. Accepted-minor follow-ups: (1) add `ORDER BY 1` to the BFS query for cross-schema determinism (already deterministic per-DB-file); (2) guard seed-loss when `SEED_TOP_K >= FRONTIER_CAP` (defaults 10 vs 64 never collide).

## Tests
17 new (7 pure signals helpers + 10 DB: BFS depth0/1/2/bidirectional/empty/cap, seeded-falls-back-on-empty, pool-provenance, no-double-count, flag-off-identical). Existing `test_augment_with_graph_merges_observations` passes (dark-by-default). clippy clean. T9 of the retrieval roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)