### PR TITLE
fix(retrieval): opt-in per-session result diversification cap (ORIGIN_ENABLE_SESSION_DIVERSITY)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -427,6 +427,33 @@ pub fn page_channel_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// True iff `ORIGIN_ENABLE_SESSION_DIVERSITY` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive).  OPT-IN, default OFF: when
+/// unset or falsey, [`MemoryDB::search_memory_cross_rerank`] output is
+/// byte-identical to pre-T20 behaviour (regression guard tests #13/#14).
+///
+/// Enables the per-session diversification cap in T20 so that a single
+/// LME conversation session cannot monopolise the top-`limit` results.
+/// Production source_ids (`mem_*`) return `None` from
+/// `retrieval::session_diversity::session_key` and are never counted
+/// against the cap — safe to enable in production without side-effects
+/// until a real session column ships.
+pub fn session_diversity_enabled() -> bool {
+    std::env::var("ORIGIN_ENABLE_SESSION_DIVERSITY")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
+/// Parse `ORIGIN_SESSION_DIVERSITY_MAX` as a `usize`.
+/// Defaults to 3 when unset or when the value fails to parse.
+fn session_diversity_max() -> usize {
+    std::env::var("ORIGIN_SESSION_DIVERSITY_MAX")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(3)
+}
+
 /// True iff `ORIGIN_ENABLE_GRAPH_GATE` is set to a truthy value
 /// (`1`, `true`, or `yes`, case-insensitive). OPT-IN: when unset or falsey,
 /// `augment_with_graph` runs unconditionally (legacy behavior, byte-identical).
@@ -7987,6 +8014,17 @@ impl MemoryDB {
         let (page_results, mem_results): (Vec<_>, Vec<_>) =
             results.into_iter().partition(|r| r.source == "page");
         let mut results = mem_results;
+        // T20: per-session diversification cap (opt-in, default OFF).
+        // Runs on the full reranked memory pool (pre-truncate) so backfill
+        // has demoted-but-valid hits to pull from.  Pages are excluded
+        // (already partitioned out above).  Byte-identical when flag unset.
+        if session_diversity_enabled() {
+            crate::retrieval::session_diversity::cap_per_session(
+                &mut results,
+                session_diversity_max(),
+                limit,
+            );
+        }
         results.truncate(limit);
         // Append top-K pages after the memory limit. K = configured pool
         // size (already capped upstream by page_channel_limit()).
@@ -34079,6 +34117,147 @@ pub(crate) mod tests {
         assert!(
             !enabled,
             "ORIGIN_ENABLE_QUERY_INTENT=unset: must be disabled"
+        );
+    }
+    // -- T20: per-session diversification cap integration tests -------------------
+
+    /// Helper: insert a memory row with a specific source_id (for LME-style ids).
+    async fn seed_memory_with_source_id(db: &MemoryDB, source_id: &str, content: &str) {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                                    last_modified, chunk_type, source_agent, space, confidence, \
+                                    confirmed, memory_type, pending_revision) \
+             VALUES (?1, ?2, 'memory', ?3, 'test', 0, 1712707200, 'text', NULL, 'general', 1.0, 0, 'fact', 0)",
+            libsql::params![source_id.to_string(), content.to_string(), source_id.to_string()],
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Regression guard: flag OFF (unset) -> search_memory_cross_rerank output
+    /// is byte-identical to pre-T20 behaviour (no reordering, no drops).
+    /// Regression guard: flag OFF (unset) and flag=0 both disable the cap,
+    /// so the output is byte-identical in both cases.
+    /// Mirrors page_channel_enabled_treats_zero_and_unset_as_disabled pattern.
+    #[tokio::test]
+    async fn session_diversity_flag_off_byte_identical() {
+        let (db, _tmp) = test_db().await;
+        // Use uniform content so FTS (no embeddings in test_db) returns
+        // consistent results across the seeded rows.
+        for i in 0..5 {
+            seed_memory_with_source_id(
+                &db,
+                &format!("lme_qX_0_t{i}"),
+                "diversity flag identity content",
+            )
+            .await;
+        }
+
+        let unset =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_SESSION_DIVERSITY", None::<&str>)], async {
+                db.search_memory_cross_rerank("diversity flag identity", 10, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+
+        let off =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_SESSION_DIVERSITY", Some("0"))], async {
+                db.search_memory_cross_rerank("diversity flag identity", 10, None, None, None, None)
+                    .await
+                    .unwrap()
+            })
+            .await;
+
+        // Both flag-off variants must produce the same output (regression guard).
+        assert_eq!(
+            unset.iter().map(|r| &r.source_id).collect::<Vec<_>>(),
+            off.iter().map(|r| &r.source_id).collect::<Vec<_>>(),
+            "flag unset vs flag=0 must return identical order"
+        );
+
+        // Flag ON must return <= results compared to flag OFF (cap can only
+        // reduce or maintain, never increase the result count).
+        let flag_on = temp_env::async_with_vars(
+            [
+                ("ORIGIN_ENABLE_SESSION_DIVERSITY", Some("1")),
+                ("ORIGIN_SESSION_DIVERSITY_MAX", Some("2")),
+            ],
+            async {
+                db.search_memory_cross_rerank("diversity flag identity", 10, None, None, None, None)
+                    .await
+                    .unwrap()
+            },
+        )
+        .await;
+
+        assert!(
+            flag_on.len() <= unset.len(),
+            "flag ON must not return MORE results than flag OFF: on={} off={}",
+            flag_on.len(),
+            unset.len()
+        );
+    }
+
+    /// Flag ON with only mem_* ids -> identity transform (production safety).
+    /// Even with diversity=ON, real daemon ids are never keyed and never capped.
+    #[tokio::test]
+    async fn session_diversity_flag_on_mem_ids_identity() {
+        let (db, _tmp) = test_db().await;
+        // Seed 4 memories with real mem_ source_ids.
+        for i in 0..4 {
+            seed_memory(
+                &db,
+                &format!("mem session diversity safety test content item {i}"),
+            )
+            .await;
+        }
+
+        let flag_off = temp_env::async_with_vars(
+            [
+                ("ORIGIN_ENABLE_SESSION_DIVERSITY", None::<&str>),
+                ("ORIGIN_SESSION_DIVERSITY_MAX", None::<&str>),
+            ],
+            async {
+                db.search_memory_cross_rerank(
+                    "mem session diversity safety test",
+                    10,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            },
+        )
+        .await;
+
+        let flag_on = temp_env::async_with_vars(
+            [
+                ("ORIGIN_ENABLE_SESSION_DIVERSITY", Some("1")),
+                ("ORIGIN_SESSION_DIVERSITY_MAX", Some("2")),
+            ],
+            async {
+                db.search_memory_cross_rerank(
+                    "mem session diversity safety test",
+                    10,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap()
+            },
+        )
+        .await;
+
+        assert_eq!(
+            flag_off.iter().map(|r| &r.source_id).collect::<Vec<_>>(),
+            flag_on.iter().map(|r| &r.source_id).collect::<Vec<_>>(),
+            "mem_* ids: flag ON must not change order vs flag OFF"
         );
     }
 }

--- a/crates/origin-core/src/retrieval/mod.rs
+++ b/crates/origin-core/src/retrieval/mod.rs
@@ -9,4 +9,5 @@ pub(crate) mod decompose;
 pub(crate) mod fts_query;
 pub(crate) mod hard_filters;
 pub(crate) mod query_intent;
+pub(crate) mod session_diversity;
 pub(crate) mod signals;

--- a/crates/origin-core/src/retrieval/session_diversity.rs
+++ b/crates/origin-core/src/retrieval/session_diversity.rs
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Per-session result diversification cap (T20).
+//!
+//! Caps how many results from the same conversation session appear in the
+//! top-`limit` output of `search_memory_cross_rerank`, preventing a single
+//! LME session from monopolising the ranking on multi-session questions.
+//!
+//! **Production safety**: session keys are only derivable for eval source_ids
+//! (`lme_*`).  Real daemon source_ids (`mem_<uuid>`) return `None` from
+//! `session_key` and are never counted against the cap — the cap is a pure
+//! no-op for production traffic until a real session column ships.
+//!
+//! **LoCoMo exempt**: `locomo_*` ids return `None`.  LoCoMo has one
+//! conversation per sample; collapsing all its observations to one session key
+//! would brutally suppress recall (recommendation (c) in the T20 spec).
+//!
+//! Enabled by `ORIGIN_ENABLE_SESSION_DIVERSITY` (truthy: `1`/`true`/`yes`).
+//! Cap size set by `ORIGIN_SESSION_DIVERSITY_MAX` (default 3).
+
+use std::collections::HashMap;
+
+use origin_types::SearchResult;
+
+/// Derive a session key from a `source_id`, or `None` if the id does not
+/// encode a session structure we recognise.
+///
+/// ### Rules
+/// * `lme_*` ids: strip the LAST `_t<digits>` suffix; return the prefix.
+///   Back-parsing (right-to-left) avoids the front-split trap that silently
+///   mis-keys ids with underscores in the question_id segment
+///   (e.g. `lme_gpt4_2655b836_4_t12`).
+/// * `locomo_*` ids: always return `None` (exempt — single conversation per
+///   sample; keying would collapse the whole pool to one session).
+/// * All other ids (e.g. `mem_<uuid>`): return `None` (production no-op).
+///
+/// Char-safe: uses `rsplit_once` / string slices at validated ASCII boundaries;
+/// no raw byte indexing on non-ASCII input.
+pub(crate) fn session_key(source_id: &str) -> Option<String> {
+    // LoCoMo: exempt — single conversation per sample, no session structure.
+    if source_id.starts_with("locomo_") {
+        return None;
+    }
+
+    // LME ids: `lme_<qid>_<session_idx>_t<turn>`.
+    // Back-strip the LAST `_t<digits>` suffix only.
+    if source_id.starts_with("lme_") {
+        // Find the last occurrence of `_t` followed by all-ASCII-digits.
+        if let Some((prefix, suffix)) = source_id.rsplit_once("_t") {
+            // `suffix` must be entirely ASCII digits (non-empty).
+            if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+                return Some(prefix.to_string());
+            }
+        }
+        return None;
+    }
+
+    // Everything else (mem_*, unrecognised) -> None.
+    None
+}
+
+/// Apply a per-session diversification cap to an already-score-sorted result
+/// list, then truncate to `limit`.
+///
+/// ### Algorithm
+/// 1. Single forward pass over `results` (already descending by score).
+/// 2. For each result:
+///    - If `session_key` returns `None` → unconditionally move to `kept`
+///      (never counts against the cap; production rows always go here).
+///    - If `session_key` returns `Some(k)` and `count[k] < max_per_session`
+///      → move to `kept`, increment `count[k]`.
+///    - Otherwise → move to `backfill`.
+/// 3. If `kept.len() < limit`, pull from the **front** of `backfill`
+///    (preserving descending-score order) until `kept.len() == limit` or
+///    backfill is exhausted.
+/// 4. Replace `*results` with `kept`.
+///
+/// ### Edge cases
+/// * `max_per_session == 0` → treated as "no cap" (identity transform).
+///   Documented behaviour; avoids divide-by-zero and foot-guns.
+/// * `limit > results.len()` → all results kept (backfill may also be
+///   exhausted before `limit` is reached).
+///
+/// ### Bite vs no-bite
+/// The cap only *bites* (actually drops items) when there are enough
+/// other-session results to fill `limit` without the demoted ones.  When the
+/// result pool is thin (fewer than `limit` total results), demoted items
+/// re-enter via backfill and the final length equals `min(limit, input.len())`.
+pub(crate) fn cap_per_session(
+    results: &mut Vec<SearchResult>,
+    max_per_session: usize,
+    limit: usize,
+) {
+    // max == 0 -> no-op (identity).
+    if max_per_session == 0 {
+        return;
+    }
+
+    let mut kept: Vec<SearchResult> = Vec::with_capacity(limit.min(results.len()));
+    let mut backfill: Vec<SearchResult> = Vec::new();
+    let mut counts: HashMap<String, usize> = HashMap::new();
+
+    for r in results.drain(..) {
+        match session_key(&r.source_id) {
+            None => {
+                // Unkeyed (production ids, LoCoMo, etc.) — always keep.
+                kept.push(r);
+            }
+            Some(key) => {
+                let count = counts.entry(key).or_insert(0);
+                if *count < max_per_session {
+                    *count += 1;
+                    kept.push(r);
+                } else {
+                    backfill.push(r);
+                }
+            }
+        }
+    }
+
+    // Refill from backfill (front-to-back preserves descending-score order).
+    if kept.len() < limit {
+        let need = limit - kept.len();
+        let take = need.min(backfill.len());
+        kept.extend(backfill.drain(..take));
+    }
+
+    // Truncate to limit (handles the case where kept grew beyond limit
+    // because unkeyed rows were interleaved and no demotion occurred).
+    kept.truncate(limit);
+    *results = kept;
+}
+
+// -- Unit tests ----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal constructor for test SearchResult — only the fields cap logic
+    /// inspects (source_id, score, source, id) need real values.
+    fn sr(id: &str, source_id: &str, score: f32) -> SearchResult {
+        SearchResult {
+            id: id.to_string(),
+            content: String::new(),
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: String::new(),
+            url: None,
+            chunk_index: 0,
+            last_modified: 0,
+            score,
+            chunk_type: None,
+            language: None,
+            semantic_unit: None,
+            memory_type: None,
+            space: None,
+            source_agent: None,
+            confidence: None,
+            confirmed: None,
+            stability: None,
+            supersedes: None,
+            summary: None,
+            entity_id: None,
+            entity_name: None,
+            quality: None,
+            is_archived: false,
+            is_recap: false,
+            structured_fields: None,
+            retrieval_cue: None,
+            source_text: None,
+            raw_score: 0.0,
+            version: 0,
+            pending_revision: false,
+            merged_from: None,
+            last_delta_summary: None,
+        }
+    }
+
+    // -- session_key tests -----------------------------------------------------
+
+    /// Basic LME id without underscores in the qid segment.
+    #[test]
+    fn session_key_lme_simple() {
+        assert_eq!(
+            session_key("lme_2c63a862_0_t3"),
+            Some("lme_2c63a862_0".to_string())
+        );
+    }
+
+    /// THE underscore-in-qid trap: back-strip `_t12` only, do NOT front-split.
+    #[test]
+    fn session_key_lme_underscore_in_qid() {
+        assert_eq!(
+            session_key("lme_gpt4_2655b836_4_t12"),
+            Some("lme_gpt4_2655b836_4".to_string())
+        );
+    }
+
+    /// LoCoMo ids are exempt: single conversation per sample.
+    #[test]
+    fn session_key_locomo_exempt() {
+        assert_eq!(session_key("locomo_42_obs_7"), None);
+    }
+
+    /// Production mem_ ids are always None.
+    #[test]
+    fn session_key_mem_uuid_none() {
+        assert_eq!(session_key("mem_8f3a-uuid"), None);
+    }
+
+    /// Unrecognised prefix -> None.
+    #[test]
+    fn session_key_unrecognised_none() {
+        assert_eq!(session_key("anything_unrecognized"), None);
+    }
+
+    /// `_t` present but suffix is NOT all-digits -> reject (don't mis-key).
+    #[test]
+    fn session_key_lme_non_digit_suffix_none() {
+        assert_eq!(session_key("lme_x_0_tABC"), None);
+    }
+
+    /// UTF-8 input must not panic regardless of content.
+    #[test]
+    fn session_key_utf8_no_panic() {
+        let _ = session_key("lme_caf\u{00e9}_t3");
+        let _ = session_key("\u{1f600}");
+        let _ = session_key("");
+    }
+
+    // -- cap_per_session tests -------------------------------------------------
+
+    /// Production mem_* rows: none are keyed -> identity transform regardless
+    /// of max/limit.
+    #[test]
+    fn cap_production_ids_identity() {
+        let mut results: Vec<SearchResult> = (0..6)
+            .map(|i| sr(&format!("r{i}"), &format!("mem_{i}"), 1.0 - i as f32 * 0.1))
+            .collect();
+        let original_ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        cap_per_session(&mut results, 3, 10);
+        let ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(
+            ids, original_ids,
+            "mem_* rows must not be reordered or dropped"
+        );
+    }
+
+    /// Cap + backfill: 5 hits from session lme_q_0, 2 from lme_q_1, max=3,
+    /// limit=6.
+    ///
+    /// Pass ordering: r0->kept(s0#1), r1->kept(s0#2), r2->kept(s0#3),
+    /// r3->backfill(s0 full), r4->backfill(s0 full),
+    /// r5->kept(s1#1), r6->kept(s1#2).
+    /// kept=[r0,r1,r2,r5,r6] len=5 < limit=6 -> pull r3 from backfill.
+    /// Final: [r0,r1,r2,r5,r6,r3]. r4 dropped.
+    #[test]
+    fn cap_and_backfill_exact_order() {
+        let mut results = vec![
+            sr("r0", "lme_q_0_t0", 0.9),
+            sr("r1", "lme_q_0_t1", 0.8),
+            sr("r2", "lme_q_0_t2", 0.7),
+            sr("r3", "lme_q_0_t3", 0.6),
+            sr("r4", "lme_q_0_t4", 0.5),
+            sr("r5", "lme_q_1_t0", 0.4),
+            sr("r6", "lme_q_1_t1", 0.3),
+        ];
+        cap_per_session(&mut results, 3, 6);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, ["r0", "r1", "r2", "r5", "r6", "r3"]);
+    }
+
+    /// Backfill preserves score order: demoted hits re-enter front-to-back
+    /// (highest score first among demoted).
+    #[test]
+    fn cap_backfill_preserves_score_order() {
+        let mut results = vec![
+            sr("r0", "lme_q_0_t0", 0.9),
+            sr("r1", "lme_q_0_t1", 0.8),
+            sr("r2", "lme_q_0_t2", 0.7),
+            sr("r3", "lme_q_0_t3", 0.6),
+        ];
+        cap_per_session(&mut results, 2, 4);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        // kept: r0, r1; backfill: r2, r3 -> refill to limit=4
+        assert_eq!(ids, ["r0", "r1", "r2", "r3"]);
+    }
+
+    /// Output length == min(limit, input.len()).
+    #[test]
+    fn cap_limit_respected() {
+        let mut results: Vec<SearchResult> = (0..5)
+            .map(|i| {
+                sr(
+                    &format!("r{i}"),
+                    &format!("lme_q_0_t{i}"),
+                    1.0 - i as f32 * 0.1,
+                )
+            })
+            .collect();
+        cap_per_session(&mut results, 10, 3);
+        assert_eq!(results.len(), 3, "must not exceed limit");
+    }
+
+    /// Limit larger than results -> all kept.
+    #[test]
+    fn cap_limit_larger_than_results() {
+        let mut results: Vec<SearchResult> = (0..3)
+            .map(|i| {
+                sr(
+                    &format!("r{i}"),
+                    &format!("lme_q_0_t{i}"),
+                    1.0 - i as f32 * 0.1,
+                )
+            })
+            .collect();
+        cap_per_session(&mut results, 2, 10);
+        assert_eq!(results.len(), 3, "limit > input.len() -> keep all");
+    }
+
+    /// Mixed keyed+unkeyed: mem_* rows interleaved with lme_* rows are never
+    /// demoted and never consume cap budget.
+    #[test]
+    fn cap_mixed_keyed_unkeyed() {
+        // r0(lme s0 #1), r1(mem_ unkeyed), r2(lme s0 #2), r3(mem_ unkeyed),
+        // r4(lme s0 -> demoted, count=2 at max).
+        // kept=[r0,r1,r2,r3] backfill=[r4].
+        // kept.len()=4 < limit=5 -> pull r4 from backfill.
+        // Final: [r0,r1,r2,r3,r4].
+        let mut results = vec![
+            sr("r0", "lme_q_0_t0", 0.9),
+            sr("r1", "mem_abc", 0.85),
+            sr("r2", "lme_q_0_t1", 0.8),
+            sr("r3", "mem_def", 0.75),
+            sr("r4", "lme_q_0_t2", 0.7),
+        ];
+        cap_per_session(&mut results, 2, 5);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, ["r0", "r1", "r2", "r3", "r4"]);
+    }
+
+    /// max=0 -> identity (no cap applied, no panic).
+    #[test]
+    fn cap_max_zero_identity() {
+        let mut results = vec![
+            sr("r0", "lme_q_0_t0", 0.9),
+            sr("r1", "lme_q_0_t1", 0.8),
+            sr("r2", "lme_q_0_t2", 0.7),
+        ];
+        let original_ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        cap_per_session(&mut results, 0, 10);
+        let ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(ids, original_ids, "max=0 must be identity");
+    }
+
+    /// Distinct sessions all under cap -> unchanged (no bite).
+    #[test]
+    fn cap_distinct_sessions_under_cap_unchanged() {
+        let mut results = vec![
+            sr("r0", "lme_q_0_t0", 0.9),
+            sr("r1", "lme_q_1_t0", 0.8),
+            sr("r2", "lme_q_2_t0", 0.7),
+        ];
+        let original_ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        cap_per_session(&mut results, 3, 10);
+        let ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        assert_eq!(ids, original_ids);
+    }
+
+    /// Cap BITES: enough other-session results to fill limit without the
+    /// demoted items -> demoted items truly drop.
+    #[test]
+    fn cap_bites_when_other_sessions_fill_limit() {
+        // 5 from session-0, 5 from session-1, max=3, limit=6.
+        // kept fills to 6 on the first pass; backfill never consulted.
+        let mut results = vec![
+            sr("r0", "lme_q_0_t0", 0.90),
+            sr("r1", "lme_q_0_t1", 0.88),
+            sr("r2", "lme_q_0_t2", 0.86),
+            sr("r3", "lme_q_1_t0", 0.84),
+            sr("r4", "lme_q_1_t1", 0.82),
+            sr("r5", "lme_q_1_t2", 0.80),
+            sr("r6", "lme_q_0_t3", 0.78), // demoted: s0 count already 3
+            sr("r7", "lme_q_0_t4", 0.76), // demoted
+            sr("r8", "lme_q_1_t3", 0.74), // demoted: s1 count already 3
+            sr("r9", "lme_q_1_t4", 0.72), // demoted
+        ];
+        cap_per_session(&mut results, 3, 6);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, ["r0", "r1", "r2", "r3", "r4", "r5"]);
+        assert_eq!(results.len(), 6);
+    }
+}

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -785,6 +785,140 @@ async fn magnitude_fusion_ab_dualbench() {
     }
 }
 
+/// T20 per-session diversification cap A/B on BOTH benches.
+///
+/// IMPORTANT: T20's cap is wired into `search_memory_cross_rerank` (the CE
+/// path), NOT the base `search_memory` path. So unlike the other dual-bench
+/// A/Bs above (which use `run_*_eval_from_db` -> `search_memory`), this test
+/// MUST use `run_*_eval_cross_rerank_from_db` -> `search_memory_cross_rerank`
+/// with a real cross-encoder reranker, or the cap never fires (all-zero delta).
+///
+/// EXPECT: LoCoMo neutral (all source_ids are `locomo_*` -> `session_key`
+/// returns None -> exempt from the cap). LME may move: its source_ids carry
+/// `lme_*_t*` session structure, so the cap demotes >max hits from one session
+/// per question and backfills from other sessions.
+///
+/// Single-run scaffold — N>=3 for any headline claim. Needs Metal GPU
+/// (cross-encoder) + cached scenario DBs. Run unsandboxed:
+///   cargo test -p origin-core --test eval_harness session_diversity_ab_dualbench -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "needs Metal GPU (cross-encoder) + cached scenario DBs"]
+async fn session_diversity_ab_dualbench() {
+    use origin_core::eval::locomo::run_locomo_eval_cross_rerank_from_db;
+    use origin_core::eval::longmemeval::run_longmemeval_eval_cross_rerank_from_db;
+    let root = resolve_scenario_db_root_from_harness();
+
+    // coverage_recall blind field (matches the dual-bench measurement vehicle).
+    let lo_cov = |r: &origin_core::eval::locomo::LocomoReport| {
+        r.coverage.as_ref().map(|c| c.blind).unwrap_or(0.0)
+    };
+    let lme_cov = |r: &origin_core::eval::longmemeval::LongMemEvalReport| {
+        r.coverage.as_ref().map(|c| c.blind).unwrap_or(0.0)
+    };
+
+    // -- LoCoMo (expected neutral: locomo_* ids are exempt) --
+    let lo_dir = root.join("locomo_v1");
+    if lo_dir.join("origin_memory.db").exists() {
+        let fx = eval_root().join("data/locomo10.json");
+        if fx.exists() {
+            let db = origin_core::db::MemoryDB::new(
+                &lo_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .unwrap();
+            let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+                .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+            let off = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_SESSION_DIVERSITY", None::<&str>)],
+                run_locomo_eval_cross_rerank_from_db(&db, &fx, reranker.clone()),
+            )
+            .await
+            .unwrap();
+            let on = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_SESSION_DIVERSITY", Some("1"))],
+                run_locomo_eval_cross_rerank_from_db(&db, &fx, reranker.clone()),
+            )
+            .await
+            .unwrap();
+            println!(
+                "[SESSDIV A/B LoCoMo] q={} | ndcg@10 off={:.4} on={:.4} d={:+.4} | recall@5 off={:.4} on={:.4} d={:+.4} | cov(blind) off={:.4} on={:.4} d={:+.4}",
+                off.total_questions,
+                off.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+                off.aggregate_recall_at_5,
+                on.aggregate_recall_at_5,
+                on.aggregate_recall_at_5 - off.aggregate_recall_at_5,
+                lo_cov(&off),
+                lo_cov(&on),
+                lo_cov(&on) - lo_cov(&off),
+            );
+        } else {
+            println!(
+                "[SESSDIV A/B LoCoMo] SKIP: locomo10.json not found at {}",
+                fx.display()
+            );
+        }
+    } else {
+        println!(
+            "[SESSDIV A/B LoCoMo] SKIP: {}/origin_memory.db missing",
+            lo_dir.display()
+        );
+    }
+
+    // -- LME (expected to move: lme_*_t* ids carry session structure) --
+    let lme_dir = root.join("lme_v1");
+    if lme_dir.join("origin_memory.db").exists() {
+        let fx = eval_root().join("data/longmemeval_oracle.json");
+        if fx.exists() {
+            let db = origin_core::db::MemoryDB::new(
+                &lme_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .unwrap();
+            let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+                .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+            let off = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_SESSION_DIVERSITY", None::<&str>)],
+                run_longmemeval_eval_cross_rerank_from_db(&db, &fx, reranker.clone()),
+            )
+            .await
+            .unwrap();
+            let on = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_SESSION_DIVERSITY", Some("1"))],
+                run_longmemeval_eval_cross_rerank_from_db(&db, &fx, reranker.clone()),
+            )
+            .await
+            .unwrap();
+            println!(
+                "[SESSDIV A/B LME] q={} | ndcg@10 off={:.4} on={:.4} d={:+.4} | recall@5 off={:.4} on={:.4} d={:+.4} | cov(blind) off={:.4} on={:.4} d={:+.4}",
+                off.total_questions,
+                off.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10,
+                on.aggregate_ndcg_at_10 - off.aggregate_ndcg_at_10,
+                off.aggregate_recall_at_5,
+                on.aggregate_recall_at_5,
+                on.aggregate_recall_at_5 - off.aggregate_recall_at_5,
+                lme_cov(&off),
+                lme_cov(&on),
+                lme_cov(&on) - lme_cov(&off),
+            );
+        } else {
+            println!(
+                "[SESSDIV A/B LME] SKIP: longmemeval_oracle.json not found at {}",
+                fx.display()
+            );
+        }
+    } else {
+        println!(
+            "[SESSDIV A/B LME] SKIP: {}/origin_memory.db missing",
+            lme_dir.display()
+        );
+    }
+}
+
 /// T19 query-adaptive channel-reweighting A/B on BOTH benches (retrieval-only).
 /// Toggles `ORIGIN_ENABLE_QUERY_INTENT` OFF vs ON over the cached scenario DBs
 /// via the base `search_memory` path. ON, Factual-classified (short, non-relational)


### PR DESCRIPTION
## What
Caps top-k results per conversation session (default max 3, backfill from demoted hits) so one session can't monopolize results. Behind opt-in `ORIGIN_ENABLE_SESSION_DIVERSITY` (default OFF = byte-identical). Wired in `search_memory_cross_rerank` between the page/memory partition and `truncate(limit)` (cap on full memory pool, pages uncapped). LME has session structure (`lme_*_t*`); LoCoMo exempt (`None` = uncapped).

## Review: SHIP
Adversarial review, no blockers/important/nits. Verified: flag-off byte-identity, insertion ordering (pages provably not capped), session_key parsing (handles underscore-in-qid), cap+backfill recall-preserving (length invariant: never drops below limit, never exceeds), max=0 identity.

## ⚠️ Eval: UNMEASURED + likely LME-negative
- The base-path `from_db` A/B can't measure T20 — the cap lives only in the CE-rerank path. Measuring needs the `cross_rerank_from_db` runner + cross-encoder model (~600MB, slow); that A/B test is included (`session_diversity_ab_dualbench`) but the run is slow and didn't complete in-band.
- **Analytical prediction (from review):** LME gold evidence concentrates in a SINGLE session, so capping it at 3 demotes gold turns → recall/ndcg likely move **negative**, not neutral. Same pattern as T4a (hard-exclude) / T19 (naive reweight): a plausible-sounding diversification that fights LME's structure.
- **Do NOT enable without measuring.** Default OFF = zero production risk. Real value: the cap mechanism + the **CE-path A/B harness test** (closes a blind spot — base-path A/B couldn't reach CE-path features).

## Tests
18 (16 unit + 2 integration). clippy clean. T20 of the retrieval roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)