### PR TITLE
fix(pages): opt-in shrink-guard for LLM page rewrites (ORIGIN_MERGE_SHRINK_GUARD)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -16067,6 +16067,9 @@ impl MemoryDB {
         merged_content: &str,
         title: Option<&str>,
     ) -> Result<String, OriginError> {
+        // TODO(T17): shrink-guard deferred -- apply_merge_by_tier passes only source_ids+merged_content
+        // (no source bodies); a shrink-guard here needs an extra DB read. Unblock when T14 adds a
+        // production caller that carries source bodies through the call chain.
         // Get metadata from the first source memory
         let conn = self.conn.lock().await;
         let mut rows = conn.query(
@@ -19004,6 +19007,8 @@ impl MemoryDB {
     /// Preserves: title, source, source_id, memory_type, domain, entity_id, confirmed,
     /// stability, quality, structured_fields, created_at, and all other metadata.
     /// Updates: content, embedding, version, changelog, last_modified, word_count.
+    // TODO(T17): shrink-guard deferred -- upsert_memory_in_place has only #[cfg(test)]
+    // callers (db.rs tests). No production shrink-guard needed until a production caller appears.
     pub async fn upsert_memory_in_place(
         &self,
         source_id: &str,

--- a/crates/origin-core/src/post_ingest.rs
+++ b/crates/origin-core/src/post_ingest.rs
@@ -573,6 +573,23 @@ pub(crate) async fn grow_page(
         return Ok(false);
     }
 
+    // Shrink-guard pre-check (T17): early-exit before calling update_page.
+    // update_page has its own shrink-guard backstop, but this early-exit
+    // preserves the Ok(false) contract (skipped-growth) rather than Err.
+    // Matches the is_empty() early-return contract at line 572.
+    if let Some(threshold) = crate::post_write::merge_shrink_threshold() {
+        if !crate::retrieval::integrity::body_shrink_ok(&page.content, updated, threshold) {
+            log::warn!(
+                "[grow_page] shrink-guard skipped growth for page {}: new body ({} chars) < {}% of old ({} chars)",
+                page.id,
+                updated.chars().count(),
+                (threshold * 100.0) as u32,
+                page.content.chars().count(),
+            );
+            return Ok(false);
+        }
+    }
+
     // Update page with new content + add source memory
     let mut source_ids = page.source_memory_ids.clone();
     if !source_ids.contains(&source_id.to_string()) {

--- a/crates/origin-core/src/post_write.rs
+++ b/crates/origin-core/src/post_write.rs
@@ -565,6 +565,26 @@ fn skip_hallucination_guard(edited_by: &str) -> bool {
     )
 }
 
+/// True iff edited_by names an LLM-rewrite path checked by the shrink-guard.
+/// Inverse-intent twin of skip_hallucination_guard -- same match arms.
+/// Do NOT merge: skip_hallucination_guard skips; is_llm_rewrite enables.
+fn is_llm_rewrite(edited_by: &str) -> bool {
+    matches!(
+        edited_by,
+        "distill" | "re_distill" | "page_growth" | "refinery_merge"
+    )
+}
+
+/// Parse ORIGIN_MERGE_SHRINK_GUARD env var as f64 threshold.
+/// Returns Some(t) when set to a valid float; None when unset/unparseable
+/// (guard OFF = byte-identical behavior to pre-T17).
+/// Mirrors page_channel_enabled() env-read discipline in db.rs.
+pub(crate) fn merge_shrink_threshold() -> Option<f64> {
+    std::env::var("ORIGIN_MERGE_SHRINK_GUARD")
+        .ok()
+        .and_then(|v| v.trim().parse::<f64>().ok())
+}
+
 /// Update a distilled wiki page. Canonical entry for all page-update paths:
 /// daemon-internal distillation, refinery re-distill, fs watcher, and
 /// future agent-HTTP routes.
@@ -622,6 +642,32 @@ pub async fn update_page(
         .ok_or_else(|| OriginError::Validation(format!("page '{page_id}' does not exist")))?;
     let current_version = current.version;
     let new_version = current_version + 1;
+
+    // Shrink-guard (T17): opt-in via ORIGIN_MERGE_SHRINK_GUARD=<f64>.
+    // OFF by default: unset/unparseable = None = zero regression.
+    // Only fires for LLM-rewrite edited_by; human edits are never blocked.
+    // Placed AFTER current page load (needs old body), BEFORE early-return.
+    // NOT inside the skip_hallucination_guard block: that skips page_growth/re_distill.
+    if is_llm_rewrite(edited_by) {
+        if let Some(threshold) = merge_shrink_threshold() {
+            if !crate::retrieval::integrity::body_shrink_ok(
+                &current.content,
+                &req.content,
+                threshold,
+            ) {
+                log::warn!(
+                    "[update_page] shrink-guard rejected {edited_by} on {page_id}: new body ({} chars) < {}% of old ({} chars)",
+                    req.content.chars().count(),
+                    (threshold * 100.0) as u32,
+                    current.content.chars().count(),
+                );
+                return Err(OriginError::Validation(format!(
+                    "page body shrank below {:.0}% of original (shrink-guard); update rejected",
+                    threshold * 100.0
+                )));
+            }
+        }
+    }
 
     let source_refs: Vec<&str> = req.source_memory_ids.iter().map(|s| s.as_str()).collect();
 
@@ -799,6 +845,18 @@ mod tests {
     use super::*;
     use crate::events::NoopEmitter;
     use std::sync::Arc;
+
+    // Serialize env-var-sensitive tests to avoid races.
+    // Uses tokio::sync::Mutex so the guard can safely span .await points.
+    async fn env_lock() -> tokio::sync::MutexGuard<'static, ()> {
+        static ENV_MUTEX: tokio::sync::OnceCell<tokio::sync::Mutex<()>> =
+            tokio::sync::OnceCell::const_new();
+        ENV_MUTEX
+            .get_or_init(|| async { tokio::sync::Mutex::new(()) })
+            .await
+            .lock()
+            .await
+    }
 
     async fn test_db() -> (MemoryDB, tempfile::TempDir) {
         let dir = tempfile::tempdir().unwrap();
@@ -2065,5 +2123,178 @@ mod tests {
             assert!(!new2, "bulk near-dup must resolve to existing, not create");
         })
         .await;
+    }
+
+    // Integration tests: update_page shrink-guard
+
+    #[tokio::test]
+    async fn update_page_shrink_guard_rejects_truncation() {
+        let _lock = env_lock().await;
+        // Guard ON + LLM-rewrite caller + body shrinks below threshold -> Err + DB unchanged
+        std::env::set_var("ORIGIN_MERGE_SHRINK_GUARD", "0.7");
+        let (db, _dir) = test_db().await;
+        let mem_id = "mem-sg-reject";
+        // 100-char body
+        let old_body = "a".repeat(100);
+        seed_memory(&db, mem_id, &old_body).await;
+        let page_id = seed_page(&db, mem_id, &old_body).await;
+
+        // New body is only 60 chars: 60 < 100 * 0.7 = 70 -> should reject
+        let short_body = "a".repeat(60);
+        let req = UpdatePageRequest {
+            content: short_body,
+            source_memory_ids: vec![mem_id.to_string()],
+        };
+        let result = update_page(&db, &page_id, req, "distill", false, None).await;
+        assert!(
+            matches!(result, Err(OriginError::Validation(_))),
+            "shrink-guard must reject truncated LLM rewrite"
+        );
+
+        // DB must still have the ORIGINAL body
+        let page = db.get_page(&page_id).await.unwrap().unwrap();
+        assert_eq!(
+            page.content,
+            "a".repeat(100),
+            "body must be unchanged after rejection"
+        );
+        assert_eq!(page.version, 1, "version must not bump on rejection");
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+    }
+
+    #[tokio::test]
+    async fn update_page_shrink_guard_allows_growth() {
+        let _lock = env_lock().await;
+        // Guard ON + LLM-rewrite caller + body grows -> Ok
+        std::env::set_var("ORIGIN_MERGE_SHRINK_GUARD", "0.7");
+        let (db, _dir) = test_db().await;
+        let mem_id = "mem-sg-grow";
+        let old_body = "a".repeat(50);
+        seed_memory(&db, mem_id, &old_body).await;
+        let page_id = seed_page(&db, mem_id, &old_body).await;
+
+        let long_body = "a".repeat(200);
+        let req = UpdatePageRequest {
+            content: long_body.clone(),
+            source_memory_ids: vec![mem_id.to_string()],
+        };
+        let result = update_page(&db, &page_id, req, "page_growth", false, None).await;
+        assert!(result.is_ok(), "shrink-guard must allow growing body");
+        let page = db.get_page(&page_id).await.unwrap().unwrap();
+        assert_eq!(page.content, long_body);
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+    }
+
+    #[tokio::test]
+    async fn update_page_shrink_guard_off_by_default() {
+        let _lock = env_lock().await;
+        // Guard UNSET: even extreme truncation must succeed (zero regression)
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+        let (db, _dir) = test_db().await;
+        let mem_id = "mem-sg-off";
+        let old_body = "a".repeat(100);
+        seed_memory(&db, mem_id, &old_body).await;
+        let page_id = seed_page(&db, mem_id, &old_body).await;
+
+        let tiny_body = "a".repeat(5); // 5 < 100 * 0.7 = 70, would fail if guard were ON
+        let req = UpdatePageRequest {
+            content: tiny_body.clone(),
+            source_memory_ids: vec![mem_id.to_string()],
+        };
+        let result = update_page(&db, &page_id, req, "distill", false, None)
+            .await
+            .unwrap();
+        assert!(result.wrote, "guard OFF must allow any size update");
+        let page = db.get_page(&page_id).await.unwrap().unwrap();
+        assert_eq!(
+            page.content, tiny_body,
+            "content must update when guard is OFF"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_page_shrink_guard_skips_human_edits() {
+        let _lock = env_lock().await;
+        // Guard ON + human edited_by: guard never fires, update goes through
+        std::env::set_var("ORIGIN_MERGE_SHRINK_GUARD", "0.7");
+        let (db, _dir) = test_db().await;
+        let mem_id = "mem-sg-human";
+        let old_body = "a".repeat(100);
+        seed_memory(&db, mem_id, &old_body).await;
+        let page_id = seed_page(&db, mem_id, &old_body).await;
+
+        // 5 chars: would fail guard if LLM rewrite, but "manual_edit" is human
+        let tiny_body = "a".repeat(5);
+        let req = UpdatePageRequest {
+            content: tiny_body.clone(),
+            source_memory_ids: vec![mem_id.to_string()],
+        };
+        // manual_edit bypasses hallucination guard AND is NOT an LLM rewrite
+        // so shrink-guard must NOT fire even though the body shrinks drastically
+        // (hallucination guard WILL fire for manual_edit -- seed with real-ish content)
+        // Actually manual_edit triggers hallucination guard, so use fs_edit instead
+        let result = update_page(&db, &page_id, req, "fs_edit", false, None).await;
+        // fs_edit IS guarded by hallucination guard and will likely fail cos-sim check.
+        // The key assertion: if it fails, it must NOT be a shrink-guard Validation error.
+        // If it succeeds, the body must be updated.
+        match result {
+            Ok(wr) => {
+                // Succeeded: body updated (hallucination guard passed)
+                if wr.wrote {
+                    let page = db.get_page(&page_id).await.unwrap().unwrap();
+                    assert_eq!(page.content, tiny_body);
+                }
+            }
+            Err(OriginError::Validation(msg)) => {
+                // Hallucination guard may reject: ensure it is NOT a shrink-guard message
+                assert!(
+                    !msg.contains("shrink-guard"),
+                    "human edit must not be rejected by shrink-guard; got: {msg}"
+                );
+            }
+            Err(e) => panic!("unexpected error: {e:?}"),
+        }
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+    }
+
+    // merge_shrink_threshold parse tests
+
+    #[test]
+    fn merge_shrink_threshold_unset_returns_none() {
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+        assert!(merge_shrink_threshold().is_none());
+    }
+
+    #[test]
+    fn merge_shrink_threshold_valid_float() {
+        std::env::set_var("ORIGIN_MERGE_SHRINK_GUARD", "0.7");
+        assert_eq!(merge_shrink_threshold(), Some(0.7));
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+    }
+
+    #[test]
+    fn merge_shrink_threshold_garbage_returns_none() {
+        std::env::set_var("ORIGIN_MERGE_SHRINK_GUARD", "garbage");
+        assert!(merge_shrink_threshold().is_none());
+        std::env::remove_var("ORIGIN_MERGE_SHRINK_GUARD");
+    }
+
+    // is_llm_rewrite tests
+
+    #[test]
+    fn is_llm_rewrite_distill_true() {
+        assert!(is_llm_rewrite("distill"));
+        assert!(is_llm_rewrite("re_distill"));
+        assert!(is_llm_rewrite("page_growth"));
+        assert!(is_llm_rewrite("refinery_merge"));
+    }
+
+    #[test]
+    fn is_llm_rewrite_user_false() {
+        assert!(!is_llm_rewrite("user"));
+        assert!(!is_llm_rewrite("manual_edit"));
+        assert!(!is_llm_rewrite("fs_edit"));
+        assert!(!is_llm_rewrite("api"));
+        assert!(!is_llm_rewrite(""));
     }
 }

--- a/crates/origin-core/src/retrieval/integrity.rs
+++ b/crates/origin-core/src/retrieval/integrity.rs
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Write-integrity helpers: shrink-guard, count-guarded find/replace, and
+//! substitution-only enrichment.
+//!
+//! All functions in this module are pure (no I/O, no env reads, no side
+//! effects). Env reads (`ORIGIN_MERGE_SHRINK_GUARD`) live at the call site in
+//! `post_write.rs` so this module stays trivially testable.
+
+/// Returns `true` iff replacing `old` with `new` is NOT a catastrophic shrink.
+///
+/// Catastrophic shrink is defined as: `new.chars().count() as f64 <
+/// old.chars().count() as f64 * threshold`.
+///
+/// Special cases:
+/// - Empty `old` → `true` (nothing to lose; guards against div-by-zero).
+/// - Growth (new longer than old) → always `true`.
+/// - `threshold = 0.0` → always `true` (guard effectively disabled).
+/// - `threshold = 1.0` → any shrink is rejected.
+///
+/// Uses [`str::chars().count()`], **not** byte length, so multibyte UTF-8
+/// characters are counted correctly (AGENTS.md UTF-8 byte-index rule).
+///
+/// Reference value: `llm_wiki BODY_SHRINK_THRESHOLD = 0.7`.
+pub fn body_shrink_ok(old: &str, new: &str, threshold: f64) -> bool {
+    let old_len = old.chars().count();
+    if old_len == 0 {
+        return true;
+    }
+    let new_len = new.chars().count() as f64;
+    new_len >= old_len as f64 * threshold
+}
+
+/// Replace ALL occurrences of `find` in `content` with `replace`, but ONLY
+/// if the actual occurrence count equals `expected`.
+///
+/// Returns `Some(result)` on success, `None` on refusal.
+///
+/// Refusal conditions:
+/// - `find` is empty → `None`.
+/// - Actual occurrence count ≠ `expected` → `None` (refuse — don't guess).
+///
+/// This is the **basic-memory count-guard** pattern: callers must supply the
+/// exact count they observed when building the replacement; any concurrent
+/// mutation that changes the count causes a safe no-op refusal.
+///
+/// # UNWIRED — forward-looking primitive
+///
+/// This function is not yet wired into any production path. It ships as a
+/// tested primitive for a future `edit_memory` HTTP route (analogous to
+/// basic-memory's count-guarded replace). Do not retrofit into existing paths
+/// without an explicit task.
+#[allow(dead_code)]
+pub fn find_replace_guarded(
+    content: &str,
+    find: &str,
+    replace: &str,
+    expected: usize,
+) -> Option<String> {
+    if find.is_empty() {
+        return None;
+    }
+    let actual = content.matches(find).count();
+    if actual != expected {
+        return None;
+    }
+    Some(content.replace(find, replace))
+}
+
+/// Apply a list of (find, replace) substitutions to `content` in order.
+///
+/// Each substitution is applied sequentially (left-to-right) via
+/// [`str::replace`]. No free-form rewriting — only exact string substitutions.
+///
+/// # UNWIRED — forward-looking primitive
+///
+/// Intended for substitution-only auto-linker enrichment (e.g. rewriting raw
+/// entity names to `[[wikilink]]` form across a page body) once a production
+/// caller exists. Ships unwired so the primitive can be tested independently.
+/// Do not wire into existing paths without an explicit task.
+#[allow(dead_code)]
+pub fn substitute_terms(content: &str, subs: &[(String, String)]) -> String {
+    let mut result = content.to_string();
+    for (find, replace) in subs {
+        result = result.replace(find.as_str(), replace.as_str());
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── body_shrink_ok ────────────────────────────────────────────────────────
+
+    #[test]
+    fn shrink_ok_at_floor_exactly() {
+        // 7 >= 10 * 0.7 = 7.0 → true (at the floor, not below)
+        assert!(body_shrink_ok("aaaaaaaaaa", "aaaaaaa", 0.7));
+    }
+
+    #[test]
+    fn shrink_ok_below_floor() {
+        // 6 < 10 * 0.7 = 7.0 → false
+        assert!(!body_shrink_ok("aaaaaaaaaa", "aaaaaa", 0.7));
+    }
+
+    #[test]
+    fn shrink_ok_growth_always_passes() {
+        assert!(body_shrink_ok("short", "a much much longer body", 0.7));
+    }
+
+    #[test]
+    fn shrink_ok_empty_old_is_always_true() {
+        assert!(body_shrink_ok("", "anything", 0.7));
+        assert!(body_shrink_ok("", "", 0.7));
+    }
+
+    #[test]
+    fn shrink_ok_multibyte_utf8_uses_char_count_not_bytes() {
+        // "ααααα" = 5 chars, 10 bytes; "αααα" = 4 chars, 8 bytes.
+        // 4 >= 5 * 0.7 = 3.5 → true by char count.
+        let old = "ααααα";
+        let new_str = "αααα";
+        assert_eq!(old.chars().count(), 5, "pin: old is 5 chars");
+        assert_eq!(old.len(), 10, "pin: old is 10 bytes (2 bytes per α)");
+        assert_eq!(new_str.chars().count(), 4, "pin: new is 4 chars");
+        assert_eq!(new_str.len(), 8, "pin: new is 8 bytes");
+        // 4 chars >= 5 chars * 0.7 = 3.5 → true
+        assert!(body_shrink_ok(old, new_str, 0.7));
+        // threshold=0.9: 4 < 5*0.9=4.5 → false (pinned to char count)
+        assert!(!body_shrink_ok(old, new_str, 0.9));
+    }
+
+    #[test]
+    fn shrink_ok_threshold_one_rejects_any_shrink() {
+        assert!(!body_shrink_ok("hello", "hell", 1.0));
+        assert!(body_shrink_ok("hello", "hello", 1.0));
+        assert!(body_shrink_ok("hello", "hello world", 1.0));
+    }
+
+    #[test]
+    fn shrink_ok_threshold_zero_accepts_everything() {
+        assert!(body_shrink_ok("hello world this is long", "x", 0.0));
+        assert!(body_shrink_ok("hello", "", 0.0));
+    }
+
+    // ── find_replace_guarded ─────────────────────────────────────────────────
+
+    #[test]
+    fn find_replace_guarded_expected_count_matches() {
+        let content = "foo bar foo baz foo";
+        let result = find_replace_guarded(content, "foo", "qux", 3).unwrap();
+        assert_eq!(result, "qux bar qux baz qux");
+    }
+
+    #[test]
+    fn find_replace_guarded_zero_occurrences_expected_zero() {
+        let content = "hello world";
+        let result = find_replace_guarded(content, "zzz", "qqq", 0).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn find_replace_guarded_wrong_count_returns_none() {
+        let content = "foo bar foo baz foo";
+        assert!(find_replace_guarded(content, "foo", "qux", 2).is_none());
+    }
+
+    #[test]
+    fn find_replace_guarded_zero_actual_nonzero_expected_returns_none() {
+        let content = "hello world";
+        assert!(find_replace_guarded(content, "zzz", "qqq", 1).is_none());
+    }
+
+    #[test]
+    fn find_replace_guarded_empty_find_returns_none() {
+        assert!(find_replace_guarded("hello", "", "x", 0).is_none());
+        assert!(find_replace_guarded("hello", "", "x", 1).is_none());
+    }
+
+    #[test]
+    fn find_replace_guarded_multibyte_utf8() {
+        let content = "αβγ αβγ";
+        let result = find_replace_guarded(content, "αβγ", "xyz", 2).unwrap();
+        assert_eq!(result, "xyz xyz");
+    }
+
+    #[test]
+    fn find_replace_guarded_single_occurrence() {
+        let content = "The quick brown fox";
+        let result = find_replace_guarded(content, "fox", "cat", 1).unwrap();
+        assert_eq!(result, "The quick brown cat");
+    }
+
+    // ── substitute_terms ─────────────────────────────────────────────────────
+
+    #[test]
+    fn substitute_terms_applies_in_order() {
+        // Pass 1 ("foo"→"bar"): "foo and bar" → "bar and bar"
+        // Pass 2 ("bar"→"baz"): "bar and bar" → "baz and baz"
+        let subs = vec![
+            ("foo".to_string(), "bar".to_string()),
+            ("bar".to_string(), "baz".to_string()),
+        ];
+        let result = substitute_terms("foo and bar", &subs);
+        assert_eq!(result, "baz and baz");
+    }
+
+    #[test]
+    fn substitute_terms_empty_pairs_unchanged() {
+        let result = substitute_terms("hello world", &[]);
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn substitute_terms_no_match_unchanged() {
+        let subs = vec![("zzz".to_string(), "qqq".to_string())];
+        let result = substitute_terms("hello world", &subs);
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn substitute_terms_multibyte_utf8() {
+        let subs = vec![("αβγ".to_string(), "xyz".to_string())];
+        let result = substitute_terms("αβγ and αβγ", &subs);
+        assert_eq!(result, "xyz and xyz");
+    }
+
+    #[test]
+    fn substitute_terms_overlapping_sequential_semantics() {
+        // Sequential semantics: each pair is a full-pass replacement.
+        // Pass 1 ("FOO"=>"BAR"): "FOO and BAR" => "BAR and BAR"
+        // Pass 2 ("BAR"=>"BAZ"): "BAR and BAR" => "BAZ and BAZ"
+        // (Uppercase avoids substring collision with "and".)
+        let subs = vec![
+            ("FOO".to_string(), "BAR".to_string()),
+            ("BAR".to_string(), "BAZ".to_string()),
+        ];
+        let result = substitute_terms("FOO and BAR", &subs);
+        assert_eq!(result, "BAZ and BAZ");
+    }
+}

--- a/crates/origin-core/src/retrieval/mod.rs
+++ b/crates/origin-core/src/retrieval/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod decompose;
 pub(crate) mod dedup;
 pub(crate) mod fts_query;
 pub(crate) mod hard_filters;
+pub(crate) mod integrity;
 pub(crate) mod query_intent;
 pub(crate) mod session_diversity;
 pub(crate) mod signals;


### PR DESCRIPTION
## What
Guard a data-loss class: an LLM rewrite (`distill`/`re_distill`/`page_growth`/`refinery_merge`) that silently shrinks a page body to near-nothing. Behind opt-in `ORIGIN_MERGE_SHRINK_GUARD` (float threshold, e.g. 0.7; unset/unparseable = OFF = byte-identical). **USER edits are NEVER blocked** (`is_llm_rewrite` gate — the inverse twin of `skip_hallucination_guard`, identical arms).

## How
- New pure `retrieval::integrity`: `body_shrink_ok` (by `chars().count()`, UTF-8) + `find_replace_guarded` + `substitute_terms` (the latter two are UNWIRED primitives for a future edit_memory route).
- Wired into `update_page` (sub-threshold LLM rewrite → `Err(Validation)` BEFORE any DB write, NOT inside the `skip_hallucination_guard` block) + `grow_page` pre-check (→ `Ok(false)` skipped-growth). `apply_merge_with_title` + `upsert_memory_in_place` deferred (TODO).

## Review: SHIP (clean first pass)
No blockers. Verified: guard-OFF byte-identical; user edits never blocked (`fs_edit`/`manual_edit`/`agent_refresh` all unguarded; `handle_refresh_page` bypasses the path entirely); insertion point returns Err before any DB write (no partial write); `body_shrink_ok` floor-boundary + UTF-8 correct; primitives genuinely unwired.
**Design note (intended):** with the guard ON, a legitimate LLM *condensation* is rejected hard (no retry loop) and the page stays at its current content until the next distill cycle. That's the opt-in tradeoff the operator accepts by setting the threshold.

## Tests + eval
28 tests (19 pure + 4 update_page-guard + parse + is_llm_rewrite). clippy clean.
**Eval N/A:** write-integrity guard, not a retrieval-metric mover; the `page_faithfulness` bench scores static TOML bodies and never calls `grow_page`/`update_page`. Validated by unit + integration tests. T17 of the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)