### PR TITLE
fix(memory): two-pool dedup+contradiction resolution in one LLM call (ORIGIN_ENABLE_DUAL_POOL_RESOLVE)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -427,6 +427,23 @@ pub fn page_channel_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// True iff `ORIGIN_ENABLE_DUAL_POOL_RESOLVE` is set to a truthy value
+/// (`1`, `true`, or `yes`, case-insensitive). When enabled, `handle_store_memory`
+/// resolves each incoming memory against two candidate pools (near-duplicates +
+/// possibly-contradicting same-entity/domain rows) in a single LLM call and acts
+/// on the result: invalidations soft-suppress the older side (bidirectional
+/// temporal expiry), duplicates file a consolidation proposal.
+///
+/// Default OFF: unset or any falsey value (`0`/`false`/`no`/`""`) leaves the
+/// write path byte-identical (no extra vector query, no LLM call, no mutation).
+/// Truthy-only parse, mirrors [`page_channel_enabled`].
+pub fn dual_pool_resolve_enabled() -> bool {
+    std::env::var("ORIGIN_ENABLE_DUAL_POOL_RESOLVE")
+        .ok()
+        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+}
+
 /// True iff `ORIGIN_ENABLE_TEMPORAL_GROUNDING` is set to a truthy value
 /// (`1`, `true`, or `yes`, case-insensitive). When enabled, `upsert_documents`
 /// deterministically rewrites relative date phrases in memory prose to include
@@ -18812,6 +18829,310 @@ impl MemoryDB {
         }
     }
 
+    /// Build the two candidate pools for T14 dual-pool resolution.
+    ///
+    /// Pool A: near-duplicates by vector cosine >= `cfg.pool_a_cosine_threshold`.
+    /// Pool B: same-entity-OR-same-domain rows that pass
+    /// `contradiction::fields_may_contradict`, with Pool-A overlaps subtracted so
+    /// the two pools are disjoint. Combined size is capped at `cfg.combined_cap`
+    /// (Pool A keeps priority; Pool B fills the remainder).
+    ///
+    /// Only confirmed, non-pending, non-recap `source='memory'` rows are
+    /// considered, and the incoming memory itself is excluded. All SQL is
+    /// parameterized.
+    pub(crate) async fn build_resolution_pools(
+        &self,
+        incoming: &crate::retrieval::resolve::IncomingMemory,
+        cfg: crate::retrieval::resolve::ResolutionConfig,
+    ) -> Result<
+        (
+            Vec<crate::retrieval::resolve::Candidate>,
+            Vec<crate::retrieval::resolve::Candidate>,
+        ),
+        OriginError,
+    > {
+        use crate::retrieval::resolve::Candidate;
+        use std::collections::HashSet;
+
+        // Fetch a bounded set of recent confirmed memories with everything the
+        // pool builder + applier need. Cap the scan generously (4x the combined
+        // cap) so cosine ranking has headroom before we trim to the final cap.
+        let scan_limit = (cfg.combined_cap.max(1) * 4) as i64;
+
+        let conn = self.conn.lock().await;
+        let sql = "SELECT source_id, content, structured_fields, memory_type, space, \
+                          entity_id, embedding, event_date, created_at, pinned, stability \
+                   FROM memories \
+                   WHERE chunk_index = 0 AND source = 'memory' AND confirmed = 1 \
+                         AND pending_revision = 0 AND COALESCE(is_recap, 0) = 0 \
+                         AND source_id != ?1 \
+                   ORDER BY \
+                     CASE WHEN entity_id IS NOT NULL AND entity_id = ?2 THEN 0 \
+                          WHEN space IS NOT NULL AND space = ?3 THEN 1 \
+                          ELSE 2 END, \
+                     last_modified DESC \
+                   LIMIT ?4";
+
+        struct Row {
+            cand: Candidate,
+            structured_fields: Option<String>,
+            memory_type: String,
+            domain: Option<String>,
+            entity_id: Option<String>,
+            embedding: Vec<f32>,
+        }
+
+        let mut rows = conn
+            .query(
+                sql,
+                libsql::params![
+                    incoming.source_id.clone(),
+                    incoming.entity_id.clone().unwrap_or_default(),
+                    incoming.domain.clone().unwrap_or_default(),
+                    scan_limit
+                ],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("build_resolution_pools query: {e}")))?;
+
+        let mut fetched: Vec<Row> = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        {
+            let source_id: String = row
+                .get(0)
+                .map_err(|e| OriginError::VectorDb(format!("resolve src_id: {e}")))?;
+            let content: String = row.get::<String>(1).unwrap_or_default();
+            let structured_fields: Option<String> = row.get::<Option<String>>(2).unwrap_or(None);
+            let memory_type: String = row
+                .get::<Option<String>>(3)
+                .unwrap_or(None)
+                .unwrap_or_default();
+            let domain: Option<String> = row.get::<Option<String>>(4).unwrap_or(None);
+            let entity_id: Option<String> = row.get::<Option<String>>(5).unwrap_or(None);
+            let embedding: Vec<f32> = row
+                .get::<Vec<u8>>(6)
+                .unwrap_or_default()
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect();
+            let event_date: Option<i64> = row.get::<Option<i64>>(7).unwrap_or(None);
+            let created_at: i64 = row.get::<Option<i64>>(8).unwrap_or(None).unwrap_or(0);
+            let pinned: bool = row.get::<i64>(9).unwrap_or(0) != 0;
+            let stability: String = row
+                .get::<Option<String>>(10)
+                .unwrap_or(None)
+                .unwrap_or_else(|| "new".to_string());
+
+            fetched.push(Row {
+                cand: Candidate {
+                    source_id,
+                    content,
+                    event_date,
+                    created_at,
+                    pinned,
+                    stability,
+                },
+                structured_fields,
+                memory_type,
+                domain,
+                entity_id,
+                embedding,
+            });
+        }
+        drop(rows);
+        drop(conn);
+
+        // --- Pool A: near-duplicates by cosine ---
+        let mut scored: Vec<(usize, f64)> = fetched
+            .iter()
+            .enumerate()
+            .map(|(i, r)| {
+                (
+                    i,
+                    crate::topic_match::cosine_similarity(&incoming.embedding, &r.embedding),
+                )
+            })
+            .filter(|(_, sim)| *sim >= cfg.pool_a_cosine_threshold)
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let mut pool_a: Vec<Candidate> = Vec::new();
+        let mut pool_a_ids: HashSet<String> = HashSet::new();
+        for (i, _sim) in &scored {
+            if pool_a.len() >= cfg.combined_cap {
+                break;
+            }
+            let r = &fetched[*i];
+            pool_a_ids.insert(r.cand.source_id.clone());
+            pool_a.push(r.cand.clone());
+        }
+
+        // --- Pool B: same-entity-OR-same-domain field-contradiction candidates ---
+        let inc_fields = incoming.structured_fields.as_deref().unwrap_or("{}");
+        let mut raw_b: Vec<Candidate> = Vec::new();
+        for r in &fetched {
+            // Same entity OR same domain as the incoming memory.
+            let same_entity = match (incoming.entity_id.as_deref(), r.entity_id.as_deref()) {
+                (Some(a), Some(b)) => a == b,
+                _ => false,
+            };
+            let same_domain = match (incoming.domain.as_deref(), r.domain.as_deref()) {
+                (Some(a), Some(b)) => a.eq_ignore_ascii_case(b),
+                _ => false,
+            };
+            if !same_entity && !same_domain {
+                continue;
+            }
+            // Same memory_type required for fields_may_contradict to compare like-for-like.
+            if r.memory_type != incoming.memory_type {
+                continue;
+            }
+            let ex_fields = r.structured_fields.as_deref().unwrap_or("{}");
+            if crate::contradiction::fields_may_contradict(
+                &incoming.memory_type,
+                ex_fields,
+                inc_fields,
+            ) {
+                raw_b.push(r.cand.clone());
+            }
+        }
+
+        // Disjoint by construction: drop any Pool-B row already in Pool A.
+        let mut pool_b = crate::retrieval::resolve::subtract_pool_a(&pool_a_ids, raw_b);
+
+        // Enforce the combined cap: Pool A keeps priority, Pool B fills remainder.
+        let remaining = cfg.combined_cap.saturating_sub(pool_a.len());
+        if pool_b.len() > remaining {
+            pool_b.truncate(remaining);
+        }
+
+        Ok((pool_a, pool_b))
+    }
+
+    /// Soft-suppress `existing_id` because `incoming_id` (newer valid-time) wins.
+    /// Sets `incoming.supersedes = existing_id` (revision linkage) and
+    /// `existing.confirmed = 0` (soft-suppress; NEVER deleted). Reuses the
+    /// canonical soft-suppress semantics from `upsert_documents`. Best-effort
+    /// per-statement so a partial failure can't corrupt one side silently;
+    /// returns the first hard error.
+    pub(crate) async fn resolve_supersede_existing(
+        &self,
+        incoming_id: &str,
+        existing_id: &str,
+    ) -> Result<(), OriginError> {
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET supersedes = ?1 WHERE source_id = ?2 AND source = 'memory'",
+            libsql::params![existing_id, incoming_id],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("resolve_supersede_existing link: {e}")))?;
+        conn.execute(
+            "UPDATE memories SET confirmed = 0 WHERE source_id = ?1 AND source = 'memory'",
+            libsql::params![existing_id],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("resolve_supersede_existing suppress: {e}")))?;
+        Ok(())
+    }
+
+    /// Soft-suppress the INCOMING memory because an existing memory has a
+    /// strictly-later valid-time (out-of-order backfill). Sets
+    /// `incoming.supersedes = existing_id` (so the incoming is linked as a
+    /// revision-of the survivor) and `incoming.confirmed = 0`. The existing
+    /// memory is left untouched. NEVER deletes.
+    pub(crate) async fn resolve_expire_incoming(
+        &self,
+        incoming_id: &str,
+        existing_id: &str,
+    ) -> Result<(), OriginError> {
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET supersedes = ?1, confirmed = 0 \
+             WHERE source_id = ?2 AND source = 'memory'",
+            libsql::params![existing_id, incoming_id],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("resolve_expire_incoming: {e}")))?;
+        Ok(())
+    }
+
+    /// Read the metadata `build_resolution_pools` + the resolver need about a
+    /// single memory by `source_id`. Returns `None` when the row is absent.
+    pub(crate) async fn get_incoming_for_resolution(
+        &self,
+        source_id: &str,
+    ) -> Result<Option<crate::retrieval::resolve::IncomingMemory>, OriginError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT content, embedding, entity_id, space, memory_type, \
+                        structured_fields, event_date, created_at \
+                 FROM memories WHERE source_id = ?1 AND chunk_index = 0 AND source = 'memory' LIMIT 1",
+                libsql::params![source_id],
+            )
+            .await
+            .map_err(|e| OriginError::VectorDb(format!("get_incoming_for_resolution: {e}")))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| OriginError::VectorDb(e.to_string()))?
+        else {
+            return Ok(None);
+        };
+        let content: String = row.get::<String>(0).unwrap_or_default();
+        let embedding: Vec<f32> = row
+            .get::<Vec<u8>>(1)
+            .unwrap_or_default()
+            .chunks_exact(4)
+            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .collect();
+        let entity_id: Option<String> = row.get::<Option<String>>(2).unwrap_or(None);
+        let domain: Option<String> = row.get::<Option<String>>(3).unwrap_or(None);
+        let memory_type: String = row
+            .get::<Option<String>>(4)
+            .unwrap_or(None)
+            .unwrap_or_default();
+        let structured_fields: Option<String> = row.get::<Option<String>>(5).unwrap_or(None);
+        let event_date: Option<i64> = row.get::<Option<i64>>(6).unwrap_or(None);
+        let created_at: i64 = row.get::<Option<i64>>(7).unwrap_or(None).unwrap_or(0);
+        Ok(Some(crate::retrieval::resolve::IncomingMemory {
+            source_id: source_id.to_string(),
+            content,
+            embedding,
+            entity_id,
+            domain,
+            memory_type,
+            structured_fields,
+            event_date,
+            created_at,
+        }))
+    }
+
+    /// Link the incoming memory as a pending revision of a PROTECTED existing
+    /// memory: sets `incoming.supersedes = existing_id` and
+    /// `incoming.pending_revision = 1`. The existing (protected) memory is left
+    /// untouched and stays `confirmed = 1` — a human approves via /brief.
+    /// Mirrors the protected-topic-match path in `memory_routes.rs`.
+    pub(crate) async fn resolve_link_pending_revision(
+        &self,
+        incoming_id: &str,
+        existing_id: &str,
+    ) -> Result<(), OriginError> {
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET supersedes = ?1, pending_revision = 1 \
+             WHERE source_id = ?2 AND source = 'memory'",
+            libsql::params![existing_id, incoming_id],
+        )
+        .await
+        .map_err(|e| OriginError::VectorDb(format!("resolve_link_pending_revision: {e}")))?;
+        Ok(())
+    }
+
     /// Mark a page as stale with a specific reason.
     pub async fn set_page_stale(&self, page_id: &str, reason: &str) -> Result<(), OriginError> {
         let conn = self.conn.lock().await;
@@ -21763,6 +22084,32 @@ pub(crate) mod tests {
         let unset =
             temp_env::async_with_vars([("ORIGIN_ENABLE_SALIENCE_PRIOR", None::<&str>)], async {
                 crate::db::salience_prior_enabled()
+            })
+            .await;
+        assert!(!unset, "expected false when unset");
+    }
+
+    #[tokio::test]
+    async fn dual_pool_resolve_enabled_truthy_parse() {
+        for val in &["1", "true", "yes", "TRUE", "Yes"] {
+            let got = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some(*val))],
+                async { crate::db::dual_pool_resolve_enabled() },
+            )
+            .await;
+            assert!(got, "expected true for {val}");
+        }
+        for val in &["0", "false", "no", ""] {
+            let got = temp_env::async_with_vars(
+                [("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some(*val))],
+                async { crate::db::dual_pool_resolve_enabled() },
+            )
+            .await;
+            assert!(!got, "expected false for {val}");
+        }
+        let unset =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", None::<&str>)], async {
+                crate::db::dual_pool_resolve_enabled()
             })
             .await;
         assert!(!unset, "expected false when unset");

--- a/crates/origin-core/src/prompts/defaults.rs
+++ b/crates/origin-core/src/prompts/defaults.rs
@@ -66,6 +66,20 @@ Compare two memories. Respond with exactly one of:\n\
 - CONTRADICTS: <brief explanation>\n\
 - SUPERSEDES: <merged version combining both>";
 
+pub(crate) const RESOLVE_DUAL_POOL: &str = "\
+You resolve an incoming memory against existing memories. You receive a numbered\n\
+candidate list split into two ranges:\n\
+- DUPLICATES range: near-identical restatements of the incoming memory.\n\
+- CONFLICTS range: same topic/entity but possibly-contradicting claims.\n\
+Decide, per candidate index:\n\
+- duplicates: indices that say the SAME thing as the incoming memory.\n\
+- invalidates: indices from the CONFLICTS range whose claim is mutually\n\
+  exclusive with the incoming memory (only one can be true).\n\
+Rules: use ONLY the integer indices shown. Never invent an index. A candidate\n\
+is a duplicate OR an invalidation, never both. If unsure, omit the index.\n\
+Respond with ONLY this JSON object, no prose, no markdown:\n\
+{\"duplicates\":[],\"invalidates\":[]}";
+
 pub(crate) const SUMMARIZE_DECISIONS: &str = "\
 You summarize a set of decisions made by one person.\n\
 State the key decisions as one concise sentence. If no coherent theme, respond: null";

--- a/crates/origin-core/src/prompts/mod.rs
+++ b/crates/origin-core/src/prompts/mod.rs
@@ -15,6 +15,7 @@ pub struct PromptRegistry {
     pub classify_screen: String,
     pub merge_memories: String,
     pub detect_contradiction: String,
+    pub resolve_dual_pool: String,
     pub summarize_decisions: String,
     pub detect_pattern: String,
     pub narrative: String,
@@ -43,6 +44,7 @@ impl Default for PromptRegistry {
             classify_screen: defaults::CLASSIFY_SCREEN.to_string(),
             merge_memories: defaults::MERGE_MEMORIES.to_string(),
             detect_contradiction: defaults::DETECT_CONTRADICTION.to_string(),
+            resolve_dual_pool: defaults::RESOLVE_DUAL_POOL.to_string(),
             summarize_decisions: defaults::SUMMARIZE_DECISIONS.to_string(),
             detect_pattern: defaults::DETECT_PATTERN.to_string(),
             narrative: defaults::NARRATIVE.to_string(),
@@ -80,6 +82,7 @@ impl PromptRegistry {
             ("classify_screen", &mut reg.classify_screen),
             ("merge_memories", &mut reg.merge_memories),
             ("detect_contradiction", &mut reg.detect_contradiction),
+            ("resolve_dual_pool", &mut reg.resolve_dual_pool),
             ("summarize_decisions", &mut reg.summarize_decisions),
             ("detect_pattern", &mut reg.detect_pattern),
             ("narrative", &mut reg.narrative),
@@ -170,6 +173,7 @@ mod tests {
         assert!(!reg.classify_screen.is_empty());
         assert!(!reg.merge_memories.is_empty());
         assert!(!reg.detect_contradiction.is_empty());
+        assert!(!reg.resolve_dual_pool.is_empty());
         assert!(!reg.summarize_decisions.is_empty());
         assert!(!reg.detect_pattern.is_empty());
         assert!(!reg.narrative.is_empty());

--- a/crates/origin-core/src/retrieval/mod.rs
+++ b/crates/origin-core/src/retrieval/mod.rs
@@ -11,5 +11,6 @@ pub(crate) mod fts_query;
 pub(crate) mod hard_filters;
 pub(crate) mod integrity;
 pub(crate) mod query_intent;
+pub(crate) mod resolve;
 pub(crate) mod session_diversity;
 pub(crate) mod signals;

--- a/crates/origin-core/src/retrieval/resolve.rs
+++ b/crates/origin-core/src/retrieval/resolve.rs
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Pure helpers for the two-pool write-time resolution (T14).
+//!
+//! An incoming memory is resolved against TWO candidate pools in a single LLM
+//! call: Pool A (near-duplicates by vector similarity) and Pool B (same
+//! entity/domain rows that may *contradict* the incoming claim). The LLM returns
+//! `{"duplicates":[...],"invalidates":[...]}` over a single continuous index
+//! space (Pool A first, then Pool B). These helpers map indices back to pools,
+//! keep the two pools disjoint, parse the LLM output defensively (silent-zero
+//! guard), and decide the direction of temporal expiry.
+//!
+//! Everything here is pure: no DB, no axum, no tauri. The orchestrator in
+//! `synthesis::refinement_queue` wires these to the database.
+
+use std::collections::HashSet;
+
+/// Which candidate pool an index falls into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Pool {
+    /// Near-duplicate by vector similarity.
+    A,
+    /// Same entity/domain, possibly-contradicting.
+    B,
+}
+
+/// Parsed LLM decision over the continuous index space.
+///
+/// Indices are 0-based over `[Pool A ++ Pool B]`. Always sanitized: any index
+/// `>= total_len` is dropped before this struct is returned by
+/// [`parse_dual_pool`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DualPoolDecision {
+    /// Indices the LLM flagged as duplicates of the incoming memory.
+    pub duplicates: Vec<usize>,
+    /// Indices the LLM flagged as invalidated-by / invalidating the incoming memory.
+    pub invalidates: Vec<usize>,
+}
+
+/// Direction of temporal expiry once a Pool-B candidate is judged to conflict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExpiryDirection {
+    /// The existing memory is older — soft-suppress the existing side.
+    ExistingSuperseded,
+    /// The existing memory is strictly *newer* (out-of-order backfill) —
+    /// soft-suppress the *incoming* side instead.
+    IncomingExpired,
+}
+
+/// A candidate memory fetched for resolution. Carries exactly what the
+/// orchestrator needs to (a) render the prompt and (b) act on the result.
+#[derive(Debug, Clone)]
+pub(crate) struct Candidate {
+    pub source_id: String,
+    pub content: String,
+    /// Valid-time event date (absolute epoch secs) when known, else `None`.
+    pub event_date: Option<i64>,
+    /// Row creation time (epoch secs) — the valid-time fallback.
+    pub created_at: i64,
+    /// Pinned by the user — never auto-mutate.
+    pub pinned: bool,
+    /// Stability tier; `"protected"` is never auto-mutated.
+    pub stability: String,
+}
+
+impl Candidate {
+    /// A candidate is *protected* (never auto-mutated) when pinned or when its
+    /// stability tier is explicitly `protected`. Note this is intentionally
+    /// narrower than `MemoryDB::is_memory_protected` (which also treats any
+    /// `confirmed`/`learned` row as protected); T14's whole point is to
+    /// soft-suppress *confirmed* stale facts, so only pin / explicit-protected
+    /// status blocks the auto-mutation.
+    pub fn is_protected(&self) -> bool {
+        self.pinned || self.stability == "protected"
+    }
+}
+
+/// Tunable knobs for the dual-pool resolution. Sensible defaults; not env-wired
+/// (the master switch is the `ORIGIN_ENABLE_DUAL_POOL_RESOLVE` flag).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ResolutionConfig {
+    /// Minimum cosine similarity for Pool A (near-duplicates).
+    pub pool_a_cosine_threshold: f64,
+    /// Maximum combined candidate count across both pools (bounds prompt cost).
+    pub combined_cap: usize,
+}
+
+impl Default for ResolutionConfig {
+    fn default() -> Self {
+        Self {
+            pool_a_cosine_threshold: 0.88,
+            combined_cap: 12,
+        }
+    }
+}
+
+/// The incoming memory being resolved, plus the fields the pool builder needs.
+#[derive(Debug, Clone)]
+pub(crate) struct IncomingMemory {
+    pub source_id: String,
+    pub content: String,
+    pub embedding: Vec<f32>,
+    pub entity_id: Option<String>,
+    pub domain: Option<String>,
+    pub memory_type: String,
+    pub structured_fields: Option<String>,
+    pub event_date: Option<i64>,
+    pub created_at: i64,
+}
+
+/// Map a continuous index into its originating pool.
+///
+/// Indices `0..a_len` belong to Pool A; `a_len..a_len+b_len` to Pool B;
+/// anything `>= a_len + b_len` is out of range and returns `None`.
+pub(crate) fn index_to_pool(idx: usize, a_len: usize, b_len: usize) -> Option<Pool> {
+    if idx < a_len {
+        Some(Pool::A)
+    } else if idx < a_len + b_len {
+        Some(Pool::B)
+    } else {
+        None
+    }
+}
+
+/// Convert a continuous Pool-B index into a 0-based offset within Pool B.
+/// Returns `None` when the index is not in the Pool-B range.
+pub(crate) fn pool_b_offset(idx: usize, a_len: usize, b_len: usize) -> Option<usize> {
+    if idx >= a_len && idx < a_len + b_len {
+        Some(idx - a_len)
+    } else {
+        None
+    }
+}
+
+/// Remove any raw Pool-B candidate whose `source_id` already appears in Pool A.
+///
+/// This keeps the two pools disjoint by construction: a row that is BOTH a
+/// near-duplicate (Pool A) AND field-contradicting (raw Pool B) stays in Pool A
+/// only, so the continuous index space never double-counts it.
+pub(crate) fn subtract_pool_a(
+    pool_a_ids: &HashSet<String>,
+    raw_b: Vec<Candidate>,
+) -> Vec<Candidate> {
+    raw_b
+        .into_iter()
+        .filter(|c| !pool_a_ids.contains(&c.source_id))
+        .collect()
+}
+
+/// Defensively parse the LLM's dual-pool response.
+///
+/// SILENT-ZERO GUARD (PR #147 class): returns an EMPTY decision on *any* parse
+/// failure — malformed JSON, missing keys, wrong types, truncation. The applier
+/// must never act on garbage, so the fail-safe is "do nothing". Out-of-range
+/// indices (`>= total_len`) are silently dropped rather than failing the whole
+/// parse, so one stray index can't void a valid decision.
+///
+/// Pipeline: `strip_think_tags` -> slice from first `{` to last `}` ->
+/// `serde_json` -> drop out-of-range indices.
+pub(crate) fn parse_dual_pool(raw: &str, total_len: usize) -> DualPoolDecision {
+    let empty = DualPoolDecision::default();
+
+    let stripped = crate::llm_provider::strip_think_tags(raw);
+
+    // Narrow to the JSON object span. `find('{')` / `rfind('}')` mirrors
+    // `engine::extract_json`; on any miss we bail to empty.
+    let (start, end) = match (stripped.find('{'), stripped.rfind('}')) {
+        (Some(s), Some(e)) if e >= s => (s, e),
+        _ => return empty,
+    };
+    let slice = &stripped[start..=end];
+
+    // Strict shape: both keys must be arrays of integers. Extra keys (e.g.
+    // "reasoning") are ignored by the typed struct.
+    #[derive(serde::Deserialize)]
+    struct Raw {
+        #[serde(default)]
+        duplicates: Vec<i64>,
+        #[serde(default)]
+        invalidates: Vec<i64>,
+    }
+
+    let parsed: Raw = match serde_json::from_str(slice) {
+        Ok(p) => p,
+        Err(_) => return empty,
+    };
+
+    let sanitize = |v: Vec<i64>| -> Vec<usize> {
+        v.into_iter()
+            .filter_map(|i| usize::try_from(i).ok())
+            .filter(|&i| i < total_len)
+            .collect()
+    };
+
+    DualPoolDecision {
+        duplicates: sanitize(parsed.duplicates),
+        invalidates: sanitize(parsed.invalidates),
+    }
+}
+
+/// Resolve the valid-time for a memory: the explicit `event_date` when set,
+/// otherwise the row's `created_at`. (event_date is deliberately NULL for
+/// anaphoric/durative facts; falling back to created_at degrades expiry to the
+/// safe monotonic "new-beats-old" default.)
+pub(crate) fn valid_time(event_date: Option<i64>, created_at: i64) -> i64 {
+    event_date.unwrap_or(created_at)
+}
+
+/// Decide which side expires when the incoming memory conflicts with an existing
+/// one. The existing memory wins (and the *incoming* expires) ONLY when its
+/// valid-time is *strictly* later than the incoming's — the out-of-order
+/// backfill case. Ties default to `ExistingSuperseded` (newer-ingested wins).
+pub(crate) fn expiry_direction(incoming_valid: i64, existing_valid: i64) -> ExpiryDirection {
+    if existing_valid > incoming_valid {
+        ExpiryDirection::IncomingExpired
+    } else {
+        ExpiryDirection::ExistingSuperseded
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cand(source_id: &str) -> Candidate {
+        Candidate {
+            source_id: source_id.into(),
+            content: "c".into(),
+            event_date: None,
+            created_at: 0,
+            pinned: false,
+            stability: "new".into(),
+        }
+    }
+
+    // ---- subtract_pool_a (Test 1) ----
+
+    #[test]
+    fn test_pools_disjoint_by_construction() {
+        // Pool A = {a, b}; raw Pool B = {b, c, d} -> B becomes {c, d}.
+        let pool_a_ids: HashSet<String> = ["a", "b"].iter().map(|s| s.to_string()).collect();
+        let raw_b = vec![cand("b"), cand("c"), cand("d")];
+        let b = subtract_pool_a(&pool_a_ids, raw_b);
+        let b_ids: Vec<&str> = b.iter().map(|c| c.source_id.as_str()).collect();
+        assert_eq!(b_ids, vec!["c", "d"]);
+        // No id appears in both pools; `b` stays in A only.
+        assert!(!b_ids.contains(&"b"), "b must stay in Pool A only");
+        for id in &b_ids {
+            assert!(!pool_a_ids.contains(*id));
+        }
+    }
+
+    #[test]
+    fn subtract_pool_a_empty_a_keeps_all_b() {
+        let pool_a_ids: HashSet<String> = HashSet::new();
+        let raw_b = vec![cand("c"), cand("d")];
+        let b = subtract_pool_a(&pool_a_ids, raw_b);
+        assert_eq!(b.len(), 2);
+    }
+
+    // ---- index_to_pool (Tests 2-4) ----
+
+    #[test]
+    fn test_continuous_index_offset() {
+        // a_len=2, b_len=3 -> 0,1 in A; 2,3,4 in B; 5 None.
+        assert_eq!(index_to_pool(0, 2, 3), Some(Pool::A));
+        assert_eq!(index_to_pool(1, 2, 3), Some(Pool::A));
+        assert_eq!(index_to_pool(2, 2, 3), Some(Pool::B));
+        assert_eq!(index_to_pool(3, 2, 3), Some(Pool::B));
+        assert_eq!(index_to_pool(4, 2, 3), Some(Pool::B));
+        assert_eq!(index_to_pool(5, 2, 3), None);
+    }
+
+    #[test]
+    fn test_empty_pool_b_offset() {
+        // a_len=2, b_len=0 -> 0,1 in A; 2 None; no panic.
+        assert_eq!(index_to_pool(0, 2, 0), Some(Pool::A));
+        assert_eq!(index_to_pool(1, 2, 0), Some(Pool::A));
+        assert_eq!(index_to_pool(2, 2, 0), None);
+    }
+
+    #[test]
+    fn test_empty_both_pools() {
+        // a_len=0, b_len=0 -> any index None.
+        assert_eq!(index_to_pool(0, 0, 0), None);
+        assert_eq!(index_to_pool(7, 0, 0), None);
+    }
+
+    #[test]
+    fn pool_b_offset_maps_continuous_to_local() {
+        // a_len=2, b_len=3: index 2 -> offset 0, index 4 -> offset 2.
+        assert_eq!(pool_b_offset(2, 2, 3), Some(0));
+        assert_eq!(pool_b_offset(4, 2, 3), Some(2));
+        // Pool-A index -> None.
+        assert_eq!(pool_b_offset(1, 2, 3), None);
+        // Out of range -> None.
+        assert_eq!(pool_b_offset(5, 2, 3), None);
+    }
+
+    // ---- parse_dual_pool (Tests 5-10) ----
+
+    #[test]
+    fn test_parse_dual_pool_well_formed() {
+        let d = parse_dual_pool(r#"{"duplicates":[0,1],"invalidates":[2]}"#, 3);
+        assert_eq!(d.duplicates, vec![0, 1]);
+        assert_eq!(d.invalidates, vec![2]);
+    }
+
+    #[test]
+    fn test_parse_dual_pool_with_think_tags() {
+        let raw = "<think>reasoning here</think>\n{\"duplicates\":[],\"invalidates\":[0]}";
+        let d = parse_dual_pool(raw, 1);
+        assert_eq!(d.duplicates, Vec::<usize>::new());
+        assert_eq!(d.invalidates, vec![0]);
+    }
+
+    #[test]
+    fn test_parse_dual_pool_noisy_preamble() {
+        // Markdown fence + prose around the JSON object.
+        let raw = "Here is the result:\n```json\n{\"duplicates\":[1],\"invalidates\":[0]}\n```";
+        let d = parse_dual_pool(raw, 2);
+        assert_eq!(d.duplicates, vec![1]);
+        assert_eq!(d.invalidates, vec![0]);
+    }
+
+    #[test]
+    fn test_parse_dual_pool_malformed_returns_empty() {
+        // Silent-zero guard: non-JSON -> empty arrays, NOT an Err.
+        let d = parse_dual_pool("not json at all", 3);
+        assert_eq!(d, DualPoolDecision::default());
+        assert!(d.duplicates.is_empty());
+        assert!(d.invalidates.is_empty());
+    }
+
+    #[test]
+    fn test_parse_dual_pool_missing_keys_returns_empty() {
+        // No duplicates/invalidates keys -> both default to empty.
+        let d = parse_dual_pool(r#"{"something_else":[1,2]}"#, 3);
+        assert_eq!(d, DualPoolDecision::default());
+    }
+
+    #[test]
+    fn test_parse_dual_pool_out_of_range_indices_dropped() {
+        // total_len=3; 5 and 99 are out of range -> dropped.
+        let d = parse_dual_pool(r#"{"duplicates":[5],"invalidates":[99]}"#, 3);
+        assert!(d.duplicates.is_empty());
+        assert!(d.invalidates.is_empty());
+    }
+
+    #[test]
+    fn test_parse_dual_pool_partial_json() {
+        // Truncated -> serde fails -> empty (fail-safe).
+        let d = parse_dual_pool(r#"{"duplicates":[0]"#, 3);
+        assert_eq!(d, DualPoolDecision::default());
+    }
+
+    #[test]
+    fn test_parse_dual_pool_extra_keys_ignored() {
+        let d = parse_dual_pool(r#"{"duplicates":[0],"invalidates":[1],"reasoning":"x"}"#, 3);
+        assert_eq!(d.duplicates, vec![0]);
+        assert_eq!(d.invalidates, vec![1]);
+    }
+
+    #[test]
+    fn test_parse_dual_pool_empty_arrays() {
+        let d = parse_dual_pool(r#"{"duplicates":[],"invalidates":[]}"#, 3);
+        assert_eq!(d, DualPoolDecision::default());
+    }
+
+    #[test]
+    fn test_parse_dual_pool_mixed_in_and_out_of_range() {
+        // total_len=3; keep 0,2 drop 3,7.
+        let d = parse_dual_pool(r#"{"duplicates":[0,3],"invalidates":[2,7]}"#, 3);
+        assert_eq!(d.duplicates, vec![0]);
+        assert_eq!(d.invalidates, vec![2]);
+    }
+
+    #[test]
+    fn test_parse_dual_pool_negative_index_dropped() {
+        // Negative -> usize::try_from fails -> dropped, rest kept.
+        let d = parse_dual_pool(r#"{"duplicates":[-1,1],"invalidates":[]}"#, 3);
+        assert_eq!(d.duplicates, vec![1]);
+    }
+
+    // ---- expiry_direction (Tests 11-13) ----
+
+    #[test]
+    fn test_expiry_incoming_newer_supersedes_existing() {
+        // incoming=200 > existing=100 -> existing superseded.
+        assert_eq!(
+            expiry_direction(200, 100),
+            ExpiryDirection::ExistingSuperseded
+        );
+    }
+
+    #[test]
+    fn test_expiry_existing_strictly_later_expires_incoming() {
+        // incoming=100, existing=200 -> incoming expired (out-of-order backfill).
+        assert_eq!(expiry_direction(100, 200), ExpiryDirection::IncomingExpired);
+    }
+
+    #[test]
+    fn test_expiry_equal_dates_defaults_existing_superseded() {
+        // tie -> newer-ingested wins; only STRICTLY-later flips.
+        assert_eq!(
+            expiry_direction(150, 150),
+            ExpiryDirection::ExistingSuperseded
+        );
+    }
+
+    // ---- valid_time (Tests 14-15) ----
+
+    #[test]
+    fn test_valid_time_uses_event_date_when_some() {
+        assert_eq!(valid_time(Some(999), 100), 999);
+    }
+
+    #[test]
+    fn test_expiry_null_event_date_falls_back_to_created_at() {
+        // incoming event_date=None created_at=100, existing None created_at=200
+        // -> valid_time uses created_at -> 200>100 -> IncomingExpired.
+        let inc = valid_time(None, 100);
+        let ex = valid_time(None, 200);
+        assert_eq!(inc, 100);
+        assert_eq!(ex, 200);
+        assert_eq!(expiry_direction(inc, ex), ExpiryDirection::IncomingExpired);
+    }
+
+    #[test]
+    fn test_expiry_incoming_null_existing_set() {
+        // incoming event_date=None created_at=50, existing event_date=300
+        // -> 300>50 -> IncomingExpired.
+        let inc = valid_time(None, 50);
+        let ex = valid_time(Some(300), 0);
+        assert_eq!(expiry_direction(inc, ex), ExpiryDirection::IncomingExpired);
+    }
+
+    // ---- Candidate::is_protected ----
+
+    #[test]
+    fn candidate_protected_by_pin() {
+        let mut c = cand("x");
+        c.pinned = true;
+        assert!(c.is_protected());
+    }
+
+    #[test]
+    fn candidate_protected_by_stability() {
+        let mut c = cand("x");
+        c.stability = "protected".into();
+        assert!(c.is_protected());
+    }
+
+    #[test]
+    fn candidate_not_protected_when_confirmed_only() {
+        // A confirmed/learned row is NOT T14-protected — T14 exists to
+        // soft-suppress stale confirmed facts.
+        let mut c = cand("x");
+        c.stability = "confirmed".into();
+        assert!(!c.is_protected());
+    }
+}

--- a/crates/origin-core/src/synthesis/refinement_queue.rs
+++ b/crates/origin-core/src/synthesis/refinement_queue.rs
@@ -309,6 +309,287 @@ pub(crate) async fn process_refinement_queue(
     Ok(processed)
 }
 
+/// Outcome of `resolve_dual_pool` — what the dual-pool resolution did.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ResolveOutcome {
+    /// source_ids of existing memories soft-suppressed (incoming won).
+    pub invalidated: Vec<String>,
+    /// True when the INCOMING memory was itself expired (existing had a
+    /// strictly-later valid-time — out-of-order backfill).
+    pub expired_incoming: bool,
+    /// source_ids of existing memories flagged for human review instead of
+    /// auto-mutated (because one side was protected).
+    pub flagged_for_review: Vec<String>,
+    /// refinement proposal ids filed for near-duplicate consolidation.
+    pub dedup_proposals: Vec<String>,
+}
+
+/// T14 — resolve an incoming memory against two candidate pools in ONE LLM call.
+///
+/// Pool A = near-duplicates (vector ~0.88). Pool B = same-entity/domain,
+/// possibly-contradicting. The single LLM call returns
+/// `{"duplicates":[...],"invalidates":[...]}`. We act on the result:
+///   - invalidate (Pool B only) -> soft-suppress the older side (bidirectional
+///     temporal expiry; newer valid-time wins). Protected side -> flag
+///     `pending_revision` instead of auto-mutating (rule 2).
+///   - duplicate -> file a consolidation refinement proposal (do NOT collapse).
+///
+/// SAFETY: never deletes (soft-suppress only); silent-zero parse guard via
+/// `parse_dual_pool`; protected rows never auto-mutated. Best-effort and
+/// timeout-bounded. No-op (returns default) when the flag is off, no LLM is
+/// wired, the incoming row is missing, or both pools are empty.
+pub async fn resolve_dual_pool(
+    db: &MemoryDB,
+    incoming_source_id: &str,
+    llm: Option<&Arc<dyn LlmProvider>>,
+    prompts: &PromptRegistry,
+    emitter: &Arc<dyn crate::events::EventEmitter>,
+) -> Result<ResolveOutcome, OriginError> {
+    use crate::retrieval::resolve::{
+        expiry_direction, index_to_pool, parse_dual_pool, pool_b_offset, valid_time, Candidate,
+        ExpiryDirection, IncomingMemory, Pool, ResolutionConfig,
+    };
+
+    let mut outcome = ResolveOutcome::default();
+
+    // Master switch + LLM presence: byte-identical no-op when off.
+    if !crate::db::dual_pool_resolve_enabled() {
+        return Ok(outcome);
+    }
+    let Some(llm) = llm else {
+        return Ok(outcome);
+    };
+
+    // Fetch the incoming memory's metadata; missing row -> no-op.
+    let Some(incoming): Option<IncomingMemory> =
+        db.get_incoming_for_resolution(incoming_source_id).await?
+    else {
+        return Ok(outcome);
+    };
+
+    let cfg = ResolutionConfig::default();
+    let (pool_a, pool_b) = db.build_resolution_pools(&incoming, cfg).await?;
+    let a_len = pool_a.len();
+    let b_len = pool_b.len();
+    if a_len == 0 && b_len == 0 {
+        return Ok(outcome);
+    }
+    let total_len = a_len + b_len;
+
+    // Build the continuous-index prompt: Pool A first, then a divider, then Pool B.
+    let user_prompt = build_resolution_prompt(&incoming.content, &pool_a, &pool_b);
+
+    // ONE LLM call, timeout-bounded (mirrors page-channel/enrichment discipline).
+    let raw = match tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        llm.generate(LlmRequest {
+            system_prompt: Some(prompts.resolve_dual_pool.clone()),
+            user_prompt,
+            max_tokens: 256,
+            temperature: 0.1,
+            label: Some("resolve_dual_pool".to_string()),
+            timeout_secs: None,
+        }),
+    )
+    .await
+    {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            log::warn!("[resolve_dual_pool] llm error: {e}");
+            return Ok(outcome);
+        }
+        Err(_) => {
+            log::warn!("[resolve_dual_pool] llm timed out after 10s");
+            return Ok(outcome);
+        }
+    };
+
+    // Defensive parse (silent-zero guard): empty decision on any failure.
+    let decision = parse_dual_pool(&raw, total_len);
+
+    let inc_valid = valid_time(incoming.event_date, incoming.created_at);
+
+    // --- Invalidations: act ONLY on Pool B (Pool A indices are duplicates,
+    //     never contradictions, so ignore them in `invalidates`). ---
+    //
+    // Two-phase + ORDER-INDEPENDENT. An incoming memory can conflict with two
+    // existings in OPPOSITE valid-time directions (one older, one newer). If
+    // ANY conflicting existing has a strictly-later valid-time, the incoming is
+    // the LOSER and must be expired — and it must NOT then go on to soft-suppress
+    // the older existing(s) (it didn't win, it lost). Iteration order over Pool B
+    // is `last_modified DESC`, unrelated to event_date, so a single in-loop guard
+    // flag would be order-sensitive (B-then-A would suppress before expiring).
+    // Phase 1 classifies every invalidated target; Phase 2 acts on the verdict.
+    let mut protected_targets: Vec<&Candidate> = Vec::new();
+    let mut supersede_targets: Vec<&Candidate> = Vec::new();
+    let mut expiring_targets: Vec<&Candidate> = Vec::new();
+    for idx in &decision.invalidates {
+        if index_to_pool(*idx, a_len, b_len) != Some(Pool::B) {
+            continue;
+        }
+        let Some(offset) = pool_b_offset(*idx, a_len, b_len) else {
+            continue;
+        };
+        let existing: &Candidate = &pool_b[offset];
+        // Rule 2: protected memories are NEVER auto-mutated.
+        if existing.is_protected() {
+            protected_targets.push(existing);
+            continue;
+        }
+        let ex_valid = valid_time(existing.event_date, existing.created_at);
+        match expiry_direction(inc_valid, ex_valid) {
+            ExpiryDirection::IncomingExpired => expiring_targets.push(existing),
+            ExpiryDirection::ExistingSuperseded => supersede_targets.push(existing),
+        }
+    }
+
+    // Protected collisions: flag the incoming for human review, link to each
+    // protected existing so /brief can surface it. Never auto-mutate either side.
+    for existing in &protected_targets {
+        if let Err(e) = db.flag_memory_for_revision(incoming_source_id).await {
+            log::warn!(
+                "[resolve_dual_pool] protected-collision review-flag failed for \
+                 {incoming_source_id}: {e}; skipping link"
+            );
+            continue;
+        }
+        let _ = db
+            .resolve_link_pending_revision(incoming_source_id, &existing.source_id)
+            .await;
+        outcome.flagged_for_review.push(existing.source_id.clone());
+        emit_resolution_event(
+            emitter,
+            "flagged_for_review",
+            incoming_source_id,
+            &existing.source_id,
+        );
+    }
+
+    if expiring_targets.is_empty() {
+        // Incoming wins (or ties) against every conflicting existing -> soft-suppress
+        // each older existing. Incoming stays confirmed.
+        for existing in &supersede_targets {
+            if let Err(e) = db
+                .resolve_supersede_existing(incoming_source_id, &existing.source_id)
+                .await
+            {
+                log::warn!("[resolve_dual_pool] supersede_existing failed: {e}");
+                continue;
+            }
+            outcome.invalidated.push(existing.source_id.clone());
+            emit_resolution_event(
+                emitter,
+                "existing_superseded",
+                incoming_source_id,
+                &existing.source_id,
+            );
+        }
+    } else {
+        // At least one existing has a strictly-later valid-time: the incoming is
+        // the loser. Expire the incoming ONCE (link it to the newest such
+        // existing) and suppress NOTHING else. The `supersede_targets` (older
+        // existings) are left untouched and stay confirmed=1 — the incoming did
+        // not win against them, so it cannot suppress them.
+        let survivor = expiring_targets
+            .iter()
+            .max_by_key(|c| valid_time(c.event_date, c.created_at))
+            .expect("expiring_targets is non-empty");
+        if let Err(e) = db
+            .resolve_expire_incoming(incoming_source_id, &survivor.source_id)
+            .await
+        {
+            log::warn!("[resolve_dual_pool] expire_incoming failed: {e}");
+        } else {
+            outcome.expired_incoming = true;
+            emit_resolution_event(
+                emitter,
+                "incoming_expired",
+                incoming_source_id,
+                &survivor.source_id,
+            );
+        }
+    }
+
+    // --- Duplicates: file a consolidation proposal, do NOT collapse. ---
+    for idx in decision.duplicates {
+        // Resolve the candidate's source_id from whichever pool the index hits.
+        let dup_id = match index_to_pool(idx, a_len, b_len) {
+            Some(Pool::A) => pool_a.get(idx).map(|c| c.source_id.clone()),
+            Some(Pool::B) => pool_b_offset(idx, a_len, b_len)
+                .and_then(|o| pool_b.get(o))
+                .map(|c| c.source_id.clone()),
+            None => None,
+        };
+        let Some(dup_id) = dup_id else { continue };
+        let prop_id = format!("ref_dual_{}", uuid::Uuid::new_v4().simple());
+        if let Err(e) = db
+            .insert_refinement_proposal(
+                &prop_id,
+                "consolidate_duplicate",
+                &[incoming_source_id.to_string(), dup_id.clone()],
+                None,
+                0.85,
+            )
+            .await
+        {
+            log::warn!("[resolve_dual_pool] insert dedup proposal failed: {e}");
+            continue;
+        }
+        outcome.dedup_proposals.push(prop_id);
+    }
+
+    Ok(outcome)
+}
+
+/// Render the numbered candidate list for the resolve prompt. Pool A is listed
+/// first (indices `0..a_len`), then a divider, then Pool B
+/// (`a_len..a_len+b_len`). Continuous numbering matches `index_to_pool`.
+fn build_resolution_prompt(
+    incoming_content: &str,
+    pool_a: &[crate::retrieval::resolve::Candidate],
+    pool_b: &[crate::retrieval::resolve::Candidate],
+) -> String {
+    let mut s = String::new();
+    s.push_str("Incoming memory:\n");
+    s.push_str(incoming_content);
+    s.push_str("\n\nCandidates:\n");
+    s.push_str(&format!(
+        "--- DUPLICATES range (indices 0..{}): near-duplicate restatements ---\n",
+        pool_a.len()
+    ));
+    for (i, c) in pool_a.iter().enumerate() {
+        s.push_str(&format!("[{i}] {}\n", c.content));
+    }
+    s.push_str(&format!(
+        "--- CONFLICTS range (indices {}..{}): same topic, possibly-contradicting ---\n",
+        pool_a.len(),
+        pool_a.len() + pool_b.len()
+    ));
+    for (j, c) in pool_b.iter().enumerate() {
+        let idx = pool_a.len() + j;
+        s.push_str(&format!("[{idx}] {}\n", c.content));
+    }
+    s
+}
+
+/// Emit one EventEmitter receipt per resolution mutation so /brief can surface
+/// it for human review. Best-effort; emit failures are swallowed.
+fn emit_resolution_event(
+    emitter: &Arc<dyn crate::events::EventEmitter>,
+    direction: &str,
+    incoming_id: &str,
+    existing_id: &str,
+) {
+    let payload = serde_json::json!({
+        "kind": "dual_pool_resolution",
+        "direction": direction,
+        "incoming": incoming_id,
+        "existing": existing_id,
+    })
+    .to_string();
+    let _ = emitter.emit("memory_resolution", &payload);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -948,6 +1229,1056 @@ mod tests {
         assert_eq!(
             count, 0,
             "no spurious resolve activity for already-awaiting proposal"
+        );
+    }
+
+    // ==================== T14 dual-pool resolution ====================
+
+    use crate::events::EventEmitter;
+    use crate::llm_provider::{LlmBackend, LlmError, LlmProvider, LlmRequest};
+    use crate::prompts::PromptRegistry;
+    use origin_types::sources::RawDocument;
+
+    /// LLM stub returning a fixed canned response (or an error).
+    struct StubLlm {
+        response: Result<String, ()>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for StubLlm {
+        async fn generate(&self, _req: LlmRequest) -> Result<String, LlmError> {
+            self.response
+                .clone()
+                .map_err(|_| LlmError::InferenceFailed("stub".into()))
+        }
+        fn is_available(&self) -> bool {
+            true
+        }
+        fn name(&self) -> &str {
+            "stub"
+        }
+        fn backend(&self) -> LlmBackend {
+            LlmBackend::OnDevice
+        }
+    }
+
+    fn stub_llm(resp: &str) -> Arc<dyn LlmProvider> {
+        Arc::new(StubLlm {
+            response: Ok(resp.to_string()),
+        })
+    }
+
+    /// EventEmitter test double that records every (event, payload) pair.
+    struct RecordingEmitter {
+        events: std::sync::Mutex<Vec<(String, String)>>,
+    }
+    impl RecordingEmitter {
+        fn new() -> Self {
+            Self {
+                events: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn count(&self) -> usize {
+            self.events.lock().unwrap().len()
+        }
+    }
+    impl EventEmitter for RecordingEmitter {
+        fn emit(&self, event: &str, payload: &str) -> anyhow::Result<()> {
+            self.events
+                .lock()
+                .unwrap()
+                .push((event.to_string(), payload.to_string()));
+            Ok(())
+        }
+    }
+
+    /// Insert a confirmed `source='memory'` row through the real upsert path
+    /// (so the embedder fills `embedding`), then patch fields the RawDocument
+    /// path can't set directly (event_date, pinned).
+    #[allow(clippy::too_many_arguments)]
+    async fn seed_memory(
+        db: &MemoryDB,
+        source_id: &str,
+        content: &str,
+        memory_type: &str,
+        domain: Option<&str>,
+        entity_id: Option<&str>,
+        structured_fields: Option<&str>,
+        last_modified: i64,
+        event_date: Option<i64>,
+        pinned: bool,
+        stability: &str,
+    ) {
+        let doc = RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: format!("title-{source_id}"),
+            content: content.to_string(),
+            memory_type: Some(memory_type.to_string()),
+            space: domain.map(|s| s.to_string()),
+            entity_id: entity_id.map(|s| s.to_string()),
+            structured_fields: structured_fields.map(|s| s.to_string()),
+            confirmed: Some(true),
+            stability: Some(stability.to_string()),
+            last_modified,
+            ..Default::default()
+        };
+        db.upsert_documents(vec![doc]).await.unwrap();
+        // confirmed=1 is needed for build_resolution_pools; upsert may store the
+        // caller-supplied confirmed but force it deterministically here.
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET confirmed = 1, pinned = ?1, event_date = ?2 \
+             WHERE source_id = ?3 AND source = 'memory'",
+            libsql::params![if pinned { 1_i64 } else { 0_i64 }, event_date, source_id],
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn confirmed_of(db: &MemoryDB, source_id: &str) -> i64 {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT confirmed FROM memories WHERE source_id = ?1 AND source = 'memory' LIMIT 1",
+                libsql::params![source_id],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        row.get::<i64>(0).unwrap()
+    }
+
+    async fn supersedes_of(db: &MemoryDB, source_id: &str) -> Option<String> {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT supersedes FROM memories WHERE source_id = ?1 AND source = 'memory' LIMIT 1",
+                libsql::params![source_id],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        row.get::<Option<String>>(0).unwrap()
+    }
+
+    async fn row_count(db: &MemoryDB) -> i64 {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM memories WHERE source = 'memory'",
+                libsql::params![],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        row.get::<i64>(0).unwrap()
+    }
+
+    fn noop_emitter() -> Arc<dyn EventEmitter> {
+        Arc::new(crate::events::NoopEmitter)
+    }
+
+    // ---- build_resolution_pools (Tests 16-20) ----
+
+    #[tokio::test]
+    async fn test_build_pools_duplicate_in_pool_a() {
+        let (db, _tmp) = test_db().await;
+        // Existing memory.
+        seed_memory(
+            &db,
+            "mem_a",
+            "I use the Rust programming language for backend work",
+            "fact",
+            Some("engineering"),
+            None,
+            None,
+            1000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        // Near-identical incoming memory.
+        seed_memory(
+            &db,
+            "mem_b",
+            "I use the Rust programming language for backend work daily",
+            "fact",
+            Some("engineering"),
+            None,
+            None,
+            2000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_b")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pool_a, pool_b) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        let a_ids: Vec<&str> = pool_a.iter().map(|c| c.source_id.as_str()).collect();
+        assert!(
+            a_ids.contains(&"mem_a"),
+            "near-identical memory should be in Pool A, got A={a_ids:?} B={:?}",
+            pool_b.iter().map(|c| &c.source_id).collect::<Vec<_>>(),
+        );
+        // It is a duplicate, NOT a field-contradiction -> excluded from Pool B.
+        assert!(
+            !pool_b.iter().any(|c| c.source_id == "mem_a"),
+            "duplicate must not also appear in Pool B (disjoint)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_pools_empty_db_returns_empty() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_inc",
+            "totally unique content about quantum widgets",
+            "fact",
+            Some("physics"),
+            None,
+            None,
+            1000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_inc")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pool_a, pool_b) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        assert!(pool_a.is_empty(), "no other memories -> empty Pool A");
+        assert!(pool_b.is_empty(), "no other memories -> empty Pool B");
+    }
+
+    #[tokio::test]
+    async fn test_build_pools_contradiction_in_pool_b() {
+        let (db, _tmp) = test_db().await;
+        // Existing claim.
+        seed_memory(
+            &db,
+            "mem_old",
+            "libSQL is built on top of SQLite",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses SQLite","domain":"databases"}"#),
+            1000,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        // Incoming contradicting claim (same domain, different claim, low sim by
+        // different wording but fields_may_contradict passes).
+        seed_memory(
+            &db,
+            "mem_new",
+            "libSQL is actually based on PostgreSQL internals",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses PostgreSQL","domain":"databases"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_new")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pool_a, pool_b) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        let b_ids: Vec<&str> = pool_b.iter().map(|c| c.source_id.as_str()).collect();
+        assert!(
+            b_ids.contains(&"mem_old"),
+            "contradicting same-domain claim should be in Pool B, got A={:?} B={:?}",
+            pool_a.iter().map(|c| &c.source_id).collect::<Vec<_>>(),
+            b_ids,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_pools_respects_candidate_cap() {
+        let (db, _tmp) = test_db().await;
+        // Seed many near-duplicate memories so Pool A would overflow without the cap.
+        for i in 0..20 {
+            seed_memory(
+                &db,
+                &format!("mem_dup_{i}"),
+                "I really enjoy using the Rust programming language daily",
+                "fact",
+                Some("engineering"),
+                None,
+                None,
+                1000 + i as i64,
+                None,
+                false,
+                "confirmed",
+            )
+            .await;
+        }
+        seed_memory(
+            &db,
+            "mem_probe",
+            "I really enjoy using the Rust programming language daily too",
+            "fact",
+            Some("engineering"),
+            None,
+            None,
+            5000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_probe")
+            .await
+            .unwrap()
+            .unwrap();
+        let cfg = crate::retrieval::resolve::ResolutionConfig::default();
+        let (pool_a, pool_b) = db.build_resolution_pools(&incoming, cfg).await.unwrap();
+        assert!(
+            pool_a.len() + pool_b.len() <= cfg.combined_cap,
+            "combined pools must respect cap {}, got {}",
+            cfg.combined_cap,
+            pool_a.len() + pool_b.len()
+        );
+    }
+
+    // ---- resolve_dual_pool orchestrator (Tests 21-28) ----
+
+    #[tokio::test]
+    async fn test_dual_pool_disabled_by_default() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_x",
+            "some fact",
+            "fact",
+            Some("d"),
+            None,
+            None,
+            1000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let llm = stub_llm(r#"{"duplicates":[],"invalidates":[0]}"#);
+        let emitter = Arc::new(RecordingEmitter::new());
+        let dyn_em: Arc<dyn EventEmitter> = emitter.clone();
+        let prompts = PromptRegistry::default();
+        // Flag unset -> no-op.
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", None::<&str>)], async {
+                resolve_dual_pool(&db, "mem_x", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            outcome,
+            ResolveOutcome::default(),
+            "flag off -> default no-op outcome"
+        );
+        assert_eq!(emitter.count(), 0, "flag off -> no events");
+    }
+
+    #[tokio::test]
+    async fn test_dual_pool_llm_none_noop() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_x",
+            "some fact",
+            "fact",
+            Some("d"),
+            None,
+            None,
+            1000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_x", None, &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(outcome, ResolveOutcome::default(), "no LLM -> no-op");
+    }
+
+    #[tokio::test]
+    async fn test_dual_pool_both_pools_empty_noop() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_solo",
+            "unique content about narwhals",
+            "fact",
+            Some("zoology"),
+            None,
+            None,
+            1000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let llm = stub_llm(r#"{"duplicates":[0],"invalidates":[1]}"#);
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_solo", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            outcome,
+            ResolveOutcome::default(),
+            "both pools empty -> no-op (no LLM action)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_invalidate_existing_soft_suppressed() {
+        let (db, _tmp) = test_db().await;
+        // Existing older claim (event_date=100).
+        seed_memory(
+            &db,
+            "mem_old",
+            "libSQL is built on top of SQLite",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses SQLite","domain":"databases"}"#),
+            1000,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        // Incoming newer contradicting claim (event_date=200).
+        seed_memory(
+            &db,
+            "mem_new",
+            "libSQL is actually based on PostgreSQL internals",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses PostgreSQL","domain":"databases"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+        // LLM marks Pool-B index (a_len + 0) as invalidates. Pool A is empty here
+        // (claims differ enough), so existing lands at index 0.
+        let incoming = db
+            .get_incoming_for_resolution("mem_new")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pa, pb) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        let inval_idx = pa.len(); // first Pool-B index
+        assert!(!pb.is_empty(), "precondition: Pool B has the contradiction");
+        let resp = format!(r#"{{"duplicates":[],"invalidates":[{inval_idx}]}}"#);
+        let llm = stub_llm(&resp);
+        let prompts = PromptRegistry::default();
+        let emitter = Arc::new(RecordingEmitter::new());
+        let dyn_em: Arc<dyn EventEmitter> = emitter.clone();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_new", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            outcome.invalidated,
+            vec!["mem_old".to_string()],
+            "existing should be invalidated"
+        );
+        assert_eq!(
+            confirmed_of(&db, "mem_old").await,
+            0,
+            "existing soft-suppressed (confirmed=0)"
+        );
+        assert_eq!(
+            confirmed_of(&db, "mem_new").await,
+            1,
+            "incoming stays confirmed"
+        );
+        // NOT deleted.
+        assert_eq!(
+            row_count(&db).await,
+            2,
+            "no row deleted -- soft-suppress only"
+        );
+        assert_eq!(
+            supersedes_of(&db, "mem_new").await.as_deref(),
+            Some("mem_old"),
+            "incoming linked as revision-of"
+        );
+        assert_eq!(emitter.count(), 1, "one expiry event emitted");
+    }
+
+    #[tokio::test]
+    async fn test_apply_invalidate_incoming_expired_when_existing_later() {
+        let (db, _tmp) = test_db().await;
+        // Existing has a STRICTLY-LATER valid-time (event_date=300).
+        seed_memory(
+            &db,
+            "mem_existing",
+            "libSQL is built on top of SQLite",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses SQLite","domain":"databases"}"#),
+            1000,
+            Some(300),
+            false,
+            "confirmed",
+        )
+        .await;
+        // Incoming is an out-of-order backfill (event_date=100, older).
+        seed_memory(
+            &db,
+            "mem_incoming",
+            "libSQL is actually based on PostgreSQL internals",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses PostgreSQL","domain":"databases"}"#),
+            2000,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_incoming")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pa, _pb) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        let inval_idx = pa.len();
+        let resp = format!(r#"{{"duplicates":[],"invalidates":[{inval_idx}]}}"#);
+        let llm = stub_llm(&resp);
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_incoming", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert!(
+            outcome.expired_incoming,
+            "incoming should be expired (existing newer)"
+        );
+        assert_eq!(
+            confirmed_of(&db, "mem_incoming").await,
+            0,
+            "incoming soft-suppressed (confirmed=0)"
+        );
+        assert_eq!(
+            confirmed_of(&db, "mem_existing").await,
+            1,
+            "existing untouched, stays confirmed"
+        );
+        assert_eq!(row_count(&db).await, 2, "no deletion");
+    }
+
+    #[tokio::test]
+    async fn test_apply_protected_never_auto_mutated() {
+        let (db, _tmp) = test_db().await;
+        // Existing is PROTECTED (pinned).
+        seed_memory(
+            &db,
+            "mem_prot",
+            "libSQL is built on top of SQLite",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses SQLite","domain":"databases"}"#),
+            1000,
+            Some(100),
+            true,
+            "confirmed",
+        )
+        .await;
+        seed_memory(
+            &db,
+            "mem_inc",
+            "libSQL is actually based on PostgreSQL internals",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses PostgreSQL","domain":"databases"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_inc")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pa, _pb) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        let inval_idx = pa.len();
+        let resp = format!(r#"{{"duplicates":[],"invalidates":[{inval_idx}]}}"#);
+        let llm = stub_llm(&resp);
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_inc", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            confirmed_of(&db, "mem_prot").await,
+            1,
+            "protected existing NEVER auto-suppressed"
+        );
+        assert_eq!(
+            outcome.flagged_for_review,
+            vec!["mem_prot".to_string()],
+            "protected -> flagged for review"
+        );
+        assert_eq!(
+            outcome.invalidated,
+            Vec::<String>::new(),
+            "no auto-invalidation on protected"
+        );
+        // Incoming flagged pending_revision + linked to the protected existing.
+        assert_eq!(
+            supersedes_of(&db, "mem_inc").await.as_deref(),
+            Some("mem_prot")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_duplicate_emits_consolidation_proposal_not_collapse() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_dup",
+            "I use the Rust programming language for all backend services",
+            "fact",
+            Some("engineering"),
+            None,
+            None,
+            1000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        seed_memory(
+            &db,
+            "mem_inc",
+            "I use the Rust programming language for all backend services now",
+            "fact",
+            Some("engineering"),
+            None,
+            None,
+            2000,
+            None,
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_inc")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pa, _pb) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        assert!(!pa.is_empty(), "precondition: near-duplicate is in Pool A");
+        // LLM marks Pool-A index 0 as a duplicate.
+        let llm = stub_llm(r#"{"duplicates":[0],"invalidates":[]}"#);
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let before = row_count(&db).await;
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_inc", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            outcome.dedup_proposals.len(),
+            1,
+            "one consolidation proposal filed"
+        );
+        // BOTH memories remain confirmed, nothing collapsed.
+        assert_eq!(confirmed_of(&db, "mem_dup").await, 1);
+        assert_eq!(confirmed_of(&db, "mem_inc").await, 1);
+        assert_eq!(row_count(&db).await, before, "no rows collapsed");
+        // Proposal exists with the consolidation action.
+        let pending = db.get_pending_refinements().await.unwrap();
+        assert!(
+            pending.iter().any(|p| p.action == "consolidate_duplicate"),
+            "consolidation proposal should be in the queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_apply_empty_arrays_is_noop() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_old",
+            "libSQL is built on top of SQLite",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses SQLite","domain":"databases"}"#),
+            1000,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        seed_memory(
+            &db,
+            "mem_new",
+            "libSQL is actually based on PostgreSQL internals",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses PostgreSQL","domain":"databases"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+        // LLM returns empty arrays -> no action.
+        let llm = stub_llm(r#"{"duplicates":[],"invalidates":[]}"#);
+        let prompts = PromptRegistry::default();
+        let emitter = Arc::new(RecordingEmitter::new());
+        let dyn_em: Arc<dyn EventEmitter> = emitter.clone();
+        let before = row_count(&db).await;
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_new", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            outcome,
+            ResolveOutcome::default(),
+            "empty arrays -> idempotent no-op"
+        );
+        assert_eq!(confirmed_of(&db, "mem_old").await, 1);
+        assert_eq!(confirmed_of(&db, "mem_new").await, 1);
+        assert_eq!(row_count(&db).await, before);
+        assert_eq!(emitter.count(), 0, "no events on no-op");
+    }
+
+    #[tokio::test]
+    async fn test_apply_malformed_llm_is_silent_zero() {
+        let (db, _tmp) = test_db().await;
+        seed_memory(
+            &db,
+            "mem_old",
+            "libSQL is built on top of SQLite",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses SQLite","domain":"databases"}"#),
+            1000,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        seed_memory(
+            &db,
+            "mem_new",
+            "libSQL is actually based on PostgreSQL internals",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"libSQL uses PostgreSQL","domain":"databases"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+        // Garbage LLM output -> silent-zero guard -> no mutation.
+        let llm = stub_llm("the model is confused and returns prose only");
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_new", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            outcome,
+            ResolveOutcome::default(),
+            "malformed LLM -> no mutation (silent-zero)"
+        );
+        assert_eq!(
+            confirmed_of(&db, "mem_old").await,
+            1,
+            "no fact wrongly expired on garbage"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_pools_subtracts_overlap() {
+        let (db, _tmp) = test_db().await;
+        // A memory that is BOTH a near-duplicate (high cosine) AND a
+        // field-contradiction (same domain+type, differing claim) must end up in
+        // Pool A only -- never double-counted in Pool B.
+        seed_memory(
+            &db,
+            "mem_both",
+            "I prefer dark mode in my code editor for long sessions",
+            "fact",
+            Some("preferences"),
+            None,
+            Some(r#"{"claim":"prefers dark mode editor","domain":"preferences"}"#),
+            1000,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        seed_memory(
+            &db,
+            "mem_inc",
+            "I prefer dark mode in my code editor for long sessions now",
+            "fact",
+            Some("preferences"),
+            None,
+            Some(r#"{"claim":"prefers light mode editor","domain":"preferences"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+        let incoming = db
+            .get_incoming_for_resolution("mem_inc")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pool_a, pool_b) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        let in_a = pool_a.iter().any(|c| c.source_id == "mem_both");
+        let in_b = pool_b.iter().any(|c| c.source_id == "mem_both");
+        assert!(in_a, "high-sim row should be in Pool A");
+        assert!(
+            !in_b,
+            "row in Pool A must be subtracted from Pool B (disjoint)"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_invalidate_incoming_expired_does_not_suppress_other_existings() {
+        // Incoming conflicts with TWO existings in OPPOSITE valid-time
+        // directions: existing_A is NEWER than incoming (-> incoming should be
+        // expired), existing_B is OLDER than incoming (-> incoming would
+        // normally supersede it). Because the incoming LOSES to A, it must NOT
+        // suppress B. Regression for the multi-invalidation short-circuit bug.
+        let (db, _tmp) = test_db().await;
+        // existing_A: newer valid-time (event_date=300).
+        seed_memory(
+            &db,
+            "mem_a",
+            "Postgres is my primary production database now",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"primary db is Postgres","domain":"databases"}"#),
+            1000,
+            Some(300),
+            false,
+            "confirmed",
+        )
+        .await;
+        // existing_B: older valid-time (event_date=100).
+        seed_memory(
+            &db,
+            "mem_b",
+            "I rely on MySQL as the main datastore for everything",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"primary db is MySQL","domain":"databases"}"#),
+            1100,
+            Some(100),
+            false,
+            "confirmed",
+        )
+        .await;
+        // incoming: valid-time=200 (between A and B).
+        seed_memory(
+            &db,
+            "mem_inc",
+            "These days SQLite is what I use as the primary database",
+            "fact",
+            Some("databases"),
+            None,
+            Some(r#"{"claim":"primary db is SQLite","domain":"databases"}"#),
+            2000,
+            Some(200),
+            false,
+            "confirmed",
+        )
+        .await;
+
+        let incoming = db
+            .get_incoming_for_resolution("mem_inc")
+            .await
+            .unwrap()
+            .unwrap();
+        let (pa, pb) = db
+            .build_resolution_pools(
+                &incoming,
+                crate::retrieval::resolve::ResolutionConfig::default(),
+            )
+            .await
+            .unwrap();
+        // Both contradicting existings must be in Pool B (precondition).
+        let b_ids: std::collections::HashSet<&str> =
+            pb.iter().map(|c| c.source_id.as_str()).collect();
+        assert!(
+            b_ids.contains("mem_a") && b_ids.contains("mem_b"),
+            "both existings should be in Pool B, got A={:?} B={b_ids:?}",
+            pa.iter().map(|c| &c.source_id).collect::<Vec<_>>(),
+        );
+        // LLM invalidates BOTH Pool-B indices.
+        let idx_a = pa.len() + pb.iter().position(|c| c.source_id == "mem_a").unwrap();
+        let idx_b = pa.len() + pb.iter().position(|c| c.source_id == "mem_b").unwrap();
+        let resp = format!(r#"{{"duplicates":[],"invalidates":[{idx_a},{idx_b}]}}"#);
+        let llm = stub_llm(&resp);
+        let prompts = PromptRegistry::default();
+        let dyn_em = noop_emitter();
+        let outcome =
+            temp_env::async_with_vars([("ORIGIN_ENABLE_DUAL_POOL_RESOLVE", Some("1"))], async {
+                resolve_dual_pool(&db, "mem_inc", Some(&llm), &prompts, &dyn_em)
+                    .await
+                    .unwrap()
+            })
+            .await;
+
+        // Incoming LOST to existing_A (newer) -> expired.
+        assert!(
+            outcome.expired_incoming,
+            "incoming should be expired (existing_A newer)"
+        );
+        assert_eq!(
+            confirmed_of(&db, "mem_inc").await,
+            0,
+            "incoming soft-suppressed"
+        );
+        // existing_A is the winner -> untouched.
+        assert_eq!(
+            confirmed_of(&db, "mem_a").await,
+            1,
+            "newer existing_A stays confirmed"
+        );
+        // existing_B must NOT be suppressed: the incoming lost, so it can't win
+        // against B either. THIS is the bug the fix prevents.
+        assert_eq!(
+            confirmed_of(&db, "mem_b").await,
+            1,
+            "older existing_B must NOT be suppressed by a losing incoming"
+        );
+        assert_eq!(
+            outcome.invalidated,
+            Vec::<String>::new(),
+            "no existing should be invalidated"
+        );
+        // No deletion.
+        assert_eq!(
+            row_count(&db).await,
+            3,
+            "no rows deleted -- soft-suppress only"
         );
     }
 }

--- a/crates/origin-server/src/memory_routes.rs
+++ b/crates/origin-server/src/memory_routes.rs
@@ -921,6 +921,50 @@ pub async fn handle_store_memory(
             {
                 tracing::warn!("[store_memory] post-ingest enrichment failed: {e}");
             }
+
+            // Phase 3 (T14): dual-pool dedup + contradiction resolution.
+            //
+            // Behind `ORIGIN_ENABLE_DUAL_POOL_RESOLVE` (default OFF -> this is a
+            // no-op and the write path is byte-identical). Runs LAST in this
+            // already-spawned task so the `event_date` Phase 1 wrote is visible
+            // for bidirectional temporal expiry. The `state_clone` read guard was
+            // dropped above (line ~755) before any `.await`; `db` + `llm` are the
+            // Arc clones snapshotted there, so no RwLock guard is held across the
+            // `.await` below. Best-effort: log-and-degrade, never blocks the
+            // store ACK (the HTTP 200 already returned before this task ran).
+            if origin_core::db::dual_pool_resolve_enabled() {
+                let resolve_emitter: std::sync::Arc<dyn origin_core::events::EventEmitter> =
+                    std::sync::Arc::new(origin_core::events::NoopEmitter);
+                match origin_core::synthesis::refinement_queue::resolve_dual_pool(
+                    &db,
+                    &source_id_clone,
+                    llm.as_ref(),
+                    &prompts,
+                    &resolve_emitter,
+                )
+                .await
+                {
+                    Ok(outcome) => {
+                        if !outcome.invalidated.is_empty()
+                            || outcome.expired_incoming
+                            || !outcome.flagged_for_review.is_empty()
+                            || !outcome.dedup_proposals.is_empty()
+                        {
+                            tracing::info!(
+                                "[store_memory] dual-pool resolve: invalidated={:?} \
+                                 expired_incoming={} flagged={:?} dedup_proposals={}",
+                                outcome.invalidated,
+                                outcome.expired_incoming,
+                                outcome.flagged_for_review,
+                                outcome.dedup_proposals.len(),
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!("[store_memory] dual-pool resolve failed: {e}");
+                    }
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## What
At write time (opt-in, default OFF), resolve an incoming memory against **Pool A** (near-duplicates, vector ~0.88) + **Pool B** (same-entity/space possibly-contradicting, `fields_may_contradict`) in **ONE LLM call** returning `{duplicates, invalidates}`. Invalidates **soft-suppress the older side** (bidirectional temporal expiry by valid-time = event_date else created_at); duplicates file a consolidation proposal (not collapsed).

## Safety (the silent-wipe class)
- **SOFT-suppress only** — `confirmed=0` + supersedes pointer (DAG, newer→older), **never `DELETE`**.
- **Protected/pinned memories never auto-mutated** — flag `pending_revision` on the incoming instead.
- **Silent-zero parse** — `parse_dual_pool` returns EMPTY on any malformed/missing-key/out-of-range/negative-index output.
- **Self-suppression impossible** (`source_id != incoming` in both pools).
- **Server wire-in** dispatches best-effort async AFTER the store ACK, **dropping the RwLock guard before the `.await`** (never blocks writers for the LLM duration).

## Review caught a data-integrity bug — fixed (better than proposed)
Multi-invalidation: if the incoming conflicts with two existings in opposite time directions, the naive loop wrongly soft-suppressed a *confirmed* existing after the incoming was already expired. Fixed with an **order-independent two-phase classification** (the in-loop guard the review suggested is order-dependent, since Pool B is `last_modified DESC` ≠ `event_date` order): classify all targets, then — if any existing out-dates the incoming, expire the incoming and suppress nothing; else suppress the older existings. New regression test `multi_invalidate_incoming_expired_does_not_suppress_other_existings`.

## Tests + eval
124 tests (26 pure resolve + 34 orchestrator + 64 server + prompts/flag). clippy clean, flag-OFF no-op, full suite green.
**Eval deferred:** write-time, state-mutating, LLM-dependent — cached DBs can't exercise it without re-ingest. Validated by unit tests. T14 of the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)