### PR TITLE
fix(retrieval): opt-in pseudo-relevance feedback retrieval (ORIGIN_PRF_ROUNDS)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -8698,6 +8698,166 @@ impl MemoryDB {
         Ok(merged)
     }
 
+    /// Hybrid search with **pseudo-relevance feedback** (PRF): iterate by
+    /// drafting a short answer from the current top-K retrieved snippets and
+    /// feeding that draft back as the next retrieval query, RRF-merging each
+    /// round's pool until the candidate set converges (no new ids) or the
+    /// `ORIGIN_PRF_ROUNDS` budget (default 0, clamp <= 4) is exhausted.
+    ///
+    /// The original literal query is always RRF round 0, so its `1/(60+rank)`
+    /// floor protects literal hits even when a hallucinated draft drifts
+    /// off-topic. Distinct from `search_memory_expanded` (paraphrases the
+    /// literal query up front, no draft, no loop): PRF reads the retrieved
+    /// *content*, drafts an answer, and iterates.
+    ///
+    /// Graceful degradation: `ORIGIN_PRF_ROUNDS=0`/unset, `llm.is_none()`, an
+    /// LLM timeout/error, or a blank draft all fall back to the round-0 pool,
+    /// never an error. When dark (rounds 0) the output is byte-identical to a
+    /// plain `search_memory`. Each LLM call is wrapped in a 10s
+    /// `tokio::time::timeout` (mirrors `search_memory_expanded`).
+    pub async fn search_memory_prf(
+        &self,
+        query: &str,
+        limit: usize,
+        memory_type: Option<&str>,
+        space: Option<&str>,
+        source_agent: Option<&str>,
+        llm: Option<Arc<dyn crate::llm_provider::LlmProvider>>,
+    ) -> Result<Vec<SearchResult>, OriginError> {
+        use crate::retrieval::prf;
+
+        let rounds = prf::prf_rounds();
+        let fetch_pool = limit * 2;
+
+        // Round 0: the literal query is always the first RRF stream.
+        let round0 = self
+            .search_memory(
+                query,
+                fetch_pool,
+                memory_type,
+                space,
+                source_agent,
+                None,
+                None,
+                None,
+            )
+            .await?;
+        let mut seen = prf::candidate_set(&round0);
+        let mut acc: Vec<Vec<SearchResult>> = vec![round0];
+
+        // Only iterate when both a round budget and an LLM are present. Without
+        // either, PRF is exactly a plain (pool-widened) search of the literal
+        // query — the round-0 stream merged through RRF below.
+        if rounds > 0 {
+            if let Some(ref llm) = llm {
+                for _ in 0..rounds {
+                    // Feedback comes from the round-0 literal-query pool (the
+                    // highest-quality anchor). A fixed-string draft therefore
+                    // converges after one feedback round.
+                    let snippets = prf::feedback_snippets(&acc[0], 5, 200);
+                    if snippets.is_empty() {
+                        break;
+                    }
+                    let req = prf::draft_answer_request(query, &snippets);
+                    let draft_result =
+                        tokio::time::timeout(std::time::Duration::from_secs(10), llm.generate(req))
+                            .await;
+                    let draft = match draft_result {
+                        Ok(Ok(text)) if !text.trim().is_empty() => text,
+                        Ok(Ok(_)) => {
+                            log::warn!("[memory_db] prf: blank draft, stopping (best-so-far)");
+                            break;
+                        }
+                        Ok(Err(e)) => {
+                            log::warn!("[memory_db] prf draft LLM failed: {e}");
+                            break;
+                        }
+                        Err(_) => {
+                            log::warn!("[memory_db] prf draft timed out");
+                            break;
+                        }
+                    };
+
+                    // Retrieve with the draft answer as the next query. A failed
+                    // search is logged and the loop stops with best-so-far.
+                    match self
+                        .search_memory(
+                            &draft,
+                            fetch_pool,
+                            memory_type,
+                            space,
+                            source_agent,
+                            None,
+                            None,
+                            None,
+                        )
+                        .await
+                    {
+                        Ok(hits) => {
+                            let cur = prf::candidate_set(&hits);
+                            acc.push(hits);
+                            if prf::converged(&seen, &cur) {
+                                break;
+                            }
+                            seen.extend(cur);
+                        }
+                        Err(e) => {
+                            log::warn!("[memory_db] prf feedback search failed: {e}");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // If round 0 somehow produced nothing AND no feedback rounds ran, fall
+        // back to a plain search on the original query (mirrors expanded).
+        if acc.iter().all(|r| r.is_empty()) {
+            return self
+                .search_memory(
+                    query,
+                    limit,
+                    memory_type,
+                    space,
+                    source_agent,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+        }
+
+        // RRF merge — verbatim block (mirrors search_memory_expanded /
+        // search_memory_decomposed): each round contributes one equal-weight
+        // stream scored 1/(60 + rank), deduped on result.id.
+        let mut score_map: HashMap<String, f32> = HashMap::new();
+        let mut result_map: HashMap<String, SearchResult> = HashMap::new();
+
+        for ranked in acc {
+            for (rank, result) in ranked.into_iter().enumerate() {
+                let rrf_score = 1.0 / (60.0 + rank as f32);
+                *score_map.entry(result.id.clone()).or_default() += rrf_score;
+                result_map.entry(result.id.clone()).or_insert(result);
+            }
+        }
+
+        let mut merged: Vec<SearchResult> = result_map
+            .into_values()
+            .map(|mut r| {
+                r.score = *score_map.get(&r.id).unwrap_or(&0.0);
+                r
+            })
+            .collect();
+        merged.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        merged.truncate(limit);
+        Ok(merged)
+    }
+
     /// Hybrid search with LLM query *decomposition* BEFORE search.
     ///
     /// Splits a compositional query into independent factual subqueries
@@ -21413,6 +21573,478 @@ pub(crate) mod tests {
                 .iter()
                 .all(|r| r.source_agent.as_deref() == Some("claude-code")),
             "all results should have source_agent=claude-code"
+        );
+    }
+
+    #[tokio::test]
+    async fn diag2_merges() {
+        let (db, _dir) = test_db().await;
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "q1",
+                "astronomy telescope observation distant galaxies nebula",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d1",
+                "astronomy telescope mirror aperture focal length optics",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d2",
+                "galaxies spiral elliptical cosmology redshift expansion",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d3",
+                "telescope mount tracking equatorial astronomy imaging",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d4",
+                "observation distant stars galaxies astronomy spectroscopy",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "e",
+                "photosynthesis chloroplast biology cellular respiration enzyme",
+                "fact",
+                "work",
+                "a",
+            ),
+        ])
+        .await
+        .unwrap();
+        for lim in [3usize, 4, 5] {
+            let p = db
+                .search_memory(
+                    "astronomy telescope galaxies",
+                    lim,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            eprintln!(
+                "DIAG2 plain lim={} -> {:?}",
+                lim,
+                p.iter().map(|r| r.source_id.clone()).collect::<Vec<_>>()
+            );
+        }
+        let d = db
+            .search_memory(
+                "photosynthesis chloroplast biology cellular respiration enzyme",
+                10,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        eprintln!(
+            "DIAG2 draft -> {:?}",
+            d.iter().map(|r| r.source_id.clone()).collect::<Vec<_>>()
+        );
+    }
+
+    // ==================== search_memory_prf (T6: pseudo-relevance feedback) ====================
+
+    // PRF tests read the process-global `ORIGIN_PRF_ROUNDS` via `prf_rounds()`.
+    // `temp_env::async_with_vars` mutates that global, so two PRF tests running
+    // concurrently can corrupt each other's flag mid-`.await`. Serialize them on
+    // a process-local async lock so the flag is stable across each test's awaits
+    // (a `tokio::sync::Mutex` avoids the `await_holding_lock` lint that a
+    // `std::sync::Mutex` would trip).
+    static PRF_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[tokio::test]
+    async fn search_memory_prf_zero_rounds_equals_plain_search() {
+        let _serial = PRF_ENV_LOCK.lock().await;
+        let (db, _dir) = test_db().await;
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "m1",
+                "Favorite color is blue for UI elements",
+                "preference",
+                "personal",
+                "claude-code",
+            ),
+            make_memory_doc(
+                "m2",
+                "Project deadline is next Friday for release",
+                "fact",
+                "work",
+                "chatgpt",
+            ),
+            make_memory_doc(
+                "m3",
+                "The database uses libSQL with vector search",
+                "fact",
+                "work",
+                "cursor",
+            ),
+        ])
+        .await
+        .unwrap();
+
+        let llm: Arc<dyn crate::llm_provider::LlmProvider> =
+            Arc::new(crate::llm_provider::MockProvider::new("a draft answer"));
+
+        let (prf, plain) =
+            temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", None::<&str>)], async {
+                let prf = db
+                    .search_memory_prf("color blue", 10, None, None, None, Some(llm.clone()))
+                    .await
+                    .unwrap();
+                let plain = db
+                    .search_memory("color blue", 10, None, None, None, None, None, None)
+                    .await
+                    .unwrap();
+                (prf, plain)
+            })
+            .await;
+
+        let prf_ids: Vec<&str> = prf.iter().map(|r| r.id.as_str()).collect();
+        let plain_ids: Vec<&str> = plain.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            prf_ids, plain_ids,
+            "ROUNDS unset must be byte-identical (same ids, same order) to plain search"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_memory_prf_no_llm_degrades_to_plain() {
+        let _serial = PRF_ENV_LOCK.lock().await;
+        let (db, _dir) = test_db().await;
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "m1",
+                "Favorite color is blue for UI elements",
+                "preference",
+                "personal",
+                "claude-code",
+            ),
+            make_memory_doc(
+                "m2",
+                "Project deadline is next Friday for release",
+                "fact",
+                "work",
+                "chatgpt",
+            ),
+        ])
+        .await
+        .unwrap();
+
+        let (prf, plain) = temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", Some("2"))], async {
+            let prf = db
+                .search_memory_prf("color blue", 10, None, None, None, None)
+                .await
+                .unwrap();
+            let plain = db
+                .search_memory("color blue", 10, None, None, None, None, None, None)
+                .await
+                .unwrap();
+            (prf, plain)
+        })
+        .await;
+
+        let prf_ids: Vec<&str> = prf.iter().map(|r| r.id.as_str()).collect();
+        let plain_ids: Vec<&str> = plain.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            prf_ids, plain_ids,
+            "llm=None must degrade to plain search even with ROUNDS=2"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_memory_prf_llm_unavailable_degrades() {
+        let _serial = PRF_ENV_LOCK.lock().await;
+        let (db, _dir) = test_db().await;
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "m1",
+                "Favorite color is blue for UI elements",
+                "preference",
+                "personal",
+                "claude-code",
+            ),
+            make_memory_doc(
+                "m2",
+                "Project deadline is next Friday for release",
+                "fact",
+                "work",
+                "chatgpt",
+            ),
+        ])
+        .await
+        .unwrap();
+
+        let llm: Arc<dyn crate::llm_provider::LlmProvider> =
+            Arc::new(crate::llm_provider::MockProvider::unavailable());
+
+        let (prf, plain) = temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", Some("2"))], async {
+            let prf = db
+                .search_memory_prf("color blue", 10, None, None, None, Some(llm.clone()))
+                .await
+                .unwrap();
+            let plain = db
+                .search_memory("color blue", 10, None, None, None, None, None, None)
+                .await
+                .unwrap();
+            (prf, plain)
+        })
+        .await;
+
+        // Every draft returns NotAvailable -> round-0 list survives, loop breaks,
+        // no panic, result equals plain search (log-and-degrade).
+        let prf_ids: Vec<&str> = prf.iter().map(|r| r.id.as_str()).collect();
+        let plain_ids: Vec<&str> = plain.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            prf_ids, plain_ids,
+            "unavailable LLM must degrade to plain search, round-0 survives"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_memory_prf_original_query_floor() {
+        let _serial = PRF_ENV_LOCK.lock().await;
+        let (db, _dir) = test_db().await;
+        // D is a strong literal match for the query.
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "dq",
+                "quantum entanglement physics experiment results",
+                "fact",
+                "work",
+                "claude-code",
+            ),
+            make_memory_doc(
+                "o1",
+                "grocery shopping list for the weekend",
+                "fact",
+                "personal",
+                "chatgpt",
+            ),
+            make_memory_doc(
+                "o2",
+                "car maintenance schedule oil change",
+                "fact",
+                "personal",
+                "cursor",
+            ),
+        ])
+        .await
+        .unwrap();
+
+        // Off-topic draft: should NOT displace the literal hit D (round-0 floor).
+        let llm: Arc<dyn crate::llm_provider::LlmProvider> = Arc::new(
+            crate::llm_provider::MockProvider::new("grocery shopping car maintenance weekend"),
+        );
+
+        let prf = temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", Some("1"))], async {
+            db.search_memory_prf(
+                "quantum entanglement physics",
+                10,
+                None,
+                None,
+                None,
+                Some(llm.clone()),
+            )
+            .await
+            .unwrap()
+        })
+        .await;
+
+        let ids: Vec<&str> = prf.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            ids.contains(&"dq"),
+            "literal hit D must survive an off-topic draft (round-0 1/(60+rank) floor); got {:?}",
+            ids
+        );
+    }
+
+    #[tokio::test]
+    async fn search_memory_prf_converges_early() {
+        let _serial = PRF_ENV_LOCK.lock().await;
+        let (db, _dir) = test_db().await;
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "m1",
+                "Favorite color is blue for UI elements",
+                "preference",
+                "personal",
+                "claude-code",
+            ),
+            make_memory_doc(
+                "m2",
+                "Project deadline is next Friday for release",
+                "fact",
+                "work",
+                "chatgpt",
+            ),
+            make_memory_doc(
+                "m3",
+                "The database uses libSQL with vector search",
+                "fact",
+                "work",
+                "cursor",
+            ),
+        ])
+        .await
+        .unwrap();
+
+        // Fixed draft every call. The draft search returns the same id-set as the
+        // round-0 pool (small corpus), so the first feedback round already
+        // converges (`cur.is_subset(seen)`) and the loop breaks -- ROUNDS=3
+        // accumulates the same streams as ROUNDS=1.
+        let llm: Arc<dyn crate::llm_provider::LlmProvider> = Arc::new(
+            crate::llm_provider::MockProvider::new("database libSQL vector search"),
+        );
+
+        let three = temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", Some("3"))], async {
+            db.search_memory_prf("color blue", 10, None, None, None, Some(llm.clone()))
+                .await
+                .unwrap()
+        })
+        .await;
+        let one = temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", Some("1"))], async {
+            db.search_memory_prf("color blue", 10, None, None, None, Some(llm.clone()))
+                .await
+                .unwrap()
+        })
+        .await;
+
+        // Convergence guarantees the same candidate SET regardless of round
+        // budget. Compare as sets: with two RRF streams some docs tie on summed
+        // 1/(60+rank) score, and `HashMap::into_values()` iteration order makes
+        // the final order of tied docs non-deterministic run-to-run -- an
+        // ordered-vec assertion would be flaky. The set is the real invariant.
+        let three_ids: std::collections::HashSet<&str> =
+            three.iter().map(|r| r.id.as_str()).collect();
+        let one_ids: std::collections::HashSet<&str> = one.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            three_ids, one_ids,
+            "fixed-draft ROUNDS=3 must converge to the same candidate set as ROUNDS=1"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_memory_prf_merges_feedback_hits() {
+        let _serial = PRF_ENV_LOCK.lock().await;
+        let (db, _dir) = test_db().await;
+        // Query matches q1 + 4 astronomy distractors. E (biology) matches the
+        // DRAFT text only -- it is NOT in the literal-query top-`limit`.
+        db.upsert_documents(vec![
+            make_memory_doc(
+                "q1",
+                "astronomy telescope observation distant galaxies nebula",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d1",
+                "astronomy telescope mirror aperture focal length optics",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d2",
+                "galaxies spiral elliptical cosmology redshift expansion",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d3",
+                "telescope mount tracking equatorial astronomy imaging",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "d4",
+                "observation distant stars galaxies astronomy spectroscopy",
+                "fact",
+                "work",
+                "a",
+            ),
+            make_memory_doc(
+                "e",
+                "photosynthesis chloroplast biology cellular respiration enzyme",
+                "fact",
+                "work",
+                "a",
+            ),
+        ])
+        .await
+        .unwrap();
+
+        // Draft = E's exact text -> draft retrieval ranks E #1, pulling it into
+        // the merged top-`limit` that the literal query alone excludes.
+        let llm: Arc<dyn crate::llm_provider::LlmProvider> =
+            Arc::new(crate::llm_provider::MockProvider::new(
+                "photosynthesis chloroplast biology cellular respiration enzyme",
+            ));
+
+        let (prf, plain) = temp_env::async_with_vars([("ORIGIN_PRF_ROUNDS", Some("1"))], async {
+            let prf = db
+                .search_memory_prf(
+                    "astronomy telescope galaxies",
+                    4,
+                    None,
+                    None,
+                    None,
+                    Some(llm.clone()),
+                )
+                .await
+                .unwrap();
+            let plain = db
+                .search_memory(
+                    "astronomy telescope galaxies",
+                    4,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .await
+                .unwrap();
+            (prf, plain)
+        })
+        .await;
+
+        let prf_sids: Vec<&str> = prf.iter().map(|r| r.source_id.as_str()).collect();
+        let plain_sids: Vec<&str> = plain.iter().map(|r| r.source_id.as_str()).collect();
+        assert!(
+            prf_sids.contains(&"e"),
+            "feedback-only doc E must appear in PRF output; got {:?}",
+            prf_sids
+        );
+        assert!(
+            !plain_sids.contains(&"e"),
+            "feedback-only doc E must be ABSENT from plain search (recall expansion); got {:?}",
+            plain_sids
         );
     }
 

--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -9021,16 +9021,18 @@ impl MemoryDB {
     /// round's pool until the candidate set converges (no new ids) or the
     /// `ORIGIN_PRF_ROUNDS` budget (default 0, clamp <= 4) is exhausted.
     ///
-    /// The original literal query is always RRF round 0, so its `1/(60+rank)`
-    /// floor protects literal hits even when a hallucinated draft drifts
-    /// off-topic. Distinct from `search_memory_expanded` (paraphrases the
-    /// literal query up front, no draft, no loop): PRF reads the retrieved
-    /// *content*, drafts an answer, and iterates.
+    /// The original literal query is always RRF round 0, which weights the
+    /// literal query as one equal RRF stream; a strong off-topic draft answer
+    /// can still displace mid-rank literal hits — this is recall expansion, not
+    /// a protection guarantee. Distinct from `search_memory_expanded`
+    /// (paraphrases the literal query up front, no draft, no loop): PRF reads
+    /// the retrieved *content*, drafts an answer, and iterates.
     ///
     /// Graceful degradation: `ORIGIN_PRF_ROUNDS=0`/unset, `llm.is_none()`, an
     /// LLM timeout/error, or a blank draft all fall back to the round-0 pool,
-    /// never an error. When dark (rounds 0) the output is byte-identical to a
-    /// plain `search_memory`. Each LLM call is wrapped in a 10s
+    /// never an error. When dark (rounds 0) the output is id-order-identical to
+    /// a plain `search_memory` (scores are re-derived as `1/(60+rank)`;
+    /// raw_score is not preserved). Each LLM call is wrapped in a 10s
     /// `tokio::time::timeout` (mirrors `search_memory_expanded`).
     pub async fn search_memory_prf(
         &self,

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1609,6 +1609,166 @@ pub async fn run_locomo_eval_expanded(
 }
 
 // ---------------------------------------------------------------------------
+// PRF benchmark runner -- same as run_locomo_eval but uses search_memory_prf
+// ---------------------------------------------------------------------------
+
+/// Same seeding/scoring logic as `run_locomo_eval`, but retrieval uses
+/// `search_memory_prf` (T6 pseudo-relevance feedback): draft an answer from the
+/// top-K retrieved, feed it back as the next query, RRF-merge until convergence.
+/// The round budget is read from `ORIGIN_PRF_ROUNDS` (default 0 = plain search);
+/// the value is stamped into `env.flags` for exact reproducibility.
+///
+/// `#[ignore]`d L7-manual (GPU + Qwen). Validate by `cargo check`; no headline
+/// number is claimed without N>=3 runs + mean±stddev (AGENTS.md Single-run rule).
+pub async fn run_locomo_eval_prf(
+    path: &Path,
+    llm: std::sync::Arc<dyn crate::llm_provider::LlmProvider>,
+) -> Result<LocomoReport, OriginError> {
+    let mut samples = load_locomo(path)?;
+    apply_locomo_limit(&mut samples);
+    let mut conversations = Vec::new();
+    // (category, ndcg_5, ndcg_10, mrr, recall_5, hit_rate_1)
+    let mut all_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_observations(sample);
+
+        // Create ephemeral DB for this conversation
+        let tmp = tempfile::tempdir().map_err(|e| OriginError::Generic(format!("tempdir: {e}")))?;
+        let db = MemoryDB::new(tmp.path(), std::sync::Arc::new(crate::events::NoopEmitter)).await?;
+
+        // Seed all observations as memories
+        let docs: Vec<RawDocument> = memories
+            .iter()
+            .enumerate()
+            .map(|(i, mem)| RawDocument {
+                content: mem.content.clone(),
+                source_id: format!("locomo_{}_obs_{}", sample.sample_id, i),
+                source: "memory".to_string(),
+                title: format!("{} session {}", mem.speaker, mem.session_num),
+                memory_type: Some("fact".to_string()),
+                space: Some("conversation".to_string()),
+                last_modified: chrono::Utc::now().timestamp(),
+                ..Default::default()
+            })
+            .collect();
+        db.upsert_documents(docs).await?;
+
+        // Map dia_id to source_id for relevance judgments
+        let dia_to_source: HashMap<String, String> = memories
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                (
+                    m.dia_id.clone(),
+                    format!("locomo_{}_obs_{}", sample.sample_id, i),
+                )
+            })
+            .collect();
+
+        let mut conv_scores: Vec<(u8, f64, f64, f64, f64, f64)> = Vec::new();
+
+        for qa in &sample.qa {
+            if qa.category == 5 {
+                continue;
+            }
+
+            let results = db
+                .search_memory_prf(&qa.question, 10, None, None, None, Some(llm.clone()))
+                .await?;
+
+            // Build relevance judgments: evidence dia_ids -> source_ids = relevant
+            let relevant_ids: HashSet<String> = qa
+                .evidence
+                .iter()
+                .filter_map(|did| dia_to_source.get(did).cloned())
+                .collect();
+
+            if relevant_ids.is_empty() {
+                continue; // Skip if no mappable evidence
+            }
+
+            let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+
+            // Binary relevance: 1 if in evidence set, 0 otherwise
+            let grades: HashMap<&str, u8> = result_ids
+                .iter()
+                .map(|id| (*id, if relevant_ids.contains(*id) { 1 } else { 0 }))
+                .collect();
+
+            let relevant_set: HashSet<&str> = relevant_ids.iter().map(|s| s.as_str()).collect();
+
+            let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+            let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+            let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+            let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+            let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+
+            conv_scores.push((qa.category, ndcg_5, ndcg_10, mrr_val, recall_5, hr_1));
+            all_scores.push((qa.category, ndcg_5, ndcg_10, mrr_val, recall_5, hr_1));
+            per_case.push(build_locomo_case_result(
+                &qa.question,
+                qa.category,
+                ndcg_5,
+                ndcg_10,
+                mrr_val,
+                recall_5,
+                hr_1,
+            ));
+        }
+
+        // Per-category for this conversation
+        let per_cat = aggregate_by_category(&conv_scores);
+
+        let n = conv_scores.len();
+        conversations.push(LocomoConversationResult {
+            sample_id: sample.sample_id.clone(),
+            memories_seeded: memories.len(),
+            questions_evaluated: n,
+            overall_ndcg_at_10: avg_field(&conv_scores, |s| s.2),
+            overall_mrr: avg_field(&conv_scores, |s| s.3),
+            overall_recall_at_5: avg_field(&conv_scores, |s| s.4),
+            per_category: per_cat,
+        });
+    }
+
+    // Global aggregates
+    let per_cat_agg = aggregate_by_category(&all_scores);
+
+    let mut report = LocomoReport {
+        conversations,
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories: samples.iter().map(|s| extract_observations(s).len()).sum(),
+        per_category_aggregate: per_cat_agg,
+        qa_accuracy: None,
+        baseline: None,
+        env: None,
+        per_case,
+        coverage: None,
+    };
+    let mut env_stamp = build_locomo_env(
+        "prf",
+        path,
+        "search_memory_prf",
+        llm.kind(),
+        &llm.model_id(),
+        None,
+    );
+    // Stamp the round budget so PRF-N baselines are distinguishable + reproducible.
+    env_stamp.flags.push(format!(
+        "prf_rounds={}",
+        crate::retrieval::prf::prf_rounds()
+    ));
+    report.env = Some(env_stamp);
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
 // Gated benchmark runner — clean / noisy / gated comparison
 // ---------------------------------------------------------------------------
 

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1496,6 +1496,151 @@ pub async fn run_longmemeval_eval_expanded(
 }
 
 // ---------------------------------------------------------------------------
+// PRF benchmark runner -- same as run_longmemeval_eval but uses search_memory_prf
+// ---------------------------------------------------------------------------
+
+/// Same seeding/scoring logic as `run_longmemeval_eval`, but retrieval uses
+/// `search_memory_prf` (T6 pseudo-relevance feedback): draft an answer from the
+/// top-K retrieved, feed it back as the next query, RRF-merge until convergence.
+/// The round budget is read from `ORIGIN_PRF_ROUNDS` (default 0 = plain search)
+/// and stamped into `env.flags` for reproducibility.
+///
+/// `#[ignore]`d L7-manual (GPU + Qwen). Validate by `cargo check`; no headline
+/// number is claimed without N>=3 runs + mean±stddev (AGENTS.md Single-run rule).
+pub async fn run_longmemeval_eval_prf(
+    path: &Path,
+    llm: std::sync::Arc<dyn crate::llm_provider::LlmProvider>,
+) -> Result<LongMemEvalReport, OriginError> {
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    // (question_type, ndcg_5, ndcg_10, mrr, recall_5, hit_rate_1)
+    let mut all_scores: Vec<(String, f64, f64, f64, f64, f64)> = Vec::new();
+    let mut per_case: Vec<crate::eval::report::CaseResult> = Vec::new();
+    let mut total_memories: usize = 0;
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+
+        // Create ephemeral DB for this question
+        let tmp = tempfile::tempdir().map_err(|e| OriginError::Generic(format!("tempdir: {e}")))?;
+        let db = MemoryDB::new(tmp.path(), std::sync::Arc::new(crate::events::NoopEmitter)).await?;
+
+        // Seed all extracted memories
+        let docs: Vec<RawDocument> = memories
+            .iter()
+            .map(|mem| {
+                let memory_type = match sample.question_type.as_str() {
+                    "single-session-preference" => "preference",
+                    _ => "fact",
+                };
+                RawDocument {
+                    content: mem.content.clone(),
+                    source_id: memory_source_id(&mem.question_id, mem.session_idx, mem.turn_idx),
+                    source: "memory".to_string(),
+                    title: format!("{} session {}", mem.role, mem.session_idx),
+                    memory_type: Some(memory_type.to_string()),
+                    space: Some("conversation".to_string()),
+                    last_modified: chrono::Utc::now().timestamp(),
+                    ..Default::default()
+                }
+            })
+            .collect();
+        total_memories += docs.len();
+        db.upsert_documents(docs).await?;
+
+        // Build relevance judgments: has_answer turns are relevant
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+
+        if relevant_source_ids.is_empty() {
+            continue; // Skip if no evidence turns
+        }
+
+        // Search with pseudo-relevance feedback
+        let results = db
+            .search_memory_prf(&sample.question, 10, None, None, None, Some(llm.clone()))
+            .await?;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+
+        // Binary relevance grades
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| {
+                (
+                    *id,
+                    if relevant_source_ids.contains(*id) {
+                        1
+                    } else {
+                        0
+                    },
+                )
+            })
+            .collect();
+
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        let ndcg_10 = metrics::ndcg_at_k(&result_ids, &grades, 10);
+        let ndcg_5 = metrics::ndcg_at_k(&result_ids, &grades, 5);
+        let mrr_val = metrics::mrr(&result_ids, &relevant_set);
+        let recall_5 = metrics::recall_at_k(&result_ids, &relevant_set, 5);
+        let hr_1 = metrics::hit_rate_at_k(&result_ids, &relevant_set, 1);
+
+        all_scores.push((
+            sample.question_type.clone(),
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+        per_case.push(build_lme_case_result(
+            &sample.question,
+            &sample.question_type,
+            ndcg_5,
+            ndcg_10,
+            mrr_val,
+            recall_5,
+            hr_1,
+        ));
+    }
+
+    // Aggregate
+    let per_category = aggregate_by_category(&all_scores);
+
+    let mut report = LongMemEvalReport {
+        aggregate_ndcg_at_10: avg_field(&all_scores, |s| s.2),
+        aggregate_mrr: avg_field(&all_scores, |s| s.3),
+        aggregate_recall_at_5: avg_field(&all_scores, |s| s.4),
+        aggregate_hit_rate_at_1: avg_field(&all_scores, |s| s.5),
+        total_questions: all_scores.len(),
+        total_memories,
+        per_category,
+        baseline: None,
+        env: None,
+        per_case,
+        coverage: None,
+    };
+    let mut env_stamp = build_lme_env(
+        "prf",
+        path,
+        "search_memory_prf",
+        llm.kind(),
+        &llm.model_id(),
+        None,
+    );
+    env_stamp.flags.push(format!(
+        "prf_rounds={}",
+        crate::retrieval::prf::prf_rounds()
+    ));
+    report.env = Some(env_stamp);
+    Ok(report)
+}
+
+// ---------------------------------------------------------------------------
 // T4a eval runner — temporal filter with haystack_dates event_date seeding
 // ---------------------------------------------------------------------------
 

--- a/crates/origin-core/src/retrieval/mod.rs
+++ b/crates/origin-core/src/retrieval/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod dedup;
 pub(crate) mod fts_query;
 pub(crate) mod hard_filters;
 pub(crate) mod integrity;
+pub(crate) mod prf;
 pub(crate) mod query_intent;
 pub(crate) mod resolve;
 pub(crate) mod session_diversity;

--- a/crates/origin-core/src/retrieval/prf.rs
+++ b/crates/origin-core/src/retrieval/prf.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Pseudo-relevance feedback (PRF): answer-as-next-query iterative retrieval.
+//!
+//! PRF generates a short *draft answer* from the current top-K retrieved
+//! snippets, then feeds that draft back as the next retrieval query and
+//! RRF-merges the new pool into the accumulated candidate set. The original
+//! literal query is always RRF round 0, so its `1/(60+rank)` floor protects
+//! literal hits even when a hallucinated draft drifts off-topic.
+//!
+//! Distinct from query *expansion* (`search_memory_expanded`): expansion
+//! paraphrases the literal query up front with no draft answer and no loop.
+//! PRF reads the *retrieved content*, drafts an answer, and iterates until the
+//! candidate set converges (no new ids) or the round budget is exhausted.
+//!
+//! All helpers here are pure + synchronous (no DB, no async, no axum/tauri) so
+//! the parse/keying/truncation contracts are unit-tested in isolation. The
+//! async orchestration lives in `db::search_memory_prf`.
+
+use crate::llm_provider::LlmRequest;
+use origin_types::SearchResult;
+use std::collections::HashSet;
+
+/// Hard ceiling on PRF rounds. Matches Cognee's `max_iter` ceiling and bounds
+/// worst-case cost (each round = 1 LLM generate + 1 hybrid search).
+const PRF_ROUNDS_MAX: usize = 4;
+
+const PRF_SYSTEM_PROMPT: &str = "Using ONLY the context below, write a 1-2 sentence direct answer to the question. Do not invent facts. If insufficient, give best partial guess using context terms.";
+
+/// Resolve the PRF round budget from `ORIGIN_PRF_ROUNDS`.
+///
+/// Default `0` (unset, empty, or unparseable) — when `0` the caller skips the
+/// feedback loop entirely and `search_memory_prf` is byte-identical to a plain
+/// `search_memory`. Parsed values are clamped to `<= PRF_ROUNDS_MAX` so an
+/// operator typo cannot blow up latency/cost. Parse failure is the default,
+/// never a panic (mirrors `db::page_channel_limit`'s parse-with-default).
+pub(crate) fn prf_rounds() -> usize {
+    std::env::var("ORIGIN_PRF_ROUNDS")
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(0)
+        .min(PRF_ROUNDS_MAX)
+}
+
+/// Collect the candidate-set keys from a result list, keyed on `r.id` (the
+/// chunk id, matching the RRF dedup key used by `search_memory_*`). Keying on
+/// `id` (not `source_id`) means two chunks of the same document are distinct
+/// candidates, consistent with how the RRF merge dedups.
+pub(crate) fn candidate_set(results: &[SearchResult]) -> HashSet<String> {
+    results.iter().map(|r| r.id.clone()).collect()
+}
+
+/// Convergence test: the loop has converged once the newest feedback round
+/// surfaced no ids the accumulated set didn't already contain — i.e. `cur` is a
+/// subset of `prev`. Boolean subset (not Jaccard) for v1 minimal correctness.
+/// Both-empty returns `true` (empty set is a subset of empty set), so a feedback
+/// round that returns nothing stops the loop instead of spinning.
+pub(crate) fn converged(prev: &HashSet<String>, cur: &HashSet<String>) -> bool {
+    cur.is_subset(prev)
+}
+
+/// Build feedback snippets from the current best result list: take the first
+/// `top_k` non-empty results and truncate each `content` to `max_chars`
+/// characters. Truncation is UTF-8-safe (`chars().take`, never byte-slice per
+/// AGENTS.md) so a multi-byte char at the boundary cannot panic. Empty-content
+/// results are skipped (they contribute no feedback signal).
+pub(crate) fn feedback_snippets(
+    results: &[SearchResult],
+    top_k: usize,
+    max_chars: usize,
+) -> Vec<String> {
+    results
+        .iter()
+        .filter(|r| !r.content.is_empty())
+        .take(top_k)
+        .map(|r| r.content.chars().take(max_chars).collect())
+        .collect()
+}
+
+/// Build the draft-answer LLM request from the original question + feedback
+/// snippets. The draft is FREE TEXT (no JSON parse), which removes the
+/// silent-zero parse-failure class (PR #147) entirely — a degenerate draft is a
+/// blank/whitespace string the caller treats as "no feedback" and degrades.
+///
+/// `max_tokens = 128` (a 1-2 sentence answer) and `temperature = 0.2` (low, to
+/// keep the draft anchored to the context rather than inventing).
+pub(crate) fn draft_answer_request(original: &str, snippets: &[String]) -> LlmRequest {
+    let context = snippets
+        .iter()
+        .map(|s| format!("- {s}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    LlmRequest {
+        system_prompt: Some(PRF_SYSTEM_PROMPT.to_string()),
+        user_prompt: format!("Question: {original}\n\nContext:\n{context}"),
+        max_tokens: 128,
+        temperature: 0.2,
+        label: None,
+        timeout_secs: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sr(id: &str, source_id: &str, content: &str) -> SearchResult {
+        SearchResult {
+            id: id.to_string(),
+            content: content.to_string(),
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: String::new(),
+            url: None,
+            chunk_index: 0,
+            last_modified: 0,
+            score: 0.0,
+            chunk_type: None,
+            language: None,
+            semantic_unit: None,
+            memory_type: None,
+            space: None,
+            source_agent: None,
+            confidence: None,
+            confirmed: None,
+            stability: None,
+            supersedes: None,
+            summary: None,
+            entity_id: None,
+            importance: None,
+            entity_name: None,
+            quality: None,
+            is_archived: false,
+            is_recap: false,
+            structured_fields: None,
+            retrieval_cue: None,
+            source_text: None,
+            raw_score: 0.0,
+            version: 0,
+            pending_revision: false,
+            merged_from: None,
+            last_delta_summary: None,
+        }
+    }
+
+    #[test]
+    fn prf_rounds_defaults_to_zero_when_unset() {
+        temp_env::with_var("ORIGIN_PRF_ROUNDS", None::<&str>, || {
+            assert_eq!(prf_rounds(), 0);
+        });
+    }
+
+    #[test]
+    fn prf_rounds_parses_value() {
+        temp_env::with_var("ORIGIN_PRF_ROUNDS", Some("2"), || {
+            assert_eq!(prf_rounds(), 2);
+        });
+        // parse failure = default 0, never a panic
+        temp_env::with_var("ORIGIN_PRF_ROUNDS", Some("garbage"), || {
+            assert_eq!(prf_rounds(), 0);
+        });
+    }
+
+    #[test]
+    fn prf_rounds_clamps_to_max() {
+        temp_env::with_var("ORIGIN_PRF_ROUNDS", Some("99"), || {
+            assert_eq!(prf_rounds(), 4);
+        });
+    }
+
+    #[test]
+    fn candidate_set_keys_on_id() {
+        // Two results with the SAME source_id but DISTINCT ids must both appear:
+        // proves keying on id, not source_id (matches the RRF dedup key).
+        let results = vec![sr("a", "doc1", "alpha"), sr("b", "doc1", "beta")];
+        let set = candidate_set(&results);
+        let expected: HashSet<String> = ["a", "b"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(set, expected);
+    }
+
+    #[test]
+    fn converged_true_when_no_new_ids() {
+        let s = |xs: &[&str]| -> HashSet<String> { xs.iter().map(|x| x.to_string()).collect() };
+        // cur subset of prev -> converged
+        assert!(converged(&s(&["a", "b", "c"]), &s(&["a", "b"])));
+        // cur has a new id (d) -> not converged
+        assert!(!converged(&s(&["a", "b"]), &s(&["a", "b", "d"])));
+        // both empty -> converged (empty subset of empty)
+        assert!(converged(&s(&[]), &s(&[])));
+    }
+
+    #[test]
+    fn feedback_snippets_truncates_utf8_safe() {
+        // Multi-byte chars (each 'é' is 2 bytes) at a truncation boundary that
+        // lands mid-byte-sequence must NOT panic and must return valid UTF-8.
+        let content = "éééééééééé"; // 10 chars, 20 bytes
+        let results = vec![sr("a", "d", content)];
+        let snippets = feedback_snippets(&results, 5, 3);
+        assert_eq!(snippets.len(), 1);
+        // char-len <= max_chars (NOT byte-len)
+        assert_eq!(snippets[0].chars().count(), 3);
+        assert_eq!(snippets[0], "ééé");
+    }
+
+    #[test]
+    fn feedback_snippets_respects_top_k_and_skips_empty() {
+        let results = vec![
+            sr("a", "d", "alpha"),
+            sr("b", "d", ""), // empty -> skipped
+            sr("c", "d", "gamma"),
+            sr("d", "d", "delta"),
+            sr("e", "d", "epsilon"),
+        ];
+        let snippets = feedback_snippets(&results, 3, 200);
+        // at most 3 non-empty snippets, none empty
+        assert!(snippets.len() <= 3);
+        assert!(snippets.iter().all(|s| !s.is_empty()));
+        // first three NON-EMPTY are alpha, gamma, delta
+        assert_eq!(snippets, vec!["alpha", "gamma", "delta"]);
+    }
+
+    #[test]
+    fn draft_answer_request_contains_question_and_context() {
+        let snippets = vec!["alpha fact".to_string(), "beta fact".to_string()];
+        let req = draft_answer_request("what is the thing?", &snippets);
+        assert!(req.user_prompt.contains("what is the thing?"));
+        assert!(req.user_prompt.contains("alpha fact"));
+        assert!(req.user_prompt.contains("beta fact"));
+        assert_eq!(req.max_tokens, 128);
+        assert_eq!(req.temperature, 0.2);
+        assert!(req.system_prompt.is_some());
+    }
+}

--- a/crates/origin-core/src/retrieval/prf.rs
+++ b/crates/origin-core/src/retrieval/prf.rs
@@ -4,8 +4,9 @@
 //! PRF generates a short *draft answer* from the current top-K retrieved
 //! snippets, then feeds that draft back as the next retrieval query and
 //! RRF-merges the new pool into the accumulated candidate set. The original
-//! literal query is always RRF round 0, so its `1/(60+rank)` floor protects
-//! literal hits even when a hallucinated draft drifts off-topic.
+//! literal query is always RRF round 0, which weights the literal query as one
+//! equal RRF stream; a strong off-topic draft answer can still displace
+//! mid-rank literal hits — this is recall expansion, not a protection guarantee.
 //!
 //! Distinct from query *expansion* (`search_memory_expanded`): expansion
 //! paraphrases the literal query up front with no draft answer and no loop.
@@ -29,8 +30,10 @@ const PRF_SYSTEM_PROMPT: &str = "Using ONLY the context below, write a 1-2 sente
 /// Resolve the PRF round budget from `ORIGIN_PRF_ROUNDS`.
 ///
 /// Default `0` (unset, empty, or unparseable) — when `0` the caller skips the
-/// feedback loop entirely and `search_memory_prf` is byte-identical to a plain
-/// `search_memory`. Parsed values are clamped to `<= PRF_ROUNDS_MAX` so an
+/// feedback loop entirely and `search_memory_prf` is id-order-identical to a
+/// plain `search_memory` when rounds==0 (scores are re-derived as
+/// `1/(60+rank)`; raw_score is not preserved). Parsed values are clamped to
+/// `<= PRF_ROUNDS_MAX` so an
 /// operator typo cannot blow up latency/cost. Parse failure is the default,
 /// never a panic (mirrors `db::page_channel_limit`'s parse-with-default).
 pub(crate) fn prf_rounds() -> usize {


### PR DESCRIPTION
## T6 — Pseudo-Relevance Feedback retrieval (opt-in)

Adds `search_memory_prf` + `retrieval/prf.rs`. Answer-as-next-query iterative retrieval: the draft answer over the top-k round-0 snippets is fed back as an additional RRF stream to expand recall.

**Opt-in, default OFF.** Gated on `ORIGIN_PRF_ROUNDS` (default 0). At 0 rounds (or no LLM), output is id-order-identical to plain `search_memory`. Eval-only; no production route wires it yet.

### Safety
- Every LLM call wrapped in a 10s timeout; timeout/error/blank-draft/no-llm all degrade to the round-0 pool (never error, never silent-zero).
- Round-0 literal query is always RRF stream 0 with a `1/(60+rank)` floor (recall expansion, not a hard protection guarantee — documented honestly).
- Draft capped at 128 tokens (« 512 embedder limit); UTF-8-safe truncation; ROUNDS clamped ≤4.

### Eval honesty
Dedicated `run_{locomo,longmemeval}_eval_prf` runners actually call `search_memory_prf` and stamp `variant=prf` + `prf_rounds=N` into the baseline env — filenames cannot lie. No headline number (single-run = scaffold per AGENTS.md; N≥3 + stddev required for any external claim).

### Review
Adversarial review: no blockers. Fixed 2 doc overclaims (the "byte-identical" and "floor-protects-literal-hits" claims the code/tests contradicted). 14 PRF tests + full origin-core lib suite green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
