### PR TITLE
chore(eval): paired per-query A/B eval apparatus

### DIFF
--- a/analyze_paired.py
+++ b/analyze_paired.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Paired-stats post-processor for the apparatus-v2 per-query JSONL emitter.
+
+Reads `<feature>_<bench>.jsonl` files produced by the `paired_ab_emit` Rust test.
+Each file holds per-query rows for BOTH flag arms (`flag_state` in {off,on}).
+The analyzer joins the OFF and ON arms by `(bench, query_id)` to form per-query
+paired deltas, then computes, per (feature, bench):
+
+  - n_touched: queries where ndcg_on != ndcg_off
+  - mean Δndcg / Δrecall over the TOUCHED subset
+  - Wilcoxon signed-rank p-value (normal approx, tie + continuity corrected)
+  - bootstrap 95% CI of mean Δndcg over ALL paired queries (B=10000, percentile)
+  - per-category mean Δ + n
+  - latency P50/P99 for on vs off + Δ
+  - graph-gate skip rate (fraction of ON-arm queries with graph_skipped=true)
+
+Across the whole family, Benjamini-Hochberg FDR at q=0.10 flags significance.
+
+Pure stdlib (no numpy/scipy). Wilcoxon uses the normal approximation, which is
+adequate for n >= ~10; for tiny n the p-value is conservative/approximate and is
+flagged in the output. Recommendation column:
+
+  FLIP-ON      iff CI_low(Δndcg) > +0.005 AND BH-significant
+                   AND no category mean Δndcg < -cat_se AND latency-neutral
+  RE-SEED-NEEDED  for temporal_filter (self-seeds; see harness note)
+  KEEP-OFF     otherwise
+
+Usage:
+  python3 analyze_paired.py [--dir EVAL_OUT] [--q 0.10] [--boot 10000]
+                            [--json out.json] [--md out.md]
+Defaults: --dir $EVAL_OUT or /tmp/eval_paired, prints markdown to stdout.
+"""
+import argparse
+import glob
+import json
+import math
+import os
+import random
+import statistics
+import sys
+from collections import defaultdict
+
+random.seed(1234)  # reproducible bootstrap
+
+
+def load_rows(path):
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def normal_cdf(x):
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def wilcoxon_signed_rank_p(deltas):
+    """Two-sided Wilcoxon signed-rank p-value via normal approximation.
+
+    Drops zero deltas (standard Wilcoxon). Applies tie correction to the
+    variance and a continuity correction. Returns (p, n_nonzero, W)."""
+    nz = [d for d in deltas if d != 0.0]
+    n = len(nz)
+    if n == 0:
+        return (1.0, 0, 0.0)
+    absd = sorted((abs(d), d) for d in nz)
+    # rank with ties averaged
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and absd[j + 1][0] == absd[i][0]:
+            j += 1
+        avg_rank = (i + 1 + j + 1) / 2.0  # 1-based ranks i..j
+        for k in range(i, j + 1):
+            ranks[k] = avg_rank
+        i = j + 1
+    w_plus = sum(r for r, (_, d) in zip(ranks, absd) if d > 0)
+    w_minus = sum(r for r, (_, d) in zip(ranks, absd) if d < 0)
+    W = min(w_plus, w_minus)
+    mean_w = n * (n + 1) / 4.0
+    # tie correction
+    from collections import Counter
+    tie_counts = Counter(a for a, _ in absd)
+    tie_term = sum(t**3 - t for t in tie_counts.values())
+    var_w = (n * (n + 1) * (2 * n + 1) - tie_term / 2.0) / 24.0
+    if var_w <= 0:
+        return (1.0, n, W)
+    z = (W - mean_w)
+    # continuity correction toward the mean
+    if z < 0:
+        z += 0.5
+    else:
+        z -= 0.5
+    z = z / math.sqrt(var_w)
+    p = 2.0 * normal_cdf(-abs(z))
+    return (min(1.0, p), n, W)
+
+
+def bootstrap_ci_mean(values, B=10000, alpha=0.05):
+    """Percentile bootstrap CI of the mean."""
+    n = len(values)
+    if n == 0:
+        return (float("nan"), float("nan"))
+    means = []
+    for _ in range(B):
+        s = 0.0
+        for _ in range(n):
+            s += values[random.randrange(n)]
+        means.append(s / n)
+    means.sort()
+    lo = means[int((alpha / 2.0) * B)]
+    hi = means[min(B - 1, int((1.0 - alpha / 2.0) * B))]
+    return (lo, hi)
+
+
+def percentile(sorted_vals, p):
+    if not sorted_vals:
+        return float("nan")
+    if len(sorted_vals) == 1:
+        return sorted_vals[0]
+    idx = p / 100.0 * (len(sorted_vals) - 1)
+    lo = int(math.floor(idx))
+    hi = int(math.ceil(idx))
+    if lo == hi:
+        return sorted_vals[lo]
+    frac = idx - lo
+    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+
+
+def benjamini_hochberg(pvals, q=0.10):
+    """Return a set of indices that are significant under BH at level q."""
+    m = len(pvals)
+    if m == 0:
+        return set()
+    order = sorted(range(m), key=lambda i: pvals[i])
+    sig = set()
+    thresh_rank = -1
+    for rank, i in enumerate(order, start=1):
+        if pvals[i] <= (rank / m) * q:
+            thresh_rank = rank
+    if thresh_rank >= 0:
+        for rank, i in enumerate(order, start=1):
+            if rank <= thresh_rank:
+                sig.add(i)
+    return sig
+
+
+def analyze_pair(feature, bench, rows):
+    off = {}
+    on = {}
+    for r in rows:
+        key = r["query_id"]
+        if r["flag_state"] == "off":
+            off[key] = r
+        elif r["flag_state"] == "on":
+            on[key] = r
+    keys = sorted(set(off) & set(on))
+    paired = [(off[k], on[k]) for k in keys]
+    if not paired:
+        return None
+
+    dndcg = [o2["ndcg10"] - o1["ndcg10"] for o1, o2 in paired]
+    drecall = [o2["recall5"] - o1["recall5"] for o1, o2 in paired]
+    dmrr = [o2["mrr"] - o1["mrr"] for o1, o2 in paired]
+
+    touched_idx = [i for i, d in enumerate(dndcg) if d != 0.0]
+    n_touched = len(touched_idx)
+    mean_dndcg_touched = (
+        statistics.fmean(dndcg[i] for i in touched_idx) if touched_idx else 0.0
+    )
+    mean_drecall_touched = (
+        statistics.fmean(drecall[i] for i in touched_idx) if touched_idx else 0.0
+    )
+
+    p, n_nonzero, _ = wilcoxon_signed_rank_p(dndcg)
+    ci_lo, ci_hi = bootstrap_ci_mean(dndcg)
+
+    # per-category
+    cat = defaultdict(list)
+    for (o1, o2), d in zip(paired, dndcg):
+        cat[o1["category"]].append(d)
+    per_cat = {}
+    worst_cat = None
+    worst_cat_mean = 0.0
+    for c, ds in sorted(cat.items()):
+        m = statistics.fmean(ds)
+        se = (statistics.pstdev(ds) / math.sqrt(len(ds))) if len(ds) > 1 else 0.0
+        per_cat[c] = {"n": len(ds), "mean_dndcg": m, "se": se}
+        if m < worst_cat_mean:
+            worst_cat_mean = m
+            worst_cat = c
+
+    # latency
+    lat_off = sorted(o1["latency_ms"] for o1, _ in paired)
+    lat_on = sorted(o2["latency_ms"] for _, o2 in paired)
+    lat = {
+        "p50_off": percentile(lat_off, 50),
+        "p99_off": percentile(lat_off, 99),
+        "p50_on": percentile(lat_on, 50),
+        "p99_on": percentile(lat_on, 99),
+    }
+    lat["d_p50"] = lat["p50_on"] - lat["p50_off"]
+    lat["d_p99"] = lat["p99_on"] - lat["p99_off"]
+
+    # graph-gate skip rate (ON arm)
+    skipped = [1 for _, o2 in paired if o2.get("graph_skipped") is True]
+    skip_rate = (len(skipped) / len(paired)) if paired else 0.0
+    has_skip = any(o2.get("graph_skipped") is not None for _, o2 in paired)
+
+    # T4a per-touched subset: when the ON arm carries a temporal_touched flag,
+    # restrict the delta to the queries whose temporal cue actually fired. The
+    # full-set delta is dominated by no-op queries (~96.6%), so this isolates the
+    # signal the feature can possibly move. Additive — does not change full-set.
+    touched_temporal_idx = [
+        i for i, (_, o2) in enumerate(paired) if o2.get("temporal_touched") is True
+    ]
+    has_temporal = any(o2.get("temporal_touched") is not None for _, o2 in paired)
+    per_touched = None
+    if has_temporal:
+        per_touched = {
+            "n": len(touched_temporal_idx),
+            "mean_dndcg": (
+                statistics.fmean(dndcg[i] for i in touched_temporal_idx)
+                if touched_temporal_idx
+                else 0.0
+            ),
+            "mean_drecall": (
+                statistics.fmean(drecall[i] for i in touched_temporal_idx)
+                if touched_temporal_idx
+                else 0.0
+            ),
+            "mean_dmrr": (
+                statistics.fmean(dmrr[i] for i in touched_temporal_idx)
+                if touched_temporal_idx
+                else 0.0
+            ),
+        }
+
+    return {
+        "feature": feature,
+        "bench": bench,
+        "n_paired": len(paired),
+        "n_touched": n_touched,
+        "n_nonzero_ndcg": n_nonzero,
+        "mean_dndcg_touched": mean_dndcg_touched,
+        "mean_drecall_touched": mean_drecall_touched,
+        "mean_dndcg_all": statistics.fmean(dndcg),
+        "mean_dmrr_all": statistics.fmean(dmrr),
+        "wilcoxon_p": p,
+        "ci95_dndcg_all": [ci_lo, ci_hi],
+        "per_category": per_cat,
+        "worst_category": worst_cat,
+        "worst_category_mean_dndcg": worst_cat_mean,
+        "latency": lat,
+        "graph_skip_rate": skip_rate if has_skip else None,
+        "per_touched_temporal": per_touched,
+    }
+
+
+def recommend(res, bh_sig):
+    if res["feature"] == "temporal_filter":
+        return "RE-SEED-NEEDED"
+    ci_lo = res["ci95_dndcg_all"][0]
+    cat_ok = True
+    for c, info in res["per_category"].items():
+        if info["mean_dndcg"] < -max(info["se"], 1e-9):
+            cat_ok = False
+            break
+    latency_neutral = res["latency"]["d_p99"] <= 5.0  # ms tolerance
+    if ci_lo > 0.005 and bh_sig and cat_ok and latency_neutral:
+        return "FLIP-ON"
+    return "KEEP-OFF"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dir", default=os.environ.get("EVAL_OUT", "/tmp/eval_paired"))
+    ap.add_argument("--q", type=float, default=0.10)
+    ap.add_argument("--boot", type=int, default=10000)
+    ap.add_argument("--json", default=None)
+    ap.add_argument("--md", default=None)
+    args = ap.parse_args()
+
+    files = sorted(glob.glob(os.path.join(args.dir, "*.jsonl")))
+    if not files:
+        print(f"No *.jsonl files in {args.dir}", file=sys.stderr)
+        sys.exit(1)
+
+    results = []
+    for path in files:
+        base = os.path.basename(path)[: -len(".jsonl")]
+        # split feature_bench: bench is last underscore token
+        if "_" not in base:
+            continue
+        feature, bench = base.rsplit("_", 1)
+        rows = load_rows(path)
+        res = analyze_pair(feature, bench, rows)
+        if res:
+            results.append(res)
+
+    # BH FDR across the family (using Δndcg Wilcoxon p)
+    pvals = [r["wilcoxon_p"] for r in results]
+    sig_idx = benjamini_hochberg(pvals, q=args.q)
+    for i, r in enumerate(results):
+        r["bh_significant"] = i in sig_idx
+        r["recommendation"] = recommend(r, r["bh_significant"])
+
+    # markdown table
+    lines = []
+    lines.append(f"# Paired A/B analysis (apparatus v2)\n")
+    lines.append(f"- input dir: `{args.dir}`")
+    lines.append(f"- BH-FDR q = {args.q}, bootstrap B = {args.boot}")
+    lines.append(f"- Wilcoxon = normal approx (tie+continuity corrected); small-n p-values approximate\n")
+    hdr = (
+        "| feature | bench | n | n_touched | meanΔndcg(all) | 95% CI | Wilcoxon p | BH-sig | worst-cat Δ | ΔP99 lat(ms) | skip% | rec |"
+    )
+    sep = "|" + "---|" * 13
+    lines.append(hdr)
+    lines.append(sep)
+    for r in results:
+        ci = r["ci95_dndcg_all"]
+        skip = (
+            f"{100*r['graph_skip_rate']:.0f}%" if r["graph_skip_rate"] is not None else "-"
+        )
+        wc = (
+            f"{r['worst_category']}={r['worst_category_mean_dndcg']:+.4f}"
+            if r["worst_category"]
+            else "-"
+        )
+        lines.append(
+            "| {f} | {b} | {n} | {nt} | {md:+.4f} | [{lo:+.4f},{hi:+.4f}] | {p:.4f} | {sig} | {wc} | {dp99:+.2f} | {skip} | {rec} |".format(
+                f=r["feature"], b=r["bench"], n=r["n_paired"], nt=r["n_touched"],
+                md=r["mean_dndcg_all"], lo=ci[0], hi=ci[1], p=r["wilcoxon_p"],
+                sig="yes" if r["bh_significant"] else "no", wc=wc,
+                dp99=r["latency"]["d_p99"], skip=skip, rec=r["recommendation"],
+            )
+        )
+    # T4a per-touched subset (temporal_filter and any future cue-gated feature):
+    # the full-set delta above averages over mostly-no-op queries, so additionally
+    # report the delta over only the queries whose cue actually fired.
+    touched_results = [r for r in results if r.get("per_touched_temporal") is not None]
+    if touched_results:
+        lines.append("\n## Per-touched subset (temporal cue fired)\n")
+        lines.append(
+            "Delta over only the ON-arm queries whose temporal cue fired "
+            "(`temporal_touched == true`); the full-set table above dilutes this "
+            "with the no-op majority.\n"
+        )
+        lines.append("| feature | bench | n_touched | meanΔndcg | meanΔrecall | meanΔmrr |")
+        lines.append("|" + "---|" * 6)
+        for r in touched_results:
+            pt = r["per_touched_temporal"]
+            lines.append(
+                "| {f} | {b} | {n} | {dn:+.4f} | {dr:+.4f} | {dm:+.4f} |".format(
+                    f=r["feature"], b=r["bench"], n=pt["n"],
+                    dn=pt["mean_dndcg"], dr=pt["mean_drecall"], dm=pt["mean_dmrr"],
+                )
+            )
+
+    md = "\n".join(lines) + "\n"
+    print(md)
+
+    if args.md:
+        with open(args.md, "w") as f:
+            f.write(md)
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"wrote JSON -> {args.json}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/origin-core/src/eval/locomo.rs
+++ b/crates/origin-core/src/eval/locomo.rs
@@ -1068,6 +1068,22 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
     path: &Path,
     reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
 ) -> Result<LocomoReport, OriginError> {
+    // Reproducibility: pin the ungated rerank-pool tuning knobs read raw at
+    // db.rs:8922-8926 (search_memory_cross_rerank) to their production defaults
+    // (compute_rerank_fetch_pool: multiplier=1, floor=10) when unset, so two
+    // cross-rerank baselines with identical env stamps can't silently measure
+    // different pool depths. --test-threads=1 makes process-global set_var safe.
+    if std::env::var_os("RERANK_POOL_MULTIPLIER").is_none() {
+        std::env::set_var("RERANK_POOL_MULTIPLIER", "1");
+    }
+    if std::env::var_os("RERANK_POOL_FLOOR").is_none() {
+        std::env::set_var("RERANK_POOL_FLOOR", "10");
+    }
+    // Threat-2 guard: assert summary_nodes is empty so an accidental future
+    // populate fails loud here instead of silently demoting gold memories via
+    // the global-prelude prepend at db.rs:9268. A missing table reads as zero.
+    crate::eval::paired::assert_summary_nodes_empty(db).await;
+
     let mut samples = load_locomo(path)?;
     apply_locomo_limit(&mut samples);
     let mut conversations = Vec::new();
@@ -1339,9 +1355,105 @@ pub async fn run_locomo_eval_cross_rerank_from_db(
         .flags
         .push(format!("episode_channel={}", episode_state));
     env_stamp.flags.push(format!("fact_channel={}", fact_state));
+    // Record the (now-pinned) rerank-pool knobs so a non-default depth carries
+    // into the env stamp / baseline filename instead of being invisible.
+    env_stamp.flags.push(format!(
+        "rerank_pool=mult{}_floor{}",
+        std::env::var("RERANK_POOL_MULTIPLIER")
+            .as_deref()
+            .unwrap_or("1"),
+        std::env::var("RERANK_POOL_FLOOR")
+            .as_deref()
+            .unwrap_or("10"),
+    ));
     env_stamp.flags.push("scenario_db=consolidated".to_string());
     report.env = Some(env_stamp);
     Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Per-query collector (paired A/B apparatus v2)
+// ---------------------------------------------------------------------------
+
+/// Per-query variant of [`run_locomo_eval_from_db`]. Identical retrieval +
+/// scoring, but emits one [`PerQueryRow`] per evaluated question (with a
+/// wall-clock latency for the `search_memory` call) instead of aggregating.
+///
+/// `feature` / `flag_state` are stamped onto each row for the downstream
+/// paired analyzer. The graph-gate skip decision is recorded per-query so the
+/// T3 "skip work, no recall regression" metric is recoverable.
+pub async fn run_locomo_eval_from_db_collect(
+    db: &MemoryDB,
+    path: &Path,
+    feature: &str,
+    flag_state: &str,
+) -> Result<Vec<crate::eval::paired::PerQueryRow>, OriginError> {
+    use crate::eval::paired::PerQueryRow;
+    use std::time::Instant;
+
+    let mut samples = load_locomo(path)?;
+    apply_locomo_limit(&mut samples);
+    let gate_on = crate::db::graph_gate_enabled();
+    let mut rows: Vec<PerQueryRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_observations(sample);
+        let dia_to_source: HashMap<String, String> = memories
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                (
+                    m.dia_id.clone(),
+                    format!("locomo_{}_obs_{}", sample.sample_id, i),
+                )
+            })
+            .collect();
+
+        for (q_idx, qa) in sample.qa.iter().enumerate() {
+            if qa.category == 5 {
+                continue;
+            }
+            let graph_skipped =
+                gate_on && !crate::retrieval::signals::query_warrants_graph(&qa.question);
+
+            let t0 = Instant::now();
+            let results = db
+                .search_memory(&qa.question, 10, None, None, None, None, None, None)
+                .await?;
+            let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+            let relevant_ids: HashSet<String> = qa
+                .evidence
+                .iter()
+                .filter_map(|did| dia_to_source.get(did).cloned())
+                .collect();
+            if relevant_ids.is_empty() {
+                continue;
+            }
+            let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+            let grades: HashMap<&str, u8> = result_ids
+                .iter()
+                .map(|id| (*id, if relevant_ids.contains(*id) { 1 } else { 0 }))
+                .collect();
+            let relevant_set: HashSet<&str> = relevant_ids.iter().map(|s| s.as_str()).collect();
+
+            rows.push(PerQueryRow {
+                feature: feature.to_string(),
+                bench: "locomo".to_string(),
+                flag_state: flag_state.to_string(),
+                query_id: format!("{}#q{}", sample.sample_id, q_idx),
+                category: qa.category.to_string(),
+                ndcg10: metrics::ndcg_at_k(&result_ids, &grades, 10),
+                recall5: metrics::recall_at_k(&result_ids, &relevant_set, 5),
+                mrr: metrics::mrr(&result_ids, &relevant_set),
+                latency_ms,
+                graph_skipped: if gate_on { Some(graph_skipped) } else { None },
+                temporal_touched: None,
+            });
+        }
+    }
+
+    Ok(rows)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1014,6 +1014,22 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
     path: &Path,
     reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
 ) -> Result<LongMemEvalReport, OriginError> {
+    // Reproducibility: pin the ungated rerank-pool tuning knobs read raw at
+    // db.rs:8922-8926 (search_memory_cross_rerank) to their production defaults
+    // (compute_rerank_fetch_pool: multiplier=1, floor=10) when unset, so two
+    // cross-rerank baselines with identical env stamps can't silently measure
+    // different pool depths. --test-threads=1 makes process-global set_var safe.
+    if std::env::var_os("RERANK_POOL_MULTIPLIER").is_none() {
+        std::env::set_var("RERANK_POOL_MULTIPLIER", "1");
+    }
+    if std::env::var_os("RERANK_POOL_FLOOR").is_none() {
+        std::env::set_var("RERANK_POOL_FLOOR", "10");
+    }
+    // Threat-2 guard: assert summary_nodes is empty so an accidental future
+    // populate fails loud here instead of silently demoting gold memories via
+    // the global-prelude prepend at db.rs:9268. A missing table reads as zero.
+    crate::eval::paired::assert_summary_nodes_empty(db).await;
+
     let mut samples = load_longmemeval(path)?;
     apply_lme_limit(&mut samples);
     // (question_type, ndcg_5, ndcg_10, mrr, recall_5, hit_rate_1)
@@ -1269,6 +1285,17 @@ pub async fn run_longmemeval_eval_cross_rerank_from_db(
         .flags
         .push(format!("episode_channel={}", episode_state));
     env_stamp.flags.push(format!("fact_channel={}", fact_state));
+    // Record the (now-pinned) rerank-pool knobs so a non-default depth carries
+    // into the env stamp / baseline filename instead of being invisible.
+    env_stamp.flags.push(format!(
+        "rerank_pool=mult{}_floor{}",
+        std::env::var("RERANK_POOL_MULTIPLIER")
+            .as_deref()
+            .unwrap_or("1"),
+        std::env::var("RERANK_POOL_FLOOR")
+            .as_deref()
+            .unwrap_or("10"),
+    ));
     env_stamp.flags.push("scenario_db=consolidated".to_string());
     report.env = Some(env_stamp);
     Ok(report)
@@ -1387,6 +1414,151 @@ pub async fn run_longmemeval_eval_from_db(
     env_stamp.flags.push("scenario_db=consolidated".to_string());
     report.env = Some(env_stamp);
     Ok(report)
+}
+
+// ---------------------------------------------------------------------------
+// Per-query collector (paired A/B apparatus v2)
+// ---------------------------------------------------------------------------
+
+/// Per-query variant of [`run_longmemeval_eval_from_db`]. Identical retrieval +
+/// scoring, but emits one [`PerQueryRow`] per evaluated question (with a
+/// wall-clock latency for the `search_memory` call) instead of aggregating.
+pub async fn run_longmemeval_eval_from_db_collect(
+    db: &MemoryDB,
+    path: &Path,
+    feature: &str,
+    flag_state: &str,
+) -> Result<Vec<crate::eval::paired::PerQueryRow>, OriginError> {
+    use crate::eval::paired::PerQueryRow;
+    use std::time::Instant;
+
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let gate_on = crate::db::graph_gate_enabled();
+    let mut rows: Vec<PerQueryRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        let graph_skipped =
+            gate_on && !crate::retrieval::signals::query_warrants_graph(&sample.question);
+
+        let t0 = Instant::now();
+        let results = db
+            .search_memory(&sample.question, 10, None, None, None, None, None, None)
+            .await?;
+        let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| (*id, u8::from(relevant_source_ids.contains(*id))))
+            .collect();
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        rows.push(PerQueryRow {
+            feature: feature.to_string(),
+            bench: "lme".to_string(),
+            flag_state: flag_state.to_string(),
+            query_id: sample.question_id.clone(),
+            category: sample.question_type.clone(),
+            ndcg10: metrics::ndcg_at_k(&result_ids, &grades, 10),
+            recall5: metrics::recall_at_k(&result_ids, &relevant_set, 5),
+            mrr: metrics::mrr(&result_ids, &relevant_set),
+            latency_ms,
+            graph_skipped: if gate_on { Some(graph_skipped) } else { None },
+            temporal_touched: None,
+        });
+    }
+
+    Ok(rows)
+}
+
+/// Cross-encoder variant of [`run_longmemeval_eval_from_db_collect`]. Identical
+/// query set + relevance judgments + scoring, but retrieval goes through
+/// `search_memory_cross_rerank` (CE rescoring over the widened pool) instead of
+/// the base `search_memory` path. Pairs OFF (base collector) against ON (this
+/// one) on the same snapshot DB to measure whether the cross-encoder helps.
+///
+/// Pins the ungated rerank-pool knobs (multiplier=1, floor=10) when unset, same
+/// as `run_longmemeval_eval_cross_rerank_from_db`, so the CE pool depth is
+/// reproducible. `--test-threads=1` makes the process-global set_var safe.
+pub async fn run_longmemeval_eval_cross_rerank_from_db_collect(
+    db: &MemoryDB,
+    path: &Path,
+    reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
+    feature: &str,
+    flag_state: &str,
+) -> Result<Vec<crate::eval::paired::PerQueryRow>, OriginError> {
+    use crate::eval::paired::PerQueryRow;
+    use std::time::Instant;
+
+    if std::env::var_os("RERANK_POOL_MULTIPLIER").is_none() {
+        std::env::set_var("RERANK_POOL_MULTIPLIER", "1");
+    }
+    if std::env::var_os("RERANK_POOL_FLOOR").is_none() {
+        std::env::set_var("RERANK_POOL_FLOOR", "10");
+    }
+
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut rows: Vec<PerQueryRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        let t0 = Instant::now();
+        let results = db
+            .search_memory_cross_rerank(
+                &sample.question,
+                10,
+                None,
+                None,
+                None,
+                Some(reranker.clone()),
+            )
+            .await?;
+        let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| (*id, u8::from(relevant_source_ids.contains(*id))))
+            .collect();
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        rows.push(PerQueryRow {
+            feature: feature.to_string(),
+            bench: "lme".to_string(),
+            flag_state: flag_state.to_string(),
+            query_id: sample.question_id.clone(),
+            category: sample.question_type.clone(),
+            ndcg10: metrics::ndcg_at_k(&result_ids, &grades, 10),
+            recall5: metrics::recall_at_k(&result_ids, &relevant_set, 5),
+            mrr: metrics::mrr(&result_ids, &relevant_set),
+            latency_ms,
+            graph_skipped: None,
+            temporal_touched: None,
+        });
+    }
+
+    Ok(rows)
 }
 
 // ---------------------------------------------------------------------------
@@ -1848,6 +2020,118 @@ pub async fn run_longmemeval_eval_temporal(path: &Path) -> Result<LongMemEvalRep
         None,
     ));
     Ok(report)
+}
+
+/// Per-query variant of [`run_longmemeval_eval_temporal`] (T4a). SELF-SEEDS a
+/// fresh ephemeral DB per question (stamps `event_date`), so unlike the cached-DB
+/// collectors this re-runs the write path — runs are reproducible only insofar as
+/// the seeding is deterministic. Emits one [`PerQueryRow`] per question with a
+/// wall-clock latency for the `search_memory_temporal` call.
+pub async fn run_longmemeval_eval_temporal_collect(
+    path: &Path,
+    feature: &str,
+    flag_state: &str,
+) -> Result<Vec<crate::eval::paired::PerQueryRow>, OriginError> {
+    use crate::eval::paired::PerQueryRow;
+    use std::time::Instant;
+
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut rows: Vec<PerQueryRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+
+        let tmp = tempfile::tempdir().map_err(|e| OriginError::Generic(format!("tempdir: {e}")))?;
+        let db = MemoryDB::new(tmp.path(), std::sync::Arc::new(crate::events::NoopEmitter)).await?;
+
+        let docs: Vec<RawDocument> = memories
+            .iter()
+            .map(|mem| {
+                let memory_type = match sample.question_type.as_str() {
+                    "single-session-preference" => "preference",
+                    _ => "fact",
+                };
+                RawDocument {
+                    content: mem.content.clone(),
+                    source_id: memory_source_id(&mem.question_id, mem.session_idx, mem.turn_idx),
+                    source: "memory".to_string(),
+                    title: format!("{} session {}", mem.role, mem.session_idx),
+                    memory_type: Some(memory_type.to_string()),
+                    space: Some("conversation".to_string()),
+                    last_modified: chrono::Utc::now().timestamp(),
+                    ..Default::default()
+                }
+            })
+            .collect();
+        db.upsert_documents(docs).await?;
+
+        {
+            let conn = db.conn.lock().await;
+            for mem in &memories {
+                if let Some(date_str) = sample.haystack_dates.get(mem.session_idx) {
+                    if let Some(ts) = parse_lme_date(date_str).map(|d| d.timestamp()) {
+                        let sid = memory_source_id(&mem.question_id, mem.session_idx, mem.turn_idx);
+                        let _ = conn
+                            .execute(
+                                "UPDATE memories SET event_date = ? WHERE source_id = ?",
+                                libsql::params![ts, sid.as_str()],
+                            )
+                            .await;
+                    }
+                }
+            }
+        }
+
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        let now = parse_lme_date(&sample.question_date).unwrap_or_else(chrono::Utc::now);
+
+        // T4a per-touched: did a high-confidence temporal cue actually fire for
+        // this query? Mirrors the gate in search_memory_temporal (db.rs:8438):
+        // only a High-confidence cue engages the hard temporal filter; None/Low
+        // degrade to plain search and leave this query a no-op. Lets the analyzer
+        // isolate the ~3.4% of queries the feature truly touches.
+        let cue_fired = crate::temporal_query::extract_cue(&sample.question, now)
+            .map(|c| c.confidence == crate::temporal_query::CueConfidence::High)
+            .unwrap_or(false);
+
+        let t0 = Instant::now();
+        let results = db
+            .search_memory_temporal(&sample.question, 10, None, None, None, now)
+            .await?;
+        let latency_ms = t0.elapsed().as_secs_f64() * 1000.0;
+
+        let result_ids: Vec<&str> = results.iter().map(|r| r.source_id.as_str()).collect();
+        let grades: HashMap<&str, u8> = result_ids
+            .iter()
+            .map(|id| (*id, u8::from(relevant_source_ids.contains(*id))))
+            .collect();
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        rows.push(PerQueryRow {
+            feature: feature.to_string(),
+            bench: "lme".to_string(),
+            flag_state: flag_state.to_string(),
+            query_id: sample.question_id.clone(),
+            category: sample.question_type.clone(),
+            ndcg10: metrics::ndcg_at_k(&result_ids, &grades, 10),
+            recall5: metrics::recall_at_k(&result_ids, &relevant_set, 5),
+            mrr: metrics::mrr(&result_ids, &relevant_set),
+            latency_ms,
+            graph_skipped: None,
+            temporal_touched: Some(cue_fired),
+        });
+    }
+
+    Ok(rows)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/origin-core/src/eval/mod.rs
+++ b/crates/origin-core/src/eval/mod.rs
@@ -21,6 +21,7 @@ pub mod locomo;
 pub mod longmemeval;
 pub mod metrics;
 pub mod page_faithfulness;
+pub mod paired;
 pub mod pipeline;
 pub mod report;
 pub mod retrieval;

--- a/crates/origin-core/src/eval/paired.rs
+++ b/crates/origin-core/src/eval/paired.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Per-query emission for paired A/B retrieval evals (validation apparatus v2).
+//!
+//! The aggregate `run_*_eval_from_db` runners are *deterministic* per
+//! `(DB, fixture, flag)` — re-running them gives stddev ≈ 0, which makes a
+//! "run N times, take stddev" protocol vacuous. The statistically valid source
+//! of variance is **across queries**: a paired per-query test (Wilcoxon signed
+//! rank / bootstrap over the per-query Δ) on a single deterministic run.
+//!
+//! These collector runners mirror the scoring loop of their aggregate siblings
+//! but emit one [`PerQueryRow`] per query (with a wall-clock retrieval latency)
+//! instead of only the aggregate. The downstream `analyze_paired.py` joins the
+//! OFF and ON JSONL arms by `(bench, query_id)` and runs the paired stats.
+//!
+//! Scaffolding only — not part of the shipped product surface.
+
+use serde::{Deserialize, Serialize};
+
+/// One query's retrieval metrics for a single flag arm.
+///
+/// Emitted as a JSONL line. The analyzer joins OFF and ON files on
+/// `(bench, query_id)` to form per-query Δ pairs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerQueryRow {
+    /// Feature under test, e.g. `"fts_hardening"`.
+    pub feature: String,
+    /// Bench, e.g. `"locomo"` or `"lme"`.
+    pub bench: String,
+    /// Flag arm: `"off"` or `"on"`.
+    pub flag_state: String,
+    /// Stable per-query id. LoCoMo: `"<sample_id>#q<idx>"`. LME: native `question_id`.
+    pub query_id: String,
+    /// Category bucket (LoCoMo numeric category as string, LME `question_type`).
+    pub category: String,
+    pub ndcg10: f64,
+    pub recall5: f64,
+    pub mrr: f64,
+    /// Wall-clock latency of the retrieval call for this query, milliseconds.
+    pub latency_ms: f64,
+    /// T3 graph-gate only: whether the graph was skipped for this query.
+    /// `None` for features that don't gate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graph_skipped: Option<bool>,
+    /// T4a temporal-filter only: whether a high-confidence temporal cue fired for
+    /// this query (i.e. the temporal hard filter actually engaged). `None` for
+    /// features whose delta is not temporal-cue-gated. Lets the analyzer report a
+    /// per-touched-subset delta instead of a corpus-averaged ~96.6% no-op figure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temporal_touched: Option<bool>,
+}
+
+/// Threat-2 guard for the cross-rerank paired runners: assert the
+/// `summary_nodes` table is empty before scoring.
+///
+/// The global-context prelude (db.rs:9268) PREPENDs `summary_nodes` rows to the
+/// search output. They carry no gold leaf id, so a populated table would push
+/// gold memories down the result list and silently depress recall/ndcg without
+/// any flag flip. The table is empty unless `ORIGIN_ENABLE_GLOBAL_PRELUDE` plus
+/// a populate step ran, so this is a no-op on the default path — but it fails
+/// loud if a future change accidentally seeds it.
+///
+/// A missing `summary_nodes` table reads as zero (the query errors, which we
+/// treat as "absent, fine"); only a positive count trips the assert.
+pub async fn assert_summary_nodes_empty(db: &crate::db::MemoryDB) {
+    let conn = db.conn.lock().await;
+    let count = match conn
+        .query("SELECT COUNT(*) FROM summary_nodes", libsql::params![])
+        .await
+    {
+        Ok(mut rows) => rows
+            .next()
+            .await
+            .ok()
+            .flatten()
+            .and_then(|r| r.get::<i64>(0).ok())
+            .unwrap_or(0),
+        // Missing table (or any read error) -> treat as empty.
+        Err(_) => 0,
+    };
+    assert_eq!(
+        count, 0,
+        "summary_nodes is non-empty ({count} rows): the global-prelude prepend \
+         would silently demote gold memories below the prelude rows; refusing to \
+         emit a misleading paired baseline"
+    );
+}

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -1278,6 +1278,282 @@ async fn graph_gate_ab_lme() {
     );
 }
 
+// ===========================================================================
+// PAIRED A/B EMITTER (validation apparatus v2)
+// ===========================================================================
+//
+// Emits one JSONL file per (feature, bench) under $EVAL_OUT, one line per query
+// per flag arm, with per-query NDCG@10 / recall@5 / MRR + a wall-clock retrieval
+// latency. The aggregate `*_ab_*` tests above are kept intact; this test exposes
+// the per-query data they discard so `analyze_paired.py` can run a paired
+// Wilcoxon / bootstrap (variance from across-queries, not across-runs).
+//
+// Run (unsandboxed, against the SNAPSHOT DBs so the seeds stay pristine):
+//   ORIGIN_EVAL_ROOT=/Users/lucian/Repos/origin/app/eval \
+//   SCENARIO_DB_ROOT=~/.cache/origin-eval/scenario_snapshot \
+//   EVAL_OUT=/tmp/eval_paired \
+//     cargo test -p origin-core --features eval-harness --test eval_harness -- \
+//     --ignored --nocapture --test-threads=1 paired_ab_emit
+//
+// Filter to one feature for a smoke run with $EVAL_PAIRED_ONLY (comma list),
+// e.g. EVAL_PAIRED_ONLY=fts_hardening.
+
+/// Resolve the per-query JSONL output directory ($EVAL_OUT, default a fresh
+/// tmp dir). Created if missing.
+fn paired_out_dir() -> std::path::PathBuf {
+    let dir = std::env::var("EVAL_OUT")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::temp_dir().join("eval_paired"));
+    std::fs::create_dir_all(&dir).expect("create EVAL_OUT dir");
+    dir
+}
+
+/// Append per-query rows to `$EVAL_OUT/<feature>_<bench>.jsonl`.
+fn write_paired_rows(feature: &str, bench: &str, rows: &[origin_core::eval::paired::PerQueryRow]) {
+    use std::io::Write;
+    let path = paired_out_dir().join(format!("{feature}_{bench}.jsonl"));
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .expect("open jsonl");
+    for r in rows {
+        let line = serde_json::to_string(r).expect("serialize PerQueryRow");
+        writeln!(f, "{line}").expect("write jsonl line");
+    }
+    println!("[paired] wrote {} rows -> {}", rows.len(), path.display());
+}
+
+fn paired_feature_selected(feature: &str) -> bool {
+    match std::env::var("EVAL_PAIRED_ONLY") {
+        Ok(only) => only.split(',').map(|s| s.trim()).any(|s| s == feature),
+        Err(_) => true,
+    }
+}
+
+/// Run one cached-DB feature on both benches (LoCoMo + LME via `search_memory`),
+/// OFF then ON, emitting per-query JSONL for each arm.
+async fn paired_run_cached_feature(feature: &str, flag: &str) {
+    use origin_core::eval::locomo::run_locomo_eval_from_db_collect;
+    use origin_core::eval::longmemeval::run_longmemeval_eval_from_db_collect;
+    let root = resolve_scenario_db_root_from_harness();
+
+    // -- LoCoMo --
+    let lo_dir = root.join("locomo_v1");
+    let lo_fx = eval_root().join("data/locomo10.json");
+    if lo_dir.join("origin_memory.db").exists() && lo_fx.exists() {
+        let db = origin_core::db::MemoryDB::new(
+            &lo_dir,
+            std::sync::Arc::new(origin_core::events::NoopEmitter),
+        )
+        .await
+        .expect("open locomo_v1 snapshot DB");
+        for (state, val) in [("off", None::<&str>), ("on", Some("1"))] {
+            let rows = temp_env::async_with_vars(
+                [(flag, val)],
+                run_locomo_eval_from_db_collect(&db, &lo_fx, feature, state),
+            )
+            .await
+            .expect("locomo collect");
+            write_paired_rows(feature, "locomo", &rows);
+        }
+    } else {
+        println!(
+            "[paired:{feature}] SKIP LoCoMo (db {} fixture {})",
+            lo_dir.join("origin_memory.db").exists(),
+            lo_fx.exists()
+        );
+    }
+
+    // -- LME --
+    let lme_dir = root.join("lme_v1");
+    let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+    if lme_dir.join("origin_memory.db").exists() && lme_fx.exists() {
+        let db = origin_core::db::MemoryDB::new(
+            &lme_dir,
+            std::sync::Arc::new(origin_core::events::NoopEmitter),
+        )
+        .await
+        .expect("open lme_v1 snapshot DB");
+        for (state, val) in [("off", None::<&str>), ("on", Some("1"))] {
+            let rows = temp_env::async_with_vars(
+                [(flag, val)],
+                run_longmemeval_eval_from_db_collect(&db, &lme_fx, feature, state),
+            )
+            .await
+            .expect("lme collect");
+            write_paired_rows(feature, "lme", &rows);
+        }
+    } else {
+        println!(
+            "[paired:{feature}] SKIP LME (db {} fixture {})",
+            lme_dir.join("origin_memory.db").exists(),
+            lme_fx.exists()
+        );
+    }
+}
+
+/// Umbrella test: emit per-query paired JSONL for the 7 Track-A features.
+///
+/// Track-A cached-DB features (`search_memory` path): T3 graph-gate, T9 graph-seed,
+/// T12 fts-hardening, T13 magnitude-fusion, T19 query-intent, T20 session-diversity.
+/// Plus T4a temporal-filter (SELF-SEEDS — tagged re-seed; runs only on LME).
+///
+/// NOTE on T20 session-diversity: its cap is wired into the CROSS-RERANK path,
+/// not the base `search_memory` path, so the `search_memory` collector will show
+/// a zero delta for it. It is included here for completeness of the cached-DB
+/// sweep; a non-zero T20 measurement needs a cross-rerank collector (GPU). The
+/// analyzer will correctly report n_touched=0 for T20 on this path.
+#[tokio::test]
+#[ignore = "needs cached scenario DBs (use SNAPSHOT copies); retrieval-only, no GPU. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
+async fn paired_ab_emit() {
+    println!("=== PAIRED A/B EMIT (apparatus v2) ===");
+    println!("EVAL_OUT = {}", paired_out_dir().display());
+
+    // (feature_tag, env_flag) for the cached-DB / search_memory features.
+    let cached: [(&str, &str); 6] = [
+        ("graph_gate", "ORIGIN_ENABLE_GRAPH_GATE"),
+        ("graph_seed", "ORIGIN_ENABLE_GRAPH_SEED"),
+        ("fts_hardening", "ORIGIN_ENABLE_FTS_HARDENING"),
+        ("magnitude_fusion", "ORIGIN_MAGNITUDE_FUSION"),
+        ("query_intent", "ORIGIN_ENABLE_QUERY_INTENT"),
+        ("session_diversity", "ORIGIN_ENABLE_SESSION_DIVERSITY"),
+    ];
+    for (feature, flag) in cached {
+        if !paired_feature_selected(feature) {
+            continue;
+        }
+        println!("--- feature {feature} (flag {flag}) ---");
+        paired_run_cached_feature(feature, flag).await;
+    }
+
+    // T4a temporal-filter: self-seeds, LME only, search_memory_temporal path.
+    if paired_feature_selected("temporal_filter") {
+        use origin_core::eval::longmemeval::run_longmemeval_eval_temporal_collect;
+        println!("--- feature temporal_filter (flag ORIGIN_ENABLE_TEMPORAL_FILTER) [RE-SEED] ---");
+        let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+        if lme_fx.exists() {
+            for (state, val) in [("off", None::<&str>), ("on", Some("1"))] {
+                let rows = temp_env::async_with_vars(
+                    [("ORIGIN_ENABLE_TEMPORAL_FILTER", val)],
+                    run_longmemeval_eval_temporal_collect(&lme_fx, "temporal_filter", state),
+                )
+                .await
+                .expect("temporal collect");
+                write_paired_rows("temporal_filter", "lme", &rows);
+            }
+        } else {
+            println!("[paired:temporal_filter] SKIP LME (fixture missing)");
+        }
+    }
+
+    // T4a temporal-soft-boost: self-seeds, LME only, search_memory_temporal path.
+    // OFF arm = plain baseline (no temporal flag); ON arm = binary in-window score boost.
+    if paired_feature_selected("temporal_soft_boost") {
+        use origin_core::eval::longmemeval::run_longmemeval_eval_temporal_collect;
+        println!("--- feature temporal_soft_boost (flag ORIGIN_ENABLE_TEMPORAL_SOFT_BOOST) [RE-SEED] ---");
+        let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+        if lme_fx.exists() {
+            for (state, val) in [("off", None::<&str>), ("on", Some("1"))] {
+                let rows = temp_env::async_with_vars(
+                    [("ORIGIN_ENABLE_TEMPORAL_SOFT_BOOST", val)],
+                    run_longmemeval_eval_temporal_collect(&lme_fx, "temporal_soft_boost", state),
+                )
+                .await
+                .expect("temporal soft-boost collect");
+                write_paired_rows("temporal_soft_boost", "lme", &rows);
+            }
+        } else {
+            println!("[paired:temporal_soft_boost] SKIP LME (fixture missing)");
+        }
+    }
+
+    println!(
+        "=== PAIRED A/B EMIT done -> run analyze_paired.py on {} ===",
+        paired_out_dir().display()
+    );
+}
+
+/// Paired base-vs-cross-encoder emitter (LME). Measures whether the cross-encoder
+/// reranker improves retrieval over the base `search_memory` path on the SAME
+/// queries + SAME snapshot DB.
+///
+/// OFF arm = base `search_memory` (the `run_longmemeval_eval_from_db_collect`
+/// path). ON arm = `search_memory_cross_rerank` (CE rescoring over the widened
+/// pool). Both write to `$EVAL_OUT/cross_rerank_lme.jsonl`; `analyze_paired.py`
+/// joins by `query_id` and runs the paired Wilcoxon / bootstrap.
+///
+/// First run downloads the BGE-reranker-v2-m3 weights (~600MB) from HuggingFace
+/// and runs on CPU (fastembed ONNX). Pin the subset with `EVAL_LME_LIMIT`.
+///
+/// Run (unsandboxed, against the SNAPSHOT DB so the seed stays pristine):
+///   ORIGIN_EVAL_ROOT=/Users/lucian/Repos/origin/app/eval \
+///   SCENARIO_DB_ROOT=~/.cache/origin-eval/scenario_snapshot \
+///   EVAL_OUT=~/.cache/origin-eval/reranker_out EVAL_LME_LIMIT=50 \
+///     cargo test -p origin-core --features eval-harness --test eval_harness -- \
+///     --ignored --nocapture --test-threads=1 paired_cross_rerank_emit
+#[tokio::test]
+#[ignore = "downloads ~600MB CE model (CPU); needs cached scenario SNAPSHOT DB. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
+async fn paired_cross_rerank_emit() {
+    use origin_core::eval::longmemeval::{
+        run_longmemeval_eval_cross_rerank_from_db_collect, run_longmemeval_eval_from_db_collect,
+    };
+    println!("=== PAIRED CROSS-RERANK EMIT (base vs cross_rerank) ===");
+    println!("EVAL_OUT = {}", paired_out_dir().display());
+
+    let lme_dir = resolve_scenario_db_root_from_harness().join("lme_v1");
+    let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+    if !lme_dir.join("origin_memory.db").exists() || !lme_fx.exists() {
+        println!(
+            "[paired:cross_rerank] SKIP LME (db {} fixture {})",
+            lme_dir.join("origin_memory.db").exists(),
+            lme_fx.exists()
+        );
+        return;
+    }
+
+    let db = origin_core::db::MemoryDB::new(
+        &lme_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open lme_v1 snapshot DB");
+
+    // OFF arm: base search_memory.
+    let off_rows = run_longmemeval_eval_from_db_collect(&db, &lme_fx, "cross_rerank", "off")
+        .await
+        .expect("base collect");
+    write_paired_rows("cross_rerank", "lme", &off_rows);
+    println!("[paired:cross_rerank] OFF (base) rows = {}", off_rows.len());
+
+    // ON arm: cross-encoder rerank. First construction downloads ~600MB + runs on CPU.
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+        .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+    println!(
+        "[paired:cross_rerank] CE model = {} (CPU)",
+        reranker.model_id()
+    );
+    let on_rows = run_longmemeval_eval_cross_rerank_from_db_collect(
+        &db,
+        &lme_fx,
+        reranker,
+        "cross_rerank",
+        "on",
+    )
+    .await
+    .expect("cross_rerank collect");
+    write_paired_rows("cross_rerank", "lme", &on_rows);
+    println!(
+        "[paired:cross_rerank] ON (cross_rerank) rows = {}",
+        on_rows.len()
+    );
+
+    println!(
+        "=== done -> python3 analyze_paired.py --dir {} ===",
+        paired_out_dir().display()
+    );
+}
+
 /// PR-B page-channel ON baseline (LoCoMo).
 ///
 /// Uses the pre-seeded consolidated scenario DB at


### PR DESCRIPTION
## What

Adds the **paired per-query A/B evaluation apparatus** (Track-A measurement spine). Scaffolding only, gated behind the `eval-harness` feature — no shipped product surface.

- `crates/origin-core/src/eval/paired.rs` — `PerQueryRow` JSONL emitter (one row per query per flag arm) + `assert_summary_nodes_empty` guard.
- `crates/origin-core/src/eval/{longmemeval,locomo}.rs` — `from_db` / `cross_rerank` / `temporal` per-query collector runners mirroring the aggregate scoring loops.
- `analyze_paired.py` — joins OFF/ON arms by `(bench, query_id)`; computes Wilcoxon signed-rank p, bootstrap 95% CI of meanΔndcg, Benjamini-Hochberg FDR (q=0.10), per-category meanΔ, P50/P99 latency, graph-gate skip rate; emits `FLIP-ON / KEEP-OFF / RE-SEED-NEEDED` per feature. Pure stdlib.
- `crates/origin-core/tests/eval_harness.rs` — `paired_ab_emit` + `paired_cross_rerank_emit` `#[ignore]`d emitter tests.

## Why

The aggregate `run_*_eval_from_db` runners are **deterministic** per `(DB, fixture, flag)` → re-running gives stddev ≈ 0, making a "run N times, take stddev" protocol vacuous. The statistically valid variance source is **across queries**: a paired signed-rank / bootstrap test over per-query Δ on a single deterministic run. This retires the old N-by-run instruction for Track A.

Two silent-failure guards baked in:
- `assert_summary_nodes_empty` — the T18 global-prelude PREPENDs `summary_nodes` rows carrying no gold leaf id; a populated table would push gold down and silently depress recall/NDCG with no flag flip. Fails loud.
- `temporal_touched` per-query tag — reports the per-touched-subset delta instead of a corpus-averaged ~96.6% no-op figure (the reason the temporal hard-filter read catastrophic on the full set but the soft-boost reads neutral-to-positive).

## Verification

- `cargo check -p origin-core --features eval-harness --tests` — clean.
- `analyze_paired.py` smoke on synthetic paired JSONL → full table + `FLIP-ON` recommendation.

Unblocks the Wave-A paired run (T3 / T4a-softboost / T12 / T13 / T19 / T20) on the cached seeded DBs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)