### PR TITLE
chore(eval): reconcile paired-report latency percentile with latency.rs + lock analyzer stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ src-tauri/
 # Local override for the plugin's MCP runner — typically a symlink to a
 # dev-built origin-mcp binary. See plugin/bin/origin-mcp-runner.sh.
 plugin/bin/origin-mcp.local
+
+# Python bytecode (analyze_paired.py + tests)
+__pycache__/
+*.pyc

--- a/analyze_paired.py
+++ b/analyze_paired.py
@@ -119,17 +119,22 @@ def bootstrap_ci_mean(values, B=10000, alpha=0.05):
 
 
 def percentile(sorted_vals, p):
+    """Nearest-rank percentile matching the production Rust estimator in
+    crates/origin-core/src/eval/latency.rs::latency_summary (the source of truth
+    for P50/P99): floor each sample to integer milliseconds, sort, then pick
+    index ``(n*p - 1) // 100`` (saturating at 0).
+
+    Deliberately NOT linear interpolation. Using the SAME estimator as
+    latency.rs lets this paired report's P50/P99 reconcile with the baseline
+    EvalReport.latency numbers instead of diverging on identical samples — the
+    old linear-interp put P99 strictly below the max at small n (e.g. n=20)
+    while latency.rs returns the max."""
     if not sorted_vals:
         return float("nan")
-    if len(sorted_vals) == 1:
-        return sorted_vals[0]
-    idx = p / 100.0 * (len(sorted_vals) - 1)
-    lo = int(math.floor(idx))
-    hi = int(math.ceil(idx))
-    if lo == hi:
-        return sorted_vals[lo]
-    frac = idx - lo
-    return sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac
+    vals_ms = sorted(int(v) for v in sorted_vals)  # floor to int ms, as latency.rs
+    n = len(vals_ms)
+    idx = max(0, n * p - 1) // 100
+    return vals_ms[min(idx, n - 1)]
 
 
 def benjamini_hochberg(pvals, q=0.10):

--- a/test_analyze_paired.py
+++ b/test_analyze_paired.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Reference tests for analyze_paired.py — the apparatus-v2 stats post-processor.
+
+Locks the decision-gating statistics with hand-computed reference values:
+  - percentile reconciliation against crates/origin-core/src/eval/latency.rs
+  - Benjamini-Hochberg FDR (the gate with no Rust twin)
+  - bootstrap CI of the mean (the FLIP-ON gate keys on its lower bound)
+  - Wilcoxon signed-rank
+
+The analyzer is a manual L7 tool (not in cargo CI), so this is its safety net.
+Pure stdlib. Run before trusting a paired report:
+
+    python3 test_analyze_paired.py
+"""
+import analyze_paired as a
+
+
+def _latency_rs_percentile(samples, p):
+    """Independent re-derivation of latency.rs::latency_summary's index pick:
+    floor to int ms, sort, idx = (n*p - 1)//100 (saturating at 0)."""
+    vals = sorted(int(v) for v in samples)
+    n = len(vals)
+    idx = max(0, n * p - 1) // 100
+    return vals[min(idx, n - 1)]
+
+
+def test_percentile_matches_latency_rs():
+    # n=20, values 1..20 ms: latency.rs P99 -> idx (20*99-1)//100=19 -> max=20;
+    # P50 -> idx 999//100=9 -> sorted[9]=10.
+    vals = sorted(range(1, 21))
+    assert a.percentile(vals, 99) == 20, a.percentile(vals, 99)
+    assert a.percentile(vals, 50) == 10, a.percentile(vals, 50)
+    # n=100, 1..100: P99 idx (9900-1)//100=98 -> 99; P50 idx 4999//100=49 -> 50.
+    vals = sorted(range(1, 101))
+    assert a.percentile(vals, 99) == 99
+    assert a.percentile(vals, 50) == 50
+    # floors to int ms like latency.rs (us/1000 floor): [1.9,2.9] -> [1,2],
+    # P50 idx (2*50-1)//100=0 -> 1.
+    assert a.percentile(sorted([1.9, 2.9]), 50) == 1
+    # n=1
+    assert a.percentile([7.4], 99) == 7
+    # breadth: cross-check against the independent re-derivation over many n.
+    for n in (1, 5, 10, 20, 37, 100, 250):
+        samples = [(i * 7 + 3) % 97 + 0.5 for i in range(n)]
+        for p in (50, 99):
+            assert a.percentile(sorted(samples), p) == _latency_rs_percentile(samples, p), (n, p)
+
+
+def test_percentile_is_not_linear_interp():
+    # Regression guard: the old bug used linear interpolation, which put P99
+    # strictly below the max at small n. Nearest-rank must return the max.
+    vals = sorted(range(1, 21))
+    assert a.percentile(vals, 99) == max(vals)
+
+
+def test_benjamini_hochberg():
+    # Classic BH: p=[.01,.02,.03,.04,.05], q=.05, m=5 -> every rank k passes
+    # p_k <= (k/5)*.05, so all five are significant.
+    assert a.benjamini_hochberg([0.01, 0.02, 0.03, 0.04, 0.05], q=0.05) == {0, 1, 2, 3, 4}
+    # One clear winner, rest null: only index 0 significant at q=0.10.
+    assert a.benjamini_hochberg([0.001, 0.5, 0.5, 0.5, 0.5], q=0.10) == {0}
+    # All large p -> empty.
+    assert a.benjamini_hochberg([0.4, 0.5, 0.6], q=0.10) == set()
+    # Empty input -> empty set.
+    assert a.benjamini_hochberg([], q=0.10) == set()
+    # Step-up property: the largest passing rank rescues lower-ranked indices.
+    # p=[.04,.01], m=2, q=.05: .01<=.025 (rank1) and .04<=.05 (rank2) -> both sig.
+    assert a.benjamini_hochberg([0.04, 0.01], q=0.05) == {0, 1}
+
+
+def test_bootstrap_ci_mean():
+    # Constant sample -> every resample has the same mean -> degenerate CI.
+    # (lo == hi exactly; value ~0.1 modulo float-sum accumulation.)
+    lo, hi = a.bootstrap_ci_mean([0.1] * 30)
+    assert lo == hi and abs(lo - 0.1) < 1e-9, (lo, hi)
+    # Empty -> (nan, nan).
+    lo, hi = a.bootstrap_ci_mean([])
+    assert lo != lo and hi != hi  # nan != nan
+    # Clearly-positive spread: CI lower bound > 0 (deterministic seed).
+    import random
+    random.seed(0)
+    lo, hi = a.bootstrap_ci_mean([0.2, 0.25, 0.3, 0.22, 0.28, 0.26, 0.24] * 5, B=2000)
+    assert lo > 0.0 and hi > lo, (lo, hi)
+
+
+def test_wilcoxon_signed_rank_p():
+    # No differences -> not significant (p == 1.0, n_nonzero == 0).
+    p, n, _ = a.wilcoxon_signed_rank_p([0.0] * 10)
+    assert p == 1.0 and n == 0
+    # Consistent positive shift -> significant (small p).
+    p, n, _ = a.wilcoxon_signed_rank_p(
+        [0.1, 0.2, 0.15, 0.3, 0.25, 0.18, 0.22, 0.27, 0.12, 0.2]
+    )
+    assert n == 10 and p < 0.05, (p, n)
+    # Two-sided: flipping every sign yields the same p (W = min(w+, w-)).
+    deltas = [0.1, -0.05, 0.2, 0.15, -0.03, 0.08, 0.12, 0.3]
+    p_pos, _, _ = a.wilcoxon_signed_rank_p(deltas)
+    p_neg, _, _ = a.wilcoxon_signed_rank_p([-d for d in deltas])
+    assert abs(p_pos - p_neg) < 1e-12
+
+
+def main():
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL {t.__name__}: {e}")
+    if failed:
+        print(f"\n{failed}/{len(tests)} FAILED")
+        raise SystemExit(1)
+    print(f"\nall {len(tests)} passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Follow-up to #241 (the paired apparatus). Two changes, scaffolding-only:

1. **`analyze_paired.py` — reconcile the latency percentile.** The analyzer computed P50/P99 with **linear interpolation** (`idx = p/100·(n−1)`), but the production estimator `crates/origin-core/src/eval/latency.rs::latency_summary` uses **nearest-rank on floored-int ms** (`idx = (n·p−1)//100`). They diverge on identical samples — at n=20, P99 is the max under `latency.rs` but strictly below it under interpolation — so a paired report's latency never reconciled with the baseline `EvalReport.latency` it was meant to be compared against. (There were three percentile impls: `latency.rs` nearest-rank, `eval_harness.rs` + this Python both linear-interp.) `percentile()` now matches `latency.rs`, cited as the source of truth.

2. **`test_analyze_paired.py` — lock the decision-gating stats.** A pure-stdlib reference test for the math that gates FLIP-ON/KEEP-OFF and has no cargo-CI coverage: percentile (reconciliation + a regression guard against linear interp), Benjamini-Hochberg FDR (the gate with no Rust twin), bootstrap CI of the mean (FLIP-ON keys on its lower bound), Wilcoxon signed-rank. `python3 test_analyze_paired.py`.

## Why

Surfaced by a convergence review of the two paired-eval surfaces (`report.rs::paired_mcnemar` vs this apparatus). The latency mismatch is a real latent reconciliation bug; the untested Python stats are the apparatus's biggest risk since they gate flip decisions.

## Scope / deferred

Both paired surfaces are dormant scaffold (not in the live pipeline), so the larger convergence is **deliberately deferred**: porting BH/bootstrap/Wilcoxon into tested Rust beside `paired_mcnemar` (dead code until a Rust analyzer exists), removing the `eval_harness.rs` second percentile copy, and unifying `PerQueryRow`/`CaseResult`. Do those only when a real feature-flip decision is imminent.

## Verification

- `python3 test_analyze_paired.py` → all 5 pass.
- `analyze_paired.py` re-run on the Wave-A LME output: report unchanged (decisions identical; latency ΔP99 now integer ms, e.g. graph_gate −18, graph_seed +12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)