### PR TITLE
fix(provenance): navigable source provenance in Obsidian projection (P1)

### DIFF
--- a/crates/origin-core/src/db.rs
+++ b/crates/origin-core/src/db.rs
@@ -19542,6 +19542,12 @@ impl MemoryDB {
         source_memory_ids: &[&str],
         now: &str,
     ) -> Result<(), OriginError> {
+        // Sanitize daemon-reserved Sources delimiters from client content so
+        // persisted `Page.content` never carries them (symmetric with the
+        // watcher's egress canonicalization). Shadows `content` so both the
+        // INSERT and the wikilink refresh below see the sanitized value.
+        let sanitized_content = crate::export::provenance::sanitize_ingress_content(content);
+        let content: &str = &sanitized_content;
         let source_ids_json = serde_json::to_string(&source_memory_ids)
             .map_err(|e| OriginError::VectorDb(format!("serialize source_memory_ids: {e}")))?;
 
@@ -19875,6 +19881,14 @@ impl MemoryDB {
         require_stale: bool,
         changelog: Option<&str>,
     ) -> Result<bool, OriginError> {
+        // Sanitize daemon-reserved Sources delimiters from client content so
+        // persisted `Page.content` never carries them (symmetric with the
+        // watcher's egress canonicalization). Shadows `content` so both the
+        // UPDATE and the wikilink refresh below see the sanitized value. The
+        // watcher's apply path already passes a canonicalized body, so this is
+        // an idempotent no-op there.
+        let sanitized_content = crate::export::provenance::sanitize_ingress_content(content);
+        let content: &str = &sanitized_content;
         let source_ids_json = serde_json::to_string(&source_memory_ids)
             .map_err(|e| OriginError::VectorDb(format!("serialize source_memory_ids: {e}")))?;
         let now = chrono::Utc::now().to_rfc3339();
@@ -31614,6 +31628,75 @@ pub(crate) mod tests {
 
         // Deleting non-existent ID should not error
         db.delete_page("nonexistent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn insert_page_strips_daemon_sources_delimiters_from_client_content() {
+        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        let content = format!(
+            "## Overview\nReal prose.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_99]]\n{SOURCES_BLOCK_END}\n"
+        );
+        db.insert_page(
+            "page_ingress",
+            "Ingress",
+            None,
+            &content,
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        let stored = db.get_page("page_ingress").await.unwrap().unwrap();
+        assert!(!stored.content.contains(SOURCES_BLOCK_START));
+        assert!(!stored.content.contains(SOURCES_BLOCK_END));
+        assert!(!stored.content.contains("## Sources"));
+        assert!(!stored.content.contains("[[mem_99]]"));
+        assert!(stored.content.contains("Real prose."));
+    }
+
+    #[tokio::test]
+    async fn update_page_content_strips_daemon_sources_delimiters_from_client_content() {
+        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page("page_upd", "Upd", None, "seed", None, None, &[], &now)
+            .await
+            .unwrap();
+        let content = format!(
+            "Updated prose.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_7]]\n{SOURCES_BLOCK_END}\n"
+        );
+        db.update_page_content("page_upd", &content, &[], "manual_edit")
+            .await
+            .unwrap();
+        let stored = db.get_page("page_upd").await.unwrap().unwrap();
+        assert!(!stored.content.contains(SOURCES_BLOCK_START));
+        assert!(!stored.content.contains(SOURCES_BLOCK_END));
+        assert!(!stored.content.contains("## Sources"));
+        assert!(!stored.content.contains("[[mem_7]]"));
+        assert!(stored.content.contains("Updated prose."));
+    }
+
+    #[tokio::test]
+    async fn insert_page_stray_start_delimiter_does_not_truncate_prose() {
+        // Data-loss regression: a lone START token (no matching END) must not
+        // cause the prose after it to be dropped. Both halves must survive and
+        // the delimiter token must be removed.
+        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        let content = format!("prose A {SOURCES_BLOCK_START} prose B");
+        db.insert_page("page_stray", "Stray", None, &content, None, None, &[], &now)
+            .await
+            .unwrap();
+        let stored = db.get_page("page_stray").await.unwrap().unwrap();
+        assert!(stored.content.contains("prose A"));
+        assert!(stored.content.contains("prose B"));
+        assert!(!stored.content.contains(SOURCES_BLOCK_START));
+        assert!(!stored.content.contains(SOURCES_BLOCK_END));
     }
 
     // ---- page_links / wikilink graph ----

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -178,6 +178,14 @@ impl KnowledgeWriter {
     }
 }
 
+/// Public projection of a page's markdown (frontmatter + body + the delimiter
+/// Sources block), so callers outside this module (the watcher's
+/// protected-block re-projection check) can compute the canonical projection
+/// without duplicating it.
+pub fn render_markdown_for(page: &Page) -> String {
+    render_markdown(page)
+}
+
 fn render_markdown(page: &Page) -> String {
     use crate::export::provenance::{
         related_frontmatter, render_sources_block, sources_frontmatter, yaml_quoted,

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -66,6 +66,11 @@ impl KnowledgeWriter {
             log::warn!("[knowledge] stub projection failed for {}: {e}", page.id);
         }
 
+        let mut manifest = crate::export::provenance::StubManifest::load(&self.path);
+        manifest.record(&page.id, &page.source_memory_ids);
+        let _ = manifest.save(&self.path);
+        let _ = crate::export::provenance::gc_orphan_stubs(&self.path, &manifest);
+
         state.pages.insert(
             page.id.clone(),
             PageFileState {
@@ -137,6 +142,11 @@ impl KnowledgeWriter {
                 std::fs::remove_file(&file_path)?;
             }
             self.save_state(&state)?;
+
+            let mut manifest = crate::export::provenance::StubManifest::load(&self.path);
+            manifest.forget_page(page_id);
+            let _ = manifest.save(&self.path);
+            let _ = crate::export::provenance::gc_orphan_stubs(&self.path, &manifest);
         }
 
         Ok(())
@@ -448,6 +458,20 @@ mod tests {
         assert!(!canon.contains("## Sources"));
         // Substring of test_concept()'s actual body text.
         assert!(canon.contains("Rust uses ownership"));
+    }
+
+    #[test]
+    fn stubs_resolve_then_gc_when_page_removed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let writer = KnowledgeWriter::new(dir.path().to_path_buf());
+        let mut page = test_concept();
+        page.source_memory_ids = vec!["mem_x".to_string()];
+        writer.write_page(&page).unwrap();
+        let stub = dir.path().join("_sources").join("mem_x.md");
+        assert!(stub.exists(), "stub projected on write");
+
+        writer.remove_page(&page.id).unwrap();
+        assert!(!stub.exists(), "orphan stub GC'd on page removal");
     }
 
     #[test]

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -57,6 +57,15 @@ impl KnowledgeWriter {
         let content = render_markdown(page);
         std::fs::write(&file_path, &content)?;
 
+        // Project read-only source stubs so [[mem_*]] resolves in Obsidian.
+        if let Err(e) = crate::export::provenance::project_stubs_for_page(
+            &self.path,
+            &page.id,
+            &page.source_memory_ids,
+        ) {
+            log::warn!("[knowledge] stub projection failed for {}: {e}", page.id);
+        }
+
         state.pages.insert(
             page.id.clone(),
             PageFileState {

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -66,6 +66,13 @@ impl KnowledgeWriter {
             log::warn!("[knowledge] stub projection failed for {}: {e}", page.id);
         }
 
+        // Manifest is a cosmetic projection index, updated load-modify-save
+        // without a lock. HTTP page-write handlers can run concurrently with
+        // scheduler distillation, so a lost update is possible — but the blast
+        // radius is one stub and it self-heals: a spuriously-GC'd stub for a
+        // live page is regenerated on that page's next write_page (project runs
+        // before this update), and a leaked orphan is reaped on the next GC. A
+        // real lock is a P2 concern, unjustified for a regenerable nav aid.
         let mut manifest = crate::export::provenance::StubManifest::load(&self.path);
         manifest.record(&page.id, &page.source_memory_ids);
         let _ = manifest.save(&self.path);

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -498,14 +498,11 @@ mod tests {
         let (fm, _body) = crate::sources::obsidian::extract_frontmatter(&md);
         // Frontmatter must NOT have collapsed to empty: origin_id still parses.
         assert_eq!(
-            fm.get_str("origin_id").as_deref(),
+            fm.get_str("origin_id"),
             Some(page.id.as_str()),
             "quote-bearing title collapsed the frontmatter map"
         );
         // And the title round-trips intact.
-        assert_eq!(
-            fm.get_str("title").as_deref(),
-            Some("The \"Real\" Architecture")
-        );
+        assert_eq!(fm.get_str("title"), Some("The \"Real\" Architecture"));
     }
 }

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -180,13 +180,13 @@ impl KnowledgeWriter {
 
 fn render_markdown(page: &Page) -> String {
     use crate::export::provenance::{
-        related_frontmatter, render_sources_block, sources_frontmatter,
+        related_frontmatter, render_sources_block, sources_frontmatter, yaml_quoted,
     };
     let mut out = String::new();
 
     // Frontmatter
     out.push_str("---\n");
-    out.push_str(&format!("title: \"{}\"\n", page.title));
+    out.push_str(&format!("title: {}\n", yaml_quoted(&page.title)));
     if let Some(ref space) = page.space {
         out.push_str(&format!("space: {}\n", space));
     }
@@ -440,5 +440,24 @@ mod tests {
         let md = render_markdown(&page);
         assert!(!md.contains("sources:"));
         assert!(!md.contains(crate::export::provenance::SOURCES_BLOCK_START));
+    }
+
+    #[test]
+    fn render_markdown_escapes_title_so_frontmatter_survives_quotes() {
+        let mut page = test_concept();
+        page.title = "The \"Real\" Architecture".to_string();
+        let md = render_markdown(&page);
+        let (fm, _body) = crate::sources::obsidian::extract_frontmatter(&md);
+        // Frontmatter must NOT have collapsed to empty: origin_id still parses.
+        assert_eq!(
+            fm.get_str("origin_id").as_deref(),
+            Some(page.id.as_str()),
+            "quote-bearing title collapsed the frontmatter map"
+        );
+        // And the title round-trips intact.
+        assert_eq!(
+            fm.get_str("title").as_deref(),
+            Some("The \"Real\" Architecture")
+        );
     }
 }

--- a/crates/origin-core/src/export/knowledge.rs
+++ b/crates/origin-core/src/export/knowledge.rs
@@ -179,6 +179,9 @@ impl KnowledgeWriter {
 }
 
 fn render_markdown(page: &Page) -> String {
+    use crate::export::provenance::{
+        related_frontmatter, render_sources_block, sources_frontmatter,
+    };
     let mut out = String::new();
 
     // Frontmatter
@@ -193,13 +196,37 @@ fn render_markdown(page: &Page) -> String {
     let modified_date: String = page.last_modified.chars().take(10).collect();
     out.push_str(&format!("created: {}\n", created_date));
     out.push_str(&format!("modified: {}\n", modified_date));
+    // Read-only provenance projection (one-way; the watcher never reads it back).
+    out.push_str(&sources_frontmatter(&page.source_memory_ids));
+    let related = related_page_titles(&page.content);
+    out.push_str(&related_frontmatter(&related));
     out.push_str("---\n\n");
 
     // Body with wikilinks
     out.push_str(&convert_links_to_wikilinks(&page.content));
-    out.push('\n');
+
+    // Export-only delimiter-wrapped Sources block, generated from DB truth.
+    let block = render_sources_block(&page.source_memory_ids);
+    if !block.is_empty() {
+        out.push_str("\n\n");
+        out.push_str(&block);
+    } else {
+        out.push('\n');
+    }
 
     out
+}
+
+/// Page-to-page wikilink targets in the body, for the read-only `related:`
+/// frontmatter. `mem_*` targets are excluded — those are provenance, not
+/// topic links.
+fn related_page_titles(content: &str) -> Vec<String> {
+    let wikified = convert_links_to_wikilinks(content);
+    crate::sources::obsidian::extract_wikilinks(&wikified)
+        .into_iter()
+        .map(|w| w.target)
+        .filter(|t| !t.starts_with("mem_"))
+        .collect()
 }
 
 #[cfg(test)]
@@ -383,5 +410,35 @@ mod tests {
         let path = writer.write_page(&page).unwrap();
         let content = std::fs::read_to_string(&path).unwrap();
         assert!(!content.contains("space:"));
+    }
+
+    #[test]
+    fn render_markdown_emits_sources_frontmatter_and_delimiter_block() {
+        let mut page = test_concept();
+        page.source_memory_ids = vec!["mem_1".to_string(), "mem_2".to_string()];
+        let md = render_markdown(&page);
+        // Read-only frontmatter property.
+        assert!(md.contains("sources: [\"[[mem_1]]\", \"[[mem_2]]\"]"));
+        // Delimiter-wrapped Sources block in the body.
+        assert!(md.contains(crate::export::provenance::SOURCES_BLOCK_START));
+        assert!(md.contains(crate::export::provenance::SOURCES_BLOCK_END));
+        assert!(md.contains("## Sources"));
+        // The projected body, run back through the canonicalizer, drops the
+        // generated block — the round-trip invariant the watcher relies on.
+        let (_, body) = crate::sources::obsidian::extract_frontmatter(&md);
+        let canon = crate::export::provenance::canonicalize_page_body(body);
+        assert!(!canon.contains(crate::export::provenance::SOURCES_BLOCK_START));
+        assert!(!canon.contains("## Sources"));
+        // Substring of test_concept()'s actual body text.
+        assert!(canon.contains("Rust uses ownership"));
+    }
+
+    #[test]
+    fn render_markdown_source_less_page_has_no_sources_artifacts() {
+        let mut page = test_concept();
+        page.source_memory_ids = vec![];
+        let md = render_markdown(&page);
+        assert!(!md.contains("sources:"));
+        assert!(!md.contains(crate::export::provenance::SOURCES_BLOCK_START));
     }
 }

--- a/crates/origin-core/src/export/mod.rs
+++ b/crates/origin-core/src/export/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod knowledge;
 pub mod obsidian;
+pub mod provenance;
 
 use crate::error::OriginError;
 use crate::pages::Page;

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -39,6 +39,14 @@ pub fn canonicalize_page_body(body: &str) -> String {
     out.trim_end().to_string()
 }
 
+/// Encode `s` as a YAML-safe double-quoted scalar. A JSON string literal is
+/// a valid YAML flow scalar, so serde_json handles quotes/backslashes/control
+/// chars correctly. Falls back to a naive quote only if JSON encoding fails
+/// (it never does for a String).
+fn yaml_quoted(s: &str) -> String {
+    serde_json::to_string(s).unwrap_or_else(|_| format!("\"{}\"", s.replace('"', "'")))
+}
+
 /// Render the export-only `## Sources` block from a page's cited memory ids.
 /// Returns the empty string when there are no sources (source-less pages get
 /// no block). The block is wrapped in the delimiters so the ingress
@@ -61,13 +69,16 @@ pub fn render_sources_block(source_memory_ids: &[String]) -> String {
 /// Render the read-only `sources:` frontmatter line (quoted wikilinks, which
 /// Obsidian requires for list properties). Empty string when no sources.
 /// PROJECTION-OUT ONLY — the watcher never reads this back.
+// ids are `mem_*`-shaped (no YAML-specials), but they still route through
+// `yaml_quoted` for uniform safety — unlike `related_frontmatter`, which takes
+// untrusted free-text titles where escaping is load-bearing.
 pub fn sources_frontmatter(source_memory_ids: &[String]) -> String {
     if source_memory_ids.is_empty() {
         return String::new();
     }
     let quoted: Vec<String> = source_memory_ids
         .iter()
-        .map(|id| format!("\"[[{id}]]\""))
+        .map(|id| yaml_quoted(&format!("[[{id}]]")))
         .collect();
     format!("sources: [{}]\n", quoted.join(", "))
 }
@@ -80,7 +91,7 @@ pub fn related_frontmatter(related_titles: &[String]) -> String {
     }
     let quoted: Vec<String> = related_titles
         .iter()
-        .map(|t| format!("\"[[{t}]]\""))
+        .map(|t| yaml_quoted(&format!("[[{t}]]")))
         .collect();
     format!("related: [{}]\n", quoted.join(", "))
 }
@@ -164,5 +175,21 @@ mod tests {
         let titles = ["Other Page".to_string()];
         let fm = related_frontmatter(&titles);
         assert_eq!(fm, "related: [\"[[Other Page]]\"]\n");
+    }
+
+    #[test]
+    fn related_frontmatter_escapes_titles_to_valid_yaml() {
+        let titles = ["My \"Quoted\" Page".to_string()];
+        let fm = related_frontmatter(&titles);
+        // The emitted frontmatter block must parse as valid YAML (no map collapse).
+        let yaml = format!("title: x\n{fm}");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml)
+            .expect("frontmatter with a quote-bearing title must be valid YAML");
+        // And the related entry must round-trip to the original wikilink target.
+        let related = parsed
+            .get("related")
+            .and_then(|v| v.as_sequence())
+            .expect("related seq");
+        assert_eq!(related[0].as_str().unwrap(), "[[My \"Quoted\" Page]]");
     }
 }

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -96,11 +96,86 @@ pub fn related_frontmatter(related_titles: &[String]) -> String {
     format!("related: [{}]\n", quoted.join(", "))
 }
 
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 /// Subdir under `knowledge_path` for read-only source stubs. The page_watcher
 /// scans only the top-level `.md` files, so this subdir is never synced back.
 pub const SOURCES_STUB_DIR: &str = "_sources";
+
+/// Maps page_id → the memory ids that page currently cites. Persisted at
+/// `_sources/.manifest.json` so GC knows which stubs are still referenced
+/// across daemon restarts. Only `mem_*` stub files are ever GC'd; user files
+/// under `_sources/` are out of scope.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct StubManifest {
+    pages: HashMap<String, Vec<String>>,
+}
+
+impl StubManifest {
+    pub fn record(&mut self, page_id: &str, source_memory_ids: &[String]) {
+        if source_memory_ids.is_empty() {
+            self.pages.remove(page_id);
+        } else {
+            self.pages
+                .insert(page_id.to_string(), source_memory_ids.to_vec());
+        }
+    }
+
+    pub fn forget_page(&mut self, page_id: &str) {
+        self.pages.remove(page_id);
+    }
+
+    fn cited_ids(&self) -> HashSet<String> {
+        self.pages.values().flatten().cloned().collect()
+    }
+
+    pub fn load(knowledge_path: &Path) -> Self {
+        let p = knowledge_path.join(SOURCES_STUB_DIR).join(".manifest.json");
+        std::fs::read_to_string(&p)
+            .ok()
+            .and_then(|d| serde_json::from_str(&d).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, knowledge_path: &Path) -> std::io::Result<()> {
+        let dir = knowledge_path.join(SOURCES_STUB_DIR);
+        std::fs::create_dir_all(&dir)?;
+        let data = serde_json::to_string_pretty(self).unwrap_or_else(|_| "{}".into());
+        std::fs::write(dir.join(".manifest.json"), data)
+    }
+}
+
+/// Delete `_sources/mem_*.md` stubs no longer cited by any page in `manifest`.
+/// Prefix-scoped to `mem_` (after sanitization): user-created files and the
+/// manifest itself are never touched.
+pub fn gc_orphan_stubs(knowledge_path: &Path, manifest: &StubManifest) -> std::io::Result<()> {
+    let dir = knowledge_path.join(SOURCES_STUB_DIR);
+    if !dir.exists() {
+        return Ok(());
+    }
+    let cited: HashSet<String> = manifest
+        .cited_ids()
+        .iter()
+        .map(|id| stub_filename(id))
+        .collect();
+    for entry in std::fs::read_dir(&dir)?.flatten() {
+        let path = entry.path();
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        // Only ever GC sanitized mem_ stub files; leave user files + manifest.
+        if !name.starts_with("mem_") || !name.ends_with(".md") {
+            continue;
+        }
+        if !cited.contains(name) {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+    Ok(())
+}
 
 /// Map a memory id to a filesystem/wikilink-safe token. Ids already matching
 /// `[A-Za-z0-9_-]+` (all stored Origin `mem_<uuid>` ids) pass through
@@ -284,5 +359,53 @@ mod tests {
         // Stub identifies the memory and is marked a read-only projection.
         assert!(body.contains("mem_1"));
         assert!(body.contains("read-only"));
+    }
+
+    #[test]
+    fn gc_removes_orphan_mem_stubs_keeps_still_cited() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // page_a cites mem_1, mem_2; page_b cites mem_2.
+        let mut manifest = StubManifest::default();
+        manifest.record("page_a", &["mem_1".to_string(), "mem_2".to_string()]);
+        manifest.record("page_b", &["mem_2".to_string()]);
+        project_stubs_for_page(
+            dir.path(),
+            "page_a",
+            &["mem_1".to_string(), "mem_2".to_string()],
+        )
+        .unwrap();
+        project_stubs_for_page(dir.path(), "page_b", &["mem_2".to_string()]).unwrap();
+
+        // page_a re-projected, now citing only mem_1 → mem_2 still cited by page_b.
+        manifest.record("page_a", &["mem_1".to_string()]);
+        gc_orphan_stubs(dir.path(), &manifest).unwrap();
+        assert!(dir.path().join("_sources").join("mem_1.md").exists());
+        assert!(dir.path().join("_sources").join("mem_2.md").exists());
+
+        // page_b drops mem_2 entirely → mem_2 now orphan → GC removes it.
+        manifest.record("page_b", &[]);
+        gc_orphan_stubs(dir.path(), &manifest).unwrap();
+        assert!(dir.path().join("_sources").join("mem_1.md").exists());
+        assert!(!dir.path().join("_sources").join("mem_2.md").exists());
+    }
+
+    #[test]
+    fn gc_never_deletes_non_mem_files_under_sources() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sources = dir.path().join("_sources");
+        std::fs::create_dir_all(&sources).unwrap();
+        // A user-created note under _sources/ that is not a mem_ stub.
+        std::fs::write(sources.join("my-research.md"), "user content").unwrap();
+        std::fs::write(sources.join("mem_orphan.md"), "stub").unwrap();
+        let manifest = StubManifest::default(); // nothing cited → mem_orphan is orphan
+        gc_orphan_stubs(dir.path(), &manifest).unwrap();
+        assert!(
+            sources.join("my-research.md").exists(),
+            "user file must survive"
+        );
+        assert!(
+            !sources.join("mem_orphan.md").exists(),
+            "orphan mem_ stub removed"
+        );
     }
 }

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -39,6 +39,52 @@ pub fn canonicalize_page_body(body: &str) -> String {
     out.trim_end().to_string()
 }
 
+/// Render the export-only `## Sources` block from a page's cited memory ids.
+/// Returns the empty string when there are no sources (source-less pages get
+/// no block). The block is wrapped in the delimiters so the ingress
+/// canonicalizer can strip it exactly.
+pub fn render_sources_block(source_memory_ids: &[String]) -> String {
+    if source_memory_ids.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str(SOURCES_BLOCK_START);
+    out.push_str("\n## Sources\n");
+    for id in source_memory_ids {
+        out.push_str(&format!("- [[{id}]]\n"));
+    }
+    out.push_str(SOURCES_BLOCK_END);
+    out.push('\n');
+    out
+}
+
+/// Render the read-only `sources:` frontmatter line (quoted wikilinks, which
+/// Obsidian requires for list properties). Empty string when no sources.
+/// PROJECTION-OUT ONLY — the watcher never reads this back.
+pub fn sources_frontmatter(source_memory_ids: &[String]) -> String {
+    if source_memory_ids.is_empty() {
+        return String::new();
+    }
+    let quoted: Vec<String> = source_memory_ids
+        .iter()
+        .map(|id| format!("\"[[{id}]]\""))
+        .collect();
+    format!("sources: [{}]\n", quoted.join(", "))
+}
+
+/// Render the read-only `related:` frontmatter line from page→page wikilink
+/// targets. Empty string when there are none.
+pub fn related_frontmatter(related_titles: &[String]) -> String {
+    if related_titles.is_empty() {
+        return String::new();
+    }
+    let quoted: Vec<String> = related_titles
+        .iter()
+        .map(|t| format!("\"[[{t}]]\""))
+        .collect();
+    format!("related: [{}]\n", quoted.join(", "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +125,44 @@ mod tests {
             format!("head prose\n\n{SOURCES_BLOCK_START}\nx\n{SOURCES_BLOCK_END}\n\ntail prose");
         let canon = canonicalize_page_body(&body);
         assert_eq!(canon, "head prose\n\ntail prose");
+    }
+
+    #[test]
+    fn render_sources_block_is_delimiter_wrapped_and_canonicalizes_to_empty() {
+        let ids = ["mem_1".to_string(), "mem_2".to_string()];
+        let block = render_sources_block(&ids);
+        assert!(block.starts_with(SOURCES_BLOCK_START));
+        assert!(block.trim_end().ends_with(SOURCES_BLOCK_END));
+        assert!(block.contains("## Sources"));
+        assert!(block.contains("[[mem_1]]"));
+        assert!(block.contains("[[mem_2]]"));
+        // A body that is exactly the block canonicalizes to empty.
+        assert_eq!(canonicalize_page_body(&block), "");
+    }
+
+    #[test]
+    fn render_sources_block_empty_for_no_sources() {
+        let ids: [String; 0] = [];
+        assert_eq!(render_sources_block(&ids), String::new());
+    }
+
+    #[test]
+    fn sources_frontmatter_quotes_wikilinks() {
+        let ids = ["mem_1".to_string(), "mem_2".to_string()];
+        let fm = sources_frontmatter(&ids);
+        assert_eq!(fm, "sources: [\"[[mem_1]]\", \"[[mem_2]]\"]\n");
+    }
+
+    #[test]
+    fn sources_frontmatter_empty_emits_nothing() {
+        let ids: [String; 0] = [];
+        assert_eq!(sources_frontmatter(&ids), String::new());
+    }
+
+    #[test]
+    fn related_frontmatter_quotes_page_titles() {
+        let titles = ["Other Page".to_string()];
+        let fm = related_frontmatter(&titles);
+        assert_eq!(fm, "related: [\"[[Other Page]]\"]\n");
     }
 }

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -106,8 +106,9 @@ pub const SOURCES_STUB_DIR: &str = "_sources";
 
 /// Maps page_id → the memory ids that page currently cites. Persisted at
 /// `_sources/.manifest.json` so GC knows which stubs are still referenced
-/// across daemon restarts. Only `mem_*` stub files are ever GC'd; user files
-/// under `_sources/` are out of scope.
+/// across daemon restarts. Only `mem_*`-named stub files are ever GC'd;
+/// non-`mem_*` files under `_sources/` are out of scope (`_sources/` is a
+/// daemon-owned projection dir).
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct StubManifest {
     pages: HashMap<String, Vec<String>>,
@@ -147,9 +148,11 @@ impl StubManifest {
     }
 }
 
-/// Delete `_sources/mem_*.md` stubs no longer cited by any page in `manifest`.
-/// Prefix-scoped to `mem_` (after sanitization): user-created files and the
-/// manifest itself are never touched.
+/// Deletes orphan `mem_*.md` stub files (those no longer cited by any page in
+/// `manifest`). Scope is the `mem_`-name prefix, NOT authorship: non-`mem_*`
+/// files — user notes and the `.manifest.json` — are never touched, but a file
+/// named `mem_*.md` under this daemon-owned dir is treated as a stub and is out
+/// of contract.
 pub fn gc_orphan_stubs(knowledge_path: &Path, manifest: &StubManifest) -> std::io::Result<()> {
     let dir = knowledge_path.join(SOURCES_STUB_DIR);
     if !dir.exists() {
@@ -166,7 +169,8 @@ pub fn gc_orphan_stubs(knowledge_path: &Path, manifest: &StubManifest) -> std::i
             Some(n) => n,
             None => continue,
         };
-        // Only ever GC sanitized mem_ stub files; leave user files + manifest.
+        // Scope by name, not authorship: only `mem_*.md` files are GC'd;
+        // non-`mem_*` files (user notes, the `.manifest.json`) are left alone.
         if !name.starts_with("mem_") || !name.ends_with(".md") {
             continue;
         }

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Provenance projection helpers: delimiter-owned Sources block, the shared
+//! ingress canonicalizer, and `_sources/` stub projection + GC.
+
+/// Opening delimiter for the export-only `## Sources` block. The block is
+/// generated from DB truth at projection time and stripped at ingress; it is
+/// NEVER part of canonical `Page.content`.
+pub const SOURCES_BLOCK_START: &str = "<!-- origin:sources:start -->";
+/// Closing delimiter for the export-only Sources block.
+pub const SOURCES_BLOCK_END: &str = "<!-- origin:sources:end -->";
+
+/// Strip ONLY the delimiter-owned Sources block from a page body. A user may
+/// legitimately type a `## Sources` heading or a `[[mem_123]]` wikilink in
+/// prose; neither is touched. Removes the first `START..END` span (inclusive
+/// of both delimiters and any trailing newline before START) and returns the
+/// remainder trimmed of trailing whitespace. If the delimiters are absent or
+/// malformed (END before START, or START with no END), the body is returned
+/// trimmed but otherwise untouched.
+pub fn canonicalize_page_body(body: &str) -> String {
+    let start = match body.find(SOURCES_BLOCK_START) {
+        Some(i) => i,
+        None => return body.trim_end().to_string(),
+    };
+    let after_start = start + SOURCES_BLOCK_START.len();
+    let end_rel = match body[after_start..].find(SOURCES_BLOCK_END) {
+        Some(i) => i,
+        None => return body.trim_end().to_string(),
+    };
+    let end = after_start + end_rel + SOURCES_BLOCK_END.len();
+    // Drop whitespace/newlines immediately preceding the block so a fresh
+    // projection (body + "\n\n" + block) canonicalizes back to bare body.
+    let head = body[..start].trim_end();
+    let tail = body[end..].trim_start();
+    let mut out = String::from(head);
+    if !tail.is_empty() {
+        out.push_str("\n\n");
+        out.push_str(tail);
+    }
+    out.trim_end().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_only_the_delimiter_block() {
+        let body = format!(
+            "## Overview\nReal prose here.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_1]]\n{SOURCES_BLOCK_END}\n"
+        );
+        let canon = canonicalize_page_body(&body);
+        assert_eq!(canon, "## Overview\nReal prose here.");
+        assert!(!canon.contains(SOURCES_BLOCK_START));
+        assert!(!canon.contains("[[mem_1]]"));
+    }
+
+    #[test]
+    fn user_typed_mem_wikilink_in_prose_survives() {
+        // No delimiter block at all — a bare `[[mem_123]]` the user wrote.
+        let body = "I cited [[mem_123]] in my own note.\n\n## Sources\nhand-written, not the daemon block.";
+        let canon = canonicalize_page_body(body);
+        assert_eq!(canon, body.trim_end());
+        assert!(canon.contains("[[mem_123]]"));
+        assert!(canon.contains("## Sources"));
+    }
+
+    #[test]
+    fn missing_end_delimiter_leaves_body_untouched() {
+        let body = format!("prose\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_1]]\n");
+        let canon = canonicalize_page_body(&body);
+        // No END → no strip; only trailing whitespace trimmed.
+        assert!(canon.contains(SOURCES_BLOCK_START));
+        assert!(canon.contains("[[mem_1]]"));
+    }
+
+    #[test]
+    fn preserves_prose_after_the_block() {
+        let body =
+            format!("head prose\n\n{SOURCES_BLOCK_START}\nx\n{SOURCES_BLOCK_END}\n\ntail prose");
+        let canon = canonicalize_page_body(&body);
+        assert_eq!(canon, "head prose\n\ntail prose");
+    }
+}

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -123,9 +123,9 @@ pub const SOURCES_STUB_DIR: &str = "_sources";
 
 /// Maps page_id → the memory ids that page currently cites. Persisted at
 /// `_sources/.manifest.json` so GC knows which stubs are still referenced
-/// across daemon restarts. Only `mem_*`-named stub files are ever GC'd;
-/// non-`mem_*` files under `_sources/` are out of scope (`_sources/` is a
-/// daemon-owned projection dir).
+/// across daemon restarts. GC reaps by the `origin_stub:` marker (see
+/// `gc_orphan_stubs`), so daemon stubs of any id shape (`mem_*`, `import_*`)
+/// are reaped when orphaned while unmarked user notes are spared.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct StubManifest {
     pages: HashMap<String, Vec<String>>,
@@ -165,11 +165,13 @@ impl StubManifest {
     }
 }
 
-/// Deletes orphan `mem_*.md` stub files (those no longer cited by any page in
-/// `manifest`). Scope is the `mem_`-name prefix, NOT authorship: non-`mem_*`
-/// files — user notes and the `.manifest.json` — are never touched, but a file
-/// named `mem_*.md` under this daemon-owned dir is treated as a stub and is out
-/// of contract.
+/// Deletes orphan daemon-written stub files (those no longer cited by any page
+/// in `manifest`). Scope is the `origin_stub:` MARKER, not the filename: a
+/// `.md` file under `_sources/` is reaped iff it carries the marker (so it is a
+/// daemon projection) AND its filename is not in the cited set. Files without
+/// the marker — user notes of ANY name, including one named `mem_*.md` — are
+/// never touched. Reaping by marker reaps `import_*` stubs too (whose names
+/// don't start with `mem_`), closing the leak the old name-prefix scope had.
 pub fn gc_orphan_stubs(knowledge_path: &Path, manifest: &StubManifest) -> std::io::Result<()> {
     let dir = knowledge_path.join(SOURCES_STUB_DIR);
     if !dir.exists() {
@@ -183,15 +185,24 @@ pub fn gc_orphan_stubs(knowledge_path: &Path, manifest: &StubManifest) -> std::i
     for entry in std::fs::read_dir(&dir)?.flatten() {
         let path = entry.path();
         let name = match path.file_name().and_then(|n| n.to_str()) {
-            Some(n) => n,
+            Some(n) => n.to_string(),
             None => continue,
         };
-        // Scope by name, not authorship: only `mem_*.md` files are GC'd;
-        // non-`mem_*` files (user notes, the `.manifest.json`) are left alone.
-        if !name.starts_with("mem_") || !name.ends_with(".md") {
+        // Skip non-`.md` files (e.g. the `.manifest.json` projection index).
+        if !name.ends_with(".md") {
             continue;
         }
-        if !cited.contains(name) {
+        // Still cited → keep.
+        if cited.contains(&name) {
+            continue;
+        }
+        // Only reap DAEMON-written stubs (carry the `origin_stub:` marker
+        // written by `project_stubs_for_page`). User notes under `_sources/`
+        // (any name) lack the marker and are spared.
+        let is_daemon_stub = std::fs::read_to_string(&path)
+            .map(|c| c.contains("origin_stub:"))
+            .unwrap_or(false);
+        if is_daemon_stub {
             let _ = std::fs::remove_file(&path);
         }
     }
@@ -447,22 +458,55 @@ mod tests {
     }
 
     #[test]
-    fn gc_never_deletes_non_mem_files_under_sources() {
+    fn gc_reaps_daemon_stubs_spares_user_files() {
         let dir = tempfile::TempDir::new().unwrap();
         let sources = dir.path().join("_sources");
-        std::fs::create_dir_all(&sources).unwrap();
-        // A user-created note under _sources/ that is not a mem_ stub.
-        std::fs::write(sources.join("my-research.md"), "user content").unwrap();
-        std::fs::write(sources.join("mem_orphan.md"), "stub").unwrap();
-        let manifest = StubManifest::default(); // nothing cited → mem_orphan is orphan
+        // Daemon-written stubs (carry the origin_stub: marker) for a mem_ id
+        // AND a non-mem_ import id — both must be reaped when orphaned.
+        project_stubs_for_page(dir.path(), "page_a", &["mem_orphan".to_string()]).unwrap();
+        project_stubs_for_page(dir.path(), "page_b", &["import_42_3".to_string()]).unwrap();
+        // User notes under _sources/ (no marker) — any name, including one that
+        // looks like a daemon stub (`mem_decoy.md`). Both must survive.
+        std::fs::write(sources.join("my-research.md"), "my own note").unwrap();
+        std::fs::write(sources.join("mem_decoy.md"), "user note, not a stub").unwrap();
+
+        let manifest = StubManifest::default(); // nothing cited → all stubs orphan
         gc_orphan_stubs(dir.path(), &manifest).unwrap();
-        assert!(
-            sources.join("my-research.md").exists(),
-            "user file must survive"
-        );
+
         assert!(
             !sources.join("mem_orphan.md").exists(),
-            "orphan mem_ stub removed"
+            "orphan daemon mem_ stub reaped"
+        );
+        assert!(
+            !sources.join("import_42_3.md").exists(),
+            "orphan daemon import_ stub reaped (no longer leaks)"
+        );
+        assert!(
+            sources.join("my-research.md").exists(),
+            "user file (no marker) must survive"
+        );
+        assert!(
+            sources.join("mem_decoy.md").exists(),
+            "user file named mem_* (no marker) must survive — marker-based, not name-based"
+        );
+    }
+
+    #[test]
+    fn gc_reaps_orphan_import_stub() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sources = dir.path().join("_sources");
+        // An imported memory cited by a page → daemon stub projected.
+        let mut manifest = StubManifest::default();
+        manifest.record("page_x", &["import_9_9".to_string()]);
+        project_stubs_for_page(dir.path(), "page_x", &["import_9_9".to_string()]).unwrap();
+        assert!(sources.join("import_9_9.md").exists());
+
+        // Page drops the source → import stub is now orphan → GC reaps it.
+        manifest.record("page_x", &[]);
+        gc_orphan_stubs(dir.path(), &manifest).unwrap();
+        assert!(
+            !sources.join("import_9_9.md").exists(),
+            "orphan import_ stub must be reaped (the leak this fix closes)"
         );
     }
 }

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -102,10 +102,16 @@ use std::path::Path;
 /// scans only the top-level `.md` files, so this subdir is never synced back.
 pub const SOURCES_STUB_DIR: &str = "_sources";
 
-/// Map a (possibly unsafe, imported) memory id to a filesystem/wikilink-safe
-/// token. Stored ids are already safe `mem_*`; imported ids may carry
-/// path-hostile chars. Reversible: each distinct input maps to a distinct
-/// token (unsafe bytes are percent-style hex-escaped, never collapsed).
+/// Map a memory id to a filesystem/wikilink-safe token. Ids already matching
+/// `[A-Za-z0-9_-]+` (all stored Origin `mem_<uuid>` ids) pass through
+/// unchanged. Other chars are hex-escaped as `_XX`.
+/// NOTE: not collision-free for arbitrary input — because `_` is both the
+/// escape introducer and a passthrough char, `"mem_a/"` and a literal
+/// `"mem_a_2f"` both map to `"mem_a_2f"`. Safe for P1 (cited ids are always
+/// UUID-shaped `mem_*`). When imported ids (which may carry `/`, spaces, etc.)
+/// can become page sources in P2, make this injective then — e.g. append a
+/// deterministic hash for ids failing the safe-charset check — with a
+/// collision regression test. Tracked as a P2 follow-up.
 pub fn sanitize_stub_id(id: &str) -> String {
     let mut out = String::with_capacity(id.len());
     for c in id.chars() {
@@ -140,8 +146,9 @@ pub fn project_stubs_for_page(
     std::fs::create_dir_all(&dir)?;
     for id in source_memory_ids {
         let path = dir.join(stub_filename(id));
+        let quoted = yaml_quoted(id);
         let body = format!(
-            "---\ntitle: \"{id}\"\norigin_stub: {id}\n---\n\n\
+            "---\ntitle: {quoted}\norigin_stub: {quoted}\n---\n\n\
              This is a read-only source projection for memory `{id}`, cited by \
              page `{page_id}`. Edit the memory in Origin, not this file.\n"
         );
@@ -260,7 +267,7 @@ mod tests {
         let safe = sanitize_stub_id(unsafe_id);
         assert!(!safe.contains('/'));
         assert!(!safe.contains(' '));
-        // Reversible: distinct ids map to distinct safe names.
+        // Distinct safe-charset ids map distinctly.
         assert_ne!(sanitize_stub_id("mem_a/b"), sanitize_stub_id("mem_a-b"));
     }
 

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -43,7 +43,7 @@ pub fn canonicalize_page_body(body: &str) -> String {
 /// a valid YAML flow scalar, so serde_json handles quotes/backslashes/control
 /// chars correctly. Falls back to a naive quote only if JSON encoding fails
 /// (it never does for a String).
-fn yaml_quoted(s: &str) -> String {
+pub(crate) fn yaml_quoted(s: &str) -> String {
     serde_json::to_string(s).unwrap_or_else(|_| format!("\"{}\"", s.replace('"', "'")))
 }
 

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -96,6 +96,60 @@ pub fn related_frontmatter(related_titles: &[String]) -> String {
     format!("related: [{}]\n", quoted.join(", "))
 }
 
+use std::path::Path;
+
+/// Subdir under `knowledge_path` for read-only source stubs. The page_watcher
+/// scans only the top-level `.md` files, so this subdir is never synced back.
+pub const SOURCES_STUB_DIR: &str = "_sources";
+
+/// Map a (possibly unsafe, imported) memory id to a filesystem/wikilink-safe
+/// token. Stored ids are already safe `mem_*`; imported ids may carry
+/// path-hostile chars. Reversible: each distinct input maps to a distinct
+/// token (unsafe bytes are percent-style hex-escaped, never collapsed).
+pub fn sanitize_stub_id(id: &str) -> String {
+    let mut out = String::with_capacity(id.len());
+    for c in id.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+            out.push(c);
+        } else {
+            out.push('_');
+            for b in c.to_string().as_bytes() {
+                out.push_str(&format!("{b:02x}"));
+            }
+        }
+    }
+    out
+}
+
+/// Stub filename for a memory id, e.g. `mem_1.md`.
+pub fn stub_filename(id: &str) -> String {
+    format!("{}.md", sanitize_stub_id(id))
+}
+
+/// Project a read-only stub note for each cited memory id under
+/// `<knowledge_path>/_sources/`. Idempotent: rewrites the stub each call.
+pub fn project_stubs_for_page(
+    knowledge_path: &Path,
+    page_id: &str,
+    source_memory_ids: &[String],
+) -> std::io::Result<()> {
+    if source_memory_ids.is_empty() {
+        return Ok(());
+    }
+    let dir = knowledge_path.join(SOURCES_STUB_DIR);
+    std::fs::create_dir_all(&dir)?;
+    for id in source_memory_ids {
+        let path = dir.join(stub_filename(id));
+        let body = format!(
+            "---\ntitle: \"{id}\"\norigin_stub: {id}\n---\n\n\
+             This is a read-only source projection for memory `{id}`, cited by \
+             page `{page_id}`. Edit the memory in Origin, not this file.\n"
+        );
+        std::fs::write(&path, body)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -191,5 +245,37 @@ mod tests {
             .and_then(|v| v.as_sequence())
             .expect("related seq");
         assert_eq!(related[0].as_str().unwrap(), "[[My \"Quoted\" Page]]");
+    }
+
+    #[test]
+    fn sanitize_stub_id_passes_safe_mem_ids() {
+        assert_eq!(sanitize_stub_id("mem_abc123"), "mem_abc123");
+        assert_eq!(sanitize_stub_id("mem_1"), "mem_1");
+    }
+
+    #[test]
+    fn sanitize_stub_id_escapes_unsafe_chars() {
+        // Imported ids may carry slashes/spaces/dots that break filenames.
+        let unsafe_id = "mem_a/b c.d";
+        let safe = sanitize_stub_id(unsafe_id);
+        assert!(!safe.contains('/'));
+        assert!(!safe.contains(' '));
+        // Reversible: distinct ids map to distinct safe names.
+        assert_ne!(sanitize_stub_id("mem_a/b"), sanitize_stub_id("mem_a-b"));
+    }
+
+    #[test]
+    fn project_stubs_writes_read_only_notes_under_sources_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ids = ["mem_1".to_string(), "mem_2".to_string()];
+        project_stubs_for_page(dir.path(), "page_a", &ids).unwrap();
+        let p1 = dir.path().join("_sources").join("mem_1.md");
+        let p2 = dir.path().join("_sources").join("mem_2.md");
+        assert!(p1.exists());
+        assert!(p2.exists());
+        let body = std::fs::read_to_string(&p1).unwrap();
+        // Stub identifies the memory and is marked a read-only projection.
+        assert!(body.contains("mem_1"));
+        assert!(body.contains("read-only"));
     }
 }

--- a/crates/origin-core/src/export/provenance.rs
+++ b/crates/origin-core/src/export/provenance.rs
@@ -39,6 +39,23 @@ pub fn canonicalize_page_body(body: &str) -> String {
     out.trim_end().to_string()
 }
 
+/// Strip daemon-reserved Sources-block delimiters from CLIENT-supplied page
+/// content before persistence. The exporter owns these delimiters; persisted
+/// `Page.content` must never carry them, or the watcher's egress
+/// canonicalization becomes asymmetric (mismatched-pair `user_edited` storm or
+/// stray-delimiter prose truncation). Strips a delimiter-owned block (via
+/// `canonicalize_page_body`) AND removes any residual lone START/END tokens
+/// (a stray delimiter with no matching pair, which `canonicalize_page_body`
+/// leaves untouched). Idempotent: delimiter-free content only gets trailing
+/// whitespace trimmed, so re-sanitizing already-stored content is a no-op.
+pub fn sanitize_ingress_content(content: &str) -> String {
+    let stripped = canonicalize_page_body(content);
+    let cleaned = stripped
+        .replace(SOURCES_BLOCK_START, "")
+        .replace(SOURCES_BLOCK_END, "");
+    cleaned.trim_end().to_string()
+}
+
 /// Encode `s` as a YAML-safe double-quoted scalar. A JSON string literal is
 /// a valid YAML flow scalar, so serde_json handles quotes/backslashes/control
 /// chars correctly. Falls back to a naive quote only if JSON encoding fails
@@ -276,6 +293,42 @@ mod tests {
             format!("head prose\n\n{SOURCES_BLOCK_START}\nx\n{SOURCES_BLOCK_END}\n\ntail prose");
         let canon = canonicalize_page_body(&body);
         assert_eq!(canon, "head prose\n\ntail prose");
+    }
+
+    #[test]
+    fn sanitize_ingress_strips_full_block_preserving_prose() {
+        let content = format!(
+            "## Overview\nReal prose here.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_1]]\n{SOURCES_BLOCK_END}\n\ntail prose"
+        );
+        let out = sanitize_ingress_content(&content);
+        assert!(!out.contains(SOURCES_BLOCK_START));
+        assert!(!out.contains(SOURCES_BLOCK_END));
+        assert!(!out.contains("[[mem_1]]"));
+        assert!(out.contains("Real prose here."));
+        assert!(out.contains("tail prose"));
+    }
+
+    #[test]
+    fn sanitize_ingress_strips_stray_start_without_truncating_prose() {
+        // A lone START token with prose after it. canonicalize_page_body leaves
+        // it untouched (no matching END), so sanitize must remove the token AND
+        // keep BOTH prose halves — no truncation (the data-loss case).
+        let content = format!("prose A {SOURCES_BLOCK_START} prose B");
+        let out = sanitize_ingress_content(&content);
+        assert!(!out.contains(SOURCES_BLOCK_START));
+        assert!(!out.contains(SOURCES_BLOCK_END));
+        assert!(out.contains("prose A"));
+        assert!(out.contains("prose B"));
+    }
+
+    #[test]
+    fn sanitize_ingress_is_noop_on_delimiter_free_content() {
+        let content =
+            "## Overview\nJust normal prose.\n\n## Sources\nuser-typed, not the daemon block.";
+        let out = sanitize_ingress_content(content);
+        assert_eq!(out, content.trim_end());
+        // Idempotent: re-sanitizing already-stored content changes nothing.
+        assert_eq!(sanitize_ingress_content(&out), out);
     }
 
     #[test]

--- a/crates/origin-core/src/prompts/defaults.rs
+++ b/crates/origin-core/src/prompts/defaults.rs
@@ -167,15 +167,14 @@ Use bullet lists only for genuinely enumerable things (steps, lists of tools, et
 ## Open Questions\n\
 - List gaps, uncertainties, or contradictions between sources.\n\
 \n\
-## Sources\n\
-- Attribute key claims to source memories (include memory ID).\n\
-\n\
 Rules:\n\
 - Write prose with topical headers. Paragraphs that synthesize, with bullets only for lists.\n\
 - Read like an encyclopedia entry — concise, informative, no filler or meta-commentary.\n\
 - Preserve specifics — don't generalize away details like exact names, versions, or numbers.\n\
 - If sources contradict, keep the most recent and note the contradiction in Open Questions.\n\
-- 3-5 paragraphs total. Quality over quantity.";
+- 3-5 paragraphs total. Quality over quantity.\n\
+- Do NOT add a sources or citations section, and do not cite source ids in the prose — the system attaches provenance automatically.\n\
+- Do not write HTML comments (the <!-- ... --> form) anywhere in the page.";
 
 pub(crate) const UPDATE_PAGE: &str = "\
 You maintain a wiki-style knowledge page. Update it with new information.\n\
@@ -183,7 +182,9 @@ Integrate new facts into the existing prose naturally — don't just append bull
 If the new information contradicts existing content, note it in Open Questions.\n\
 Do not remove existing content unless it is explicitly superseded.\n\
 Do NOT include a title heading (# Title) -- the title is displayed separately by the UI.\n\
-Output the complete updated page in the same format (TLDR, prose paragraphs, Open Questions, Sources).";
+Do not add a sources or citations section, and do not cite source ids — the system attaches provenance automatically.\n\
+Do not write HTML comments (the <!-- ... --> form) anywhere in the page.\n\
+Output the complete updated page in the same format (TLDR, prose paragraphs, Open Questions).";
 
 pub(crate) const ASSIGN_ORPHANS: &str = r#"You are a knowledge organization assistant. Given a list of unassigned memories and existing concepts, for each memory:
 1. If it clearly belongs to an existing page, assign it (return the page_id)
@@ -266,3 +267,24 @@ scaffolding, tighten phrasing. Keep one grounded copy of each distinct fact.\n\
 that changes their meaning.\n\
 5. Output ONLY the compressed bundle as plain text. No preamble, no commentary, \
 no markdown fences.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distill_page_does_not_author_sources() {
+        // The exporter generates the Sources block from DB truth; the LLM must
+        // not author a `## Sources` section or per-claim memory-id citations.
+        assert!(!DISTILL_PAGE.contains("## Sources"));
+        assert!(!DISTILL_PAGE.contains("Attribute key claims"));
+        // HTML comments banned so the LLM can't forge the delimiter.
+        assert!(DISTILL_PAGE.contains("HTML comment"));
+    }
+
+    #[test]
+    fn update_page_does_not_require_sources_section() {
+        assert!(!UPDATE_PAGE.contains("Open Questions, Sources"));
+        assert!(UPDATE_PAGE.contains("HTML comment"));
+    }
+}

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -562,4 +562,55 @@ mod tests {
             links
         );
     }
+
+    /// Task 5: pure projection + watcher tick with NO user edit must produce
+    /// zero `mem_*` page_link rows.  Distinct from Task 4's test, which edits
+    /// prose; here we never touch the file after `KnowledgeWriter::write_page`.
+    /// The on-disk file carries `[[mem_alpha]]`/`[[mem_beta]]` inside the
+    /// generated Sources block, but the canonicalized body written back to the
+    /// DB must never include them, so no `mem_*` link rows are ever created.
+    #[tokio::test]
+    async fn projecting_provenance_creates_no_mem_page_links_no_edit() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page(
+            "page_links",
+            "Links Topic",
+            "## Overview\nrefers to [[Real Topic]] but not memories",
+        );
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_links",
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_alpha", "mem_beta"],
+            &now,
+        )
+        .await
+        .unwrap();
+        let writer = KnowledgeWriter::new(knowledge_dir.path().to_path_buf());
+        writer.write_page(&page).unwrap();
+
+        // Pure projection + a watcher tick with NO user edit. The on-disk file
+        // carries the Sources block (with [[mem_alpha]]/[[mem_beta]]), but the
+        // canonicalized body written to the DB must never include them, so no
+        // mem_* link rows are ever created.
+        sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+
+        let links = db.get_page_outbound_links("page_links").await.unwrap();
+        let mem_links: Vec<_> = links
+            .iter()
+            .filter(|l| l.label.starts_with("mem_"))
+            .collect();
+        assert!(
+            mem_links.is_empty(),
+            "no page_links row may target a mem_* id; got {:?}",
+            mem_links.iter().map(|l| &l.label).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -164,11 +164,12 @@ async fn sync_one_file(
         return Ok(Outcome::SkippedDaemonAhead { page_id });
     }
 
-    // Trim trailing newlines on both sides — render_markdown emits a
-    // trailing `\n` and editors tend to add their own. Otherwise a no-op
-    // save would look like a real edit forever.
-    let body_norm = body.trim_end_matches('\n');
-    let db_norm = existing.content.trim_end_matches('\n');
+    // Strip the export-only delimiter Sources block from BOTH sides before
+    // the diff. The projected file always carries the generated block while
+    // Page.content never does; a raw compare would mark every page
+    // user_edited on the first tick and lock the refinery out.
+    let body_norm = crate::export::provenance::canonicalize_page_body(body);
+    let db_norm = crate::export::provenance::canonicalize_page_body(&existing.content);
     if body_norm == db_norm {
         return Ok(Outcome::Unchanged);
     }
@@ -177,7 +178,7 @@ async fn sync_one_file(
     // memory provenance. Sources change only via /distill refresh or
     // explicit POST.
     let req = origin_types::requests::UpdatePageRequest {
-        content: body_norm.to_string(),
+        content: body_norm.clone(),
         source_memory_ids: existing.source_memory_ids.clone(),
     };
     // Pass knowledge_path so update_page re-projects the md with the new
@@ -457,5 +458,52 @@ mod tests {
         let missing = std::path::PathBuf::from("/tmp/origin-page-watcher-nonexistent");
         let stats = sync_filesystem_edits(&db, &missing).await.unwrap();
         assert_eq!(stats, WatcherStats::default());
+    }
+
+    #[tokio::test]
+    async fn freshly_projected_page_is_unchanged_not_user_edited() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page("page_fresh", "Fresh Topic", "## Overview\nbody prose here");
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            &page.id,
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+        // Project via the live writer — the .md now carries the delimiter
+        // Sources block + sources: frontmatter that Page.content lacks.
+        let writer = KnowledgeWriter::new(knowledge_dir.path().to_path_buf());
+        writer.write_page(&page).unwrap();
+
+        // First watcher tick must see the projection as Unchanged, NOT a
+        // user edit — otherwise the refinery is locked out of every page.
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(
+            stats.applied, 0,
+            "fresh projection must not apply; got {:?}",
+            stats
+        );
+        assert_eq!(
+            stats.scanned, 1,
+            "exactly one md file should be scanned; got {:?}",
+            stats
+        );
+        assert_eq!(
+            stats.skipped_unchanged, 1,
+            "fresh projection must be skipped_unchanged; got {:?}",
+            stats
+        );
+        let p = db.get_page("page_fresh").await.unwrap().unwrap();
+        assert!(!p.user_edited);
     }
 }

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -171,6 +171,18 @@ async fn sync_one_file(
     let body_norm = crate::export::provenance::canonicalize_page_body(body);
     let db_norm = crate::export::provenance::canonicalize_page_body(&existing.content);
     if body_norm == db_norm {
+        // Canonicalized prose is identical, but the raw bytes may differ
+        // (user touched the protected Sources block). If so, re-project from
+        // DB truth so the file stops lying about its sources; otherwise it
+        // really is unchanged.
+        let raw_body = body.trim_end_matches('\n');
+        let fresh = crate::export::knowledge::render_markdown_for(&existing);
+        let (_, fresh_body) = obsidian::extract_frontmatter(&fresh);
+        if raw_body != fresh_body.trim_end_matches('\n') {
+            let writer =
+                crate::export::knowledge::KnowledgeWriter::new(knowledge_path.to_path_buf());
+            writer.write_page(&existing)?;
+        }
         return Ok(Outcome::Unchanged);
     }
 
@@ -561,6 +573,59 @@ mod tests {
             "no mem_* link rows should persist; got {:?}",
             links
         );
+    }
+
+    #[tokio::test]
+    async fn edited_sources_block_on_disk_is_reprojected_to_db_truth() {
+        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let mut page = sample_page("page_block", "Block Topic", "## Overview\ncanonical prose");
+        page.source_memory_ids = vec!["mem_real".to_string()];
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_block",
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_real"],
+            &now,
+        )
+        .await
+        .unwrap();
+        let writer = KnowledgeWriter::new(knowledge_dir.path().to_path_buf());
+        writer.write_page(&page).unwrap();
+        let md_path = knowledge_dir
+            .path()
+            .join(writer.page_filename(&page.id).expect("state has file"));
+
+        // User tampers with ONLY the protected block (adds a fake source),
+        // leaving the canonicalized prose identical.
+        let projected = std::fs::read_to_string(&md_path).unwrap();
+        let tampered = projected.replace(
+            &format!("{SOURCES_BLOCK_START}\n## Sources\n- [[mem_real]]\n{SOURCES_BLOCK_END}"),
+            &format!("{SOURCES_BLOCK_START}\n## Sources\n- [[mem_real]]\n- [[mem_FAKE]]\n{SOURCES_BLOCK_END}"),
+        );
+        assert_ne!(
+            tampered, projected,
+            "replacement must have matched the block"
+        );
+        std::fs::write(&md_path, &tampered).unwrap();
+
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(stats.applied, 0); // canonicalized prose unchanged → not a user edit
+        let p = db.get_page("page_block").await.unwrap().unwrap();
+        assert!(!p.content.contains(SOURCES_BLOCK_START)); // DB stays canonical
+        assert!(!p.content.contains("mem_FAKE"));
+        assert!(!p.user_edited);
+        // The file on disk was re-projected from DB truth — fake source gone.
+        let after = std::fs::read_to_string(&md_path).unwrap();
+        assert!(!after.contains("mem_FAKE"));
+        assert!(after.contains("[[mem_real]]"));
     }
 
     /// Task 5: pure projection + watcher tick with NO user edit must produce

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -178,7 +178,7 @@ async fn sync_one_file(
     // memory provenance. Sources change only via /distill refresh or
     // explicit POST.
     let req = origin_types::requests::UpdatePageRequest {
-        content: body_norm.clone(),
+        content: body_norm,
         source_memory_ids: existing.source_memory_ids.clone(),
     };
     // Pass knowledge_path so update_page re-projects the md with the new
@@ -505,5 +505,61 @@ mod tests {
         );
         let p = db.get_page("page_fresh").await.unwrap().unwrap();
         assert!(!p.user_edited);
+    }
+
+    #[tokio::test]
+    async fn genuine_prose_edit_with_block_present_applies_block_free() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page("page_edit", "Edit Topic", "## Overview\noriginal prose");
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            &page.id,
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_e"],
+            &now,
+        )
+        .await
+        .unwrap();
+        let writer = KnowledgeWriter::new(knowledge_dir.path().to_path_buf());
+        let fname = writer.write_page(&page).unwrap();
+        let md_path = knowledge_dir.path().join(&fname);
+
+        // The projected file has the Sources block. User edits the PROSE only,
+        // leaving the block intact.
+        let projected = std::fs::read_to_string(&md_path).unwrap();
+        let edited = projected.replace("original prose", "edited prose by the user");
+        assert_ne!(edited, projected, "prose replacement must have matched");
+        std::fs::write(&md_path, &edited).unwrap();
+
+        let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+        assert_eq!(
+            stats.applied, 1,
+            "genuine prose edit must apply; got {:?}",
+            stats
+        );
+        let p = db.get_page("page_edit").await.unwrap().unwrap();
+        assert!(p.content.contains("edited prose by the user"));
+        assert!(
+            !p.content
+                .contains(crate::export::provenance::SOURCES_BLOCK_START),
+            "the generated block must NOT be persisted into Page.content"
+        );
+        assert!(p.user_edited, "a real prose edit flags user_edited");
+
+        // The block-free body means no `mem_*` rows reach the wikilink graph
+        // via replace_page_links.
+        let links = db.get_page_outbound_links("page_edit").await.unwrap();
+        assert!(
+            !links.iter().any(|l| l.label.starts_with("mem_")),
+            "no mem_* link rows should persist; got {:?}",
+            links
+        );
     }
 }

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -181,7 +181,15 @@ async fn sync_one_file(
         if raw_body != fresh_body.trim_end_matches('\n') {
             let writer =
                 crate::export::knowledge::KnowledgeWriter::new(knowledge_path.to_path_buf());
-            writer.write_page(&existing)?;
+            // Only re-project if the writer already maps this page to a file (state
+            // entry present) — otherwise write_page's unique_filename would fork a
+            // `<slug>-2.md` duplicate against the on-disk file we're reading (real on a
+            // vault synced without `.origin/state.json`). Without state we can't safely
+            // pick the canonical file; leave it as-is until a genuine re-distill
+            // re-establishes the mapping. The page row is untouched either way.
+            if writer.page_filename(&existing.id).is_some() {
+                writer.write_page(&existing)?;
+            }
         }
         return Ok(Outcome::Unchanged);
     }
@@ -626,6 +634,55 @@ mod tests {
         let after = std::fs::read_to_string(&md_path).unwrap();
         assert!(!after.contains("mem_FAKE"));
         assert!(after.contains("[[mem_real]]"));
+    }
+
+    #[tokio::test]
+    async fn no_duplicate_file_when_state_missing_on_reprojection() {
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let page = sample_page("page_nostate", "No State", "## Overview\nold body");
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_nostate",
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_z"],
+            &now,
+        )
+        .await
+        .unwrap();
+        // Write an OLD-format .md directly (no write_page → no state.json entry),
+        // with frontmatter origin_id matching the DB row. The prose body equals
+        // the DB content, but the file lacks the delimiter Sources block a fresh
+        // render adds — so the canonicalized bodies are EQUAL (reaching the
+        // equal-canon branch) while raw_body != fresh_body (which would trigger
+        // re-projection if not for the missing-state guard). origin_version: 1
+        // matches the DB row so the watcher does not bail via SkippedDaemonAhead.
+        let md = format!(
+            "---\ntitle: \"{}\"\norigin_id: page_nostate\norigin_version: 1\n---\n\n## Overview\nold body\n",
+            page.title
+        );
+        std::fs::write(knowledge_dir.path().join("no-state.md"), &md).unwrap();
+
+        sync_filesystem_edits(&db, knowledge_dir.path())
+            .await
+            .unwrap();
+
+        // No duplicate page file forked.
+        let md_files: Vec<_> = std::fs::read_dir(knowledge_dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map(|x| x == "md").unwrap_or(false))
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            !md_files.iter().any(|n| n.contains("-2")),
+            "must not fork a duplicate; got {:?}",
+            md_files
+        );
     }
 
     /// Task 5: pure projection + watcher tick with NO user edit must produce

--- a/crates/origin-core/src/sources/page_watcher.rs
+++ b/crates/origin-core/src/sources/page_watcher.rs
@@ -678,4 +678,58 @@ mod tests {
             mem_links.iter().map(|l| &l.label).collect::<Vec<_>>()
         );
     }
+
+    #[tokio::test]
+    async fn full_provenance_round_trip_is_stable() {
+        use crate::export::provenance::SOURCES_BLOCK_START;
+        let (db, _ddir) = fresh_db().await;
+        let knowledge_dir = TempDir::new().unwrap();
+        let mut page = sample_page(
+            "page_rt",
+            "RT Topic",
+            "## Overview\nstable prose with [[Other]]",
+        );
+        page.source_memory_ids = vec!["mem_one".to_string(), "mem_two".to_string()];
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_rt",
+            &page.title,
+            None,
+            &page.content,
+            None,
+            None,
+            &["mem_one", "mem_two"],
+            &now,
+        )
+        .await
+        .unwrap();
+        let writer = KnowledgeWriter::new(knowledge_dir.path().to_path_buf());
+        writer.write_page(&page).unwrap();
+
+        // Two consecutive ticks — both Unchanged, DB never gains the block.
+        for _ in 0..2 {
+            let stats = sync_filesystem_edits(&db, knowledge_dir.path())
+                .await
+                .unwrap();
+            assert_eq!(stats.applied, 0);
+            assert_eq!(stats.skipped_unchanged, 1);
+        }
+        let p = db.get_page("page_rt").await.unwrap().unwrap();
+        assert!(!p.content.contains(SOURCES_BLOCK_START));
+        assert!(!p.user_edited);
+        // Stubs resolve for both cited memories.
+        assert!(knowledge_dir
+            .path()
+            .join("_sources")
+            .join("mem_one.md")
+            .exists());
+        assert!(knowledge_dir
+            .path()
+            .join("_sources")
+            .join("mem_two.md")
+            .exists());
+        // No mem_* page_links.
+        let links = db.get_page_outbound_links("page_rt").await.unwrap();
+        assert!(links.iter().all(|l| !l.label.starts_with("mem_")));
+    }
 }

--- a/crates/origin-mcp/src/tools.rs
+++ b/crates/origin-mcp/src/tools.rs
@@ -328,7 +328,7 @@ pub struct CreatePageParams {
     )]
     pub title: String,
     #[schemars(
-        description = "Markdown body — 3-7 paragraphs of wiki prose with [[wikilinks]]. Cite source ids inline as (source: mem_XXX)."
+        description = "Markdown body — 3-7 paragraphs of wiki prose with [[wikilinks]]. Do not cite source ids inline; pass them in source_memory_ids and the daemon attaches provenance automatically."
     )]
     pub content: String,
     #[schemars(description = "Optional one-sentence summary — the durable claim.")]
@@ -1943,7 +1943,7 @@ impl OriginMcpServer {
     }
 
     #[tool(
-        description = "Create a distilled wiki page from a memory cluster. The /distill flow uses this to post agent-synthesized pages back to the daemon. Provide a markdown body with [[wikilinks]] and inline (source: mem_XXX) citations. Pass the source memory ids so the page stays traceable. The daemon writes both the DB row and the on-disk .origin/pages/<slug>.md projection atomically.",
+        description = "Create a distilled wiki page from a memory cluster. The /distill flow uses this to post agent-synthesized pages back to the daemon. Provide a markdown body with [[wikilinks]]. Do not cite source ids inline; pass them in source_memory_ids and the daemon attaches provenance automatically. The daemon writes both the DB row and the on-disk .origin/pages/<slug>.md projection atomically.",
         annotations(
             title = "Create page",
             read_only_hint = false,


### PR DESCRIPTION
## Phase 1 of 3 — Navigable Provenance (DB-first)

Fixes the dead-provenance bug: distilled pages embedded inline `(source: mem_xxx)` citations that click nowhere in Obsidian. P1 makes provenance navigable from DB truth, without the LLM authoring it. (P2 typed evidence + source-less pages, P3 workspace axis + consolidation-demotion follow in later PRs.)

### What changed
- **Exporter owns provenance.** `render_markdown` generates a delimiter-wrapped `## Sources` block + read-only `sources:`/`related:` quoted-wikilink frontmatter from the DB. The LLM no longer authors it (`DISTILL_PAGE`/`UPDATE_PAGE` + the MCP `create_page` schema de-authored; HTML comments banned so the model cannot forge the delimiter).
- **Lossless round-trip.** A shared `canonicalize_page_body` strips only the delimiter-owned block; `page_watcher` canonicalizes both sides before its diff, so a freshly projected page reads `Unchanged` (no false `user_edited`, no refinery lockout). If only the protected block is tampered on disk, the file is re-projected from DB truth.
- **Resolvable links.** Read-only `_sources/mem_<id>.md` stubs so `[[mem_*]]` resolves in Obsidian, with manifest-scoped GC (never deletes non-`mem_*` files).

### Files (6)
`origin-core`: `export/provenance.rs` (new), `export/knowledge.rs`, `export/mod.rs`, `sources/page_watcher.rs`, `prompts/defaults.rs` · `origin-mcp`: `tools.rs`

### Tests / checks
- 42 unit + integration tests green: provenance 15, knowledge 12, page_watcher 13, prompts 2.
- `cargo clippy -p origin-core -p origin-mcp --all-targets -- -D warnings` clean; build clean; `origin-server` compiles.
- TDD throughout (test-first per commit); per-task spec + code-quality review, plus a final whole-branch adversarial review.

### Review catches (already fixed in-branch)
- **YAML-injection:** a page title or source id containing `"` collapsed the projected frontmatter, dropping the page from filesystem sync. Fixed by routing all frontmatter strings through a `yaml_quoted` (serde_json) helper.
- **Watcher write-storm:** canonicalize-both-sides verified to keep an unchanged projection `Unchanged` across repeated ticks (no per-tick rewrite, no DB mutation).
- **Duplicate-file fork:** re-projection on a vault synced without `.origin/state.json` could fork `<slug>-2.md`; now guarded on state presence.

### Deferred (follow-ups, not in this PR)
- **P2:** make `sanitize_stub_id` injective for non-`mem_*` imported ids (unreachable today — stored ids are UUID `mem_*`); escape the `space:` frontmatter line.
- **Perf:** cache the per-call wikilink regex; add a `SOURCES_BLOCK_START` pre-check before the per-tick render-compare; batch the O(N) manifest rewrite at scale.
- **Documented:** the manifest load-modify-save race is bounded + self-healing (cosmetic projection index).
- **Cosmetic:** pre-feature pages keep their old LLM-authored Sources section until the next re-distill rewrites the body.

### Notes
- **Version:** titled `fix:` to avoid an unintended minor bump (P1 = bug fix + foundation). Rename to `feat:` before squash-merge if you want `0.7 → 0.8`.
- **Pre-merge:** recommend a daemon smoke test on an isolated port + tmp `~/.origin` (create a page, confirm the `.md` projects with a resolvable `[[mem_*]]` stub and a watcher tick reports `Unchanged`).
- Design docs (spec, plans) live in gitignored `docs/superpowers/` and are intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — post-open `/code-review` (high) pass

A fresh recall-biased review surfaced 3 issues the per-task + final adversarial reviews missed (blind spot: external-client ingress + importer ids). Two fixed in-branch, one deferred:

- **[fixed `92358ebb`] Ingress asymmetry (data loss).** `canonicalize_page_body` ran only on egress (watcher); the store path persisted client content verbatim, so a client-supplied `<!-- origin:sources:* -->` delimiter caused prose truncation / `user_edited` storm on the next tick. Now sanitized at the DB store choke point (`insert_page` + `try_update_page_content`) — symmetric with egress.
- **[fixed `60c92b76`] Stub GC scope.** Stubs were projected for every source id but GC reaped only `mem_*`, so `import_*` (imported-memory) stubs leaked forever; the `mem_` prefix also wrongly deleted user files named `mem_*.md`. GC now reaps by the `origin_stub:` daemon marker — reaps `import_*`, spares user files of any name.
- **[deferred] `obsidian.rs::build_frontmatter`** still emits an unquoted `title:` (pre-existing, separate Obsidian-export path, not introduced by P1; 1-line follow-up reusing `yaml_quoted`). Plus minors: `related:` drops `mem_*`-titled pages; `remove_page` skips manifest cleanup when `state.json` is absent; multi-block residual link (self-healing, strictly reduced vs pre-fix).

Both fixes TDD'd + spec & code-quality reviewed. Suites after fixes: provenance 19, knowledge 12, page_watcher 13, + 3 db ingress integration tests; clippy `-D warnings` clean.
