### PR TITLE
test(eval): decompose probe ladder — headroom, recall, and CE-conversion probes

### DIFF
--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1646,6 +1646,154 @@ pub async fn run_longmemeval_headroom_probe_from_db(
     Ok(rows)
 }
 
+/// One row of the decompose-recall probe (Step 1 of the decompose probe
+/// ladder): does multi-anchor fetch reach gold that single-query fetch cannot?
+///
+/// All arms fetch at the CE knee window (limit=30, `RERANK_POOL_FLOOR=30`
+/// semantics) so the comparison is against the post-knee production shape:
+/// - `gold_in_base30` — single original query (control arm)
+/// - `gold_in_date30` — Zep-style question-date prefix `(date: ...) question`
+/// - `gold_in_union`  — presence anywhere in the union of per-stream pools
+///   (original + subqueries, 30 each): the ceiling for ANY downstream ranker
+/// - `gold_in_rrf30`  — top-30 of the equal-weight RRF merge, mirroring the
+///   production `search_memory_decomposed` merge: what the CURRENT merge
+///   realizes of that ceiling
+///
+/// Pool-size control is by construction: union ≤ 4 streams × 30 = 120, and the
+/// headroom probe already measured the single-query limit=100 ceiling on the
+/// same questions — join the two JSONLs on `query_id` to separate anchor
+/// diversity from pool size.
+#[derive(Debug, serde::Serialize)]
+pub struct DecomposeRecallRow {
+    pub query_id: String,
+    pub category: String,
+    pub n_gold: usize,
+    /// Subqueries from the fixture (excluding the original). 0 = atomic:
+    /// the union/rrf arms degrade to the base arm by construction.
+    pub n_subqueries: usize,
+    pub gold_in_base30: usize,
+    pub gold_in_date30: usize,
+    pub gold_in_union: usize,
+    pub union_size: usize,
+    pub gold_in_rrf30: usize,
+}
+
+#[derive(serde::Deserialize)]
+struct SubqFixtureRow {
+    query_id: String,
+    subqueries: Vec<String>,
+}
+
+/// Load the pre-generated subquery fixture (JSONL: `{query_id, subqueries}`).
+/// Subqueries exclude the original question (the probe prepends it, mirroring
+/// `retrieval::decompose::parse_subqueries`). Fails loud on malformed lines —
+/// the fixture is generated input, not user data.
+fn load_subquery_fixture(path: &Path) -> Result<HashMap<String, Vec<String>>, OriginError> {
+    let text = std::fs::read_to_string(path)
+        .map_err(|e| OriginError::Generic(format!("read subquery fixture: {e}")))?;
+    let mut map = HashMap::new();
+    for line in text.lines().filter(|l| !l.trim().is_empty()) {
+        let row: SubqFixtureRow = serde_json::from_str(line)
+            .map_err(|e| OriginError::Generic(format!("parse subquery fixture line: {e}")))?;
+        map.insert(row.query_id, row.subqueries);
+    }
+    Ok(map)
+}
+
+/// Equal-weight RRF merge of per-stream ranked id lists, truncated to `k`.
+/// Mirrors the `search_memory_decomposed` merge (score = Σ 1/(60+rank)), with
+/// a stable id tiebreak the production code leaves to HashMap order.
+fn rrf_merge_ids(streams: &[Vec<String>], k: usize) -> Vec<String> {
+    let mut scores: HashMap<&str, f32> = HashMap::new();
+    for ranked in streams {
+        for (rank, id) in ranked.iter().enumerate() {
+            *scores.entry(id.as_str()).or_default() += 1.0 / (60.0 + rank as f32);
+        }
+    }
+    let mut merged: Vec<(&str, f32)> = scores.into_iter().collect();
+    merged.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(b.0))
+    });
+    merged.truncate(k);
+    merged.into_iter().map(|(id, _)| id.to_string()).collect()
+}
+
+/// Decompose-recall probe over the base `search_memory` path (Step 1 of the
+/// decompose probe ladder). Consumes a pre-generated subquery fixture
+/// (agent-delegated decomposition — the primary lane from the 2026-05-30
+/// decision) instead of calling an LLM, so the run is deterministic and
+/// GPU-free. See [`DecomposeRecallRow`] for the four arms.
+pub async fn run_longmemeval_decompose_recall_probe_from_db(
+    db: &MemoryDB,
+    path: &Path,
+    subq_path: &Path,
+) -> Result<Vec<DecomposeRecallRow>, OriginError> {
+    const K: usize = 30;
+    let subq_map = load_subquery_fixture(subq_path)?;
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut rows: Vec<DecomposeRecallRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+        let gold_in = |ids: &[String]| {
+            ids.iter()
+                .filter(|id| relevant_source_ids.contains(*id))
+                .count()
+        };
+
+        let subqueries = subq_map
+            .get(&sample.question_id)
+            .cloned()
+            .unwrap_or_default();
+
+        // Streams mirror parse_subqueries: original first, then subqueries.
+        let mut streams: Vec<Vec<String>> = Vec::with_capacity(1 + subqueries.len());
+        for q in std::iter::once(&sample.question).chain(subqueries.iter()) {
+            let results = db
+                .search_memory(q, K, None, None, None, None, None, None)
+                .await?;
+            streams.push(results.into_iter().map(|r| r.source_id).collect());
+        }
+
+        let date_query = format!("(date: {}) {}", sample.question_date, sample.question);
+        let date_results = db
+            .search_memory(&date_query, K, None, None, None, None, None, None)
+            .await?;
+        let date_ids: Vec<String> = date_results.into_iter().map(|r| r.source_id).collect();
+
+        let union: HashSet<&str> = streams.iter().flatten().map(|s| s.as_str()).collect();
+        let rrf_top = rrf_merge_ids(&streams, K);
+
+        rows.push(DecomposeRecallRow {
+            query_id: sample.question_id.clone(),
+            category: sample.question_type.clone(),
+            n_gold: relevant_source_ids.len(),
+            n_subqueries: subqueries.len(),
+            gold_in_base30: gold_in(&streams[0]),
+            gold_in_date30: gold_in(&date_ids),
+            gold_in_union: relevant_source_ids
+                .iter()
+                .filter(|gid| union.contains(gid.as_str()))
+                .count(),
+            union_size: union.len(),
+            gold_in_rrf30: gold_in(&rrf_top),
+        });
+    }
+
+    Ok(rows)
+}
+
 /// Cross-encoder variant of [`run_longmemeval_eval_from_db_collect`]. Identical
 /// query set + relevance judgments + scoring, but retrieval goes through
 /// `search_memory_cross_rerank` (CE rescoring over the widened pool) instead of
@@ -2865,6 +3013,45 @@ mod tests {
         assert_eq!(gold_in_top_k(&[-1, -1], 100), 0);
         // boundary: rank 9 in, rank 10 out at k=10
         assert_eq!(gold_in_top_k(&[9, 10], 10), 1);
+    }
+
+    #[test]
+    fn rrf_merge_prefers_multi_stream_ids() {
+        // id "b" appears in both streams (ranks 1 and 0) and must beat "a"
+        // (rank 0 in one stream only): 1/61 + 1/60 > 1/60.
+        let streams = vec![
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            vec!["b".to_string(), "d".to_string()],
+        ];
+        let merged = rrf_merge_ids(&streams, 3);
+        assert_eq!(merged[0], "b");
+        assert_eq!(merged[1], "a");
+        assert_eq!(merged.len(), 3);
+        // truncation respected
+        assert_eq!(rrf_merge_ids(&streams, 1), vec!["b".to_string()]);
+        // single stream degrades to identity order
+        let single = vec![vec!["x".to_string(), "y".to_string()]];
+        assert_eq!(
+            rrf_merge_ids(&single, 30),
+            vec!["x".to_string(), "y".to_string()]
+        );
+    }
+
+    #[test]
+    fn subquery_fixture_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("subq.jsonl");
+        std::fs::write(
+            &p,
+            "{\"query_id\":\"q1\",\"subqueries\":[\"a\",\"b\"]}\n{\"query_id\":\"q2\",\"subqueries\":[]}\n",
+        )
+        .unwrap();
+        let map = load_subquery_fixture(&p).unwrap();
+        assert_eq!(map["q1"], vec!["a", "b"]);
+        assert!(map["q2"].is_empty());
+        // malformed line fails loud, not silently skipped
+        std::fs::write(&p, "{\"query_id\":\"q1\"\n").unwrap();
+        assert!(load_subquery_fixture(&p).is_err());
     }
 
     fn sample_json() -> &'static str {

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1540,6 +1540,112 @@ pub async fn run_longmemeval_eval_from_db_collect(
     Ok(rows)
 }
 
+/// One row of the recall-headroom probe: where the gold evidence turns sit in
+/// the base path's ranked list at three separate fetch limits.
+///
+/// Each limit is a SEPARATE `search_memory` call because candidate generation
+/// scales with the limit (`fetch_limit = limit * 3` per channel) and dedup +
+/// graph augmentation run over that scaled pool — ranks from one deep call do
+/// NOT equal where gold sits in a shallower production call. `gold_in_10` is
+/// production semantics (limit=10), `gold_in_30` is the CE knee window
+/// (RERANK_POOL_FLOOR=30) semantics, `gold_in_100` is the deep single-query
+/// fetch ceiling.
+#[derive(Debug, serde::Serialize)]
+pub struct HeadroomRow {
+    pub query_id: String,
+    pub category: String,
+    pub n_gold: usize,
+    /// 0-based rank of each gold id in the limit=100 call, -1 = absent.
+    /// Sorted ascending with absences last so output is deterministic.
+    pub gold_ranks_100: Vec<i64>,
+    pub gold_in_10: usize,
+    pub gold_in_30: usize,
+    pub gold_in_100: usize,
+    pub hit_any_10: bool,
+    pub hit_any_30: bool,
+    pub hit_any_100: bool,
+}
+
+/// Count gold ranks that landed inside the top-`k` (absences are `-1`).
+fn gold_in_top_k(ranks: &[i64], k: usize) -> usize {
+    ranks
+        .iter()
+        .filter(|&&r| r >= 0 && (r as usize) < k)
+        .count()
+}
+
+/// Recall-headroom probe over the base `search_memory` path (Step 0 of the
+/// decompose probe ladder). For each question, runs the base path at three
+/// fetch limits (10 / 30 / 100) and records how many gold evidence turns each
+/// list contains. Gold absent at the deep limit is recall headroom a
+/// single-query fetch cannot reach — the multi-anchor / decompose case; gold
+/// reachable at 30 but not 10 is CE-knee-window territory (RERANK_POOL_FLOOR);
+/// gold reachable at 100 but not 30 is pool-widening territory.
+/// No flag arms: this measures the substrate, not a lever, so there is no
+/// substrate-liveness gate either (the base path has no starvable channel).
+pub async fn run_longmemeval_headroom_probe_from_db(
+    db: &MemoryDB,
+    path: &Path,
+) -> Result<Vec<HeadroomRow>, OriginError> {
+    const LIMITS: [usize; 3] = [10, 30, 100];
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut rows: Vec<HeadroomRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+
+        // One independent search per limit: per-limit candidate generation is
+        // the point (see HeadroomRow docs), so ranks are computed within each
+        // call's own list, never derived by truncating the deep call.
+        let mut gold_in = [0usize; 3];
+        let mut deep_ranks: Vec<i64> = Vec::new();
+        for (i, &k) in LIMITS.iter().enumerate() {
+            let results = db
+                .search_memory(&sample.question, k, None, None, None, None, None, None)
+                .await?;
+            let ranks: Vec<i64> = relevant_source_ids
+                .iter()
+                .map(|gid| {
+                    results
+                        .iter()
+                        .position(|r| r.source_id == *gid)
+                        .map(|p| p as i64)
+                        .unwrap_or(-1)
+                })
+                .collect();
+            gold_in[i] = gold_in_top_k(&ranks, k);
+            if k == 100 {
+                deep_ranks = ranks;
+                deep_ranks.sort_by_key(|&r| if r < 0 { i64::MAX } else { r });
+            }
+        }
+
+        rows.push(HeadroomRow {
+            query_id: sample.question_id.clone(),
+            category: sample.question_type.clone(),
+            n_gold: relevant_source_ids.len(),
+            gold_ranks_100: deep_ranks,
+            gold_in_10: gold_in[0],
+            gold_in_30: gold_in[1],
+            gold_in_100: gold_in[2],
+            hit_any_10: gold_in[0] > 0,
+            hit_any_30: gold_in[1] > 0,
+            hit_any_100: gold_in[2] > 0,
+        });
+    }
+
+    Ok(rows)
+}
+
 /// Cross-encoder variant of [`run_longmemeval_eval_from_db_collect`]. Identical
 /// query set + relevance judgments + scoring, but retrieval goes through
 /// `search_memory_cross_rerank` (CE rescoring over the widened pool) instead of
@@ -2747,6 +2853,19 @@ pub use crate::eval::judge::{
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gold_in_top_k_bands() {
+        // ranks: two in top-10, one at 11-30, one at 31-100, one absent
+        let ranks = vec![0, 7, 22, 64, -1];
+        assert_eq!(gold_in_top_k(&ranks, 10), 2);
+        assert_eq!(gold_in_top_k(&ranks, 30), 3);
+        assert_eq!(gold_in_top_k(&ranks, 100), 4);
+        // absent-only never counts
+        assert_eq!(gold_in_top_k(&[-1, -1], 100), 0);
+        // boundary: rank 9 in, rank 10 out at k=10
+        assert_eq!(gold_in_top_k(&[9, 10], 10), 1);
+    }
 
     fn sample_json() -> &'static str {
         r#"[{

--- a/crates/origin-core/src/eval/longmemeval.rs
+++ b/crates/origin-core/src/eval/longmemeval.rs
@@ -1794,6 +1794,156 @@ pub async fn run_longmemeval_decompose_recall_probe_from_db(
     Ok(rows)
 }
 
+/// CE-rank a candidate pool against `query` and return source_ids in CE-score
+/// order (descending, stable id tiebreak). Fail-loud on reranker errors — this
+/// is probe code, not the production degrade path.
+async fn ce_rank_ids(
+    reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
+    query: &str,
+    pool: Vec<(String, String)>,
+) -> Result<Vec<String>, OriginError> {
+    if pool.len() <= 1 {
+        return Ok(pool.into_iter().map(|(id, _)| id).collect());
+    }
+    let q = query.to_string();
+    let mut scored = tokio::task::spawn_blocking(move || reranker.rerank(&q, &pool))
+        .await
+        .map_err(|e| OriginError::Generic(format!("rerank join: {e}")))??;
+    scored.sort_by(|a, b| {
+        b.1.partial_cmp(&a.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.0.cmp(&b.0))
+    });
+    Ok(scored.into_iter().map(|(id, _)| id).collect())
+}
+
+/// Step 2 of the decompose probe ladder: CE conversion at MATCHED budget.
+///
+/// Both arms feed the cross-encoder exactly 30 candidates (the measured knee,
+/// PR #244) and score the CE's top-10 — so any delta is pool COMPOSITION
+/// (anchor diversity), never pool size:
+/// - OFF arm: base `search_memory(question, 30)` pool (current CE-path shape
+///   under `RERANK_POOL_FLOOR=30`)
+/// - ON arm: equal-weight RRF merge of original+subquery streams (30 each,
+///   per-stream dedup by source_id), truncated to 30 — the
+///   `search_memory_decomposed` merge feeding the CE instead of bypassing it
+///
+/// Atomic questions (no subqueries in the fixture) have byte-identical pools;
+/// the CE is deterministic, so the OFF metrics are emitted for both arms
+/// without a second CE pass (mirrors a production gate where decompose no-ops
+/// on atomic queries). `latency_ms` covers the CE call only — per-stream
+/// searches are shared across arms and excluded.
+///
+/// Emits both arms as [`crate::eval::paired::PerQueryRow`]s
+/// (feature `decompose_ce`) so `analyze_paired.py` reads the output directly.
+pub async fn run_longmemeval_decompose_ce_probe_from_db(
+    db: &MemoryDB,
+    path: &Path,
+    subq_path: &Path,
+    reranker: std::sync::Arc<dyn crate::reranker::Reranker>,
+) -> Result<Vec<crate::eval::paired::PerQueryRow>, OriginError> {
+    use crate::eval::paired::PerQueryRow;
+    use std::time::Instant;
+    const K: usize = 30;
+
+    let subq_map = load_subquery_fixture(subq_path)?;
+    let mut samples = load_longmemeval(path)?;
+    apply_lme_limit(&mut samples);
+    let mut rows: Vec<PerQueryRow> = Vec::new();
+
+    for sample in &samples {
+        let memories = extract_memories(sample);
+        let relevant_source_ids: HashSet<String> = memories
+            .iter()
+            .filter(|m| m.has_answer)
+            .map(|m| memory_source_id(&m.question_id, m.session_idx, m.turn_idx))
+            .collect();
+        if relevant_source_ids.is_empty() {
+            continue;
+        }
+        let relevant_set: HashSet<&str> = relevant_source_ids.iter().map(|s| s.as_str()).collect();
+
+        let subqueries = subq_map
+            .get(&sample.question_id)
+            .cloned()
+            .unwrap_or_default();
+
+        // Per-stream searches: ordered unique source_ids + first-seen content
+        // (the CE candidate text, trimmed to 512 chars like the production path).
+        let mut streams: Vec<Vec<String>> = Vec::with_capacity(1 + subqueries.len());
+        let mut content_by_id: HashMap<String, String> = HashMap::new();
+        for q in std::iter::once(&sample.question).chain(subqueries.iter()) {
+            let results = db
+                .search_memory(q, K, None, None, None, None, None, None)
+                .await?;
+            let mut ids = Vec::with_capacity(results.len());
+            let mut seen: HashSet<&str> = HashSet::new();
+            for r in &results {
+                if seen.insert(r.source_id.as_str()) {
+                    ids.push(r.source_id.clone());
+                }
+            }
+            for r in &results {
+                content_by_id
+                    .entry(r.source_id.clone())
+                    .or_insert_with(|| r.content.chars().take(512).collect());
+            }
+            streams.push(ids);
+        }
+
+        let pool_of = |ids: &[String]| -> Vec<(String, String)> {
+            ids.iter()
+                .map(|id| {
+                    (
+                        id.clone(),
+                        content_by_id.get(id).cloned().unwrap_or_default(),
+                    )
+                })
+                .collect()
+        };
+        let on_ids = rrf_merge_ids(&streams, K);
+        let off_ids = &streams[0];
+
+        let mut emit = |state: &str, ranked: &[String], latency_ms: f64| {
+            let top10: Vec<&str> = ranked.iter().take(10).map(|s| s.as_str()).collect();
+            let grades: HashMap<&str, u8> = top10
+                .iter()
+                .map(|id| (*id, u8::from(relevant_set.contains(*id))))
+                .collect();
+            rows.push(PerQueryRow {
+                feature: "decompose_ce".to_string(),
+                bench: "lme".to_string(),
+                flag_state: state.to_string(),
+                query_id: sample.question_id.clone(),
+                category: sample.question_type.clone(),
+                ndcg10: metrics::ndcg_at_k(&top10, &grades, 10),
+                recall5: metrics::recall_at_k(&top10, &relevant_set, 5),
+                mrr: metrics::mrr(&top10, &relevant_set),
+                latency_ms,
+                graph_skipped: None,
+                temporal_touched: None,
+            });
+        };
+
+        let t0 = Instant::now();
+        let off_ranked = ce_rank_ids(reranker.clone(), &sample.question, pool_of(off_ids)).await?;
+        let off_latency = t0.elapsed().as_secs_f64() * 1000.0;
+        emit("off", &off_ranked, off_latency);
+
+        if subqueries.is_empty() {
+            // Atomic: pools identical, CE deterministic — reuse the OFF ranking.
+            emit("on", &off_ranked, off_latency);
+        } else {
+            let t1 = Instant::now();
+            let on_ranked =
+                ce_rank_ids(reranker.clone(), &sample.question, pool_of(&on_ids)).await?;
+            emit("on", &on_ranked, t1.elapsed().as_secs_f64() * 1000.0);
+        }
+    }
+
+    Ok(rows)
+}
+
 /// Cross-encoder variant of [`run_longmemeval_eval_from_db_collect`]. Identical
 /// query set + relevance judgments + scoring, but retrieval goes through
 /// `search_memory_cross_rerank` (CE rescoring over the widened pool) instead of

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -2984,6 +2984,60 @@ async fn decompose_recall_probe_emit() {
     );
 }
 
+/// Decompose-CE probe (Step 2 of the decompose ladder, the wire/kill gate):
+/// CE conversion at MATCHED budget. OFF = CE over the base pool@30, ON = CE
+/// over the decompose RRF-merge@30 — same 30-candidate CE input both arms, so
+/// the delta is pool composition, never pool size. Emits standard PerQueryRows
+/// (`decompose_ce_lme.jsonl`) for analyze_paired.py. Needs `EVAL_SUBQ_PATH`
+/// (same fixture as `decompose_recall_probe_emit`).
+#[tokio::test]
+#[ignore = "downloads ~600MB CE model (CPU); needs cached scenario SNAPSHOT DB + EVAL_SUBQ_PATH. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT + EVAL_SUBQ_PATH"]
+async fn decompose_ce_probe_emit() {
+    println!("=== DECOMPOSE-CE PROBE (decompose ladder Step 2, matched budget 30) ===");
+    let out_dir = paired_out_dir();
+    println!("EVAL_OUT = {}", out_dir.display());
+
+    let Some(subq_path) = std::env::var_os("EVAL_SUBQ_PATH").map(std::path::PathBuf::from) else {
+        println!("SKIP: EVAL_SUBQ_PATH not set (path to subquery fixture JSONL)");
+        return;
+    };
+    let root = resolve_scenario_db_root_from_harness();
+    let lme_dir = root.join("lme_v1");
+    let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+    if !lme_dir.join("origin_memory.db").exists() || !lme_fx.exists() || !subq_path.exists() {
+        println!(
+            "SKIP: lme_v1 snapshot DB ({}) or fixture ({}) or subquery fixture ({}) missing",
+            lme_dir.join("origin_memory.db").exists(),
+            lme_fx.exists(),
+            subq_path.exists()
+        );
+        return;
+    }
+
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+        .expect("init_cross_encoder_reranker failed (downloads ~600MB on first run)");
+    println!("CE model = {} (CPU)", reranker.model_id());
+
+    let db = origin_core::db::MemoryDB::new(
+        &lme_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open lme_v1 snapshot DB");
+
+    let rows = origin_core::eval::longmemeval::run_longmemeval_decompose_ce_probe_from_db(
+        &db, &lme_fx, &subq_path, reranker,
+    )
+    .await
+    .expect("decompose CE probe");
+
+    write_paired_rows("decompose_ce", "lme", &rows);
+    println!(
+        "=== done -> python3 analyze_paired.py --dir {} ===",
+        out_dir.display()
+    );
+}
+
 #[tokio::test]
 #[ignore = "needs cached scenario DBs (use SNAPSHOT copies); retrieval-only, no GPU. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
 async fn paired_ab_emit() {

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -2887,6 +2887,46 @@ async fn paired_run_cached_feature_cross_rerank_vals(
 /// when at least one CE feature is selected, so base-only smoke runs stay light.
 #[tokio::test]
 #[ignore = "needs cached scenario DBs (use SNAPSHOT copies); retrieval-only, no GPU. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
+async fn headroom_probe_emit() {
+    println!("=== RECALL-HEADROOM PROBE (decompose ladder Step 0) ===");
+    let out_dir = paired_out_dir();
+    println!("EVAL_OUT = {}", out_dir.display());
+
+    let root = resolve_scenario_db_root_from_harness();
+    let lme_dir = root.join("lme_v1");
+    let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+    if !lme_dir.join("origin_memory.db").exists() || !lme_fx.exists() {
+        println!(
+            "SKIP: lme_v1 snapshot DB ({}) or fixture ({}) missing",
+            lme_dir.join("origin_memory.db").exists(),
+            lme_fx.exists()
+        );
+        return;
+    }
+
+    let db = origin_core::db::MemoryDB::new(
+        &lme_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open lme_v1 snapshot DB");
+
+    let rows = origin_core::eval::longmemeval::run_longmemeval_headroom_probe_from_db(&db, &lme_fx)
+        .await
+        .expect("headroom probe");
+
+    use std::io::Write;
+    let path = out_dir.join("headroom_lme.jsonl");
+    let mut f = std::fs::File::create(&path).expect("create headroom jsonl");
+    for r in &rows {
+        let line = serde_json::to_string(r).expect("serialize HeadroomRow");
+        writeln!(f, "{line}").expect("write jsonl line");
+    }
+    println!("[headroom] wrote {} rows -> {}", rows.len(), path.display());
+}
+
+#[tokio::test]
+#[ignore = "needs cached scenario DBs (use SNAPSHOT copies); retrieval-only, no GPU. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
 async fn paired_ab_emit() {
     println!("=== PAIRED A/B EMIT (apparatus v2) ===");
     println!("EVAL_OUT = {}", paired_out_dir().display());

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -2925,6 +2925,65 @@ async fn headroom_probe_emit() {
     println!("[headroom] wrote {} rows -> {}", rows.len(), path.display());
 }
 
+/// Decompose-recall probe (Step 1 of the decompose ladder): base@30 vs
+/// date-prefix@30 vs subquery union vs RRF-merge@30, all on the base
+/// `search_memory` path. Consumes the pre-generated subquery fixture at
+/// `EVAL_SUBQ_PATH` (JSONL `{query_id, subqueries}` — agent-delegated
+/// decomposition, the primary lane from the 2026-05-30 decision). Join the
+/// emitted `decompose_recall_lme.jsonl` with `headroom_lme.jsonl` on
+/// `query_id` to compare the union arm against the single-query limit=100
+/// ceiling (pool-size control).
+#[tokio::test]
+#[ignore = "needs cached scenario DBs (use SNAPSHOT copies) + EVAL_SUBQ_PATH subquery fixture; retrieval-only, no GPU. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT + EVAL_SUBQ_PATH"]
+async fn decompose_recall_probe_emit() {
+    println!("=== DECOMPOSE-RECALL PROBE (decompose ladder Step 1) ===");
+    let out_dir = paired_out_dir();
+    println!("EVAL_OUT = {}", out_dir.display());
+
+    let Some(subq_path) = std::env::var_os("EVAL_SUBQ_PATH").map(std::path::PathBuf::from) else {
+        println!("SKIP: EVAL_SUBQ_PATH not set (path to subquery fixture JSONL)");
+        return;
+    };
+    let root = resolve_scenario_db_root_from_harness();
+    let lme_dir = root.join("lme_v1");
+    let lme_fx = eval_root().join("data/longmemeval_oracle.json");
+    if !lme_dir.join("origin_memory.db").exists() || !lme_fx.exists() || !subq_path.exists() {
+        println!(
+            "SKIP: lme_v1 snapshot DB ({}) or fixture ({}) or subquery fixture ({}) missing",
+            lme_dir.join("origin_memory.db").exists(),
+            lme_fx.exists(),
+            subq_path.exists()
+        );
+        return;
+    }
+
+    let db = origin_core::db::MemoryDB::new(
+        &lme_dir,
+        std::sync::Arc::new(origin_core::events::NoopEmitter),
+    )
+    .await
+    .expect("open lme_v1 snapshot DB");
+
+    let rows = origin_core::eval::longmemeval::run_longmemeval_decompose_recall_probe_from_db(
+        &db, &lme_fx, &subq_path,
+    )
+    .await
+    .expect("decompose recall probe");
+
+    use std::io::Write;
+    let path = out_dir.join("decompose_recall_lme.jsonl");
+    let mut f = std::fs::File::create(&path).expect("create decompose recall jsonl");
+    for r in &rows {
+        let line = serde_json::to_string(r).expect("serialize DecomposeRecallRow");
+        writeln!(f, "{line}").expect("write jsonl line");
+    }
+    println!(
+        "[decompose_recall] wrote {} rows -> {}",
+        rows.len(),
+        path.display()
+    );
+}
+
 #[tokio::test]
 #[ignore = "needs cached scenario DBs (use SNAPSHOT copies); retrieval-only, no GPU. Set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
 async fn paired_ab_emit() {


### PR DESCRIPTION
## What

Three permanent eval-harness probes (decompose probe ladder, Steps 0-2) measuring whether query decomposition has retrieval headroom on LME_S before any production wiring. All retrieval-only, no GPU, run against the cached lme_v1 snapshot DB.

- **Step 0 — `headroom_probe_emit`** (`run_longmemeval_headroom_probe_from_db`): gold-rank bands at three SEPARATE fetch limits (10/30/100; per-limit calls because candidate generation scales with limit via `fetch_limit = limit*3`). Emits `headroom_lme.jsonl`.
- **Step 1 — `decompose_recall_probe_emit`** (`run_longmemeval_decompose_recall_probe_from_db`): four arms at the CE knee window (30) — base, Zep-style question-date prefix, union of per-stream pools (ceiling), production `search_memory_decomposed` RRF merge. Consumes a pre-generated subquery fixture (`EVAL_SUBQ_PATH`, agent-delegated decomposition per the 2026-05-30 decision). Emits `decompose_recall_lme.jsonl`; joins with Step 0 on `query_id` for the pool-size control.
- **Step 2 — `decompose_ce_probe_emit`** (`run_longmemeval_decompose_ce_probe_from_db`): the wire/kill gate. CE over base pool@30 vs CE over decompose-RRF@30 — same 30-candidate CE budget both arms, so the paired delta is pool composition, never pool size. Emits standard `PerQueryRow`s (`decompose_ce_lme.jsonl`) consumed directly by `analyze_paired.py`.

Unit tests: `gold_in_top_k_bands`, `rrf_merge_prefers_multi_stream_ids`, `subquery_fixture_roundtrip` (fail-loud fixture parse).

## Findings (single-run scaffold, N=479, snapshot substrate)

- Step 0: biggest recoverable band everywhere is gold at rank 11-30 (~20% of TR/MS gold) — already addressable by the measured `RERANK_POOL_FLOOR=30` knee (PR #244), no decompose needed.
- Step 1: decompose union ceiling is real on compositional questions (TR +0.129, MS +0.114 recall, sign-p<0.0001) but recovers only 18% of the gold absent at single-query@100, and does not beat deep single fetch at matched budget. Date-prefix arm is net negative (ALL -0.024; SSP -0.128) — KILL.
- Step 2: CE conversion at matched budget is NULL — dNDCG\@10 -0.0006 agg (Wilcoxon p=0.92, BH no), inside the A/A noise floor (+0.0014). CE's top-10 changed on only 42/204 compositional questions; touched-subset has no direction. TR +0.0019, MS +0.0006.

**Verdict: decompose route CLOSED for LME_S retrieval NDCG** (third independent null/negative after the 2026-05-01 LoCoMo shelve and PR #189 closure). The apparatus stays for any future re-entry case.

## Test plan

- [x] `cargo test -p origin-core --lib longmemeval::tests` (19 passed)
- [x] clippy clean (lib + eval-harness test target)
- [x] All three probes ran end-to-end against the lme_v1 snapshot (479 rows each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)