### PR TITLE
test(eval): smaller-CE model sweep — latency/quality decision matrix (#187)

### DIFF
--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3627,8 +3627,10 @@ async fn rerank_window_knee_sweep() {
 /// must select exactly ONE model feature via `EVAL_PAIRED_ONLY`. The test
 /// panics if more than one model feature is selected while the dir is set
 /// (subsumes the unset case: unset selects all three), and cross-checks the
-/// constructed reranker's `model_id()` against the feature label so mounted
-/// weights can't run under the wrong tag.
+/// constructed reranker's `model_id()` against the feature label. The check
+/// validates label-vs-label (the BYO model_id comes from ORIGIN_RERANKER_MODEL_ID
+/// or the dir basename), so it catches copy-paste cross-wiring, not wrong
+/// weights inside a correctly-named dir.
 ///
 /// Run (unsandboxed, against SNAPSHOT DBs so seeds stay pristine):
 ///   ORIGIN_EVAL_ROOT=/Users/lucian/Repos/origin/app/eval \

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3607,6 +3607,201 @@ async fn rerank_window_knee_sweep() {
     );
 }
 
+/// Smaller-CE model sweep (#187): per model, paired arms on the cached DBs.
+///
+/// OFF arm = base `search_memory` collector (no CE).
+/// ON arm  = CE collector with `ORIGIN_RERANKER_MODEL=<model>`.
+///
+/// Plus one A/A floor arm (`rerank_model_aa`, base vs base, no CE) per bench so
+/// `analyze_paired.py` has a noise floor that matches the OFF arm path.
+///
+/// Models:
+///   `rerank_model_v2m3` -- BGE-reranker-v2-m3 (~568M params, default production)
+///   `rerank_model_turbo` -- JINA-v1-turbo-en  (~37M params, CPU-fast, English-only)
+///   `rerank_model_base`  -- BGE-reranker-base  (~278M params, mid-size)
+///
+/// `jina-turbo` is Xet-backed (hf-hub cannot fetch it directly). Use
+/// `ORIGIN_RERANKER_ONNX_DIR` pointing to a pre-downloaded local ONNX dir when
+/// running with that model. When `ORIGIN_RERANKER_ONNX_DIR` is set the BYO path
+/// is active and `ORIGIN_RERANKER_MODEL` is ignored -- so the caller MUST scope
+/// to exactly one model via `EVAL_PAIRED_ONLY`. The test panics loudly if
+/// `ORIGIN_RERANKER_ONNX_DIR` is set without an explicit `EVAL_PAIRED_ONLY`
+/// (running the three-model loop with BYO weights would silently use the same
+/// weights for every iteration -- a latency-confounded result with mislabeled
+/// feature tags).
+///
+/// Run (unsandboxed, against SNAPSHOT DBs so seeds stay pristine):
+///   ORIGIN_EVAL_ROOT=/Users/lucian/Repos/origin/app/eval \
+///   SCENARIO_DB_ROOT=~/.cache/origin-eval/scenario_snapshot \
+///   EVAL_OUT=~/.cache/origin-eval/rerank_model_sweep_out \
+///     cargo test -p origin-core --test eval_harness rerank_model_sweep -- \
+///     --ignored --nocapture --test-threads=1
+///
+/// For jina-turbo (BYO):
+///   EVAL_PAIRED_ONLY=rerank_model_turbo \
+///   ORIGIN_RERANKER_ONNX_DIR=~/.cache/origin-eval/rerankers/jina-turbo \
+///   ORIGIN_RERANKER_MODEL_ID=jina-turbo \
+///   ... (same env above) ...
+#[tokio::test]
+#[ignore = "cached scenario DBs; CPU ONNX; set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
+async fn rerank_model_sweep() {
+    use origin_core::eval::locomo::run_locomo_eval_cross_rerank_from_db_collect;
+    use origin_core::eval::locomo::run_locomo_eval_from_db_collect;
+    use origin_core::eval::longmemeval::run_longmemeval_eval_cross_rerank_from_db_collect;
+    use origin_core::eval::longmemeval::run_longmemeval_eval_from_db_collect;
+
+    println!("=== RERANK-MODEL SWEEP (smaller-CE latency/quality matrix, #187) ===");
+    println!("EVAL_OUT = {}", paired_out_dir().display());
+
+    // Guard: when ORIGIN_RERANKER_ONNX_DIR is set the BYO path is active and
+    // ORIGIN_RERANKER_MODEL is ignored by init_cross_encoder_reranker. Running
+    // the three-model loop in that mode would silently apply the same weights to
+    // every iteration while tagging the rows with different feature labels --
+    // producing a mislabeled, latency-confounded matrix. Require an explicit
+    // EVAL_PAIRED_ONLY to scope to the one model whose ONNX dir is mounted.
+    if std::env::var_os("ORIGIN_RERANKER_ONNX_DIR").is_some()
+        && std::env::var("EVAL_PAIRED_ONLY").is_err()
+    {
+        panic!(
+            "ORIGIN_RERANKER_ONNX_DIR is set (BYO weights) but EVAL_PAIRED_ONLY is unset.              The BYO path ignores ORIGIN_RERANKER_MODEL, so running all three model features              would tag rows with different labels while using the same weights.              Scope to the one mounted model via EVAL_PAIRED_ONLY=rerank_model_turbo (or whichever)."
+        );
+    }
+
+    let root = resolve_scenario_db_root_from_harness();
+    let benches: [(&str, &str); 2] = [
+        ("locomo", "data/locomo10.json"),
+        ("lme", "data/longmemeval_oracle.json"),
+    ];
+
+    // A/A floor: base (search_memory, no CE) vs base -- same collector on both
+    // arms. Must read ~zero delta, establishing the noise floor for the OFF arm
+    // path. One pair per bench.
+    if paired_feature_selected("rerank_model_aa") {
+        println!("--- feature rerank_model_aa (A/A no-op: base vs base) ---");
+        for (bench, fx_rel) in benches {
+            let db_dir = root.join(format!("{bench}_v1"));
+            let fx_path = eval_root().join(fx_rel);
+            if !db_dir.join("origin_memory.db").exists() || !fx_path.exists() {
+                println!(
+                    "[paired:rerank_model_aa] SKIP {bench} (db {} fixture {})",
+                    db_dir.join("origin_memory.db").exists(),
+                    fx_path.exists()
+                );
+                continue;
+            }
+            let db = origin_core::db::MemoryDB::new(
+                &db_dir,
+                std::sync::Arc::new(origin_core::events::NoopEmitter),
+            )
+            .await
+            .expect("open snapshot DB for rerank_model_aa");
+            for state in ["off", "on"] {
+                let rows = if bench == "locomo" {
+                    run_locomo_eval_from_db_collect(&db, &fx_path, "rerank_model_aa", state)
+                        .await
+                        .expect("rerank_model_aa locomo collect")
+                } else {
+                    run_longmemeval_eval_from_db_collect(&db, &fx_path, "rerank_model_aa", state)
+                        .await
+                        .expect("rerank_model_aa lme collect")
+                };
+                write_paired_rows("rerank_model_aa", bench, &rows);
+            }
+        }
+    }
+
+    // Per-model sweep: OFF = base search_memory (no CE), ON = CE with that model.
+    let models: [(&str, &str); 3] = [
+        ("rerank_model_v2m3", "bge-v2-m3"),
+        ("rerank_model_turbo", "turbo"),
+        ("rerank_model_base", "bge-base"),
+    ];
+    for (feature, model) in models {
+        if !paired_feature_selected(feature) {
+            continue;
+        }
+        println!("--- {feature} (ORIGIN_RERANKER_MODEL={model}) ---");
+        // Set the model env var so init_cross_encoder_reranker picks it up.
+        // The test runs alone with --test-threads=1 so there is no concurrency
+        // hazard. We remove the var after constructing the reranker to avoid
+        // leaking it into subsequent iterations (the reranker object already
+        // captures the model choice).
+        std::env::set_var("ORIGIN_RERANKER_MODEL", model);
+        let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+            .expect("init_cross_encoder_reranker failed (first run downloads weights)");
+        std::env::remove_var("ORIGIN_RERANKER_MODEL");
+        println!("CE model_id = {} (CPU)", reranker.model_id());
+
+        for (bench, fx_rel) in benches {
+            let db_dir = root.join(format!("{bench}_v1"));
+            let fx_path = eval_root().join(fx_rel);
+            if !db_dir.join("origin_memory.db").exists() || !fx_path.exists() {
+                println!(
+                    "[paired:{feature}] SKIP {bench} (db {} fixture {})",
+                    db_dir.join("origin_memory.db").exists(),
+                    fx_path.exists()
+                );
+                continue;
+            }
+            // OFF arm: base search_memory (no CE), labeled "off".
+            {
+                let db = origin_core::db::MemoryDB::new(
+                    &db_dir,
+                    std::sync::Arc::new(origin_core::events::NoopEmitter),
+                )
+                .await
+                .expect("open snapshot DB for off arm");
+                let rows = if bench == "locomo" {
+                    run_locomo_eval_from_db_collect(&db, &fx_path, feature, "off")
+                        .await
+                        .expect("locomo base off collect")
+                } else {
+                    run_longmemeval_eval_from_db_collect(&db, &fx_path, feature, "off")
+                        .await
+                        .expect("lme base off collect")
+                };
+                write_paired_rows(feature, bench, &rows);
+            }
+            // ON arm: CE collector with the selected model, labeled "on".
+            {
+                let db = origin_core::db::MemoryDB::new(
+                    &db_dir,
+                    std::sync::Arc::new(origin_core::events::NoopEmitter),
+                )
+                .await
+                .expect("open snapshot DB for on arm");
+                let rows = if bench == "locomo" {
+                    run_locomo_eval_cross_rerank_from_db_collect(
+                        &db,
+                        &fx_path,
+                        reranker.clone(),
+                        feature,
+                        "on",
+                    )
+                    .await
+                    .expect("locomo CE on collect")
+                } else {
+                    run_longmemeval_eval_cross_rerank_from_db_collect(
+                        &db,
+                        &fx_path,
+                        reranker.clone(),
+                        feature,
+                        "on",
+                    )
+                    .await
+                    .expect("lme CE on collect")
+                };
+                write_paired_rows(feature, bench, &rows);
+            }
+        }
+    }
+
+    println!(
+        "=== done -> python3 analyze_paired.py --dir {} ===",
+        paired_out_dir().display()
+    );
+}
+
 /// PR-B page-channel ON baseline (LoCoMo).
 ///
 /// Uses the pre-seeded consolidated scenario DB at

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3634,8 +3634,8 @@ async fn rerank_window_knee_sweep() {
 ///   ORIGIN_EVAL_ROOT=/Users/lucian/Repos/origin/app/eval \
 ///   SCENARIO_DB_ROOT=~/.cache/origin-eval/scenario_snapshot \
 ///   EVAL_OUT=~/.cache/origin-eval/rerank_model_sweep_out \
-///     cargo test -p origin-core --test eval_harness rerank_model_sweep -- \
-///     --ignored --nocapture --test-threads=1
+///     cargo test -p origin-core --features eval-harness --test eval_harness \
+///     rerank_model_sweep -- --ignored --nocapture --test-threads=1
 ///
 /// For jina-turbo (BYO):
 ///   EVAL_PAIRED_ONLY=rerank_model_turbo \
@@ -3663,7 +3663,10 @@ async fn rerank_model_sweep() {
         && std::env::var("EVAL_PAIRED_ONLY").is_err()
     {
         panic!(
-            "ORIGIN_RERANKER_ONNX_DIR is set (BYO weights) but EVAL_PAIRED_ONLY is unset.              The BYO path ignores ORIGIN_RERANKER_MODEL, so running all three model features              would tag rows with different labels while using the same weights.              Scope to the one mounted model via EVAL_PAIRED_ONLY=rerank_model_turbo (or whichever)."
+            "ORIGIN_RERANKER_ONNX_DIR is set (BYO weights) but EVAL_PAIRED_ONLY is unset. \
+             The BYO path ignores ORIGIN_RERANKER_MODEL, so running all three model features \
+             would tag rows with different labels while using the same weights. Scope to the \
+             one mounted model via EVAL_PAIRED_ONLY=rerank_model_turbo (or whichever)."
         );
     }
 

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -3623,12 +3623,12 @@ async fn rerank_window_knee_sweep() {
 /// `jina-turbo` is Xet-backed (hf-hub cannot fetch it directly). Use
 /// `ORIGIN_RERANKER_ONNX_DIR` pointing to a pre-downloaded local ONNX dir when
 /// running with that model. When `ORIGIN_RERANKER_ONNX_DIR` is set the BYO path
-/// is active and `ORIGIN_RERANKER_MODEL` is ignored -- so the caller MUST scope
-/// to exactly one model via `EVAL_PAIRED_ONLY`. The test panics loudly if
-/// `ORIGIN_RERANKER_ONNX_DIR` is set without an explicit `EVAL_PAIRED_ONLY`
-/// (running the three-model loop with BYO weights would silently use the same
-/// weights for every iteration -- a latency-confounded result with mislabeled
-/// feature tags).
+/// is active and `ORIGIN_RERANKER_MODEL` is ignored -- so each BYO invocation
+/// must select exactly ONE model feature via `EVAL_PAIRED_ONLY`. The test
+/// panics if more than one model feature is selected while the dir is set
+/// (subsumes the unset case: unset selects all three), and cross-checks the
+/// constructed reranker's `model_id()` against the feature label so mounted
+/// weights can't run under the wrong tag.
 ///
 /// Run (unsandboxed, against SNAPSHOT DBs so seeds stay pristine):
 ///   ORIGIN_EVAL_ROOT=/Users/lucian/Repos/origin/app/eval \
@@ -3637,11 +3637,15 @@ async fn rerank_window_knee_sweep() {
 ///     cargo test -p origin-core --features eval-harness --test eval_harness \
 ///     rerank_model_sweep -- --ignored --nocapture --test-threads=1
 ///
-/// For jina-turbo (BYO):
-///   EVAL_PAIRED_ONLY=rerank_model_turbo \
-///   ORIGIN_RERANKER_ONNX_DIR=~/.cache/origin-eval/rerankers/jina-turbo \
-///   ORIGIN_RERANKER_MODEL_ID=jina-turbo \
-///   ... (same env above) ...
+/// BYO runbook (one model per invocation, shared EVAL_OUT). The FIRST run must
+/// also select the A/A floor (`rerank_model_aa` is not a model feature, so the
+/// pair stays legal under the one-model guard) or no run ever writes
+/// `rerank_model_aa_*.jsonl` and every verdict comes out NO-FLOOR:
+///   run 1: EVAL_PAIRED_ONLY=rerank_model_v2m3,rerank_model_aa \
+///          ORIGIN_RERANKER_ONNX_DIR=~/.cache/origin-eval/rerankers/bge-v2-m3 \
+///          ORIGIN_RERANKER_MODEL_ID=bge-v2-m3 ... (same env above) ...
+///   run 2: EVAL_PAIRED_ONLY=rerank_model_turbo + the jina-turbo dir + id
+///   run 3: EVAL_PAIRED_ONLY=rerank_model_base + the bge-base dir + id
 #[tokio::test]
 #[ignore = "cached scenario DBs; CPU ONNX; set ORIGIN_EVAL_ROOT + SCENARIO_DB_ROOT + EVAL_OUT"]
 async fn rerank_model_sweep() {
@@ -3653,21 +3657,38 @@ async fn rerank_model_sweep() {
     println!("=== RERANK-MODEL SWEEP (smaller-CE latency/quality matrix, #187) ===");
     println!("EVAL_OUT = {}", paired_out_dir().display());
 
+    // (feature tag, ORIGIN_RERANKER_MODEL value, expected model_id substring).
+    let models: [(&str, &str, &str); 3] = [
+        ("rerank_model_v2m3", "bge-v2-m3", "v2-m3"),
+        ("rerank_model_turbo", "turbo", "turbo"),
+        ("rerank_model_base", "bge-base", "base"),
+    ];
+
     // Guard: when ORIGIN_RERANKER_ONNX_DIR is set the BYO path is active and
-    // ORIGIN_RERANKER_MODEL is ignored by init_cross_encoder_reranker. Running
-    // the three-model loop in that mode would silently apply the same weights to
-    // every iteration while tagging the rows with different feature labels --
-    // producing a mislabeled, latency-confounded matrix. Require an explicit
-    // EVAL_PAIRED_ONLY to scope to the one model whose ONNX dir is mounted.
-    if std::env::var_os("ORIGIN_RERANKER_ONNX_DIR").is_some()
-        && std::env::var("EVAL_PAIRED_ONLY").is_err()
-    {
-        panic!(
-            "ORIGIN_RERANKER_ONNX_DIR is set (BYO weights) but EVAL_PAIRED_ONLY is unset. \
-             The BYO path ignores ORIGIN_RERANKER_MODEL, so running all three model features \
-             would tag rows with different labels while using the same weights. Scope to the \
-             one mounted model via EVAL_PAIRED_ONLY=rerank_model_turbo (or whichever)."
-        );
+    // ORIGIN_RERANKER_MODEL is ignored by init_cross_encoder_reranker, so every
+    // selected model feature would run on the SAME mounted weights under
+    // different labels -- a mislabeled, latency-confounded matrix. Allow at most
+    // one selected model feature per BYO invocation (`> 1`, not `!= 1`, so an
+    // aa-only floor run stays legal with the dir exported -- the A/A arm builds
+    // no reranker). EVAL_PAIRED_ONLY unset selects all three, so the unset case
+    // is subsumed.
+    let byo_active = std::env::var_os("ORIGIN_RERANKER_ONNX_DIR").is_some();
+    if byo_active {
+        let selected: Vec<&str> = models
+            .iter()
+            .map(|(f, _, _)| *f)
+            .filter(|f| paired_feature_selected(f))
+            .collect();
+        if selected.len() > 1 {
+            panic!(
+                "ORIGIN_RERANKER_ONNX_DIR is set (BYO weights) but {} model features \
+                 are selected ({selected:?}). The BYO path ignores ORIGIN_RERANKER_MODEL, \
+                 so every selected feature would run on the same mounted weights under \
+                 different labels. Select exactly one of rerank_model_{{v2m3,turbo,base}} \
+                 via EVAL_PAIRED_ONLY.",
+                selected.len()
+            );
+        }
     }
 
     let root = resolve_scenario_db_root_from_harness();
@@ -3675,6 +3696,7 @@ async fn rerank_model_sweep() {
         ("locomo", "data/locomo10.json"),
         ("lme", "data/longmemeval_oracle.json"),
     ];
+    let mut wrote_any = false;
 
     // A/A floor: base (search_memory, no CE) vs base -- same collector on both
     // arms. Must read ~zero delta, establishing the noise floor for the OFF arm
@@ -3697,29 +3719,29 @@ async fn rerank_model_sweep() {
                 std::sync::Arc::new(origin_core::events::NoopEmitter),
             )
             .await
-            .expect("open snapshot DB for rerank_model_aa");
+            .unwrap_or_else(|e| panic!("rerank_model_aa/{bench} open snapshot DB: {e}"));
             for state in ["off", "on"] {
                 let rows = if bench == "locomo" {
                     run_locomo_eval_from_db_collect(&db, &fx_path, "rerank_model_aa", state)
                         .await
-                        .expect("rerank_model_aa locomo collect")
+                        .unwrap_or_else(|e| {
+                            panic!("rerank_model_aa/{bench} base collect ({state} arm): {e}")
+                        })
                 } else {
                     run_longmemeval_eval_from_db_collect(&db, &fx_path, "rerank_model_aa", state)
                         .await
-                        .expect("rerank_model_aa lme collect")
+                        .unwrap_or_else(|e| {
+                            panic!("rerank_model_aa/{bench} base collect ({state} arm): {e}")
+                        })
                 };
                 write_paired_rows("rerank_model_aa", bench, &rows);
+                wrote_any = true;
             }
         }
     }
 
     // Per-model sweep: OFF = base search_memory (no CE), ON = CE with that model.
-    let models: [(&str, &str); 3] = [
-        ("rerank_model_v2m3", "bge-v2-m3"),
-        ("rerank_model_turbo", "turbo"),
-        ("rerank_model_base", "bge-base"),
-    ];
-    for (feature, model) in models {
+    for (feature, model, expect_sub) in models {
         if !paired_feature_selected(feature) {
             continue;
         }
@@ -3730,10 +3752,26 @@ async fn rerank_model_sweep() {
         // leaking it into subsequent iterations (the reranker object already
         // captures the model choice).
         std::env::set_var("ORIGIN_RERANKER_MODEL", model);
-        let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
-            .expect("init_cross_encoder_reranker failed (first run downloads weights)");
+        let reranker =
+            origin_core::reranker::init_cross_encoder_reranker(None).unwrap_or_else(|e| {
+                panic!("{feature}: init_cross_encoder_reranker (first run downloads weights): {e}")
+            });
         std::env::remove_var("ORIGIN_RERANKER_MODEL");
         println!("CE model_id = {} (CPU)", reranker.model_id());
+        // Label/weights cross-check (BYO only): the BYO loader stamps model_id
+        // from ORIGIN_RERANKER_MODEL_ID (or the dir basename), so assert it
+        // contains the feature's expected token -- mounted weights can't run
+        // under the wrong feature label. The enum path stamps the fastembed
+        // Debug repr (e.g. "BGERerankerV2M3", no hyphens) and selects weights
+        // from the same tuple, so label/weights divergence is impossible there.
+        if byo_active {
+            assert!(
+                reranker.model_id().to_lowercase().contains(expect_sub),
+                "feature {feature} expected model_id containing {expect_sub:?}, got {:?} -- \
+                 the mounted ORIGIN_RERANKER_ONNX_DIR weights do not match the feature label",
+                reranker.model_id()
+            );
+        }
 
         for (bench, fx_rel) in benches {
             let db_dir = root.join(format!("{bench}_v1"));
@@ -3753,26 +3791,29 @@ async fn rerank_model_sweep() {
                     std::sync::Arc::new(origin_core::events::NoopEmitter),
                 )
                 .await
-                .expect("open snapshot DB for off arm");
+                .unwrap_or_else(|e| panic!("{feature}/{bench} open snapshot DB (off arm): {e}"));
                 let rows = if bench == "locomo" {
                     run_locomo_eval_from_db_collect(&db, &fx_path, feature, "off")
                         .await
-                        .expect("locomo base off collect")
+                        .unwrap_or_else(|e| panic!("{feature}/{bench} base collect (off arm): {e}"))
                 } else {
                     run_longmemeval_eval_from_db_collect(&db, &fx_path, feature, "off")
                         .await
-                        .expect("lme base off collect")
+                        .unwrap_or_else(|e| panic!("{feature}/{bench} base collect (off arm): {e}"))
                 };
                 write_paired_rows(feature, bench, &rows);
             }
             // ON arm: CE collector with the selected model, labeled "on".
+            // (wrote_any is set once per bench iteration, after this arm --
+            // a straight-line OFF-arm assignment would be dead, the ON arm
+            // always follows in the same iteration.)
             {
                 let db = origin_core::db::MemoryDB::new(
                     &db_dir,
                     std::sync::Arc::new(origin_core::events::NoopEmitter),
                 )
                 .await
-                .expect("open snapshot DB for on arm");
+                .unwrap_or_else(|e| panic!("{feature}/{bench} open snapshot DB (on arm): {e}"));
                 let rows = if bench == "locomo" {
                     run_locomo_eval_cross_rerank_from_db_collect(
                         &db,
@@ -3782,7 +3823,7 @@ async fn rerank_model_sweep() {
                         "on",
                     )
                     .await
-                    .expect("locomo CE on collect")
+                    .unwrap_or_else(|e| panic!("{feature}/{bench} CE collect (on arm): {e}"))
                 } else {
                     run_longmemeval_eval_cross_rerank_from_db_collect(
                         &db,
@@ -3792,12 +3833,24 @@ async fn rerank_model_sweep() {
                         "on",
                     )
                     .await
-                    .expect("lme CE on collect")
+                    .unwrap_or_else(|e| panic!("{feature}/{bench} CE collect (on arm): {e}"))
                 };
                 write_paired_rows(feature, bench, &rows);
+                wrote_any = true;
             }
         }
     }
+
+    // A typo'd EVAL_PAIRED_ONLY selects nothing and would otherwise exit green
+    // having written zero files; missing DBs/fixtures on every selected arm
+    // would too. Fail loud instead of green-zero.
+    assert!(
+        wrote_any,
+        "rerank_model_sweep wrote NO paired rows -- check EVAL_PAIRED_ONLY spelling \
+         (valid: rerank_model_aa, rerank_model_v2m3, rerank_model_turbo, \
+         rerank_model_base) and that SCENARIO_DB_ROOT / ORIGIN_EVAL_ROOT point at \
+         the seeded DBs + fixtures"
+    );
 
     println!(
         "=== done -> python3 analyze_paired.py --dir {} ===",


### PR DESCRIPTION
## What

New `#[ignore]` harness test `rerank_model_sweep` (#187 follow-up): per cross-encoder model, paired OFF arm (base `search_memory` collector) and ON arm (CE collector) on the cached scenario snapshot DBs, plus a base-vs-base A/A floor arm — `analyze_paired.py` turns the rows into a per-model ΔNDCG + latency decision matrix. Includes a BYO-ONNX safety guard (the BYO path overrides `ORIGIN_RERANKER_MODEL`, so >1 selected model feature with `ORIGIN_RERANKER_ONNX_DIR` set panics instead of silently running three labels on one set of weights), a label↔model_id cross-check, labeled failure messages, and a wrote-nothing assert.

Apparatus only — **no production code changed, no default flipped**. The CE default-ON decision stays with the user.

## Decision matrix (LME, n=479 paired, single run — scaffold N=1, not externally citable)

Env: M2 Pro CPU, fastembed ONNX BYO dirs, BGE-Base-EN-v1.5-Q embedder, cached lme_v1 snapshot (post-P3 re-seed 2026-06-10), harness @ 3fa0714b on main 5a61ad9e, analyze_paired BH-FDR q=0.1, machine otherwise idle. LoCoMo excluded by standing directive (locomo_v1 not mounted in SCENARIO_DB_ROOT → auto-skip).

| model | size | Δndcg@10 agg | 95% CI | BH-sig | off P50 | on P50 | ΔP50 | G3 |
|---|---|---|---|---|---|---|---|---|
| bge-reranker-v2-m3 | 2.27 GB | +0.1130 | [+0.0837,+0.1420] | yes | 185ms | 1279ms | +1094ms | SIGNAL |
| bge-reranker-base | 1.1 GB | +0.1058 | [+0.0766,+0.1353] | yes | 192ms | 510ms | +318ms | SIGNAL |
| jina-reranker-v1-turbo-en | 146 MB | +0.0804 | [+0.0509,+0.1093] | yes | 192ms | 212ms | +20ms | SIGNAL |
| A/A floor (rerank_model_aa) | — | +0.0014 | [-0.0015,+0.0051] | no (p=0.53) | 169ms | 163ms | −6ms | FLOOR-SRC |

All 18 per-category verdicts (3 models × 6 LME categories) ABOVE-FLOOR positive; no category negative anywhere. Per-query paired ΔP50 medians: turbo +23ms (IQR −1..+43), base +316ms, v2-m3 +1081ms, A/A −4ms — the turbo latency claim is paired same-process, not a warm/cold artifact.

## Reading

- **turbo**: CE for +20ms P50 — effectively free on CPU — keeping 71% of v2-m3's lift, BH-sig, no category negative. The analyzer's mechanical rec is FLIP-ON.
- **bge-base**: 94% of v2-m3's lift at 29% of its P50 cost. Not dominated (the 2026-06-04 survey dropped it on answer-acc task-avg; retrieval NDCG says otherwise).
- **v2-m3**: quality ceiling, still latency-blocked (+1094ms P50).
- Today's v2-m3 +0.113 vs the historical +0.178 receipt is baseline strengthening, not CE regression: the off arm now carries graph_stream default-ON (#257, +0.0545 quick-path receipt) on a re-seeded substrate; the CE path skips the stream under a live reranker by design (`allow_graph_stream = reranker.is_none()`).
- Attribution note: analyzer n_touched (pairs with Δndcg≠0) = 293-305/479; the #258 path-level channel_touched probe fires 479/479 → attribution ratio 1.0, G3 condition satisfied but non-discriminative for a CE-vs-base A/B.
- Demotion (P3): 91 stamps live in-window; applies POST-CE → active on ON arms only by design; ±0.3pt effect understates, not inflates, CE gains.
- Env-pin disclosure: page-channel / graph-stream / graph-gate envs rode at defaults (rows show graph_skipped=None; off-arm latency consistent with stream-ON). Future sweeps should pin them explicitly.

## Decision rule (user decides)

Default-ON candidate iff (a) BH-sig positive Δ, (b) no category below floor, (c) P50 within budget. All three pass (a)+(b) on LME; (c) is the call:
- budget "imperceptible" (<100ms over base) → **turbo** is the only candidate (v2-m3 stays the opt-in quality setting)
- budget ~0.5s → **bge-base** buys +0.025 NDCG over turbo
- LoCoMo + answer-accuracy legs and an N≥3 re-run required before any headline claim.

Full report (gitignored): docs/superpowers/rerank-model-sweep-2026-06-10.md. Raw rows archived at ~/.cache/origin-eval/paired_runs/rerank_model_sweep_2026-06-10/.

## Verification

- [x] spec review + code-quality review (fix loop: BYO multi-select guard, floor runbook, model_id cross-check, labeled failures, wrote_any assert) + final adversarial review (APPROVED; wording fixes applied)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test --workspace --lib` — 1804+190+71+60 passed, 0 failed
- [x] smoke (5q) + full run (479q × 3 models + A/A) end-to-end on lme_v1 snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
