### PR TITLE
fix(eval): CE answer-accuracy 2-arm gate (event_date + power)

### DIFF
--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -580,6 +580,7 @@ pub async fn run_e2e_locomo_eval(
                         answer,
                         context_tokens: origin_ctx_tokens,
                         category: String::new(),
+                        question_id: String::new(),
                     });
                 }
                 Err(e) => {
@@ -634,6 +635,7 @@ pub async fn run_e2e_locomo_eval(
                             answer,
                             context_tokens: compressed_ctx_tokens,
                             category: String::new(),
+                            question_id: String::new(),
                         });
                     }
                     Err(e) => {
@@ -673,6 +675,7 @@ pub async fn run_e2e_locomo_eval(
                             answer,
                             context_tokens: replay_ctx_tokens,
                             category: String::new(),
+                            question_id: String::new(),
                         });
                     }
                     Err(e) => {
@@ -712,6 +715,7 @@ pub async fn run_e2e_locomo_eval(
                         answer,
                         context_tokens: 0,
                         category: String::new(),
+                        question_id: String::new(),
                     });
                 }
                 Err(e) => {
@@ -817,6 +821,7 @@ async fn generate_e2e_answers_for_question(
             answer,
             context_tokens: flat_tokens,
             category: category.to_string(),
+            question_id: String::new(),
         });
     }
 
@@ -861,6 +866,7 @@ async fn generate_e2e_answers_for_question(
             answer,
             context_tokens: structured_tokens,
             category: category.to_string(),
+            question_id: String::new(),
         });
     }
 
@@ -2189,6 +2195,7 @@ pub async fn run_fullpipeline_locomo_batch(
                 answer: answer.clone(),
                 context_tokens: meta.context_tokens,
                 category: meta.category.clone(),
+                question_id: String::new(),
             });
             matched += 1;
             if matched.is_multiple_of(10) {
@@ -2684,6 +2691,7 @@ pub async fn run_fullpipeline_lme_batch(
                 answer: answer.clone(),
                 context_tokens: meta.context_tokens,
                 category: meta.category.clone(),
+                question_id: String::new(),
             });
             matched += 1;
             if matched.is_multiple_of(10) {
@@ -2733,6 +2741,17 @@ pub async fn run_fullpipeline_lme_batch(
 ///
 /// Approach labels: `"ce_off_{category}"` / `"ce_on_{category}"`.
 ///
+/// ## MEASUREMENT SCOPE
+///
+/// This isolates the cross-encoder. The confounder gate forces the graph stream
+/// (and skip-preference / temporal boost+filter) OFF on BOTH arms, so the only
+/// deliberate difference is the CE rescore. Production, however, runs the graph
+/// stream DEFAULT-ON, where CE-off keeps the stream and CE-on drops it
+/// (allow_graph_stream = reranker.is_none(), db.rs). A positive delta here therefore
+/// supports 'the CE rescore adds answer accuracy in isolation' — it does NOT by
+/// itself prove the production default-flip (CE-on coupled with stream-off) is a net
+/// win; that needs a separate stream-on-vs-CE-on comparison. Interpret accordingly.
+///
 /// # Errors
 ///
 /// Returns `Err` immediately if `ORIGIN_GRAPH_MEMORY_STREAM` is not one of
@@ -2748,19 +2767,45 @@ pub async fn run_fullpipeline_lme_ce_ab(
     use crate::eval::longmemeval::{category_name, extract_memories, load_longmemeval};
     use crate::llm_provider::{strip_think_tags, LlmRequest};
 
-    // Safety gate: the A/B is invalid when ORIGIN_GRAPH_MEMORY_STREAM is ON
-    // (default ON since 2026-06-10), because reranker=None on the OFF arm
-    // re-enables the graph stream, making the A/B measure CE vs graph+CE.
-    // Reuse `graph_memory_stream_enabled` so the guard cannot drift from the
-    // predicate that actually gates the stream inside cross_rerank.
-    if crate::db::graph_memory_stream_enabled() {
-        return Err(OriginError::Generic(
-            "ORIGIN_GRAPH_MEMORY_STREAM must be explicitly set to 0/false/no/off before \
-             running the CE A/B. Without it the OFF arm (reranker=None) re-enables the \
-             graph stream while the ON arm suppresses it, so the A/B measures \
-             CE vs graph+CE instead of CE alone. Set the env var and retry."
-                .to_string(),
-        ));
+    // Safety gate: the CE A/B isolates the cross-encoder only when no other
+    // retrieval flag perturbs ONE arm asymmetrically. graph stream: the OFF arm
+    // (reranker=None) re-enables it while the ON arm suppresses it; skip-pref: the
+    // ON arm bypasses the CE on preference queries; temporal boost/filter: alters
+    // the base pool. Reuse the same predicates that gate each feature so the guard
+    // cannot drift. Refuse loud, naming the offenders, rather than emit a
+    // confounded delta.
+    let confounders: [(&str, bool); 4] = [
+        (
+            "ORIGIN_GRAPH_MEMORY_STREAM",
+            crate::db::graph_memory_stream_enabled(),
+        ),
+        (
+            "ORIGIN_RERANK_SKIP_PREFERENCE",
+            crate::db::rerank_skip_preference_enabled(),
+        ),
+        (
+            "ORIGIN_ENABLE_TEMPORAL_SOFT_BOOST",
+            crate::db::temporal_soft_boost_enabled(),
+        ),
+        (
+            "ORIGIN_ENABLE_TEMPORAL_FILTER",
+            crate::db::temporal_filter_enabled(),
+        ),
+    ];
+    let active: Vec<&str> = confounders
+        .iter()
+        .filter(|(_, on)| *on)
+        .map(|(name, _)| *name)
+        .collect();
+    if !active.is_empty() {
+        return Err(OriginError::Generic(format!(
+            "CE A/B refused: confounding flag(s) active: {}. Each perturbs one arm \
+             asymmetrically (graph stream re-enabled on the OFF arm; CE bypass on \
+             preference queries; temporal boost/filter alters the base pool), so the \
+             A/B would not isolate the cross-encoder. Set them all to 0/false/no/off \
+             and retry.",
+            active.join(", ")
+        )));
     }
 
     let mut samples = load_longmemeval(longmemeval_path)?;
@@ -2912,19 +2957,29 @@ pub async fn run_fullpipeline_lme_ce_ab(
         // gate, NOT a direct answer fix: event_date is not rendered into the CE
         // A/B context (build_structured_context renders only content) and no
         // temporal ranking flag is set on this path, so dates influence neither
-        // ranking nor the prompt today. Their value is (a) the contract gate
-        // below can enforce presence (no starved-temporal null), (b) a future
-        // temporal lever has live data to read. source_id keys mirror the seed
-        // closure's `lme_{qid}_{sess}_t{turn}` exactly via event_date_map ->
-        // memory_source_id; a key mismatch updates 0 rows and the gate then
-        // refuses (loud), never silently passes.
+        // ranking nor the prompt today. Their value is (a) a per-question liveness
+        // signal (the rows-updated count below), (b) a future temporal lever has
+        // live data to read. source_id keys mirror the seed closure's
+        // `lme_{qid}_{sess}_t{turn}` exactly via event_date_map -> memory_source_id.
         let date_map = crate::eval::longmemeval::event_date_map(std::slice::from_ref(sample));
         if !date_map.is_empty() {
             let updates: Vec<(String, i64)> = date_map.into_iter().collect();
-            db.set_event_dates_by_source_id(&updates).await?;
-            // Refuse rather than emit a starved-temporal null (eval ONE-contract).
-            let conn = db.conn.lock().await;
-            crate::eval::seed_contract::assert_feature_substrate_live(&conn, "temporal").await?;
+            let n_total = updates.len();
+            let rows = db.set_event_dates_by_source_id(&updates).await?;
+            if rows == 0 {
+                // Per-question log + continue (NOT whole-run abort): a non-empty
+                // date_map that updates 0 rows means source_id-format drift for
+                // THIS question. Skip it rather than nuke a multi-hour decision run;
+                // the rows-updated count is an earlier, more precise signal than a
+                // DB-wide liveness assert (which propagated and aborted the run).
+                log::warn!(
+                    "[ce_ab_lme] event_date injection updated 0/{} rows for question {} \
+                     — source_id drift; skipping question",
+                    n_total,
+                    sample.question_id
+                );
+                continue;
+            }
         }
 
         let category = category_name(&sample.question_type);
@@ -2996,6 +3051,7 @@ pub async fn run_fullpipeline_lme_ce_ab(
                 answer,
                 context_tokens: ctx_tokens,
                 category: category.to_string(),
+                question_id: sample.question_id.clone(),
             });
         }
 

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -1144,6 +1144,17 @@ struct PendingAnswer {
 const E2E_SYSTEM_PROMPT: &str =
     "Answer the question using only the provided context. Be specific and concise. Respond in 1-3 sentences.";
 
+/// Controls which retrieval path `build_structured_context` uses.
+///
+/// - `Quick`: existing `search_memory` quick path (unchanged behavior, graph stream ON).
+/// - `CrossRerank(r)`: `search_memory_cross_rerank`; `r=None` disables the CE while
+///   still routing through cross_rerank so P3 distill-demotion is symmetric across arms.
+///   Pass `ORIGIN_GRAPH_MEMORY_STREAM=0` to suppress the stream on the None arm.
+pub(crate) enum CtxRetrieval {
+    Quick,
+    CrossRerank(Option<Arc<dyn crate::reranker::Reranker>>),
+}
+
 /// Build structured context for a question against an enriched DB.
 ///
 /// Returns the structured context: search_memory results + concept articles.
@@ -1154,12 +1165,20 @@ async fn build_structured_context(
     question: &str,
     search_limit: usize,
     domain: Option<&str>,
+    retrieval: CtxRetrieval,
 ) -> Result<(String, usize), OriginError> {
     use crate::pages::filter_pages_by_source_overlap;
 
-    let results = db
-        .search_memory(question, search_limit, None, domain, None, None, None, None)
-        .await?;
+    let results = match retrieval {
+        CtxRetrieval::Quick => {
+            db.search_memory(question, search_limit, None, domain, None, None, None, None)
+                .await?
+        }
+        CtxRetrieval::CrossRerank(reranker) => {
+            db.search_memory_cross_rerank(question, search_limit, None, domain, None, reranker)
+                .await?
+        }
+    };
 
     // Source IDs from search results — used to gate concept relevance
     let search_source_ids: std::collections::HashSet<String> =
@@ -1872,7 +1891,9 @@ pub async fn run_fullpipeline_locomo_batch(
                 }
 
                 let category = category_name(qa.category);
-                let ctx_result = build_structured_context(&db, &qa.question, 10, None).await;
+                let ctx_result =
+                    build_structured_context(&db, &qa.question, 10, None, CtxRetrieval::Quick)
+                        .await;
                 let (ctx, ctx_tokens) = match ctx_result {
                     Ok(v) => v,
                     Err(e) => {
@@ -2009,9 +2030,14 @@ pub async fn run_fullpipeline_locomo_batch(
                             }
 
                             let category = category_name(qa.category);
-                            let ctx_result =
-                                build_structured_context(&db, &qa.question, 10, None)
-                                    .await;
+                            let ctx_result = build_structured_context(
+                                &db,
+                                &qa.question,
+                                10,
+                                None,
+                                CtxRetrieval::Quick,
+                            )
+                            .await;
                             let (ctx, ctx_tokens) = match ctx_result {
                                 Ok(v) => v,
                                 Err(e) => {
@@ -2358,7 +2384,9 @@ pub async fn run_fullpipeline_lme_batch(
             );
 
             let category = category_name(&sample.question_type);
-            let ctx_result = build_structured_context(&db, &sample.question, 10, None).await;
+            let ctx_result =
+                build_structured_context(&db, &sample.question, 10, None, CtxRetrieval::Quick)
+                    .await;
             let (ctx, ctx_tokens) = match ctx_result {
                 Ok(v) => v,
                 Err(e) => {
@@ -2501,8 +2529,14 @@ pub async fn run_fullpipeline_lme_batch(
                         );
 
                         let category = category_name(&sample.question_type);
-                        let ctx_result =
-                            build_structured_context(&db, &sample.question, 10, None).await;
+                        let ctx_result = build_structured_context(
+                            &db,
+                            &sample.question,
+                            10,
+                            None,
+                            CtxRetrieval::Quick,
+                        )
+                        .await;
                         let (ctx, ctx_tokens) = match ctx_result {
                             Ok(v) => v,
                             Err(e) => {
@@ -2670,6 +2704,301 @@ pub async fn run_fullpipeline_lme_batch(
         .map_err(|e| OriginError::Generic(format!("save: {e}")))?;
     eprintln!(
         "[fullpipeline_lme] Saved {} total tuples to {:?}",
+        finished_tuples.len(),
+        output_path
+    );
+
+    Ok(finished_tuples)
+}
+
+// ===== Fair CE A/B answer runner =====
+
+/// Fair cross-encoder (CE) answer-accuracy A/B for LongMemEval.
+///
+/// **FAIR design**: both arms route through `search_memory_cross_rerank` so
+/// P3 distill-demotion is symmetric, and the caller MUST set
+/// `ORIGIN_GRAPH_MEMORY_STREAM=0` (enforced at entry) so the OFF arm
+/// (reranker=None) does not re-enable the graph stream that the ON arm
+/// (reranker=Some) suppresses — without this, the A/B measures
+/// graph-stream vs CE, not CE alone.
+///
+/// - OFF arm: `CrossRerank(None)` — no CE, graph stream off.
+/// - ON  arm: `CrossRerank(Some(reranker))` — CE active, graph stream off.
+///
+/// Per question, both arms share the same seeded DB (same seed/enrichment
+/// as `run_fullpipeline_lme_batch`). Answers are generated on-device by the
+/// supplied `llm` provider (Qwen3.5-9B) at `temperature = 0.0` so both arms
+/// are deterministic and self-judging is avoided (the downstream judge is a
+/// different model). Mirrors `generate_e2e_answers_for_question`'s LLM call.
+///
+/// Approach labels: `"ce_off_{category}"` / `"ce_on_{category}"`.
+///
+/// # Errors
+///
+/// Returns `Err` immediately if `ORIGIN_GRAPH_MEMORY_STREAM` is not one of
+/// "0"/"false"/"no"/"off" — the A/B is statistically invalid without it.
+pub async fn run_fullpipeline_lme_ce_ab(
+    longmemeval_path: &std::path::Path,
+    enrichment: crate::eval::shared::EnrichmentMode,
+    llm: Arc<dyn crate::llm_provider::LlmProvider>,
+    output_path: &std::path::Path,
+    reranker: Arc<dyn crate::reranker::Reranker>,
+) -> Result<Vec<crate::eval::judge::JudgmentTuple>, OriginError> {
+    use crate::eval::judge::{save_judgment_tuples, JudgmentTuple};
+    use crate::eval::longmemeval::{category_name, extract_memories, load_longmemeval};
+    use crate::llm_provider::{strip_think_tags, LlmRequest};
+
+    // Safety gate: the A/B is invalid when ORIGIN_GRAPH_MEMORY_STREAM is ON
+    // (default ON since 2026-06-10), because reranker=None on the OFF arm
+    // re-enables the graph stream, making the A/B measure CE vs graph+CE.
+    // Reuse `graph_memory_stream_enabled` so the guard cannot drift from the
+    // predicate that actually gates the stream inside cross_rerank.
+    if crate::db::graph_memory_stream_enabled() {
+        return Err(OriginError::Generic(
+            "ORIGIN_GRAPH_MEMORY_STREAM must be explicitly set to 0/false/no/off before \
+             running the CE A/B. Without it the OFF arm (reranker=None) re-enables the \
+             graph stream while the ON arm suppresses it, so the A/B measures \
+             CE vs graph+CE instead of CE alone. Set the env var and retry."
+                .to_string(),
+        ));
+    }
+
+    let mut samples = load_longmemeval(longmemeval_path)?;
+    let limit_active = std::env::var("LME_LIMIT_QUESTIONS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok());
+    if let Some(n) = limit_active {
+        let total_before = samples.len();
+        samples.truncate(n);
+        eprintln!(
+            "[ce_ab_lme] LME_LIMIT_QUESTIONS={n} -> processing {}/{}",
+            samples.len(),
+            total_before
+        );
+    }
+    let shared_embedder = crate::eval::shared::eval_shared_embedder();
+
+    // Resume: load any already-generated tuples.
+    let mut finished_tuples: Vec<JudgmentTuple> = if output_path.exists() {
+        let existing = crate::eval::judge::load_judgment_tuples(output_path)
+            .map_err(|e| OriginError::Generic(format!("load resume: {e}")))?;
+        eprintln!(
+            "[ce_ab_lme] Resuming with {} existing tuples",
+            existing.len()
+        );
+        existing
+    } else {
+        Vec::new()
+    };
+    if limit_active.is_some() {
+        let allowed: std::collections::HashSet<String> =
+            samples.iter().map(|s| s.question.clone()).collect();
+        let before = finished_tuples.len();
+        finished_tuples.retain(|t| allowed.contains(&t.question));
+        if before != finished_tuples.len() {
+            eprintln!(
+                "[ce_ab_lme] resume filter: kept {}/{} tuples within limit window",
+                finished_tuples.len(),
+                before
+            );
+        }
+    }
+
+    // A question is done only when BOTH arms are present.
+    let done_questions: std::collections::HashSet<String> = {
+        let mut off_qs: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut on_qs: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for t in &finished_tuples {
+            if t.approach.starts_with("ce_off_") {
+                off_qs.insert(t.question.clone());
+            } else if t.approach.starts_with("ce_on_") {
+                on_qs.insert(t.question.clone());
+            }
+        }
+        off_qs.intersection(&on_qs).cloned().collect()
+    };
+
+    let baselines_dir = output_path
+        .parent()
+        .ok_or_else(|| OriginError::Generic("output_path has no parent".to_string()))?;
+
+    let mut processed = 0usize;
+    let mut save_counter = 0usize;
+
+    for (q_idx, sample) in samples.iter().enumerate() {
+        if done_questions.contains(&sample.question) {
+            continue;
+        }
+
+        // Ground truth: LME answers are JSON strings; handle non-string values
+        // explicitly rather than borrowing a temporary (M1).
+        let ground_truth = match &sample.answer {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        if ground_truth.is_empty() {
+            continue;
+        }
+
+        let memories = extract_memories(sample);
+        if memories.is_empty() {
+            continue;
+        }
+
+        let scope_dir =
+            crate::eval::shared::scenario_db_dir(baselines_dir, "lme", &sample.question_id);
+
+        let question_id = sample.question_id.clone();
+        let question_type = sample.question_type.clone();
+        let memories_owned = memories.clone();
+
+        let db = match crate::eval::shared::open_or_seed_scenario_db(
+            &scope_dir,
+            shared_embedder.clone(),
+            move || {
+                memories_owned
+                    .iter()
+                    .map(|mem| crate::sources::RawDocument {
+                        content: mem.content.clone(),
+                        source_id: format!(
+                            "lme_{}_{}_t{}",
+                            question_id, mem.session_idx, mem.turn_idx
+                        ),
+                        source: "memory".to_string(),
+                        title: format!("session {} turn {}", mem.session_idx, mem.turn_idx),
+                        memory_type: Some(
+                            if question_type == "single-session-preference" {
+                                "preference"
+                            } else {
+                                "fact"
+                            }
+                            .to_string(),
+                        ),
+                        space: Some("conversation".to_string()),
+                        last_modified: chrono::Utc::now().timestamp(),
+                        ..Default::default()
+                    })
+                    .collect()
+            },
+            &enrichment,
+        )
+        .await
+        {
+            Ok(db) => db,
+            Err(e) => {
+                return Err(OriginError::Generic(format!(
+                    "[ce_ab_lme] scenario {} failed to open/seed DB: {e}. Refusing to \
+                     silently drop the question — re-seed and retry.",
+                    sample.question_id
+                )));
+            }
+        };
+
+        // Substrate-liveness: a per-question DB with zero memories yields a
+        // vacuous A/B (both arms retrieve nothing). Fail loud rather than
+        // emit a misleading null, per the eval ONE-contract discipline (H2).
+        let db_mem_count = db.memory_count().await.unwrap_or(0);
+        if db_mem_count == 0 {
+            return Err(OriginError::Generic(format!(
+                "EVAL REFUSED [ce_ab_lme]: scenario {} seeded DB has 0 memories. \
+                 A CE A/B over an empty substrate measures noise, not CE. Re-seed and retry.",
+                sample.question_id
+            )));
+        }
+
+        let category = category_name(&sample.question_type);
+
+        // Generate an answer for both arms from the same seeded DB.
+        // OFF = CrossRerank(None) (CE off); ON = CrossRerank(Some(reranker)) (CE on).
+        // Both route through cross_rerank so P3 demotion is symmetric.
+        for (arm_label, retrieval) in [
+            (
+                format!("ce_off_{category}"),
+                CtxRetrieval::CrossRerank(None),
+            ),
+            (
+                format!("ce_on_{category}"),
+                CtxRetrieval::CrossRerank(Some(reranker.clone())),
+            ),
+        ] {
+            let (ctx, ctx_tokens) =
+                match build_structured_context(&db, &sample.question, 10, None, retrieval).await {
+                    Ok(v) => v,
+                    Err(e) => {
+                        return Err(OriginError::Generic(format!(
+                            "[ce_ab_lme] scenario {} arm {arm_label} context build failed: {e}",
+                            sample.question_id
+                        )));
+                    }
+                };
+
+            let request = LlmRequest {
+                system_prompt: Some(E2E_SYSTEM_PROMPT.to_string()),
+                user_prompt: format!("Context:\n{}\n\nQuestion: {}", ctx, sample.question),
+                max_tokens: 200,
+                // Pinned to 0.0 (vs the 0.1 used elsewhere) so both arms are
+                // deterministic — fairness depends on identical decoding.
+                temperature: 0.0,
+                label: Some(arm_label.clone()),
+                timeout_secs: None,
+            };
+
+            let answer = match llm.generate(request).await {
+                Ok(raw) => strip_think_tags(&raw).trim().to_string(),
+                Err(e) => {
+                    // Skip BOTH arms for this question rather than persisting a
+                    // half-pair; on resume the question is reprocessed (H1).
+                    eprintln!(
+                        "[ce_ab_lme] WARN: scenario {} arm {arm_label} generation failed: {e}. \
+                         Dropping both arms for this question; will retry on resume.",
+                        sample.question_id
+                    );
+                    break;
+                }
+            };
+
+            // Never persist an empty answer — it would mark the question DONE on
+            // resume and silently bias the arm to score 0 (H1).
+            if answer.is_empty() {
+                eprintln!(
+                    "[ce_ab_lme] WARN: scenario {} arm {arm_label} produced empty answer. \
+                     Dropping both arms; will retry on resume.",
+                    sample.question_id
+                );
+                break;
+            }
+
+            finished_tuples.push(JudgmentTuple {
+                question: sample.question.clone(),
+                ground_truth: ground_truth.clone(),
+                approach: arm_label,
+                answer,
+                context_tokens: ctx_tokens,
+                category: category.to_string(),
+            });
+        }
+
+        processed += 1;
+        save_counter += 1;
+        if save_counter >= 10 {
+            save_counter = 0;
+            if let Err(e) = save_judgment_tuples(&finished_tuples, output_path) {
+                eprintln!("[ce_ab_lme] WARN: incremental save failed: {e}");
+            }
+        }
+        if q_idx % 100 == 99 {
+            eprintln!(
+                "[ce_ab_lme] {}/{} questions processed",
+                q_idx + 1,
+                samples.len()
+            );
+        }
+    }
+
+    save_judgment_tuples(&finished_tuples, output_path)
+        .map_err(|e| OriginError::Generic(format!("save: {e}")))?;
+    eprintln!(
+        "[ce_ab_lme] Processed {processed} new questions; saved {} total tuples to {:?}",
         finished_tuples.len(),
         output_path
     );

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -2906,6 +2906,27 @@ pub async fn run_fullpipeline_lme_ce_ab(
             )));
         }
 
+        // Make the temporal substrate LIVE for this question's scenario DB by
+        // injecting per-session event_date (turn text carries no date; the date
+        // is per-session haystack metadata). This is substrate-prep + a liveness
+        // gate, NOT a direct answer fix: event_date is not rendered into the CE
+        // A/B context (build_structured_context renders only content) and no
+        // temporal ranking flag is set on this path, so dates influence neither
+        // ranking nor the prompt today. Their value is (a) the contract gate
+        // below can enforce presence (no starved-temporal null), (b) a future
+        // temporal lever has live data to read. source_id keys mirror the seed
+        // closure's `lme_{qid}_{sess}_t{turn}` exactly via event_date_map ->
+        // memory_source_id; a key mismatch updates 0 rows and the gate then
+        // refuses (loud), never silently passes.
+        let date_map = crate::eval::longmemeval::event_date_map(std::slice::from_ref(sample));
+        if !date_map.is_empty() {
+            let updates: Vec<(String, i64)> = date_map.into_iter().collect();
+            db.set_event_dates_by_source_id(&updates).await?;
+            // Refuse rather than emit a starved-temporal null (eval ONE-contract).
+            let conn = db.conn.lock().await;
+            crate::eval::seed_contract::assert_feature_substrate_live(&conn, "temporal").await?;
+        }
+
         let category = category_name(&sample.question_type);
 
         // Generate an answer for both arms from the same seeded DB.
@@ -3007,3 +3028,62 @@ pub async fn run_fullpipeline_lme_ce_ab(
 }
 
 // ===== Flat cache loaders =====
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eval::longmemeval::{ChatTurn, LongMemEvalSample};
+
+    #[tokio::test]
+    async fn event_date_injection_lands_on_seeded_rows() {
+        let sample = LongMemEvalSample {
+            question_id: "qtest".to_string(),
+            question_type: "temporal-reasoning".to_string(),
+            question: "What happened after the May session?".to_string(),
+            answer: serde_json::json!("the answer"),
+            question_date: "2023/05/02 (Tue) 10:00".to_string(),
+            haystack_dates: vec!["2023/05/01 (Mon) 10:00".to_string()],
+            haystack_session_ids: vec!["s0".to_string()],
+            haystack_sessions: vec![vec![ChatTurn {
+                role: "user".to_string(),
+                content: "I had the planning session today.".to_string(),
+                has_answer: true,
+            }]],
+            answer_session_ids: vec!["s0".to_string()],
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new_with_shared_embedder(
+            tmp.path(),
+            Arc::new(NoopEmitter),
+            eval_shared_embedder(),
+        )
+        .await
+        .unwrap();
+
+        db.upsert_documents(vec![RawDocument {
+            source: "memory".to_string(),
+            source_id: format!("lme_{}_{}_t{}", sample.question_id, 0usize, 0usize),
+            title: "session 0 turn 0".to_string(),
+            content: "I had the planning session today.".to_string(),
+            last_modified: chrono::Utc::now().timestamp(),
+            memory_type: Some("fact".to_string()),
+            space: Some("conversation".to_string()),
+            ..Default::default()
+        }])
+        .await
+        .unwrap();
+
+        let updates: Vec<(String, i64)> =
+            crate::eval::longmemeval::event_date_map(std::slice::from_ref(&sample))
+                .into_iter()
+                .collect();
+        let updated = db.set_event_dates_by_source_id(&updates).await.unwrap();
+        assert_eq!(updated, 1, "event_date_map key must match seeded source_id");
+
+        let conn = db.conn.lock().await;
+        crate::eval::seed_contract::assert_feature_substrate_live(&conn, "temporal")
+            .await
+            .unwrap();
+    }
+}

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -2854,10 +2854,18 @@ pub async fn run_fullpipeline_lme_ce_ab(
         let mut off_qs: std::collections::HashSet<String> = std::collections::HashSet::new();
         let mut on_qs: std::collections::HashSet<String> = std::collections::HashSet::new();
         for t in &finished_tuples {
+            // Key on question_id (fallback to text for pre-question_id caches) so two
+            // questions sharing text are not treated as one done unit — mirrors the
+            // McNemar pairing key.
+            let k = if t.question_id.is_empty() {
+                t.question.clone()
+            } else {
+                t.question_id.clone()
+            };
             if t.approach.starts_with("ce_off_") {
-                off_qs.insert(t.question.clone());
+                off_qs.insert(k);
             } else if t.approach.starts_with("ce_on_") {
-                on_qs.insert(t.question.clone());
+                on_qs.insert(k);
             }
         }
         off_qs.intersection(&on_qs).cloned().collect()
@@ -2871,7 +2879,13 @@ pub async fn run_fullpipeline_lme_ce_ab(
     let mut save_counter = 0usize;
 
     for (q_idx, sample) in samples.iter().enumerate() {
-        if done_questions.contains(&sample.question) {
+        // Match the done-set key (question_id, fallback to text) — see build above.
+        let sample_key: &str = if sample.question_id.is_empty() {
+            sample.question.as_str()
+        } else {
+            sample.question_id.as_str()
+        };
+        if done_questions.contains(sample_key) {
             continue;
         }
 

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -1685,3 +1685,486 @@ mod tests {
         assert_eq!(back2, verdicts[1]);
     }
 }
+
+// ===== Paired McNemar answer-accuracy comparator =====
+
+/// Aggregate + per-category McNemar test on paired CE answer-accuracy A/B results.
+///
+/// `results` must contain entries with `approach` prefixed by `"ce_off_"` or `"ce_on_"`.
+/// Pairs are joined on `question`. Unpaired questions are excluded with a log line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McNemarReport {
+    /// Aggregate OFF accuracy (fraction of pairs where OFF arm scored 1).
+    pub off_acc: f64,
+    /// Aggregate ON accuracy (fraction of pairs where ON arm scored 1).
+    pub on_acc: f64,
+    /// on_acc − off_acc.
+    pub delta: f64,
+    /// Pairs where OFF=1, ON=0.
+    pub b: u64,
+    /// Pairs where OFF=0, ON=1.
+    pub c: u64,
+    /// Total complete pairs used.
+    pub n_pairs: u64,
+    /// Test statistic (χ² or exact-binomial n_min for small-n path).
+    pub stat: f64,
+    /// Two-sided p-value.
+    pub p_value: f64,
+    /// "mcnemar_chi2" or "exact_binomial" (when b+c < 25).
+    pub test_used: String,
+    /// Per-category breakdown (category parsed from approach suffix after `ce_off_`/`ce_on_`).
+    pub by_category: Vec<McNemarCategory>,
+}
+
+/// Per-category slice of a McNemar report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McNemarCategory {
+    pub category: String,
+    pub off_acc: f64,
+    pub on_acc: f64,
+    pub delta: f64,
+    pub b: u64,
+    pub c: u64,
+    pub n_pairs: u64,
+}
+
+/// Compute `McNemarReport` from a slice of `JudgmentResult`s.
+///
+/// Arms are identified by approach prefix (`ce_off_<category>` / `ce_on_<category>`).
+/// Pairs are joined on `question`. Unpaired entries are skipped.
+pub fn paired_answer_mcnemar(results: &[JudgmentResult]) -> McNemarReport {
+    use std::collections::HashMap;
+
+    // Collect per-question score for each arm. Key = question text.
+    let mut off_map: HashMap<&str, (u8, String)> = HashMap::new(); // question -> (score, category)
+    let mut on_map: HashMap<&str, u8> = HashMap::new();
+
+    for r in results {
+        if let Some(cat) = r.approach.strip_prefix("ce_off_") {
+            off_map.insert(r.question.as_str(), (r.score, cat.to_string()));
+        } else if r.approach.starts_with("ce_on_") {
+            on_map.insert(r.question.as_str(), r.score);
+        }
+    }
+
+    // Build complete pairs.
+    let mut agg_b = 0u64; // off=1, on=0
+    let mut agg_c = 0u64; // off=0, on=1
+    let mut agg_off_correct = 0u64;
+    let mut agg_on_correct = 0u64;
+    let mut agg_n = 0u64;
+
+    // Per-category accumulation.
+    let mut cat_b: HashMap<String, u64> = HashMap::new();
+    let mut cat_c: HashMap<String, u64> = HashMap::new();
+    let mut cat_off: HashMap<String, u64> = HashMap::new();
+    let mut cat_on: HashMap<String, u64> = HashMap::new();
+    let mut cat_n: HashMap<String, u64> = HashMap::new();
+
+    for (question, (off_score, category)) in &off_map {
+        if let Some(on_score) = on_map.get(question) {
+            agg_n += 1;
+            agg_off_correct += u64::from(*off_score);
+            agg_on_correct += u64::from(*on_score);
+            if *off_score == 1 && *on_score == 0 {
+                agg_b += 1;
+            } else if *off_score == 0 && *on_score == 1 {
+                agg_c += 1;
+            }
+
+            *cat_n.entry(category.clone()).or_default() += 1;
+            *cat_off.entry(category.clone()).or_default() += u64::from(*off_score);
+            *cat_on.entry(category.clone()).or_default() += u64::from(*on_score);
+            if *off_score == 1 && *on_score == 0 {
+                *cat_b.entry(category.clone()).or_default() += 1;
+            } else if *off_score == 0 && *on_score == 1 {
+                *cat_c.entry(category.clone()).or_default() += 1;
+            }
+        }
+    }
+
+    let unpaired_off = off_map.len().saturating_sub(agg_n as usize);
+    let unpaired_on = on_map.len().saturating_sub(agg_n as usize);
+    if unpaired_off > 0 || unpaired_on > 0 {
+        log::warn!(
+            "[mcnemar] {} OFF-only and {} ON-only entries excluded (unpaired)",
+            unpaired_off,
+            unpaired_on
+        );
+    }
+
+    let (stat, p_value, test_used) = mcnemar_stat(agg_b, agg_c);
+
+    let off_acc = if agg_n > 0 {
+        agg_off_correct as f64 / agg_n as f64
+    } else {
+        0.0
+    };
+    let on_acc = if agg_n > 0 {
+        agg_on_correct as f64 / agg_n as f64
+    } else {
+        0.0
+    };
+
+    // Build per-category vec, sorted by category name for determinism.
+    let mut all_cats: Vec<String> = cat_n.keys().cloned().collect();
+    all_cats.sort();
+    let by_category: Vec<McNemarCategory> = all_cats
+        .into_iter()
+        .map(|cat| {
+            let n = *cat_n.get(&cat).unwrap_or(&0);
+            let off_c = *cat_off.get(&cat).unwrap_or(&0);
+            let on_c = *cat_on.get(&cat).unwrap_or(&0);
+            let b = *cat_b.get(&cat).unwrap_or(&0);
+            let c = *cat_c.get(&cat).unwrap_or(&0);
+            McNemarCategory {
+                category: cat,
+                off_acc: if n > 0 { off_c as f64 / n as f64 } else { 0.0 },
+                on_acc: if n > 0 { on_c as f64 / n as f64 } else { 0.0 },
+                delta: if n > 0 {
+                    on_c as f64 / n as f64 - off_c as f64 / n as f64
+                } else {
+                    0.0
+                },
+                b,
+                c,
+                n_pairs: n,
+            }
+        })
+        .collect();
+
+    McNemarReport {
+        off_acc,
+        on_acc,
+        delta: on_acc - off_acc,
+        b: agg_b,
+        c: agg_c,
+        n_pairs: agg_n,
+        stat,
+        p_value,
+        test_used,
+        by_category,
+    }
+}
+
+/// Compute McNemar statistic + two-sided p-value.
+///
+/// Uses exact two-sided binomial when `b + c < 25` (standard small-n threshold),
+/// McNemar χ²=(|b−c|−1)²/(b+c) with continuity correction otherwise.
+fn mcnemar_stat(b: u64, c: u64) -> (f64, f64, String) {
+    let n_disc = b + c;
+    if n_disc == 0 {
+        // No discordant pairs — cannot distinguish arms.
+        return (0.0, 1.0, "mcnemar_chi2".to_string());
+    }
+
+    if n_disc < 25 {
+        // Exact two-sided binomial: P(X <= min(b,c)) * 2, clamped to [0,1].
+        // Under H0, B ~ Binomial(n=b+c, p=0.5).
+        let n = n_disc;
+        let k = b.min(c);
+        let p_one_tail = binomial_cdf(n, k, 0.5);
+        let p = (p_one_tail * 2.0).min(1.0);
+        return (k as f64, p, "exact_binomial".to_string());
+    }
+
+    // McNemar χ² with continuity correction.
+    let diff = (b as f64 - c as f64).abs() - 1.0;
+    let chi2 = (diff * diff) / n_disc as f64;
+    let p = chi2_df1_p_value(chi2);
+    (chi2, p, "mcnemar_chi2".to_string())
+}
+
+/// Cumulative binomial P(X <= k) for X ~ Bin(n, 0.5), computed EXACTLY.
+///
+/// McNemar's exact path only ever uses `p = 0.5` with `n = b + c < 25`
+/// (the `n >= 25` case takes the chi² path). For that regime the CDF is the
+/// closed form `sum_{i=0}^{k} C(n,i) / 2^n`, which f64 represents exactly:
+/// the largest term `C(24,12) ≈ 2.7e6` and `2^24` both fit with no rounding,
+/// so there is no need for a regularized-incomplete-beta approximation.
+///
+/// `p` is accepted for signature clarity but must be `0.5`; any other value
+/// would be a programming error (debug-asserted).
+fn binomial_cdf(n: u64, k: u64, p: f64) -> f64 {
+    debug_assert!((p - 0.5).abs() < 1e-12, "binomial_cdf only supports p=0.5");
+    if k >= n {
+        return 1.0;
+    }
+    let mut sum: f64 = 0.0;
+    for i in 0..=k {
+        sum += binomial_coeff(n, i);
+    }
+    sum / 2f64.powi(n as i32)
+}
+
+/// Exact binomial coefficient C(n, k) as f64. Exact for the small `n < 25`
+/// McNemar regime (values stay well under 2^53).
+fn binomial_coeff(n: u64, k: u64) -> f64 {
+    if k > n {
+        return 0.0;
+    }
+    let k = k.min(n - k); // symmetry: C(n,k) = C(n,n-k)
+    let mut result: f64 = 1.0;
+    for i in 0..k {
+        result = result * (n - i) as f64 / (i + 1) as f64;
+    }
+    result
+}
+
+/// Two-sided p-value from a chi-squared(df=1) statistic via the complementary error function.
+///
+/// P(chi2(1) > t) = erfc(sqrt(t/2)).
+fn chi2_df1_p_value(chi2: f64) -> f64 {
+    if chi2 <= 0.0 {
+        return 1.0;
+    }
+    erfc(chi2.sqrt() / std::f64::consts::SQRT_2)
+}
+
+/// Complementary error function erfc(x) = 1 - erf(x).
+/// Implemented via polynomial approximation; accurate to ~1e-7.
+fn erfc(x: f64) -> f64 {
+    if x < 0.0 {
+        return 2.0 - erfc(-x);
+    }
+    if x > 10.0 {
+        return 0.0;
+    }
+    // Use asymptotic expansion for large x.
+    if x >= 4.0 {
+        let t = 1.0 / (x * x);
+        let series = 1.0 - t * (0.5 - t * (0.75 - t * (1.875 - t * (6.5625 - t * 29.53125))));
+        return series * (-x * x).exp() / (x * std::f64::consts::PI.sqrt());
+    }
+    // For 0 <= x < 4, use Horner's polynomial (Abramowitz & Stegun 7.1.26, p=0.47047).
+    let p = 0.47047_f64;
+    let a1 = 0.3480242_f64;
+    let a2 = -0.0958798_f64;
+    let a3 = 0.7478556_f64;
+    let t = 1.0 / (1.0 + p * x);
+    let erf_x = 1.0 - (a1 * t + a2 * t * t + a3 * t * t * t) * (-x * x).exp();
+    1.0 - erf_x
+}
+
+#[cfg(test)]
+mod mcnemar_tests {
+    use super::*;
+
+    fn make_result(question: &str, approach: &str, score: u8) -> JudgmentResult {
+        JudgmentResult {
+            question: question.to_string(),
+            approach: approach.to_string(),
+            score,
+            reason: String::new(),
+            context_tokens: 0,
+        }
+    }
+
+    #[test]
+    fn mcnemar_clear_on_win() {
+        // ON wins on 10 questions, OFF wins on 0. c=10, b=0, n=10.
+        let mut results = Vec::new();
+        for i in 0..10 {
+            let q = format!("question_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 0));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.n_pairs, 10);
+        assert_eq!(report.b, 0);
+        assert_eq!(report.c, 10);
+        assert!(report.delta > 0.0, "ON should win: delta={}", report.delta);
+        assert_eq!(report.test_used, "exact_binomial", "n_disc=10 < 25");
+        // Exact binomial with k=0, n=10: p = 2*(0.5^10) ~ 0.002
+        assert!(report.p_value < 0.05, "p={}", report.p_value);
+        assert_eq!(report.by_category.len(), 1);
+        assert_eq!(report.by_category[0].category, "single-hop");
+        assert_eq!(report.by_category[0].c, 10);
+    }
+
+    #[test]
+    fn mcnemar_clear_off_win() {
+        // OFF wins on 8 questions. b=8, c=0.
+        let mut results = Vec::new();
+        for i in 0..8 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_temporal-reasoning", 1));
+            results.push(make_result(&q, "ce_on_temporal-reasoning", 0));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.b, 8);
+        assert_eq!(report.c, 0);
+        assert!(report.delta < 0.0, "OFF should win");
+        assert_eq!(report.test_used, "exact_binomial");
+        assert!(report.p_value < 0.05);
+    }
+
+    #[test]
+    fn mcnemar_tie_no_discordant() {
+        // Both arms always agree — no discordant pairs. b=c=0.
+        let mut results = Vec::new();
+        for i in 0..20 {
+            let q = format!("q_{i}");
+            let score = if i % 2 == 0 { 1 } else { 0 };
+            results.push(make_result(&q, "ce_off_single-hop", score));
+            results.push(make_result(&q, "ce_on_single-hop", score));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.b, 0);
+        assert_eq!(report.c, 0);
+        assert_eq!(report.p_value, 1.0, "no discordant pairs -> p=1");
+        assert!((report.delta).abs() < 1e-10, "tie -> delta=0");
+    }
+
+    #[test]
+    fn mcnemar_small_n_exact_binomial_path() {
+        // 5 discordant pairs (b+c=5 < 25) -> exact_binomial path.
+        let mut results = Vec::new();
+        // 10 concordant pairs (both score 1) — ignored by McNemar.
+        for i in 0..10 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_multi-session", 1));
+            results.push(make_result(&q, "ce_on_multi-session", 1));
+        }
+        // 5 discordant ON-wins (off=0, on=1).
+        for i in 10..15 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_multi-session", 0));
+            results.push(make_result(&q, "ce_on_multi-session", 1));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.test_used, "exact_binomial", "5 discordant -> exact");
+        assert_eq!(report.c, 5);
+        assert_eq!(report.b, 0);
+    }
+
+    #[test]
+    fn mcnemar_per_category_split() {
+        // Two categories: ON wins single-hop, tie on temporal-reasoning.
+        let mut results = Vec::new();
+        for i in 0..5 {
+            let q = format!("sh_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 0));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+        }
+        for i in 0..5 {
+            let q = format!("tr_{i}");
+            results.push(make_result(&q, "ce_off_temporal-reasoning", 1));
+            results.push(make_result(&q, "ce_on_temporal-reasoning", 1));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.n_pairs, 10);
+        assert_eq!(report.by_category.len(), 2);
+
+        let sh = report
+            .by_category
+            .iter()
+            .find(|c| c.category == "single-hop")
+            .expect("single-hop category");
+        assert_eq!(sh.c, 5);
+        assert_eq!(sh.b, 0);
+        assert!((sh.on_acc - 1.0).abs() < 1e-9);
+        assert!((sh.off_acc).abs() < 1e-9);
+
+        let tr = report
+            .by_category
+            .iter()
+            .find(|c| c.category == "temporal-reasoning")
+            .expect("temporal-reasoning category");
+        assert_eq!(tr.b, 0);
+        assert_eq!(tr.c, 0);
+        assert!((tr.delta).abs() < 1e-9);
+    }
+
+    #[test]
+    fn mcnemar_large_n_chi2_path() {
+        // 30 discordant ON-wins (b+c=30 >= 25) -> chi2 path.
+        let mut results = Vec::new();
+        for i in 0..30 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 0));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.test_used, "mcnemar_chi2", "30 discordant -> chi2");
+        assert!(report.stat > 0.0);
+        assert!(report.p_value < 0.05, "p={}", report.p_value);
+    }
+
+    // ----- value-pinned numeric guards (regression-protect beta-CF / erfc) -----
+
+    /// Helper: build `b` OFF-wins + `c` ON-wins (all discordant) and return the report.
+    fn report_for_bc(b: usize, c: usize) -> McNemarReport {
+        let mut results = Vec::new();
+        let mut i = 0;
+        for _ in 0..b {
+            let q = format!("b_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 1));
+            results.push(make_result(&q, "ce_on_single-hop", 0));
+            i += 1;
+        }
+        for _ in 0..c {
+            let q = format!("c_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 0));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+            i += 1;
+        }
+        paired_answer_mcnemar(&results)
+    }
+
+    #[test]
+    fn mcnemar_pinned_exact_binomial_0_10() {
+        // b=0, c=10: exact two-sided binomial p = 2*(0.5)^10 = 0.001953125.
+        let r = report_for_bc(0, 10);
+        assert_eq!(r.test_used, "exact_binomial");
+        assert!(
+            (r.p_value - 0.001_953_125).abs() < 1e-9,
+            "p={} expected 0.001953125",
+            r.p_value
+        );
+    }
+
+    #[test]
+    fn mcnemar_pinned_exact_binomial_0_8() {
+        // b=0, c=8: p = 2*(0.5)^8 = 0.0078125.
+        let r = report_for_bc(0, 8);
+        assert_eq!(r.test_used, "exact_binomial");
+        assert!(
+            (r.p_value - 0.007_812_5).abs() < 1e-9,
+            "p={} expected 0.0078125",
+            r.p_value
+        );
+    }
+
+    #[test]
+    fn mcnemar_pinned_balanced_discordance_clamps_to_one() {
+        // b=c=5 (b+c=10 < 25): exact-binomial path; 2*P(X<=5) > 1 so clamps to 1.0.
+        // This exercises the `(p*2).min(1.0)` clamp and the b==c symmetry, which
+        // the no-discordant tie test (b=c=0) short-circuits before reaching.
+        let r = report_for_bc(5, 5);
+        assert_eq!(r.test_used, "exact_binomial");
+        assert!(
+            (r.p_value - 1.0).abs() < 1e-12,
+            "p={} expected exactly 1.0 (clamped)",
+            r.p_value
+        );
+    }
+
+    #[test]
+    fn mcnemar_pinned_chi2_0_30() {
+        // b=0, c=30 (b+c=30 >= 25): chi2 with continuity = (|0-30|-1)^2/30 = 28.0333…,
+        // p = erfc(sqrt(chi2/2)) ≈ 1.1924e-7. Guards erfc accuracy in the small-p tail.
+        let r = report_for_bc(0, 30);
+        assert_eq!(r.test_used, "mcnemar_chi2");
+        assert!(
+            (r.stat - 28.033_333).abs() < 1e-4,
+            "stat={} expected ~28.0333",
+            r.stat
+        );
+        assert!(
+            (r.p_value - 1.192_436_7e-7).abs() < 1e-8,
+            "p={} expected ~1.1924e-7",
+            r.p_value
+        );
+    }
+}

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -201,12 +201,28 @@ pub async fn judge_with_claude_model_persistent(
 
     let cached_keys: HashSet<(String, String)> = cached
         .iter()
-        .map(|r| (r.question.clone(), r.approach.clone()))
+        .map(|r| {
+            // Dedup key: question_id when present (fallback to text for
+            // pre-question_id caches), so two questions sharing text don't collide.
+            let k = if r.question_id.is_empty() {
+                r.question.clone()
+            } else {
+                r.question_id.clone()
+            };
+            (k, r.approach.clone())
+        })
         .collect();
 
     let todo: Vec<JudgmentTuple> = tuples
         .iter()
-        .filter(|t| !cached_keys.contains(&(t.question.clone(), t.approach.clone())))
+        .filter(|t| {
+            let k = if t.question_id.is_empty() {
+                t.question.clone()
+            } else {
+                t.question_id.clone()
+            };
+            !cached_keys.contains(&(k, t.approach.clone()))
+        })
         .cloned()
         .collect();
 
@@ -682,12 +698,28 @@ pub async fn judge_with_claude_model_batched_persistent(
 
     let cached_keys: HashSet<(String, String)> = cached
         .iter()
-        .map(|r| (r.question.clone(), r.approach.clone()))
+        .map(|r| {
+            // Dedup key: question_id when present (fallback to text for
+            // pre-question_id caches), so two questions sharing text don't collide.
+            let k = if r.question_id.is_empty() {
+                r.question.clone()
+            } else {
+                r.question_id.clone()
+            };
+            (k, r.approach.clone())
+        })
         .collect();
 
     let todo: Vec<&JudgmentTuple> = tuples
         .iter()
-        .filter(|t| !cached_keys.contains(&(t.question.clone(), t.approach.clone())))
+        .filter(|t| {
+            let k = if t.question_id.is_empty() {
+                t.question.clone()
+            } else {
+                t.question_id.clone()
+            };
+            !cached_keys.contains(&(k, t.approach.clone()))
+        })
         .collect();
 
     eprintln!(

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -41,6 +41,12 @@ pub struct JudgmentTuple {
     /// "single-hop"). Defaults to empty for backward compat with existing JSON.
     #[serde(default)]
     pub category: String,
+    /// Stable question identifier used to pair arms in `paired_answer_mcnemar`.
+    /// Pairing on question TEXT collapses distinct questions that share text;
+    /// keying on this id is correct-by-construction. Empty for non-paired paths
+    /// and old JSON (the pairing falls back to question text when empty).
+    #[serde(default)]
+    pub question_id: String,
 }
 
 /// Result from the LLM judge.
@@ -52,6 +58,10 @@ pub struct JudgmentResult {
     pub score: u8,
     pub reason: String,
     pub context_tokens: usize,
+    /// Stable question identifier carried from the `JudgmentTuple`. Used to pair
+    /// arms in `paired_answer_mcnemar` (falls back to question text when empty).
+    #[serde(default)]
+    pub question_id: String,
 }
 
 // Cost telemetry has been moved to `cli_batch::CliCostInfo` and is shared across
@@ -509,6 +519,7 @@ pub async fn judge_single_tuple_model_with_cost(
             score,
             reason,
             context_tokens: tuple.context_tokens,
+            question_id: tuple.question_id.clone(),
         },
         cost,
     ))
@@ -791,6 +802,7 @@ pub async fn judge_with_claude_model_batched_persistent(
                         score: *score,
                         reason: reason.clone(),
                         context_tokens: tuple.context_tokens,
+                        question_id: tuple.question_id.clone(),
                     };
                     let line = match serde_json::to_string(&r) {
                         Ok(s) => s,
@@ -1197,6 +1209,7 @@ pub async fn judge_with_batch_api(
             score,
             reason,
             context_tokens: tuple.context_tokens,
+            question_id: tuple.question_id.clone(),
         });
     }
 
@@ -1739,15 +1752,21 @@ pub struct McNemarCategory {
 pub fn paired_answer_mcnemar(results: &[JudgmentResult]) -> McNemarReport {
     use std::collections::HashMap;
 
-    // Collect per-question score for each arm. Key = question text.
-    let mut off_map: HashMap<&str, (u8, String)> = HashMap::new(); // question -> (score, category)
+    // Collect per-question score for each arm. Key = question_id when present,
+    // else question text (distinct questions sharing text must not collapse).
+    let mut off_map: HashMap<&str, (u8, String)> = HashMap::new(); // key -> (score, category)
     let mut on_map: HashMap<&str, u8> = HashMap::new();
 
     for r in results {
+        let key: &str = if r.question_id.is_empty() {
+            r.question.as_str()
+        } else {
+            r.question_id.as_str()
+        };
         if let Some(cat) = r.approach.strip_prefix("ce_off_") {
-            off_map.insert(r.question.as_str(), (r.score, cat.to_string()));
+            off_map.insert(key, (r.score, cat.to_string()));
         } else if r.approach.starts_with("ce_on_") {
-            on_map.insert(r.question.as_str(), r.score);
+            on_map.insert(key, r.score);
         }
     }
 
@@ -1963,6 +1982,7 @@ mod mcnemar_tests {
             score,
             reason: String::new(),
             context_tokens: 0,
+            question_id: String::new(),
         }
     }
 
@@ -2226,5 +2246,53 @@ mod mcnemar_tests {
             "p={} expected ~1.1924e-7",
             r.p_value
         );
+    }
+
+    #[test]
+    fn mcnemar_pairs_on_question_id_not_text() {
+        // Two distinct questions share identical question text but have different question_ids.
+        // With old text-keying both collapse into one pair (collision → n_pairs=1).
+        // With question_id keying they are treated as separate pairs (n_pairs=2).
+        let results = vec![
+            JudgmentResult {
+                question: "same question text".to_string(),
+                approach: "ce_off_single-hop".to_string(),
+                score: 1,
+                reason: String::new(),
+                context_tokens: 0,
+                question_id: "q_a".to_string(),
+            },
+            JudgmentResult {
+                question: "same question text".to_string(),
+                approach: "ce_on_single-hop".to_string(),
+                score: 0,
+                reason: String::new(),
+                context_tokens: 0,
+                question_id: "q_a".to_string(),
+            },
+            JudgmentResult {
+                question: "same question text".to_string(),
+                approach: "ce_off_single-hop".to_string(),
+                score: 0,
+                reason: String::new(),
+                context_tokens: 0,
+                question_id: "q_b".to_string(),
+            },
+            JudgmentResult {
+                question: "same question text".to_string(),
+                approach: "ce_on_single-hop".to_string(),
+                score: 1,
+                reason: String::new(),
+                context_tokens: 0,
+                question_id: "q_b".to_string(),
+            },
+        ];
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(
+            report.n_pairs, 2,
+            "should be 2 distinct pairs keyed by question_id"
+        );
+        assert_eq!(report.b, 1, "q_a: off=1,on=0 → b");
+        assert_eq!(report.c, 1, "q_b: off=0,on=1 → c");
     }
 }

--- a/crates/origin-core/src/eval/judge.rs
+++ b/crates/origin-core/src/eval/judge.rs
@@ -1706,6 +1706,10 @@ pub struct McNemarReport {
     pub c: u64,
     /// Total complete pairs used.
     pub n_pairs: u64,
+    /// Discordant pairs (b + c) — the only pairs McNemar's test uses.
+    pub n_discordant: u64,
+    /// True when b + c < 10: too few discordant pairs for a trustworthy test.
+    pub underpowered: bool,
     /// Test statistic (χ² or exact-binomial n_min for small-n path).
     pub stat: f64,
     /// Two-sided p-value.
@@ -1840,6 +1844,8 @@ pub fn paired_answer_mcnemar(results: &[JudgmentResult]) -> McNemarReport {
         b: agg_b,
         c: agg_c,
         n_pairs: agg_n,
+        n_discordant: agg_b + agg_c,
+        underpowered: (agg_b + agg_c) < 10,
         stat,
         p_value,
         test_used,
@@ -2089,6 +2095,60 @@ mod mcnemar_tests {
         assert_eq!(report.test_used, "mcnemar_chi2", "30 discordant -> chi2");
         assert!(report.stat > 0.0);
         assert!(report.p_value < 0.05, "p={}", report.p_value);
+    }
+
+    #[test]
+    fn mcnemar_underpowered_small_discordant() {
+        // Test with b+c=3 (underpowered, < 10).
+        // 5 concordant pairs + 3 discordant pairs.
+        let mut results = Vec::new();
+        // 5 concordant (both score 1)
+        for i in 0..5 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 1));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+        }
+        // 3 discordant ON-wins
+        for i in 5..8 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 0));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.n_pairs, 8);
+        assert_eq!(report.b, 0);
+        assert_eq!(report.c, 3);
+        assert_eq!(report.n_discordant, 3);
+        assert!(report.underpowered, "3 < 10, should be underpowered");
+    }
+
+    #[test]
+    fn mcnemar_powered_sufficient_discordant() {
+        // Test with b+c=15 (powered, >= 10).
+        let mut results = Vec::new();
+        for i in 0..15 {
+            let q = format!("q_{i}");
+            results.push(make_result(&q, "ce_off_single-hop", 0));
+            results.push(make_result(&q, "ce_on_single-hop", 1));
+        }
+        let report = paired_answer_mcnemar(&results);
+        assert_eq!(report.n_discordant, 15);
+        assert!(!report.underpowered, "15 >= 10, should not be underpowered");
+    }
+
+    #[test]
+    fn mcnemar_underpowered_boundary_at_ten() {
+        // Pin the exact `b + c < 10` floor so an off-by-one (`<` vs `<=`) in the
+        // underpowered comparator is caught — this flag drives how a null delta
+        // is interpreted, so the boundary must be exact.
+        assert!(
+            report_for_bc(0, 9).underpowered,
+            "b+c=9 is below the floor -> underpowered"
+        );
+        assert!(
+            !report_for_bc(0, 10).underpowered,
+            "b+c=10 meets the floor -> NOT underpowered"
+        );
     }
 
     // ----- value-pinned numeric guards (regression-protect beta-CF / erfc) -----

--- a/crates/origin-core/src/eval/retrieval.rs
+++ b/crates/origin-core/src/eval/retrieval.rs
@@ -3741,6 +3741,7 @@ mod tests {
                 .to_string(),
             context_tokens: 50,
             category: String::new(),
+            question_id: String::new(),
         };
 
         let result = judge_single_tuple(&tuple).await.unwrap();

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -8505,3 +8505,172 @@ async fn print_top_hubs(db: &origin_core::db::MemoryDB, n: usize) {
         Err(e) => println!("[gate] top_hubs err: {e}"),
     }
 }
+
+// ===== CE A/B answer-accuracy harness =====
+
+/// Fair CE A/B answer-accuracy eval for LongMemEval.
+///
+/// Both arms route through `search_memory_cross_rerank` so P3 distill-demotion
+/// is symmetric. Graph stream must be OFF (ORIGIN_GRAPH_MEMORY_STREAM=0) so
+/// the OFF arm does not re-enable it. Answers are generated on-device by
+/// Qwen3.5-9B at temperature 0.0 (NOT Claude — avoids self-judge with the
+/// Haiku judge).
+///
+/// ```bash
+/// ORIGIN_GRAPH_MEMORY_STREAM=0 \
+/// LME_LIMIT_QUESTIONS=50 \
+///   cargo test -p origin-core --test eval_harness generate_ce_ab_lme -- --ignored --nocapture
+/// ```
+#[tokio::test]
+#[ignore]
+async fn generate_ce_ab_lme() {
+    use origin_core::eval::answer_quality::run_fullpipeline_lme_ce_ab;
+    use origin_core::llm_provider::{LlmProvider, OnDeviceProvider};
+    use std::sync::Arc;
+
+    let lme_path = eval_root().join("data/longmemeval_oracle.json");
+    if !lme_path.exists() {
+        eprintln!("SKIP: longmemeval_oracle.json not found at {:?}", lme_path);
+        return;
+    }
+
+    // The enrichment phase (entity extraction, distillation) is configured via
+    // EnrichmentMode; answer-gen is on-device Qwen3.5-9B (see below), so these
+    // only steer enrichment, not the answers being measured.
+    let enrich_model =
+        std::env::var("EVAL_ANSWER_MODEL").unwrap_or_else(|_| "claude-haiku-4-5-20251001".into());
+    let cost_cap: f64 = std::env::var("EVAL_COST_CAP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10.0);
+
+    // Safety: the runner enforces this, but surfacing it early gives a clearer
+    // message when the operator forgot to set it.
+    if origin_core::db::graph_memory_stream_enabled() {
+        panic!(
+            "Set ORIGIN_GRAPH_MEMORY_STREAM=0 before running this test. \
+             The CE A/B is invalid without it (see run_fullpipeline_lme_ce_ab docs)."
+        );
+    }
+
+    let baselines = origin_core::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| eval_root().join("baselines"));
+    std::fs::create_dir_all(&baselines).ok();
+    let output_path = baselines.join("ce_ab_lme_tuples.json");
+
+    eprintln!(
+        "[generate_ce_ab_lme]\n  answer model: on-device qwen3.5-9b (temp 0.0)\n  enrich model: {}\n  output: {:?}",
+        enrich_model, output_path,
+    );
+
+    // On-device Qwen3.5-9B generates the answers being measured (NOT Claude).
+    let llm: Arc<dyn LlmProvider> = Arc::new(
+        OnDeviceProvider::new_with_model(Some("qwen3.5-9b"))
+            .expect("OnDeviceProvider::new_with_model failed — is the Qwen3.5-9B model available?"),
+    );
+
+    let enrichment = origin_core::eval::shared::EnrichmentMode::from_env(&enrich_model, cost_cap)
+        .expect("EnrichmentMode::from_env failed");
+
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None).expect(
+        "init_cross_encoder_reranker failed (downloads ~1.1GB bge-reranker-base on first run)",
+    );
+
+    let tuples = run_fullpipeline_lme_ce_ab(&lme_path, enrichment, llm, &output_path, reranker)
+        .await
+        .expect("run_fullpipeline_lme_ce_ab failed");
+
+    eprintln!(
+        "\n[generate_ce_ab_lme] Done: {} tuples saved to {:?}",
+        tuples.len(),
+        output_path
+    );
+}
+
+/// Judge CE A/B tuples and print McNemar report.
+///
+/// Load tuples from `ce_ab_lme_tuples.json`, judge via Haiku (or
+/// `LME_JUDGE_MODEL` override), then print the paired McNemar report.
+///
+/// For N>=3 runs, execute `generate_ce_ab_lme` N times and merge the
+/// tuple files before judging.
+///
+/// ```bash
+/// ORIGIN_GRAPH_MEMORY_STREAM=0 \
+/// ANTHROPIC_API_KEY=... \
+///   cargo test -p origin-core --test eval_harness judge_ce_ab_lme -- --ignored --nocapture
+/// ```
+#[tokio::test]
+#[ignore]
+async fn judge_ce_ab_lme() {
+    use origin_core::eval::judge::{
+        judge_with_claude_model_batched_persistent, load_judgment_tuples, paired_answer_mcnemar,
+    };
+
+    let baselines = origin_core::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| eval_root().join("baselines"));
+    let tuples_path = baselines.join("ce_ab_lme_tuples.json");
+
+    if !tuples_path.exists() {
+        eprintln!(
+            "SKIP: {:?} not found. Run generate_ce_ab_lme first.",
+            tuples_path
+        );
+        return;
+    }
+
+    // The judge runs via the `claude` CLI (OAuth subscription, no API spend).
+    // ANTHROPIC_API_KEY must be UNSET for a $-free run: if it is set, the
+    // `claude` CLI bills the Anthropic API instead of the subscription. Warn
+    // loudly rather than require the key (the old `expect` forced the billing
+    // trap on every run).
+    if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+        eprintln!(
+            "[judge_ce_ab_lme] WARNING: ANTHROPIC_API_KEY is set — the `claude` CLI will \
+             bill the API instead of your OAuth subscription. Unset it for a $-free run."
+        );
+    }
+
+    let judge_model = std::env::var("LME_JUDGE_MODEL")
+        .unwrap_or_else(|_| "claude-haiku-4-5-20251001".to_string());
+
+    let tuples = load_judgment_tuples(&tuples_path).expect("load_judgment_tuples failed");
+    eprintln!("[judge_ce_ab_lme] Loaded {} tuples", tuples.len());
+
+    let cache_path = baselines.join("ce_ab_lme_judge_cache.jsonl");
+    let results = judge_with_claude_model_batched_persistent(
+        &tuples,
+        10, // batch_size
+        3,  // rotation_calls
+        &judge_model,
+        &cache_path,
+        3, // max_retries
+    )
+    .await
+    .expect("judging failed");
+
+    let report = paired_answer_mcnemar(&results);
+
+    eprintln!("\n=== CE A/B McNemar Report ===");
+    eprintln!(
+        "n_pairs={} | OFF acc={:.4} | ON acc={:.4} | delta={:+.4}",
+        report.n_pairs, report.off_acc, report.on_acc, report.delta
+    );
+    eprintln!(
+        "b(off✓ on✗)={} | c(off✗ on✓)={} | stat={:.4} | p={:.4} | test={}",
+        report.b, report.c, report.stat, report.p_value, report.test_used
+    );
+    eprintln!("\nPer-category:");
+    for cat in &report.by_category {
+        eprintln!(
+            "  {:<30} n={:4} off={:.4} on={:.4} delta={:+.4} b={} c={}",
+            cat.category, cat.n_pairs, cat.off_acc, cat.on_acc, cat.delta, cat.b, cat.c
+        );
+    }
+
+    // Print JSON for machine consumption.
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&report).unwrap_or_default()
+    );
+}

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -7783,6 +7783,7 @@ async fn smoke_tool_use_judge_returns_structured_verdict() {
         category: "single-session-user".to_string(),
         approach: "smoke".to_string(),
         context_tokens: 0,
+        question_id: String::new(),
     };
 
     let judge_model = std::env::var("EVAL_JUDGE_MODEL")

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -8508,6 +8508,95 @@ async fn print_top_hubs(db: &origin_core::db::MemoryDB, n: usize) {
 
 // ===== CE A/B answer-accuracy harness =====
 
+/// Runtime proof for the CE A/B per-question seed loop.
+///
+/// GPU/Metal + minutes, NOT run in CI/gate. This seeds one temporal-reasoning
+/// LongMemEval oracle question through `run_fullpipeline_lme_ce_ab`, then opens
+/// that question's scenario DB and verifies the temporal substrate was populated.
+/// Post-fix GREEN-only proof (not a red/green pair): with the seed-loop injection
+/// in place, event_date count is > 0; it cannot exhibit the pre-fix RED state
+/// against current code.
+#[tokio::test]
+#[ignore = "GPU/Metal + minutes; runtime proof for CE A/B event_date injection"]
+async fn ce_ab_seed_injects_event_date() {
+    use origin_core::eval::answer_quality::run_fullpipeline_lme_ce_ab;
+    use origin_core::eval::shared::{scenario_db_dir, EnrichmentMode};
+    use origin_core::llm_provider::{LlmProvider, OnDeviceProvider};
+    use std::sync::Arc;
+
+    let lme_path = eval_root().join("data/longmemeval_oracle.json");
+    if !lme_path.exists() {
+        eprintln!("SKIP: longmemeval_oracle.json not found at {:?}", lme_path);
+        return;
+    }
+
+    let raw = std::fs::read_to_string(&lme_path).expect("read longmemeval_oracle.json");
+    let samples: Vec<serde_json::Value> =
+        serde_json::from_str(&raw).expect("parse longmemeval_oracle.json");
+    let sample = samples
+        .into_iter()
+        .find(|sample| {
+            sample.get("question_type").and_then(|v| v.as_str()) == Some("temporal-reasoning")
+        })
+        .expect("fixture should contain a temporal-reasoning question");
+    let question_id = sample
+        .get("question_id")
+        .and_then(|v| v.as_str())
+        .expect("temporal sample has question_id")
+        .to_string();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let fixture_path = tmp.path().join("one_temporal_lme.json");
+    std::fs::write(
+        &fixture_path,
+        serde_json::to_vec_pretty(&vec![sample]).expect("serialize one-question fixture"),
+    )
+    .expect("write one-question fixture");
+
+    let previous_graph_stream = std::env::var_os("ORIGIN_GRAPH_MEMORY_STREAM");
+    std::env::set_var("ORIGIN_GRAPH_MEMORY_STREAM", "0");
+
+    let llm: Arc<dyn LlmProvider> = Arc::new(
+        OnDeviceProvider::new_with_model(Some("qwen3.5-9b"))
+            .expect("Qwen3.5-9B on-device provider"),
+    );
+    let enrichment = EnrichmentMode::OnDevice(llm.clone());
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None)
+        .expect("init_cross_encoder_reranker");
+    let output_path = tmp.path().join("ce_ab_lme_tuples.json");
+
+    run_fullpipeline_lme_ce_ab(&fixture_path, enrichment, llm, &output_path, reranker)
+        .await
+        .expect("run_fullpipeline_lme_ce_ab");
+
+    if let Some(value) = previous_graph_stream {
+        std::env::set_var("ORIGIN_GRAPH_MEMORY_STREAM", value);
+    } else {
+        std::env::remove_var("ORIGIN_GRAPH_MEMORY_STREAM");
+    }
+
+    let scenario_dir = scenario_db_dir(tmp.path(), "lme", &question_id);
+    let scenario_db =
+        libsql::Builder::new_local(scenario_dir.join("origin_memory.db").to_str().unwrap())
+            .build()
+            .await
+            .expect("open scenario DB");
+    let conn = scenario_db.connect().expect("connect scenario DB");
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM memories WHERE event_date IS NOT NULL",
+            (),
+        )
+        .await
+        .expect("query event_date count");
+    let row = rows.next().await.unwrap().unwrap();
+    let event_date_count = row.get::<i64>(0).unwrap();
+    assert!(
+        event_date_count > 0,
+        "CE A/B per-question scenario DB must have temporal substrate"
+    );
+}
+
 /// Fair CE A/B answer-accuracy eval for LongMemEval.
 ///
 /// Both arms route through `search_memory_cross_rerank` so P3 distill-demotion
@@ -8659,6 +8748,15 @@ async fn judge_ce_ab_lme() {
     eprintln!(
         "b(off✓ on✗)={} | c(off✗ on✓)={} | stat={:.4} | p={:.4} | test={}",
         report.b, report.c, report.stat, report.p_value, report.test_used
+    );
+    eprintln!(
+        "discordant pairs (b+c): {}{}",
+        report.n_discordant,
+        if report.underpowered {
+            "  [UNDERPOWERED: b+c < 10]"
+        } else {
+            ""
+        }
     );
     eprintln!("\nPer-category:");
     for cat in &report.by_category {


### PR DESCRIPTION
## What

Lands the **decision-critical** piece of the LongMemEval CE-default-on work: an honest 2-arm (CE-off vs CE-on) **answer-accuracy** harness, with the temporal substrate made live and the statistical test power-aware. This PR is what the gated CE decision run executes against.

Split out of an over-scoped plan after an adversarial 3-lab council (2026-06-13); the de-fork / provenance-migration / 3rd-graph-arm work is deliberately deferred to follow-up PRs (they are not on the CE *sign-of-delta* critical path).

## Commits

1. `feat(eval)` — **2-arm CE answer harness foundation**: per-question isolated scenario DBs (each Q sees only its own sessions = LME-correct), on-device Qwen3.5-9B answers at temp 0.0, paired McNemar over Haiku-judged answers via the `claude -p` CLI (no API spend). Judge guard relaxed to *warn* on `ANTHROPIC_API_KEY` (billing trap) instead of requiring it.
2. `fix(eval)` — **temporal gate + McNemar power** (this PR's hardening):
   - **T1.1** inject per-session `event_date` into each per-Q seed, then `assert_feature_substrate_live("temporal")` so a starved temporal substrate **refuses loud** instead of emitting a misleading null (eval ONE-contract). Reuses the canonical `event_date_map` + `set_event_dates_by_source_id` helpers — **no training-serving skew**; `source_id` keys are byte-identical to the seed closure.
   - **T1.2** `McNemarReport` gains `n_discordant` (b+c) + `underpowered` (b+c<10), printed by the judge so a null delta at small n (first gated run = 50 Q) is not misread as "CE doesn't help".

## Honest scope note (caught in review)

The `event_date` injection is **substrate-prep + a liveness gate, not a direct answer fix**: `event_date` is not rendered into the CE A/B context and no temporal-ranking flag is on this path, so dates influence neither ranking nor the prompt **today**. Temporal-reasoning answers therefore stay date-blind — but the **CE delta remains valid** because both arms see identical content-only context (CE rerank is the only difference). Rendering dates / wiring a temporal lever is future work, not this PR.

## Council flaws addressed

- **Flaw 3** (temporal starvation) → T1.1 inject + gate.
- **Flaw 4** (power / underpower at n=50, single-pair) → T1.2 (Holm/FWER across pairs is deferred to the 3-arm PR).

## Tests

- `event_date_injection_lands_on_seeded_rows` — deterministic contract test guarding the `source_id`↔`event_date_map` key-alignment silent-zero (real DB, real upsert, asserts exactly 1 row updated).
- `mcnemar_underpowered_small_discordant` / `_powered_sufficient_discordant` / `_boundary_at_ten` — pin the `<10` floor incl. the exact boundary (off-by-one guard).
- `ce_ab_seed_injects_event_date` — `#[ignore]` GPU runtime proof (Metal + minutes; runs in the gated run, not CI).

Full verify green: `cargo fmt --check`, `cargo clippy -p origin-core --all-targets --features eval-harness -- -D warnings`, `cargo test -p origin-core --lib eval` = **525 passed / 0 failed**.

## Not in this PR (gated)

The headline CE decision number itself. Running this harness (first-50 oracle N=1 → resume to 500) is **held for explicit trigger**; single-run = scaffold, headline claims need N≥3 + stddev per eval-citation discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)