### PR TITLE
fix(eval): scenario concurrency for on-device LME CE A/B + batch-log instrumentation

### DIFF
--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -3694,13 +3694,18 @@ mod tests {
                 .pow(2)
         }
 
-        let qids: Vec<String> = (0..5).map(|i| format!("q{i}")).collect();
+        // Create 10 qids to increase chance of completion-order mismatch.
+        let qids: Vec<String> = (0..10).map(|i| format!("q{i}")).collect();
         let serial_map: HashMap<String, u64> =
             qids.iter().map(|qid| (qid.clone(), val(qid))).collect();
 
+        // Intentionally reverse the sleep order so earlier inputs (smaller qids) sleep LONGER,
+        // forcing completion order != input order with very high probability.
         let n = qids.len() as u64;
         let outputs: Vec<(String, u64)> = futures::stream::iter(qids.iter().enumerate())
             .map(|(idx, qid)| async move {
+                // q0 sleeps 100ms, q1 sleeps 90ms, ..., q9 sleeps 10ms
+                // So completion order will be: q9, q8, ..., q1, q0 (reverse of input)
                 tokio::time::sleep(Duration::from_millis((n - idx as u64) * 10)).await;
                 (qid.clone(), val(qid))
             })
@@ -3708,18 +3713,31 @@ mod tests {
             .collect()
             .await;
 
+        // WRONG approach: zip original qids with completion-ordered values.
+        // Since completion order is reversed, zipping produces:
+        // q0 -> val(q9)=81, q1 -> val(q8)=64, q2 -> val(q7)=49, etc.
+        // This is WRONG and must NOT equal serial_map.
         let wrong_index_map: HashMap<String, u64> = qids
             .iter()
             .cloned()
             .zip(outputs.iter().map(|(_, v)| *v))
             .collect();
+
+        // The WRONG map MUST differ from the serial map (the whole point of this test).
+        // If this assertion fails, it means the test isn't detecting misattribution properly.
         assert_ne!(
             wrong_index_map, serial_map,
-            "associating completion-ordered values by original input index misattributes out-of-order results"
+            "CRITICAL: wrong_index_map MUST differ from serial_map to validate this test's effectiveness. \
+             This failure means the scrambling didn't work as expected or the test logic is flawed."
         );
 
+        // RIGHT approach: collect tuples that CARRY their qid alongside their value.
+        // Each tuple remembers its own qid, so reassembly is correct regardless of completion order.
         let concurrent_map: HashMap<String, u64> = outputs.into_iter().collect();
-        assert_eq!(concurrent_map, serial_map);
+        assert_eq!(
+            concurrent_map, serial_map,
+            "concurrent_map MUST match serial_map when tuples carry their own qid"
+        );
     }
 
     #[test]

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -3584,6 +3584,17 @@ pub async fn run_fullpipeline_lme(
             if !tuples.is_empty() {
                 processed += 1;
                 finished_tuples.extend(tuples);
+                // Mirror the serial path's incremental checkpoint (see save_counter above):
+                // this drain loop is sequential (single-writer), so saving every 10 questions
+                // bounds crash loss to ~10 questions instead of the entire run when
+                // scenario_concurrency > 1. The final save below flushes the remainder.
+                save_counter += 1;
+                if save_counter >= 10 {
+                    save_counter = 0;
+                    if let Err(e) = save_judgment_tuples(&finished_tuples, output_path) {
+                        eprintln!("[ce_ab_lme] WARN: incremental save failed: {e}");
+                    }
+                }
             }
         }
     }

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -3122,149 +3122,170 @@ pub async fn run_fullpipeline_lme(
         .parent()
         .ok_or_else(|| OriginError::Generic("output_path has no parent".to_string()))?;
 
+    let scenario_concurrency: usize = std::env::var("EVAL_SCENARIO_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1)
+        .min(8);
+    eprintln!("[ce_ab_lme] scenario concurrency = {scenario_concurrency}");
+
     let mut processed = 0usize;
     let mut save_counter = 0usize;
 
-    for (q_idx, sample) in samples.iter().enumerate() {
-        // Match the done-set key (question_id, fallback to text) — see build above.
-        let sample_key: &str = if sample.question_id.is_empty() {
-            sample.question.as_str()
-        } else {
-            sample.question_id.as_str()
-        };
-        if done_questions.contains(sample_key) {
-            continue;
-        }
+    if scenario_concurrency <= 1 {
+        for (q_idx, sample) in samples.iter().enumerate() {
+            // Match the done-set key (question_id, fallback to text) — see build above.
+            let sample_key: &str = if sample.question_id.is_empty() {
+                sample.question.as_str()
+            } else {
+                sample.question_id.as_str()
+            };
+            if done_questions.contains(sample_key) {
+                continue;
+            }
 
-        // Ground truth: LME answers are JSON strings; handle non-string values
-        // explicitly rather than borrowing a temporary (M1).
-        let ground_truth = match &sample.answer {
-            serde_json::Value::String(s) => s.clone(),
-            other => other.to_string(),
-        };
-        if ground_truth.is_empty() {
-            continue;
-        }
+            // Ground truth: LME answers are JSON strings; handle non-string values
+            // explicitly rather than borrowing a temporary (M1).
+            let ground_truth = match &sample.answer {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            if ground_truth.is_empty() {
+                continue;
+            }
 
-        // Acquire this question's retrieval DB. Consolidated reuses the ONE
-        // shared large-pool DB opened above (skip per-question seeding +
-        // event_date injection — it is already enriched + 100% dated, and is
-        // never mutated). SeedPerQuestion seeds a fresh oracle-pool scenario DB
-        // from the sample's own sessions, byte-identical to the prior behavior.
-        let db: Arc<MemoryDB> = match &db_source {
-            DbSource::Consolidated(_) => consolidated_db
-                .clone()
-                .expect("consolidated_db is Some for DbSource::Consolidated"),
-            DbSource::SeedPerQuestion => {
-                let memories = extract_memories(sample);
-                if memories.is_empty() {
-                    continue;
-                }
+            // Acquire this question's retrieval DB. Consolidated reuses the ONE
+            // shared large-pool DB opened above (skip per-question seeding +
+            // event_date injection — it is already enriched + 100% dated, and is
+            // never mutated). SeedPerQuestion seeds a fresh oracle-pool scenario DB
+            // from the sample's own sessions, byte-identical to the prior behavior.
+            let db: Arc<MemoryDB> = match &db_source {
+                DbSource::Consolidated(_) => consolidated_db
+                    .clone()
+                    .expect("consolidated_db is Some for DbSource::Consolidated"),
+                DbSource::SeedPerQuestion => {
+                    let memories = extract_memories(sample);
+                    if memories.is_empty() {
+                        continue;
+                    }
 
-                let scope_dir =
-                    crate::eval::shared::scenario_db_dir(baselines_dir, "lme", &sample.question_id);
+                    let scope_dir = crate::eval::shared::scenario_db_dir(
+                        baselines_dir,
+                        "lme",
+                        &sample.question_id,
+                    );
 
-                let question_id = sample.question_id.clone();
-                let question_type = sample.question_type.clone();
-                let memories_owned = memories.clone();
+                    let question_id = sample.question_id.clone();
+                    let question_type = sample.question_type.clone();
+                    let memories_owned = memories.clone();
 
-                let seeded = match crate::eval::shared::open_or_seed_scenario_db(
-                    &scope_dir,
-                    shared_embedder.clone(),
-                    move || {
-                        memories_owned
-                            .iter()
-                            .map(|mem| crate::sources::RawDocument {
-                                content: mem.content.clone(),
-                                source_id: format!(
-                                    "lme_{}_{}_t{}",
-                                    question_id, mem.session_idx, mem.turn_idx
-                                ),
-                                source: "memory".to_string(),
-                                title: format!("session {} turn {}", mem.session_idx, mem.turn_idx),
-                                memory_type: Some(
-                                    if question_type == "single-session-preference" {
-                                        "preference"
-                                    } else {
-                                        "fact"
-                                    }
-                                    .to_string(),
-                                ),
-                                space: Some("conversation".to_string()),
-                                last_modified: chrono::Utc::now().timestamp(),
-                                ..Default::default()
-                            })
-                            .collect()
-                    },
-                    &enrichment,
-                )
-                .await
-                {
-                    Ok(db) => db,
-                    Err(e) => {
+                    let seeded = match crate::eval::shared::open_or_seed_scenario_db(
+                        &scope_dir,
+                        shared_embedder.clone(),
+                        move || {
+                            memories_owned
+                                .iter()
+                                .map(|mem| crate::sources::RawDocument {
+                                    content: mem.content.clone(),
+                                    source_id: format!(
+                                        "lme_{}_{}_t{}",
+                                        question_id, mem.session_idx, mem.turn_idx
+                                    ),
+                                    source: "memory".to_string(),
+                                    title: format!(
+                                        "session {} turn {}",
+                                        mem.session_idx, mem.turn_idx
+                                    ),
+                                    memory_type: Some(
+                                        if question_type == "single-session-preference" {
+                                            "preference"
+                                        } else {
+                                            "fact"
+                                        }
+                                        .to_string(),
+                                    ),
+                                    space: Some("conversation".to_string()),
+                                    last_modified: chrono::Utc::now().timestamp(),
+                                    ..Default::default()
+                                })
+                                .collect()
+                        },
+                        &enrichment,
+                    )
+                    .await
+                    {
+                        Ok(db) => db,
+                        Err(e) => {
+                            return Err(OriginError::Generic(format!(
+                                "[ce_ab_lme] scenario {} failed to open/seed DB: {e}. Refusing to \
+                                 silently drop the question — re-seed and retry.",
+                                sample.question_id
+                            )));
+                        }
+                    };
+
+                    // Substrate-liveness: a per-question DB with zero memories yields a
+                    // vacuous A/B (both arms retrieve nothing). Fail loud rather than
+                    // emit a misleading null, per the eval ONE-contract discipline (H2).
+                    let db_mem_count = seeded.memory_count().await.unwrap_or(0);
+                    if db_mem_count == 0 {
                         return Err(OriginError::Generic(format!(
-                            "[ce_ab_lme] scenario {} failed to open/seed DB: {e}. Refusing to \
-                             silently drop the question — re-seed and retry.",
+                            "EVAL REFUSED [ce_ab_lme]: scenario {} seeded DB has 0 memories. \
+                             A CE A/B over an empty substrate measures noise, not CE. Re-seed and retry.",
                             sample.question_id
                         )));
                     }
-                };
 
-                // Substrate-liveness: a per-question DB with zero memories yields a
-                // vacuous A/B (both arms retrieve nothing). Fail loud rather than
-                // emit a misleading null, per the eval ONE-contract discipline (H2).
-                let db_mem_count = seeded.memory_count().await.unwrap_or(0);
-                if db_mem_count == 0 {
-                    return Err(OriginError::Generic(format!(
-                        "EVAL REFUSED [ce_ab_lme]: scenario {} seeded DB has 0 memories. \
-                         A CE A/B over an empty substrate measures noise, not CE. Re-seed and retry.",
-                        sample.question_id
-                    )));
-                }
-
-                // Make the temporal substrate LIVE for this question's scenario DB by
-                // injecting per-session event_date (turn text carries no date; the date
-                // is per-session haystack metadata). This is substrate-prep + a liveness
-                // gate, NOT a direct answer fix: event_date is not rendered into the CE
-                // A/B context (build_structured_context renders only content) and no
-                // temporal ranking flag is set on this path, so dates influence neither
-                // ranking nor the prompt today. Their value is (a) a per-question liveness
-                // signal (the rows-updated count below), (b) a future temporal lever has
-                // live data to read. source_id keys mirror the seed closure's
-                // `lme_{qid}_{sess}_t{turn}` exactly via event_date_map -> memory_source_id.
-                let date_map =
-                    crate::eval::longmemeval::event_date_map(std::slice::from_ref(sample));
-                if !date_map.is_empty() {
-                    let updates: Vec<(String, i64)> = date_map.into_iter().collect();
-                    let n_total = updates.len();
-                    let rows = seeded.set_event_dates_by_source_id(&updates).await?;
-                    if rows == 0 {
-                        // Per-question log + continue (NOT whole-run abort): a non-empty
-                        // date_map that updates 0 rows means source_id-format drift for
-                        // THIS question. Skip it rather than nuke a multi-hour decision run;
-                        // the rows-updated count is an earlier, more precise signal than a
-                        // DB-wide liveness assert (which propagated and aborted the run).
-                        log::warn!(
-                            "[ce_ab_lme] event_date injection updated 0/{} rows for question {} \
-                             — source_id drift; skipping question",
-                            n_total,
-                            sample.question_id
-                        );
-                        continue;
+                    // Make the temporal substrate LIVE for this question's scenario DB by
+                    // injecting per-session event_date (turn text carries no date; the date
+                    // is per-session haystack metadata). This is substrate-prep + a liveness
+                    // gate, NOT a direct answer fix: event_date is not rendered into the CE
+                    // A/B context (build_structured_context renders only content) and no
+                    // temporal ranking flag is set on this path, so dates influence neither
+                    // ranking nor the prompt today. Their value is (a) a per-question liveness
+                    // signal (the rows-updated count below), (b) a future temporal lever has
+                    // live data to read. source_id keys mirror the seed closure's
+                    // `lme_{qid}_{sess}_t{turn}` exactly via event_date_map -> memory_source_id.
+                    let date_map =
+                        crate::eval::longmemeval::event_date_map(std::slice::from_ref(sample));
+                    if !date_map.is_empty() {
+                        let updates: Vec<(String, i64)> = date_map.into_iter().collect();
+                        let n_total = updates.len();
+                        let rows = seeded.set_event_dates_by_source_id(&updates).await?;
+                        if rows == 0 {
+                            // Per-question log + continue (NOT whole-run abort): a non-empty
+                            // date_map that updates 0 rows means source_id-format drift for
+                            // THIS question. Skip it rather than nuke a multi-hour decision run;
+                            // the rows-updated count is an earlier, more precise signal than a
+                            // DB-wide liveness assert (which propagated and aborted the run).
+                            log::warn!(
+                                "[ce_ab_lme] event_date injection updated 0/{} rows for question {} \
+                                 — source_id drift; skipping question",
+                                n_total,
+                                sample.question_id
+                            );
+                            continue;
+                        }
                     }
+
+                    Arc::new(seeded)
                 }
+            };
 
-                Arc::new(seeded)
-            }
-        };
+            let category = category_name(&sample.question_type);
 
-        let category = category_name(&sample.question_type);
-
-        // Generate an answer for all arms from the same seeded DB.
-        let arm_pairs = arms.resolve(category, &reranker)?;
-        for (arm_label, retrieval) in arm_pairs {
-            let (ctx, ctx_tokens) =
-                match build_structured_context(&db, &sample.question, 10, None, retrieval).await {
+            // Generate an answer for all arms from the same seeded DB.
+            let arm_pairs = arms.resolve(category, &reranker)?;
+            for (arm_label, retrieval) in arm_pairs {
+                let (ctx, ctx_tokens) = match build_structured_context(
+                    &db,
+                    &sample.question,
+                    10,
+                    None,
+                    retrieval,
+                )
+                .await
+                {
                     Ok(v) => v,
                     Err(e) => {
                         return Err(OriginError::Generic(format!(
@@ -3274,67 +3295,296 @@ pub async fn run_fullpipeline_lme(
                     }
                 };
 
-            let request = LlmRequest {
-                system_prompt: Some(e2e_system_prompt()),
-                user_prompt: format!("Context:\n{}\n\nQuestion: {}", ctx, sample.question),
-                max_tokens: e2e_max_answer_tokens() as u32,
-                // Pinned to 0.0 (vs the 0.1 used elsewhere) so both arms are
-                // deterministic — fairness depends on identical decoding.
-                temperature: 0.0,
-                label: Some(arm_label.clone()),
-                timeout_secs: None,
-            };
+                let request = LlmRequest {
+                    system_prompt: Some(e2e_system_prompt()),
+                    user_prompt: format!("Context:\n{}\n\nQuestion: {}", ctx, sample.question),
+                    max_tokens: e2e_max_answer_tokens() as u32,
+                    // Pinned to 0.0 (vs the 0.1 used elsewhere) so both arms are
+                    // deterministic — fairness depends on identical decoding.
+                    temperature: 0.0,
+                    label: Some(arm_label.clone()),
+                    timeout_secs: None,
+                };
 
-            let answer = match llm.generate(request).await {
-                Ok(raw) => strip_think_tags(&raw).trim().to_string(),
-                Err(e) => {
-                    // Skip ALL arms for this question rather than persisting a
-                    // half-pair; on resume the question is reprocessed (H1).
+                let answer = match llm.generate(request).await {
+                    Ok(raw) => strip_think_tags(&raw).trim().to_string(),
+                    Err(e) => {
+                        // Skip ALL arms for this question rather than persisting a
+                        // half-pair; on resume the question is reprocessed (H1).
+                        eprintln!(
+                            "[ce_ab_lme] WARN: scenario {} arm {arm_label} generation failed: {e}. \
+                             Dropping all arms for this question; will retry on resume.",
+                            sample.question_id
+                        );
+                        break;
+                    }
+                };
+
+                // Never persist an empty answer — it would mark the question DONE on
+                // resume and silently bias the arm to score 0 (H1).
+                if answer.is_empty() {
                     eprintln!(
-                        "[ce_ab_lme] WARN: scenario {} arm {arm_label} generation failed: {e}. \
-                         Dropping all arms for this question; will retry on resume.",
+                        "[ce_ab_lme] WARN: scenario {} arm {arm_label} produced empty answer. \
+                         Dropping all arms; will retry on resume.",
                         sample.question_id
                     );
                     break;
                 }
-            };
 
-            // Never persist an empty answer — it would mark the question DONE on
-            // resume and silently bias the arm to score 0 (H1).
-            if answer.is_empty() {
+                finished_tuples.push(JudgmentTuple {
+                    question: sample.question.clone(),
+                    ground_truth: ground_truth.clone(),
+                    approach: arm_label,
+                    answer,
+                    context_tokens: ctx_tokens,
+                    category: category.to_string(),
+                    question_id: sample.question_id.clone(),
+                });
+            }
+
+            processed += 1;
+            save_counter += 1;
+            if save_counter >= 10 {
+                save_counter = 0;
+                if let Err(e) = save_judgment_tuples(&finished_tuples, output_path) {
+                    eprintln!("[ce_ab_lme] WARN: incremental save failed: {e}");
+                }
+            }
+            if q_idx % 100 == 99 {
                 eprintln!(
-                    "[ce_ab_lme] WARN: scenario {} arm {arm_label} produced empty answer. \
-                     Dropping all arms; will retry on resume.",
-                    sample.question_id
+                    "[ce_ab_lme] {}/{} questions processed",
+                    q_idx + 1,
+                    samples.len()
                 );
-                break;
-            }
-
-            finished_tuples.push(JudgmentTuple {
-                question: sample.question.clone(),
-                ground_truth: ground_truth.clone(),
-                approach: arm_label,
-                answer,
-                context_tokens: ctx_tokens,
-                category: category.to_string(),
-                question_id: sample.question_id.clone(),
-            });
-        }
-
-        processed += 1;
-        save_counter += 1;
-        if save_counter >= 10 {
-            save_counter = 0;
-            if let Err(e) = save_judgment_tuples(&finished_tuples, output_path) {
-                eprintln!("[ce_ab_lme] WARN: incremental save failed: {e}");
             }
         }
-        if q_idx % 100 == 99 {
-            eprintln!(
-                "[ce_ab_lme] {}/{} questions processed",
-                q_idx + 1,
-                samples.len()
-            );
+    } else {
+        use futures::StreamExt;
+
+        let enrichment_arc = Arc::new(enrichment);
+        let done_arc = Arc::new(done_questions.clone());
+        let baselines_dir_owned = baselines_dir.to_path_buf();
+        let db_source_owned = db_source.clone();
+        let consolidated_db_owned = consolidated_db.clone();
+        let arms_owned = arms.clone();
+        let total = samples.len();
+
+        let scenario_outputs: Vec<Result<Vec<JudgmentTuple>, OriginError>> =
+            futures::stream::iter(samples.iter().enumerate())
+                .map(|(q_idx, sample)| {
+                    let shared_embedder = shared_embedder.clone();
+                    let enrichment_arc = enrichment_arc.clone();
+                    let done_arc = done_arc.clone();
+                    let baselines_dir_owned = baselines_dir_owned.clone();
+                    let db_source = db_source_owned.clone();
+                    let consolidated_db = consolidated_db_owned.clone();
+                    let arms = arms_owned.clone();
+                    let reranker = reranker.clone();
+                    let llm = llm.clone();
+                    async move {
+                        let sample_key: &str = if sample.question_id.is_empty() {
+                            sample.question.as_str()
+                        } else {
+                            sample.question_id.as_str()
+                        };
+                        if done_arc.contains(sample_key) {
+                            return Ok(Vec::new());
+                        }
+
+                        let ground_truth = match &sample.answer {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        if ground_truth.is_empty() {
+                            return Ok(Vec::new());
+                        }
+
+                        let db: Arc<MemoryDB> = match &db_source {
+                            DbSource::Consolidated(_) => consolidated_db
+                                .clone()
+                                .expect("consolidated_db is Some for DbSource::Consolidated"),
+                            DbSource::SeedPerQuestion => {
+                                let memories = extract_memories(sample);
+                                if memories.is_empty() {
+                                    return Ok(Vec::new());
+                                }
+
+                                let scope_dir = crate::eval::shared::scenario_db_dir(
+                                    &baselines_dir_owned,
+                                    "lme",
+                                    &sample.question_id,
+                                );
+
+                                let question_id = sample.question_id.clone();
+                                let question_type = sample.question_type.clone();
+                                let memories_owned = memories.clone();
+
+                                let seeded = match crate::eval::shared::open_or_seed_scenario_db(
+                                    &scope_dir,
+                                    shared_embedder,
+                                    move || {
+                                        memories_owned
+                                            .iter()
+                                            .map(|mem| crate::sources::RawDocument {
+                                                content: mem.content.clone(),
+                                                source_id: format!(
+                                                    "lme_{}_{}_t{}",
+                                                    question_id, mem.session_idx, mem.turn_idx
+                                                ),
+                                                source: "memory".to_string(),
+                                                title: format!(
+                                                    "session {} turn {}",
+                                                    mem.session_idx, mem.turn_idx
+                                                ),
+                                                memory_type: Some(
+                                                    if question_type
+                                                        == "single-session-preference"
+                                                    {
+                                                        "preference"
+                                                    } else {
+                                                        "fact"
+                                                    }
+                                                    .to_string(),
+                                                ),
+                                                space: Some("conversation".to_string()),
+                                                last_modified: chrono::Utc::now().timestamp(),
+                                                ..Default::default()
+                                            })
+                                            .collect()
+                                    },
+                                    &enrichment_arc,
+                                )
+                                .await
+                                {
+                                    Ok(db) => db,
+                                    Err(e) => {
+                                        return Err(OriginError::Generic(format!(
+                                            "[ce_ab_lme] scenario {} failed to open/seed DB: {e}. Refusing to \
+                                             silently drop the question — re-seed and retry.",
+                                            sample.question_id
+                                        )));
+                                    }
+                                };
+
+                                let db_mem_count = seeded.memory_count().await.unwrap_or(0);
+                                if db_mem_count == 0 {
+                                    return Err(OriginError::Generic(format!(
+                                        "EVAL REFUSED [ce_ab_lme]: scenario {} seeded DB has 0 memories. \
+                                         A CE A/B over an empty substrate measures noise, not CE. Re-seed and retry.",
+                                        sample.question_id
+                                    )));
+                                }
+
+                                let date_map = crate::eval::longmemeval::event_date_map(
+                                    std::slice::from_ref(sample),
+                                );
+                                if !date_map.is_empty() {
+                                    let updates: Vec<(String, i64)> =
+                                        date_map.into_iter().collect();
+                                    let n_total = updates.len();
+                                    let rows = seeded.set_event_dates_by_source_id(&updates).await?;
+                                    if rows == 0 {
+                                        log::warn!(
+                                            "[ce_ab_lme] event_date injection updated 0/{} rows for question {} \
+                                             — source_id drift; skipping question",
+                                            n_total,
+                                            sample.question_id
+                                        );
+                                        return Ok(Vec::new());
+                                    }
+                                }
+
+                                Arc::new(seeded)
+                            }
+                        };
+
+                        let category = category_name(&sample.question_type);
+                        let arm_pairs = arms.resolve(category, &reranker)?;
+                        let mut tuples = Vec::with_capacity(arm_pairs.len());
+                        for (arm_label, retrieval) in arm_pairs {
+                            let (ctx, ctx_tokens) = match build_structured_context(
+                                &db,
+                                &sample.question,
+                                10,
+                                None,
+                                retrieval,
+                            )
+                            .await
+                            {
+                                Ok(v) => v,
+                                Err(e) => {
+                                    return Err(OriginError::Generic(format!(
+                                        "[ce_ab_lme] scenario {} arm {arm_label} context build failed: {e}",
+                                        sample.question_id
+                                    )));
+                                }
+                            };
+
+                            let request = LlmRequest {
+                                system_prompt: Some(e2e_system_prompt()),
+                                user_prompt: format!(
+                                    "Context:\n{}\n\nQuestion: {}",
+                                    ctx, sample.question
+                                ),
+                                max_tokens: e2e_max_answer_tokens() as u32,
+                                temperature: 0.0,
+                                label: Some(arm_label.clone()),
+                                timeout_secs: None,
+                            };
+
+                            let answer = match llm.generate(request).await {
+                                Ok(raw) => strip_think_tags(&raw).trim().to_string(),
+                                Err(e) => {
+                                    eprintln!(
+                                        "[ce_ab_lme] WARN: scenario {} arm {arm_label} generation failed: {e}. \
+                                         Dropping all arms for this question; will retry on resume.",
+                                        sample.question_id
+                                    );
+                                    return Ok(Vec::new());
+                                }
+                            };
+
+                            if answer.is_empty() {
+                                eprintln!(
+                                    "[ce_ab_lme] WARN: scenario {} arm {arm_label} produced empty answer. \
+                                     Dropping all arms; will retry on resume.",
+                                    sample.question_id
+                                );
+                                return Ok(Vec::new());
+                            }
+
+                            tuples.push(JudgmentTuple {
+                                question: sample.question.clone(),
+                                ground_truth: ground_truth.clone(),
+                                approach: arm_label,
+                                answer,
+                                context_tokens: ctx_tokens,
+                                category: category.to_string(),
+                                question_id: sample.question_id.clone(),
+                            });
+                        }
+
+                        if q_idx % 100 == 99 {
+                            eprintln!(
+                                "[ce_ab_lme] {}/{} questions processed",
+                                q_idx + 1,
+                                total
+                            );
+                        }
+
+                        Ok(tuples)
+                    }
+                })
+                .buffer_unordered(scenario_concurrency)
+                .collect()
+                .await;
+
+        for result in scenario_outputs {
+            let tuples = result?;
+            if !tuples.is_empty() {
+                processed += 1;
+                finished_tuples.extend(tuples);
+            }
         }
     }
 
@@ -3355,6 +3605,8 @@ pub async fn run_fullpipeline_lme(
 mod tests {
     use super::*;
     use crate::eval::longmemeval::{ChatTurn, LongMemEvalSample};
+    use std::collections::HashMap;
+    use std::time::Duration;
 
     #[test]
     fn answer_prompt_v2_gate_default_off_byte_identical() {
@@ -3428,6 +3680,46 @@ mod tests {
         crate::eval::seed_contract::assert_feature_substrate_live(&conn, "temporal")
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrent_collection_preserves_qid_attribution() {
+        use futures::StreamExt;
+
+        fn val(qid: &str) -> u64 {
+            qid.strip_prefix('q')
+                .unwrap()
+                .parse::<u64>()
+                .unwrap()
+                .pow(2)
+        }
+
+        let qids: Vec<String> = (0..5).map(|i| format!("q{i}")).collect();
+        let serial_map: HashMap<String, u64> =
+            qids.iter().map(|qid| (qid.clone(), val(qid))).collect();
+
+        let n = qids.len() as u64;
+        let outputs: Vec<(String, u64)> = futures::stream::iter(qids.iter().enumerate())
+            .map(|(idx, qid)| async move {
+                tokio::time::sleep(Duration::from_millis((n - idx as u64) * 10)).await;
+                (qid.clone(), val(qid))
+            })
+            .buffer_unordered(8)
+            .collect()
+            .await;
+
+        let wrong_index_map: HashMap<String, u64> = qids
+            .iter()
+            .cloned()
+            .zip(outputs.iter().map(|(_, v)| *v))
+            .collect();
+        assert_ne!(
+            wrong_index_map, serial_map,
+            "associating completion-ordered values by original input index misattributes out-of-order results"
+        );
+
+        let concurrent_map: HashMap<String, u64> = outputs.into_iter().collect();
+        assert_eq!(concurrent_map, serial_map);
     }
 
     #[test]

--- a/crates/origin-core/src/llm_provider.rs
+++ b/crates/origin-core/src/llm_provider.rs
@@ -551,84 +551,52 @@ impl OnDeviceProvider {
                                 None => (30, true),
                             };
 
-                            let result = if batch_log_enabled {
-                                let call_class = batch_log_call_class(req.label.as_deref());
-                                let t = std::time::Instant::now();
-                                let result = match persistent_ctx.as_mut() {
-                                    Some(ctx) => engine.run_inference_persistent(
-                                        ctx,
-                                        &full_prompt,
-                                        req.max_tokens,
-                                        req.temperature,
-                                        timeout_secs,
-                                        strip_think,
-                                        req.label.as_deref(),
-                                    ),
-                                    None => {
-                                        log::warn!(
-                                            "[on_device_provider] worker {i} persistent context \
-                                             unavailable, falling back to per-call context"
-                                        );
-                                        match req.timeout_secs {
-                                            Some(secs) => engine.run_inference_raw(
-                                                &full_prompt,
-                                                req.max_tokens,
-                                                req.temperature,
-                                                secs,
-                                                req.ctx_size,
-                                            ),
-                                            None => engine.run_inference(
-                                                &full_prompt,
-                                                req.max_tokens,
-                                                req.temperature,
-                                                req.ctx_size,
-                                                req.label.as_deref(),
-                                            ),
-                                        }
+                            // Optionally time the inference only when batch_log_enabled.
+                            let t = batch_log_enabled.then(std::time::Instant::now);
+
+                            let result = match persistent_ctx.as_mut() {
+                                Some(ctx) => engine.run_inference_persistent(
+                                    ctx,
+                                    &full_prompt,
+                                    req.max_tokens,
+                                    req.temperature,
+                                    timeout_secs,
+                                    strip_think,
+                                    req.label.as_deref(),
+                                ),
+                                None => {
+                                    log::warn!(
+                                        "[on_device_provider] worker {i} persistent context \
+                                         unavailable, falling back to per-call context"
+                                    );
+                                    match req.timeout_secs {
+                                        Some(secs) => engine.run_inference_raw(
+                                            &full_prompt,
+                                            req.max_tokens,
+                                            req.temperature,
+                                            secs,
+                                            req.ctx_size,
+                                        ),
+                                        None => engine.run_inference(
+                                            &full_prompt,
+                                            req.max_tokens,
+                                            req.temperature,
+                                            req.ctx_size,
+                                            req.label.as_deref(),
+                                        ),
                                     }
-                                };
+                                }
+                            };
+
+                            if let Some(t) = t {
+                                let call_class = batch_log_call_class(req.label.as_deref());
                                 eprintln!(
                                     "[batch_log] n_seqs={} call_class={} wall_ms={}",
                                     batch_n_seqs,
                                     call_class,
                                     t.elapsed().as_millis()
                                 );
-                                result
-                            } else {
-                                match persistent_ctx.as_mut() {
-                                    Some(ctx) => engine.run_inference_persistent(
-                                        ctx,
-                                        &full_prompt,
-                                        req.max_tokens,
-                                        req.temperature,
-                                        timeout_secs,
-                                        strip_think,
-                                        req.label.as_deref(),
-                                    ),
-                                    None => {
-                                        log::warn!(
-                                            "[on_device_provider] worker {i} persistent context \
-                                             unavailable, falling back to per-call context"
-                                        );
-                                        match req.timeout_secs {
-                                            Some(secs) => engine.run_inference_raw(
-                                                &full_prompt,
-                                                req.max_tokens,
-                                                req.temperature,
-                                                secs,
-                                                req.ctx_size,
-                                            ),
-                                            None => engine.run_inference(
-                                                &full_prompt,
-                                                req.max_tokens,
-                                                req.temperature,
-                                                req.ctx_size,
-                                                req.label.as_deref(),
-                                            ),
-                                        }
-                                    }
-                                }
-                            };
+                            }
 
                             let response = match result {
                                 Some(text) => {
@@ -669,93 +637,59 @@ impl OnDeviceProvider {
                                 })
                                 .collect();
 
-                        let outputs: Vec<Option<String>> = if batch_log_enabled {
-                            let batch_n_seqs = batch_reqs.len();
-                            let batch_call_class = batch_log_call_class(
-                                batch_reqs.first().and_then(|req| req.label.as_deref()),
-                            );
-                            let t = std::time::Instant::now();
-                            let outputs = match persistent_ctx.as_mut() {
-                                Some(ctx) => {
-                                    engine.run_inference_continuous_batch(ctx, &prompts, m)
-                                }
-                                None => {
-                                    log::warn!(
-                                        "[on_device_provider] worker {i} persistent multi-seq \
-                                         context unavailable, falling back to serial per-call"
-                                    );
-                                    // Serial fallback: run each request through
-                                    // run_inference_raw / run_inference. Slower
-                                    // but preserves correctness.
-                                    prompts
-                                        .iter()
-                                        .zip(batch_reqs.iter())
-                                        .map(|((p, max_t, temp, timeout, _strip, label), req)| {
-                                            match req.timeout_secs {
-                                                Some(_) => engine.run_inference_raw(
-                                                    p,
-                                                    *max_t,
-                                                    *temp,
-                                                    *timeout,
-                                                    req.ctx_size,
-                                                ),
-                                                None => engine.run_inference(
-                                                    p,
-                                                    *max_t,
-                                                    *temp,
-                                                    req.ctx_size,
-                                                    label.as_deref(),
-                                                ),
-                                            }
-                                        })
-                                        .collect()
-                                }
-                            };
+                        let batch_n_seqs = batch_reqs.len();
+                        let batch_call_class = batch_log_call_class(
+                            batch_reqs.first().and_then(|req| req.label.as_deref()),
+                        );
+
+                        // Optionally time the inference only when batch_log_enabled.
+                        let t = batch_log_enabled.then(std::time::Instant::now);
+
+                        let outputs: Vec<Option<String>> = match persistent_ctx.as_mut() {
+                            Some(ctx) => engine.run_inference_continuous_batch(ctx, &prompts, m),
+                            None => {
+                                log::warn!(
+                                    "[on_device_provider] worker {i} persistent multi-seq \
+                                     context unavailable, falling back to serial per-call"
+                                );
+                                // Serial fallback: run each request through
+                                // run_inference_raw / run_inference. Slower
+                                // but preserves correctness.
+                                prompts
+                                    .iter()
+                                    .zip(batch_reqs.iter())
+                                    .map(
+                                        |((p, max_t, temp, timeout, _strip, label), req)| match req
+                                            .timeout_secs
+                                        {
+                                            Some(_) => engine.run_inference_raw(
+                                                p,
+                                                *max_t,
+                                                *temp,
+                                                *timeout,
+                                                req.ctx_size,
+                                            ),
+                                            None => engine.run_inference(
+                                                p,
+                                                *max_t,
+                                                *temp,
+                                                req.ctx_size,
+                                                label.as_deref(),
+                                            ),
+                                        },
+                                    )
+                                    .collect()
+                            }
+                        };
+
+                        if let Some(t) = t {
                             eprintln!(
                                 "[batch_log] n_seqs={} call_class={} wall_ms={}",
                                 batch_n_seqs,
                                 batch_call_class,
                                 t.elapsed().as_millis()
                             );
-                            outputs
-                        } else {
-                            match persistent_ctx.as_mut() {
-                                Some(ctx) => {
-                                    engine.run_inference_continuous_batch(ctx, &prompts, m)
-                                }
-                                None => {
-                                    log::warn!(
-                                        "[on_device_provider] worker {i} persistent multi-seq \
-                                         context unavailable, falling back to serial per-call"
-                                    );
-                                    // Serial fallback: run each request through
-                                    // run_inference_raw / run_inference. Slower
-                                    // but preserves correctness.
-                                    prompts
-                                        .iter()
-                                        .zip(batch_reqs.iter())
-                                        .map(|((p, max_t, temp, timeout, _strip, label), req)| {
-                                            match req.timeout_secs {
-                                                Some(_) => engine.run_inference_raw(
-                                                    p,
-                                                    *max_t,
-                                                    *temp,
-                                                    *timeout,
-                                                    req.ctx_size,
-                                                ),
-                                                None => engine.run_inference(
-                                                    p,
-                                                    *max_t,
-                                                    *temp,
-                                                    req.ctx_size,
-                                                    label.as_deref(),
-                                                ),
-                                            }
-                                        })
-                                        .collect()
-                                }
-                            }
-                        };
+                        }
 
                         // Demultiplex per-seq results back to per-request channels.
                         let mut any_ok = false;

--- a/crates/origin-core/src/llm_provider.rs
+++ b/crates/origin-core/src/llm_provider.rs
@@ -210,7 +210,7 @@ fn context_seq_max_for_batch(batch_len: usize, parallel_seqs: usize) -> u32 {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct BatchLogRecord {
     pub(crate) n_seqs: usize,
     pub(crate) call_class: String,
@@ -218,13 +218,20 @@ pub(crate) struct BatchLogRecord {
 }
 
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct BatchLogSummary {
     pub(crate) batching_rate: f64,
     pub(crate) wall_ms_share_by_class: std::collections::HashMap<String, f64>,
 }
 
-#[allow(dead_code)]
+/// Aggregate a batch of `BatchLogRecord`s to compute:
+/// - `batching_rate`: fraction of records with n_seqs >= 2 (i.e., batched requests)
+/// - `wall_ms_share_by_class`: per-class wall-time share as a fraction of total wall_ms
+///
+/// Used for offline log analysis. A parser (see `parse_batch_log_line`) transforms
+/// emitted `[batch_log]` stderr lines into `BatchLogRecord`s, which can then be
+/// aggregated over a collection interval.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn aggregate_batch_log(records: &[BatchLogRecord]) -> BatchLogSummary {
     let batching_rate = if records.is_empty() {
         0.0
@@ -255,6 +262,43 @@ pub(crate) fn aggregate_batch_log(records: &[BatchLogRecord]) -> BatchLogSummary
 
 fn batch_log_call_class(label: Option<&str>) -> &str {
     label.unwrap_or("unknown")
+}
+
+/// Parse a `[batch_log]` stderr line into a `BatchLogRecord`.
+/// The expected format is: `[batch_log] n_seqs=N call_class=TAG wall_ms=MS`
+/// Returns None if the line does not match the expected format.
+#[cfg(test)]
+fn parse_batch_log_line(line: &str) -> Option<BatchLogRecord> {
+    // Trim and check prefix
+    let line = line.trim();
+    if !line.starts_with("[batch_log] ") {
+        return None;
+    }
+    let rest = &line["[batch_log] ".len()..];
+
+    // Parse key=value pairs
+    let mut n_seqs: Option<usize> = None;
+    let mut call_class: Option<String> = None;
+    let mut wall_ms: Option<u64> = None;
+
+    for part in rest.split_whitespace() {
+        if let Some(val) = part.strip_prefix("n_seqs=") {
+            n_seqs = val.parse().ok();
+        } else if let Some(val) = part.strip_prefix("call_class=") {
+            call_class = Some(val.to_string());
+        } else if let Some(val) = part.strip_prefix("wall_ms=") {
+            wall_ms = val.parse().ok();
+        }
+    }
+
+    match (n_seqs, call_class, wall_ms) {
+        (Some(n), Some(c), Some(w)) => Some(BatchLogRecord {
+            n_seqs: n,
+            call_class: c,
+            wall_ms: w,
+        }),
+        _ => None,
+    }
 }
 
 /// On-device LLM provider that runs inference on a dedicated `std::thread`.
@@ -1525,6 +1569,43 @@ mod tests {
         let empty = aggregate_batch_log(&[]);
         assert_eq!(empty.batching_rate, 0.0);
         assert!(empty.wall_ms_share_by_class.is_empty());
+    }
+
+    #[test]
+    fn batch_log_round_trip_parse_and_aggregate() {
+        // Test that the emitted [batch_log] format can be parsed back into
+        // BatchLogRecord and fed to the aggregator. This ensures the emitted
+        // format and aggregator input stay reconciled. The emitted format is:
+        // [batch_log] n_seqs=N call_class=TAG wall_ms=MS
+        let lines = vec![
+            "[batch_log] n_seqs=1 call_class=distill wall_ms=100",
+            "[batch_log] n_seqs=4 call_class=extract wall_ms=60",
+            "[batch_log] n_seqs=2 call_class=extract wall_ms=40",
+            "[batch_log] n_seqs=1 call_class=classify wall_ms=50",
+        ];
+
+        let parsed: Vec<BatchLogRecord> = lines
+            .iter()
+            .filter_map(|line| parse_batch_log_line(line))
+            .collect();
+
+        assert_eq!(parsed.len(), 4, "all lines should parse");
+        let summary = aggregate_batch_log(&parsed);
+
+        // Verify the parsed records produce the same aggregation as the
+        // hand-constructed records from the previous test.
+        assert!((summary.batching_rate - 0.5).abs() < 1e-9);
+        assert!((summary.wall_ms_share_by_class["extract"] - 0.4).abs() < 1e-9);
+        assert!((summary.wall_ms_share_by_class["distill"] - 0.4).abs() < 1e-9);
+        assert!((summary.wall_ms_share_by_class["classify"] - 0.2).abs() < 1e-9);
+
+        // Test malformed lines are rejected
+        assert!(parse_batch_log_line("garbage").is_none());
+        assert!(parse_batch_log_line("[batch_log] n_seqs=1").is_none());
+        assert!(
+            parse_batch_log_line("[batch_log] n_seqs=invalid call_class=test wall_ms=100")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/origin-core/src/llm_provider.rs
+++ b/crates/origin-core/src/llm_provider.rs
@@ -209,6 +209,54 @@ fn context_seq_max_for_batch(batch_len: usize, parallel_seqs: usize) -> u32 {
     }
 }
 
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) struct BatchLogRecord {
+    pub(crate) n_seqs: usize,
+    pub(crate) call_class: String,
+    pub(crate) wall_ms: u64,
+}
+
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) struct BatchLogSummary {
+    pub(crate) batching_rate: f64,
+    pub(crate) wall_ms_share_by_class: std::collections::HashMap<String, f64>,
+}
+
+#[allow(dead_code)]
+pub(crate) fn aggregate_batch_log(records: &[BatchLogRecord]) -> BatchLogSummary {
+    let batching_rate = if records.is_empty() {
+        0.0
+    } else {
+        let batched_count = records.iter().filter(|record| record.n_seqs >= 2).count();
+        batched_count as f64 / records.len() as f64
+    };
+
+    let total_wall_ms: u128 = records.iter().map(|record| record.wall_ms as u128).sum();
+    let mut wall_ms_share_by_class = std::collections::HashMap::new();
+
+    if total_wall_ms > 0 {
+        for record in records {
+            *wall_ms_share_by_class
+                .entry(record.call_class.clone())
+                .or_insert(0.0) += record.wall_ms as f64;
+        }
+        for share in wall_ms_share_by_class.values_mut() {
+            *share /= total_wall_ms as f64;
+        }
+    }
+
+    BatchLogSummary {
+        batching_rate,
+        wall_ms_share_by_class,
+    }
+}
+
+fn batch_log_call_class(label: Option<&str>) -> &str {
+    label.unwrap_or("unknown")
+}
+
 /// On-device LLM provider that runs inference on a dedicated `std::thread`.
 ///
 /// Construction downloads the model (cached), loads it via Metal GPU, and
@@ -469,6 +517,7 @@ impl OnDeviceProvider {
                         let target_ctx_size =
                             batch_reqs.iter().map(|r| r.ctx_size).max().unwrap_or(0);
                         let target_seq_max = context_seq_max_for_batch(batch_reqs.len(), m);
+                        let batch_log_enabled = std::env::var("ORIGIN_BATCH_LOG").is_ok();
 
                         if persistent_ctx.is_none()
                             || persistent_ctx_size != target_ctx_size
@@ -493,6 +542,7 @@ impl OnDeviceProvider {
                         // inference). This is critical for backward compat —
                         // single-request latency must not regress.
                         if m == 1 || batch_reqs.len() == 1 {
+                            let batch_n_seqs = batch_reqs.len();
                             let req = batch_reqs.pop().expect("batch has at least 1 req");
                             let full_prompt =
                                 format_chatml_prompt(req.system_prompt.as_deref(), &req.prompt);
@@ -501,36 +551,81 @@ impl OnDeviceProvider {
                                 None => (30, true),
                             };
 
-                            let result = match persistent_ctx.as_mut() {
-                                Some(ctx) => engine.run_inference_persistent(
-                                    ctx,
-                                    &full_prompt,
-                                    req.max_tokens,
-                                    req.temperature,
-                                    timeout_secs,
-                                    strip_think,
-                                    req.label.as_deref(),
-                                ),
-                                None => {
-                                    log::warn!(
-                                        "[on_device_provider] worker {i} persistent context \
-                                         unavailable, falling back to per-call context"
-                                    );
-                                    match req.timeout_secs {
-                                        Some(secs) => engine.run_inference_raw(
-                                            &full_prompt,
-                                            req.max_tokens,
-                                            req.temperature,
-                                            secs,
-                                            req.ctx_size,
-                                        ),
-                                        None => engine.run_inference(
-                                            &full_prompt,
-                                            req.max_tokens,
-                                            req.temperature,
-                                            req.ctx_size,
-                                            req.label.as_deref(),
-                                        ),
+                            let result = if batch_log_enabled {
+                                let call_class = batch_log_call_class(req.label.as_deref());
+                                let t = std::time::Instant::now();
+                                let result = match persistent_ctx.as_mut() {
+                                    Some(ctx) => engine.run_inference_persistent(
+                                        ctx,
+                                        &full_prompt,
+                                        req.max_tokens,
+                                        req.temperature,
+                                        timeout_secs,
+                                        strip_think,
+                                        req.label.as_deref(),
+                                    ),
+                                    None => {
+                                        log::warn!(
+                                            "[on_device_provider] worker {i} persistent context \
+                                             unavailable, falling back to per-call context"
+                                        );
+                                        match req.timeout_secs {
+                                            Some(secs) => engine.run_inference_raw(
+                                                &full_prompt,
+                                                req.max_tokens,
+                                                req.temperature,
+                                                secs,
+                                                req.ctx_size,
+                                            ),
+                                            None => engine.run_inference(
+                                                &full_prompt,
+                                                req.max_tokens,
+                                                req.temperature,
+                                                req.ctx_size,
+                                                req.label.as_deref(),
+                                            ),
+                                        }
+                                    }
+                                };
+                                eprintln!(
+                                    "[batch_log] n_seqs={} call_class={} wall_ms={}",
+                                    batch_n_seqs,
+                                    call_class,
+                                    t.elapsed().as_millis()
+                                );
+                                result
+                            } else {
+                                match persistent_ctx.as_mut() {
+                                    Some(ctx) => engine.run_inference_persistent(
+                                        ctx,
+                                        &full_prompt,
+                                        req.max_tokens,
+                                        req.temperature,
+                                        timeout_secs,
+                                        strip_think,
+                                        req.label.as_deref(),
+                                    ),
+                                    None => {
+                                        log::warn!(
+                                            "[on_device_provider] worker {i} persistent context \
+                                             unavailable, falling back to per-call context"
+                                        );
+                                        match req.timeout_secs {
+                                            Some(secs) => engine.run_inference_raw(
+                                                &full_prompt,
+                                                req.max_tokens,
+                                                req.temperature,
+                                                secs,
+                                                req.ctx_size,
+                                            ),
+                                            None => engine.run_inference(
+                                                &full_prompt,
+                                                req.max_tokens,
+                                                req.temperature,
+                                                req.ctx_size,
+                                                req.label.as_deref(),
+                                            ),
+                                        }
                                     }
                                 }
                             };
@@ -574,40 +669,91 @@ impl OnDeviceProvider {
                                 })
                                 .collect();
 
-                        let outputs: Vec<Option<String>> = match persistent_ctx.as_mut() {
-                            Some(ctx) => engine.run_inference_continuous_batch(ctx, &prompts, m),
-                            None => {
-                                log::warn!(
-                                    "[on_device_provider] worker {i} persistent multi-seq \
-                                     context unavailable, falling back to serial per-call"
-                                );
-                                // Serial fallback: run each request through
-                                // run_inference_raw / run_inference. Slower
-                                // but preserves correctness.
-                                prompts
-                                    .iter()
-                                    .zip(batch_reqs.iter())
-                                    .map(
-                                        |((p, max_t, temp, timeout, _strip, label), req)| match req
-                                            .timeout_secs
-                                        {
-                                            Some(_) => engine.run_inference_raw(
-                                                p,
-                                                *max_t,
-                                                *temp,
-                                                *timeout,
-                                                req.ctx_size,
-                                            ),
-                                            None => engine.run_inference(
-                                                p,
-                                                *max_t,
-                                                *temp,
-                                                req.ctx_size,
-                                                label.as_deref(),
-                                            ),
-                                        },
-                                    )
-                                    .collect()
+                        let outputs: Vec<Option<String>> = if batch_log_enabled {
+                            let batch_n_seqs = batch_reqs.len();
+                            let batch_call_class = batch_log_call_class(
+                                batch_reqs.first().and_then(|req| req.label.as_deref()),
+                            );
+                            let t = std::time::Instant::now();
+                            let outputs = match persistent_ctx.as_mut() {
+                                Some(ctx) => {
+                                    engine.run_inference_continuous_batch(ctx, &prompts, m)
+                                }
+                                None => {
+                                    log::warn!(
+                                        "[on_device_provider] worker {i} persistent multi-seq \
+                                         context unavailable, falling back to serial per-call"
+                                    );
+                                    // Serial fallback: run each request through
+                                    // run_inference_raw / run_inference. Slower
+                                    // but preserves correctness.
+                                    prompts
+                                        .iter()
+                                        .zip(batch_reqs.iter())
+                                        .map(|((p, max_t, temp, timeout, _strip, label), req)| {
+                                            match req.timeout_secs {
+                                                Some(_) => engine.run_inference_raw(
+                                                    p,
+                                                    *max_t,
+                                                    *temp,
+                                                    *timeout,
+                                                    req.ctx_size,
+                                                ),
+                                                None => engine.run_inference(
+                                                    p,
+                                                    *max_t,
+                                                    *temp,
+                                                    req.ctx_size,
+                                                    label.as_deref(),
+                                                ),
+                                            }
+                                        })
+                                        .collect()
+                                }
+                            };
+                            eprintln!(
+                                "[batch_log] n_seqs={} call_class={} wall_ms={}",
+                                batch_n_seqs,
+                                batch_call_class,
+                                t.elapsed().as_millis()
+                            );
+                            outputs
+                        } else {
+                            match persistent_ctx.as_mut() {
+                                Some(ctx) => {
+                                    engine.run_inference_continuous_batch(ctx, &prompts, m)
+                                }
+                                None => {
+                                    log::warn!(
+                                        "[on_device_provider] worker {i} persistent multi-seq \
+                                         context unavailable, falling back to serial per-call"
+                                    );
+                                    // Serial fallback: run each request through
+                                    // run_inference_raw / run_inference. Slower
+                                    // but preserves correctness.
+                                    prompts
+                                        .iter()
+                                        .zip(batch_reqs.iter())
+                                        .map(|((p, max_t, temp, timeout, _strip, label), req)| {
+                                            match req.timeout_secs {
+                                                Some(_) => engine.run_inference_raw(
+                                                    p,
+                                                    *max_t,
+                                                    *temp,
+                                                    *timeout,
+                                                    req.ctx_size,
+                                                ),
+                                                None => engine.run_inference(
+                                                    p,
+                                                    *max_t,
+                                                    *temp,
+                                                    req.ctx_size,
+                                                    label.as_deref(),
+                                                ),
+                                            }
+                                        })
+                                        .collect()
+                                }
                             }
                         };
 
@@ -1409,6 +1555,42 @@ mod tests {
         assert_eq!(context_seq_max_for_batch(1, 8), 1);
         assert_eq!(context_seq_max_for_batch(2, 8), 8);
         assert_eq!(context_seq_max_for_batch(8, 8), 8);
+    }
+
+    #[test]
+    fn aggregate_batch_log_rate_and_class_share() {
+        let records = vec![
+            BatchLogRecord {
+                n_seqs: 1,
+                call_class: "distill".to_string(),
+                wall_ms: 100,
+            },
+            BatchLogRecord {
+                n_seqs: 4,
+                call_class: "extract".to_string(),
+                wall_ms: 60,
+            },
+            BatchLogRecord {
+                n_seqs: 2,
+                call_class: "extract".to_string(),
+                wall_ms: 40,
+            },
+            BatchLogRecord {
+                n_seqs: 1,
+                call_class: "classify".to_string(),
+                wall_ms: 50,
+            },
+        ];
+
+        let summary = aggregate_batch_log(&records);
+        assert!((summary.batching_rate - 0.5).abs() < 1e-9);
+        assert!((summary.wall_ms_share_by_class["extract"] - 0.4).abs() < 1e-9);
+        assert!((summary.wall_ms_share_by_class["distill"] - 0.4).abs() < 1e-9);
+        assert!((summary.wall_ms_share_by_class["classify"] - 0.2).abs() < 1e-9);
+
+        let empty = aggregate_batch_log(&[]);
+        assert_eq!(empty.batching_rate, 0.0);
+        assert!(empty.wall_ms_share_by_class.is_empty());
     }
 
     #[test]

--- a/crates/origin-core/src/llm_provider.rs
+++ b/crates/origin-core/src/llm_provider.rs
@@ -1611,7 +1611,7 @@ mod tests {
         // BatchLogRecord and fed to the aggregator. This ensures the emitted
         // format and aggregator input stay reconciled. The emitted format is:
         // [batch_log] n_seqs=N call_class=TAG wall_ms=MS
-        let lines = vec![
+        let lines = [
             "[batch_log] n_seqs=1 call_class=distill wall_ms=100",
             "[batch_log] n_seqs=4 call_class=extract wall_ms=60",
             "[batch_log] n_seqs=2 call_class=extract wall_ms=40",


### PR DESCRIPTION
## What

Two eval-infra changes (default-off / default-identical), split clean off `main` (touches only `answer_quality.rs` + `llm_provider.rs`; the parked PR-3 adaptive-rerank-pool work is a separate branch).

- **Task A** — `EVAL_SCENARIO_CONCURRENCY` (default 1, cap 8) in `run_fullpipeline_lme` (the on-device CE A/B path). The whole per-scenario body (seed→context→inline per-arm answer) runs in one async closure returning `Result<Vec<JudgmentTuple>>`, fed through `buffer_unordered`. Tuples stay keyed by immutable `question_id`+approach (completion order is not used for attribution). K=1 is byte-identical to today.
- **Task B** — `ORIGIN_BATCH_LOG` (silent/alloc-free when unset) emits realized `n_seqs` + call-class + wall_ms at each worker drain, plus a pure aggregation fn (batching-rate + per-class wall-share) with a parser round-trip test locking the emitted format to the aggregator.

## Determinism evidence (GPU, seeded LME-S qids, temp 0)

| arm | result |
|---|---|
| serial K=1 vs **K=8 / M=1** | **12/12 byte-identical** ✅ scenario concurrency is correct |
| serial vs **K=8 / M=8** (before coalescer fix) | 6/12 mismatched |
| serial vs **K=8 / M=8** (after #272) | 2/12 mismatched (deterministic corruption gone) |
| serial vs **K=8 / M=8** (after #272, 2nd run) | 0/12 — byte-identical; mismatch set moves run-to-run |

## M>1 determinism — deterministic corruption fixed in #272; residual is inherent FP

The K>1 *speedup* only materializes when the on-device continuous-batch coalescer batches ≥2 sequences (`ORIGIN_LLM_PARALLEL_SEQS>1`). The earlier M>1 corruption had two layers:

1. **Deterministic template-leak / truncation corruption** — a real latent bug in the prior continuous-batch PR. **Fixed in #272** (prompt-aware batch admission + truncation→refusal). Mismatch count dropped 6/12 → 2/12.
2. **Residual: sporadic batched-GEMM FP non-determinism** at greedy temp=0. A second M=8 run after #272 was 0/12 (byte-identical to serial), and the mismatch set moves run-to-run — different batch composition changes the GEMM reduction order, occasionally flipping a greedy argmax. **Not a code bug; inherent to batched inference on llama.cpp/Metal (no batch-invariant kernels).**

**Guidance:** for bit-reproducible evals (e.g. the PR-3 pool sweep) use **M=1**. M>1 is a throughput lever for large-N runs where aggregate accuracy absorbs the sporadic per-question noise. M>1 long-prompt safety depends on #272.

This PR's concurrency (Task A) is correct + byte-identical at M=1; the determinism gate fired exactly as predicted and is now explained, not open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
