### PR TITLE
ci: notify claude-plugins marketplace on release

### DIFF
--- a/.github/workflows/notify-marketplace.yml
+++ b/.github/workflows/notify-marketplace.yml
@@ -1,0 +1,21 @@
+name: notify-marketplace
+
+# On a published release, tell the claude-plugins marketplace to re-sync pins.
+# The marketplace's sync-marketplace workflow re-derives every plugin's pin itself,
+# so this only needs to fire the dispatch (the client_payload is informational).
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to claude-plugins
+        env:
+          GH_TOKEN: ${{ secrets.MARKETPLACE_SYNC_TOKEN }}
+        run: |
+          gh api repos/7xuanlu/claude-plugins/dispatches \
+            -f event_type=plugin-released \
+            -F "client_payload[plugin]=origin" \
+            -F "client_payload[tag]=${{ github.event.release.tag_name }}"


### PR DESCRIPTION
On `release: published`, fires a `repository_dispatch` (`plugin-released`) to `7xuanlu/claude-plugins` so its `sync-marketplace` workflow advances origin's pin instantly (advance-only — it never rolls origin's post-release pin backward).

Uses secret `MARKETPLACE_SYNC_TOKEN` (fine-grained PAT, Contents: read/write + Metadata: read on `claude-plugins`). Inert until that secret is set; the marketplace's nightly cron is the backstop.

Companion: the sync engine in `7xuanlu/claude-plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)