### PR TITLE
test(eval): pages on/off toggle + pages_ab arms for page-channel answer-acc A/B

### DIFF
--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -1213,9 +1213,8 @@ async fn build_structured_context(
     search_limit: usize,
     domain: Option<&str>,
     retrieval: CtxRetrieval,
+    include_pages: bool,
 ) -> Result<(String, usize), OriginError> {
-    use crate::pages::filter_pages_by_source_overlap;
-
     let results = match retrieval {
         CtxRetrieval::Quick => {
             db.search_memory(question, search_limit, None, domain, None, None, None, None)
@@ -1231,42 +1230,46 @@ async fn build_structured_context(
     let search_source_ids: std::collections::HashSet<String> =
         results.iter().map(|r| r.source_id.clone()).collect();
 
-    // Structured: concepts + search results (matches production /api/chat-context).
-    // EVAL_CONCEPT_MIN_OVERLAP env var lets us sweep thresholds without code changes;
-    // defaults to the production tuning value (2).
-    let min_overlap: usize = std::env::var("EVAL_CONCEPT_MIN_OVERLAP")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or_else(|| crate::tuning::DistillationConfig::default().page_min_overlap);
-
     let mut parts: Vec<String> = Vec::new();
-    let raw_concepts = db.search_pages(question, 3, None).await.unwrap_or_default();
-    let concepts = filter_pages_by_source_overlap(&raw_concepts, &search_source_ids, min_overlap);
+    if include_pages {
+        use crate::pages::filter_pages_by_source_overlap;
+        // Structured: concepts + search results (matches production /api/chat-context).
+        // EVAL_CONCEPT_MIN_OVERLAP env var lets us sweep thresholds without code changes;
+        // defaults to the production tuning value (2).
+        let min_overlap: usize = std::env::var("EVAL_CONCEPT_MIN_OVERLAP")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| crate::tuning::DistillationConfig::default().page_min_overlap);
 
-    if !raw_concepts.is_empty() {
-        for c in &raw_concepts {
-            let kept = concepts.iter().any(|k| k.id == c.id);
-            let overlap = c
-                .source_memory_ids
-                .iter()
-                .filter(|sid| search_source_ids.contains(sid.as_str()))
-                .count();
-            log::info!(
-                "[eval:concept] score={:.4} overlap={}/{} {} title={:?} q={:?}",
-                c.relevance_score,
-                overlap,
-                results.len(),
-                if kept { "KEPT" } else { "FILTERED" },
-                c.title.chars().take(40).collect::<String>(),
-                question.chars().take(50).collect::<String>(),
-            );
+        let raw_concepts = db.search_pages(question, 3, None).await.unwrap_or_default();
+        let concepts =
+            filter_pages_by_source_overlap(&raw_concepts, &search_source_ids, min_overlap);
+
+        if !raw_concepts.is_empty() {
+            for c in &raw_concepts {
+                let kept = concepts.iter().any(|k| k.id == c.id);
+                let overlap = c
+                    .source_memory_ids
+                    .iter()
+                    .filter(|sid| search_source_ids.contains(sid.as_str()))
+                    .count();
+                log::info!(
+                    "[eval:concept] score={:.4} overlap={}/{} {} title={:?} q={:?}",
+                    c.relevance_score,
+                    overlap,
+                    results.len(),
+                    if kept { "KEPT" } else { "FILTERED" },
+                    c.title.chars().take(40).collect::<String>(),
+                    question.chars().take(50).collect::<String>(),
+                );
+            }
         }
-    }
-    if !concepts.is_empty() {
-        parts.push("## Compiled Knowledge".to_string());
-        for c in &concepts {
-            let summary = c.summary.as_deref().unwrap_or("");
-            parts.push(format!("**{}**: {}\n{}", c.title, summary, c.content));
+        if !concepts.is_empty() {
+            parts.push("## Compiled Knowledge".to_string());
+            for c in &concepts {
+                let summary = c.summary.as_deref().unwrap_or("");
+                parts.push(format!("**{}**: {}\n{}", c.title, summary, c.content));
+            }
         }
     }
     if !results.is_empty() {
@@ -1938,9 +1941,15 @@ pub async fn run_fullpipeline_locomo_batch(
                 }
 
                 let category = category_name(qa.category);
-                let ctx_result =
-                    build_structured_context(&db, &qa.question, 10, None, CtxRetrieval::Quick)
-                        .await;
+                let ctx_result = build_structured_context(
+                    &db,
+                    &qa.question,
+                    10,
+                    None,
+                    CtxRetrieval::Quick,
+                    true,
+                )
+                .await;
                 let (ctx, ctx_tokens) = match ctx_result {
                     Ok(v) => v,
                     Err(e) => {
@@ -2083,6 +2092,7 @@ pub async fn run_fullpipeline_locomo_batch(
                                 10,
                                 None,
                                 CtxRetrieval::Quick,
+                                true,
                             )
                             .await;
                             let (ctx, ctx_tokens) = match ctx_result {
@@ -2432,9 +2442,15 @@ pub async fn run_fullpipeline_lme_batch(
             );
 
             let category = category_name(&sample.question_type);
-            let ctx_result =
-                build_structured_context(&db, &sample.question, 10, None, CtxRetrieval::Quick)
-                    .await;
+            let ctx_result = build_structured_context(
+                &db,
+                &sample.question,
+                10,
+                None,
+                CtxRetrieval::Quick,
+                true,
+            )
+            .await;
             let (ctx, ctx_tokens) = match ctx_result {
                 Ok(v) => v,
                 Err(e) => {
@@ -2583,6 +2599,7 @@ pub async fn run_fullpipeline_lme_batch(
                             10,
                             None,
                             CtxRetrieval::Quick,
+                            true,
                         )
                         .await;
                         let (ctx, ctx_tokens) = match ctx_result {
@@ -3283,6 +3300,7 @@ pub async fn run_fullpipeline_lme(
                     10,
                     None,
                     retrieval,
+                    true,
                 )
                 .await
                 {
@@ -3508,6 +3526,7 @@ pub async fn run_fullpipeline_lme(
                                 10,
                                 None,
                                 retrieval,
+                                true,
                             )
                             .await
                             {
@@ -3789,6 +3808,92 @@ mod tests {
         assert!(
             !spec.needs_confounder_isolation(),
             "full_stack has no CeOff arm — confounder gate must be skipped so features can be ON"
+        );
+    }
+
+    /// Task 1: `include_pages=true` surfaces `## Compiled Knowledge`; `false` omits it.
+    #[tokio::test]
+    async fn build_structured_context_include_pages_toggle() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new_with_shared_embedder(
+            tmp.path(),
+            Arc::new(NoopEmitter),
+            eval_shared_embedder(),
+        )
+        .await
+        .unwrap();
+
+        // Seed two memories so the page overlap gate (default min_overlap=2) passes.
+        let source_id_1 = "test_mem_p1";
+        let source_id_2 = "test_mem_p2";
+        db.upsert_documents(vec![
+            RawDocument {
+                source: "memory".to_string(),
+                source_id: source_id_1.to_string(),
+                title: "planning session".to_string(),
+                content: "I discussed project planning with the team.".to_string(),
+                last_modified: chrono::Utc::now().timestamp(),
+                memory_type: Some("fact".to_string()),
+                space: Some("conversation".to_string()),
+                ..Default::default()
+            },
+            RawDocument {
+                source: "memory".to_string(),
+                source_id: source_id_2.to_string(),
+                title: "team coordination".to_string(),
+                content: "We coordinated the planning tasks across the team.".to_string(),
+                last_modified: chrono::Utc::now().timestamp(),
+                memory_type: Some("fact".to_string()),
+                space: Some("conversation".to_string()),
+                ..Default::default()
+            },
+        ])
+        .await
+        .unwrap();
+
+        // Insert a page referencing both memories (satisfies default min_overlap=2 gate).
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_test_001",
+            "Project Planning Guide",
+            Some("Overview of planning practices."),
+            "This page covers project planning discussions and team coordination.",
+            None,
+            None,
+            &[source_id_1, source_id_2],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        let question = "planning";
+
+        let (ctx_on, _) =
+            build_structured_context(&db, question, 10, None, CtxRetrieval::Quick, true)
+                .await
+                .unwrap();
+
+        let (ctx_off, _) =
+            build_structured_context(&db, question, 10, None, CtxRetrieval::Quick, false)
+                .await
+                .unwrap();
+
+        assert!(
+            ctx_on.contains("## Compiled Knowledge"),
+            "include_pages=true must include ## Compiled Knowledge; got: {ctx_on}"
+        );
+        assert!(
+            !ctx_off.contains("## Compiled Knowledge"),
+            "include_pages=false must NOT include ## Compiled Knowledge; got: {ctx_off}"
+        );
+        // Both should contain memory content when there are hits.
+        assert!(
+            ctx_on.contains("## Relevant Memories") || ctx_on.contains("planning"),
+            "include_pages=true context should contain memory content"
+        );
+        assert!(
+            ctx_off.contains("## Relevant Memories") || ctx_off.contains("planning"),
+            "include_pages=false context should contain memory content"
         );
     }
 }

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -2800,22 +2800,16 @@ pub enum ArmKind {
     // PR-3 will add CeOnGraph -> CrossRerankGraph. Do NOT add it now.
 }
 
-impl ArmKind {
-    /// Stable label prefix, e.g. "ce_off" / "ce_on".
-    fn label_prefix(self) -> &'static str {
-        match self {
-            ArmKind::CeOff => "ce_off",
-            ArmKind::CeOn => "ce_on",
-            ArmKind::FullStack => "fullstack",
-        }
-    }
-}
-
 /// One arm: a retrieval mode paired with whether to include pages in context.
+/// `label_prefix` is the stable identity used in baseline filenames — assigned
+/// explicitly by each constructor, independent of `include_pages`.
 #[derive(Debug, Clone)]
 pub struct Arm {
     pub kind: ArmKind,
     pub include_pages: bool,
+    /// Stable baseline label prefix, e.g. "ce_off", "ce_on", "ce_on_pages".
+    /// Assigned by the constructor, NOT derived from `include_pages`.
+    pub label_prefix: &'static str,
 }
 
 /// The set of arms to run, in order.
@@ -2832,10 +2826,12 @@ impl ArmSpec {
                 Arm {
                     kind: ArmKind::CeOff,
                     include_pages: true,
+                    label_prefix: "ce_off",
                 },
                 Arm {
                     kind: ArmKind::CeOn,
                     include_pages: true,
+                    label_prefix: "ce_on",
                 },
             ],
         }
@@ -2850,6 +2846,7 @@ impl ArmSpec {
             arms: vec![Arm {
                 kind: ArmKind::FullStack,
                 include_pages: true,
+                label_prefix: "fullstack",
             }],
         }
     }
@@ -2862,14 +2859,17 @@ impl ArmSpec {
                 Arm {
                     kind: ArmKind::CeOff,
                     include_pages: false,
+                    label_prefix: "ce_off",
                 },
                 Arm {
                     kind: ArmKind::CeOn,
                     include_pages: false,
+                    label_prefix: "ce_on",
                 },
                 Arm {
                     kind: ArmKind::CeOn,
                     include_pages: true,
+                    label_prefix: "ce_on_pages",
                 },
             ],
         }
@@ -2885,36 +2885,18 @@ impl ArmSpec {
     }
 
     /// One label per arm for a given category, in order.
-    /// Arms with `include_pages=true` get a `_pages` suffix: "ce_off_pages_cat".
-    /// Arms with `include_pages=false` omit the suffix: "ce_off_cat".
+    /// Label is `<arm.label_prefix>_<category>`; the prefix is assigned explicitly per
+    /// constructor (e.g. "ce_off_cat", "ce_on_pages_cat"), NOT derived from `include_pages`.
     pub fn labels(&self, category: &str) -> Vec<String> {
         self.arms
             .iter()
-            .map(|arm| {
-                let base = arm.kind.label_prefix();
-                let prefix = if arm.include_pages {
-                    format!("{base}_pages")
-                } else {
-                    base.to_string()
-                };
-                format!("{prefix}_{category}")
-            })
+            .map(|arm| format!("{}_{}", arm.label_prefix, category))
             .collect()
     }
 
-    /// Label prefixes (for the done-set), e.g. `["ce_off_pages", "ce_on_pages"]`.
-    fn prefixes(&self) -> Vec<String> {
-        self.arms
-            .iter()
-            .map(|arm| {
-                let base = arm.kind.label_prefix();
-                if arm.include_pages {
-                    format!("{base}_pages")
-                } else {
-                    base.to_string()
-                }
-            })
-            .collect()
+    /// Label prefixes (for the done-set), e.g. `["ce_off", "ce_on"]`.
+    fn prefixes(&self) -> Vec<&'static str> {
+        self.arms.iter().map(|arm| arm.label_prefix).collect()
     }
 
     /// Resolve arms to `(label, CtxRetrieval, include_pages)` for a category, given the reranker.
@@ -2927,13 +2909,7 @@ impl ArmSpec {
     ) -> Result<Vec<(String, CtxRetrieval, bool)>, OriginError> {
         let mut result = Vec::with_capacity(self.arms.len());
         for arm in &self.arms {
-            let base = arm.kind.label_prefix();
-            let prefix = if arm.include_pages {
-                format!("{base}_pages")
-            } else {
-                base.to_string()
-            };
-            let label = format!("{prefix}_{category}");
+            let label = format!("{}_{}", arm.label_prefix, category);
             let retrieval = match arm.kind {
                 ArmKind::CeOff => CtxRetrieval::CrossRerank(None),
                 ArmKind::CeOn | ArmKind::FullStack => {
@@ -3840,24 +3816,20 @@ mod tests {
         assert_eq!(
             spec.labels("single-session-user"),
             vec![
-                "ce_off_pages_single-session-user".to_string(),
-                "ce_on_pages_single-session-user".to_string(),
+                "ce_off_single-session-user".to_string(),
+                "ce_on_single-session-user".to_string(),
             ],
             "ce_two labels for single-session-user"
         );
         assert_eq!(
             spec.labels("temporal-reasoning"),
             vec![
-                "ce_off_pages_temporal-reasoning".to_string(),
-                "ce_on_pages_temporal-reasoning".to_string(),
+                "ce_off_temporal-reasoning".to_string(),
+                "ce_on_temporal-reasoning".to_string(),
             ],
             "ce_two labels for temporal-reasoning"
         );
-        assert_eq!(
-            spec.prefixes(),
-            vec!["ce_off_pages".to_string(), "ce_on_pages".to_string()],
-            "ce_two prefixes"
-        );
+        assert_eq!(spec.prefixes(), vec!["ce_off", "ce_on"], "ce_two prefixes");
         assert!(
             spec.needs_confounder_isolation(),
             "ce_two is an isolation A/B (has CeOff) — gate must apply"
@@ -3869,14 +3841,10 @@ mod tests {
         let spec = ArmSpec::full_stack();
         assert_eq!(
             spec.labels("single-session-user"),
-            vec!["fullstack_pages_single-session-user".to_string()],
+            vec!["fullstack_single-session-user".to_string()],
             "full_stack is a single arm"
         );
-        assert_eq!(
-            spec.prefixes(),
-            vec!["fullstack_pages".to_string()],
-            "full_stack prefix"
-        );
+        assert_eq!(spec.prefixes(), vec!["fullstack"], "full_stack prefix");
         assert!(
             !spec.needs_confounder_isolation(),
             "full_stack has no CeOff arm — confounder gate must be skipped so features can be ON"

--- a/crates/origin-core/src/eval/answer_quality.rs
+++ b/crates/origin-core/src/eval/answer_quality.rs
@@ -2811,27 +2811,67 @@ impl ArmKind {
     }
 }
 
+/// One arm: a retrieval mode paired with whether to include pages in context.
+#[derive(Debug, Clone)]
+pub struct Arm {
+    pub kind: ArmKind,
+    pub include_pages: bool,
+}
+
 /// The set of arms to run, in order.
 #[derive(Debug, Clone)]
 pub struct ArmSpec {
-    arms: Vec<ArmKind>,
+    arms: Vec<Arm>,
 }
 
 impl ArmSpec {
-    /// The shipped 2-arm CE A/B: [CeOff, CeOn].
+    /// The shipped 2-arm CE A/B: [CeOff+pages, CeOn+pages].
     pub fn ce_two() -> Self {
         ArmSpec {
-            arms: vec![ArmKind::CeOff, ArmKind::CeOn],
+            arms: vec![
+                Arm {
+                    kind: ArmKind::CeOff,
+                    include_pages: true,
+                },
+                Arm {
+                    kind: ArmKind::CeOn,
+                    include_pages: true,
+                },
+            ],
         }
     }
 
-    /// Single-arm "best-possible ceiling": [FullStack]. All feature env flags are
+    /// Single-arm "best-possible ceiling": [FullStack+pages]. All feature env flags are
     /// the operator's responsibility (page channel / graph / temporal / deep
     /// `RERANK_POOL_FLOOR`); this spec just runs one CE-reranked arm and measures
     /// its accuracy, with NO confounder isolation (see `needs_confounder_isolation`).
     pub fn full_stack() -> Self {
         ArmSpec {
-            arms: vec![ArmKind::FullStack],
+            arms: vec![Arm {
+                kind: ArmKind::FullStack,
+                include_pages: true,
+            }],
+        }
+    }
+
+    /// 3-arm pages A/B: [CeOff-no-pages, CeOn-no-pages, CeOn+pages].
+    /// Isolates the page-channel contribution on top of the CE baseline.
+    pub fn pages_ab() -> Self {
+        ArmSpec {
+            arms: vec![
+                Arm {
+                    kind: ArmKind::CeOff,
+                    include_pages: false,
+                },
+                Arm {
+                    kind: ArmKind::CeOn,
+                    include_pages: false,
+                },
+                Arm {
+                    kind: ArmKind::CeOn,
+                    include_pages: true,
+                },
+            ],
         }
     }
 
@@ -2841,36 +2881,60 @@ impl ArmSpec {
     /// asymmetrically vs an ON arm. A single-arm ceiling (`full_stack`) has no
     /// OFF arm, so the isolation gate does not apply — features are meant to be ON.
     fn needs_confounder_isolation(&self) -> bool {
-        self.arms.contains(&ArmKind::CeOff)
+        self.arms.iter().any(|a| a.kind == ArmKind::CeOff)
     }
 
     /// One label per arm for a given category, in order.
-    /// e.g. `ce_two().labels("single-session-user")`
-    ///        == `["ce_off_single-session-user", "ce_on_single-session-user"]`
+    /// Arms with `include_pages=true` get a `_pages` suffix: "ce_off_pages_cat".
+    /// Arms with `include_pages=false` omit the suffix: "ce_off_cat".
     pub fn labels(&self, category: &str) -> Vec<String> {
         self.arms
             .iter()
-            .map(|arm| format!("{}_{}", arm.label_prefix(), category))
+            .map(|arm| {
+                let base = arm.kind.label_prefix();
+                let prefix = if arm.include_pages {
+                    format!("{base}_pages")
+                } else {
+                    base.to_string()
+                };
+                format!("{prefix}_{category}")
+            })
             .collect()
     }
 
-    /// Label prefixes (for the done-set), e.g. `["ce_off", "ce_on"]`.
-    fn prefixes(&self) -> Vec<&'static str> {
-        self.arms.iter().map(|arm| arm.label_prefix()).collect()
+    /// Label prefixes (for the done-set), e.g. `["ce_off_pages", "ce_on_pages"]`.
+    fn prefixes(&self) -> Vec<String> {
+        self.arms
+            .iter()
+            .map(|arm| {
+                let base = arm.kind.label_prefix();
+                if arm.include_pages {
+                    format!("{base}_pages")
+                } else {
+                    base.to_string()
+                }
+            })
+            .collect()
     }
 
-    /// Resolve arms to `(label, CtxRetrieval)` for a category, given the reranker.
+    /// Resolve arms to `(label, CtxRetrieval, include_pages)` for a category, given the reranker.
     /// `CeOn` requires `reranker.is_some()` — returns `Err` if an arm needs it and
     /// it is `None`.
     fn resolve(
         &self,
         category: &str,
         reranker: &Option<Arc<dyn crate::reranker::Reranker>>,
-    ) -> Result<Vec<(String, CtxRetrieval)>, OriginError> {
+    ) -> Result<Vec<(String, CtxRetrieval, bool)>, OriginError> {
         let mut result = Vec::with_capacity(self.arms.len());
         for arm in &self.arms {
-            let label = format!("{}_{}", arm.label_prefix(), category);
-            let retrieval = match arm {
+            let base = arm.kind.label_prefix();
+            let prefix = if arm.include_pages {
+                format!("{base}_pages")
+            } else {
+                base.to_string()
+            };
+            let label = format!("{prefix}_{category}");
+            let retrieval = match arm.kind {
                 ArmKind::CeOff => CtxRetrieval::CrossRerank(None),
                 ArmKind::CeOn | ArmKind::FullStack => {
                     let r = reranker.clone().ok_or_else(|| {
@@ -2882,7 +2946,7 @@ impl ArmSpec {
                     CtxRetrieval::CrossRerank(Some(r))
                 }
             };
-            result.push((label, retrieval));
+            result.push((label, retrieval, arm.include_pages));
         }
         Ok(result)
     }
@@ -3293,14 +3357,14 @@ pub async fn run_fullpipeline_lme(
 
             // Generate an answer for all arms from the same seeded DB.
             let arm_pairs = arms.resolve(category, &reranker)?;
-            for (arm_label, retrieval) in arm_pairs {
+            for (arm_label, retrieval, include_pages) in arm_pairs {
                 let (ctx, ctx_tokens) = match build_structured_context(
                     &db,
                     &sample.question,
                     10,
                     None,
                     retrieval,
-                    true,
+                    include_pages,
                 )
                 .await
                 {
@@ -3519,14 +3583,14 @@ pub async fn run_fullpipeline_lme(
                         let category = category_name(&sample.question_type);
                         let arm_pairs = arms.resolve(category, &reranker)?;
                         let mut tuples = Vec::with_capacity(arm_pairs.len());
-                        for (arm_label, retrieval) in arm_pairs {
+                        for (arm_label, retrieval, include_pages) in arm_pairs {
                             let (ctx, ctx_tokens) = match build_structured_context(
                                 &db,
                                 &sample.question,
                                 10,
                                 None,
                                 retrieval,
-                                true,
+                                include_pages,
                             )
                             .await
                             {
@@ -3776,20 +3840,24 @@ mod tests {
         assert_eq!(
             spec.labels("single-session-user"),
             vec![
-                "ce_off_single-session-user".to_string(),
-                "ce_on_single-session-user".to_string(),
+                "ce_off_pages_single-session-user".to_string(),
+                "ce_on_pages_single-session-user".to_string(),
             ],
             "ce_two labels for single-session-user"
         );
         assert_eq!(
             spec.labels("temporal-reasoning"),
             vec![
-                "ce_off_temporal-reasoning".to_string(),
-                "ce_on_temporal-reasoning".to_string(),
+                "ce_off_pages_temporal-reasoning".to_string(),
+                "ce_on_pages_temporal-reasoning".to_string(),
             ],
             "ce_two labels for temporal-reasoning"
         );
-        assert_eq!(spec.prefixes(), vec!["ce_off", "ce_on"], "ce_two prefixes");
+        assert_eq!(
+            spec.prefixes(),
+            vec!["ce_off_pages".to_string(), "ce_on_pages".to_string()],
+            "ce_two prefixes"
+        );
         assert!(
             spec.needs_confounder_isolation(),
             "ce_two is an isolation A/B (has CeOff) — gate must apply"
@@ -3801,10 +3869,14 @@ mod tests {
         let spec = ArmSpec::full_stack();
         assert_eq!(
             spec.labels("single-session-user"),
-            vec!["fullstack_single-session-user".to_string()],
+            vec!["fullstack_pages_single-session-user".to_string()],
             "full_stack is a single arm"
         );
-        assert_eq!(spec.prefixes(), vec!["fullstack"], "full_stack prefix");
+        assert_eq!(
+            spec.prefixes(),
+            vec!["fullstack_pages".to_string()],
+            "full_stack prefix"
+        );
         assert!(
             !spec.needs_confounder_isolation(),
             "full_stack has no CeOff arm — confounder gate must be skipped so features can be ON"
@@ -3895,5 +3967,54 @@ mod tests {
             ctx_off.contains("## Relevant Memories") || ctx_off.contains("planning"),
             "include_pages=false context should contain memory content"
         );
+    }
+
+    /// Task 2 (pure, no DB): pages_ab() has 3 arms with the right kinds and include_pages flags.
+    #[test]
+    fn arm_spec_pages_ab_arms() {
+        let spec = ArmSpec::pages_ab();
+        let arms: Vec<_> = spec.arms.iter().collect();
+        assert_eq!(arms.len(), 3, "pages_ab must have 3 arms");
+        assert_eq!(arms[0].kind, ArmKind::CeOff, "arm 0 kind");
+        assert_eq!(arms[1].kind, ArmKind::CeOn, "arm 1 kind");
+        assert_eq!(arms[2].kind, ArmKind::CeOn, "arm 2 kind");
+        assert!(!arms[0].include_pages, "arm 0 include_pages must be false");
+        assert!(!arms[1].include_pages, "arm 1 include_pages must be false");
+        assert!(arms[2].include_pages, "arm 2 include_pages must be true");
+    }
+
+    /// Task 2 (pure, no DB): pages_ab().labels() produces the correct suffixed label strings.
+    #[test]
+    fn arm_spec_pages_ab_labels() {
+        let spec = ArmSpec::pages_ab();
+        assert_eq!(
+            spec.labels("x"),
+            vec![
+                "ce_off_x".to_string(),
+                "ce_on_x".to_string(),
+                "ce_on_pages_x".to_string()
+            ],
+            "pages_ab labels"
+        );
+    }
+
+    /// Task 2 (pure, no DB): ce_two() and full_stack() all arms have include_pages=true
+    /// (byte-identical preservation guard).
+    #[test]
+    fn arm_spec_existing_arms_include_pages_true() {
+        for arm in &ArmSpec::ce_two().arms {
+            assert!(
+                arm.include_pages,
+                "ce_two arm {:?} must have include_pages=true",
+                arm.kind
+            );
+        }
+        for arm in &ArmSpec::full_stack().arms {
+            assert!(
+                arm.include_pages,
+                "full_stack arm {:?} must have include_pages=true",
+                arm.kind
+            );
+        }
     }
 }

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -9285,6 +9285,124 @@ async fn generate_lme_fullstack_ceiling() {
 /// FULL-STACK accuracy on the DEEP per-question LME-S substrate (pool-decision +
 /// headline instrument).
 ///
+/// Judge the pages A/B tuples (`generate_pages_ab_lme_s` output) via `claude -p` (no API
+/// key — Max OAuth). `aggregate_judgments` groups by the tuple `approach` field
+/// (`ce_off`/`ce_on`/`ce_on_pages` x category); collapse arms across categories in
+/// post-processing for the directional pages-help verdict (ce_on_pages vs ce_on).
+///
+/// ```bash
+/// EVAL_BASELINES_DIR=$HOME/.cache/origin-eval-pool90-mig \
+///   cargo test -p origin-core --test eval_harness --features eval-harness \
+///   judge_pages_ab_lme_s -- --ignored --nocapture
+/// ```
+#[tokio::test]
+#[ignore]
+async fn judge_pages_ab_lme_s() {
+    use origin_core::eval::token_efficiency::{
+        aggregate_judgments, judge_with_claude, load_judgment_tuples,
+    };
+    let baselines = origin_core::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| eval_root().join("baselines"));
+    let tuples_path = baselines.join("pages_ab_lme_s_tuples.json");
+    if !tuples_path.exists() {
+        eprintln!(
+            "SKIP: run generate_pages_ab_lme_s first ({:?} missing)",
+            tuples_path
+        );
+        return;
+    }
+    let tuples = load_judgment_tuples(&tuples_path).expect("load pages-ab tuples");
+    let conc: usize = std::env::var("EVAL_JUDGE_CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+    eprintln!(
+        "Judging {} pages-A/B tuples via claude -p (conc={})...",
+        tuples.len(),
+        conc
+    );
+    let results = judge_with_claude(&tuples, conc)
+        .await
+        .expect("judge failed");
+    let report = aggregate_judgments(&results, "haiku");
+    eprintln!("\n=== Pages A/B (deep LME-S, claude -p judge) ===");
+    eprintln!(
+        "{:<36} | {:<9} | {:<8} | Total",
+        "approach (arm_category)", "accuracy", "correct"
+    );
+    for r in &report.results_by_approach {
+        eprintln!(
+            "{:<36} | {:<8.1}% | {:<8} | {}",
+            r.approach,
+            r.accuracy * 100.0,
+            r.correct,
+            r.total
+        );
+    }
+    eprintln!("\nTotal judged: {}", report.total_judged);
+}
+
+/// STEP (manual unblock): inject real dataset `event_date` into the PER-QUESTION
+/// LME-S fullpipeline DBs under `EVAL_BASELINES_DIR/fullpipeline/lme/<qid>`. The pool90
+/// seed (`enrich_fullpipeline_lme_only`) skipped temporal injection, so the migrate-read
+/// substrate-live guard refuses (0 event_date rows). This loops each per-Q DB and writes
+/// `event_date` from dataset session metadata (`event_date_map` -> `set_event_dates_by_source_id`):
+/// GPU-free, non-destructive (fills `event_date` only). Run against a COPY of pool90 so the
+/// original stays pristine.
+///
+/// ```bash
+/// EVAL_BASELINES_DIR=$HOME/.cache/origin-eval-pool90-mig LME_S_FIXTURE=/tmp/claude/lme_s_90.json \
+///   cargo test -p origin-core --test eval_harness --features eval-harness \
+///   seed_inject_event_dates_per_q_lme_s -- --ignored --nocapture
+/// ```
+#[tokio::test]
+#[ignore]
+async fn seed_inject_event_dates_per_q_lme_s() {
+    use origin_core::eval::longmemeval;
+    use origin_core::eval::shared::{eval_baselines_dir_override, scenario_db_dir};
+    let baselines = eval_baselines_dir_override()
+        .expect("EVAL_BASELINES_DIR must point at the per-Q baselines dir (the copy)");
+    let lme_path = std::path::PathBuf::from(
+        std::env::var("LME_S_FIXTURE").expect("LME_S_FIXTURE must point at the deep LME-S fixture"),
+    );
+    let samples = longmemeval::load_longmemeval(&lme_path).expect("load lme-s fixture");
+    let updates: Vec<(String, i64)> = longmemeval::event_date_map(&samples).into_iter().collect();
+    eprintln!(
+        "[inject_per_q] {} source_id->date mappings across {} questions; baselines={:?}",
+        updates.len(),
+        samples.len(),
+        baselines
+    );
+    let emitter = || std::sync::Arc::new(origin_core::events::NoopEmitter);
+    let mut dbs = 0usize;
+    let mut missing = 0usize;
+    for sample in &samples {
+        let dir = scenario_db_dir(&baselines, "lme", &sample.question_id);
+        if !dir.join("origin_memory.db").exists() {
+            missing += 1;
+            continue;
+        }
+        let db = origin_core::db::MemoryDB::new(&dir, emitter())
+            .await
+            .expect("open per-q db");
+        let n = db
+            .set_event_dates_by_source_id(&updates)
+            .await
+            .expect("inject event_dates");
+        eprintln!("[inject_per_q] {} -> {} rows", sample.question_id, n);
+        dbs += 1;
+    }
+    eprintln!(
+        "[inject_per_q] done: {} DBs updated, {} qids had no DB under baselines",
+        dbs, missing
+    );
+    assert!(
+        dbs > 0,
+        "no per-q DBs found under {:?}/fullpipeline/lme",
+        baselines
+    );
+}
+
 /// Pages answer-acc A/B over the DEEP per-question LME-S substrate, reusing the
 /// pre-seeded pool90 DBs in `EVAL_BASELINES_DIR` (NO re-seed; cache-hit reads the
 /// existing per-question seeds, so the substrate stays untouched). `ArmSpec::pages_ab()`

--- a/crates/origin-core/tests/eval_harness.rs
+++ b/crates/origin-core/tests/eval_harness.rs
@@ -9285,6 +9285,108 @@ async fn generate_lme_fullstack_ceiling() {
 /// FULL-STACK accuracy on the DEEP per-question LME-S substrate (pool-decision +
 /// headline instrument).
 ///
+/// Pages answer-acc A/B over the DEEP per-question LME-S substrate, reusing the
+/// pre-seeded pool90 DBs in `EVAL_BASELINES_DIR` (NO re-seed; cache-hit reads the
+/// existing per-question seeds, so the substrate stays untouched). `ArmSpec::pages_ab()`
+/// = 3 arms isolating the page channel in the ANSWER context: ce_off (CE off, no pages)
+/// / ce_on (CE on, no pages) / ce_on_pages (CE on, pages). Answers on-device
+/// Qwen3.5-9B (temp 0.0); the judge is a separate `claude -p` step over the saved
+/// tuples. A `CeOff` arm is present so `needs_confounder_isolation` is true and the
+/// runner enforces `ORIGIN_GRAPH_MEMORY_STREAM=0`. The page fetch is driven by the
+/// per-arm `include_pages` toggle (independent of `ORIGIN_ENABLE_PAGE_CHANNEL`).
+///
+/// ```bash
+/// EVAL_BASELINES_DIR=$HOME/.cache/origin-eval-pool90 LME_S_FIXTURE=/tmp/claude/lme_s_90.json \
+/// ORIGIN_GRAPH_MEMORY_STREAM=0 EVAL_ENRICHMENT=local LME_LIMIT_QUESTIONS=20 \
+///   cargo test -p origin-core --test eval_harness --features eval-harness \
+///   generate_pages_ab_lme_s -- --ignored --nocapture
+/// ```
+#[tokio::test]
+#[ignore]
+async fn generate_pages_ab_lme_s() {
+    use origin_core::eval::answer_quality::{run_fullpipeline_lme, ArmSpec, DbSource};
+    use origin_core::llm_provider::{LlmProvider, OnDeviceProvider};
+    use std::sync::Arc;
+
+    let lme_path = match std::env::var("LME_S_FIXTURE") {
+        Ok(p) => std::path::PathBuf::from(p),
+        Err(_) => {
+            let data_dir = eval_root().join("data");
+            let cleaned = data_dir.join("longmemeval_s_cleaned.json");
+            if cleaned.exists() {
+                cleaned
+            } else {
+                data_dir.join("longmemeval_s.json")
+            }
+        }
+    };
+    if !lme_path.exists() {
+        eprintln!(
+            "SKIP: LME-S fixture not found at {:?}. Set LME_S_FIXTURE=<path> or point \
+             ORIGIN_EVAL_ROOT at the main checkout's app/eval.",
+            lme_path
+        );
+        return;
+    }
+
+    let enrich_model =
+        std::env::var("EVAL_ANSWER_MODEL").unwrap_or_else(|_| "claude-haiku-4-5-20251001".into());
+    let cost_cap: f64 = std::env::var("EVAL_COST_CAP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10.0);
+
+    let baselines = origin_core::eval::shared::eval_baselines_dir_override()
+        .unwrap_or_else(|| eval_root().join("baselines"));
+    std::fs::create_dir_all(&baselines).ok();
+    let output_path = baselines.join("pages_ab_lme_s_tuples.json");
+
+    eprintln!(
+        "[generate_pages_ab_lme_s] PAGES A/B (DEEP S fixture, pool90 reuse):\n  \
+         fixture: {:?}\n  \
+         arms: ce_off (no pages) / ce_on (no pages) / ce_on_pages (pages)\n  \
+         page_channel_flag={}  graph_stream_flag={}\n  \
+         RERANK_POOL_FLOOR={}\n  \
+         answer model: on-device qwen3.5-9b (temp 0.0)\n  enrich model: {}\n  output: {:?}",
+        lme_path,
+        origin_core::db::page_channel_enabled(),
+        origin_core::db::graph_memory_stream_enabled(),
+        std::env::var("RERANK_POOL_FLOOR").unwrap_or_else(|_| "10 (default)".into()),
+        enrich_model,
+        output_path,
+    );
+
+    let llm: Arc<dyn LlmProvider> =
+        Arc::new(OnDeviceProvider::new_with_model(Some("qwen3.5-9b")).expect(
+            "OnDeviceProvider::new_with_model failed -- is the Qwen3.5-9B model available?",
+        ));
+
+    let enrichment = origin_core::eval::shared::EnrichmentMode::from_env(&enrich_model, cost_cap)
+        .expect("EnrichmentMode::from_env failed");
+
+    let reranker = origin_core::reranker::init_cross_encoder_reranker(None).expect(
+        "init_cross_encoder_reranker failed (downloads ~1.1GB bge-reranker-base on first run)",
+    );
+
+    let tuples = run_fullpipeline_lme(
+        &lme_path,
+        enrichment,
+        llm,
+        Some(reranker),
+        &ArmSpec::pages_ab(),
+        DbSource::SeedPerQuestion,
+        &output_path,
+    )
+    .await
+    .expect("run_fullpipeline_lme (pages_ab deep-S) failed");
+
+    eprintln!(
+        "\n[generate_pages_ab_lme_s] Done: {} tuples saved to {:?}",
+        tuples.len(),
+        output_path
+    );
+}
+
 /// Same as `generate_lme_fullstack_ceiling` but uses the DEEP `longmemeval_s.json`
 /// fixture (each question carries its own sessions + ~47 real distractor sessions)
 /// instead of the shallow oracle fixture, so the CE fetch pool has genuine


### PR DESCRIPTION
## What

Adds a pages on/off capability to the eval answer-gen so the page-channel **answer-accuracy** A/B is runnable. Today `build_structured_context` calls `search_pages` unconditionally — there is no pages-OFF arm to compare against. This is the prerequisite for the EVAL phase (does surfacing distilled pages in the answer context help end-task accuracy?).

Eval-harness only. No production/daemon code, no `db.rs`, no migrations. Single file: `crates/origin-core/src/eval/answer_quality.rs`.

## Changes

- `build_structured_context` gains `include_pages: bool`. When `false`: skips `search_pages` + `filter_pages_by_source_overlap` + the `## Compiled Knowledge` block; keeps `## Relevant Memories`. When `true`: byte-identical to today. All 4 pre-existing `Quick` callsites pass `true`.
- Thin `Arm { kind: ArmKind, include_pages, label_prefix }` carries the page axis (orthogonal to the CE axis). `label_prefix` is an **explicit per-arm field** (baseline-file identity), not derived from `include_pages`.
- `ArmSpec::pages_ab()` = `[CeOff·no-pages, CeOn·no-pages, CeOn·pages]` → labels `ce_off` / `ce_on` / `ce_on_pages` = context-base / context-turbo-CE / +pages.
- `ce_two()` / `full_stack()` keep pages ON and their historical labels (`ce_off`/`ce_on`/`fullstack`) byte-identical.

## Tests (9/9 green, `cargo test -p origin-core --lib eval::answer_quality`)

- `build_structured_context_include_pages_toggle` — seeds a page, asserts pages-ON includes `## Compiled Knowledge` and pages-OFF omits it (both keep `## Relevant Memories`).
- `arm_spec_ce_two_labels` / `arm_spec_full_stack_labels` — historical labels preserved.
- `arm_spec_pages_ab_arms` / `arm_spec_pages_ab_labels` — the 3-arm isolation spec.
- `arm_spec_existing_arms_include_pages_true` — byte-identical context guard.

## Not in this PR (gated, follow-up)

- Running the EVAL (multi-hour GPU job, `claude -p` judge) — decides whether pages help answer accuracy.
- The page-in-context production default + PR-B (`ORIGIN_RERANKER_MODE`) depend on that EVAL verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
