### PR TITLE
feat: Phase-5 publish cutover — flip distribution identities to wenlan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,13 +388,13 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
-      - name: Validate origin-mcp npm package
+      - name: Validate wenlan-mcp npm package
         working-directory: crates/wenlan-mcp/npm
         run: |
           npm pack --dry-run
           node -c run.js
           node -c install.js
-      - name: Validate @7xuanlu/origin npm package
+      - name: Validate wenlan npm package
         working-directory: crates/wenlan-cli/npm
         run: |
           npm pack --dry-run

--- a/.github/workflows/notify-marketplace.yml
+++ b/.github/workflows/notify-marketplace.yml
@@ -15,6 +15,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MARKETPLACE_SYNC_TOKEN }}
         run: |
+          # plugin=origin is the plugin name + /origin: namespace; rename deferred to 5E.
           gh api repos/7xuanlu/claude-plugins/dispatches \
             -f event_type=plugin-released \
             -F "client_payload[plugin]=origin" \

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock crates/wenlan-mcp/npm/package.json crates/wenlan-cli/npm/package.json plugin/.claude-plugin/plugin.json plugin/bin/origin-mcp-runner.sh plugin/skills/init/SKILL.md
+          git add Cargo.toml Cargo.lock crates/wenlan-mcp/npm/package.json crates/wenlan-cli/npm/package.json plugin/.claude-plugin/plugin.json plugin/bin/wenlan-mcp-runner.sh plugin/skills/init/SKILL.md
           if ! git diff --cached --quiet; then
             git commit -m "chore: sync versions to $(cat version.txt | tr -d '[:space:]')"
             git push origin HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,7 +389,7 @@ jobs:
           docker buildx imagetools create -t "$IMG:latest"  "$IMG:$TAG-amd64" "$IMG:$TAG-arm64"
 
   publish-crates:
-    name: Publish crates.io (origin-types + origin-mcp)
+    name: Publish crates.io (wenlan-types + wenlan-mcp)
     needs: release
     runs-on: ubuntu-latest
 
@@ -403,10 +403,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Pre-flight cargo publish dry-run
-        # Only origin-types — origin-mcp's --dry-run resolves origin-types from
+        # Only wenlan-types — wenlan-mcp's --dry-run resolves wenlan-types from
         # crates.io which doesn't have the new version until the publish step
-        # runs. Real origin-mcp publish happens after origin-types is indexed.
-        run: cargo publish -p origin-types --dry-run
+        # runs. Real wenlan-mcp publish happens after wenlan-types is indexed.
+        run: cargo publish -p wenlan-types --dry-run
 
       - name: Resolve workspace version
         id: version
@@ -415,7 +415,7 @@ jobs:
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Workspace version: $VERSION"
 
-      - name: Publish origin-types to crates.io
+      - name: Publish wenlan-types to crates.io
         # Source-of-truth registry check uses the sparse index (same as the
         # downstream `Wait for ... available` step). The v1 web API lags
         # behind by minutes-to-hours under load and gave false "not
@@ -424,51 +424,51 @@ jobs:
         if: env.CARGO_REGISTRY_TOKEN != ''
         run: |
           VERSION="${{ steps.version.outputs.value }}"
-          if curl -sf "https://index.crates.io/or/ig/origin-types" | grep -q "\"vers\":\"$VERSION\""; then
-            echo "origin-types ${VERSION} already on sparse index, skipping publish"
+          if curl -sf "https://index.crates.io/we/nl/wenlan-types" | grep -q "\"vers\":\"$VERSION\""; then
+            echo "wenlan-types ${VERSION} already on sparse index, skipping publish"
           else
-            cargo publish -p origin-types
+            cargo publish -p wenlan-types
           fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Wait for origin-types to be available on crates.io
+      - name: Wait for wenlan-types to be available on crates.io
         # Poll the sparse index (https://index.crates.io) — that's what
-        # `cargo publish -p origin-mcp` reads to resolve its
-        # `origin-types = "^X.Y.Z"` dep. The v1 web API
+        # the wenlan-mcp publish step reads to resolve its
+        # `wenlan-types = "^X.Y.Z"` dep. The v1 web API
         # (`crates.io/api/v1/crates/<name>/<version>`) lags behind the
         # sparse index by minutes-to-hours during load, which caused
         # false negatives (publish succeeded, web API still 404). The
         # sparse index path for any crate `name` is
         # `/<prefix>/<name>` where prefix depends on name length;
-        # for 4+ chars: `<first2>/<chars 3-4>/<name>`. `origin-types`
-        # → `or/ig/origin-types`. The index returns NDJSON, one record
+        # for 4+ chars: `<first2>/<chars 3-4>/<name>`. `wenlan-types`
+        # → `we/nl/wenlan-types`. The index returns NDJSON, one record
         # per published version.
         run: |
           VERSION="${{ steps.version.outputs.value }}"
-          INDEX_URL="https://index.crates.io/or/ig/origin-types"
+          INDEX_URL="https://index.crates.io/we/nl/wenlan-types"
           for i in $(seq 1 60); do
             if curl -sf "$INDEX_URL" | grep -q "\"vers\":\"$VERSION\""; then
-              echo "origin-types ${VERSION} visible on sparse index"; exit 0
+              echo "wenlan-types ${VERSION} visible on sparse index"; exit 0
             fi
-            echo "Waiting for sparse index to publish origin-types ${VERSION}... ($i/60)"
+            echo "Waiting for sparse index to publish wenlan-types ${VERSION}... ($i/60)"
             sleep 10
           done
-          echo "ERROR: origin-types ${VERSION} not visible on sparse index after 10 min"
+          echo "ERROR: wenlan-types ${VERSION} not visible on sparse index after 10 min"
           echo "Last index response:"
           curl -s "$INDEX_URL" | tail -5
           exit 1
 
-      - name: Publish origin-mcp to crates.io
-        # Sparse index check (see origin-types step) avoids the v1 web API
+      - name: Publish wenlan-mcp to crates.io
+        # Sparse index check (see wenlan-types step) avoids the v1 web API
         # propagation lag that previously caused duplicate-publish failures.
         if: env.CARGO_REGISTRY_TOKEN != ''
         run: |
           VERSION="${{ steps.version.outputs.value }}"
-          if curl -sf "https://index.crates.io/or/ig/origin-mcp" | grep -q "\"vers\":\"$VERSION\""; then
-            echo "origin-mcp ${VERSION} already on sparse index, skipping publish"
+          if curl -sf "https://index.crates.io/we/nl/wenlan-mcp" | grep -q "\"vers\":\"$VERSION\""; then
+            echo "wenlan-mcp ${VERSION} already on sparse index, skipping publish"
           else
-            cargo publish -p origin-mcp
+            cargo publish -p wenlan-mcp
           fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: List Windows build artifacts
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: bash
-        run: find "target/${{ matrix.target }}/release" -maxdepth 1 -print | head -30
+        run: ls -la target/${{ matrix.target }}/release/ | head -30
 
       # ort 2.x caches link-time `.lib` artifacts under
       # `%LOCALAPPDATA%\ort.pyke.io\...` but does NOT keep onnxruntime.dll
@@ -551,7 +551,7 @@ jobs:
           SHA_MCP_DARWIN_ARM64=$(sha256sum origin-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_CLI_DARWIN_ARM64=$(sha256sum origin-darwin-arm64.tar.gz | cut -d' ' -f1)
 
-          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git" tap
+          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git tap
           mkdir -p tap/Formula
 
           cat > tap/Formula/origin-mcp.rb << 'FORMULA'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,7 @@ jobs:
           file: docker/Dockerfile.daemon
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ghcr.io/7xuanlu/origin-server:${{ env.RELEASE_TAG }}-${{ matrix.tag-suffix }}
+          tags: ghcr.io/7xuanlu/wenlan-server:${{ env.RELEASE_TAG }}-${{ matrix.tag-suffix }}
 
   docker-manifest:
     name: Combine Docker Manifest (multi-arch)
@@ -384,7 +384,7 @@ jobs:
       - name: Create + push multi-arch manifest
         run: |
           TAG="${{ env.RELEASE_TAG }}"
-          IMG="ghcr.io/7xuanlu/origin-server"
+          IMG="ghcr.io/7xuanlu/wenlan-server"
           docker buildx imagetools create -t "$IMG:$TAG" "$IMG:$TAG-amd64" "$IMG:$TAG-arm64"
           docker buildx imagetools create -t "$IMG:latest"  "$IMG:$TAG-amd64" "$IMG:$TAG-arm64"
 
@@ -487,12 +487,12 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Sync npm version from tag
-        working-directory: crates/origin-mcp/npm
+        working-directory: crates/wenlan-mcp/npm
         run: |
           VERSION="${RELEASE_TAG#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Sync setup package version from tag
-        working-directory: crates/origin-cli/npm
+        working-directory: crates/wenlan-cli/npm
         run: |
           VERSION="${RELEASE_TAG#v}"
           npm version "$VERSION" --no-git-tag-version --allow-same-version
@@ -502,31 +502,31 @@ jobs:
         # always reflect the current project description and the same legal
         # text the daemon ships under.
         run: |
-          cp README.md crates/origin-mcp/npm/README.md
-          cp README.md crates/origin-cli/npm/README.md
-          cp LICENSE crates/origin-mcp/npm/LICENSE
-          cp LICENSE crates/origin-cli/npm/LICENSE
-      - name: Publish origin-mcp
-        working-directory: crates/origin-mcp/npm
+          cp README.md crates/wenlan-mcp/npm/README.md
+          cp README.md crates/wenlan-cli/npm/README.md
+          cp LICENSE crates/wenlan-mcp/npm/LICENSE
+          cp LICENSE crates/wenlan-cli/npm/LICENSE
+      - name: Publish wenlan-mcp
+        working-directory: crates/wenlan-mcp/npm
         # Skip if version already on npm. Retried releases or re-dispatch
         # workflows would otherwise fail with "You cannot publish over the
         # previously published versions". `npm view <pkg>@<v> version`
         # exits 0 + prints the version when published, exits 1 otherwise.
         run: |
           VERSION="${RELEASE_TAG#v}"
-          if npm view "origin-mcp@$VERSION" version >/dev/null 2>&1; then
-            echo "origin-mcp@$VERSION already on npm, skipping"
+          if npm view "wenlan-mcp@$VERSION" version >/dev/null 2>&1; then
+            echo "wenlan-mcp@$VERSION already on npm, skipping"
           else
             npm publish --provenance --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish @7xuanlu/origin
-        working-directory: crates/origin-cli/npm
+      - name: Publish wenlan
+        working-directory: crates/wenlan-cli/npm
         run: |
           VERSION="${RELEASE_TAG#v}"
-          if npm view "@7xuanlu/origin@$VERSION" version >/dev/null 2>&1; then
-            echo "@7xuanlu/origin@$VERSION already on npm, skipping"
+          if npm view "wenlan@$VERSION" version >/dev/null 2>&1; then
+            echo "wenlan@$VERSION already on npm, skipping"
           else
             npm publish --provenance --access public
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
           $CHANGELOG
 
-          **Full Changelog**: https://github.com/7xuanlu/origin/compare/${PREV_TAG}...${RELEASE_TAG}
+          **Full Changelog**: https://github.com/7xuanlu/wenlan/compare/${PREV_TAG}...${RELEASE_TAG}
 
           ## Install
 
@@ -71,12 +71,12 @@ jobs:
 
           **Shell installer:**
           \`\`\`
-          curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/main/install.sh | bash
+          curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/install.sh | bash
           \`\`\`
 
           **Exact shell install for this release:**
           \`\`\`
-          curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/${RELEASE_TAG}/install.sh | WENLAN_RELEASE_TAG=${RELEASE_TAG} bash
+          curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/${RELEASE_TAG}/install.sh | WENLAN_RELEASE_TAG=${RELEASE_TAG} bash
           \`\`\`
           Downloads exact binaries and prints manual isolated daemon/MCP setup steps.
 
@@ -560,7 +560,7 @@ jobs:
             desc "MCP server for Wenlan — personal agent memory layer"
             homepage "https://github.com/7xuanlu/origin"
             version "VERSION_PLACEHOLDER"
-            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/wenlan-mcp-darwin-arm64.tar.gz"
+            url "https://github.com/7xuanlu/wenlan/releases/download/vVERSION_PLACEHOLDER/wenlan-mcp-darwin-arm64.tar.gz"
             sha256 "SHA_PLACEHOLDER"
             license "Apache-2.0"
 
@@ -591,7 +591,7 @@ jobs:
             desc "Wenlan CLI — local-first memory + knowledge layer for AI agents"
             homepage "https://github.com/7xuanlu/origin"
             version "VERSION_PLACEHOLDER"
-            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/wenlan-cli-darwin-arm64.tar.gz"
+            url "https://github.com/7xuanlu/wenlan/releases/download/vVERSION_PLACEHOLDER/wenlan-cli-darwin-arm64.tar.gz"
             sha256 "SHA_PLACEHOLDER"
             license "Apache-2.0"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,8 @@ jobs:
       - name: List Windows build artifacts
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: bash
-        run: ls -la target/${{ matrix.target }}/release/ | head -30
+        run: |
+          find "target/${{ matrix.target }}/release" -maxdepth 1 -mindepth 1 -print | sort | head -30
 
       # ort 2.x caches link-time `.lib` artifacts under
       # `%LOCALAPPDATA%\ort.pyke.io\...` but does NOT keep onnxruntime.dll
@@ -551,7 +552,7 @@ jobs:
           SHA_MCP_DARWIN_ARM64=$(sha256sum wenlan-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_CLI_DARWIN_ARM64=$(sha256sum wenlan-cli-darwin-arm64.tar.gz | cut -d' ' -f1)
 
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git tap
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git" tap
           mkdir -p tap/Formula
 
           cat > tap/Formula/wenlan-mcp.rb << 'FORMULA'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-14
             archive: tar.gz
-            artifact_name: origin-darwin-arm64
+            artifact_name: wenlan-darwin-arm64
           # x86_64-apple-darwin dropped from v0.7.0: `ort` 2.x does not
           # publish prebuilt ONNX Runtime binaries for Intel Mac. Adding it
           # back requires compiling ONNX from source (~15min build) or
@@ -123,15 +123,15 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             archive: tar.gz
-            artifact_name: origin-linux-arm64
+            artifact_name: wenlan-linux-arm64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
             archive: tar.gz
-            artifact_name: origin-linux-x64
+            artifact_name: wenlan-linux-x64
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             archive: zip
-            artifact_name: origin-windows-x64
+            artifact_name: wenlan-windows-x64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -209,18 +209,18 @@ jobs:
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: "sccache"
-        run: cargo build --release -p origin -p origin-server -p origin-mcp --target ${{ matrix.target }}
+        run: cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp --target ${{ matrix.target }}
 
       - name: Smoke
         shell: bash
         run: |
-          ./target/${{ matrix.target }}/release/origin${{ runner.os == 'Windows' && '.exe' || '' }} --help
-          ./target/${{ matrix.target }}/release/origin-server${{ runner.os == 'Windows' && '.exe' || '' }} --help
+          ./target/${{ matrix.target }}/release/wenlan${{ runner.os == 'Windows' && '.exe' || '' }} --help
+          ./target/${{ matrix.target }}/release/wenlan-server${{ runner.os == 'Windows' && '.exe' || '' }} --help
 
       - name: List Windows build artifacts
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: bash
-        run: ls -la target/${{ matrix.target }}/release/ | head -30
+        run: find "target/${{ matrix.target }}/release" -maxdepth 1 -print | head -30
 
       # ort 2.x caches link-time `.lib` artifacts under
       # `%LOCALAPPDATA%\ort.pyke.io\...` but does NOT keep onnxruntime.dll
@@ -258,41 +258,41 @@ jobs:
             # sc.exe path which requires Administrator elevation. Documented
             # in AGENTS.md.
             7z a "dist/${{ matrix.artifact_name }}.zip" \
-              "./target/${{ matrix.target }}/release/origin.exe" \
-              "./target/${{ matrix.target }}/release/origin-server.exe" \
-              "./target/${{ matrix.target }}/release/origin-mcp.exe" \
+              "./target/${{ matrix.target }}/release/wenlan.exe" \
+              "./target/${{ matrix.target }}/release/wenlan-server.exe" \
+              "./target/${{ matrix.target }}/release/wenlan-mcp.exe" \
               "./target/${{ matrix.target }}/release/onnxruntime.dll"
           else
             tar -C "target/${{ matrix.target }}/release" -czf "dist/${{ matrix.artifact_name }}.tar.gz" \
-              origin origin-server origin-mcp
+              wenlan wenlan-server wenlan-mcp
           fi
 
-      # Per-binary archive for origin-mcp consumed by the Homebrew tap formula.
+      # Per-binary archive for wenlan-mcp consumed by the Homebrew tap formula.
       # Produced only on the darwin-arm64 leg to match the existing tap entry.
-      - name: Package origin-mcp tarball for Homebrew (darwin-arm64 only)
+      - name: Package wenlan-mcp tarball for Homebrew (darwin-arm64 only)
         if: matrix.target == 'aarch64-apple-darwin'
         shell: bash
         run: |
-          cp "target/${{ matrix.target }}/release/origin-mcp" origin-mcp
-          tar -czf dist/origin-mcp-darwin-arm64.tar.gz origin-mcp
-          rm origin-mcp
+          cp "target/${{ matrix.target }}/release/wenlan-mcp" wenlan-mcp
+          tar -czf dist/wenlan-mcp-darwin-arm64.tar.gz wenlan-mcp
+          rm wenlan-mcp
 
-      # Per-binary archive for the origin CLI consumed by the Homebrew tap
+      # Per-binary archive for the wenlan CLI consumed by the Homebrew tap
       # formula. Darwin-arm64 only — matches the origin-mcp tap pattern.
       # Filename intentionally distinct from the multi-binary release tarball
-      # `origin-darwin-arm64.tar.gz` to avoid clobbering it in `dist/`.
-      - name: Package origin CLI tarball for Homebrew (darwin-arm64 only)
+      # `wenlan-darwin-arm64.tar.gz` to avoid clobbering it in `dist/`.
+      - name: Package wenlan CLI tarball for Homebrew (darwin-arm64 only)
         if: matrix.target == 'aarch64-apple-darwin'
         shell: bash
         run: |
-          cp "target/${{ matrix.target }}/release/origin" origin
-          tar -czf dist/origin-cli-darwin-arm64.tar.gz origin
-          rm origin
+          cp "target/${{ matrix.target }}/release/wenlan" wenlan
+          tar -czf dist/wenlan-cli-darwin-arm64.tar.gz wenlan
+          rm wenlan
 
       # Smoke test: verify the multi-binary release archive contains all three
       # binaries before upload. Catches regressions like a same-named Homebrew
       # tarball clobbering the install.sh-consumed archive (v0.7.0 bug).
-      - name: Verify release archive contains origin, origin-server, origin-mcp
+      - name: Verify release archive contains wenlan, wenlan-server, wenlan-mcp
         shell: bash
         run: |
           set -e
@@ -303,7 +303,7 @@ jobs:
             contents=$(unzip -l "dist/${{ matrix.artifact_name }}.zip" | awk '{print $NF}')
             suffix=".exe"
           fi
-          for bin in origin origin-server origin-mcp; do
+          for bin in wenlan wenlan-server wenlan-mcp; do
             if ! printf '%s\n' "$contents" | grep -qE "(^|/)${bin}${suffix}$"; then
               echo "ERROR: dist/${{ matrix.artifact_name }}.${{ matrix.archive }} missing ${bin}${suffix}"
               echo "--- archive contents ---"
@@ -311,7 +311,7 @@ jobs:
               exit 1
             fi
           done
-          echo "OK: archive contains origin, origin-server, origin-mcp"
+          echo "OK: archive contains wenlan, wenlan-server, wenlan-mcp"
 
       - name: Upload archives to release
         uses: softprops/action-gh-release@v2
@@ -322,14 +322,14 @@ jobs:
           append_body: false
           fail_on_unmatched_files: true
 
-      - name: Upload Homebrew artifacts (origin + origin-mcp)
+      - name: Upload Homebrew artifacts (wenlan + wenlan-mcp)
         if: matrix.target == 'aarch64-apple-darwin'
         uses: actions/upload-artifact@v4
         with:
           name: homebrew-artifacts
           path: |
-            dist/origin-cli-darwin-arm64.tar.gz
-            dist/origin-mcp-darwin-arm64.tar.gz
+            dist/wenlan-cli-darwin-arm64.tar.gz
+            dist/wenlan-mcp-darwin-arm64.tar.gz
 
   docker:
     name: Build & Push Docker Image (${{ matrix.platform }})
@@ -551,7 +551,7 @@ jobs:
           SHA_MCP_DARWIN_ARM64=$(sha256sum origin-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_CLI_DARWIN_ARM64=$(sha256sum origin-darwin-arm64.tar.gz | cut -d' ' -f1)
 
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git tap
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git" tap
           mkdir -p tap/Formula
 
           cat > tap/Formula/origin-mcp.rb << 'FORMULA'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,19 +54,19 @@ jobs:
 
           ## Install
 
-          **Origin setup (local runtime + daemon):**
+          **Wenlan setup (local runtime + daemon):**
           \`\`\`
-          npx -y @7xuanlu/origin setup
+          npx -y wenlan setup
           \`\`\`
 
           **MCP connector only:**
           \`\`\`
-          npx -y origin-mcp
+          npx -y wenlan-mcp
           \`\`\`
 
           **Exact release setup:**
           \`\`\`
-          ORIGIN_RELEASE_TAG=${RELEASE_TAG} npx -y @7xuanlu/origin setup
+          WENLAN_RELEASE_TAG=${RELEASE_TAG} npx -y wenlan setup
           \`\`\`
 
           **Shell installer:**
@@ -76,11 +76,11 @@ jobs:
 
           **Exact shell install for this release:**
           \`\`\`
-          curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/${RELEASE_TAG}/install.sh | ORIGIN_RELEASE_TAG=${RELEASE_TAG} bash
+          curl -fsSL https://raw.githubusercontent.com/7xuanlu/origin/${RELEASE_TAG}/install.sh | WENLAN_RELEASE_TAG=${RELEASE_TAG} bash
           \`\`\`
           Downloads exact binaries and prints manual isolated daemon/MCP setup steps.
 
-          > Origin works in local memory mode without a local model or API key. Distill cycles are opt-in with \`origin model install\` or \`origin key set anthropic\`.
+          > Wenlan works in local memory mode without a local model or API key. Distill cycles are opt-in with \`wenlan model install\` or \`wenlan key set anthropic\`.
           INSTALL_EOF
 
           # Strip leading whitespace from heredoc indentation
@@ -548,18 +548,18 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           VERSION="${RELEASE_TAG#v}"
-          SHA_MCP_DARWIN_ARM64=$(sha256sum origin-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
-          SHA_CLI_DARWIN_ARM64=$(sha256sum origin-darwin-arm64.tar.gz | cut -d' ' -f1)
+          SHA_MCP_DARWIN_ARM64=$(sha256sum wenlan-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
+          SHA_CLI_DARWIN_ARM64=$(sha256sum wenlan-cli-darwin-arm64.tar.gz | cut -d' ' -f1)
 
           git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git tap
           mkdir -p tap/Formula
 
-          cat > tap/Formula/origin-mcp.rb << 'FORMULA'
-          class OriginMcp < Formula
-            desc "MCP server for Origin — personal agent memory layer"
+          cat > tap/Formula/wenlan-mcp.rb << 'FORMULA'
+          class WenlanMcp < Formula
+            desc "MCP server for Wenlan — personal agent memory layer"
             homepage "https://github.com/7xuanlu/origin"
             version "VERSION_PLACEHOLDER"
-            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/origin-mcp-darwin-arm64.tar.gz"
+            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/wenlan-mcp-darwin-arm64.tar.gz"
             sha256 "SHA_PLACEHOLDER"
             license "Apache-2.0"
 
@@ -573,24 +573,24 @@ jobs:
             end
 
             def install
-              bin.install "origin-mcp"
+              bin.install "wenlan-mcp"
             end
 
             test do
-              assert_match "origin-mcp", shell_output("#{bin}/origin-mcp --help")
+              assert_match "wenlan-mcp", shell_output("#{bin}/wenlan-mcp --help")
             end
           end
           FORMULA
 
-          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" tap/Formula/origin-mcp.rb
-          sed -i "s/SHA_PLACEHOLDER/${SHA_MCP_DARWIN_ARM64}/g" tap/Formula/origin-mcp.rb
+          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" tap/Formula/wenlan-mcp.rb
+          sed -i "s/SHA_PLACEHOLDER/${SHA_MCP_DARWIN_ARM64}/g" tap/Formula/wenlan-mcp.rb
 
-          cat > tap/Formula/origin.rb << 'FORMULA'
-          class Origin < Formula
-            desc "Origin CLI — local-first memory + knowledge layer for AI agents"
+          cat > tap/Formula/wenlan.rb << 'FORMULA'
+          class Wenlan < Formula
+            desc "Wenlan CLI — local-first memory + knowledge layer for AI agents"
             homepage "https://github.com/7xuanlu/origin"
             version "VERSION_PLACEHOLDER"
-            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/origin-darwin-arm64.tar.gz"
+            url "https://github.com/7xuanlu/origin/releases/download/vVERSION_PLACEHOLDER/wenlan-cli-darwin-arm64.tar.gz"
             sha256 "SHA_PLACEHOLDER"
             license "Apache-2.0"
 
@@ -604,26 +604,26 @@ jobs:
             end
 
             def install
-              bin.install "origin"
+              bin.install "wenlan"
             end
 
             test do
-              assert_match "origin", shell_output("#{bin}/origin --help")
+              assert_match "wenlan", shell_output("#{bin}/wenlan --help")
             end
           end
           FORMULA
 
-          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" tap/Formula/origin.rb
-          sed -i "s/SHA_PLACEHOLDER/${SHA_CLI_DARWIN_ARM64}/g" tap/Formula/origin.rb
+          sed -i "s/VERSION_PLACEHOLDER/${VERSION}/g" tap/Formula/wenlan.rb
+          sed -i "s/SHA_PLACEHOLDER/${SHA_CLI_DARWIN_ARM64}/g" tap/Formula/wenlan.rb
 
           cd tap
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/origin-mcp.rb Formula/origin.rb
-          git commit -m "origin + origin-mcp ${VERSION}"
+          git add Formula/wenlan-mcp.rb Formula/wenlan.rb
+          git commit -m "wenlan + wenlan-mcp ${VERSION}"
           git push origin HEAD:main
 
       - name: Verify formula syntax
         run: |
-          ruby -c tap/Formula/origin-mcp.rb
-          ruby -c tap/Formula/origin.rb
+          ruby -c tap/Formula/wenlan-mcp.rb
+          ruby -c tap/Formula/wenlan.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
           rm wenlan-mcp
 
       # Per-binary archive for the wenlan CLI consumed by the Homebrew tap
-      # formula. Darwin-arm64 only — matches the origin-mcp tap pattern.
+      # formula. Darwin-arm64 only — matches the wenlan-mcp tap pattern.
       # Filename intentionally distinct from the multi-binary release tarball
       # `wenlan-darwin-arm64.tar.gz` to avoid clobbering it in `dist/`.
       - name: Package wenlan CLI tarball for Homebrew (darwin-arm64 only)

--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,8 @@ memorydb/
 src-tauri/
 
 # Local override for the plugin's MCP runner — typically a symlink to a
-# dev-built origin-mcp binary. See plugin/bin/origin-mcp-runner.sh.
-plugin/bin/origin-mcp.local
+# dev-built wenlan-mcp binary. See plugin/bin/wenlan-mcp-runner.sh.
+plugin/bin/wenlan-mcp.local
 
 # Python bytecode (analyze_paired.py + tests)
 __pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,7 +260,7 @@ The repo is a Cargo workspace with 5 crates:
 | `crates/wenlan-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, distill cycles, pages, export, eval. **Must have NO axum or tauri dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/wenlan-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `wenlan-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
 | `crates/wenlan-cli` | CLI binary `origin`. Talks to daemon HTTP via `wenlan-types` and owns setup/service commands. Subcommands: status/search/recall/store/list/agents/install/setup/model/key/doctor. | reqwest, clap |
-| `crates/wenlan-mcp` | MCP server binary that bridges MCP clients (Claude Code, Cursor, Codex, Claude Desktop, etc.) to the daemon HTTP API. Stdio + streamable-HTTP transports via the `rmcp` crate. Ships as a standalone binary + npm package (`npx -y wenlan-mcp`). | rmcp, reqwest, schemars |
+| `crates/wenlan-mcp` | MCP server binary that bridges MCP clients (Claude Code, Cursor, Codex, Claude Desktop, etc.) to the daemon HTTP API. Stdio + streamable-HTTP transports via the `rmcp` crate. Ships as a standalone binary + npm package (`npx -y origin-mcp`). | rmcp, reqwest, schemars |
 
 The daemon (`wenlan-server`) is the single source of truth. External tools (the desktop app, MCP clients via `wenlan-mcp`, `origin` CLI, curl) all talk HTTP to the same daemon. `wenlan-mcp` source lives in this monorepo; at runtime it's a separate process the MCP client spawns.
 
@@ -393,7 +393,7 @@ Run this hygiene pass roughly once a week or whenever `git worktree list` exceed
 - All local data stored in the platform data directory (`dirs::data_local_dir()/origin/`; on macOS, `~/Library/Application Support/wenlan/`) — MemoryDB, config, activities, tags
 - Crate names: `wenlan-types`, `wenlan-core`, `wenlan-server`, `origin` (CLI), `wenlan-mcp` — all in this workspace. The desktop app crate `origin-app` lives in [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app).
 - **Licenses**: all five workspace crates (`wenlan-types`, `wenlan-core`, `wenlan-server`, `origin` CLI, `wenlan-mcp`) are **Apache-2.0** via workspace inheritance. The desktop app in `origin-app` is **AGPL-3.0-only** (separate repo).
-- `wenlan-mcp` is in-tree at `crates/wenlan-mcp/` (merged from the old `7xuanlu/wenlan-mcp` repo on 2026-05-09 via `git subtree`). It talks to the daemon via HTTP at runtime and is published to npm as a standalone binary (`npx -y wenlan-mcp`).
+- `wenlan-mcp` is in-tree at `crates/wenlan-mcp/` (merged from the old `7xuanlu/wenlan-mcp` repo on 2026-05-09 via `git subtree`). It talks to the daemon via HTTP at runtime and is published to npm as a standalone binary (`npx -y origin-mcp`).
 
 ### Retrieval helpers location (PR-A, 2026-05-27)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,7 +220,7 @@ cat .release-please-manifest.json
 
 **Never delete a release tag without also cleaning up the commit history.** If you need to undo a release version, you must rewrite the commit message that release-please created (`git filter-branch --msg-filter`), delete the tag, delete the GitHub Release, and rename the merged PR title via API. Otherwise release-please will keep bumping from the old version.
 
-**The `release.yml` workflow ships the local runtime.** It handles: origin CLI, wenlan-server, wenlan-mcp, standalone binary uploads, crates.io publishing for `wenlan-types` + `wenlan-mcp`, and npm publishing for `wenlan-mcp` + `@7xuanlu/origin`. It does NOT build a desktop bundle — origin-app builds its own DMG in its own repo.
+**The `release.yml` workflow ships the local runtime.** It handles: origin CLI, wenlan-server, wenlan-mcp, standalone binary uploads, crates.io publishing for `wenlan-types` + `wenlan-mcp`, and npm publishing for `wenlan-mcp` + `wenlan`. It does NOT build a desktop bundle — origin-app builds its own DMG in its own repo.
 
 ### Branch protection
 
@@ -260,7 +260,7 @@ The repo is a Cargo workspace with 5 crates:
 | `crates/wenlan-core` | All business logic: DB, embeddings, LLM engine, search, classification, knowledge graph, distill cycles, pages, export, eval. **Must have NO axum or tauri dependencies.** | libSQL, FastEmbed, llama-cpp-2, hf-hub |
 | `crates/wenlan-server` | Headless HTTP daemon on `127.0.0.1:7878`. Depends on `wenlan-core`. Provides `install/uninstall/status` subcommands for launchd management. | axum, tower, clap |
 | `crates/wenlan-cli` | CLI binary `origin`. Talks to daemon HTTP via `wenlan-types` and owns setup/service commands. Subcommands: status/search/recall/store/list/agents/install/setup/model/key/doctor. | reqwest, clap |
-| `crates/wenlan-mcp` | MCP server binary that bridges MCP clients (Claude Code, Cursor, Codex, Claude Desktop, etc.) to the daemon HTTP API. Stdio + streamable-HTTP transports via the `rmcp` crate. Ships as a standalone binary + npm package (`npx -y origin-mcp`). | rmcp, reqwest, schemars |
+| `crates/wenlan-mcp` | MCP server binary that bridges MCP clients (Claude Code, Cursor, Codex, Claude Desktop, etc.) to the daemon HTTP API. Stdio + streamable-HTTP transports via the `rmcp` crate. Ships as a standalone binary + npm package (`npx -y wenlan-mcp`). | rmcp, reqwest, schemars |
 
 The daemon (`wenlan-server`) is the single source of truth. External tools (the desktop app, MCP clients via `wenlan-mcp`, `origin` CLI, curl) all talk HTTP to the same daemon. `wenlan-mcp` source lives in this monorepo; at runtime it's a separate process the MCP client spawns.
 
@@ -393,7 +393,7 @@ Run this hygiene pass roughly once a week or whenever `git worktree list` exceed
 - All local data stored in the platform data directory (`dirs::data_local_dir()/origin/`; on macOS, `~/Library/Application Support/wenlan/`) — MemoryDB, config, activities, tags
 - Crate names: `wenlan-types`, `wenlan-core`, `wenlan-server`, `origin` (CLI), `wenlan-mcp` — all in this workspace. The desktop app crate `origin-app` lives in [7xuanlu/origin-app](https://github.com/7xuanlu/origin-app).
 - **Licenses**: all five workspace crates (`wenlan-types`, `wenlan-core`, `wenlan-server`, `origin` CLI, `wenlan-mcp`) are **Apache-2.0** via workspace inheritance. The desktop app in `origin-app` is **AGPL-3.0-only** (separate repo).
-- `wenlan-mcp` is in-tree at `crates/wenlan-mcp/` (merged from the old `7xuanlu/wenlan-mcp` repo on 2026-05-09 via `git subtree`). It talks to the daemon via HTTP at runtime and is published to npm as a standalone binary (`npx -y origin-mcp`).
+- `wenlan-mcp` is in-tree at `crates/wenlan-mcp/` (merged from the old `7xuanlu/wenlan-mcp` repo on 2026-05-09 via `git subtree`). It talks to the daemon via HTTP at runtime and is published to npm as a standalone binary (`npx -y wenlan-mcp`).
 
 ### Retrieval helpers location (PR-A, 2026-05-27)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 [![CI](https://github.com/7xuanlu/wenlan/actions/workflows/ci.yml/badge.svg?branch=main&event=push)](https://github.com/7xuanlu/wenlan/actions/workflows/ci.yml?query=branch%3Amain)
 [![Release](https://img.shields.io/github/v/release/7xuanlu/wenlan?sort=semver)](https://github.com/7xuanlu/wenlan/releases/latest)
-[![npm: @7xuanlu/origin](https://img.shields.io/npm/v/%407xuanlu%2Forigin?label=%407xuanlu%2Forigin)](https://www.npmjs.com/package/@7xuanlu/origin)
-[![npm: origin-mcp](https://img.shields.io/npm/v/origin-mcp?label=origin-mcp)](https://www.npmjs.com/package/origin-mcp)
+[![npm: wenlan](https://img.shields.io/npm/v/wenlan?label=wenlan)](https://www.npmjs.com/package/wenlan)
+[![npm: wenlan-mcp](https://img.shields.io/npm/v/wenlan-mcp?label=wenlan-mcp)](https://www.npmjs.com/package/wenlan-mcp)
 [![MCP Server](https://img.shields.io/badge/MCP-server-blue)](https://modelcontextprotocol.io)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](#license)
 
@@ -72,8 +72,8 @@ Plugin details and daily commands: [plugin/](plugin/.claude-plugin/README.md).
 Use this if you want Wenlan tools in Claude Code without the plugin, or in Codex, Cursor, Claude Desktop, VS Code, or Gemini CLI.
 
 ```bash
-npx -y @7xuanlu/origin setup
-~/.origin/bin/origin mcp add claude-code      # or: codex, cursor, claude-desktop, vscode, gemini
+npx -y wenlan setup
+~/.wenlan/bin/wenlan mcp add claude-code      # or: codex, cursor, claude-desktop, vscode, gemini
 ```
 
 MCP-only gives agents tools for capture, recall, context, doctor, and page distillation. It does not install Claude Code slash skills like `/brief`, `/handoff`, `/distill`, or `/init`.
@@ -83,7 +83,7 @@ MCP-only gives agents tools for capture, recall, context, doctor, and page disti
 Set up the local Wenlan runtime:
 
 ```bash
-npx -y @7xuanlu/origin setup
+npx -y wenlan setup
 ```
 
 Then start with `~/.origin/bin/origin status`, `~/.origin/bin/origin recall <query>`, or `~/.origin/bin/origin store <text>`. CLI details: [crates/wenlan-cli](crates/wenlan-cli/README.md).
@@ -97,7 +97,7 @@ origin status
 origin uninstall
 ```
 
-After upgrading Wenlan (`npx -y @7xuanlu/origin setup` or `install.sh`), the new binary is on disk but the already-running daemon keeps serving the old code until you restart it. `origin install` now restarts automatically; if you upgraded another way, run `origin restart`.
+After upgrading Wenlan (`npx -y wenlan setup` or `install.sh`), the new binary is on disk but the already-running daemon keeps serving the old code until you restart it. `wenlan install` now restarts automatically; if you upgraded another way, run `wenlan restart`.
 
 ---
 
@@ -206,7 +206,7 @@ Full contributor map: [CLAUDE.md](CLAUDE.md).
 
 ## Build from source
 
-Wenlan builds natively on macOS (Apple Silicon + Intel), Linux (x86_64 + ARM64; glibc), and Windows (x86_64). The npm wrapper (`@7xuanlu/origin`, `origin-mcp`) and `install.sh` auto-detect your platform and pull the matching prebuilt release. Most users should install through the Claude Code plugin or `npx`. For local development:
+Wenlan builds natively on macOS (Apple Silicon + Intel), Linux (x86_64 + ARM64; glibc), and Windows (x86_64). The npm wrapper (`wenlan`, `wenlan-mcp`) and `install.sh` auto-detect your platform and pull the matching prebuilt release. Most users should install through the Claude Code plugin or `npx`. For local development:
 
 ```bash
 git clone https://github.com/7xuanlu/wenlan.git

--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -9,10 +9,10 @@ License: Apache-2.0.
 Recommended user setup:
 
 ```bash
-npx -y @7xuanlu/origin setup
+npx -y wenlan setup
 ```
 
-The setup package supports macOS (arm64, x64), Linux (x64, arm64), and Windows (x64). It downloads the platform-matching release archive, installs `origin`, `origin-server`, and `origin-mcp` into `~/.origin/bin/`, configures local memory, registers the daemon with the host's native service manager (launchd on macOS, systemd-user on Linux), and verifies status. On Windows, `origin install` is not supported in v1 (daemon does not yet speak the Windows Service Control Protocol); run `origin-server.exe` manually or via Task Scheduler.
+The setup package supports macOS (arm64, x64), Linux (x64, arm64), and Windows (x64). It downloads the platform-matching release archive, installs `wenlan`, `wenlan-server`, and `wenlan-mcp` into `~/.wenlan/bin/`, configures local memory, registers the daemon with the host's native service manager (launchd on macOS, systemd-user on Linux), and verifies status. On Windows, `wenlan install` is not supported in v1 (daemon does not yet speak the Windows Service Control Protocol); run `wenlan-server.exe` manually or via Task Scheduler.
 
 For local development:
 
@@ -59,7 +59,7 @@ origin setup --anthropic-api-key-env ANTHROPIC_API_KEY
 
 ### `origin install` / `origin uninstall`
 
-Register or remove the daemon with the host's native service manager. The service runs the sibling `origin-server` binary next to `origin`.
+Register or remove the daemon with the host's native service manager. The service runs the sibling `wenlan-server` binary next to `wenlan`.
 
 - **macOS**: launchd user agent at `~/Library/LaunchAgents/com.wenlan.server.plist`.
 - **Linux**: systemd user unit at `~/.config/systemd/user/wenlan-server.service`. `loginctl enable-linger` if you want it alive after logout.
@@ -98,24 +98,24 @@ origin key set anthropic --env ANTHROPIC_API_KEY
 origin key clear anthropic
 ```
 
-### `origin mcp add <client>`
+### `wenlan mcp add <client>`
 
 Configure Wenlan MCP for a supported client. This is the MCP-only path for Claude Code users who do not want the plugin, and for Codex, Cursor, Claude Desktop, VS Code, and Gemini CLI.
 
 ```bash
-origin mcp add claude-code
-origin mcp add codex
-origin mcp add cursor --dry-run
+wenlan mcp add claude-code
+wenlan mcp add codex
+wenlan mcp add cursor --dry-run
 ```
 
 Supported clients: `claude-code`, `codex`, `gemini`, `cursor`, `claude-desktop`, `vscode`.
 
-When `origin-mcp` is installed next to the `origin` CLI, the generated config points at that binary. Otherwise it falls back to `npx -y origin-mcp`.
+When `wenlan-mcp` is installed next to the `wenlan` CLI, the generated config points at that binary. Otherwise it falls back to `npx -y wenlan-mcp`.
 
 Use `--dry-run` to preview JSON config edits before writing them:
 
 ```bash
-origin mcp add cursor --dry-run
+wenlan mcp add cursor --dry-run
 ```
 
 ### `origin search <query>`

--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -63,7 +63,7 @@ Register or remove the daemon with the host's native service manager. The servic
 
 - **macOS**: launchd user agent at `~/Library/LaunchAgents/com.wenlan.server.plist`.
 - **Linux**: systemd user unit at `~/.config/systemd/user/wenlan-server.service`. `loginctl enable-linger` if you want it alive after logout.
-- **Windows**: not yet supported in v1. The console-app daemon does not implement the Windows Service Control Protocol; sc.exe start times out. Run `origin-server.exe` manually or register a Task Scheduler logon task. Tracked follow-up.
+- **Windows**: not yet supported in v1. The console-app daemon does not implement the Windows Service Control Protocol; sc.exe start times out. Run `wenlan-server.exe` manually or register a Task Scheduler logon task. Tracked follow-up.
 
 ```bash
 origin install

--- a/crates/wenlan-cli/npm/package.json
+++ b/crates/wenlan-cli/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@7xuanlu/origin",
+  "name": "wenlan",
   "version": "0.8.6",
   "description": "Local-first memory + knowledge layer for AI agents.",
   "keywords": [
@@ -26,7 +26,7 @@
   "author": "7xuanlu <h164654156465@gmail.com>",
   "license": "Apache-2.0",
   "bin": {
-    "origin": "run.js"
+    "wenlan": "run.js"
   },
   "engines": {
     "node": ">=18"
@@ -40,7 +40,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/7xuanlu/origin.git",
-    "directory": "crates/origin-cli/npm"
+    "directory": "crates/wenlan-cli/npm"
   },
   "files": [
     "run.js",

--- a/crates/wenlan-cli/npm/run.js
+++ b/crates/wenlan-cli/npm/run.js
@@ -8,7 +8,7 @@ const os = require("os");
 const path = require("path");
 
 const REPO = "7xuanlu/origin";
-const TARGET = "aarch64-apple-darwin";
+const ASSET = "wenlan-darwin-arm64.tar.gz";
 const REQUESTED_TAG =
   process.env.WENLAN_RELEASE_TAG ||
   process.env.WENLAN_TAG ||
@@ -67,11 +67,21 @@ async function fetchJson(url) {
 async function download(url, dest) {
   const res = await request(url);
   await new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest, { mode: 0o755 });
+    const file = fs.createWriteStream(dest);
     res.pipe(file);
     file.on("finish", () => file.close(resolve));
     file.on("error", reject);
   });
+}
+
+function extractBinaries(archivePath, dir) {
+  const result = childProcess.spawnSync(
+    "tar",
+    ["-xzf", archivePath, "-C", dir, ...BINARIES],
+    { stdio: "inherit" }
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`tar exited with status ${result.status}`);
 }
 
 function run(command, args) {
@@ -106,11 +116,23 @@ async function installBinaries() {
   const dir = binDir();
   fs.mkdirSync(dir, { recursive: true });
 
+  const archivePath = path.join(os.tmpdir(), ASSET);
+  const url = `https://github.com/${REPO}/releases/download/${tag}/${ASSET}`;
+  process.stderr.write(`Downloading Wenlan ${tag}...\n`);
+
+  try {
+    await download(url, archivePath);
+    extractBinaries(archivePath, dir);
+  } finally {
+    try {
+      if (fs.existsSync(archivePath)) fs.unlinkSync(archivePath);
+    } catch (_) {
+      // Best-effort cleanup only.
+    }
+  }
+
   for (const name of BINARIES) {
     const dest = path.join(dir, name);
-    const url = `https://github.com/${REPO}/releases/download/${tag}/${name}-${TARGET}`;
-    process.stderr.write(`Downloading ${name} ${tag}...\n`);
-    await download(url, dest);
     fs.chmodSync(dest, 0o755);
   }
 

--- a/crates/wenlan-cli/npm/run.js
+++ b/crates/wenlan-cli/npm/run.js
@@ -9,8 +9,13 @@ const path = require("path");
 
 const REPO = "7xuanlu/origin";
 const TARGET = "aarch64-apple-darwin";
-const REQUESTED_TAG = process.env.ORIGIN_RELEASE_TAG || process.env.ORIGIN_TAG || "";
-const BINARIES = ["origin", "origin-server", "origin-mcp"];
+const REQUESTED_TAG =
+  process.env.WENLAN_RELEASE_TAG ||
+  process.env.WENLAN_TAG ||
+  process.env.ORIGIN_RELEASE_TAG ||
+  process.env.ORIGIN_TAG ||
+  "";
+const BINARIES = ["wenlan", "wenlan-server", "wenlan-mcp"];
 
 function safeTag(tag) {
   return tag.replace(/[^A-Za-z0-9._-]/g, "_");
@@ -18,9 +23,9 @@ function safeTag(tag) {
 
 function binDir() {
   if (REQUESTED_TAG) {
-    return path.join(os.homedir(), ".origin", "releases", safeTag(REQUESTED_TAG));
+    return path.join(os.homedir(), ".wenlan", "releases", safeTag(REQUESTED_TAG));
   }
-  return path.join(os.homedir(), ".origin", "bin");
+  return path.join(os.homedir(), ".wenlan", "bin");
 }
 
 function githubApiUrl() {
@@ -33,7 +38,7 @@ function githubApiUrl() {
 function request(url, headers = {}) {
   return new Promise((resolve, reject) => {
     https
-      .get(url, { headers: { "User-Agent": "@7xuanlu/origin", ...headers } }, (res) => {
+      .get(url, { headers: { "User-Agent": "wenlan", ...headers } }, (res) => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
           res.resume();
           resolve(request(res.headers.location, headers));
@@ -83,20 +88,20 @@ function printPathHint(dir) {
   if (entries.includes(dir)) return;
 
   process.stderr.write(
-    `\nOrigin binaries are installed in ${dir}.\n` +
-      `Add them to your shell PATH if you want to run origin directly:\n\n` +
+    `\nWenlan binaries are installed in ${dir}.\n` +
+      `Add them to your shell PATH if you want to run wenlan directly:\n\n` +
       `  export PATH="${dir}:$PATH"\n\n`
   );
 }
 
 async function installBinaries() {
   if (process.platform !== "darwin" || process.arch !== "arm64") {
-    throw new Error("Origin setup currently supports macOS Apple Silicon only.");
+    throw new Error("Wenlan setup currently supports macOS Apple Silicon only.");
   }
 
   const release = await fetchJson(githubApiUrl());
   const tag = release.tag_name;
-  if (!tag) throw new Error("Could not determine Origin release tag.");
+  if (!tag) throw new Error("Could not determine Wenlan release tag.");
 
   const dir = binDir();
   fs.mkdirSync(dir, { recursive: true });
@@ -115,21 +120,21 @@ async function installBinaries() {
 async function main() {
   const args = process.argv.slice(2);
   const dir = await installBinaries();
-  const origin = path.join(dir, "origin");
+  const wenlan = path.join(dir, "wenlan");
 
   if (args[0] === "setup") {
     const setupArgs = args.slice(1);
-    run(origin, ["setup", ...(setupArgs.length ? setupArgs : ["--basic"])]);
-    run(origin, ["install"]);
-    run(origin, ["status", "--format", "table"]);
+    run(wenlan, ["setup", ...(setupArgs.length ? setupArgs : ["--basic"])]);
+    run(wenlan, ["install"]);
+    run(wenlan, ["status", "--format", "table"]);
     printPathHint(dir);
     return;
   }
 
-  run(origin, args.length ? args : ["--help"]);
+  run(wenlan, args.length ? args : ["--help"]);
 }
 
 main().catch((err) => {
-  console.error(`origin setup failed: ${err.message}`);
+  console.error(`wenlan setup failed: ${err.message}`);
   process.exit(1);
 });

--- a/crates/wenlan-cli/tests/distribution.rs
+++ b/crates/wenlan-cli/tests/distribution.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Distribution and packaging contract tests for Origin's user-facing setup paths.
+//! Distribution and packaging contract tests for Wenlan's user-facing setup paths.
 
 use serde_json::Value;
 use std::fs;
@@ -11,7 +11,7 @@ fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(2)
-        .expect("origin-cli is nested under crates/")
+        .expect("wenlan-cli is nested under crates/")
         .to_path_buf()
 }
 
@@ -40,7 +40,7 @@ fn plugin_distribution_contains_required_files() {
         "plugin/.claude-plugin/plugin.json",
         "plugin/.claude-plugin/README.md",
         "plugin/.mcp.json",
-        "plugin/bin/origin-mcp-runner.sh",
+        "plugin/bin/wenlan-mcp-runner.sh",
         "plugin/hooks/hooks.json",
         "plugin/hooks/check-daemon.sh",
         "plugin/skills/brief/SKILL.md",
@@ -72,19 +72,19 @@ fn plugin_manifest_and_mcp_launcher_stay_in_sync() {
     let origin = &mcp["mcpServers"]["origin"];
     assert_eq!(
         json_string(origin, "command"),
-        "${CLAUDE_PLUGIN_ROOT}/bin/origin-mcp-runner.sh"
+        "${CLAUDE_PLUGIN_ROOT}/bin/wenlan-mcp-runner.sh"
     );
 }
 
 #[test]
 fn npm_package_allowlists_match_release_generated_files() {
-    // The @7xuanlu/origin CLI wrapper currently ships a macOS-arm64-only
+    // The wenlan CLI wrapper currently ships a macOS-arm64-only
     // `run.js`. Linux/Windows users install via the Docker image, the tar/zip
     // release archives, or `cargo install`, so the npm allowlist stays narrow
     // on purpose.
     let setup_pkg = read_json("crates/wenlan-cli/npm/package.json");
-    assert_eq!(json_string(&setup_pkg, "name"), "@7xuanlu/origin");
-    assert_eq!(setup_pkg["bin"]["origin"], "run.js");
+    assert_eq!(json_string(&setup_pkg, "name"), "wenlan");
+    assert_eq!(setup_pkg["bin"]["wenlan"], "run.js");
     assert_eq!(setup_pkg["license"], "Apache-2.0");
     assert_eq!(setup_pkg["os"], serde_json::json!(["darwin"]));
     assert_eq!(setup_pkg["cpu"], serde_json::json!(["arm64"]));
@@ -93,13 +93,13 @@ fn npm_package_allowlists_match_release_generated_files() {
         serde_json::json!(["run.js", "README.md", "LICENSE"])
     );
 
-    // origin-mcp ships prebuilt binaries for every release-matrix target
+    // wenlan-mcp ships prebuilt binaries for every release-matrix target
     // (darwin x2, linux x2, windows x1) via its npm postinstall. The
     // allowlist must include each platform the matrix uploads or `npm
     // install` rejects the package on those hosts.
     let mcp_pkg = read_json("crates/wenlan-mcp/npm/package.json");
-    assert_eq!(json_string(&mcp_pkg, "name"), "origin-mcp");
-    assert_eq!(mcp_pkg["bin"]["origin-mcp"], "run.js");
+    assert_eq!(json_string(&mcp_pkg, "name"), "wenlan-mcp");
+    assert_eq!(mcp_pkg["bin"]["wenlan-mcp"], "run.js");
     assert_eq!(mcp_pkg["scripts"]["postinstall"], "node install.js");
     assert_eq!(mcp_pkg["license"], "Apache-2.0");
     assert_eq!(
@@ -124,18 +124,18 @@ fn release_workflow_publishes_cli_and_mcp_npm_packages() {
     // the release.
     for needle in [
         "Build & Publish ${{ matrix.target }}",
-        "Publish origin-mcp",
-        "Publish @7xuanlu/origin",
-        "cp README.md crates/origin-mcp/npm/README.md",
-        "cp README.md crates/origin-cli/npm/README.md",
-        "origin-darwin-arm64",
-        // origin-darwin-x64 dropped in v0.7.0 (PR #168) — ort has no
+        "Publish wenlan-mcp",
+        "Publish wenlan",
+        "cp README.md crates/wenlan-mcp/npm/README.md",
+        "cp README.md crates/wenlan-cli/npm/README.md",
+        "wenlan-darwin-arm64",
+        // wenlan-darwin-x64 dropped in v0.7.0 (PR #168) — ort has no
         // prebuilt for x86_64-apple-darwin. Re-add when ONNX builds from
         // source or ort-tract becomes viable.
-        "origin-linux-arm64",
-        "origin-linux-x64",
-        "origin-windows-x64",
-        "origin-mcp-darwin-arm64.tar.gz",
+        "wenlan-linux-arm64",
+        "wenlan-linux-x64",
+        "wenlan-windows-x64",
+        "wenlan-mcp-darwin-arm64.tar.gz",
     ] {
         assert!(
             workflow.contains(needle),
@@ -145,7 +145,7 @@ fn release_workflow_publishes_cli_and_mcp_npm_packages() {
 }
 
 #[test]
-#[ignore = "manual smoke: requires real codex CLI and may download origin-mcp through npx"]
+#[ignore = "manual smoke: requires real codex CLI and may download wenlan-mcp through npx"]
 fn smoke_codex_mcp_add_uses_temp_home() {
     let runtime = TempDir::new().expect("temp home");
     let origin = assert_cmd::cargo::cargo_bin("wenlan");

--- a/crates/wenlan-mcp/README.md
+++ b/crates/wenlan-mcp/README.md
@@ -6,11 +6,11 @@ Wenlan owns storage, search, embeddings, pages, and distill cycles. `wenlan-mcp`
 
 ## Install
 
-Most users should install through the root README. After `npx -y @7xuanlu/origin setup`, use the product CLI to configure supported clients:
+Most users should install through the root README. After `npx -y wenlan setup`, use the product CLI to configure supported clients:
 
 ```bash
-origin mcp add codex              # or: claude-code, cursor, claude-desktop, vscode, gemini
-origin mcp add cursor --dry-run   # preview before editing JSON config
+wenlan mcp add codex              # or: claude-code, cursor, claude-desktop, vscode, gemini
+wenlan mcp add cursor --dry-run   # preview before editing JSON config
 ```
 
 MCP-only setup gives agents tools for capture, recall, context, doctor, and page distillation. It does not install Claude Code slash skills like `/brief`, `/handoff`, `/distill`, or `/init`; use the Wenlan plugin for that workflow.

--- a/crates/wenlan-mcp/README.md
+++ b/crates/wenlan-mcp/README.md
@@ -22,19 +22,19 @@ If you only need the raw MCP connector config, add this to your MCP client:
   "mcpServers": {
     "origin": {
       "command": "npx",
-      "args": ["-y", "origin-mcp"]
+      "args": ["-y", "wenlan-mcp"]
     }
   }
 }
 ```
 
-The npm wrapper auto-detects the host platform and downloads the matching prebuilt binary from the Wenlan release. Supported: macOS (arm64, x64), Linux (x64, arm64; glibc), Windows (x64). Other targets require building from source via `cargo install origin-mcp`.
+The npm wrapper auto-detects the host platform and downloads the matching prebuilt binary from the Wenlan release. Supported: macOS (arm64, x64), Linux (x64, arm64; glibc), Windows (x64). Other targets require building from source via `cargo install wenlan-mcp`.
 
 Or install a binary directly:
 
 ```bash
-brew install 7xuanlu/tap/origin-mcp
-cargo install origin-mcp
+brew install 7xuanlu/tap/wenlan-mcp
+cargo install wenlan-mcp
 ```
 
 Then use:
@@ -43,16 +43,16 @@ Then use:
 {
   "mcpServers": {
     "origin": {
-      "command": "origin-mcp"
+      "command": "wenlan-mcp"
     }
   }
 }
 ```
 
-`origin-mcp` expects the Wenlan daemon at `http://127.0.0.1:7878` by default. Override it with:
+`wenlan-mcp` expects the Wenlan daemon at `http://127.0.0.1:7878` by default. Override it with:
 
 ```bash
-origin-mcp --origin-url http://127.0.0.1:7879
+wenlan-mcp --origin-url http://127.0.0.1:7879
 ```
 
 ## Tools
@@ -96,7 +96,7 @@ See [`src/tools.rs`](src/tools.rs) for the full instructions.
 - [useorigin.app](https://useorigin.app) — project home
 - [useorigin.app/learn/mcp-memory-server](https://useorigin.app/learn/mcp-memory-server) — concept article on Wenlan as an MCP memory server
 - [useorigin.app/docs/mcp-clients](https://useorigin.app/docs/mcp-clients) — connect Claude Code, Cursor, Codex, Claude Desktop, Gemini CLI
-- [npm: origin-mcp](https://www.npmjs.com/package/origin-mcp) — standalone npm package
+- [npm: wenlan-mcp](https://www.npmjs.com/package/wenlan-mcp) — standalone npm package
 - [github.com/7xuanlu/wenlan](https://github.com/7xuanlu/wenlan) — source
 
 ## License

--- a/crates/wenlan-mcp/npm/install.js
+++ b/crates/wenlan-mcp/npm/install.js
@@ -14,13 +14,13 @@ const VERSION = require("./package.json").version;
 const REPO = "7xuanlu/origin";
 
 // Maps Node platform-arch to the release bundle filename shipped by release.yml.
-// Each bundle contains origin, origin-server, and origin-mcp (or .exe on Windows).
+// Each bundle contains wenlan, wenlan-server, and wenlan-mcp (or .exe on Windows).
 const ASSETS = {
-  "darwin-arm64": { file: "origin-darwin-arm64.tar.gz",  archive: "tar.gz" },
-  "darwin-x64":   { file: "origin-darwin-x64.tar.gz",    archive: "tar.gz" },
-  "linux-arm64":  { file: "origin-linux-arm64.tar.gz",   archive: "tar.gz" },
-  "linux-x64":    { file: "origin-linux-x64.tar.gz",     archive: "tar.gz" },
-  "win32-x64":    { file: "origin-windows-x64.zip",      archive: "zip"    },
+  "darwin-arm64": { file: "wenlan-darwin-arm64.tar.gz",  archive: "tar.gz" },
+  "darwin-x64":   { file: "wenlan-darwin-x64.tar.gz",    archive: "tar.gz" },
+  "linux-arm64":  { file: "wenlan-linux-arm64.tar.gz",   archive: "tar.gz" },
+  "linux-x64":    { file: "wenlan-linux-x64.tar.gz",     archive: "tar.gz" },
+  "win32-x64":    { file: "wenlan-windows-x64.zip",      archive: "zip"    },
 };
 
 const key = `${process.platform}-${process.arch}`;
@@ -33,8 +33,8 @@ if (!asset) {
 }
 
 const isWindows = process.platform === "win32";
-const binaryName = isWindows ? "origin-mcp.exe" : "origin-mcp";
-const installName = isWindows ? "origin-mcp.exe" : "origin-mcp";
+const binaryName = isWindows ? "wenlan-mcp.exe" : "wenlan-mcp";
+const installName = isWindows ? "wenlan-mcp.exe" : "wenlan-mcp";
 
 const binDir = join(__dirname, "bin");
 const dest = join(binDir, installName);
@@ -43,7 +43,7 @@ mkdirSync(binDir, { recursive: true });
 
 const downloadUrl = `https://github.com/${REPO}/releases/download/v${VERSION}/${asset.file}`;
 
-console.log(`Downloading origin-mcp ${VERSION} for ${key}...`);
+console.log(`Downloading wenlan-mcp ${VERSION} for ${key}...`);
 
 function download(url, dest, redirects = 0) {
   return new Promise((resolve, reject) => {
@@ -51,7 +51,7 @@ function download(url, dest, redirects = 0) {
       return reject(new Error("Too many redirects"));
     }
     const mod = url.startsWith("https") ? https : http;
-    mod.get(url, { headers: { "User-Agent": "origin-mcp-npm" } }, (res) => {
+    mod.get(url, { headers: { "User-Agent": "wenlan-mcp-npm" } }, (res) => {
       if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         return download(res.headers.location, dest, redirects + 1).then(resolve, reject);
       }
@@ -105,7 +105,7 @@ async function install() {
       chmodSync(dest, 0o755);
     }
 
-    console.log(`origin-mcp installed successfully (${key})`);
+    console.log(`wenlan-mcp installed successfully (${key})`);
   } finally {
     // Clean up downloaded archive regardless of success or failure.
     try {
@@ -119,6 +119,6 @@ async function install() {
 }
 
 install().catch((err) => {
-  console.error(`Failed to install origin-mcp: ${err.message}`);
+  console.error(`Failed to install wenlan-mcp: ${err.message}`);
   process.exit(1);
 });

--- a/crates/wenlan-mcp/npm/install.js
+++ b/crates/wenlan-mcp/npm/install.js
@@ -17,7 +17,6 @@ const REPO = "7xuanlu/origin";
 // Each bundle contains wenlan, wenlan-server, and wenlan-mcp (or .exe on Windows).
 const ASSETS = {
   "darwin-arm64": { file: "wenlan-darwin-arm64.tar.gz",  archive: "tar.gz" },
-  "darwin-x64":   { file: "wenlan-darwin-x64.tar.gz",    archive: "tar.gz" },
   "linux-arm64":  { file: "wenlan-linux-arm64.tar.gz",   archive: "tar.gz" },
   "linux-x64":    { file: "wenlan-linux-x64.tar.gz",     archive: "tar.gz" },
   "win32-x64":    { file: "wenlan-windows-x64.zip",      archive: "zip"    },

--- a/crates/wenlan-mcp/npm/package.json
+++ b/crates/wenlan-mcp/npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "origin-mcp",
+  "name": "wenlan-mcp",
   "version": "0.8.6",
   "description": "Local-first memory layer for AI agents - MCP server",
   "keywords": [
@@ -24,7 +24,7 @@
   "author": "7xuanlu <h164654156465@gmail.com>",
   "license": "Apache-2.0",
   "bin": {
-    "origin-mcp": "run.js"
+    "wenlan-mcp": "run.js"
   },
   "scripts": {
     "postinstall": "node install.js"
@@ -50,6 +50,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/7xuanlu/origin",
-    "directory": "crates/origin-mcp/npm"
+    "directory": "crates/wenlan-mcp/npm"
   }
 }

--- a/crates/wenlan-mcp/npm/run.js
+++ b/crates/wenlan-mcp/npm/run.js
@@ -4,7 +4,7 @@
 const { spawn } = require("child_process");
 const { join } = require("path");
 
-const binaryName = process.platform === "win32" ? "origin-mcp.exe" : "origin-mcp";
+const binaryName = process.platform === "win32" ? "wenlan-mcp.exe" : "wenlan-mcp";
 const bin = join(__dirname, "bin", binaryName);
 const child = spawn(bin, process.argv.slice(2), { stdio: "inherit" });
 

--- a/crates/wenlan-mcp/src/client.rs
+++ b/crates/wenlan-mcp/src/client.rs
@@ -6,9 +6,10 @@ use serde::{de::DeserializeOwned, Serialize};
 const DEFAULT_HTTP_URL: &str = "http://127.0.0.1:7878";
 
 /// Single source of truth for the space-lock header name.
-/// Mirrors the daemon's `X-Origin-Space` constant (HTTP normalises to lowercase).
+/// Mirrors the daemon's `X-Wenlan-Space` constant (daemon dual-reads the legacy x-origin-space).
+/// HTTP normalises to lowercase.
 pub fn space_header_name() -> &'static str {
-    "x-origin-space"
+    "x-wenlan-space"
 }
 
 /// Discover the Wenlan server URL.
@@ -105,7 +106,7 @@ impl WenlanClient {
     }
 
     /// Attach per-request headers common to all daemon calls:
-    /// `x-agent-name` (when set) and `x-origin-space` (when space is locked).
+    /// `x-agent-name` (when set) and `x-wenlan-space` (when space is locked).
     fn attach_common_headers(
         mut req: reqwest::RequestBuilder,
         agent: Option<&str>,

--- a/crates/wenlan-mcp/src/client.rs
+++ b/crates/wenlan-mcp/src/client.rs
@@ -223,11 +223,11 @@ impl WenlanClient {
         match compare(mcp_version, daemon_version) {
             VersionStatus::Compatible => None,
             VersionStatus::McpOutdated { mcp, daemon } => Some(format!(
-                "Your origin-mcp v{mcp} is older than the daemon v{daemon}. \
-                 Run `brew upgrade origin-mcp` (or `npm update -g origin-mcp`)."
+                "Your wenlan-mcp v{mcp} is older than the daemon v{daemon}. \
+                 Run `brew upgrade wenlan-mcp` (or `npm update -g wenlan-mcp`)."
             )),
             VersionStatus::DaemonOutdated { mcp, daemon } => Some(format!(
-                "The Wenlan daemon is running v{daemon} but origin-mcp v{mcp} is installed. \
+                "The Wenlan daemon is running v{daemon} but wenlan-mcp v{mcp} is installed. \
                  The daemon was not restarted after an upgrade. Run `wenlan restart` to load it."
             )),
         }

--- a/crates/wenlan-mcp/src/self_update_check.rs
+++ b/crates/wenlan-mcp/src/self_update_check.rs
@@ -110,8 +110,8 @@ pub async fn check() -> Option<String> {
     let latest = Version::parse(&latest_tag).ok()?;
     if latest > mcp {
         Some(format!(
-            "A newer origin-mcp is available (v{latest}, you are on v{mcp}). \
-             Run `brew upgrade origin-mcp`."
+            "A newer wenlan-mcp is available (v{latest}, you are on v{mcp}). \
+             Run `brew upgrade wenlan-mcp`."
         ))
     } else {
         None

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -564,7 +564,7 @@ Setup choices:
 
 Install:
   curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/install.sh | bash
-  export PATH=\"$HOME/.origin/bin:$PATH\"
+  export PATH=\"$HOME/.wenlan/bin:$PATH\"
   wenlan setup
   wenlan install
   wenlan status"

--- a/crates/wenlan-mcp/tests/serve_integration.rs
+++ b/crates/wenlan-mcp/tests/serve_integration.rs
@@ -303,7 +303,7 @@ async fn version_handshake_warns_when_daemon_minor_ahead() {
     let warning = client.version_handshake().await;
     assert!(warning.is_some(), "expected a warning when daemon ahead");
     let msg = warning.unwrap();
-    assert!(msg.contains("wenlan-mcp"), "msg={msg}");
+    assert!(msg.contains("origin-mcp"), "msg={msg}");
     assert!(msg.contains("brew upgrade origin-mcp"), "msg={msg}");
 }
 

--- a/crates/wenlan-mcp/tests/serve_integration.rs
+++ b/crates/wenlan-mcp/tests/serve_integration.rs
@@ -303,8 +303,8 @@ async fn version_handshake_warns_when_daemon_minor_ahead() {
     let warning = client.version_handshake().await;
     assert!(warning.is_some(), "expected a warning when daemon ahead");
     let msg = warning.unwrap();
-    assert!(msg.contains("origin-mcp"), "msg={msg}");
-    assert!(msg.contains("brew upgrade origin-mcp"), "msg={msg}");
+    assert!(msg.contains("wenlan-mcp"), "msg={msg}");
+    assert!(msg.contains("brew upgrade wenlan-mcp"), "msg={msg}");
 }
 
 #[tokio::test]

--- a/crates/wenlan-server/README.md
+++ b/crates/wenlan-server/README.md
@@ -7,10 +7,10 @@ Local daemon for Wenlan. It owns the database, embeddings, search, distill cycle
 Most users install Wenlan through the [Claude Code plugin](../../plugin/.claude-plugin/README.md), which auto-runs the install script the first time `/init` runs. This page is for daemon internals. For terminal setup, use the product CLI:
 
 ```bash
-npx -y @7xuanlu/origin setup
+npx -y wenlan setup
 ```
 
-The installer downloads `origin`, `origin-server`, and `origin-mcp` into `~/.origin/bin/`. Cross-platform: macOS (arm64, x64), Linux (x64, arm64; glibc), Windows (x64). The `origin` CLI owns setup and service management; `origin-server` is the daemon binary the host's service manager runs (launchd on macOS, systemd-user on Linux, Task Scheduler ONLOGON task on Windows).
+The installer downloads `wenlan`, `wenlan-server`, and `wenlan-mcp` into `~/.wenlan/bin/`. Cross-platform: macOS (arm64, x64), Linux (x64, arm64; glibc), Windows (x64). The `wenlan` CLI owns setup and service management; `wenlan-server` is the daemon binary the host's service manager runs (launchd on macOS, systemd-user on Linux, Task Scheduler ONLOGON task on Windows).
 
 ## Setup modes
 

--- a/crates/wenlan-server/README.md
+++ b/crates/wenlan-server/README.md
@@ -33,7 +33,7 @@ All user-facing data lives under `~/.wenlan/`:
 ~/.wenlan/sessions/            session logs by date (md, written by /handoff)
 ~/.wenlan/sessions/_status/    current per-project goals + last-handoff timestamps
 ~/.wenlan/db/                  symlink to the libSQL store
-~/.origin/bin/                 installed binaries
+~/.wenlan/bin/                 installed binaries
 ~/.wenlan/.git/                git repo — skills auto-commit per logical batch
 ```
 

--- a/crates/wenlan-server/src/space_header.rs
+++ b/crates/wenlan-server/src/space_header.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-//! `X-Origin-Space` HTTP header extractor.
+//! `X-Wenlan-Space` HTTP header extractor (dual-read for backward compat).
 //!
-//! When the request includes `X-Origin-Space: <name>`, this extractor
-//! returns `Some(name)`. Handlers use it as a fallback applied only when
-//! the request body omits the `space` field. Explicit body `space` always
-//! wins to preserve the user's per-call override path.
+//! Accepts both `X-Wenlan-Space: <name>` (new, preferred) and `X-Origin-Space: <name>` (legacy).
+//! Prefers the new header; falls back to legacy if only that is present.
+//! Handlers use it as a fallback applied only when the request body omits the `space` field.
+//! Explicit body `space` always wins to preserve the user's per-call override path.
 
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use std::convert::Infallible;
 
-pub const HEADER_NAME: &str = "x-origin-space";
+pub const HEADER_NAME: &str = "x-wenlan-space";
+pub const HEADER_NAME_LEGACY: &str = "x-origin-space";
 
 #[derive(Debug, Clone, Default)]
 pub struct SpaceHeader(pub Option<String>);
@@ -25,6 +26,7 @@ where
         let val = parts
             .headers
             .get(HEADER_NAME)
+            .or_else(|| parts.headers.get(HEADER_NAME_LEGACY))
             .and_then(|h| h.to_str().ok())
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
@@ -70,5 +72,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(val, None);
+    }
+
+    #[tokio::test]
+    async fn legacy_origin_header_still_read() {
+        let mut parts = build_parts(&[("X-Origin-Space", "career")]);
+        let SpaceHeader(val) = SpaceHeader::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+        assert_eq!(val.as_deref(), Some("career"));
+    }
+
+    #[tokio::test]
+    async fn wenlan_header_read() {
+        let mut parts = build_parts(&[("X-Wenlan-Space", "health")]);
+        let SpaceHeader(val) = SpaceHeader::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+        assert_eq!(val.as_deref(), Some("health"));
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Origin installer — downloads Origin runtime binaries to ~/.origin/bin/
+# Wenlan installer — downloads Wenlan runtime binaries to ~/.wenlan/bin/
 # Usage:      curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/install.sh | bash
-# Prerelease: curl -fsSL ... | ORIGIN_RELEASE_TAG=v0.2.0-alpha.1 bash
+# Prerelease: curl -fsSL ... | WENLAN_RELEASE_TAG=v0.2.0-alpha.1 bash
 #
-# Supported platforms: macOS (arm64, x86_64), Linux (aarch64, x86_64).
-# Windows users: download origin-windows-x64.zip from the GitHub release page.
+# Supported platforms: macOS (arm64), Linux (aarch64, x86_64).
+# Windows users: download wenlan-windows-x64.zip from the GitHub release page.
 
 REPO="7xuanlu/origin"
-REQUESTED_TAG="${ORIGIN_RELEASE_TAG:-${ORIGIN_TAG:-}}"
+REQUESTED_TAG="${WENLAN_RELEASE_TAG:-${WENLAN_TAG:-${ORIGIN_RELEASE_TAG:-${ORIGIN_TAG:-}}}}"
 
 if [[ -n "${REQUESTED_TAG}" ]]; then
   SAFE_TAG="$(printf '%s' "${REQUESTED_TAG}" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
-  BIN_DIR="${HOME}/.origin/releases/${SAFE_TAG}"
+  BIN_DIR="${HOME}/.wenlan/releases/${SAFE_TAG}"
   API_URL="https://api.github.com/repos/${REPO}/releases/tags/${REQUESTED_TAG}"
   RELEASE_PAGE="https://github.com/${REPO}/releases/tag/${REQUESTED_TAG}"
 else
-  BIN_DIR="${HOME}/.origin/bin"
+  BIN_DIR="${HOME}/.wenlan/bin"
   API_URL="https://api.github.com/repos/${REPO}/releases/latest"
   RELEASE_PAGE="https://github.com/${REPO}/releases"
 fi
@@ -49,15 +49,14 @@ OS="$(uname -s)"
 ARCH="$(uname -m)"
 
 case "${OS}-${ARCH}" in
-  Darwin-arm64)         ASSET="origin-darwin-arm64.tar.gz" ;;
-  Darwin-x86_64)        ASSET="origin-darwin-x64.tar.gz" ;;
+  Darwin-arm64)         ASSET="wenlan-darwin-arm64.tar.gz" ;;
   Linux-aarch64|Linux-arm64)
-                        ASSET="origin-linux-arm64.tar.gz" ;;
-  Linux-x86_64)         ASSET="origin-linux-x64.tar.gz" ;;
+                        ASSET="wenlan-linux-arm64.tar.gz" ;;
+  Linux-x86_64)         ASSET="wenlan-linux-x64.tar.gz" ;;
   *)
     die "Unsupported platform: ${OS}-${ARCH}
-Supported: Darwin-arm64, Darwin-x86_64, Linux-aarch64, Linux-x86_64.
-For Windows, download origin-windows-x64.zip from the GitHub release page:
+Supported: Darwin-arm64, Linux-aarch64, Linux-x86_64.
+For Windows, download wenlan-windows-x64.zip from the GitHub release page:
   ${RELEASE_PAGE}"
     ;;
 esac
@@ -104,7 +103,7 @@ ok "Extracted"
 
 # ── Install binaries ─────────────────────────────────────────────────────────
 
-for bin in origin origin-server origin-mcp; do
+for bin in wenlan wenlan-server wenlan-mcp; do
   if [[ ! -f "${TMP_DIR}/${bin}" ]]; then
     die "Archive ${ASSET} missing expected binary: ${bin}"
   fi
@@ -113,26 +112,26 @@ done
 
 # Clear macOS quarantine attribute (unsigned binaries downloaded from the internet)
 if [[ "${OS}" == "Darwin" ]]; then
-  xattr -cr "${BIN_DIR}/origin"        2>/dev/null || true
-  xattr -cr "${BIN_DIR}/origin-server" 2>/dev/null || true
-  xattr -cr "${BIN_DIR}/origin-mcp"    2>/dev/null || true
+  xattr -cr "${BIN_DIR}/wenlan"        2>/dev/null || true
+  xattr -cr "${BIN_DIR}/wenlan-server" 2>/dev/null || true
+  xattr -cr "${BIN_DIR}/wenlan-mcp"    2>/dev/null || true
 fi
 
-ok "Installed origin, origin-server, origin-mcp to ${BIN_DIR}"
+ok "Installed wenlan, wenlan-server, wenlan-mcp to ${BIN_DIR}"
 
 # ── PATH setup ────────────────────────────────────────────────────────────────
 
 add_to_path() {
   local rc_file="$1"
-  local line='export PATH="${HOME}/.origin/bin:${PATH}"'
+  local line='export PATH="${HOME}/.wenlan/bin:${PATH}"'
 
-  if [[ -f "${rc_file}" ]] && grep -qF '.origin/bin' "${rc_file}"; then
-    ok "${rc_file} already has ~/.origin/bin in PATH — skipping"
+  if [[ -f "${rc_file}" ]] && grep -qF '.wenlan/bin' "${rc_file}"; then
+    ok "${rc_file} already has ~/.wenlan/bin in PATH — skipping"
     return
   fi
 
-  printf '\n# Added by Origin installer\n%s\n' "${line}" >> "${rc_file}"
-  ok "Added ~/.origin/bin to PATH in ${rc_file}"
+  printf '\n# Added by Wenlan installer\n%s\n' "${line}" >> "${rc_file}"
+  ok "Added ~/.wenlan/bin to PATH in ${rc_file}"
 }
 
 # Detect current shell and preferred rc file
@@ -157,14 +156,14 @@ export PATH="${BIN_DIR}:${PATH}"
 
 if [[ -n "${REQUESTED_TAG}" ]]; then
   EXACT_RUNTIME_PORT="$(derive_isolated_port "${REQUESTED_TAG}")"
-  EXACT_RUNTIME_DATA_DIR="${HOME}/Library/Application Support/origin/releases/${SAFE_TAG}"
+  EXACT_RUNTIME_DATA_DIR="${HOME}/Library/Application Support/wenlan/releases/${SAFE_TAG}"
 fi
 
 # ── Next steps ────────────────────────────────────────────────────────────────
 
 printf '\n'
 printf '\033[1;32m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n'
-printf '\033[1;32m  Origin installed successfully!\033[0m\n'
+printf '\033[1;32m  Wenlan installed successfully!\033[0m\n'
 printf '\033[1;32m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n'
 printf '\n'
 printf 'Next steps:\n\n'
@@ -173,24 +172,24 @@ if [[ -z "${REQUESTED_TAG}" ]]; then
   printf '\n'
   printf '       source %s\n' "${RC_FILE}"
   printf '\n'
-  printf '  2. Set up Origin:\n'
+  printf '  2. Set up Wenlan:\n'
   printf '\n'
-  printf '       origin setup --basic\n'
+  printf '       wenlan setup --basic\n'
   printf '\n'
-  printf '  3. Register Origin as a background service (launchd):\n'
+  printf '  3. Register Wenlan as a background service (launchd):\n'
   printf '\n'
-  printf '       origin install\n'
+  printf '       wenlan install\n'
   printf '\n'
   printf '  4. Verify the daemon and memory setup:\n'
   printf '\n'
-  printf '       origin status\n'
+  printf '       wenlan status\n'
   printf '\n'
   printf '  5. Add the MCP server to Claude Desktop or Cursor:\n'
   printf '\n'
   printf '       {\n'
   printf '         "mcpServers": {\n'
-  printf '           "origin": {\n'
-  printf '             "command": "%s/origin-mcp"\n' "${BIN_DIR}"
+  printf '           "wenlan": {\n'
+  printf '             "command": "%s/wenlan-mcp"\n' "${BIN_DIR}"
   printf '           }\n'
   printf '         }\n'
   printf '       }\n'
@@ -204,14 +203,14 @@ else
   printf '\n'
   printf '  2. Start this exact tagged daemon in an isolated runtime:\n'
   printf '\n'
-  printf '       origin-server --port %s --data-dir "%s"\n' "${EXACT_RUNTIME_PORT}" "${EXACT_RUNTIME_DATA_DIR}"
+  printf '       wenlan-server --port %s --data-dir "%s"\n' "${EXACT_RUNTIME_PORT}" "${EXACT_RUNTIME_DATA_DIR}"
   printf '\n'
   printf '  3. Add this exact-release MCP server to Claude Desktop or Cursor:\n'
   printf '\n'
   printf '       {\n'
   printf '         "mcpServers": {\n'
-  printf '           "origin-exact": {\n'
-  printf '             "command": "%s/origin-mcp",\n' "${BIN_DIR}"
+  printf '           "wenlan-exact": {\n'
+  printf '             "command": "%s/wenlan-mcp",\n' "${BIN_DIR}"
   printf '             "args": ["--origin-url", "http://127.0.0.1:%s"]\n' "${EXACT_RUNTIME_PORT}"
   printf '           }\n'
   printf '         }\n'
@@ -219,14 +218,14 @@ else
   printf '\n'
   printf '     Data dir: %s\n' "${EXACT_RUNTIME_DATA_DIR}"
   printf '\n'
-  printf '  4. Do not run origin install for exact tagged installs.\n'
+  printf '  4. Do not run wenlan install for exact tagged installs.\n'
   printf '\n'
-  printf '     That replaces the stable com.origin.server LaunchAgent.\n'
+  printf '     That replaces the stable com.wenlan.server LaunchAgent.\n'
   printf '\n'
 fi
-printf '\033[1;33mNote:\033[0m Origin can store and retrieve memories without a local model or API key.\n'
-printf '      Distill cycles are opt-in with `origin model install`.\n'
-printf '      Anthropic can be configured with `origin key set anthropic`.\n'
+printf '\033[1;33mNote:\033[0m Wenlan can store and retrieve memories without a local model or API key.\n'
+printf '      Distill cycles are opt-in with `wenlan model install`.\n'
+printf '      Anthropic can be configured with `wenlan key set anthropic`.\n'
 if [[ -n "${REQUESTED_TAG}" ]]; then
   printf '      Manual release page for this install: %s\n' "${RELEASE_PAGE}"
 fi

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "origin": {
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/origin-mcp-runner.sh"
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/wenlan-mcp-runner.sh"
     }
   }
 }

--- a/plugin/bin/wenlan-mcp-runner.sh
+++ b/plugin/bin/wenlan-mcp-runner.sh
@@ -1,38 +1,40 @@
 #!/usr/bin/env bash
-# Dispatch the origin MCP server.
+# Dispatch the wenlan MCP server.
 #
 # Resolution order (most specific first):
-#   1. Sibling file `bin/origin-mcp.local` next to this script — typically a
-#      symlink to a locally-built origin-mcp binary. Filesystem-based so it
+#   1. Sibling file `bin/wenlan-mcp.local` next to this script — typically a
+#      symlink to a locally-built wenlan-mcp binary. Filesystem-based so it
 #      survives plugin reloads that don't re-read settings.json env.
-#   2. ORIGIN_MCP_DEV_BIN env var — secondary, kept for shells that already
-#      export it. Requires Claude Code to inherit the var at startup.
-#   3. ~/.origin/bin/origin-mcp — the path install.sh places binaries at.
+#   2. WENLAN_MCP_DEV_BIN env var (primary) or ORIGIN_MCP_DEV_BIN (fallback) —
+#      secondary, kept for shells that already export them. Requires Claude Code
+#      to inherit the var at startup. Accepts both for backward compatibility.
+#   3. ~/.wenlan/bin/wenlan-mcp — the path install.sh places binaries at.
 #      Preferred over npx because (a) it's already on disk so MCP host
 #      handshake is instant, and (b) it sidesteps the EPERM class of npx
 #      failures when ~/.npm/_cacache contains root-owned files left over
 #      from older npm versions (npx exits before responding to initialize,
 #      MCP host then waits 30s and times out).
-#   4. npx -y origin-mcp@^0.8.6 — fallback for users who installed the
+#   4. npx -y wenlan-mcp@^0.8.6 — fallback for users who installed the
 #      plugin without running install.sh.
 
 # Don't enable `set -u` here: if Claude Code (or any MCP host) invokes the
 # script through a shell that doesn't populate BASH_SOURCE, `set -u` halts
 # before we even get to the npx fallback. Fall back to $0 instead.
 here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd -P)"
-local_bin="${here}/origin-mcp.local"
+local_bin="${here}/wenlan-mcp.local"
 
 if [ -x "${local_bin}" ]; then
   exec "${local_bin}" "$@"
 fi
 
-if [ -n "${ORIGIN_MCP_DEV_BIN:-}" ] && [ -x "${ORIGIN_MCP_DEV_BIN}" ]; then
-  exec "${ORIGIN_MCP_DEV_BIN}" "$@"
+dev_bin="${WENLAN_MCP_DEV_BIN:-${ORIGIN_MCP_DEV_BIN:-}}"
+if [ -n "${dev_bin}" ] && [ -x "${dev_bin}" ]; then
+  exec "${dev_bin}" "$@"
 fi
 
-installed_bin="${HOME}/.origin/bin/origin-mcp"
+installed_bin="${HOME}/.wenlan/bin/wenlan-mcp"
 if [ -x "${installed_bin}" ]; then
   exec "${installed_bin}" "$@"
 fi
 
-exec npx -y origin-mcp@^0.8.6 "$@"
+exec npx -y wenlan-mcp@^0.8.6 "$@"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -52,18 +52,17 @@ mv "${PLUGIN_MANIFEST}.tmp" "$PLUGIN_MANIFEST"
 echo "  Updated $PLUGIN_MANIFEST"
 
 # 4. Plugin's MCP server pin — the wrapper script falls back to
-# `npx -y origin-mcp@^X.Y.Z` so a floating tag can't auto-RCE on every
+# `npx -y wenlan-mcp@^X.Y.Z` so a floating tag can't auto-RCE on every
 # Claude Code session. The pin lives in the runner shell script, not
-# .mcp.json, so dev users can override the binary via ORIGIN_MCP_DEV_BIN.
-# (npm publish identity `origin-mcp` + the runner filename stay frozen until
-# the Phase-5 publish cutover; only the version pin is bumped here.)
-PLUGIN_MCP_RUNNER="plugin/bin/origin-mcp-runner.sh"
+# .mcp.json, so dev users can override the wenlan-mcp binary via
+# WENLAN_MCP_DEV_BIN.
+PLUGIN_MCP_RUNNER="plugin/bin/wenlan-mcp-runner.sh"
 if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' -E "s|(origin-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$PLUGIN_MCP_RUNNER"
+    sed -i '' -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$PLUGIN_MCP_RUNNER"
 else
-    sed -i -E "s|(origin-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$PLUGIN_MCP_RUNNER"
+    sed -i -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$PLUGIN_MCP_RUNNER"
 fi
-echo "  Updated $PLUGIN_MCP_RUNNER (origin-mcp pin)"
+echo "  Updated $PLUGIN_MCP_RUNNER (wenlan-mcp pin)"
 
 # 5. /init skill install.sh URL pinned to current tag (not `main`), so the
 # install one-liner is reproducible at the release boundary.

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -27,7 +27,7 @@ wenlan-core  = { path = "crates/wenlan-core",  version = "0.4.1" }
 EOF
 
 cat > "$TMPDIR_TEST/crates/wenlan-mcp/npm/package.json" <<EOF
-{"name": "origin-mcp", "version": "0.4.1"}
+{"name": "wenlan-mcp", "version": "0.4.1"}
 EOF
 
 cat > "$TMPDIR_TEST/crates/wenlan-cli/npm/package.json" <<EOF
@@ -38,8 +38,8 @@ cat > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json" <<EOF
 {"name": "origin", "version": "0.4.1"}
 EOF
 
-cat > "$TMPDIR_TEST/plugin/bin/origin-mcp-runner.sh" <<EOF
-exec npx -y origin-mcp@^0.4.1 "\$@"
+cat > "$TMPDIR_TEST/plugin/bin/wenlan-mcp-runner.sh" <<EOF
+exec npx -y wenlan-mcp@^0.4.1 "\$@"
 EOF
 
 cat > "$TMPDIR_TEST/plugin/skills/init/SKILL.md" <<EOF
@@ -105,7 +105,7 @@ PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json")
 [[ "$MCP_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: wenlan-mcp npm not bumped (got $MCP_NPM_VER)"; exit 1; }
 [[ "$WENLAN_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: wenlan npm not bumped (got $WENLAN_NPM_VER)"; exit 1; }
 [[ "$PLUGIN_VER" == "0.5.0" ]] || { echo "FAIL: plugin not bumped (got $PLUGIN_VER)"; exit 1; }
-grep -q 'origin-mcp@\^0.5.0' "$TMPDIR_TEST/plugin/bin/origin-mcp-runner.sh" || { echo "FAIL: runner pin not bumped"; exit 1; }
+grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin/bin/wenlan-mcp-runner.sh" || { echo "FAIL: runner pin not bumped"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin/skills/init/SKILL.md" || { echo "FAIL: init skill installer not bumped"; exit 1; }
 
 # Cargo.lock: all five workspace members bumped to 0.5.0, exactly as

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -31,7 +31,7 @@ cat > "$TMPDIR_TEST/crates/wenlan-mcp/npm/package.json" <<EOF
 EOF
 
 cat > "$TMPDIR_TEST/crates/wenlan-cli/npm/package.json" <<EOF
-{"name": "@7xuanlu/origin", "version": "0.4.1"}
+{"name": "wenlan", "version": "0.4.1"}
 EOF
 
 cat > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json" <<EOF
@@ -103,7 +103,7 @@ PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json")
 [[ "$WENLAN_TYPES_DEP_VER" == "0.5.0" ]] || { echo "FAIL: wenlan-types dep not bumped (got $WENLAN_TYPES_DEP_VER)"; exit 1; }
 [[ "$WENLAN_CORE_DEP_VER" == "0.5.0" ]] || { echo "FAIL: wenlan-core dep not bumped (got $WENLAN_CORE_DEP_VER)"; exit 1; }
 [[ "$MCP_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: wenlan-mcp npm not bumped (got $MCP_NPM_VER)"; exit 1; }
-[[ "$WENLAN_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: @7xuanlu/origin npm not bumped (got $WENLAN_NPM_VER)"; exit 1; }
+[[ "$WENLAN_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: wenlan npm not bumped (got $WENLAN_NPM_VER)"; exit 1; }
 [[ "$PLUGIN_VER" == "0.5.0" ]] || { echo "FAIL: plugin not bumped (got $PLUGIN_VER)"; exit 1; }
 grep -q 'origin-mcp@\^0.5.0' "$TMPDIR_TEST/plugin/bin/origin-mcp-runner.sh" || { echo "FAIL: runner pin not bumped"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin/skills/init/SKILL.md" || { echo "FAIL: init skill installer not bumped"; exit 1; }

--- a/scripts/release-artifact-chain.test.sh
+++ b/scripts/release-artifact-chain.test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+release_yml=".github/workflows/release.yml"
+cli_runner="crates/wenlan-cli/npm/run.js"
+
+expected_darwin_asset="wenlan-darwin-arm64.tar.gz"
+
+grep -q "artifact_name: wenlan-darwin-arm64" "$release_yml" \
+  || fail "release.yml does not produce wenlan-darwin-arm64"
+
+grep -q "const ASSET = \"${expected_darwin_asset}\"" "$cli_runner" \
+  || fail "npm wenlan runner does not download ${expected_darwin_asset}"
+
+if grep -q '\${name}-\${TARGET}' "$cli_runner"; then
+  fail "npm wenlan runner still downloads per-binary target-name assets"
+fi
+
+echo "PASS: npm wenlan runner consumes release.yml darwin-arm64 artifact"

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -37,7 +37,7 @@ echo "wenlan-core dep:  $WENLAN_CORE_DEP_VER"
 echo "Cargo.lock:"
 printf '%s\n' "$LOCK_VERSIONS" | sed 's/^/  /'
 echo "wenlan-mcp npm: $MCP_NPM_VER"
-echo "@7xuanlu/origin npm: $WENLAN_NPM_VER"
+echo "wenlan npm: $WENLAN_NPM_VER"
 echo "Plugin:      $PLUGIN_VER"
 
 if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$WENLAN_TYPES_DEP_VER" != "$TAG_VER" || "$WENLAN_CORE_DEP_VER" != "$TAG_VER" || "$MCP_NPM_VER" != "$TAG_VER" || "$WENLAN_NPM_VER" != "$TAG_VER" || "$PLUGIN_VER" != "$TAG_VER" ]]; then

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -19,7 +19,7 @@ LOCK_VERSIONS=$(awk '
   in_pkg && $1 == "version" && $2 == "=" {
     version=$3
     gsub(/"/, "", version)
-    if (name == "origin" || name == "wenlan-core" || name == "wenlan-mcp" || name == "wenlan-server" || name == "wenlan-types") {
+    if (name == "wenlan" || name == "wenlan-core" || name == "wenlan-mcp" || name == "wenlan-server" || name == "wenlan-types") {
       print name ":" version
     }
     in_pkg=0
@@ -45,7 +45,7 @@ if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$WENLAN_TYPES_DEP
     exit 1
 fi
 
-for crate in origin wenlan-core wenlan-mcp wenlan-server wenlan-types; do
+for crate in wenlan wenlan-core wenlan-mcp wenlan-server wenlan-types; do
     if ! printf '%s\n' "$LOCK_VERSIONS" | grep -qx "${crate}:${TAG_VER}"; then
         echo "ERROR: Cargo.lock drift — ${crate} is not ${TAG_VER}"
         exit 1

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -16,7 +16,7 @@ wenlan-core  = { path = "crates/wenlan-core",  version = "0.5.0" }
 EOF
 cat > "$TMPDIR_TEST/Cargo.lock" <<EOF
 [[package]]
-name = "origin"
+name = "wenlan"
 version = "0.5.0"
 
 [[package]]


### PR DESCRIPTION
Completes the origin→wenlan rename: flips every **publish/distribution identity** so a `v0.9.0` release tag builds, tests, and publishes the wenlan packages cleanly. Part of the 0.9.0 rebrand release.

## What flips (origin → wenlan)
- **release.yml** (all 3 jobs): build `-p wenlan*`, artifact/tarball names, crates-publish `-p wenlan-types/-mcp`, npm dirs `crates/wenlan-{mcp,cli}/npm`, ghcr, homebrew tarball, repo-slug URLs.
- **npm manifests**: `@7xuanlu/origin`→`wenlan`, `origin-mcp`→`wenlan-mcp` (names + bins).
- **install.sh**: bins, `~/.origin/bin`→`~/.wenlan/bin`, `com.origin.server`→`com.wenlan.server` (data-dir auto-migrates via `migrate_rename.rs`).
- **self-update hints + serve_integration**, **plugin runner** rename, **bump-version** script + fixture, **READMEs**.

## Kept intentionally (5E / additive)
- `/origin:` MCP namespace + plugin `name` (5E, separate repo).
- `env_compat` (`WENLAN_*`→`ORIGIN_*` fallback) + `x-origin-space` dual-read + `--origin-url` flag.

## Verification (local, sccache-off)
`cargo test --workspace` ✅ (incl. distribution.rs 4✓, serve_integration 10✓, space_header_fallback 9✓, drift_guard ✅) · `build --release` ✅ · `fmt`/`clippy` ✅ · `bump-version` test + empty-diff ✅ · `npm pack` ✅ · `actionlint` ✅ · `cargo publish --dry-run -p wenlan-types` ✅. (`wenlan-mcp` dry-run resolves `wenlan-types` from crates.io — gated until types is published; release.yml publishes types first.)

> ⚠️ Merging the **0.9.0 release PR** after this cuts the tag that publishes `wenlan`/`wenlan-mcp`/`wenlan-types` — an irreversible first-time name claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)