### PR TITLE
fix: CLI MCP server handle origin → wenlan (+ drop tracked ffmpeg2pass junk)

### DIFF
--- a/crates/wenlan-cli/src/commands/mcp.rs
+++ b/crates/wenlan-cli/src/commands/mcp.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const SERVER_NAME: &str = "origin";
+const SERVER_NAME: &str = "wenlan";
 const FALLBACK_SERVER_COMMAND: &str = "npx";
 const FALLBACK_SERVER_ARGS: [&str; 2] = ["-y", "wenlan-mcp"];
 

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -233,7 +233,7 @@ fn mcp_add_claude_code_dry_run_explains_tools_only() {
         .assert()
         .success()
         .stdout(predicate::str::contains(format!(
-            "claude mcp add -s user origin -- {}",
+            "claude mcp add -s user wenlan -- {}",
             origin_mcp_sibling_arg()
         )))
         .stdout(predicate::str::contains("MCP tools only"))
@@ -250,17 +250,17 @@ fn mcp_add_native_clients_run_add_without_destructive_remove() {
         (
             "claude-code",
             "claude",
-            format!("claude\tmcp\tadd\t-s\tuser\torigin\t--\t{wenlan_mcp}\n"),
+            format!("claude\tmcp\tadd\t-s\tuser\twenlan\t--\t{wenlan_mcp}\n"),
         ),
         (
             "codex",
             "codex",
-            format!("codex\tmcp\tadd\torigin\t--\t{wenlan_mcp}\n"),
+            format!("codex\tmcp\tadd\twenlan\t--\t{wenlan_mcp}\n"),
         ),
         (
             "gemini",
             "gemini",
-            format!("gemini\tmcp\tadd\t-s\tuser\torigin\t{wenlan_mcp}\n"),
+            format!("gemini\tmcp\tadd\t-s\tuser\twenlan\t{wenlan_mcp}\n"),
         ),
     ];
 
@@ -286,13 +286,13 @@ fn mcp_add_native_clients_run_add_without_destructive_remove() {
 }
 
 #[test]
-fn mcp_add_cursor_preserves_existing_servers_and_backs_up_changed_origin() {
+fn mcp_add_cursor_preserves_existing_servers_and_backs_up_changed_wenlan() {
     let runtime = IsolatedRuntime::new();
     let config_path = runtime.home.path().join(".cursor/mcp.json");
     fs::create_dir_all(config_path.parent().expect("cursor config parent")).unwrap();
     fs::write(
         &config_path,
-        r#"{"mcpServers":{"origin":{"command":"old-origin"},"other":{"command":"other-cmd"}}}"#,
+        r#"{"mcpServers":{"wenlan":{"command":"old-wenlan"},"other":{"command":"other-cmd"}}}"#,
     )
     .unwrap();
 
@@ -325,11 +325,11 @@ fn mcp_add_cursor_preserves_existing_servers_and_backs_up_changed_origin() {
         .collect();
     assert_eq!(backups.len(), 1, "expected one backup");
     let backup = fs::read_to_string(backups[0].path()).expect("backup content");
-    assert!(backup.contains("old-origin"), "{backup}");
+    assert!(backup.contains("old-wenlan"), "{backup}");
 }
 
 #[test]
-fn mcp_add_cursor_dry_run_prints_only_origin_block() {
+fn mcp_add_cursor_dry_run_prints_only_wenlan_block() {
     let runtime = IsolatedRuntime::new();
     let config_path = runtime.home.path().join(".cursor/mcp.json");
     fs::create_dir_all(config_path.parent().expect("cursor config parent")).unwrap();
@@ -343,7 +343,7 @@ fn mcp_add_cursor_dry_run_prints_only_origin_block() {
         .args(["mcp", "add", "cursor", "--dry-run"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("mcpServers.origin"))
+        .stdout(predicate::str::contains("mcpServers.wenlan"))
         .stdout(predicate::str::contains("wenlan-mcp"))
         .stdout(predicate::str::contains("SECRET_TOKEN").not())
         .stdout(predicate::str::contains("secret-tool").not());

--- a/crates/wenlan-cli/tests/distribution.rs
+++ b/crates/wenlan-cli/tests/distribution.rs
@@ -171,6 +171,6 @@ fn smoke_codex_mcp_add_uses_temp_home() {
         config.display()
     );
     let text = fs::read_to_string(config).expect("read Codex config");
-    assert!(text.contains("origin"), "{text}");
+    assert!(text.contains("wenlan"), "{text}");
     assert!(text.contains("wenlan-mcp"), "{text}");
 }


### PR DESCRIPTION
`wenlan mcp add` registered the server as `origin`; aligns it to `wenlan` (manifest + daemon already use it) and updates the golden/integration tests that pinned the old name. Also drops a 22.9 MB `ffmpeg2pass-0.log.mbtree` that was accidentally tracked.

Verified locally: `cli_integration` 21/21, `distribution` 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)