### PR TITLE
ci: don't cancel in-progress CI on main so the L6 eval canary always completes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PRs: cancel superseded pushes to save runner time. main: never cancel, so
+  # every code-push's L6 eval canary runs to completion. A cancelled canary plus
+  # a release commit that skips the test job left 0.9.1 with no canary run.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## What

Keep `cancel-in-progress` on PRs (runner-time saver), but never cancel on `main`.

```diff
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

## Why

The L6 embedding-only eval canary lives inside the `test` job. Two things combined to leave **0.9.1 with no canary run**:

1. The `test` job is guarded `!startsWith(head_commit.message, 'chore(main): release')`, so the release commit itself skips it (correct — release commits only bump version files, code-identical to the prior commit).
2. `cancel-in-progress: true` cancelled the preceding non-release main pushes (#293, #294) mid-run.

Net: the shipped code never got its canary. This fixes the root cause — every main code-push now runs CI (incl. the canary) to completion. PRs still cancel superseded runs.

Verified: `workflow_dispatch` run [28111000100](https://github.com/7xuanlu/wenlan/actions/runs/28111000100) ran the canary green against the 0.9.1 tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)