### PR TITLE
fix: repair stale wenlan plugin runtime

### DIFF
--- a/crates/wenlan-types/tests/plugin_distribution.rs
+++ b/crates/wenlan-types/tests/plugin_distribution.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Lightweight plugin distribution contract tests.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("wenlan-types is nested under crates/")
+        .to_path_buf()
+}
+
+fn read_text(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()))
+}
+
+#[test]
+fn plugin_init_repairs_stale_daemon_versions() {
+    let init = read_text("plugin/skills/init/SKILL.md");
+    let hook = read_text("plugin/hooks/check-daemon.sh");
+
+    for needle in [
+        "Compare daemon version vs plugin manifest version",
+        "If mismatch, repair the runtime",
+        "curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v${EXPECTED_VER}/install.sh | bash",
+        "export PATH=\"$HOME/.wenlan/bin:$PATH\" && wenlan setup --basic && wenlan install",
+    ] {
+        assert!(
+            init.contains(needle),
+            "/init missing stale-daemon repair contract: {needle}"
+        );
+    }
+
+    assert!(
+        hook.contains("Run /wenlan:init to repair"),
+        "SessionStart hook should direct version mismatches to the self-healing /init entrypoint"
+    );
+    assert!(
+        !hook.contains("Otherwise upgrade: curl -fsSL"),
+        "SessionStart hook should not print raw upgrade commands when /init owns repair"
+    );
+    assert!(
+        hook.contains("for i in 1 2 3") && hook.contains("curl -fsS -m 3"),
+        "SessionStart hook should retry daemon health checks to avoid false down reports"
+    );
+}

--- a/plugin/hooks/check-daemon.sh
+++ b/plugin/hooks/check-daemon.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env bash
 # SessionStart hook: probe the local Wenlan daemon and surface two issues:
 #   1. Daemon not running → point user at /wenlan:init (it auto-installs).
-#   2. Daemon version mismatches the plugin manifest → print the upgrade
-#      one-liner directly so the user can copy-paste.
+#   2. Daemon version mismatches the plugin manifest → point user at
+#      /wenlan:init (it upgrades/restarts and verifies the runtime).
 # Hook never blocks (always exit 0) and never prints command soup.
 set -u
 
 URL="http://127.0.0.1:7878/api/health"
 PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
 
-RESP=$(curl -fsS -m 1 "$URL" 2>/dev/null) || {
+RESP=""
+for i in 1 2 3; do
+  RESP=$(curl -fsS -m 3 "$URL" 2>/dev/null) && break
+  sleep 1
+done
+
+if [ -z "$RESP" ]; then
   cat <<MSG
 [wenlan] daemon not running. Run /wenlan:init to set up.
 MSG
   exit 0
-}
+fi
 
 # Compare daemon version vs plugin manifest version. Silent unless mismatch.
 [ -r "$PLUGIN_JSON" ] || exit 0
@@ -30,8 +36,7 @@ EXPECTED_VER=$(extract_version <"$PLUGIN_JSON")
 if [ -n "$DAEMON_VER" ] && [ -n "$EXPECTED_VER" ] && [ "$DAEMON_VER" != "$EXPECTED_VER" ]; then
   cat <<MSG
 [wenlan] daemon v${DAEMON_VER}, plugin expects v${EXPECTED_VER}.
-  If you already upgraded, the daemon may not have restarted. Run: wenlan restart
-  Otherwise upgrade: curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v${EXPECTED_VER}/install.sh | bash
+  Run /wenlan:init to repair. It will upgrade/restart the runtime and verify MCP.
 MSG
 fi
 

--- a/plugin/skills/init/SKILL.md
+++ b/plugin/skills/init/SKILL.md
@@ -23,11 +23,32 @@ attention. Otherwise, push through automatically.
 ### 1. Daemon health probe
 
 ```
-Bash: curl -fsS -m 1 http://127.0.0.1:7878/api/health
+Bash: for i in 1 2 3; do curl -fsS -m 3 http://127.0.0.1:7878/api/health && break; sleep 1; done
 ```
 
-- 200 OK → skip to step 4.
+- 200 OK → continue to version drift probe.
 - Anything else → step 2.
+
+### 1.5. Version drift probe
+
+Compare daemon version vs plugin manifest version:
+
+```
+Bash: PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"; if command -v python3 >/dev/null 2>&1 && [ -r "$PLUGIN_JSON" ]; then RESP="$(curl -fsS -m 3 http://127.0.0.1:7878/api/health)"; DAEMON_VER="$(printf '%s' "$RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("version",""))')"; EXPECTED_VER="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' "$PLUGIN_JSON")"; printf 'daemon=%s expected=%s\n' "$DAEMON_VER" "$EXPECTED_VER"; else echo "version_check=skipped"; fi
+```
+
+- Same version → skip to step 4.
+- If `PLUGIN_JSON` is unreadable or `python3` is missing, skip to step 4;
+  the daemon is healthy and the hook will keep surfacing a mismatch if one
+  exists.
+- If mismatch, repair the runtime (no human prompts):
+
+```
+Bash: PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"; EXPECTED_VER="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version",""))' "$PLUGIN_JSON")"; curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v${EXPECTED_VER}/install.sh | bash
+Bash: export PATH="$HOME/.wenlan/bin:$PATH" && wenlan setup --basic && wenlan install
+```
+
+Then continue to step 3.
 
 ### 2. Bootstrap (auto-install if missing)
 
@@ -62,7 +83,7 @@ writes the launchd plist and starts the daemon.
 ### 3. Re-probe daemon health
 
 ```
-Bash: for i in 1 2 3 4 5; do curl -fsS -m 1 http://127.0.0.1:7878/api/health && break; sleep 1; done
+Bash: for i in 1 2 3 4 5; do curl -fsS -m 3 http://127.0.0.1:7878/api/health && break; sleep 1; done
 ```
 
 If the daemon still isn't reachable after ~5s, surface the error and stop.
@@ -122,6 +143,7 @@ work in local memory mode.
 
 - Right after `/plugin install wenlan@7xuanlu`.
 - Hook printed "daemon down — run /wenlan:init".
+- Hook printed "Run /wenlan:init to repair" for a version mismatch.
 - User says "set up wenlan", "is it working", "reinstall wenlan".
 
 ## When NOT to use


### PR DESCRIPTION
## What changed

- Route stale daemon/plugin version mismatches through `/wenlan:init` instead of printing raw upgrade commands from the SessionStart hook.
- Teach `/wenlan:init` to compare daemon health version with the plugin manifest and repair the installed runtime when they differ.
- Add a lightweight plugin distribution contract test under `wenlan-types` so this check does not compile the full CLI/core dependency graph.

## Why

The hook could detect version drift, but repair was left to the user through manual command output. The plugin now has one repair interface: `/wenlan:init`.

## Verification

- `cargo fmt --all -- --check`
- `env CARGO_TARGET_DIR=/private/tmp/wenlan-pr-target RUSTC_WRAPPER= CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 cargo test -p wenlan-types --test plugin_distribution plugin_init_repairs_stale_daemon_versions -- --nocapture`
- `env CLAUDE_PLUGIN_ROOT=/Users/lucian/Repos/wenlan/.worktrees/wenlan-plugin-self-repair/plugin plugin/hooks/check-daemon.sh`
- fake mismatch smoke with plugin version `9.9.9` prints `Run /wenlan:init to repair` and no raw upgrade command
- `/init` version probe prints `daemon=0.9.1 expected=0.9.1`
