### PR TITLE
fix: include document tag map in tags response

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -6734,6 +6734,32 @@ impl MemoryDB {
         Ok(out)
     }
 
+    /// List tags grouped by frontend document key (`source::source_id`).
+    pub async fn list_document_tags(&self) -> Result<HashMap<String, Vec<String>>, WenlanError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT source, source_id, tag FROM document_tags ORDER BY source, source_id, tag",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("list_document_tags: {e}")))?;
+        let mut out: HashMap<String, Vec<String>> = HashMap::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+        {
+            let source: String = row.get(0).unwrap_or_default();
+            let source_id: String = row.get(1).unwrap_or_default();
+            let tag: String = row.get(2).unwrap_or_default();
+            out.entry(format!("{source}::{source_id}"))
+                .or_default()
+                .push(tag);
+        }
+        Ok(out)
+    }
+
     /// Get memories that need re-embedding (structured content was set but embedding is stale).
     pub async fn get_reembed_candidates(
         &self,
@@ -39480,6 +39506,42 @@ pub(crate) mod tests {
         let all = db.list_all_tags().await.unwrap();
         // Distinct + sorted: rust appears in both docs but must appear once.
         assert_eq!(all, vec!["rust", "tauri", "wasm"]);
+    }
+
+    #[tokio::test]
+    async fn test_list_document_tags_groups_by_document_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = MemoryDB::new(
+            &tmp.path().join("test.db"),
+            Arc::new(crate::events::NoopEmitter),
+        )
+        .await
+        .unwrap();
+
+        db.set_document_tags(
+            "memory",
+            "doc1",
+            vec!["Rust".to_string(), "Tauri".to_string()],
+        )
+        .await
+        .unwrap();
+        db.set_document_tags(
+            "page",
+            "page1",
+            vec!["Rust".to_string(), "Wiki".to_string()],
+        )
+        .await
+        .unwrap();
+
+        let document_tags = db.list_document_tags().await.unwrap();
+        assert_eq!(
+            document_tags.get("memory::doc1"),
+            Some(&vec!["rust".to_string(), "tauri".to_string()])
+        );
+        assert_eq!(
+            document_tags.get("page::page1"),
+            Some(&vec!["rust".to_string(), "wiki".to_string()])
+        );
     }
 
     // ── migration 51 replay test ──────────────────────────────────────────────

--- a/crates/wenlan-server/src/memory_routes.rs
+++ b/crates/wenlan-server/src/memory_routes.rs
@@ -2510,7 +2510,14 @@ pub async fn handle_list_tags(
         .list_all_tags()
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?;
-    Ok(Json(wenlan_types::responses::TagsResponse { tags }))
+    let document_tags = db
+        .list_document_tags()
+        .await
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    Ok(Json(wenlan_types::responses::TagsResponse {
+        tags,
+        document_tags,
+    }))
 }
 
 /// DELETE /api/tags/{name}
@@ -2538,11 +2545,23 @@ pub async fn handle_set_document_tags(
         let s = state.read().await;
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
+    let source = document_tag_source(&req).to_string();
     let tags = db
-        .set_document_tags("memory", &source_id, req.tags)
+        .set_document_tags(&source, &source_id, req.tags)
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?;
-    Ok(Json(wenlan_types::responses::TagsResponse { tags }))
+    Ok(Json(wenlan_types::responses::TagsResponse {
+        tags,
+        document_tags: HashMap::new(),
+    }))
+}
+
+fn document_tag_source(req: &wenlan_types::requests::SetDocumentTagsRequest) -> &str {
+    req.source
+        .as_deref()
+        .map(str::trim)
+        .filter(|source| !source.is_empty())
+        .unwrap_or("memory")
 }
 
 #[derive(Debug, Deserialize)]
@@ -2598,7 +2617,35 @@ pub async fn handle_suggest_tags(
         }
     }
 
-    Ok(Json(wenlan_types::responses::TagsResponse { tags }))
+    Ok(Json(wenlan_types::responses::TagsResponse {
+        tags,
+        document_tags: HashMap::new(),
+    }))
+}
+
+#[cfg(test)]
+mod tag_route_tests {
+    use super::*;
+
+    #[test]
+    fn document_tag_source_prefers_request_source() {
+        let req = wenlan_types::requests::SetDocumentTagsRequest {
+            source: Some("manual".to_string()),
+            tags: vec!["rust".to_string()],
+        };
+
+        assert_eq!(document_tag_source(&req), "manual");
+    }
+
+    #[test]
+    fn document_tag_source_defaults_to_memory_for_old_payloads() {
+        let req = wenlan_types::requests::SetDocumentTagsRequest {
+            source: None,
+            tags: vec!["rust".to_string()],
+        };
+
+        assert_eq!(document_tag_source(&req), "memory");
+    }
 }
 
 /// GET /api/capture-stats

--- a/crates/wenlan-types/src/requests.rs
+++ b/crates/wenlan-types/src/requests.rs
@@ -413,6 +413,8 @@ pub struct SetDocumentSpaceRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SetDocumentTagsRequest {
+    #[serde(default)]
+    pub source: Option<String>,
     pub tags: Vec<String>,
 }
 
@@ -571,5 +573,27 @@ mod list_memories_confirmed_test {
         };
         let s = serde_json::to_string(&req).unwrap();
         assert!(!s.contains("confirmed"), "got: {s}");
+    }
+}
+
+#[cfg(test)]
+mod set_document_tags_test {
+    use super::*;
+
+    #[test]
+    fn set_document_tags_request_accepts_optional_source() {
+        let req: SetDocumentTagsRequest =
+            serde_json::from_str(r#"{"source":"manual","tags":["rust"]}"#).unwrap();
+
+        assert_eq!(req.source.as_deref(), Some("manual"));
+        assert_eq!(req.tags, vec!["rust"]);
+    }
+
+    #[test]
+    fn set_document_tags_request_defaults_source_for_old_payloads() {
+        let req: SetDocumentTagsRequest = serde_json::from_str(r#"{"tags":["rust"]}"#).unwrap();
+
+        assert!(req.source.is_none());
+        assert_eq!(req.tags, vec!["rust"]);
     }
 }

--- a/crates/wenlan-types/src/responses.rs
+++ b/crates/wenlan-types/src/responses.rs
@@ -462,6 +462,8 @@ pub struct VersionChainResponse {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TagsResponse {
     pub tags: Vec<String>,
+    #[serde(default)]
+    pub document_tags: HashMap<String, Vec<String>>,
 }
 
 // ===== Activity =====
@@ -975,6 +977,33 @@ mod tests {
         let parsed: StoreMemoryResponse = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.enrichment, ""); // default
         assert_eq!(parsed.hint, ""); // default
+    }
+
+    #[test]
+    fn tags_response_defaults_document_tags_for_older_responses() {
+        let json = r#"{"tags":["rust","tauri"]}"#;
+        let parsed: TagsResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(parsed.tags, vec!["rust", "tauri"]);
+        assert!(parsed.document_tags.is_empty());
+    }
+
+    #[test]
+    fn tags_response_deserializes_document_tag_map() {
+        let json = r#"{
+            "tags":["rust","tauri"],
+            "document_tags":{"memory::mem1":["rust"],"page::page1":["tauri"]}
+        }"#;
+        let parsed: TagsResponse = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            parsed.document_tags.get("memory::mem1"),
+            Some(&vec!["rust".to_string()])
+        );
+        assert_eq!(
+            parsed.document_tags.get("page::page1"),
+            Some(&vec!["tauri".to_string()])
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add additive document_tags to the daemon /api/tags response
- expose grouped document tag maps from wenlan-core using source::source_id keys
- accept optional source on document tag updates, defaulting to memory for older clients

## Verification
- cargo fmt --check
- cargo test -p wenlan-types set_document_tags_request
- cargo test -p wenlan-server --lib document_tag_source
- cargo test -p wenlan-core --lib document_tags
- git diff --check HEAD

## Structural checks
- CodeGraph was unavailable in this backend worktree, so ast-grep and rg were used as fallback.
- ast-grep verified SetDocumentTagsRequest contains source and tags.
- rg verified the route resolves document_tag_source before set_document_tags.

## App pair
- Paired wenlan-app PR follows: preserves additive document_tags and sends source on tag edits.