### PR TITLE
fix: share on-device model DTOs

### DIFF
--- a/crates/wenlan-server/src/config_routes.rs
+++ b/crates/wenlan-server/src/config_routes.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use wenlan_core::config;
 use wenlan_core::on_device_models::{self, OnDeviceModel};
-use wenlan_types::requests::UpdateConfigRequest;
-use wenlan_types::responses::ConfigResponse;
+use wenlan_types::requests::{OnDeviceModelRequest, UpdateConfigRequest};
+use wenlan_types::responses::{ConfigResponse, OnDeviceModelEntry, OnDeviceModelResponse};
 
 fn config_to_response(cfg: &config::Config) -> ConfigResponse {
     ConfigResponse {
@@ -225,27 +225,6 @@ pub async fn handle_clear_anthropic_key(
 
 // ── On-device model endpoints ──────────────────────────────────────────────
 
-#[derive(Debug, Serialize)]
-pub struct OnDeviceModelEntry {
-    pub id: String,
-    pub display_name: String,
-    pub param_count: String,
-    pub ram_required_gb: f64,
-    pub file_size_gb: f64,
-    pub cached: bool,
-}
-
-#[derive(Debug, Serialize)]
-pub struct OnDeviceModelResponse {
-    /// ID of the model currently loaded in the daemon (if any).
-    pub loaded: Option<String>,
-    /// ID the user has selected in config (may differ from loaded if a
-    /// download is pending or a restart is needed).
-    pub selected: Option<String>,
-    /// All available models with per-model cache/download state.
-    pub models: Vec<OnDeviceModelEntry>,
-}
-
 fn model_entry(model: &OnDeviceModel) -> OnDeviceModelEntry {
     OnDeviceModelEntry {
         id: model.id.to_string(),
@@ -280,11 +259,6 @@ pub async fn handle_get_on_device_model(
         selected,
         models,
     }))
-}
-
-#[derive(Debug, Deserialize)]
-pub struct OnDeviceModelRequest {
-    pub model_id: String,
 }
 
 /// POST /api/on-device-model/download — download (if needed) and hot-load a model.

--- a/crates/wenlan-types/src/lib.rs
+++ b/crates/wenlan-types/src/lib.rs
@@ -40,9 +40,10 @@ pub use pages::{Page, PageEvidence};
 pub use responses::{
     ContradictionDismissResponse, ExportStats, ListMemoryRevisionsResponse,
     ListPageRevisionsResponse, ListRefinementsResponse, MemoryDetail, MemoryRevisionEntry,
-    OrphanLink, OrphanLinksResponse, PageChangelogEntry, PendingRevision, PendingRevisionItem,
-    ProposalAction, RefinementPayload, RefinementProposalSummary, RejectRefinementResponse,
-    RevisionAcceptResponse, RevisionDismissResponse,
+    OnDeviceModelEntry, OnDeviceModelResponse, OrphanLink, OrphanLinksResponse, PageChangelogEntry,
+    PendingRevision, PendingRevisionItem, ProposalAction, RefinementPayload,
+    RefinementProposalSummary, RejectRefinementResponse, RevisionAcceptResponse,
+    RevisionDismissResponse,
 };
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 

--- a/crates/wenlan-types/src/requests.rs
+++ b/crates/wenlan-types/src/requests.rs
@@ -502,6 +502,14 @@ pub struct TestLlmResponse {
     pub response: String,
 }
 
+// ===== On-device model =====
+
+/// Body for `POST /api/on-device-model/download`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OnDeviceModelRequest {
+    pub model_id: String,
+}
+
 // ===== Default value functions =====
 
 fn default_limit() -> usize {
@@ -595,5 +603,21 @@ mod set_document_tags_test {
 
         assert!(req.source.is_none());
         assert_eq!(req.tags, vec!["rust"]);
+    }
+}
+
+#[cfg(test)]
+mod on_device_model_request_test {
+    use super::*;
+
+    #[test]
+    fn on_device_model_request_round_trips_model_id() {
+        let req: OnDeviceModelRequest = serde_json::from_str(r#"{"model_id":"qwen3-4b"}"#).unwrap();
+
+        assert_eq!(req.model_id, "qwen3-4b");
+        assert_eq!(
+            serde_json::to_string(&req).unwrap(),
+            r#"{"model_id":"qwen3-4b"}"#
+        );
     }
 }

--- a/crates/wenlan-types/src/responses.rs
+++ b/crates/wenlan-types/src/responses.rs
@@ -396,6 +396,30 @@ pub struct ConfigResponse {
     pub external_llm_model: Option<String>,
 }
 
+// ===== On-device model =====
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OnDeviceModelEntry {
+    pub id: String,
+    pub display_name: String,
+    pub param_count: String,
+    pub ram_required_gb: f64,
+    pub file_size_gb: f64,
+    pub cached: bool,
+}
+
+/// Response envelope for `GET /api/on-device-model`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OnDeviceModelResponse {
+    /// ID of the model currently loaded in the daemon, if any.
+    pub loaded: Option<String>,
+    /// ID the user has selected in config; may differ from loaded when a
+    /// download is pending or a restart is needed.
+    pub selected: Option<String>,
+    /// All available models with per-model cache/download state.
+    pub models: Vec<OnDeviceModelEntry>,
+}
+
 // ===== Indexed files / chunks =====
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -808,6 +832,50 @@ mod refinement_wire_tests {
         let json = serde_json::to_string(&resp).unwrap();
         let parsed: RejectRefinementResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.id, "ref_x");
+    }
+}
+
+#[cfg(test)]
+mod on_device_model_response_tests {
+    use super::*;
+
+    #[test]
+    fn on_device_model_response_preserves_selected_loaded_and_models() {
+        let response = OnDeviceModelResponse {
+            loaded: Some("qwen3-4b".to_string()),
+            selected: Some("qwen3-4b".to_string()),
+            models: vec![OnDeviceModelEntry {
+                id: "qwen3-4b".to_string(),
+                display_name: "Qwen3 4B".to_string(),
+                param_count: "4B".to_string(),
+                ram_required_gb: 6.0,
+                file_size_gb: 2.7,
+                cached: true,
+            }],
+        };
+
+        let value = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(value["loaded"], "qwen3-4b");
+        assert_eq!(value["selected"], "qwen3-4b");
+        assert_eq!(value["models"][0]["id"], "qwen3-4b");
+        assert_eq!(value["models"][0]["cached"], true);
+
+        let parsed: OnDeviceModelResponse = serde_json::from_value(value).unwrap();
+        assert_eq!(parsed.loaded.as_deref(), Some("qwen3-4b"));
+        assert_eq!(parsed.selected.as_deref(), Some("qwen3-4b"));
+        assert_eq!(parsed.models.len(), 1);
+        assert!(parsed.models[0].cached);
+    }
+
+    #[test]
+    fn on_device_model_response_allows_null_loaded_and_selected() {
+        let parsed: OnDeviceModelResponse =
+            serde_json::from_str(r#"{"loaded":null,"selected":null,"models":[]}"#).unwrap();
+
+        assert!(parsed.loaded.is_none());
+        assert!(parsed.selected.is_none());
+        assert!(parsed.models.is_empty());
     }
 }
 


### PR DESCRIPTION
## Summary
- Move /api/on-device-model request/response DTOs from wenlan-server-local structs into wenlan-types.
- Keep the existing wire shape for model_id, loaded, selected, and models.
- Add serde round-trip coverage for request and response envelopes.

## Verification
- cargo test -p wenlan-types
- cargo test -p wenlan-server --lib
- cargo clippy -p wenlan-types -p wenlan-server --all-targets -- -D warnings
- cargo fmt --all --check
- git diff --check

## Review
- Focused subagent review found no Critical, Important, or Minor issues.