### PR TITLE
chore(hooks): fail closed on parse failure; cover MultiEdit in release-please guard

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -4,7 +4,13 @@
 set -euo pipefail
 
 INPUT="$(cat)"
-CMD="$(printf '%s' "$INPUT" | /usr/bin/python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("tool_input",{}).get("command",""))' 2>/dev/null || true)"
+# Fail CLOSED: if extraction fails (python3 missing, malformed JSON) we cannot
+# prove the command is safe — block instead of silently allowing. The old
+# `|| true` swallowed the error and let `git commit --no-verify` through.
+CMD="$(printf '%s' "$INPUT" | /usr/bin/python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("tool_input",{}).get("command",""))' 2>/dev/null)" || {
+  echo "🛑 block-no-verify hook: could not parse tool input — failing closed." >&2
+  exit 2
+}
 
 # Only gate actual git invocations — otherwise an innocent grep/heredoc that merely
 # mentions "--no-verify" gets blocked.

--- a/.claude/hooks/block-release-please-files.sh
+++ b/.claude/hooks/block-release-please-files.sh
@@ -9,7 +9,13 @@ set -euo pipefail
 # Hook receives tool input as JSON on stdin.
 input="$(cat)"
 
-file_path="$(echo "$input" | jq -r '.tool_input.file_path // empty')"
+# Fail CLOSED: a jq failure (missing binary, bad JSON) previously killed the
+# script under `set -euo pipefail` with a non-2 exit — which Claude Code
+# treats as allow, silently disabling this guard.
+file_path="$(echo "$input" | jq -r '.tool_input.file_path // empty')" || {
+  echo "BLOCKED: release-please guard could not parse tool input (jq missing?) — failing closed." >&2
+  exit 2
+}
 
 if [[ -z "$file_path" ]]; then
   exit 0

--- a/.claude/hooks/cargo-check-crate.sh
+++ b/.claude/hooks/cargo-check-crate.sh
@@ -7,7 +7,12 @@ set -euo pipefail
 export CARGO_TARGET_DIR="${HOME}/.cache/origin-hook-target"
 
 input="$(cat)"
-file_path="$(echo "$input" | jq -r '.tool_input.file_path // empty')"
+# Loud, not silent: jq failure surfaces to Claude (PostToolUse exit 2 shows
+# stderr) instead of a fail-open crash vanishing the compile check.
+file_path="$(echo "$input" | jq -r '.tool_input.file_path // empty')" || {
+  echo "cargo-check hook: could not parse tool input (jq missing?) — compile check skipped." >&2
+  exit 2
+}
 
 # Only .rs files under crates/<name>/
 [[ "$file_path" == *.rs ]] || exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,7 +19,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Fresh-eye silent-wrong audit of the hook layer (same defect class as today's user-level harness audit: gates that pass while checking nothing) found three defects, all fixed:

1. **`block-no-verify.sh` failed open on parse failure** — `|| true` swallowed extraction errors, so a missing `/usr/bin/python3` or malformed input meant `git commit --no-verify` ran unblocked with zero signal. Now exits 2 (block) when it cannot prove the command safe.
2. **Both jq hooks crashed fail-open** — under `set -euo pipefail`, a jq failure kills the script with a non-2 exit, which Claude Code treats as *allow* for PreToolUse. The CHANGELOG/Cargo.toml release-please guard could silently disable itself. Both hooks now surface parse failures with exit 2 (ironically, `cargo-check-crate.sh` was already fail-closed against a missing `cargo` on the very same code path).
3. **Matcher asymmetry** — release-please PreToolUse guard matched `Edit|Write` while the PostToolUse cargo-check matched `Edit|Write|MultiEdit`; a MultiEdit against CHANGELOG.md bypassed the guard entirely. Synced.

## Testing

10 synthetic stdin cases: block `--no-verify`, allow plain git, allow innocent `--no-verify` mention, block CHANGELOG.md, allow normal file, allow missing file_path, malformed JSON fails closed (×2), non-.rs skip, malformed JSON loud — **all pass**. `settings.json` validates. `bash -n` clean on all three scripts.

## Not included (found by the same audit, left as decisions)

- `ci.yml` `plugin`/`npm` jobs are not in `conclusion.needs` (undocumented, unlike the intentional test-quarantine lane) — decide: intentional or gate them.
- `ci.yml:65` stale `.claude-plugin/**` path filter from the `plugin/` move (harmless — sibling glob covers it).
- No hook has a durable block-event trail, and `pre-stop-gate.sh` structurally can only log clean stops — a hook canary (verify-the-verifier) would close "nobody notices if hooks die"; proposing rather than building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ni1f2XvKDy9YPaeHd7Dh8r