### PR TITLE
chore(release): repair 0.10.1 version drift; rot-proof the release sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
+              # Release PRs must run the drift guard: 0.10.1 merged with
+              # version drift precisely because these two files don't match
+              # any glob above, so the rust tests (incl. drift_guard) skipped
+              # on the one PR class most likely to introduce drift.
+              - 'version.txt'
+              - '.release-please-manifest.json'
             plugin:
               - 'plugin/**'
               - 'plugin-codex/**'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,7 +47,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock crates/wenlan-mcp/npm/package.json crates/wenlan-cli/npm/package.json plugin/.claude-plugin/plugin.json plugin/bin/wenlan-mcp-runner.sh plugin/skills/init/SKILL.md
+          # -u stages whatever bump-version.sh actually modified. A hardcoded
+          # path list rots when files move: the 0.10.1 release merged with
+          # version drift because `git add ... plugin/skills/init/SKILL.md`
+          # crashed (exit 128) after that skill was renamed to setup/.
+          git add -u
           if ! git diff --cached --quiet; then
             git commit -m "chore: sync versions to $(cat version.txt | tr -d '[:space:]')"
             git push origin HEAD

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5494,7 +5494,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wenlan"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "wenlan-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "wenlan-mcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "wenlan-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "wenlan-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"   # x-release-please-version
+version = "0.10.1"   # x-release-please-version
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/7xuanlu/wenlan"
 
 [workspace.dependencies]
 # Internal crates — both path AND version required for cargo publish
-wenlan-types = { path = "crates/wenlan-types", version = "0.10.0" }
-wenlan-core  = { path = "crates/wenlan-core",  version = "0.10.0" }
+wenlan-types = { path = "crates/wenlan-types", version = "0.10.1" }
+wenlan-core  = { path = "crates/wenlan-core",  version = "0.10.1" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/wenlan-cli/npm/package.json
+++ b/crates/wenlan-cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wenlan",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local-first memory + knowledge layer for AI agents.",
   "keywords": [
     "ai-memory",

--- a/crates/wenlan-mcp/npm/package.json
+++ b/crates/wenlan-mcp/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wenlan-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Local-first memory layer for AI agents - MCP server",
   "keywords": [
     "mcp",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wenlan",
   "description": "AI work memory for Claude Code. Carries sessions, decisions, lessons, and project context forward, then turns them into searchable memory and wiki pages.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "Qi-Xuan Lu",
     "url": "https://github.com/7xuanlu"

--- a/plugin/bin/wenlan-mcp-runner.sh
+++ b/plugin/bin/wenlan-mcp-runner.sh
@@ -14,7 +14,7 @@
 #      failures when ~/.npm/_cacache contains root-owned files left over
 #      from older npm versions (npx exits before responding to initialize,
 #      MCP host then waits 30s and times out).
-#   4. npx -y wenlan-mcp@^0.10.0 — fallback for users who installed the
+#   4. npx -y wenlan-mcp@^0.10.1 — fallback for users who installed the
 #      plugin without running install.sh.
 
 # Don't enable `set -u` here: if Claude Code (or any MCP host) invokes the
@@ -37,4 +37,4 @@ if [ -x "${installed_bin}" ]; then
   exec "${installed_bin}" "$@"
 fi
 
-exec npx -y wenlan-mcp@^0.10.0 "$@"
+exec npx -y wenlan-mcp@^0.10.1 "$@"

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -79,7 +79,7 @@ command -v wenlan >/dev/null 2>&1 && echo present || echo absent
 If absent, install and configure local memory:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.10.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.10.1/install.sh | bash
 export PATH="$HOME/.wenlan/bin:$PATH"
 wenlan setup --basic
 wenlan background on


### PR DESCRIPTION
## Summary

Main's rust tests are currently red: `drift_guard::version_files_are_in_sync` fails because release 0.10.1 (#326) merged with `Cargo.toml` (and the npm/plugin manifest fleet) still at 0.10.0. This PR fixes the drift AND both mechanisms that let it through.

**Causal chain** (from run [28635654970](https://github.com/7xuanlu/wenlan/actions/runs/28635654970)):
1. `fix: clean up Wenlan command surface` renamed `plugin/skills/init/` → `setup/`
2. release-please re-spun PR #326 to 0.10.1; its sync step crashed: `fatal: pathspec 'plugin/skills/init/SKILL.md' did not match any files` (the workflow's hardcoded `git add` list rotted — `bump-version.sh` itself was already updated)
3. #326 merged 4 min later without the sync commit
4. #326's own CI never ran the drift guard: `version.txt`/`.release-please-manifest.json` match no rust-filter glob, so tests skipped on the one PR class most likely to drift

## Changes

- **Repair**: ran `scripts/bump-version.sh` — 7 files move to 0.10.1 (byte-identical to what the sync would have committed)
- **release-please.yml**: hardcoded `git add <list>` → `git add -u` (stages whatever bump-version.sh modified; path lists rot)
- **ci.yml**: `version.txt` + `.release-please-manifest.json` added to the rust filter so release PRs run the drift guard (windows filter deliberately untouched — the guard is OS-independent, no need for the ~30min Windows lane)

## Testing

`cargo test -p wenlan-core --lib drift_guard`: **9/9 pass** locally against this tree. Both workflows YAML-validate. The next release PR exercises the repaired sync path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ni1f2XvKDy9YPaeHd7Dh8r