### PR TITLE
fix(server): bind port before any data-dir work

### DIFF
--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -104,6 +104,47 @@ async fn run_daemon() -> anyhow::Result<()> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(7878);
 
+    // Bind BEFORE touching the data dir. Losing the port race must be free:
+    // under launchd KeepAlive, a retry loop that first runs full MemoryDB init
+    // (schema/FTS writes + embedder load) hammers the live daemon's SQLite
+    // file every ~10s — enough lock/CPU pressure to wedge the daemon that
+    // actually owns the port.
+    let addr = resolve_bind_addr(port);
+    let listener = match tokio::net::TcpListener::bind(&addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            // Check if existing daemon is healthy
+            tracing::warn!("Failed to bind {}: {}", addr, e);
+            let url = format!("http://127.0.0.1:{}/api/health", port);
+            match reqwest::get(&url).await {
+                Ok(resp) if resp.status().is_success() => {
+                    // Port already taken by a healthy daemon. If launchd is the
+                    // parent (XPC_SERVICE_NAME set), exit non-zero so launchd
+                    // retries after ThrottleInterval — otherwise launchd marks
+                    // this attempt as a clean exit and refuses to respawn even
+                    // after the winning daemon dies (KeepAlive.SuccessfulExit
+                    // = false treats exit-0 as success). For sidecar invocation
+                    // by the app, exit 0 is the right answer.
+                    if std::env::var_os("XPC_SERVICE_NAME").is_some() {
+                        tracing::info!(
+                            "Existing healthy daemon on port {} — exiting 75 (launchd retry)",
+                            port
+                        );
+                        std::process::exit(75);
+                    }
+                    tracing::info!("Existing healthy daemon on port {} — exiting cleanly", port);
+                    return Ok(());
+                }
+                _ => {
+                    return Err(anyhow::anyhow!(
+                        "Port {} in use and no healthy daemon",
+                        port
+                    ));
+                }
+            }
+        }
+    };
+
     // One-time origin -> wenlan data migration (default locations only). Runs here,
     // before the DB opens, so the daemon is the sole writer. No-op once migrated.
     if wenlan_core::env_compat::var_compat("WENLAN_DATA_DIR").is_none() {
@@ -748,43 +789,6 @@ async fn run_daemon() -> anyhow::Result<()> {
 
     // Build router
     let app = router::build_router(shared);
-
-    // Bind
-    let addr = resolve_bind_addr(port);
-    let listener = match tokio::net::TcpListener::bind(&addr).await {
-        Ok(l) => l,
-        Err(e) => {
-            // Check if existing daemon is healthy
-            tracing::warn!("Failed to bind {}: {}", addr, e);
-            let url = format!("http://127.0.0.1:{}/api/health", port);
-            match reqwest::get(&url).await {
-                Ok(resp) if resp.status().is_success() => {
-                    // Port already taken by a healthy daemon. If launchd is the
-                    // parent (XPC_SERVICE_NAME set), exit non-zero so launchd
-                    // retries after ThrottleInterval — otherwise launchd marks
-                    // this attempt as a clean exit and refuses to respawn even
-                    // after the winning daemon dies (KeepAlive.SuccessfulExit
-                    // = false treats exit-0 as success). For sidecar invocation
-                    // by the app, exit 0 is the right answer.
-                    if std::env::var_os("XPC_SERVICE_NAME").is_some() {
-                        tracing::info!(
-                            "Existing healthy daemon on port {} — exiting 75 (launchd retry)",
-                            port
-                        );
-                        std::process::exit(75);
-                    }
-                    tracing::info!("Existing healthy daemon on port {} — exiting cleanly", port);
-                    return Ok(());
-                }
-                _ => {
-                    return Err(anyhow::anyhow!(
-                        "Port {} in use and no healthy daemon",
-                        port
-                    ));
-                }
-            }
-        }
-    };
 
     // Advertise the bound port before accepting requests.
     // `addr` may be `127.0.0.1:0`; `local_addr()` gives the real ephemeral port.

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -116,7 +116,15 @@ async fn run_daemon() -> anyhow::Result<()> {
             // Check if existing daemon is healthy
             tracing::warn!("Failed to bind {}: {}", addr, e);
             let url = format!("http://127.0.0.1:{}/api/health", port);
-            match reqwest::get(&url).await {
+            // Bounded probe: a mute port-holder (accepts, never responds)
+            // must not hang this process forever — under launchd KeepAlive
+            // a hung loser also blocks the retry that would recover things.
+            let probe = reqwest::Client::new()
+                .get(&url)
+                .timeout(std::time::Duration::from_secs(5))
+                .send()
+                .await;
+            match probe {
                 Ok(resp) if resp.status().is_success() => {
                     // Port already taken by a healthy daemon. If launchd is the
                     // parent (XPC_SERVICE_NAME set), exit non-zero so launchd

--- a/crates/wenlan-server/tests/port_taken_no_db_init.rs
+++ b/crates/wenlan-server/tests/port_taken_no_db_init.rs
@@ -36,6 +36,51 @@ fn spawn_fake_healthy_daemon() -> u16 {
     port
 }
 
+/// Holds a port but never answers HTTP: connections queue in the accept
+/// backlog and get no response. The server must error out ("no healthy
+/// daemon"), not hang forever on its health probe.
+#[test]
+fn port_taken_by_mute_listener_errors_instead_of_hanging() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    // Keep the listener alive but never accept/respond.
+
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().join("data");
+
+    let mut child = Command::new(binary_path())
+        .env("WENLAN_PORT", port.to_string())
+        .env_remove("WENLAN_BIND_ADDR")
+        .env_remove("XPC_SERVICE_NAME")
+        .env("WENLAN_DATA_DIR", &data_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn wenlan-server");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("server hung on the health probe against a mute port-holder");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    assert!(
+        !status.success(),
+        "expected error exit (port in use, no healthy daemon), got {status:?}"
+    );
+    assert!(
+        !data_dir.join("memorydb").exists(),
+        "MemoryDB was initialized even though the port was already taken"
+    );
+    drop(listener);
+}
+
 #[test]
 fn port_taken_by_healthy_daemon_exits_before_db_init() {
     let port = spawn_fake_healthy_daemon();

--- a/crates/wenlan-server/tests/port_taken_no_db_init.rs
+++ b/crates/wenlan-server/tests/port_taken_no_db_init.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Integration test: when the port is already held by a healthy daemon, the
+//! server must bail out BEFORE initializing MemoryDB. A launchd KeepAlive
+//! retry loop otherwise re-runs full DB init (schema writes + embedder load)
+//! against the live daemon's SQLite file every ~10s — enough lock/CPU
+//! pressure to wedge the daemon that actually owns the port.
+
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn binary_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_wenlan-server"))
+}
+
+/// Minimal "healthy daemon": answers HTTP 200 to every request on an
+/// ephemeral port.
+fn spawn_fake_healthy_daemon() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            let mut stream = stream;
+            let mut buf = [0_u8; 1024];
+            let _ = stream.read(&mut buf);
+            let body = r#"{"status":"ok","db_initialized":true,"version":"0.0.0-test"}"#;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(resp.as_bytes());
+        }
+    });
+    port
+}
+
+#[test]
+fn port_taken_by_healthy_daemon_exits_before_db_init() {
+    let port = spawn_fake_healthy_daemon();
+    let tmp = tempfile::tempdir().unwrap();
+    let data_dir = tmp.path().join("data");
+
+    let mut child = Command::new(binary_path())
+        .env("WENLAN_PORT", port.to_string())
+        .env_remove("WENLAN_BIND_ADDR")
+        // Non-launchd path: a healthy daemon on the port means clean exit 0.
+        .env_remove("XPC_SERVICE_NAME")
+        .env("WENLAN_DATA_DIR", &data_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn wenlan-server");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let status = loop {
+        if let Some(status) = child.try_wait().unwrap() {
+            break status;
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("server did not exit; it should bail when the port is taken");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    };
+
+    assert!(status.success(), "expected clean exit, got {status:?}");
+    assert!(
+        !data_dir.join("memorydb").exists(),
+        "MemoryDB was initialized even though the port was already taken"
+    );
+}


### PR DESCRIPTION
## Problem

When `wenlan-server` starts and its port is already held by another daemon, it does **all** of its data-dir work first — origin→wenlan migration, MemoryDB init (SQLite schema/FTS/trigger writes), embedder load, migration-55 backfill — and only *then* tries to bind, discovers the port is taken, and exits.

Under launchd `KeepAlive.SuccessfulExit=false` this becomes a retry storm: a stale installed daemon that loses the port race to a live one re-runs full DB init against the live daemon's SQLite file every ~10s. Observed on macOS 2026-07-06: a stale v0.9.5 LaunchAgent hammering a live v0.11.0 daemon's DB wedged it badly enough that its health endpoint stalled ~24s and the desktop app's startup sync failed with `HTTP POST /api/ingest/text: error sending request` (root-cause writeup in 7xuanlu/wenlan-app#74).

## Fix

Move the bind-or-bail block (bind → on failure probe `/api/health` → exit 75 under launchd / exit 0 otherwise) from after router build to **immediately after port resolution**, before the migrate-rename step and any data-dir access. A losing launchd retry is now start → bind-fail → health probe → exit 75, with zero DB writes.

The advertise block (`WENLAN_LISTENING_ON=` println — format unchanged — and `WENLAN_PORT_FILE`) stays at its original late position, still printing just before serving. Early-bound-but-not-yet-serving connections queue in the accept backlog during the ~3s init, so clients see a slightly slower first response instead of a connection error.

## Test

New integration test `crates/wenlan-server/tests/port_taken_no_db_init.rs`: spawns a fake healthy daemon on an ephemeral port, launches the real `wenlan-server` binary against that port with a fresh `WENLAN_DATA_DIR`, and asserts (a) clean exit and (b) **no `memorydb/` directory was created**. Red before the reorder (MemoryDB was initialized), green after.

Gates: `cargo fmt --check`, `cargo clippy -p wenlan-server --all-targets -- -D warnings`, `cargo test -p wenlan-server` (190 passed, 14 suites) — all green.

## Related

- 7xuanlu/wenlan-app#74 — app-side hardening (client timeouts + daemon/app version-mismatch warning) for the same incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVZQykWoZ5hL2CD4ApBxje