### PR TITLE
fix: guard loopback daemon against cross-origin browser access; gate release publish on build success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,16 @@ jobs:
           if [[ "$RELEASE_TAG" == *-* ]]; then
             PRERELEASE_FLAG="--prerelease"
           fi
+          # Create as a DRAFT so a failed build below never leaves a public,
+          # torn release. The finalize-release job publishes it only after every
+          # build + publish job succeeds. Draft releases are invisible to
+          # `releases/latest` and do not fire `release: published`.
           gh release create "$RELEASE_TAG" \
+            --draft \
             --title "$RELEASE_TAG" \
             --notes-file release-body.md \
             $PRERELEASE_FLAG \
-            || gh release edit "$RELEASE_TAG" --notes-file release-body.md
+            || gh release edit "$RELEASE_TAG" --draft --notes-file release-body.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -319,6 +324,9 @@ jobs:
         with:
           files: dist/*
           tag_name: ${{ env.RELEASE_TAG }}
+          # Keep the release a draft while assets upload; finalize-release
+          # flips it public only after every build + publish job succeeds.
+          draft: true
           # Don't touch the release body composed in prepare-release.
           append_body: false
           fail_on_unmatched_files: true
@@ -628,3 +636,18 @@ jobs:
         run: |
           ruby -c tap/Formula/wenlan-mcp.rb
           ruby -c tap/Formula/wenlan.rb
+
+  finalize-release:
+    name: Publish the draft release
+    # Runs only after EVERY build + publish job succeeds. A failure in any of
+    # them skips this job (GitHub requires all `needs` to succeed), so the
+    # release stays a draft — never a public, half-built `releases/latest`.
+    # Flipping draft -> published here is also what fires `release: published`
+    # (and notify-marketplace) at the right moment: after the artifacts exist.
+    needs: [release, docker-manifest, publish-crates, publish-npm, update-homebrew]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish
+        run: gh release edit "$RELEASE_TAG" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/crates/wenlan-server/src/lib.rs
+++ b/crates/wenlan-server/src/lib.rs
@@ -17,6 +17,7 @@ pub mod reflection_debounce;
 pub mod router;
 pub mod routes;
 pub mod scheduler;
+pub mod security;
 pub mod source_routes;
 pub mod space_header;
 pub mod state;

--- a/crates/wenlan-server/src/router.rs
+++ b/crates/wenlan-server/src/router.rs
@@ -4,18 +4,28 @@
 use crate::state::SharedState;
 use crate::{
     config_routes, import_routes, ingest_routes, knowledge_routes, memory_routes,
-    onboarding_routes, refinery_routes, routes, source_routes, websocket,
+    onboarding_routes, refinery_routes, routes, security, source_routes, websocket,
 };
 use axum::{
     routing::{delete, get, post, put},
     Router,
 };
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
 /// Build the shared application router with all routes.
 pub fn build_router(state: SharedState) -> Router {
+    // Reflect CORS only for local origins so a legit localhost/Tauri browser
+    // can read responses; every other origin is refused. The real protection
+    // is `security::guard_local_only` below — this just stops browsers from
+    // exposing responses to non-local sites. Native clients (app/CLI/MCP over
+    // reqwest) send no Origin and are unaffected.
     let cors = CorsLayer::new()
-        .allow_origin(Any)
+        .allow_origin(AllowOrigin::predicate(|origin, _parts| {
+            origin
+                .to_str()
+                .map(crate::security::origin_is_local)
+                .unwrap_or(false)
+        }))
         .allow_methods(Any)
         .allow_headers(Any);
 
@@ -483,5 +493,7 @@ pub fn build_router(state: SharedState) -> Router {
         // WebSocket
         .route("/ws/updates", get(websocket::handle_ws_upgrade))
         .layer(cors)
+        // Outermost: reject cross-origin browser traffic before CORS/handlers.
+        .layer(axum::middleware::from_fn(security::guard_local_only))
         .with_state(state)
 }

--- a/crates/wenlan-server/src/security.rs
+++ b/crates/wenlan-server/src/security.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-origin request guard for the loopback daemon.
+//!
+//! The daemon has no auth and binds `127.0.0.1:7878` by default, so without a
+//! guard any web page the user visits could drive it — cross-origin reads of
+//! the whole memory store, CSRF writes, or DNS-rebinding. Native clients (the
+//! desktop app, the `wenlan` CLI, `wenlan-mcp`) all talk to the daemon over
+//! reqwest and send no `Origin` header, so they pass through untouched.
+//! Browsers always attach `Origin` on cross-origin requests; a non-local one
+//! is rejected. A non-local `Host` (DNS rebinding) is rejected too — unless the
+//! operator deliberately exposed the daemon via `WENLAN_BIND_ADDR` (e.g. the
+//! Docker image), which opts out of the Host check and owns its own access
+//! control.
+
+use axum::{
+    extract::Request,
+    http::{header, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+
+/// Reject browser-driven cross-origin requests before they reach a handler.
+pub async fn guard_local_only(req: Request, next: Next) -> Result<Response, StatusCode> {
+    let headers = req.headers();
+
+    if let Some(origin) = headers.get(header::ORIGIN).and_then(|v| v.to_str().ok()) {
+        if !origin_is_local(origin) {
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
+
+    // DNS-rebinding defense applies only to the default loopback bind. When the
+    // operator sets WENLAN_BIND_ADDR (Docker/LAN), the Host is legitimately
+    // non-loopback and access control is their responsibility.
+    if wenlan_core::env_compat::var_compat("WENLAN_BIND_ADDR").is_none() {
+        if let Some(host) = headers.get(header::HOST).and_then(|v| v.to_str().ok()) {
+            if !host_is_local(host) {
+                return Err(StatusCode::FORBIDDEN);
+            }
+        }
+    }
+
+    Ok(next.run(req).await)
+}
+
+/// True for `localhost` / `127.0.0.1` / `::1`, with or without a `:port`.
+fn host_is_local(host: &str) -> bool {
+    let hostname = if let Some(rest) = host.strip_prefix('[') {
+        // Bracketed IPv6: "[::1]" or "[::1]:7878" — take up to the closing ']'.
+        rest.split(']').next().unwrap_or(rest)
+    } else if host.matches(':').count() == 1 {
+        // "host:port" — strip the port (a single colon can't be bare IPv6).
+        host.split(':').next().unwrap_or(host)
+    } else {
+        // Bare hostname / IPv4, or a bare IPv6 literal like "::1" (2+ colons).
+        host
+    };
+    matches!(hostname, "localhost" | "127.0.0.1" | "::1")
+}
+
+/// True for a local `Origin` header value (or the Tauri webview origins).
+pub(crate) fn origin_is_local(origin: &str) -> bool {
+    if origin == "tauri://localhost" || origin == "http://tauri.localhost" {
+        return true;
+    }
+    let after_scheme = origin
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(origin);
+    host_is_local(after_scheme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_local_variants() {
+        for h in [
+            "127.0.0.1",
+            "127.0.0.1:7878",
+            "localhost",
+            "localhost:7878",
+            "::1",
+            "[::1]",
+            "[::1]:7878",
+        ] {
+            assert!(host_is_local(h), "expected local: {h}");
+        }
+    }
+
+    #[test]
+    fn host_non_local_rejected() {
+        for h in [
+            "evil.com",
+            "evil.com:7878",
+            "192.168.1.5:7878",
+            "wenlan.evil.com",
+        ] {
+            assert!(!host_is_local(h), "expected non-local: {h}");
+        }
+    }
+
+    #[test]
+    fn origin_local_and_tauri_allowed() {
+        for o in [
+            "http://localhost:1420",
+            "http://127.0.0.1:7878",
+            "https://localhost",
+            "tauri://localhost",
+            "http://tauri.localhost",
+        ] {
+            assert!(origin_is_local(o), "expected local origin: {o}");
+        }
+    }
+
+    #[test]
+    fn origin_cross_site_and_null_rejected() {
+        for o in ["https://evil.com", "http://attacker.test:1420", "null"] {
+            assert!(!origin_is_local(o), "expected rejected origin: {o}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two fixes surfaced by the repo audit — one security, one release-pipeline correctness.

### 1. Loopback daemon had no cross-origin defense (security)

`wenlan-server` runs on `127.0.0.1:7878` with **no auth** and previously reflected CORS for **any** origin (`allow_origin(Any)`). Any web page the user visited could drive the daemon: cross-origin reads of the entire memory store, CSRF writes, and DNS-rebinding.

- New `security::guard_local_only` middleware (outermost layer, runs before CORS): rejects a non-local `Origin`, and a non-local `Host` (DNS-rebinding) **unless** the operator set `WENLAN_BIND_ADDR` (the Docker/LAN opt-out, which owns its own access control).
- `CorsLayer` now reflects only local + Tauri origins instead of `Any`.
- **Native clients are unaffected** — the desktop app, `wenlan` CLI, and `wenlan-mcp` all talk to the daemon over `reqwest` and send no `Origin` header, so they pass straight through. Only browsers attach `Origin` cross-origin.
- 4 unit tests cover the host/origin matcher (loopback + bracketed/bare IPv6 `::1` + port variants, Tauri origins, cross-site + `null` rejection). All pass.

### 2. Release published before builds ran (torn releases)

`release.yml` created the GitHub Release as **published** at the very first step, before any binary built. A failed build then left a torn public release: `releases/latest` pointing at a tag with no assets, and `release: published` (notify-marketplace) firing early.

- Create the release as a **draft**; keep it draft through asset upload (`softprops draft: true`).
- New `finalize-release` job (`needs: [release, docker-manifest, publish-crates, publish-npm, update-homebrew]`) flips it public only after **every** build + publish job succeeds. A failure in any job skips finalize, so the release stays a draft — never a half-built `releases/latest`. Publishing here also fires `release: published` at the correct moment (after artifacts exist).

## Test plan

- `cargo test -p wenlan-server --lib security` → 4 passed.
- CORS tightening is app-safe: reqwest clients send no `Origin`, so they can't be affected by CORS at all.
- `WENLAN_BIND_ADDR` gates the Host check, so Docker/LAN deployments (deliberate exposure) are not broken by the guard.
- Full clippy + workspace tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)