### PR TITLE
fix: route document source pages through PageWrite

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -20935,22 +20935,27 @@ impl MemoryDB {
     ) -> Result<String, libsql::Error> {
         let mut rows = conn
             .query(
-                "SELECT source, source_agent FROM memories WHERE source_id = ?1 LIMIT 1",
+                "SELECT source, source_agent, source_id FROM memories \
+                 WHERE source_id = ?1 OR id = ?1 \
+                 ORDER BY CASE WHEN source_id = ?1 THEN 0 ELSE 1 END \
+                 LIMIT 1",
                 libsql::params![source_id],
             )
             .await?;
-        let (source, source_agent) = match rows.next().await? {
+        let (source, source_agent, resolved_source_id) = match rows.next().await? {
             Some(row) => (
                 row.get::<String>(0).unwrap_or_default(),
                 row.get::<Option<String>>(1).unwrap_or(None),
+                row.get::<String>(2)
+                    .unwrap_or_else(|_| source_id.to_string()),
             ),
-            None => (String::new(), None),
+            None => (String::new(), None, source_id.to_string()),
         };
         drop(rows);
         Ok(crate::citations::resolve_page_evidence_source_kind(
             &source,
             source_agent.as_deref(),
-            source_id,
+            &resolved_source_id,
         )
         .to_string())
     }

--- a/crates/wenlan-core/src/document_enrichment.rs
+++ b/crates/wenlan-core/src/document_enrichment.rs
@@ -38,10 +38,12 @@ use std::sync::Arc;
 use crate::db::{DocEnrichmentQueueEntry, MemoryDB, MemoryDetail};
 use crate::error::WenlanError;
 use crate::llm_provider::{LlmProvider, LlmRequest};
+use crate::post_write::{page_write, PageWrite};
 use crate::prompts::PromptRegistry;
 use crate::sources::directory::{
     document_source_id, file_to_documents, provenance_path, FileOutcome,
 };
+use wenlan_types::requests::CreateConceptRequest;
 
 /// Rolling-digest character cap (~15K).
 const DIGEST_CHAR_CAP: usize = 15_000;
@@ -460,23 +462,30 @@ async fn write_source_page(
     chunk_ids: &[String],
 ) -> Result<(), WenlanError> {
     let _ = db.delete_page(page_id).await;
-    let now = chrono::Utc::now().to_rfc3339();
-    let cite: Vec<&str> = chunk_ids.iter().map(|s| s.as_str()).collect();
-    db.insert_page_with_kind(
-        page_id,
-        title,
-        summary,
-        content,
-        None,
-        None,
-        &cite,
-        &now,
-        "source",
-        "unconfirmed",
-        None,
-        None, // citations: SOURCE pages are chunk-granular provenance, not distilled citations
+    let req = CreateConceptRequest {
+        title: title.to_string(),
+        content: content.to_string(),
+        summary: summary.map(str::to_string),
+        entity_id: None,
+        space: None,
+        source_memory_ids: chunk_ids.to_vec(),
+        creation_kind: Some("source".to_string()),
+        workspace: None,
+    };
+    page_write(
+        db,
+        PageWrite::Create {
+            page_id: Some(page_id),
+            req,
+            agent: "doc-enrich",
+            knowledge_path: None,
+            page_min_cluster_size: 1,
+            page_match_threshold: 0.0,
+            citations_json: None,
+        },
     )
     .await
+    .map(|_| ())
 }
 
 /// Retry backoff (seconds) for a paused document, given the attempt count BEFORE
@@ -974,6 +983,46 @@ mod tests {
         assert_eq!(q.status, "paused");
         assert_eq!(q.attempt_count, 1);
         assert!(q.next_retry_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn document_source_page_creation_routes_through_pagewrite() {
+        let (db, dir) = test_db().await;
+        let path = write_doc(dir.path());
+        let file_path = path.to_string_lossy().to_string();
+        db.enqueue_document("folder-notes", &file_path, Some("hashA"))
+            .await
+            .unwrap();
+        let entry = db.claim_next_pending().await.unwrap().expect("claim");
+        let prompts = PromptRegistry::default();
+
+        let outcome = run_document_enrichment(&db, &entry, None, None, &prompts).await;
+
+        assert!(!outcome.paused);
+        assert!(!outcome.page_id.is_empty());
+        let page = db
+            .get_page(&outcome.page_id)
+            .await
+            .unwrap()
+            .expect("source page");
+        assert_eq!(page.creation_kind, "source");
+        assert_eq!(page.review_status, "unconfirmed");
+        let activity = db.list_agent_activity(20, None, None).await.unwrap();
+        assert!(
+            activity.iter().any(|entry| {
+                entry.action == "page_create"
+                    && entry.memory_ids.as_deref() == Some(&outcome.chunk_ids.join(","))
+            }),
+            "document source-page creation must route through PageWrite and log page_create with chunk provenance, got {activity:?}"
+        );
+        let evidence = db.get_page_evidence(&outcome.page_id).await.unwrap();
+        assert_eq!(evidence.len(), outcome.chunk_ids.len());
+        assert!(
+            evidence
+                .iter()
+                .all(|row| row.source_kind == "external_file"),
+            "document source-page evidence must preserve folder chunk provenance, got {evidence:?}"
+        );
     }
 
     // ── self-healing loop: LLM failure pauses with backoff, then re-claims ────

--- a/crates/wenlan-core/src/post_write.rs
+++ b/crates/wenlan-core/src/post_write.rs
@@ -33,7 +33,8 @@ fn is_false(value: &bool) -> bool {
     !*value
 }
 
-const VALID_PAGE_CREATION_KINDS: [&str; 4] = ["distilled", "authored", "research", "imported"];
+const VALID_PAGE_CREATION_KINDS: [&str; 5] =
+    ["distilled", "authored", "research", "imported", "source"];
 const PAGE_BIRTH_REVIEW_STATUS: &str = "unconfirmed";
 
 pub enum PageWrite<'a> {
@@ -44,6 +45,7 @@ pub enum PageWrite<'a> {
         agent: &'a str,
     },
     Create {
+        page_id: Option<&'a str>,
         req: CreateConceptRequest,
         agent: &'a str,
         knowledge_path: Option<&'a Path>,
@@ -70,6 +72,7 @@ pub async fn page_write(db: &MemoryDB, write: PageWrite<'_>) -> Result<WriteResu
             agent,
         } => attach_page_sources_impl(db, page_id, source_memory_ids, link_reason, agent).await,
         PageWrite::Create {
+            page_id,
             req,
             agent,
             knowledge_path,
@@ -79,12 +82,15 @@ pub async fn page_write(db: &MemoryDB, write: PageWrite<'_>) -> Result<WriteResu
         } => {
             create_page_impl(
                 db,
-                req,
-                agent,
-                knowledge_path,
-                page_min_cluster_size,
-                page_match_threshold,
-                citations_json.as_deref(),
+                CreatePageInput {
+                    page_id,
+                    req,
+                    agent,
+                    knowledge_path,
+                    page_min_cluster_size,
+                    page_match_threshold,
+                    citations_json: citations_json.as_deref(),
+                },
             )
             .await
         }
@@ -600,6 +606,7 @@ pub async fn create_page_with_tuning(
     page_write(
         db,
         PageWrite::Create {
+            page_id: None,
             req,
             agent,
             knowledge_path,
@@ -611,15 +618,55 @@ pub async fn create_page_with_tuning(
     .await
 }
 
-async fn create_page_impl(
+async fn page_source_reference_exists(
     db: &MemoryDB,
+    creation_kind: &str,
+    source_id: &str,
+) -> Result<bool, WenlanError> {
+    if db.get_memory_detail(source_id).await?.is_some() {
+        return Ok(true);
+    }
+    if creation_kind != "source" {
+        return Ok(false);
+    }
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM memories WHERE id = ?1 AND pending_revision = 0 AND source != 'episode' LIMIT 1",
+            libsql::params![source_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("source page chunk lookup: {e}")))?;
+    rows.next()
+        .await
+        .map(|row| row.is_some())
+        .map_err(|e| WenlanError::VectorDb(format!("source page chunk lookup row: {e}")))
+}
+
+struct CreatePageInput<'a> {
+    page_id: Option<&'a str>,
     req: CreateConceptRequest,
-    agent: &str,
-    knowledge_path: Option<&Path>,
+    agent: &'a str,
+    knowledge_path: Option<&'a Path>,
     page_min_cluster_size: usize,
     page_match_threshold: f64,
-    citations_json: Option<&str>,
+    citations_json: Option<&'a str>,
+}
+
+async fn create_page_impl(
+    db: &MemoryDB,
+    input: CreatePageInput<'_>,
 ) -> Result<WriteResult, WenlanError> {
+    let CreatePageInput {
+        page_id,
+        req,
+        agent,
+        knowledge_path,
+        page_min_cluster_size,
+        page_match_threshold,
+        citations_json,
+    } = input;
+
     // Pre-write validation
     if req.title.trim().is_empty() {
         return Err(WenlanError::Validation(
@@ -639,8 +686,18 @@ async fn create_page_impl(
     }
     if !VALID_PAGE_CREATION_KINDS.contains(&creation_kind) {
         return Err(WenlanError::Validation(format!(
-            "invalid creation_kind '{creation_kind}' (expected one of: distilled, authored, research, imported)"
+            "invalid creation_kind '{creation_kind}' (expected one of: distilled, authored, research, imported, source)"
         )));
+    }
+    if creation_kind == "source" && page_id.is_none() {
+        return Err(WenlanError::Validation(
+            "source page requires a deterministic page id".into(),
+        ));
+    }
+    if creation_kind == "source" && req.source_memory_ids.is_empty() {
+        return Err(WenlanError::Validation(
+            "source page must cite at least one source memory".into(),
+        ));
     }
     let distinct_source_count = req
         .source_memory_ids
@@ -656,7 +713,7 @@ async fn create_page_impl(
     let review_status = PAGE_BIRTH_REVIEW_STATUS;
     // Resolution check: every source id must exist
     for sid in &req.source_memory_ids {
-        if db.get_memory_detail(sid).await?.is_none() {
+        if !page_source_reference_exists(db, creation_kind, sid).await? {
             return Err(WenlanError::Validation(format!(
                 "source memory '{sid}' does not exist"
             )));
@@ -710,7 +767,9 @@ async fn create_page_impl(
     }
 
     // Build page
-    let id = crate::pages::new_page_id();
+    let id = page_id
+        .map(str::to_string)
+        .unwrap_or_else(crate::pages::new_page_id);
     let now = chrono::Utc::now().to_rfc3339();
     let page = crate::pages::Page {
         id: id.clone(),

--- a/crates/wenlan-core/src/synthesis/distill.rs
+++ b/crates/wenlan-core/src/synthesis/distill.rs
@@ -741,6 +741,7 @@ async fn distill_one_cluster_with_tuning(
             let write_result = page_write(
                 db,
                 PageWrite::Create {
+                    page_id: None,
                     req: CreateConceptRequest {
                         title: title.clone(),
                         content: content.clone(),

--- a/crates/wenlan-core/src/synthesis/refinement_queue.rs
+++ b/crates/wenlan-core/src/synthesis/refinement_queue.rs
@@ -284,6 +284,7 @@ async fn apply_cross_space_discovery(
     page_write(
         db,
         PageWrite::Create {
+            page_id: None,
             req,
             agent,
             knowledge_path: None,


### PR DESCRIPTION
## Summary
- Route `document_enrichment::write_source_page` through canonical `PageWrite::Create` instead of direct page insertion.
- Allow deterministic PageWrite source-page IDs while keeping existing non-source create callers on generated IDs.
- Preserve folder chunk provenance as `external_file` evidence and lock the PageWrite birth contract in a focused regression test.

## Review
Deep review meeting completed before PR creation:
- QA lane: PASS.
- Code quality lane: PASS.
- Security lane: PASS, no critical/high blockers.
- Context mining initially found one narrow blocker: the regression did not assert `review_status == "unconfirmed"`. Fixed before commit.
- Goal verification retry: PASS after the contract was rechecked.

## Verification
Ran on latest `origin/main` after creating the branch:
- `rtk cargo fmt --check`
- `rtk cargo clippy -p wenlan-core --all-targets -- -D warnings`
- `rtk cargo test -p wenlan-core document_source_page_creation_routes_through_pagewrite --lib` -> 1 passed, 2034 filtered out
- `rtk cargo test -p wenlan-core document_enrichment::tests --lib` -> 12 passed, 2023 filtered out
- `rtk cargo test -p wenlan-core pagewrite_create_records_resolved_source_kinds_for_file_and_url_sources --test provenance_p2` -> 1 passed, 13 filtered out
- `rtk cargo test -p wenlan-core --test folder_ingest_e2e` -> 1 passed, 1 ignored
- `rtk cargo test -p wenlan-core --lib` -> 2011 passed, 24 ignored
- `rtk cargo check -p wenlan-core`
- `rtk git diff --check`

Draft until CI completes.