### PR TITLE
Guard Wenlan 0.12 release sync surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Set up Wenlan once:
 npx -y wenlan setup
 ```
 
-Then download the current macOS Apple Silicon build: [wenlan-app-darwin-arm64.dmg](https://github.com/7xuanlu/wenlan/releases/latest/download/wenlan-app-darwin-arm64.dmg).
+Then open the desktop app releases page and download the latest macOS Apple Silicon DMG: [wenlan-app releases](https://github.com/7xuanlu/wenlan-app/releases/latest).
 
 App source: [wenlan-app](https://github.com/7xuanlu/wenlan-app). Product details: [wenlan.app](https://wenlan.app).
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=48f15ffc51953d7eb90b7a80805d539ca88b5e2e041f9ee01cc75cbe681ef88d -->
+<!-- README_SYNC: source=README.md sha256=bf29a5dde4cf2efa63e8e847a5f16a3a1ecc3f95601c3b92ac1e8500a6c992b8 -->
 
 <p align="center">
   <img src="./docs/assets/social-preview.png" alt="Wenlan：面向 AI 原生时代的、会生长的个人知识库。" width="100%">
@@ -48,7 +48,7 @@ Wenlan（文澜）的名字来自文澜阁。这座皇家藏书楼藏有《四�
 npx -y wenlan setup
 ```
 
-然后下载当前 macOS Apple Silicon build：[wenlan-app-darwin-arm64.dmg](https://github.com/7xuanlu/wenlan/releases/latest/download/wenlan-app-darwin-arm64.dmg)。
+然后打开桌面 app releases 页面，下载最新 macOS Apple Silicon DMG：[wenlan-app releases](https://github.com/7xuanlu/wenlan-app/releases/latest)。
 
 App 源码：[wenlan-app](https://github.com/7xuanlu/wenlan-app)。产品详情：[wenlan.app](https://wenlan.app)。
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=48f15ffc51953d7eb90b7a80805d539ca88b5e2e041f9ee01cc75cbe681ef88d -->
+<!-- README_SYNC: source=README.md sha256=bf29a5dde4cf2efa63e8e847a5f16a3a1ecc3f95601c3b92ac1e8500a6c992b8 -->
 
 <p align="center">
   <img src="./docs/assets/social-preview.png" alt="Wenlan：面向 AI 原生時代的、會生長的個人知識庫。" width="100%">
@@ -48,7 +48,7 @@ Wenlan（文瀾）的名字來自文瀾閣。這座皇家藏書樓藏有《四�
 npx -y wenlan setup
 ```
 
-然後下載目前 macOS Apple Silicon build：[wenlan-app-darwin-arm64.dmg](https://github.com/7xuanlu/wenlan/releases/latest/download/wenlan-app-darwin-arm64.dmg)。
+然後打開桌面 app releases 頁面，下載最新 macOS Apple Silicon DMG：[wenlan-app releases](https://github.com/7xuanlu/wenlan-app/releases/latest)。
 
 App 原始碼：[wenlan-app](https://github.com/7xuanlu/wenlan-app)。產品詳情：[wenlan.app](https://wenlan.app)。
 

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -12,19 +12,25 @@ This project keeps publishable benchmark numbers in a local gitignored file so R
 
 1. Run benchmark(s) locally and record headline metrics.
 2. Update `${EVAL_BASELINES_DIR:-~/.cache/origin-eval}/readme_metrics.json`.
-3. Regenerate README snapshots:
+3. Check tracked publishable metrics against their tracked source summaries:
+
+```bash
+python3 scripts/update-readme-eval.py --check docs/eval/readme_metrics.example.json
+```
+
+4. Regenerate README snapshots:
 
 ```bash
 python3 scripts/update-readme-eval.py
 ```
 
-4. Check translated README sync:
+5. Check translated README sync:
 
 ```bash
 python3 scripts/check-readme-translations.py
 ```
 
-5. Commit the README and script/docs changes (the local metrics JSON stays untracked).
+6. Commit the README and script/docs changes (the local metrics JSON stays untracked).
 
 ## Notes
 
@@ -32,6 +38,7 @@ python3 scripts/check-readme-translations.py
 - Current README retrieval numbers are retrieval-only, single-run local snapshots unless a reproducibility pass is explicitly documented.
 - LME-S 90 retrieval is saved in `docs/eval/results/lme_s_90_bge_base_pool20.summary.json` with raw rows in `docs/eval/results/lme_s_90_bge_base_pool20.jsonl`.
 - `scripts/update-readme-eval.py` updates the generated retrieval block in English, Simplified Chinese, and Traditional Chinese READMEs.
+- Rows with `source_summary` are checked against tracked summary artifacts before they are treated as publishable README metrics.
 - `scripts/check-readme-translations.py` fails when translated READMEs do not carry the current English README sync hash.
 - Name the retrieval mode once in surrounding prose when all rows use the same mode.
 - Keep `notes` in the metrics JSON for maintainer-facing caveats and run metadata; the root README does not render them.

--- a/docs/eval/readme_metrics.example.json
+++ b/docs/eval/readme_metrics.example.json
@@ -10,6 +10,8 @@
     },
     "longmemeval_s": {
       "label": "LME_S (deep, 90 Q)",
+      "source_summary": "docs/eval/results/lme_s_90_bge_base_pool20.summary.json",
+      "source_metrics": "retrieval",
       "recall_at_5": 0.8767857142857144,
       "mrr": 0.8145975056689342,
       "ndcg_at_10": 0.8223431120728476,

--- a/plugin-codex/.codex-plugin/plugin.json
+++ b/plugin-codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wenlan",
-  "version": "0.10.0+codex",
+  "version": "0.12.0+codex",
   "description": "Codex-native workflow layer for Wenlan, the local-first personal memory layer for AI agents.",
   "author": {
     "name": "Qi-Xuan Lu",

--- a/plugin-codex/README.md
+++ b/plugin-codex/README.md
@@ -26,7 +26,7 @@ codex plugin add wenlan@wenlan-local
 ```
 
 The plugin runner uses `~/.wenlan/bin/wenlan-mcp` when available and falls back
-to `npx -y wenlan-mcp@^0.9.5`. It passes `--agent-name codex` so captures are
+to `npx -y wenlan-mcp@^0.12.0`. It passes `--agent-name codex` so captures are
 labeled as Codex writes.
 
 Before changing plugin skills, manifests, MCP runner wiring, or the local

--- a/plugin-codex/bin/wenlan-mcp-runner.sh
+++ b/plugin-codex/bin/wenlan-mcp-runner.sh
@@ -5,7 +5,7 @@
 #   1. Sibling file `bin/wenlan-mcp.local` next to this script.
 #   2. WENLAN_MCP_DEV_BIN env var, for local development.
 #   3. ~/.wenlan/bin/wenlan-mcp, installed by install.sh.
-#   4. npx -y wenlan-mcp@^0.10.0, package fallback.
+#   4. npx -y wenlan-mcp@^0.12.0, package fallback.
 #
 # The explicit agent name is a Codex plugin requirement: stdio MCP clients may
 # send a client name during initialize, but the fallback must not mislabel
@@ -29,4 +29,4 @@ if [ -x "${installed_bin}" ]; then
   exec "${installed_bin}" --agent-name "${agent_name}" "$@"
 fi
 
-exec npx -y wenlan-mcp@^0.10.0 --agent-name "${agent_name}" "$@"
+exec npx -y wenlan-mcp@^0.12.0 --agent-name "${agent_name}" "$@"

--- a/plugin-codex/skills/setup/SKILL.md
+++ b/plugin-codex/skills/setup/SKILL.md
@@ -79,7 +79,7 @@ command -v wenlan >/dev/null 2>&1 && echo present || echo absent
 If absent, install and configure local memory:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.10.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.12.0/install.sh | bash
 export PATH="$HOME/.wenlan/bin:$PATH"
 wenlan setup --basic
 wenlan background on

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -51,6 +51,11 @@ jq ".version = \"$NEW_VERSION\"" "$PLUGIN_MANIFEST" > "${PLUGIN_MANIFEST}.tmp"
 mv "${PLUGIN_MANIFEST}.tmp" "$PLUGIN_MANIFEST"
 echo "  Updated $PLUGIN_MANIFEST"
 
+CODEX_PLUGIN_MANIFEST="plugin-codex/.codex-plugin/plugin.json"
+jq ".version = \"${NEW_VERSION}+codex\"" "$CODEX_PLUGIN_MANIFEST" > "${CODEX_PLUGIN_MANIFEST}.tmp"
+mv "${CODEX_PLUGIN_MANIFEST}.tmp" "$CODEX_PLUGIN_MANIFEST"
+echo "  Updated $CODEX_PLUGIN_MANIFEST"
+
 # 4. Plugin's MCP server pin — the wrapper script falls back to
 # `npx -y wenlan-mcp@^X.Y.Z` so a floating tag can't auto-RCE on every
 # Claude Code session. The pin lives in the runner shell script, not
@@ -64,6 +69,22 @@ else
 fi
 echo "  Updated $PLUGIN_MCP_RUNNER (wenlan-mcp pin)"
 
+CODEX_PLUGIN_MCP_RUNNER="plugin-codex/bin/wenlan-mcp-runner.sh"
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_MCP_RUNNER"
+else
+    sed -i -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_MCP_RUNNER"
+fi
+echo "  Updated $CODEX_PLUGIN_MCP_RUNNER (wenlan-mcp pin)"
+
+CODEX_PLUGIN_README="plugin-codex/README.md"
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_README"
+else
+    sed -i -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_README"
+fi
+echo "  Updated $CODEX_PLUGIN_README (wenlan-mcp pin)"
+
 # 5. /setup skill install.sh URL pinned to current tag (not `main`), so the
 # install one-liner is reproducible at the release boundary.
 SETUP_SKILL="plugin/skills/setup/SKILL.md"
@@ -73,6 +94,14 @@ else
     sed -i -E "s|(raw\\.githubusercontent\\.com/7xuanlu/wenlan/)(main\|v[0-9]+\\.[0-9]+\\.[0-9]+)(/install\\.sh)|\\1v${NEW_VERSION}\\3|g" "$SETUP_SKILL"
 fi
 echo "  Updated $SETUP_SKILL (install.sh tag pin)"
+
+CODEX_SETUP_SKILL="plugin-codex/skills/setup/SKILL.md"
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' -E "s|(raw\\.githubusercontent\\.com/7xuanlu/wenlan/)(main\|v[0-9]+\\.[0-9]+\\.[0-9]+)(/install\\.sh)|\\1v${NEW_VERSION}\\3|g" "$CODEX_SETUP_SKILL"
+else
+    sed -i -E "s|(raw\\.githubusercontent\\.com/7xuanlu/wenlan/)(main\|v[0-9]+\\.[0-9]+\\.[0-9]+)(/install\\.sh)|\\1v${NEW_VERSION}\\3|g" "$CODEX_SETUP_SKILL"
+fi
+echo "  Updated $CODEX_SETUP_SKILL (install.sh tag pin)"
 
 # 6. Cargo.lock workspace member versions. release-please bumps the manifests
 # above but never regenerates the lockfile, so validate-versions.sh (run in

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -12,6 +12,9 @@ mkdir -p "$TMPDIR_TEST/crates/wenlan-cli/npm"
 mkdir -p "$TMPDIR_TEST/plugin/.claude-plugin"
 mkdir -p "$TMPDIR_TEST/plugin/bin"
 mkdir -p "$TMPDIR_TEST/plugin/skills/setup"
+mkdir -p "$TMPDIR_TEST/plugin-codex/.codex-plugin"
+mkdir -p "$TMPDIR_TEST/plugin-codex/bin"
+mkdir -p "$TMPDIR_TEST/plugin-codex/skills/setup"
 
 cat > "$TMPDIR_TEST/version.txt" <<EOF
 0.5.0
@@ -38,11 +41,27 @@ cat > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json" <<EOF
 {"name": "wenlan", "version": "0.4.1"}
 EOF
 
+cat > "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json" <<EOF
+{"name": "wenlan", "version": "0.4.1+codex"}
+EOF
+
 cat > "$TMPDIR_TEST/plugin/bin/wenlan-mcp-runner.sh" <<EOF
 exec npx -y wenlan-mcp@^0.4.1 "\$@"
 EOF
 
+cat > "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" <<EOF
+exec npx -y wenlan-mcp@^0.4.1 --agent-name "\${agent_name}" "\$@"
+EOF
+
+cat > "$TMPDIR_TEST/plugin-codex/README.md" <<EOF
+Falls back to npx -y wenlan-mcp@^0.4.1 when no local runtime exists.
+EOF
+
 cat > "$TMPDIR_TEST/plugin/skills/setup/SKILL.md" <<EOF
+Bash: curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.4.1/install.sh | bash
+EOF
+
+cat > "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" <<EOF
 Bash: curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.4.1/install.sh | bash
 EOF
 
@@ -98,6 +117,7 @@ WENLAN_CORE_DEP_VER=$(grep -E '^wenlan-core[[:space:]]+=' "$TMPDIR_TEST/Cargo.to
 MCP_NPM_VER=$(jq -r .version "$TMPDIR_TEST/crates/wenlan-mcp/npm/package.json")
 WENLAN_NPM_VER=$(jq -r .version "$TMPDIR_TEST/crates/wenlan-cli/npm/package.json")
 PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json")
+CODEX_PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json")
 
 [[ "$WS_VER" == "0.5.0" ]]   || { echo "FAIL: Cargo.toml not bumped (got $WS_VER)"; exit 1; }
 [[ "$WENLAN_TYPES_DEP_VER" == "0.5.0" ]] || { echo "FAIL: wenlan-types dep not bumped (got $WENLAN_TYPES_DEP_VER)"; exit 1; }
@@ -105,8 +125,12 @@ PLUGIN_VER=$(jq -r .version "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json")
 [[ "$MCP_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: wenlan-mcp npm not bumped (got $MCP_NPM_VER)"; exit 1; }
 [[ "$WENLAN_NPM_VER" == "0.5.0" ]]  || { echo "FAIL: wenlan npm not bumped (got $WENLAN_NPM_VER)"; exit 1; }
 [[ "$PLUGIN_VER" == "0.5.0" ]] || { echo "FAIL: plugin not bumped (got $PLUGIN_VER)"; exit 1; }
+[[ "$CODEX_PLUGIN_VER" == "0.5.0+codex" ]] || { echo "FAIL: Codex plugin not bumped (got $CODEX_PLUGIN_VER)"; exit 1; }
 grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin/bin/wenlan-mcp-runner.sh" || { echo "FAIL: runner pin not bumped"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin/skills/setup/SKILL.md" || { echo "FAIL: setup skill installer not bumped"; exit 1; }
+grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" || { echo "FAIL: Codex runner pin not bumped"; exit 1; }
+grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin-codex/README.md" || { echo "FAIL: Codex README runner pin not bumped"; exit 1; }
+grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" || { echo "FAIL: Codex setup skill installer not bumped"; exit 1; }
 
 # Cargo.lock: all five workspace members bumped to 0.5.0, exactly as
 # validate-versions.sh reads them (name:version pairs).

--- a/scripts/update-readme-eval.py
+++ b/scripts/update-readme-eval.py
@@ -7,10 +7,13 @@ Targets: README files with blocks between EVAL_SNAPSHOT_START / EVAL_SNAPSHOT_EN
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 import os
+import sys
 from pathlib import Path
+from typing import Final, TypeAlias
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -22,6 +25,9 @@ BASELINES_DIR = Path(
 METRICS = BASELINES_DIR / "readme_metrics.json"
 START = "<!-- EVAL_SNAPSHOT_START -->"
 END = "<!-- EVAL_SNAPSHOT_END -->"
+METRIC_FIELDS: Final = ("recall_at_5", "mrr", "ndcg_at_10")
+JsonValue: TypeAlias = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
 
 
 def pct(v: float | None) -> str:
@@ -34,6 +40,70 @@ def score(v: float | None) -> str:
     if v is None:
         return "-"
     return f"{v:.3f}"
+
+
+def load_metrics(path: Path) -> JsonObject:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit(f"{path}: expected JSON object")
+    return data
+
+
+def object_at(value: JsonValue | None, context: str) -> JsonObject:
+    if isinstance(value, dict):
+        return value
+    raise ValueError(f"{context}: expected object")
+
+
+def string_at(value: JsonValue | None, context: str) -> str:
+    if isinstance(value, str):
+        return value
+    raise ValueError(f"{context}: expected string")
+
+
+def number_at(value: JsonValue | None, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{context}: expected number")
+    return float(value)
+
+
+def validate_source_summaries(data: JsonObject, root: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        benchmarks = object_at(data.get("benchmarks"), "benchmarks")
+    except ValueError as exc:
+        return [str(exc)]
+
+    for benchmark_key, row_value in benchmarks.items():
+        try:
+            row = object_at(row_value, benchmark_key)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+
+        source_summary_value = row.get("source_summary")
+        if source_summary_value is None:
+            continue
+
+        try:
+            source_summary = string_at(source_summary_value, f"{benchmark_key}.source_summary")
+            source_metrics = string_at(row.get("source_metrics", "retrieval"), f"{benchmark_key}.source_metrics")
+            summary_path = root / source_summary
+            summary = load_metrics(summary_path)
+            source_values = object_at(summary.get(source_metrics), f"{source_summary} {source_metrics}")
+
+            for field in METRIC_FIELDS:
+                actual = number_at(row.get(field), f"{benchmark_key}.{field}")
+                expected = number_at(source_values.get(field), f"{source_summary} {source_metrics}.{field}")
+                if actual != expected:
+                    errors.append(
+                        f"{benchmark_key}.{field}: {actual} does not match "
+                        f"{source_summary} {source_metrics}.{field} {expected}"
+                    )
+        except (OSError, json.JSONDecodeError, SystemExit, ValueError) as exc:
+            errors.append(f"{benchmark_key}: {exc}")
+
+    return errors
 
 
 def benchmark_rows(data: dict) -> list[dict]:
@@ -112,13 +182,33 @@ def update_tree(root: Path, table: str) -> int:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", type=Path, help="validate benchmark rows against tracked source summaries")
+    args = parser.parse_args()
+
+    if args.check:
+        data = load_metrics(args.check)
+        errors = validate_source_summaries(data, ROOT)
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            raise SystemExit(1)
+        print(f"Metrics source check passed: {args.check}")
+        return
+
     if not METRICS.exists():
         raise SystemExit(
             f"Missing local metrics file: {METRICS}\n"
             "Create it from docs/eval/readme_metrics.example.json first."
         )
 
-    data = json.loads(METRICS.read_text(encoding="utf-8"))
+    data = load_metrics(METRICS)
+    errors = validate_source_summaries(data, ROOT)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        raise SystemExit(1)
+
     table = build_table(data)
     changed = update_tree(ROOT, table)
     print(f"Updated {changed} README file(s) from {METRICS}")

--- a/scripts/update-readme-eval.test.py
+++ b/scripts/update-readme-eval.test.py
@@ -94,6 +94,49 @@ class UpdateReadmeEvalTests(unittest.TestCase):
                     (root / rel).read_text(encoding="utf-8"),
                 )
 
+    def test_metrics_source_check_detects_lme_s_summary_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            summary = root / "docs/eval/results/lme_s.summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                """
+{
+  "retrieval": {
+    "recall_at_5": 0.8767857142857144,
+    "mrr": 0.8145975056689342,
+    "ndcg_at_10": 0.8223431120728476
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            errors = module.validate_source_summaries(
+                {
+                    "benchmarks": {
+                        "longmemeval_s": {
+                            "source_summary": "docs/eval/results/lme_s.summary.json",
+                            "source_metrics": "retrieval",
+                            "recall_at_5": 0.1,
+                            "mrr": 0.8145975056689342,
+                            "ndcg_at_10": 0.8223431120728476,
+                        }
+                    }
+                },
+                root,
+            )
+
+            self.assertEqual(
+                errors,
+                ["longmemeval_s.recall_at_5: 0.1 does not match docs/eval/results/lme_s.summary.json retrieval.recall_at_5 0.8767857142857144"],
+            )
+
+    def test_tracked_example_metrics_match_tracked_summaries(self) -> None:
+        data = module.load_metrics(module.ROOT / "docs/eval/readme_metrics.example.json")
+
+        self.assertEqual(module.validate_source_summaries(data, module.ROOT), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -28,6 +28,11 @@ LOCK_VERSIONS=$(awk '
 MCP_NPM_VER=$(jq -r .version crates/wenlan-mcp/npm/package.json)
 WENLAN_NPM_VER=$(jq -r .version crates/wenlan-cli/npm/package.json)
 PLUGIN_VER=$(jq -r .version plugin/.claude-plugin/plugin.json)
+CODEX_PLUGIN_VER_RAW=$(jq -r .version plugin-codex/.codex-plugin/plugin.json)
+CODEX_PLUGIN_VER="${CODEX_PLUGIN_VER_RAW%%+*}"
+CODEX_RUNNER_PINS=$(grep -Eo 'wenlan-mcp@\^[0-9]+\.[0-9]+\.[0-9]+' plugin-codex/bin/wenlan-mcp-runner.sh | sed -E 's/.*@\^//' | sort -u || true)
+CODEX_README_PINS=$(grep -Eo 'wenlan-mcp@\^[0-9]+\.[0-9]+\.[0-9]+' plugin-codex/README.md | sed -E 's/.*@\^//' | sort -u || true)
+CODEX_SETUP_TAGS=$(grep -Eo '/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' plugin-codex/skills/setup/SKILL.md | sed -E 's|/v([^/]+)/install\.sh|\1|' | sort -u || true)
 
 echo "Tag:         $TAG_VER"
 echo "version.txt: $VTXT_VER"
@@ -39,9 +44,28 @@ printf '%s\n' "$LOCK_VERSIONS" | sed 's/^/  /'
 echo "wenlan-mcp npm: $MCP_NPM_VER"
 echo "wenlan npm: $WENLAN_NPM_VER"
 echo "Plugin:      $PLUGIN_VER"
+echo "Codex plugin: $CODEX_PLUGIN_VER_RAW"
+echo "Codex runner pins:"
+printf '%s\n' "$CODEX_RUNNER_PINS" | sed 's/^/  /'
+echo "Codex README pins:"
+printf '%s\n' "$CODEX_README_PINS" | sed 's/^/  /'
+echo "Codex setup tags:"
+printf '%s\n' "$CODEX_SETUP_TAGS" | sed 's/^/  /'
 
-if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$WENLAN_TYPES_DEP_VER" != "$TAG_VER" || "$WENLAN_CORE_DEP_VER" != "$TAG_VER" || "$MCP_NPM_VER" != "$TAG_VER" || "$WENLAN_NPM_VER" != "$TAG_VER" || "$PLUGIN_VER" != "$TAG_VER" ]]; then
+if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$WENLAN_TYPES_DEP_VER" != "$TAG_VER" || "$WENLAN_CORE_DEP_VER" != "$TAG_VER" || "$MCP_NPM_VER" != "$TAG_VER" || "$WENLAN_NPM_VER" != "$TAG_VER" || "$PLUGIN_VER" != "$TAG_VER" || "$CODEX_PLUGIN_VER" != "$TAG_VER" ]]; then
     echo "ERROR: version drift — bump-version.sh likely failed in release-please.yml"
+    exit 1
+fi
+
+for pin in $CODEX_RUNNER_PINS $CODEX_README_PINS $CODEX_SETUP_TAGS; do
+    if [[ "$pin" != "$TAG_VER" ]]; then
+        echo "ERROR: Codex plugin release pin drift — ${pin} is not ${TAG_VER}"
+        exit 1
+    fi
+done
+
+if [[ -z "$CODEX_RUNNER_PINS" || -z "$CODEX_README_PINS" || -z "$CODEX_SETUP_TAGS" ]]; then
+    echo "ERROR: Codex plugin release pin missing"
     exit 1
 fi
 

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 TMPDIR_TEST=$(mktemp -d)
 trap "rm -rf $TMPDIR_TEST" EXIT
 
-mkdir -p "$TMPDIR_TEST/crates/wenlan-mcp/npm" "$TMPDIR_TEST/crates/wenlan-cli/npm" "$TMPDIR_TEST/plugin/.claude-plugin"
+mkdir -p \
+    "$TMPDIR_TEST/crates/wenlan-mcp/npm" \
+    "$TMPDIR_TEST/crates/wenlan-cli/npm" \
+    "$TMPDIR_TEST/plugin/.claude-plugin" \
+    "$TMPDIR_TEST/plugin-codex/.codex-plugin" \
+    "$TMPDIR_TEST/plugin-codex/bin" \
+    "$TMPDIR_TEST/plugin-codex/skills/setup"
 echo "0.5.0" > "$TMPDIR_TEST/version.txt"
 cat > "$TMPDIR_TEST/Cargo.toml" <<EOF
 [workspace.package]
@@ -38,6 +44,16 @@ EOF
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/crates/wenlan-mcp/npm/package.json"
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/crates/wenlan-cli/npm/package.json"
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/plugin/.claude-plugin/plugin.json"
+echo '{"version": "0.5.0+codex"}' > "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json"
+cat > "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" <<EOF
+exec npx -y wenlan-mcp@^0.5.0 --agent-name "\${agent_name}" "\$@"
+EOF
+cat > "$TMPDIR_TEST/plugin-codex/README.md" <<EOF
+Fallbacks to npx -y wenlan-mcp@^0.5.0 when no local runtime exists.
+EOF
+cat > "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" <<EOF
+curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.5.0/install.sh | bash
+EOF
 
 # Test 1: all match → exit 0
 (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh")
@@ -68,3 +84,49 @@ if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-ver
     exit 1
 fi
 echo "PASS test 4: Cargo.lock drift detected"
+
+perl -0pi -e 's/name = "wenlan-core"\nversion = "0\.4\.9"/name = "wenlan-core"\nversion = "0.5.0"/' "$TMPDIR_TEST/Cargo.lock"
+echo '{"version": "0.4.9+codex"}' > "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json"
+if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
+    echo "FAIL test 5: should have detected Codex plugin manifest drift"
+    exit 1
+fi
+echo "PASS test 5: Codex plugin manifest drift detected"
+
+echo '{"version": "0.5.0+codex"}' > "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json"
+perl -0pi -e 's/wenlan-mcp@\^0\.5\.0/wenlan-mcp@^0.4.9/g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
+    echo "FAIL test 6: should have detected Codex runner pin drift"
+    exit 1
+fi
+echo "PASS test 6: Codex runner pin drift detected"
+
+perl -0pi -e 's/wenlan-mcp@\^0\.4\.9/wenlan-mcp@^0.5.0/g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+perl -0pi -e 's|/v0\.5\.0/install\.sh|/v0.4.9/install.sh|g' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md"
+if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
+    echo "FAIL test 7: should have detected Codex setup install tag drift"
+    exit 1
+fi
+echo "PASS test 7: Codex setup install tag drift detected"
+
+perl -0pi -e 's|/v0\.4\.9/install\.sh|/v0.5.0/install.sh|g' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md"
+perl -0pi -e 's/wenlan-mcp@\^0\.5\.0/wenlan-mcp@^0.4.9/g' "$TMPDIR_TEST/plugin-codex/README.md"
+if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
+    echo "FAIL test 8: should have detected Codex README runner pin drift"
+    exit 1
+fi
+echo "PASS test 8: Codex README runner pin drift detected"
+
+cat > "$TMPDIR_TEST/plugin-codex/README.md" <<EOF
+No package fallback is documented here.
+EOF
+if output=$(cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh" 2>&1); then
+    echo "FAIL test 9: should have detected missing Codex README runner pin"
+    exit 1
+fi
+if ! printf '%s\n' "$output" | grep -q "Codex plugin release pin missing"; then
+    echo "FAIL test 9: missing pin error was not reported"
+    printf '%s\n' "$output"
+    exit 1
+fi
+echo "PASS test 9: Codex README runner pin missing detected"


### PR DESCRIPTION
## What changed

- Extend version sync and validation to the Codex plugin manifest, runner fallback pin, README pin, and setup install tag.
- Add README eval metric source-summary validation so tracked publishable benchmark rows are checked against tracked summary artifacts.
- Document the new eval check in `docs/eval/README.md`.

## Why

The release truth spans code/package metadata, plugin install surfaces, and publishable docs/eval rows. Before this change, Codex plugin pins and README eval metrics could drift without the release guard catching them.

## Impact

Release preparation now fails earlier when a Codex plugin version/pin or README eval row diverges from the authoritative product artifacts.

## Validation

- `python3 scripts/update-readme-eval.test.py`
- `python3 scripts/update-readme-eval.py --check docs/eval/readme_metrics.example.json`
- `python3 scripts/check-readme-translations.py`
- `RELEASE_TAG=v0.12.0 bash scripts/validate-versions.sh`
- `bash scripts/bump-version.test.sh`
- `bash scripts/validate-versions.test.sh`