### PR TITLE
fix: enforce release and public contract drift checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '**.md'
-      - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'
       - 'LICENSE'
@@ -31,6 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       rust:    ${{ steps.filter.outputs.rust }}
+      docs:    ${{ steps.filter.outputs.docs }}
       plugin:  ${{ steps.filter.outputs.plugin }}
       npm:     ${{ steps.filter.outputs.npm }}
       windows: ${{ steps.filter.outputs.windows }}
@@ -68,6 +67,19 @@ jobs:
               - 'scripts/validate-codex-plugin-slice.py'
               - 'scripts/validate-plugin-contract.py'
               - 'scripts/validate-plugin-contract.test.sh'
+            docs:
+              - 'README.md'
+              - 'README.zh-Hans.md'
+              - 'README.zh-Hant.md'
+              - 'docs/eval/**'
+              - 'scripts/check-readme-translations.py'
+              - 'scripts/check-readme-translations.test.sh'
+              - 'scripts/update-readme-eval.py'
+              - 'scripts/update-readme-eval.test.py'
+              - 'scripts/validate-versions.sh'
+              - 'scripts/validate-versions.test.sh'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
             npm:
               - 'crates/*/npm/**'
             windows:
@@ -409,6 +421,21 @@ jobs:
       - name: Quarantined tests (wenlan-mcp + wenlan-types)
         run: cargo nextest run -p wenlan-mcp -p wenlan-types
 
+  docs:
+    name: docs provenance
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.docs == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate README translations and eval provenance
+        run: |
+          python3 scripts/check-readme-translations.py
+          bash scripts/check-readme-translations.test.sh
+          python3 scripts/update-readme-eval.py --check docs/eval/readme_metrics.example.json
+          python3 scripts/update-readme-eval.test.py
+          bash scripts/validate-versions.test.sh
+
   # Aggregate gate for branch protection. `if: always()` lets docs-only PRs
   # (where the test matrix skips via detect-changes) report success instead
   # of stalling forever on a never-run required check.
@@ -419,7 +446,7 @@ jobs:
   # is their normal state on PRs not touching those surfaces.
   conclusion:
     name: conclusion
-    needs: [detect-changes, fmt, lint, test, plugin, npm]
+    needs: [detect-changes, fmt, lint, test, docs, plugin, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -430,7 +457,7 @@ jobs:
             echo "detect-changes did not succeed: $dc"
             exit 1
           fi
-          for r in '${{ needs.fmt.result }}' '${{ needs.lint.result }}' '${{ needs.test.result }}' '${{ needs.plugin.result }}' '${{ needs.npm.result }}'; do
+          for r in '${{ needs.fmt.result }}' '${{ needs.lint.result }}' '${{ needs.test.result }}' '${{ needs.docs.result }}' '${{ needs.plugin.result }}' '${{ needs.npm.result }}'; do
             case "$r" in
               success|skipped) ;;
               *) echo "Upstream job failed: $r"; exit 1 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Verify release checkout
+        shell: bash
+        run: |
+          expected=$(git rev-list -n1 "refs/tags/$RELEASE_TAG")
+          actual=$(git rev-parse HEAD)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "ERROR: checkout $actual does not match refs/tags/$RELEASE_TAG ($expected)"
+            exit 1
+          fi
 
       - name: Validate version consistency
         run: bash scripts/validate-versions.sh
         env:
           RELEASE_TAG: ${{ env.RELEASE_TAG }}
+
+      - name: Validate README translations and eval provenance
+        run: |
+          python3 scripts/check-readme-translations.py
+          python3 scripts/update-readme-eval.py --check docs/eval/readme_metrics.example.json
 
       - name: Compose release body
         run: |
@@ -142,9 +157,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Verify release checkout
+        shell: bash
+        run: |
+          expected=$(git rev-list -n1 "refs/tags/$RELEASE_TAG")
+          actual=$(git rev-parse HEAD)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "ERROR: checkout $actual does not match refs/tags/$RELEASE_TAG ($expected)"
+            exit 1
+          fi
 
       - name: Validate version consistency
         if: runner.os != 'Windows'
@@ -363,7 +388,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Verify release checkout
+        shell: bash
+        run: |
+          expected=$(git rev-list -n1 "refs/tags/$RELEASE_TAG")
+          actual=$(git rev-parse HEAD)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "ERROR: checkout $actual does not match refs/tags/$RELEASE_TAG ($expected)"
+            exit 1
+          fi
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -406,7 +442,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify release checkout
+        shell: bash
+        run: |
+          expected=$(git rev-list -n1 "refs/tags/$RELEASE_TAG")
+          actual=$(git rev-parse HEAD)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "ERROR: checkout $actual does not match refs/tags/$RELEASE_TAG ($expected)"
+            exit 1
+          fi
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -491,6 +539,19 @@ jobs:
       id-token: write    # OIDC trusted publishing
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{ env.RELEASE_TAG }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Verify release checkout
+        shell: bash
+        run: |
+          expected=$(git rev-list -n1 "refs/tags/$RELEASE_TAG")
+          actual=$(git rev-parse HEAD)
+          if [[ "$actual" != "$expected" ]]; then
+            echo "ERROR: checkout $actual does not match refs/tags/$RELEASE_TAG ($expected)"
+            exit 1
+          fi
       - uses: actions/setup-node@v4
         with:
           node-version: "24"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Pre-commit auto-formats Rust and runs Clippy on changed crates. Pre-push runs wo
 
 ## Cross-platform
 
-Wenlan runs on macOS (arm64, x86_64), Linux (x86_64, aarch64; musl), and Windows (x86_64).
+Wenlan builds from source on macOS (arm64, x86_64), Linux (x86_64, aarch64; glibc), and Windows (x86_64). Current prebuilt releases cover macOS arm64, Linux x86_64/aarch64 with glibc, and Windows x86_64; macOS x86_64 is source-build only.
 
 | OS | Data dir | Service registration |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Retrieval-only snapshot, not end-to-end answer quality. Method and update workfl
 
 ## Build from source
 
-Wenlan builds natively on macOS (Apple Silicon + Intel), Linux (x86_64 + ARM64; glibc), and Windows (x86_64). The npm wrapper (`wenlan`, `wenlan-mcp`) and `install.sh` auto-detect your platform and pull the matching prebuilt release. Most users should install through the Claude Code plugin or `npx`. For local development:
+Wenlan builds from source on macOS (Apple Silicon + Intel), Linux (x86_64 + ARM64; glibc), and Windows (x86_64). Current prebuilt releases cover macOS Apple Silicon, Linux x86_64/ARM64 with glibc, and Windows x86_64; macOS Intel remains source-build only. The npm wrapper (`wenlan`, `wenlan-mcp`) and `install.sh` auto-detect supported prebuilt platforms. Most users should install through the Claude Code plugin or `npx`. For local development:
 
 ```bash
 git clone https://github.com/7xuanlu/wenlan.git
@@ -221,9 +221,9 @@ Longer-form writing on AI work memory and how Wenlan compares lives at [wenlan.a
 - [AI agent handoff loop](https://wenlan.app/learn/ai-agent-handoff-loop): session-end discipline that prevents context loss
 
 **Comparisons**
-- [Wenlan vs Basic Memory](https://wenlan.app/learn/origin-vs-basic-memory): Markdown knowledge base vs AI work-session memory
-- [Wenlan vs claude-mem](https://wenlan.app/learn/origin-vs-claude-mem): observer-style Claude Code memory vs MCP-first cross-tool memory
-- [Wenlan vs Superlocal Memory](https://wenlan.app/learn/origin-vs-superlocal-memory): tradeoffs against another local memory shape
+- [Wenlan vs Basic Memory](https://wenlan.app/learn/wenlan-vs-basic-memory): Markdown knowledge base vs AI work-session memory
+- [Wenlan vs claude-mem](https://wenlan.app/learn/wenlan-vs-claude-mem): observer-style Claude Code memory vs MCP-first cross-tool memory
+- [Wenlan vs Superlocal Memory](https://wenlan.app/learn/wenlan-vs-superlocal-memory): tradeoffs against another local memory shape
 
 **Docs**
 - [Get started](https://wenlan.app/docs/get-started): install + verify the first local memory loop

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=bf29a5dde4cf2efa63e8e847a5f16a3a1ecc3f95601c3b92ac1e8500a6c992b8 -->
+<!-- README_SYNC: source=README.md sha256=0175f0eb27ebc55eec6f29fe9e1e39d2f90cdafc0eb3d764ea489d5d57e823fb -->
 
 <p align="center">
   <img src="./docs/assets/social-preview.png" alt="Wenlan：面向 AI 原生时代的、会生长的个人知识库。" width="100%">
@@ -202,7 +202,7 @@ CLI 细节见：[crates/wenlan-cli](crates/wenlan-cli/README.md)。
 
 ## 从源码构建
 
-Wenlan 可以在 macOS（Apple Silicon + Intel）、Linux（x86_64 + ARM64；glibc）和 Windows（x86_64）上原生构建。npm wrapper（`wenlan`、`wenlan-mcp`）和 `install.sh` 会自动检测平台并拉取匹配的 prebuilt release。大多数用户应该通过 Claude Code 插件或 `npx` 安装。本地开发：
+Wenlan 可以在 macOS（Apple Silicon + Intel）、Linux（x86_64 + ARM64；glibc）和 Windows（x86_64）上从源码构建。当前预编译 release 覆盖 macOS Apple Silicon、使用 glibc 的 Linux x86_64/ARM64，以及 Windows x86_64；macOS Intel 仍仅支持源码构建。npm wrapper（`wenlan`、`wenlan-mcp`）和 `install.sh` 会自动检测受支持的预编译平台。大多数用户应该通过 Claude Code 插件或 `npx` 安装。本地开发：
 
 ```bash
 git clone https://github.com/7xuanlu/wenlan.git
@@ -227,9 +227,9 @@ daemon、MCP server、CLI 和 core crates 的构建细节在上面链接的 crat
 - [AI agent handoff loop](https://wenlan.app/learn/ai-agent-handoff-loop)：防止 context loss 的 session-end discipline
 
 **Comparisons**
-- [Wenlan vs Basic Memory](https://wenlan.app/learn/origin-vs-basic-memory)：Markdown knowledge base vs AI work-session memory
-- [Wenlan vs claude-mem](https://wenlan.app/learn/origin-vs-claude-mem)：observer-style Claude Code memory vs MCP-first cross-tool memory
-- [Wenlan vs Superlocal Memory](https://wenlan.app/learn/origin-vs-superlocal-memory)：与另一种本地记忆形态的 tradeoffs
+- [Wenlan vs Basic Memory](https://wenlan.app/learn/wenlan-vs-basic-memory)：Markdown knowledge base vs AI work-session memory
+- [Wenlan vs claude-mem](https://wenlan.app/learn/wenlan-vs-claude-mem)：observer-style Claude Code memory vs MCP-first cross-tool memory
+- [Wenlan vs Superlocal Memory](https://wenlan.app/learn/wenlan-vs-superlocal-memory)：与另一种本地记忆形态的 tradeoffs
 
 **Docs**
 - [Get started](https://wenlan.app/docs/get-started)：install + verify 第一个本地 memory loop

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=bf29a5dde4cf2efa63e8e847a5f16a3a1ecc3f95601c3b92ac1e8500a6c992b8 -->
+<!-- README_SYNC: source=README.md sha256=0175f0eb27ebc55eec6f29fe9e1e39d2f90cdafc0eb3d764ea489d5d57e823fb -->
 
 <p align="center">
   <img src="./docs/assets/social-preview.png" alt="Wenlan：面向 AI 原生時代的、會生長的個人知識庫。" width="100%">
@@ -202,7 +202,7 @@ CLI 細節見：[crates/wenlan-cli](crates/wenlan-cli/README.md)。
 
 ## 從原始碼構建
 
-Wenlan 可以在 macOS（Apple Silicon + Intel）、Linux（x86_64 + ARM64；glibc）和 Windows（x86_64）上原生構建。npm wrapper（`wenlan`、`wenlan-mcp`）和 `install.sh` 會自動偵測平台並拉取匹配的 prebuilt release。大多數使用者應該透過 Claude Code 插件或 `npx` 安裝。本地開發：
+Wenlan 可以在 macOS（Apple Silicon + Intel）、Linux（x86_64 + ARM64；glibc）和 Windows（x86_64）上從原始碼構建。目前預編譯 release 覆蓋 macOS Apple Silicon、使用 glibc 的 Linux x86_64/ARM64，以及 Windows x86_64；macOS Intel 仍僅支援原始碼構建。npm wrapper（`wenlan`、`wenlan-mcp`）和 `install.sh` 會自動偵測受支援的預編譯平台。大多數使用者應該透過 Claude Code 插件或 `npx` 安裝。本地開發：
 
 ```bash
 git clone https://github.com/7xuanlu/wenlan.git
@@ -227,9 +227,9 @@ daemon、MCP server、CLI 和 core crates 的構建細節在上面連結的 crat
 - [AI agent handoff loop](https://wenlan.app/learn/ai-agent-handoff-loop)：防止 context loss 的 session-end discipline
 
 **Comparisons**
-- [Wenlan vs Basic Memory](https://wenlan.app/learn/origin-vs-basic-memory)：Markdown knowledge base vs AI work-session memory
-- [Wenlan vs claude-mem](https://wenlan.app/learn/origin-vs-claude-mem)：observer-style Claude Code memory vs MCP-first cross-tool memory
-- [Wenlan vs Superlocal Memory](https://wenlan.app/learn/origin-vs-superlocal-memory)：與另一種本地記憶形態的 tradeoffs
+- [Wenlan vs Basic Memory](https://wenlan.app/learn/wenlan-vs-basic-memory)：Markdown knowledge base vs AI work-session memory
+- [Wenlan vs claude-mem](https://wenlan.app/learn/wenlan-vs-claude-mem)：observer-style Claude Code memory vs MCP-first cross-tool memory
+- [Wenlan vs Superlocal Memory](https://wenlan.app/learn/wenlan-vs-superlocal-memory)：與另一種本地記憶形態的 tradeoffs
 
 **Docs**
 - [Get started](https://wenlan.app/docs/get-started)：install + verify 第一個本地 memory loop

--- a/plugin-codex/README.md
+++ b/plugin-codex/README.md
@@ -13,7 +13,7 @@ codex plugin add wenlan@wenlan-local
 ```
 
 Start a new Codex thread after installing so the skills and MCP server load.
-Then try `/init`, `/brief`, `/capture <memory>`, `/recall <query>`,
+Then try `/setup`, `/brief`, `/capture <memory>`, `/recall <query>`,
 `/pages <query>`, or `/handoff`.
 
 ## Development

--- a/scripts/validate-plugin-contract.py
+++ b/scripts/validate-plugin-contract.py
@@ -219,6 +219,15 @@ def validate_resolver_parity(root: Path) -> None:
         fail("plugin-codex/bin/resolve-space.sh must match plugin/bin/resolve-space.sh")
 
 
+def validate_codex_readme(root: Path) -> None:
+    path = root / "plugin-codex" / "README.md"
+    text = read_text(root, path)
+    if not re.search(r"(?<![A-Za-z0-9_-])/setup\b", text):
+        fail(f"{rel(root, path)} must direct users to /setup")
+    if re.search(r"(?<![A-Za-z0-9_-])/init\b", text):
+        fail(f"{rel(root, path)} must not advertise the retired /init command")
+
+
 def iter_matching_plugin(plugins: list[Any], plugin_name: str):
     for item in plugins:
         if isinstance(item, dict) and item.get("name") == plugin_name:
@@ -336,6 +345,7 @@ def validate_contract(root: Path) -> None:
         validate_runner(root, surface, config)
 
     validate_resolver_parity(root)
+    validate_codex_readme(root)
     validate_marketplace(root, surfaces["codex"])
 
     validate_skill_surface(

--- a/scripts/validate-plugin-contract.test.sh
+++ b/scripts/validate-plugin-contract.test.sh
@@ -54,6 +54,10 @@ assert_rejects "setup autocomplete drift" \
     perl -0pi -e 's/user-invocable: true/user-invocable: false/' \
     "$TMPDIR_TEST/root/plugin-codex/skills/setup/SKILL.md"
 
+assert_rejects "codex README setup command drift" \
+    perl -0pi -e 's|/setup|/init|g' \
+    "$TMPDIR_TEST/root/plugin-codex/README.md"
+
 assert_rejects "codex resolver parity drift" \
     perl -0pi -e 's/cwd-config-default/codex-default/' \
     "$TMPDIR_TEST/root/plugin-codex/bin/resolve-space.sh"

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 TMPDIR_TEST=$(mktemp -d)
 trap "rm -rf $TMPDIR_TEST" EXIT
 
@@ -130,3 +131,36 @@ if ! printf '%s\n' "$output" | grep -q "Codex plugin release pin missing"; then
     exit 1
 fi
 echo "PASS test 9: Codex README runner pin missing detected"
+
+assert_release_job_pins_tag() {
+    local workflow="$1"
+    local job="$2"
+    python3 - "$workflow" "$job" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+workflow = Path(sys.argv[1]).read_text()
+job = re.escape(sys.argv[2])
+match = re.search(rf"^  {job}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)", workflow, re.MULTILINE | re.DOTALL)
+if not match:
+    raise SystemExit(1)
+body = match.group("body")
+checkout = re.search(r"^      - (?:name: Checkout\n        )?uses: actions/checkout@[^\n]+\n(?P<body>.*?)(?=^      - |\Z)", body, re.MULTILINE | re.DOTALL)
+if not checkout or not re.search(r"^          ref: refs/tags/\$\{\{ env\.RELEASE_TAG \}\}\s*$", checkout.group("body"), re.MULTILINE):
+    raise SystemExit(1)
+verify = re.search(r"^      - name: Verify release checkout\n(?P<body>.*?)(?=^      - |\Z)", body, re.MULTILINE | re.DOTALL)
+if not verify or not re.search(r"^        shell: bash\s*$", verify.group("body"), re.MULTILINE):
+    raise SystemExit(1)
+if 'git rev-parse HEAD' not in verify.group("body") or 'git rev-list -n1 "refs/tags/$RELEASE_TAG"' not in verify.group("body"):
+    raise SystemExit(1)
+PY
+}
+
+for job in prepare-release release docker publish-crates publish-npm; do
+    if ! assert_release_job_pins_tag "$REPO_ROOT/.github/workflows/release.yml" "$job"; then
+        echo "FAIL test 10: $job must checkout and verify RELEASE_TAG"
+        exit 1
+    fi
+done
+echo "PASS test 10: release-producing jobs checkout and verify RELEASE_TAG"


### PR DESCRIPTION
## Summary
- pin every release-producing checkout to the requested tag and assert the checked-out commit matches it
- enforce README translation/eval provenance and version drift checks in CI and release preparation
- align Codex setup command and public platform wording with current product/release facts

## Validation
- README translation check + self-test
- README eval source check + 4 unit tests
- current v0.12.0 version validation + 10 validator witness tests
- plugin contract validation + 10 contract tests
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- repository pre-commit checks