### PR TITLE
fix: harden lint diagnostics from live dogfood

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -12166,28 +12166,56 @@ impl MemoryDB {
         source_id: &str,
     ) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
-        conn.execute(
-            "DELETE FROM memories WHERE source = ?1 AND source_id = ?2",
-            libsql::params![source.to_string(), source_id.to_string()],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("delete_by_source_id: {}", e)))?;
-        // Clean up orphaned enrichment_steps (no FK cascade)
-        conn.execute(
-            "DELETE FROM enrichment_steps WHERE source_id = ?1",
-            libsql::params![source_id.to_string()],
-        )
-        .await
-        .ok();
-        // T15a: clean up orphaned child_vectors for memory parents (no FK cascade;
-        // parent_id is source_id not rowid). Scoped to memory deletes.
-        if source == "memory" {
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("delete_by_source_id BEGIN: {e}")))?;
+        let result: Result<(), WenlanError> = async {
             conn.execute(
-                "DELETE FROM child_vectors WHERE parent_kind = 'memory' AND parent_id = ?1",
+                "DELETE FROM memories WHERE source = ?1 AND source_id = ?2",
+                libsql::params![source.to_string(), source_id.to_string()],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("delete_by_source_id: {e}")))?;
+            // Clean up orphaned enrichment_steps (no FK cascade).
+            conn.execute(
+                "DELETE FROM enrichment_steps WHERE source_id = ?1",
                 libsql::params![source_id.to_string()],
             )
             .await
-            .ok();
+            .map_err(|e| WenlanError::VectorDb(format!("delete enrichment steps: {e}")))?;
+            // T15a: clean up derived memory state whose parent key is source_id.
+            if source == "memory" {
+                conn.execute(
+                    "DELETE FROM child_vectors WHERE parent_kind = 'memory' AND parent_id = ?1",
+                    libsql::params![source_id.to_string()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("delete child vectors: {e}")))?;
+                conn.execute(
+                    "DELETE FROM memory_entities WHERE memory_id = ?1",
+                    libsql::params![source_id.to_string()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("delete memory entity links: {e}")))?;
+                conn.execute(
+                    "DELETE FROM document_tags WHERE source = 'memory' AND source_id = ?1",
+                    libsql::params![source_id.to_string()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("delete memory tags: {e}")))?;
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(error) = result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(error);
+        }
+        if let Err(error) = conn.execute("COMMIT", ()).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(WenlanError::VectorDb(format!(
+                "delete_by_source_id COMMIT: {error}"
+            )));
         }
         Ok(())
     }
@@ -28209,6 +28237,92 @@ pub(crate) mod tests {
         // Should not error on missing source_id
         let result = db.delete_by_source_id("local_files", "nonexistent").await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_delete_memory_cleans_derived_links_and_tags() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        conn.execute_batch(
+            "INSERT INTO entities
+                 (id,name,entity_type,confirmed,created_at,updated_at)
+             VALUES ('entity-delete','Delete Target','concept',0,1,1);
+             INSERT INTO memories
+                 (id,content,source,source_id,title,chunk_index,last_modified,chunk_type)
+             VALUES ('row-delete','Delete Target','memory','mem-delete','delete',0,1,'text');
+             INSERT INTO memory_entities (memory_id,entity_id)
+             VALUES ('mem-delete','entity-delete');
+             INSERT INTO document_tags (source,source_id,tag)
+             VALUES ('memory','mem-delete','derived');",
+        )
+        .await
+        .unwrap();
+        drop(conn);
+
+        db.delete_by_source_id("memory", "mem-delete")
+            .await
+            .unwrap();
+
+        let conn = db.conn.lock().await;
+        for (table, sql) in [
+            (
+                "memory_entities",
+                "SELECT COUNT(*) FROM memory_entities WHERE memory_id='mem-delete'",
+            ),
+            (
+                "document_tags",
+                "SELECT COUNT(*) FROM document_tags WHERE source='memory' AND source_id='mem-delete'",
+            ),
+        ] {
+            let count: i64 = conn
+                .query(sql, ())
+                .await
+                .unwrap()
+                .next()
+                .await
+                .unwrap()
+                .unwrap()
+                .get(0)
+                .unwrap();
+            assert_eq!(count, 0, "{table} must not retain deleted memory state");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_memory_rolls_back_when_derived_cleanup_fails() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        conn.execute_batch(
+            "INSERT INTO entities
+                 (id,name,entity_type,confirmed,created_at,updated_at)
+             VALUES ('entity-rollback','Rollback Target','concept',0,1,1);
+             INSERT INTO memories
+                 (id,content,source,source_id,title,chunk_index,last_modified,chunk_type)
+             VALUES ('row-rollback','Rollback Target','memory','mem-rollback','rollback',0,1,'text');
+             INSERT INTO memory_entities (memory_id,entity_id)
+             VALUES ('mem-rollback','entity-rollback');
+             CREATE TRIGGER reject_memory_entity_cleanup
+             BEFORE DELETE ON memory_entities
+             BEGIN SELECT RAISE(ABORT, 'forced cleanup failure'); END;",
+        )
+        .await
+        .unwrap();
+        drop(conn);
+
+        assert!(db
+            .delete_by_source_id("memory", "mem-rollback")
+            .await
+            .is_err());
+
+        let rows = db
+            .get_memories_by_source_id("memory", "mem-rollback")
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.len(),
+            1,
+            "failed cleanup must roll back primary delete"
+        );
     }
 
     // ==================== delete_bulk ====================

--- a/crates/wenlan-core/src/export/knowledge.rs
+++ b/crates/wenlan-core/src/export/knowledge.rs
@@ -10,11 +10,20 @@ use std::path::PathBuf;
 
 const KNOWLEDGE_STATE_SCHEMA_V2: u32 = 2;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct KnowledgeState {
     #[serde(default = "default_schema_v2")]
     schema_version: u32,
     pages: HashMap<String, PageFileState>,
+}
+
+impl Default for KnowledgeState {
+    fn default() -> Self {
+        Self {
+            schema_version: KNOWLEDGE_STATE_SCHEMA_V2,
+            pages: HashMap::new(),
+        }
+    }
 }
 
 fn default_schema_v2() -> u32 {
@@ -252,7 +261,11 @@ impl KnowledgeWriter {
             };
         }
 
-        serde_json::from_str(&data).unwrap_or_default()
+        let mut state: KnowledgeState = serde_json::from_str(&data).unwrap_or_default();
+        if state.schema_version == 0 {
+            state.schema_version = KNOWLEDGE_STATE_SCHEMA_V2;
+        }
+        state
     }
 
     fn save_state(&self, state: &KnowledgeState) -> Result<(), WenlanError> {
@@ -422,6 +435,7 @@ mod tests {
         writer.write_page_for_test(&test_concept()).unwrap();
 
         let state = writer.load_state();
+        assert_eq!(state.schema_version, KNOWLEDGE_STATE_SCHEMA_V2);
         assert!(state.pages.contains_key("concept_test123"));
         assert_eq!(state.pages["concept_test123"].file, "rust-ownership.md");
         assert_eq!(state.pages["concept_test123"].version, 2);
@@ -531,6 +545,23 @@ mod tests {
         assert!(written.contains("\"pages\""));
         assert!(!written.contains("\"concepts\""));
         assert!(written.contains("\"schema_version\""));
+    }
+
+    #[test]
+    fn test_load_state_upgrades_writer_default_v0() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let writer = KnowledgeWriter::new_for_test(dir.path().to_path_buf());
+        std::fs::create_dir_all(dir.path().join(".wenlan")).unwrap();
+        std::fs::write(
+            dir.path().join(".wenlan/state.json"),
+            r#"{"schema_version":0,"pages":{}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            writer.load_state().schema_version,
+            KNOWLEDGE_STATE_SCHEMA_V2
+        );
     }
 
     #[test]

--- a/crates/wenlan-core/src/lint/deep.rs
+++ b/crates/wenlan-core/src/lint/deep.rs
@@ -108,7 +108,8 @@ async fn memory_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()
         context,
         &format!(
             "WITH heads AS (
-                 SELECT m.source_id, LOWER(TRIM(MIN(m.content))) AS normalized
+                 SELECT m.source_id,
+                        LOWER(TRIM(MAX(CASE WHEN m.chunk_index=0 THEN m.content END))) AS normalized
                    FROM memories m
                   WHERE m.source='memory' AND m.pending_revision=0
                     AND COALESCE(m.is_recap,0)=0 AND m.supersede_mode!='evicted'{scope}

--- a/crates/wenlan-core/src/lint/deep_test.rs
+++ b/crates/wenlan-core/src/lint/deep_test.rs
@@ -94,6 +94,40 @@ async fn deep_profile_detects_structural_and_advisory_counterexamples() {
 }
 
 #[tokio::test]
+async fn duplicate_inventory_compares_memory_heads_not_shared_later_chunks() {
+    let (db, _dir) = test_db().await;
+    db.conn
+        .lock()
+        .await
+        .execute_batch(
+            "INSERT INTO memories
+                 (id,content,source,source_id,title,chunk_index,last_modified,chunk_type,
+                  memory_type,pending_revision,is_recap,supersede_mode)
+             VALUES
+                 ('row_a0','session alpha','memory','mem_a','a',0,0,'text',
+                  'fact',0,0,'hide'),
+                 ('row_a1','## Notes','memory','mem_a','a',1,0,'text',
+                  'fact',0,0,'hide'),
+                 ('row_b0','session beta','memory','mem_b','b',0,0,'text',
+                  'fact',0,0,'hide'),
+                 ('row_b1','## Notes','memory','mem_b','b',1,0,'text',
+                  'fact',0,0,'hide');",
+        )
+        .await
+        .unwrap();
+
+    let report = deep_report(&db, None).await;
+    assert_eq!(
+        check(&report, MEMORY_DUPLICATES).outcome(),
+        LintOutcome::Pass
+    );
+    assert_eq!(
+        check(&report, MEMORY_DUPLICATES).coverage().denominator(),
+        2
+    );
+}
+
+#[tokio::test]
 async fn deep_page_body_alignment_uses_state_mapping_and_canonical_body() {
     let (db, _dir) = test_db().await;
     db.conn

--- a/crates/wenlan-core/src/lint/identity/query.rs
+++ b/crates/wenlan-core/src/lint/identity/query.rs
@@ -111,12 +111,12 @@ SELECT invalid FROM (
 ) ORDER BY key";
 
 const MEMORY_SQL: &str = "
-SELECT CASE WHEN COALESCE(m.confirmed,-1) NOT IN (0,1) OR COALESCE(m.pinned,-1) NOT IN (0,1)
+SELECT CASE WHEN (m.confirmed IS NOT NULL AND m.confirmed NOT IN (0,1)) OR COALESCE(m.pinned,-1) NOT IN (0,1)
  OR COALESCE(m.pending_revision,-1) NOT IN (0,1) OR (m.pinned=1 AND COALESCE(m.confirmed,0)!=1)
  OR m.stability NOT IN ('new','learned','confirmed') OR m.supersedes=m.source_id
  OR (m.pending_revision=1 AND (m.supersedes IS NULL OR NOT EXISTS(SELECT 1 FROM memories prior WHERE prior.source='memory' AND prior.source_id=m.supersedes)))
  OR (m.space IS NOT NULL AND NOT EXISTS(SELECT 1 FROM spaces s WHERE s.name=m.space))
- OR (m.source_agent IS NOT NULL AND NOT EXISTS(SELECT 1 FROM agent_connections a WHERE a.name=m.source_agent))
+ OR (m.source_agent IS NOT NULL AND TRIM(m.source_agent)='')
  THEN 1 ELSE 0 END
 FROM memories m WHERE m.source='memory' AND m.chunk_index=0{scope} ORDER BY m.source_id";
 

--- a/crates/wenlan-core/src/lint/identity_test.rs
+++ b/crates/wenlan-core/src/lint/identity_test.rs
@@ -70,6 +70,27 @@ async fn impossible_registry_session_cache_and_tag_rows_are_findings() {
 }
 
 #[tokio::test]
+async fn importer_unknown_confirmation_and_provenance_agent_are_valid() {
+    let (db, _temp) = test_db().await;
+    db.conn
+        .lock()
+        .await
+        .execute(
+            "INSERT INTO memories
+                 (id,content,source,source_id,title,chunk_index,last_modified,chunk_type,
+                  confirmed,pinned,pending_revision,stability,supersede_mode,source_agent)
+             VALUES ('import-row','imported','memory','import-source','imported',0,1,'text',
+                     NULL,0,0,'new','hide','folder')",
+            (),
+        )
+        .await
+        .unwrap();
+
+    let report = run_lint(&db, None).await;
+    assert_eq!(check(&report, MEMORY).outcome(), LintOutcome::Pass);
+}
+
+#[tokio::test]
 async fn cross_owner_and_out_of_window_session_rows_are_findings() {
     let (db, _temp) = test_db().await;
     db.conn

--- a/crates/wenlan-core/src/lint/kg/query.rs
+++ b/crates/wenlan-core/src/lint/kg/query.rs
@@ -105,7 +105,7 @@ async fn link_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
             "SELECT CASE WHEN m.source_id IS NULL OR e.id IS NULL THEN 1 ELSE 0 END
                FROM memory_entities me
                LEFT JOIN (SELECT source_id, MAX(id) AS id, MAX(space) AS space FROM memories
-                           WHERE source='memory' GROUP BY source_id) m
+                           GROUP BY source_id) m
                  ON m.source_id=me.memory_id
                LEFT JOIN entities e ON e.id=me.entity_id
                {clause} ORDER BY me.memory_id, me.entity_id"

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -50,6 +50,29 @@ async fn structural_orphans_and_invalid_rows_are_errors_without_mutation() {
 }
 
 #[tokio::test]
+async fn imported_document_entity_links_have_a_valid_memory_owner() {
+    let (db, _tmp) = test_db().await;
+    db.conn
+        .lock()
+        .await
+        .execute_batch(
+            "INSERT INTO entities
+                 (id,name,entity_type,confirmed,created_at,updated_at)
+             VALUES ('entity-doc','Imported Topic','concept',0,1,1);
+             INSERT INTO memories
+                 (id,content,source,source_id,title,chunk_index,last_modified,chunk_type)
+             VALUES ('row-doc','Imported Topic','local_files','/tmp/doc.md','doc',0,1,'text');
+             INSERT INTO memory_entities (memory_id,entity_id)
+             VALUES ('/tmp/doc.md','entity-doc');",
+        )
+        .await
+        .unwrap();
+
+    let report = run(&db, None, test_config(true)).await;
+    assert_eq!(check(&report, LINKS).outcome(), LintOutcome::Pass);
+}
+
+#[tokio::test]
 async fn scoped_rows_follow_memory_or_entity_ownership_but_aggregates_stay_global() {
     let (db, _tmp) = test_db().await;
     seed_valid_scoped_graph(&db).await;

--- a/crates/wenlan-core/src/lint/semantic.rs
+++ b/crates/wenlan-core/src/lint/semantic.rs
@@ -54,6 +54,13 @@ struct Adjudication {
     agent_submissions: u64,
 }
 
+#[derive(Clone, Copy, Default)]
+struct SemanticTelemetry<'a> {
+    adjudication: Option<&'a Adjudication>,
+    judged: u64,
+    unresolved: u64,
+}
+
 pub(super) async fn run(
     context: &LintContext<'_, '_>,
     provider: Option<&dyn LlmProvider>,
@@ -440,6 +447,24 @@ fn semantic_result(
         .iter()
         .filter(|candidate| candidate.check_id() == check_id)
         .collect::<Vec<_>>();
+    let adjudicated_verdicts = adjudication
+        .map(|value| {
+            check_candidates
+                .iter()
+                .filter_map(|candidate| value.verdicts.get(&candidate.reference()))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let judged = adjudicated_verdicts.len() as u64;
+    let unresolved = adjudicated_verdicts
+        .iter()
+        .filter(|verdict| verdict.has_unresolved_disagreement())
+        .count() as u64;
+    let telemetry = SemanticTelemetry {
+        adjudication,
+        judged,
+        unresolved,
+    };
     let result = if population.eligible() == 0 {
         terminal_result(
             context,
@@ -447,6 +472,7 @@ fn semantic_result(
             population,
             LintOutcome::NotRunPrerequisite,
             LintReasonCode::InsufficientSemanticEvidence,
+            telemetry,
         )
     } else if population.truncated() {
         terminal_result(
@@ -455,6 +481,7 @@ fn semantic_result(
             population,
             LintOutcome::FailedToRun,
             LintReasonCode::SemanticPopulationIncomplete,
+            telemetry,
         )
     } else if check_candidates.is_empty() {
         terminal_result(
@@ -463,6 +490,7 @@ fn semantic_result(
             population,
             LintOutcome::NotRunPrerequisite,
             LintReasonCode::InsufficientSemanticEvidence,
+            telemetry,
         )
     } else {
         match adjudication {
@@ -478,12 +506,10 @@ fn semantic_result(
                     LintOutcome::FailedToRun
                 },
                 missing_reason,
+                SemanticTelemetry::default(),
             ),
             Some(adjudication) => {
-                let verdicts = check_candidates
-                    .iter()
-                    .filter_map(|candidate| adjudication.verdicts.get(&candidate.reference()))
-                    .collect::<Vec<_>>();
+                let verdicts = &adjudicated_verdicts;
                 if verdicts.len() != check_candidates.len() {
                     terminal_result(
                         context,
@@ -491,6 +517,7 @@ fn semantic_result(
                         population,
                         LintOutcome::FailedToRun,
                         LintReasonCode::SemanticPopulationIncomplete,
+                        telemetry,
                     )
                 } else if verdicts
                     .iter()
@@ -502,22 +529,22 @@ fn semantic_result(
                         population,
                         LintOutcome::FailedToRun,
                         LintReasonCode::SemanticDisagreementUnresolved,
+                        telemetry,
                     )
-                } else if check_candidates
-                    .iter()
-                    .zip(&verdicts)
-                    .any(|(candidate, verdict)| {
+                } else if check_candidates.iter().zip(verdicts.iter()).any(
+                    |(candidate, verdict)| {
                         verdict.decision() == LintSemanticDecision::Finding
                             && requires_second_judge(candidate.proposed_action())
                             && verdict.second_decision().is_none()
-                    })
-                {
+                    },
+                ) {
                     terminal_result(
                         context,
                         check_id,
                         population,
                         LintOutcome::FailedToRun,
                         LintReasonCode::SemanticSecondJudgeRequired,
+                        telemetry,
                     )
                 } else {
                     completed_result(
@@ -525,7 +552,7 @@ fn semantic_result(
                         candidates,
                         check_id,
                         population,
-                        &verdicts,
+                        verdicts,
                         Some(adjudication),
                     )
                 }
@@ -590,6 +617,10 @@ fn completed_result(
         .collect::<Vec<_>>();
     let affected = evidence.len() as u64;
     let finding = affected > 0;
+    let unresolved = verdicts
+        .iter()
+        .filter(|verdict| verdict.has_unresolved_disagreement())
+        .count() as u64;
     LintCheckResult::try_new_with_gate_effect(
         LintCheckResultInput {
             check_id: check_id.as_str().to_string(),
@@ -618,7 +649,13 @@ fn completed_result(
                 affected,
             )
             .expect("complete semantic coverage"),
-            metrics: semantic_metrics(population, population.candidates(), affected, adjudication),
+            metrics: semantic_metrics(
+                population,
+                population.candidates(),
+                affected,
+                adjudication,
+                unresolved,
+            ),
             summary_code: if finding {
                 LintSummaryCode::FindingDetected
             } else {
@@ -639,6 +676,7 @@ fn terminal_result(
     population: &LintSemanticPopulation,
     outcome: LintOutcome,
     reason_code: LintReasonCode,
+    telemetry: SemanticTelemetry<'_>,
 ) -> LintCheckResult {
     let prerequisite = outcome == LintOutcome::NotRunPrerequisite;
     LintCheckResult::try_new_with_gate_effect(
@@ -665,7 +703,13 @@ fn terminal_result(
                 1,
             )
             .expect("incomplete semantic coverage"),
-            metrics: semantic_metrics(population, 0, 0, None),
+            metrics: semantic_metrics(
+                population,
+                telemetry.judged,
+                0,
+                telemetry.adjudication,
+                telemetry.unresolved,
+            ),
             summary_code: if prerequisite {
                 LintSummaryCode::PrerequisiteUnavailable
             } else {
@@ -691,6 +735,7 @@ fn semantic_metrics(
     judged: u64,
     affected: u64,
     adjudication: Option<&Adjudication>,
+    unresolved: u64,
 ) -> Vec<LintMetric> {
     vec![
         metric(
@@ -715,16 +760,7 @@ fn semantic_metrics(
             LintMetricCode::SemanticAgentSubmissions,
             adjudication.map_or(0, |value| value.agent_submissions),
         ),
-        metric(
-            LintMetricCode::SemanticUnresolvedDisagreements,
-            adjudication.map_or(0, |value| {
-                value
-                    .verdicts
-                    .values()
-                    .filter(|verdict| verdict.has_unresolved_disagreement())
-                    .count() as u64
-            }),
-        ),
+        metric(LintMetricCode::SemanticUnresolvedDisagreements, unresolved),
         boolean_metric(
             LintMetricCode::SemanticProviderOnDevice,
             adjudication.is_some_and(|value| value.route == LintSemanticProviderRoute::OnDevice),
@@ -765,7 +801,7 @@ fn inconsistent_results(
                         1,
                     )
                     .expect("snapshot coverage"),
-                    metrics: semantic_metrics(population, 0, 0, None),
+                    metrics: semantic_metrics(population, 0, 0, None, 0),
                     summary_code: LintSummaryCode::SnapshotInconsistent,
                     recommendation_code: Some(LintRecommendationCode::RerunAfterSnapshotStabilizes),
                     evidence: vec![LintEvidenceRef::ReasonCode {
@@ -800,6 +836,7 @@ fn failed_generation(context: &LintContext<'_, '_>, reason_code: LintReasonCode)
                 &population,
                 LintOutcome::FailedToRun,
                 reason_code,
+                SemanticTelemetry::default(),
             );
             context
                 .record_population(check_id.as_str(), population_basis(context), 0)

--- a/crates/wenlan-core/src/lint/semantic_candidates.rs
+++ b/crates/wenlan-core/src/lint/semantic_candidates.rs
@@ -42,11 +42,19 @@ struct Entity {
     selected: bool,
 }
 
+struct Relation {
+    from_entity: String,
+    to_entity: String,
+    relation_type: String,
+}
+
 #[derive(Clone)]
 struct Page {
     id: String,
     content: String,
     workspace: Option<String>,
+    creation_kind: String,
+    review_status: String,
     content_tokens: BTreeSet<String>,
 }
 
@@ -223,12 +231,15 @@ pub(super) async fn load(context: &LintContext<'_, '_>) -> Result<CandidateSet, 
         }
     }
 
-    let relation_pairs = relations.into_iter().collect::<BTreeSet<_>>();
-    for (from, to) in &relation_pairs {
+    let relation_pairs = relations
+        .iter()
+        .map(|relation| (relation.from_entity.clone(), relation.to_entity.clone()))
+        .collect::<BTreeSet<_>>();
+    for relation in &relations {
         candidate_checkpoint(context, &mut work_units).await?;
         let (Some(left), Some(right)) = (
-            entity_by_id.get(from.as_str()),
-            entity_by_id.get(to.as_str()),
+            entity_by_id.get(relation.from_entity.as_str()),
+            entity_by_id.get(relation.to_entity.as_str()),
         ) else {
             continue;
         };
@@ -238,7 +249,10 @@ pub(super) async fn load(context: &LintContext<'_, '_>) -> Result<CandidateSet, 
         builder.add(
             LintSemanticCheckId::EntityRelations,
             LintSemanticCandidateKind::ExistingLink,
-            vec![entity_record(left), entity_record(right)],
+            vec![
+                relation_entity_record(left, &relation.relation_type, "from"),
+                relation_entity_record(right, &relation.relation_type, "to"),
+            ],
             Vec::new(),
             LintSemanticAction::RemoveEntityRelation,
             LintSemanticReasonCode::ExistingRelationMismatch,
@@ -802,15 +816,19 @@ async fn load_memory_entity_links(
     Ok(output)
 }
 
-async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<(String, String)>, ()> {
+async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<Relation>, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "source.space");
     let mut rows = context.snapshot().query(
-        &format!("SELECT r.from_entity,r.to_entity FROM relations r JOIN entities source ON source.id=r.from_entity WHERE 1=1{scope} ORDER BY r.from_entity,r.to_entity,r.id"),
+        &format!("SELECT r.from_entity,r.to_entity,r.relation_type FROM relations r JOIN entities source ON source.id=r.from_entity WHERE 1=1{scope} ORDER BY r.from_entity,r.to_entity,r.id"),
         params,
     ).await.map_err(|_| ())?;
     let mut output = Vec::new();
     while let Some(row) = rows.next().await.map_err(|_| ())? {
-        output.push((row.get(0).map_err(|_| ())?, row.get(1).map_err(|_| ())?));
+        output.push(Relation {
+            from_entity: row.get(0).map_err(|_| ())?,
+            to_entity: row.get(1).map_err(|_| ())?,
+            relation_type: row.get(2).map_err(|_| ())?,
+        });
     }
     Ok(output)
 }
@@ -818,7 +836,7 @@ async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<(String, St
 async fn load_pages(context: &LintContext<'_, '_>) -> Result<Vec<Page>, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "p.workspace");
     let mut rows = context.snapshot().query(
-        &format!("SELECT p.id,p.content,p.workspace FROM pages p WHERE p.status='active'{scope} ORDER BY p.id"),
+        &format!("SELECT p.id,p.content,p.workspace,p.creation_kind,p.review_status FROM pages p WHERE p.status='active'{scope} ORDER BY p.id"),
         params,
     ).await.map_err(|_| ())?;
     let mut output = Vec::new();
@@ -829,6 +847,8 @@ async fn load_pages(context: &LintContext<'_, '_>) -> Result<Vec<Page>, ()> {
             content_tokens: content_tokens(&content),
             content,
             workspace: row.get(2).map_err(|_| ())?,
+            creation_kind: row.get(3).map_err(|_| ())?,
+            review_status: row.get(4).map_err(|_| ())?,
         });
     }
     Ok(output)
@@ -869,7 +889,7 @@ fn memory_record(memory: &Memory) -> Record {
     Record {
         key: format!("memory:{}", memory.id),
         kind: LintAgentRecordKind::Memory,
-        excerpt: bounded(&memory.content),
+        excerpt: contextual_excerpt(memory.space.as_deref(), &memory.content),
         memory_type: memory.memory_type.clone(),
         evidence_count: None,
         source_excerpt: None,
@@ -880,7 +900,26 @@ fn entity_record(entity: &Entity) -> Record {
     Record {
         key: format!("entity:{}", entity.id),
         kind: LintAgentRecordKind::Entity,
-        excerpt: bounded(&entity.name),
+        excerpt: contextual_excerpt(entity.space.as_deref(), &entity.name),
+        memory_type: None,
+        evidence_count: None,
+        source_excerpt: None,
+    }
+}
+
+fn relation_entity_record(entity: &Entity, relation_type: &str, endpoint: &str) -> Record {
+    let scope = entity.space.as_deref().unwrap_or("uncategorized");
+    Record {
+        key: format!("relation-entity:{}:{relation_type}:{endpoint}", entity.id),
+        kind: LintAgentRecordKind::Entity,
+        excerpt: contextual_excerpt_with(
+            &[
+                ("scope", scope),
+                ("relation_type", relation_type),
+                ("endpoint", endpoint),
+            ],
+            &entity.name,
+        ),
         memory_type: None,
         evidence_count: None,
         source_excerpt: None,
@@ -888,14 +927,56 @@ fn entity_record(entity: &Entity) -> Record {
 }
 
 fn page_record(page: &Page, evidence_count: u64, source: Option<&str>) -> Record {
+    let scope = page.workspace.as_deref().unwrap_or("uncategorized");
     Record {
         key: format!("page:{}", page.id),
         kind: LintAgentRecordKind::Page,
-        excerpt: bounded(&page.content),
+        excerpt: contextual_excerpt_with(
+            &[
+                ("scope", scope),
+                ("creation_kind", &page.creation_kind),
+                ("review_status", &page.review_status),
+            ],
+            &page.content,
+        ),
         memory_type: None,
         evidence_count: Some(evidence_count),
         source_excerpt: source.map(bounded),
     }
+}
+
+fn contextual_excerpt(scope: Option<&str>, value: &str) -> String {
+    contextual_excerpt_with(&[("scope", scope.unwrap_or("uncategorized"))], value)
+}
+
+fn contextual_excerpt_with(fields: &[(&str, &str)], value: &str) -> String {
+    let metadata = fields
+        .iter()
+        .map(|(key, value)| format!("{key}={}", context_value(value)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let prefix = format!("[lint_context {metadata}]\n");
+    let content = redact_excerpt(value);
+    prefix
+        .chars()
+        .chain(content.chars())
+        .take(LINT_AGENT_EXCERPT_CHAR_CAP)
+        .collect()
+}
+
+fn context_value(value: &str) -> String {
+    let redacted = redact_excerpt(value);
+    redacted
+        .trim_matches(['[', ']'])
+        .chars()
+        .map(|character| {
+            if character.is_whitespace() || matches!(character, '[' | ']') {
+                '_'
+            } else {
+                character
+            }
+        })
+        .collect()
 }
 
 fn bounded(value: &str) -> String {
@@ -1134,4 +1215,17 @@ fn digest_id(key: &str) -> LintDigest {
     LintDigest::from_u64(u64::from_le_bytes(
         digest[..8].try_into().expect("digest prefix"),
     ))
+}
+
+#[cfg(test)]
+mod excerpt_tests {
+    use super::contextual_excerpt;
+
+    #[test]
+    fn redacted_scope_keeps_context_marker_well_formed() {
+        let excerpt = contextual_excerpt(Some("/Users/alice/private"), "visible evidence");
+
+        assert_eq!(excerpt, "[lint_context scope=redacted]\nvisible evidence");
+        assert!(!excerpt.contains("/Users/alice"));
+    }
 }

--- a/crates/wenlan-core/src/lint/semantic_test.rs
+++ b/crates/wenlan-core/src/lint/semantic_test.rs
@@ -316,18 +316,46 @@ async fn scoped_candidates_hydrate_cross_space_existing_link_endpoints() {
 
     let report = prepare(&db, Some("work")).await;
     let work = report.agent_work().unwrap();
-    assert!(candidates_for(work, LintSemanticCheckId::MemoryEntityLinks)
-        .iter()
-        .any(|candidate| {
+    let memory_link = candidates_for(work, LintSemanticCheckId::MemoryEntityLinks)
+        .into_iter()
+        .find(|candidate| {
             candidate.kind() == LintSemanticCandidateKind::ExistingLink
                 && candidate.proposed_action() == LintSemanticAction::RemoveMemoryEntityLink
-        }));
-    assert!(candidates_for(work, LintSemanticCheckId::EntityRelations)
+        })
+        .expect("cross-space memory link candidate");
+    let memory_link_excerpts = memory_link
+        .evidence_refs()
         .iter()
-        .any(|candidate| {
+        .map(|reference| work.records()[usize::from(*reference - 1)].excerpt())
+        .collect::<Vec<_>>();
+    assert!(memory_link_excerpts
+        .iter()
+        .any(|value| value.contains("scope=work")));
+    assert!(memory_link_excerpts
+        .iter()
+        .any(|value| value.contains("scope=personal")));
+
+    let relation = candidates_for(work, LintSemanticCheckId::EntityRelations)
+        .into_iter()
+        .find(|candidate| {
             candidate.kind() == LintSemanticCandidateKind::ExistingLink
                 && candidate.proposed_action() == LintSemanticAction::RemoveEntityRelation
-        }));
+        })
+        .expect("cross-space relation candidate");
+    let relation_excerpts = relation
+        .evidence_refs()
+        .iter()
+        .map(|reference| work.records()[usize::from(*reference - 1)].excerpt())
+        .collect::<Vec<_>>();
+    assert!(relation_excerpts
+        .iter()
+        .all(|value| value.contains("relation_type=related")));
+    assert!(relation_excerpts
+        .iter()
+        .any(|value| value.contains("scope=work")));
+    assert!(relation_excerpts
+        .iter()
+        .any(|value| value.contains("scope=personal")));
 }
 
 #[tokio::test]
@@ -487,6 +515,24 @@ async fn candidate_truncation_is_incomplete_not_clean() {
         LintOutcome::FailedToRun,
         LintReasonCode::SemanticPopulationIncomplete,
     );
+
+    let submission = submission_for(work, None, false);
+    let submitted = submit(&db, submission, None).await;
+    let result = check(&submitted, LintSemanticCheckId::MemoryEntityLinks);
+    assert_reason(
+        &submitted,
+        LintSemanticCheckId::MemoryEntityLinks,
+        LintOutcome::FailedToRun,
+        LintReasonCode::SemanticPopulationIncomplete,
+    );
+    assert_eq!(
+        metric_value(result, LintMetricCode::SemanticJudgedRecords),
+        Some(&LintMetricValue::Count { value: 6 })
+    );
+    assert_eq!(
+        metric_value(result, LintMetricCode::SemanticAgentSubmissions),
+        Some(&LintMetricValue::Count { value: 1 })
+    );
 }
 
 #[tokio::test]
@@ -536,6 +582,15 @@ async fn page_evidence_candidates_ignore_high_frequency_token_noise() {
         .candidates(),
         1
     );
+
+    let work = report.agent_work().unwrap();
+    let provenance = candidates_for(work, LintSemanticCheckId::PageProvenanceAdequacy);
+    assert_eq!(provenance.len(), 2);
+    for candidate in provenance {
+        let excerpt = work.records()[usize::from(candidate.evidence_refs()[0] - 1)].excerpt();
+        assert!(excerpt.contains("creation_kind=authored"));
+        assert!(excerpt.contains("review_status=confirmed"));
+    }
 }
 
 #[tokio::test]
@@ -553,13 +608,39 @@ async fn disagreement_and_missing_second_judge_remain_incomplete() {
     );
 
     let prepared = prepare(&db, None).await;
-    let disagreement = disagreement_submission(prepared.agent_work().unwrap());
+    let work = prepared.agent_work().unwrap();
+    let contradiction_count =
+        candidates_for(work, LintSemanticCheckId::MemoryContradiction).len() as u64;
+    let disagreement = disagreement_submission(work);
     let report = submit(&db, disagreement, None).await;
     assert_reason(
         &report,
         LintSemanticCheckId::MemoryContradiction,
         LintOutcome::FailedToRun,
         LintReasonCode::SemanticDisagreementUnresolved,
+    );
+    let contradiction = check(&report, LintSemanticCheckId::MemoryContradiction);
+    assert_eq!(
+        metric_value(contradiction, LintMetricCode::SemanticJudgedRecords),
+        Some(&LintMetricValue::Count {
+            value: contradiction_count
+        })
+    );
+    assert_eq!(
+        metric_value(
+            contradiction,
+            LintMetricCode::SemanticUnresolvedDisagreements
+        ),
+        Some(&LintMetricValue::Count {
+            value: contradiction_count
+        })
+    );
+    assert_eq!(
+        metric_value(
+            check(&report, LintSemanticCheckId::MemoryClassification),
+            LintMetricCode::SemanticUnresolvedDisagreements
+        ),
+        Some(&LintMetricValue::Count { value: 0 })
     );
 }
 


### PR DESCRIPTION
## What changed

- make memory deletion atomic and remove derived entity/tag state
- eliminate lint false positives for imported-document links, importer provenance, and duplicate memory chunks
- upgrade writer-default Page state v0 to the canonical v2 state contract
- add scope, relation, Page creation, and review context to bounded redacted semantic evidence packets
- preserve judged, submission, and disagreement telemetry when semantic checks remain incomplete

## Why

Live dogfooding against the real Wenlan store exposed several diagnostics that were structurally valid but operationally misleading. Some imported records were reported as broken, duplicate detection compared later chunks instead of memory heads, fresh Page projections wrote schema v0, and incomplete semantic reports discarded useful adjudication telemetry. The external review also found that memory deletion could partially commit and that path-like scope metadata could be malformed by redaction.

## Impact

`wenlan lint` remains read-only. General and deep profiles keep the same report and daemon contract, but findings are more accurate and semantic packets carry enough bounded context for a Codex/agent judge. Memory deletion now commits primary and derived cleanup together.

## Validation

- `cargo test -p wenlan-core --lib lint::` (190 passed, 2 ignored)
- `cargo test --workspace --lib` (all workspace library suites passed)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Claude Code Opus review; confirmed follow-up fixes added for deletion atomicity and metadata redaction
- live general/deep lint against the real store plus an exact-snapshot controlled daemon run
