### PR TITLE
fix: keep daemon responsive during directory sync

### DIFF
--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -279,6 +279,7 @@ pub async fn run_periodic_steep(
     tuning: &crate::tuning::RefineryConfig,
     _confidence_cfg: &crate::tuning::ConfidenceConfig,
     distillation: &crate::tuning::DistillationConfig,
+    knowledge_path: Option<&std::path::Path>,
 ) -> Result<SteepResult, WenlanError> {
     // Forward to implementation with no API/synthesis LLM and full Backstop
     // trigger (preserves pre-PR-A behavior for callers that don't care about
@@ -293,6 +294,7 @@ pub async fn run_periodic_steep(
         tuning,
         _confidence_cfg,
         distillation,
+        knowledge_path,
         TriggerKind::Backstop,
     )
     .await
@@ -313,6 +315,7 @@ pub async fn run_periodic_steep_with_api(
     tuning: &crate::tuning::RefineryConfig,
     _confidence_cfg: &crate::tuning::ConfidenceConfig,
     distillation: &crate::tuning::DistillationConfig,
+    knowledge_path: Option<&std::path::Path>,
     trigger: TriggerKind,
 ) -> Result<SteepResult, WenlanError> {
     let steep_start = std::time::Instant::now();
@@ -534,11 +537,7 @@ pub async fn run_periodic_steep_with_api(
     // Phase 6: Normal distill — create new concepts from clusters
     // Prefer synthesis LLM, API LLM, external/BYOK API, then on-device.
     let compile_llm = synthesis_llm.or(api_llm).or(external_llm).or(llm);
-    let knowledge_path = {
-        let config = crate::config::load_config();
-        Some(config.knowledge_path_or_default())
-    };
-    let kp_ref = knowledge_path.as_deref();
+    let kp_ref = knowledge_path;
     if trigger.runs_phase(Phase::Emergence) {
         let phase = run_phase(Phase::Emergence, || async {
             let cloud_compile_llm = [synthesis_llm, api_llm, external_llm, llm]
@@ -1533,6 +1532,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Backstop,
         )
         .await
@@ -1564,6 +1564,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::BurstEnd,
         )
         .await
@@ -1613,6 +1614,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Backstop,
         )
         .await
@@ -1635,6 +1637,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::BurstEnd,
         )
         .await
@@ -1678,6 +1681,7 @@ mod tests {
                 &crate::tuning::RefineryConfig::default(),
                 &crate::tuning::ConfidenceConfig::default(),
                 &crate::tuning::DistillationConfig::default(),
+                None,
                 TriggerKind::Backstop,
             )
             .await
@@ -1709,6 +1713,7 @@ mod tests {
                 &crate::tuning::RefineryConfig::default(),
                 &crate::tuning::ConfidenceConfig::default(),
                 &crate::tuning::DistillationConfig::default(),
+                None,
                 TriggerKind::Backstop,
             )
             .await
@@ -1740,6 +1745,7 @@ mod tests {
                 &crate::tuning::RefineryConfig::default(),
                 &crate::tuning::ConfidenceConfig::default(),
                 &crate::tuning::DistillationConfig::default(),
+                None,
                 TriggerKind::BurstEnd,
             )
             .await
@@ -1777,6 +1783,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Idle,
         )
         .await
@@ -1854,6 +1861,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Daily,
         )
         .await
@@ -1924,6 +1932,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Backstop,
         )
         .await
@@ -1998,6 +2007,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
         )
         .await
         .unwrap();
@@ -2057,6 +2067,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
         )
         .await
         .unwrap();
@@ -2170,6 +2181,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
         )
         .await
         .unwrap();
@@ -2363,6 +2375,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Idle,
         )
         .await
@@ -2440,6 +2453,7 @@ mod tests {
                 &crate::tuning::RefineryConfig::default(),
                 &crate::tuning::ConfidenceConfig::default(),
                 &crate::tuning::DistillationConfig::default(),
+                None,
                 TriggerKind::Idle,
             ),
         )
@@ -2529,6 +2543,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Idle,
         )
         .await
@@ -2614,6 +2629,7 @@ mod tests {
                     &crate::tuning::RefineryConfig::default(),
                     &crate::tuning::ConfidenceConfig::default(),
                     &crate::tuning::DistillationConfig::default(),
+                    None,
                     TriggerKind::Idle,
                 )
                 .await
@@ -2695,6 +2711,7 @@ mod tests {
                     &crate::tuning::RefineryConfig::default(),
                     &crate::tuning::ConfidenceConfig::default(),
                     &crate::tuning::DistillationConfig::default(),
+                    None,
                     TriggerKind::Daily,
                 )
                 .await
@@ -3028,6 +3045,7 @@ mod tests {
             &crate::tuning::RefineryConfig::default(),
             &crate::tuning::ConfidenceConfig::default(),
             &crate::tuning::DistillationConfig::default(),
+            None,
             TriggerKind::Backstop,
         )
         .await

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -732,6 +732,7 @@ pub async fn handle_steep(
             s.tuning.distillation.clone(),
         )
     };
+    let knowledge_path = wenlan_core::config::load_config().knowledge_path_or_default();
     let result = wenlan_core::refinery::run_periodic_steep_with_api(
         &db,
         llm.as_ref(),
@@ -742,6 +743,7 @@ pub async fn handle_steep(
         &tuning,
         &confidence_cfg,
         &distillation_cfg,
+        Some(&knowledge_path),
         wenlan_core::refinery::TriggerKind::Backstop,
     )
     .await

--- a/crates/wenlan-server/src/scheduler.rs
+++ b/crates/wenlan-server/src/scheduler.rs
@@ -528,11 +528,18 @@ pub fn spawn_scheduler(shared: SharedState, write_signal: WriteSignal) {
     });
 }
 
+/// Background polling respects an explicit pause but keeps probing unavailable
+/// roots so transient filesystem failures can recover automatically.
+fn should_poll_directory_source(source: &wenlan_types::sources::Source) -> bool {
+    source.source_type == wenlan_types::sources::SourceType::Directory
+        && !matches!(source.status, wenlan_types::sources::SyncStatus::Paused)
+}
+
 /// One Directory-source sync + document-enrichment-queue-drive pass (§4).
 /// Factored out of the 30s poll loop so it is unit-testable without the timer.
 ///
 /// Each call:
-/// 1. syncs every registered Directory source via the SHARED
+/// 1. syncs every recoverable Directory source via the SHARED
 ///    [`crate::source_routes::sync_directory_source`] (cheap mtime/hash diff +
 ///    deletion propagation — no LLM, no network), enqueueing changed files, then
 /// 2. drains up to `max_docs` claimable documents through
@@ -553,11 +560,11 @@ async fn run_directory_sync_tick(
     let config = wenlan_core::config::load_config();
     let knowledge_path = config.knowledge_path_or_default();
 
-    // 1. Sync every Directory source (log-and-continue on error).
+    // 1. Sync recoverable Directory sources (log-and-continue on error).
     for source in config
         .sources
         .iter()
-        .filter(|s| s.source_type == wenlan_types::sources::SourceType::Directory)
+        .filter(|source| should_poll_directory_source(source))
     {
         if let Err(e) =
             crate::source_routes::sync_directory_source(db.clone(), source, &config).await
@@ -708,6 +715,7 @@ async fn fire_steep(
     label: &str,
 ) {
     let started = std::time::Instant::now();
+    let knowledge_path = wenlan_core::config::load_config().knowledge_path_or_default();
     match wenlan_core::refinery::run_periodic_steep_with_api(
         db,
         llm,
@@ -718,6 +726,7 @@ async fn fire_steep(
         refinery_cfg,
         confidence_cfg,
         distillation_cfg,
+        Some(&knowledge_path),
         trigger,
     )
     .await
@@ -1012,6 +1021,38 @@ mod tests {
             ..wenlan_core::config::Config::default()
         })
         .unwrap();
+    }
+
+    #[test]
+    fn directory_sync_tick_polls_recoverable_sources_but_not_paused() {
+        let mut source = wenlan_types::sources::Source {
+            id: "directory-notes".to_string(),
+            source_type: wenlan_types::sources::SourceType::Directory,
+            path: std::path::PathBuf::from("/tmp/notes"),
+            status: wenlan_types::sources::SyncStatus::Active,
+            last_sync: None,
+            file_count: 0,
+            memory_count: 0,
+            last_sync_errors: 0,
+            last_sync_error_detail: None,
+        };
+
+        assert!(should_poll_directory_source(&source));
+
+        source.status =
+            wenlan_types::sources::SyncStatus::Unavailable("filesystem stalled".to_string());
+        assert!(should_poll_directory_source(&source));
+
+        source.status =
+            wenlan_types::sources::SyncStatus::Error("transient file error".to_string());
+        assert!(should_poll_directory_source(&source));
+
+        source.status = wenlan_types::sources::SyncStatus::Paused;
+        assert!(!should_poll_directory_source(&source));
+
+        source.status = wenlan_types::sources::SyncStatus::Active;
+        source.source_type = wenlan_types::sources::SourceType::Obsidian;
+        assert!(!should_poll_directory_source(&source));
     }
 
     async fn new_test_db() -> (Arc<wenlan_core::db::MemoryDB>, tempfile::TempDir) {

--- a/crates/wenlan-server/src/source_routes.rs
+++ b/crates/wenlan-server/src/source_routes.rs
@@ -320,7 +320,18 @@ pub(crate) async fn sync_directory_source(
     // the root live auto-recovers it. For a single-file source the root IS
     // the file, so a deleted file lands here too: never auto-deleted, the
     // user removes the source explicitly.
-    if !directory_root_is_live(&source.path) {
+    let root = source.path.clone();
+    let root_display = root.display().to_string();
+    let files = tokio::task::spawn_blocking(move || {
+        directory_root_is_live(&root).then(|| scan_directory(&root))
+    })
+    .await
+    .map_err(|error| {
+        ServerError::Internal(format!(
+            "directory filesystem task failed for source {id} at {root_display}: {error}"
+        ))
+    })?;
+    let Some(files) = files else {
         mark_source_unavailable(&id, "source path is missing or unreadable");
         return Ok(SyncStatsResponse {
             files_found: 0,
@@ -330,9 +341,8 @@ pub(crate) async fn sync_directory_source(
             error_detail: None,
             paused: None,
         });
-    }
+    };
 
-    let files = scan_directory(&source.path);
     let knowledge_path = config.knowledge_path_or_default();
     let scanned: std::collections::HashSet<String> = files
         .iter()
@@ -384,18 +394,29 @@ pub(crate) async fn sync_directory_source(
         let file_key = file_path.to_string_lossy().to_string();
         let is_gdrive = is_google_drive_path(file_path);
 
-        let metadata = match std::fs::metadata(file_path) {
-            Ok(m) => m,
-            Err(e) => {
-                tracing::warn!("[sync] stat failed for {}: {}", file_path.display(), e);
-                errors += 1;
-                file_errors += 1;
-                if is_gdrive {
-                    gdrive_errors += 1;
+        let metadata_path = file_path.clone();
+        let metadata =
+            match tokio::task::spawn_blocking(move || std::fs::metadata(metadata_path)).await {
+                Ok(Ok(metadata)) => metadata,
+                Ok(Err(e)) => {
+                    tracing::warn!("[sync] stat failed for {}: {}", file_path.display(), e);
+                    errors += 1;
+                    file_errors += 1;
+                    if is_gdrive {
+                        gdrive_errors += 1;
+                    }
+                    continue;
                 }
-                continue;
-            }
-        };
+                Err(e) => {
+                    tracing::warn!("[sync] stat task failed for {}: {}", file_path.display(), e);
+                    errors += 1;
+                    file_errors += 1;
+                    if is_gdrive {
+                        gdrive_errors += 1;
+                    }
+                    continue;
+                }
+            };
         let mtime_ns = metadata
             .modified()
             .ok()
@@ -411,9 +432,15 @@ pub(crate) async fn sync_directory_source(
             }
         }
 
-        let bytes = match std::fs::read(file_path) {
-            Ok(bytes) => bytes,
-            Err(e) => {
+        // The mtime fast path above keeps unchanged files out of the read/hash phase.
+        let read_path = file_path.clone();
+        let hash = match tokio::task::spawn_blocking(move || {
+            std::fs::read(read_path).map(|bytes| content_hash_bytes(&bytes))
+        })
+        .await
+        {
+            Ok(Ok(hash)) => hash,
+            Ok(Err(e)) => {
                 tracing::warn!("[sync] read failed for {}: {}", file_path.display(), e);
                 errors += 1;
                 file_errors += 1;
@@ -422,8 +449,16 @@ pub(crate) async fn sync_directory_source(
                 }
                 continue;
             }
+            Err(e) => {
+                tracing::warn!("[sync] read task failed for {}: {}", file_path.display(), e);
+                errors += 1;
+                file_errors += 1;
+                if is_gdrive {
+                    gdrive_errors += 1;
+                }
+                continue;
+            }
         };
-        let hash = content_hash_bytes(&bytes);
         if let Some(ref ss) = existing {
             if ss.content_hash == hash {
                 let _ = db.upsert_sync_state(&id, &file_key, mtime_ns, &hash).await;


### PR DESCRIPTION
## Summary

- Move directory root probes, metadata reads, and changed-file read/hash work onto Tokio's blocking pool so a stalled filesystem provider cannot starve daemon HTTP work.
- Skip explicitly paused directory sources in background polling while continuing to probe `Unavailable` and `Error` sources for automatic recovery.
- Make the refinery Page projection path an explicit core-runner input so unit and integration callers cannot silently project test pages into the live Wenlan wiki.

## Root cause

Live dogfood found `/Users/lucian/Documents/Books` could answer `stat` while `read_dir` stalled inside macOS File Provider. `sync_directory_source` performed that synchronous scan on the async runtime, which made `/api/health` and `wenlan lint` hang with it.

The same verification run found a separate isolation defect: core refinery tests loaded the global config and wrote `Overview`, `Test Topic`, and fake `ondevice_default_*` provenance projections into `~/.wenlan/pages` even though their Page rows lived only in temporary test databases. The runner now receives `knowledge_path` explicitly; tests pass `None`, while daemon callers pass the configured path.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --lib --quiet`
  - CLI: 22 passed
  - core: 2214 passed, 26 ignored
  - MCP: 184 passed
  - server: 154 passed
  - types: 99 passed
- Page projection tree fingerprint before/after the full workspace library suite: identical (`67dfad7ae0ec9668b7891d33a613ed9d69782f266a127cd134733f6ff964e5e8`).
- Two Claude Code review rounds; final verdict: correctness looks fine.
- Final installed release dogfood: a Books sync remained blocked for 12 seconds and timed out client-side, while `/api/health` returned in 0.000509 seconds and `wenlan lint` completed with 48 passes, 7 findings, 0 incomplete checks. Lint's DB and Page before/after digests were unchanged.

## Residual state

The `directory-books` source remains `Unavailable`, so `operations.source_configuration` correctly stays actionable. It was not deleted because it owns real indexed files/memories. A started `spawn_blocking` filesystem call cannot be cancelled; a permanently stalled provider may hold one blocking worker, but it no longer blocks health, lint, or other async daemon work.
