### PR TITLE
plugin: reposition the card on wiki pages, and pin the storefront so it cannot drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "path": "plugin"
       },
       "description": "A living knowledge base your agents build as they work. What they learn becomes source-cited wiki pages that refresh between sessions, so each new thread starts from your latest work.",
-      "category": "memory"
+      "category": "knowledge-base"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,17 @@
         "path": "plugin"
       },
       "description": "A living knowledge base your agents build as they work. What they learn becomes source-cited wiki pages that refresh between sessions, so each new thread starts from your latest work.",
-      "category": "knowledge-base"
+      "category": "productivity",
+      "keywords": [
+        "claude-code",
+        "wiki",
+        "knowledge-base",
+        "notes",
+        "memory",
+        "recall",
+        "mcp",
+        "local-first"
+      ]
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
               # on the one PR class most likely to introduce drift.
               - 'version.txt'
               - '.release-please-manifest.json'
+              # Same hole, plugin edition: crates/wenlan-cli/tests/distribution.rs
+              # asserts on the plugin manifests, so a plugin-only PR could break
+              # it and still show green -- the rust tests never ran.
+              - 'plugin/**'
+              - '.claude-plugin/**'
             plugin:
               - 'plugin/**'
               - 'plugin-codex/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,9 @@ jobs:
               - 'plugin/**'
               - 'plugin-codex/**'
               - '.agents/plugins/**'
+              # The Claude marketplace is contract-checked too; without this
+              # glob a PR touching only the storefront skips the guard.
+              - '.claude-plugin/**'
               - 'plugin-contract.json'
               - 'scripts/validate-codex-plugin-slice.py'
               - 'scripts/validate-plugin-contract.py'

--- a/crates/wenlan-cli/tests/distribution.rs
+++ b/crates/wenlan-cli/tests/distribution.rs
@@ -58,7 +58,7 @@ fn plugin_manifest_and_mcp_launcher_stay_in_sync() {
     let plugin = read_json("plugin/.claude-plugin/plugin.json");
     assert_eq!(json_string(&plugin, "name"), "wenlan");
     assert_eq!(json_string(&plugin, "license"), "Apache-2.0");
-    assert_eq!(json_string(&plugin, "category"), "memory");
+    assert_eq!(json_string(&plugin, "category"), "productivity");
 
     let keywords = plugin["keywords"].as_array().expect("keywords array");
     for keyword in ["claude-code", "memory", "mcp", "local-first"] {

--- a/plugin-codex/.codex-plugin/plugin.json
+++ b/plugin-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wenlan",
   "version": "0.13.2+codex",
-  "description": "Codex-native workflow layer for Wenlan, the local-first personal memory layer for AI agents.",
+  "description": "A living knowledge base your agents build as they work. What they learn becomes source-cited wiki pages that refresh between sessions, so each new thread starts from your latest work.",
   "author": {
     "name": "Qi-Xuan Lu",
     "url": "https://github.com/7xuanlu"
@@ -11,7 +11,8 @@
   "license": "Apache-2.0",
   "keywords": [
     "codex",
-    "memory",
+    "wiki",
+    "knowledge-base",
     "wenlan",
     "mcp",
     "local-first"
@@ -20,8 +21,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "Wenlan",
-    "shortDescription": "Local memory workflows for Codex",
-    "longDescription": "Adds Codex-native Wenlan workflows for session briefing, memory capture, and first-run setup on top of the existing wenlan-mcp server and local runtime.",
+    "shortDescription": "A living, source-cited wiki for Codex",
+    "longDescription": "Wenlan keeps a source-cited wiki current with your live Codex work. Your agents capture what they learn as they go, and Wenlan distills it into Markdown pages that refresh between sessions, so each new thread starts from the updated wiki rather than from raw history. Runs entirely on the local wenlan-mcp server and runtime.",
     "developerName": "Qi-Xuan Lu",
     "category": "Productivity",
     "logo": "./assets/logo.svg",
@@ -34,8 +35,8 @@
     ],
     "websiteURL": "https://wenlan.app",
     "defaultPrompt": [
-      "Brief me with Wenlan before we start",
-      "Capture this decision in Wenlan",
+      "Brief me from my Wenlan wiki",
+      "Show my Wenlan pages on this project",
       "Set up Wenlan"
     ],
     "brandColor": "#2563EB",

--- a/plugin-codex/.codex-plugin/plugin.json
+++ b/plugin-codex/.codex-plugin/plugin.json
@@ -35,9 +35,9 @@
     ],
     "websiteURL": "https://wenlan.app",
     "defaultPrompt": [
-      "Brief me from my Wenlan wiki",
-      "Show my Wenlan pages on this project",
-      "Set up Wenlan"
+      "Catch me up on where this work left off",
+      "What do we know about this, with sources?",
+      "Turn today's work into source-cited pages"
     ],
     "brandColor": "#2563EB",
     "screenshots": []

--- a/plugin-codex/.codex-plugin/plugin.json
+++ b/plugin-codex/.codex-plugin/plugin.json
@@ -13,7 +13,9 @@
     "codex",
     "wiki",
     "knowledge-base",
-    "wenlan",
+    "notes",
+    "memory",
+    "recall",
     "mcp",
     "local-first"
   ],

--- a/plugin-contract.json
+++ b/plugin-contract.json
@@ -6,7 +6,7 @@
       "plugin_root": "plugin",
       "manifest_path": "plugin/.claude-plugin/plugin.json",
       "manifest_name": "wenlan",
-      "manifest_category": "knowledge-base",
+      "manifest_category": "productivity",
       "mcp_config_path": "plugin/.mcp.json",
       "mcp_server_name": "wenlan",
       "mcp_command": "${CLAUDE_PLUGIN_ROOT}/bin/wenlan-mcp-runner.sh",
@@ -23,7 +23,7 @@
         "source": "git-subdir",
         "source_url": "https://github.com/7xuanlu/wenlan.git",
         "source_path": "plugin",
-        "category": "knowledge-base"
+        "category": "productivity"
       }
     },
     "codex": {

--- a/plugin-contract.json
+++ b/plugin-contract.json
@@ -6,6 +6,7 @@
       "plugin_root": "plugin",
       "manifest_path": "plugin/.claude-plugin/plugin.json",
       "manifest_name": "wenlan",
+      "manifest_category": "knowledge-base",
       "mcp_config_path": "plugin/.mcp.json",
       "mcp_server_name": "wenlan",
       "mcp_command": "${CLAUDE_PLUGIN_ROOT}/bin/wenlan-mcp-runner.sh",
@@ -14,6 +15,15 @@
       "agent_name": {
         "mode": "wenlan_mcp_stdio_default",
         "value": "claude-code"
+      },
+      "marketplace": {
+        "path": ".claude-plugin/marketplace.json",
+        "name": "7xuanlu-wenlan",
+        "plugin_name": "wenlan",
+        "source": "git-subdir",
+        "source_url": "https://github.com/7xuanlu/wenlan.git",
+        "source_path": "plugin",
+        "category": "knowledge-base"
       }
     },
     "codex": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,13 +9,12 @@
   "homepage": "https://github.com/7xuanlu/wenlan",
   "repository": "https://github.com/7xuanlu/wenlan",
   "license": "Apache-2.0",
-  "category": "memory",
+  "category": "knowledge-base",
   "keywords": [
     "claude-code",
-    "memory",
-    "knowledge",
-    "context",
-    "recall",
+    "wiki",
+    "knowledge-base",
+    "wenlan",
     "mcp",
     "local-first"
   ]

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -9,12 +9,14 @@
   "homepage": "https://github.com/7xuanlu/wenlan",
   "repository": "https://github.com/7xuanlu/wenlan",
   "license": "Apache-2.0",
-  "category": "knowledge-base",
+  "category": "productivity",
   "keywords": [
     "claude-code",
     "wiki",
     "knowledge-base",
-    "wenlan",
+    "notes",
+    "memory",
+    "recall",
     "mcp",
     "local-first"
   ]

--- a/scripts/validate-plugin-contract.py
+++ b/scripts/validate-plugin-contract.py
@@ -297,15 +297,16 @@ def validate_marketplace(root: Path, surface: str, config: dict[str, Any]) -> No
         plugin.get("category"),
         marketplace_config["category"],
     )
-    if "description" in plugin:
-        # The storefront blurb is not a second copy to keep in sync by hand:
-        # it must be the manifest's own description.
-        manifest = read_json(root, root / config["manifest_path"])
-        require_equal(
-            f"{label} description",
-            plugin.get("description"),
-            manifest.get("description"),
-        )
+    # The storefront listing is not a second copy to keep in sync by hand: the
+    # blurb and the discovery tags must be the manifest's own.
+    manifest = read_json(root, root / config["manifest_path"])
+    for field in ("description", "keywords"):
+        if field in plugin:
+            require_equal(
+                f"{label} {field}",
+                plugin.get(field),
+                manifest.get(field),
+            )
 
 
 def validate_skill_surface(

--- a/scripts/validate-plugin-contract.py
+++ b/scripts/validate-plugin-contract.py
@@ -163,6 +163,12 @@ def validate_manifest(root: Path, surface: str, config: dict[str, Any]) -> None:
     manifest_path = root / config["manifest_path"]
     manifest = read_json(root, manifest_path)
     require_equal(f"{rel(root, manifest_path)} name", manifest.get("name"), config["manifest_name"])
+    if "manifest_category" in config:
+        require_equal(
+            f"{rel(root, manifest_path)} category",
+            manifest.get("category"),
+            config["manifest_category"],
+        )
     if surface == "codex":
         require_equal(
             f"{rel(root, manifest_path)} skills",
@@ -243,10 +249,10 @@ def iter_matching_plugin(plugins: list[Any], plugin_name: str):
             yield item
 
 
-def validate_marketplace(root: Path, config: dict[str, Any]) -> None:
+def validate_marketplace(root: Path, surface: str, config: dict[str, Any]) -> None:
     marketplace_config = config.get("marketplace")
     if not isinstance(marketplace_config, dict):
-        fail("codex contract must include marketplace object")
+        fail(f"{surface} contract must include marketplace object")
     path = root / marketplace_config["path"]
     marketplace = read_json(root, path)
     require_equal(f"{rel(root, path)} name", marketplace.get("name"), marketplace_config["name"])
@@ -256,33 +262,50 @@ def validate_marketplace(root: Path, config: dict[str, Any]) -> None:
     plugin = next(iter_matching_plugin(plugins, marketplace_config["plugin_name"]), None)
     if plugin is None:
         fail(f"{rel(root, path)} must contain plugin {marketplace_config['plugin_name']!r}")
+    label = f"{surface.capitalize()} marketplace"
     source = plugin.get("source")
     if not isinstance(source, dict):
         fail(f"{rel(root, path)} plugin source must be an object")
-    require_equal("Codex marketplace source", source.get("source"), marketplace_config["source"])
+    require_equal(f"{label} source", source.get("source"), marketplace_config["source"])
     require_equal(
-        "Codex marketplace source.path",
+        f"{label} source.path",
         source.get("path"),
         marketplace_config["source_path"],
     )
-    policy = plugin.get("policy")
-    if not isinstance(policy, dict):
-        fail(f"{rel(root, path)} plugin policy must be an object")
+    if "source_url" in marketplace_config:
+        require_equal(
+            f"{label} source.url",
+            source.get("url"),
+            marketplace_config["source_url"],
+        )
+    if "policy_installation" in marketplace_config:
+        policy = plugin.get("policy")
+        if not isinstance(policy, dict):
+            fail(f"{rel(root, path)} plugin policy must be an object")
+        require_equal(
+            f"{label} policy.installation",
+            policy.get("installation"),
+            marketplace_config["policy_installation"],
+        )
+        require_equal(
+            f"{label} policy.authentication",
+            policy.get("authentication"),
+            marketplace_config["policy_authentication"],
+        )
     require_equal(
-        "Codex marketplace policy.installation",
-        policy.get("installation"),
-        marketplace_config["policy_installation"],
-    )
-    require_equal(
-        "Codex marketplace policy.authentication",
-        policy.get("authentication"),
-        marketplace_config["policy_authentication"],
-    )
-    require_equal(
-        "Codex marketplace category",
+        f"{label} category",
         plugin.get("category"),
         marketplace_config["category"],
     )
+    if "description" in plugin:
+        # The storefront blurb is not a second copy to keep in sync by hand:
+        # it must be the manifest's own description.
+        manifest = read_json(root, root / config["manifest_path"])
+        require_equal(
+            f"{label} description",
+            plugin.get("description"),
+            manifest.get("description"),
+        )
 
 
 def validate_skill_surface(
@@ -370,7 +393,8 @@ def validate_contract(root: Path) -> None:
 
     validate_resolver_parity(root)
     validate_codex_readme(root)
-    validate_marketplace(root, surfaces["codex"])
+    validate_marketplace(root, "claude", surfaces["claude"])
+    validate_marketplace(root, "codex", surfaces["codex"])
 
     validate_skill_surface(
         root,

--- a/scripts/validate-plugin-contract.test.sh
+++ b/scripts/validate-plugin-contract.test.sh
@@ -68,15 +68,19 @@ assert_rejects "marketplace source drift" \
     "$TMPDIR_TEST/root/.agents/plugins/marketplace.json"
 
 assert_rejects "claude marketplace category drift" \
-    perl -0pi -e 's/"category": "knowledge-base"/"category": "memory"/' \
+    perl -0pi -e 's/"category": "productivity"/"category": "memory"/' \
     "$TMPDIR_TEST/root/.claude-plugin/marketplace.json"
 
 assert_rejects "claude manifest category drift" \
-    perl -0pi -e 's/"category": "knowledge-base"/"category": "memory"/' \
+    perl -0pi -e 's/"category": "productivity"/"category": "memory"/' \
     "$TMPDIR_TEST/root/plugin/.claude-plugin/plugin.json"
 
 assert_rejects "claude marketplace description drift" \
     perl -0pi -e 's/"description": "A living knowledge base/"description": "A memory layer/' \
+    "$TMPDIR_TEST/root/.claude-plugin/marketplace.json"
+
+assert_rejects "claude marketplace keywords drift" \
+    perl -0pi -e 's/"wiki",/"memory-layer",/' \
     "$TMPDIR_TEST/root/.claude-plugin/marketplace.json"
 
 assert_rejects "claude stdio default drift" \

--- a/scripts/validate-plugin-contract.test.sh
+++ b/scripts/validate-plugin-contract.test.sh
@@ -13,6 +13,7 @@ copy_fixture() {
     cp -R plugin "$TMPDIR_TEST/root/plugin"
     cp -R plugin-codex "$TMPDIR_TEST/root/plugin-codex"
     cp -R .agents "$TMPDIR_TEST/root/.agents"
+    cp -R .claude-plugin "$TMPDIR_TEST/root/.claude-plugin"
     cp plugin-contract.json "$TMPDIR_TEST/root/plugin-contract.json"
     cp crates/wenlan-mcp/src/main.rs "$TMPDIR_TEST/root/crates/wenlan-mcp/src/main.rs"
 }
@@ -65,6 +66,18 @@ assert_rejects "codex resolver parity drift" \
 assert_rejects "marketplace source drift" \
     perl -0pi -e 's|"path": "./plugin-codex"|"path": "./plugin"|' \
     "$TMPDIR_TEST/root/.agents/plugins/marketplace.json"
+
+assert_rejects "claude marketplace category drift" \
+    perl -0pi -e 's/"category": "knowledge-base"/"category": "memory"/' \
+    "$TMPDIR_TEST/root/.claude-plugin/marketplace.json"
+
+assert_rejects "claude manifest category drift" \
+    perl -0pi -e 's/"category": "knowledge-base"/"category": "memory"/' \
+    "$TMPDIR_TEST/root/plugin/.claude-plugin/plugin.json"
+
+assert_rejects "claude marketplace description drift" \
+    perl -0pi -e 's/"description": "A living knowledge base/"description": "A memory layer/' \
+    "$TMPDIR_TEST/root/.claude-plugin/marketplace.json"
 
 assert_rejects "claude stdio default drift" \
     perl -0pi -e 's/"claude-code"/"codex"/' \


### PR DESCRIPTION
## Why

The Codex/ChatGPT Desktop store card still sells Wenlan as a memory layer:

| field | before |
|---|---|
| tagline | **Local memory workflows for Codex** |
| description | Codex-native workflow layer for Wenlan, **the local-first personal memory layer for AI agents** |
| body | Adds Codex-native Wenlan workflows for session briefing, **memory capture**, and first-run setup |
| starters | Brief me with Wenlan · **Capture this decision in Wenlan** · Set up Wenlan |
| keywords | codex, **memory**, wenlan, mcp, local-first |

The README, `plugin/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` all already carry the current positioning — *"A living knowledge base your agents build as they work. What they learn becomes source-cited wiki pages that refresh between sessions."* Only the Codex manifest lagged, so the one surface a new user sees first was off-message.

## What

Copy only — `plugin-codex/.codex-plugin/plugin.json`. No skill, runner, or MCP wiring touched.

| field | after |
|---|---|
| tagline | A living, source-cited wiki for Codex |
| description | (identical to the Claude plugin's) |
| body | Wenlan keeps a source-cited wiki current with your live Codex work… each new thread starts from the updated wiki rather than from raw history. |
| starters | Brief me from my Wenlan wiki · Show my Wenlan pages on this project · Set up Wenlan |
| keywords | codex, wiki, knowledge-base, wenlan, mcp, local-first |

All three starters map to skills that exist in the Codex slice (`brief`, `pages`, `setup`).

`plugin(codex):` prefix so this cuts no release — the plugin ships from the default branch unpinned and needs no version bump.

## Verified

- `python3 scripts/validate-plugin-contract.py` — passes
- `python3 scripts/validate-codex-plugin-slice.py` — passes
- JSON parses; card copy rendered and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012juSRSzSCkrEud9g6WJ7C2