### PR TITLE
feat: Tier 1 vocabulary auto-heal (deterministic folds auto-applied, semantic values queued for review)

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -336,7 +336,7 @@ impl MemoryDB {
                 // Does a canonical edge already exist for this pair?
                 let mut ex = conn
                     .query(
-                        "SELECT id, confidence, explanation, source_memory_id FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
+                        "SELECT id, confidence, explanation, source_memory_id, source_agent, created_at FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
                         libsql::params![from.clone(), to.clone(), canonical.to_string()],
                     )
                     .await
@@ -346,10 +346,21 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(e.to_string()))?
                 {
+                    let s_id: String = sr.get(0).unwrap_or_default();
                     let s_conf: Option<f64> = sr.get(1).ok();
                     let s_expl: Option<String> = sr.get(2).ok();
                     let s_smid: Option<String> = sr.get(3).ok();
+                    let s_sagent: Option<String> = sr.get(4).ok();
+                    let s_created: Option<i64> = sr.get(5).ok();
                     drop(ex);
+                    // The survivor is mutated too (its provenance is COALESCE-merged
+                    // below), so per spec §2.5 ledger its full pre-image BEFORE the
+                    // UPDATE, same shape as the loser's, so undo can restore it.
+                    pre_image.push(serde_json::json!({
+                        "id": s_id, "from_entity": from, "to_entity": to, "relation_type": canonical,
+                        "confidence": s_conf, "explanation": s_expl, "source_memory_id": s_smid,
+                        "source_agent": s_sagent, "created_at": s_created,
+                    }));
                     // Merge provenance into the survivor: higher confidence wins; fill nulls.
                     let merged_conf = match (s_conf, conf) {
                         (Some(a), Some(b)) => Some(a.max(*b)),
@@ -442,10 +453,17 @@ impl MemoryDB {
         old_type: &str,
         canonical: &str,
     ) -> Result<usize, WenlanError> {
-        // Snapshot the affected ids for the ledger, then rewrite. No unique
-        // constraint on entities.entity_type, so no collision handling needed.
-        let (pre_json, ids) = {
-            let conn = self.conn.lock().await;
+        // Snapshot the affected ids, rewrite them, and ledger the pre-image inside
+        // ONE transaction so the UPDATE and the ledger write are atomic (mirrors
+        // fold_relation_type's begin/commit/rollback). The ledger INSERT is inlined
+        // on the held `conn` rather than routed through `insert_vocab_ledger_entry`,
+        // which would re-lock the non-reentrant conn Mutex and self-deadlock.
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("fold_entity begin: {e}")))?;
+
+        let result: Result<usize, WenlanError> = async {
             let mut rows = conn
                 .query(
                     "SELECT id FROM entities WHERE entity_type = ?1",
@@ -461,30 +479,48 @@ impl MemoryDB {
             {
                 ids.push(r.get::<String>(0).unwrap_or_default());
             }
+            drop(rows);
+            if ids.is_empty() {
+                return Ok(0);
+            }
             let pre: Vec<serde_json::Value> = ids
                 .iter()
                 .map(|id| serde_json::json!({"id": id, "entity_type": old_type}))
                 .collect();
-            (
-                serde_json::to_string(&pre).unwrap_or_else(|_| "[]".into()),
-                ids,
-            )
-        };
-        if ids.is_empty() {
-            return Ok(0);
-        }
-        {
-            let conn = self.conn.lock().await;
+            let pre_json = serde_json::to_string(&pre).unwrap_or_else(|_| "[]".into());
+
             conn.execute(
                 "UPDATE entities SET entity_type = ?1 WHERE entity_type = ?2",
                 libsql::params![canonical.to_string(), old_type.to_string()],
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("fold_entity_type: {e}")))?;
+
+            let ledger_id = format!("vheal-{}", uuid::Uuid::new_v4());
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "INSERT INTO vocab_heal_ledger (id, kind, old_value, new_value, pre_image, created_at) VALUES (?1, 'entity', ?2, ?3, ?4, ?5)",
+                libsql::params![ledger_id, old_type, canonical, pre_json, now],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("insert_vocab_ledger: {e}")))?;
+
+            Ok(ids.len())
         }
-        self.insert_vocab_ledger_entry("entity", old_type, canonical, &pre_json)
-            .await?;
-        Ok(ids.len())
+        .await;
+
+        match result {
+            Ok(n) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("fold_entity commit: {e}")))?;
+                Ok(n)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
     }
 }
 
@@ -21357,7 +21393,13 @@ impl MemoryDB {
     }
 
     /// Insert a `vocab_promote` proposal, deduped by fingerprint. Returns true iff
-    /// a new row was created (existing pending/dismissed/resolved rows are kept).
+    /// a new row was created (existing awaiting_review/dismissed/resolved rows are kept).
+    ///
+    /// Self-promotes to `status='awaiting_review'` at insert (mirroring the
+    /// `maintenance.rs` card producers), because nothing transitions a pending
+    /// `vocab_promote` and every human-facing lister filters to `awaiting_review`.
+    /// Without this the proposal would accumulate invisibly (spec §2.7 anti-dark-flag).
+    /// The `ON CONFLICT(id) DO NOTHING` guard still makes a dismissal permanent.
     pub async fn insert_vocab_promote_proposal(
         &self,
         kind: &str,
@@ -21375,8 +21417,8 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let affected = conn
             .execute(
-                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence) \
-                 VALUES (?1, 'vocab_promote', '[]', ?2, 1.0) ON CONFLICT(id) DO NOTHING",
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) \
+                 VALUES (?1, 'vocab_promote', '[]', ?2, 1.0, 'awaiting_review') ON CONFLICT(id) DO NOTHING",
                 libsql::params![id, payload],
             )
             .await
@@ -46906,6 +46948,29 @@ pub(crate) mod tests {
                 .filter(|p| p.action == "vocab_promote")
                 .count(),
             0
+        );
+    }
+
+    /// Regression (Critical, spec §2.7/§2.9): a freshly inserted `vocab_promote`
+    /// must self-promote to `awaiting_review` so it surfaces on the human path.
+    /// Every lister (`handle_list_refinements`, the MCP `list_refinements` tool)
+    /// filters `get_pending_refinements()` to `status == "awaiting_review"`; a
+    /// row left at the default `pending` would accumulate invisibly (dark feature).
+    #[tokio::test]
+    async fn vocab_promote_proposal_self_promotes_to_awaiting_review() {
+        let (db, _tmp) = test_db().await;
+        assert!(db
+            .insert_vocab_promote_proposal("relation", "design_inspiration", None)
+            .await
+            .unwrap());
+        let pending = db.get_pending_refinements().await.unwrap();
+        let prop = pending
+            .iter()
+            .find(|p| p.action == "vocab_promote")
+            .expect("vocab_promote proposal must be retrievable via get_pending_refinements");
+        assert_eq!(
+            prop.status, "awaiting_review",
+            "vocab_promote must surface as awaiting_review, not the default pending"
         );
     }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -16037,9 +16037,21 @@ impl MemoryDB {
             Some(c) => c,
             None => {
                 log::warn!(
-                    "[create_relation] non-vocabulary type '{}' coerced to 'related_to' (caller should use a canonical type)",
+                    "[create_relation] non-vocabulary type '{}' coerced to 'related_to' (queued as promote candidate)",
                     relation_type
                 );
+                // Capture-at-coercion: keep the review queue fed. Best-effort —
+                // a failed insert must never fail ingest. resolve_relation_type
+                // has released its lock; insert_vocab_promote_proposal takes its
+                // own, and we have not locked self.conn yet.
+                if let Err(e) = self
+                    .insert_vocab_promote_proposal("relation", relation_type, None)
+                    .await
+                {
+                    log::warn!(
+                        "[create_relation] capture-at-coercion insert failed (ignored): {e}"
+                    );
+                }
                 "related_to".to_string()
             }
         };
@@ -43857,6 +43869,45 @@ pub(crate) mod tests {
             stored, "related_to",
             "unknown relation type should be coerced to related_to"
         );
+    }
+
+    #[tokio::test]
+    async fn create_relation_captures_coerced_type_as_promote_candidate() {
+        let (db, _tmp) = test_db().await;
+        let e1 = db.create_entity("Alice", "person", None).await.unwrap();
+        let e2 = db.create_entity("Bob", "person", None).await.unwrap();
+        // Coerced twice -> still exactly one promote proposal (fingerprint dedup).
+        db.create_relation(&e1, &e2, "is_friend_of", None, Some(0.9), None, None)
+            .await
+            .unwrap();
+        let e3 = db.create_entity("Carol", "person", None).await.unwrap();
+        db.create_relation(&e1, &e3, "is_friend_of", None, Some(0.9), None, None)
+            .await
+            .unwrap();
+        let pending = db.get_pending_refinements().await.unwrap();
+        let promos: Vec<_> = pending
+            .iter()
+            .filter(|p| {
+                p.action == "vocab_promote"
+                    && p.payload.as_deref().unwrap_or("").contains("is_friend_of")
+            })
+            .collect();
+        assert_eq!(
+            promos.len(),
+            1,
+            "coerced type should queue exactly one promote candidate"
+        );
+        // The row itself is still related_to (write unchanged).
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT relation_type FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
+                libsql::params![e1.clone(), e2.clone()],
+            )
+            .await
+            .unwrap();
+        let stored: String = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(stored, "related_to");
     }
 
     #[tokio::test]

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -21075,6 +21075,40 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Stable fingerprint for a vocab proposal — keyed on (kind, old_value) ONLY,
+    /// never the suggested target. One human dismissal of a value is permanent.
+    fn vocab_proposal_fingerprint(kind: &str, old_value: &str) -> String {
+        format!("vocab_promote::{kind}::{}", old_value.to_lowercase())
+    }
+
+    /// Insert a `vocab_promote` proposal, deduped by fingerprint. Returns true iff
+    /// a new row was created (existing pending/dismissed/resolved rows are kept).
+    pub async fn insert_vocab_promote_proposal(
+        &self,
+        kind: &str,
+        old_value: &str,
+        category: Option<&str>,
+    ) -> Result<bool, WenlanError> {
+        let id = Self::vocab_proposal_fingerprint(kind, old_value);
+        let payload = serde_json::json!({
+            "action": "vocab_promote",
+            "kind": kind,
+            "old_value": old_value,
+            "category": category,
+        })
+        .to_string();
+        let conn = self.conn.lock().await;
+        let affected = conn
+            .execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence) \
+                 VALUES (?1, 'vocab_promote', '[]', ?2, 1.0) ON CONFLICT(id) DO NOTHING",
+                libsql::params![id, payload],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("insert_vocab_promote: {e}")))?;
+        Ok(affected > 0)
+    }
+
     /// Get all pending/awaiting_review refinement proposals.
     pub async fn get_pending_refinements(&self) -> Result<Vec<RefinementProposal>, WenlanError> {
         let conn = self.conn.lock().await;
@@ -46429,6 +46463,52 @@ pub(crate) mod tests {
             r1 + r2,
             1,
             "exactly one caller should see rows=1, got {r1} + {r2}"
+        );
+    }
+
+    #[tokio::test]
+    async fn vocab_promote_proposal_is_idempotent_and_respects_dismissal() {
+        let (db, _tmp) = test_db().await;
+        // First insert creates a row.
+        assert!(db
+            .insert_vocab_promote_proposal("relation", "design_inspiration", None)
+            .await
+            .unwrap());
+        // Second insert with the same (kind, old_value) is a no-op.
+        assert!(!db
+            .insert_vocab_promote_proposal("relation", "design_inspiration", None)
+            .await
+            .unwrap());
+        let pending = db.get_pending_refinements().await.unwrap();
+        assert_eq!(
+            pending
+                .iter()
+                .filter(|p| p.action == "vocab_promote")
+                .count(),
+            1
+        );
+
+        // Dismiss it, then re-insert: must stay dismissed (no resurrection).
+        let fp = pending
+            .iter()
+            .find(|p| p.action == "vocab_promote")
+            .unwrap()
+            .id
+            .clone();
+        db.resolve_refinement_if_open(&fp, "dismissed")
+            .await
+            .unwrap();
+        assert!(!db
+            .insert_vocab_promote_proposal("relation", "design_inspiration", None)
+            .await
+            .unwrap());
+        let pending2 = db.get_pending_refinements().await.unwrap();
+        assert_eq!(
+            pending2
+                .iter()
+                .filter(|p| p.action == "vocab_promote")
+                .count(),
+            0
         );
     }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -15422,6 +15422,27 @@ impl MemoryDB {
         Ok(None)
     }
 
+    /// All canonical relation types (lowercase), for safe-transform matching.
+    pub async fn relation_canonicals(&self) -> Result<Vec<String>, WenlanError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT canonical FROM relation_type_vocabulary ORDER BY canonical",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("relation_canonicals: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(r) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+        {
+            out.push(r.get::<String>(0).unwrap_or_default());
+        }
+        Ok(out)
+    }
+
     /// Increment the usage count for a canonical relation type.
     pub async fn increment_relation_type_count(&self, canonical: &str) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -202,19 +202,17 @@ pub struct VocabLedgerEntry {
 
 impl MemoryDB {
     /// Record a vocab auto-heal's full pre-image so the mutation can be undone.
-    /// `affected` (row ids) is provenance only — the caller already folds them
-    /// into `pre_image_json`; it is not stored as a separate column.
+    /// Every affected row id already lives inside `pre_image_json`; the ledger
+    /// has no separate `affected` column.
     pub async fn insert_vocab_ledger_entry(
         &self,
         kind: &str,
         old_value: &str,
         new_value: &str,
         pre_image_json: &str,
-        affected: &[String],
     ) -> Result<String, WenlanError> {
         let id = format!("vheal-{}", uuid::Uuid::new_v4());
         let now = chrono::Utc::now().timestamp();
-        let _ = affected;
         let conn = self.conn.lock().await;
         conn.execute(
             "INSERT INTO vocab_heal_ledger (id, kind, old_value, new_value, pre_image, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
@@ -265,6 +263,129 @@ impl MemoryDB {
             })),
             None => Ok(None),
         }
+    }
+
+    /// Fold every relation of `old_type` into `canonical`, collision-aware.
+    ///
+    /// Rewrites each `relations` row of `old_type` to `canonical`. On a
+    /// `(from, to, canonical)` collision, merges the loser's provenance into the
+    /// survivor (higher confidence wins; COALESCE explanation/source_memory_id)
+    /// then deletes the loser — never a blind delete. Every folded row's
+    /// pre-image is recorded to the ledger so the whole fold is reversible.
+    /// Returns the number of rows folded.
+    pub async fn fold_relation_type(
+        &self,
+        old_type: &str,
+        canonical: &str,
+    ) -> Result<usize, WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("fold begin: {e}")))?;
+
+        // Snapshot every row of old_type (the pre-image, for the ledger + undo).
+        let mut rows = conn
+            .query(
+                "SELECT id, from_entity, to_entity, confidence, explanation, source_memory_id, source_agent, created_at FROM relations WHERE relation_type = ?1",
+                libsql::params![old_type],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("fold snapshot: {e}")))?;
+        let mut pre_image: Vec<serde_json::Value> = Vec::new();
+        #[allow(clippy::type_complexity)]
+        let mut ids: Vec<(
+            String,
+            String,
+            String,
+            Option<f64>,
+            Option<String>,
+            Option<String>,
+        )> = Vec::new();
+        while let Some(r) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+        {
+            let id: String = r.get(0).unwrap_or_default();
+            let from: String = r.get(1).unwrap_or_default();
+            let to: String = r.get(2).unwrap_or_default();
+            let conf: Option<f64> = r.get(3).ok();
+            let expl: Option<String> = r.get(4).ok();
+            let smid: Option<String> = r.get(5).ok();
+            pre_image.push(serde_json::json!({
+                "id": id, "from_entity": from, "to_entity": to, "relation_type": old_type,
+                "confidence": conf, "explanation": expl, "source_memory_id": smid,
+            }));
+            ids.push((id, from, to, conf, expl, smid));
+        }
+        drop(rows);
+
+        let mut folded = 0usize;
+        for (id, from, to, conf, expl, smid) in &ids {
+            // Does a canonical edge already exist for this pair?
+            let mut ex = conn
+                .query(
+                    "SELECT id, confidence, explanation, source_memory_id FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
+                    libsql::params![from.clone(), to.clone(), canonical.to_string()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+            if let Some(sr) = ex
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                let s_conf: Option<f64> = sr.get(1).ok();
+                let s_expl: Option<String> = sr.get(2).ok();
+                let s_smid: Option<String> = sr.get(3).ok();
+                drop(ex);
+                // Merge provenance into the survivor: higher confidence wins; fill nulls.
+                let merged_conf = match (s_conf, conf) {
+                    (Some(a), Some(b)) => Some(a.max(*b)),
+                    (a, b) => a.or(*b),
+                };
+                let merged_expl = s_expl.or_else(|| expl.clone());
+                let merged_smid = s_smid.or_else(|| smid.clone());
+                conn.execute(
+                    "UPDATE relations SET confidence = ?1, explanation = ?2, source_memory_id = ?3 WHERE from_entity = ?4 AND to_entity = ?5 AND relation_type = ?6",
+                    libsql::params![
+                        merged_conf.map(libsql::Value::Real).unwrap_or(libsql::Value::Null),
+                        merged_expl.map(libsql::Value::Text).unwrap_or(libsql::Value::Null),
+                        merged_smid.map(libsql::Value::Text).unwrap_or(libsql::Value::Null),
+                        from.clone(), to.clone(), canonical.to_string()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                // Delete the loser (its pre-image is already captured above).
+                conn.execute(
+                    "DELETE FROM relations WHERE id = ?1",
+                    libsql::params![id.clone()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+            } else {
+                drop(ex);
+                conn.execute(
+                    "UPDATE relations SET relation_type = ?1 WHERE id = ?2",
+                    libsql::params![canonical.to_string(), id.clone()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+            }
+            folded += 1;
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("fold commit: {e}")))?;
+        drop(conn);
+
+        if !pre_image.is_empty() {
+            let pre_json = serde_json::to_string(&pre_image).unwrap_or_else(|_| "[]".into());
+            self.insert_vocab_ledger_entry("relation", old_type, canonical, &pre_json)
+                .await?;
+        }
+        Ok(folded)
     }
 }
 
@@ -51349,7 +51470,7 @@ pub(crate) mod tests {
         let (db, _tmp) = test_db().await;
         let pre = r#"[{"id":"rel-1","relation_type":"working_at","confidence":0.5}]"#;
         let id = db
-            .insert_vocab_ledger_entry("relation", "working_at", "works_on", pre, &["rel-1".into()])
+            .insert_vocab_ledger_entry("relation", "working_at", "works_on", pre)
             .await
             .unwrap();
         let got = db.get_vocab_ledger_entry(&id).await.unwrap().unwrap();

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -188,12 +188,92 @@ pub struct Migration55Report {
     pub entity_links_inserted: usize,
 }
 
+/// A `vocab_heal_ledger` row: the full pre-image of rows an auto-heal mutated,
+/// so the fix is reversible.
+#[derive(Debug, Clone)]
+pub struct VocabLedgerEntry {
+    pub id: String,
+    pub kind: String,
+    pub old_value: String,
+    pub new_value: String,
+    pub pre_image: String,
+    pub created_at: i64,
+}
+
+impl MemoryDB {
+    /// Record a vocab auto-heal's full pre-image so the mutation can be undone.
+    /// `affected` (row ids) is provenance only — the caller already folds them
+    /// into `pre_image_json`; it is not stored as a separate column.
+    pub async fn insert_vocab_ledger_entry(
+        &self,
+        kind: &str,
+        old_value: &str,
+        new_value: &str,
+        pre_image_json: &str,
+        affected: &[String],
+    ) -> Result<String, WenlanError> {
+        let id = format!("vheal-{}", uuid::Uuid::new_v4());
+        let now = chrono::Utc::now().timestamp();
+        let _ = affected;
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "INSERT INTO vocab_heal_ledger (id, kind, old_value, new_value, pre_image, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            libsql::params![id.clone(), kind, old_value, new_value, pre_image_json, now],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("insert_vocab_ledger: {e}")))?;
+        Ok(id)
+    }
+
+    /// Look up a vocab ledger entry by id, for reading back the pre-image on undo.
+    pub async fn get_vocab_ledger_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<VocabLedgerEntry>, WenlanError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT id, kind, old_value, new_value, pre_image, created_at FROM vocab_heal_ledger WHERE id = ?1",
+                libsql::params![id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("get_vocab_ledger: {e}")))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+        {
+            Some(row) => Ok(Some(VocabLedgerEntry {
+                id: row
+                    .get(0)
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?,
+                kind: row
+                    .get(1)
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?,
+                old_value: row
+                    .get(2)
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?,
+                new_value: row
+                    .get(3)
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?,
+                pre_image: row
+                    .get(4)
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?,
+                created_at: row
+                    .get(5)
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?,
+            })),
+            None => Ok(None),
+        }
+    }
+}
+
 /// Embedding dimension — must match the model (GTE-Base-EN-v1.5-Q = 768).
 pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 70;
+pub const SCHEMA_VERSION: u32 = 71;
 
 /// Shared embedder reference. Pass to [`MemoryDB::new_with_shared_embedder`] to
 /// reuse a single embedder across many `MemoryDB` instances. Created via
@@ -6642,6 +6722,28 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("migration 70 bump: {e}")))?;
                 log::info!("[migration] Migration 70 applied: entity_type_vocabulary table seeded with 6 live canonicals");
+            }
+
+            // Migration 71: vocab_heal_ledger table. Stores the full pre-image
+            // JSON of rows a vocab auto-heal mutates, so any fix is reversible.
+            if version < 71 {
+                let conn = self.conn.lock().await;
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS vocab_heal_ledger (
+                        id TEXT PRIMARY KEY,
+                        kind TEXT NOT NULL,
+                        old_value TEXT NOT NULL,
+                        new_value TEXT NOT NULL,
+                        pre_image TEXT NOT NULL,
+                        created_at INTEGER NOT NULL
+                    );",
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("migration 71 DDL: {e}")))?;
+                conn.execute("PRAGMA user_version = 71", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("migration 71 bump: {e}")))?;
+                log::info!("[migration] Migration 71 applied: vocab_heal_ledger table for reversible auto-heal");
             }
         }
 
@@ -50970,7 +51072,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 70);
+        assert_eq!(uv, 71);
     }
 
     #[tokio::test]
@@ -50987,7 +51089,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 70,
+            uv, 71,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -51021,7 +51123,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 70);
+        assert_eq!(uv, 71);
     }
 
     #[tokio::test]
@@ -51038,7 +51140,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 70,
+            uv, 71,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -51086,10 +51188,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(
-            uv, 70,
-            "terminal version is 70 after entity_type_vocabulary"
-        );
+        assert_eq!(uv, 71, "terminal version is 71 after vocab_heal_ledger");
     }
 
     #[tokio::test]
@@ -51106,7 +51205,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 70,
+            uv, 71,
             "user_version restored to current terminal version after idempotent re-run"
         );
 
@@ -51120,6 +51219,24 @@ pub(crate) mod tests {
             .unwrap();
         let present: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(present, 1, "child_vectors survives idempotent re-run");
+    }
+
+    #[tokio::test]
+    async fn vocab_ledger_round_trips_pre_image() {
+        let (db, _tmp) = test_db().await;
+        let pre = r#"[{"id":"rel-1","relation_type":"working_at","confidence":0.5}]"#;
+        let id = db
+            .insert_vocab_ledger_entry("relation", "working_at", "works_on", pre, &["rel-1".into()])
+            .await
+            .unwrap();
+        let got = db.get_vocab_ledger_entry(&id).await.unwrap().unwrap();
+        assert_eq!(got.kind, "relation");
+        assert_eq!(got.old_value, "working_at");
+        assert_eq!(got.new_value, "works_on");
+        assert_eq!(
+            got.pre_image, pre,
+            "full pre-image JSON must round-trip for undo"
+        );
     }
 
     // ── T15a: fact-channel producer + retrieval integration ───────────────────

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -193,7 +193,7 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 69;
+pub const SCHEMA_VERSION: u32 = 70;
 
 /// Shared embedder reference. Pass to [`MemoryDB::new_with_shared_embedder`] to
 /// reuse a single embedder across many `MemoryDB` instances. Created via
@@ -6614,6 +6614,34 @@ impl MemoryDB {
                     .await
                     .map_err(|error| WenlanError::VectorDb(format!("m69 bump: {error}")))?;
                 log::info!("[migration] Migration 69 applied: derived artifact sweep receipts");
+            }
+
+            // Migration 70: entity_type_vocabulary table (mirrors
+            // relation_type_vocabulary from migration 41), seeded with the
+            // 6 live canonical entity types.
+            if version < 70 {
+                let conn = self.conn.lock().await;
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS entity_type_vocabulary (
+                        canonical TEXT PRIMARY KEY,
+                        aliases TEXT,
+                        category TEXT,
+                        count INTEGER DEFAULT 0
+                    );
+                    INSERT OR IGNORE INTO entity_type_vocabulary (canonical, aliases, category, count) VALUES
+                        ('concept',      '[]', 'general', 0),
+                        ('technology',   '[]', 'general', 0),
+                        ('project',      '[]', 'general', 0),
+                        ('organization', '[]', 'general', 0),
+                        ('person',       '[]', 'general', 0),
+                        ('place',        '[]', 'general', 0);",
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("migration 70 DDL: {e}")))?;
+                conn.execute("PRAGMA user_version = 70", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("migration 70 bump: {e}")))?;
+                log::info!("[migration] Migration 70 applied: entity_type_vocabulary table seeded with 6 live canonicals");
             }
         }
 
@@ -15156,6 +15184,68 @@ impl MemoryDB {
         )
         .await
         .map_err(|e| WenlanError::VectorDb(format!("increment_relation_type_count: {}", e)))?;
+        Ok(())
+    }
+
+    /// Resolve an entity type against the vocabulary. Canonical-first, then a
+    /// deterministic ordered alias scan. Mirrors `resolve_relation_type`.
+    pub async fn resolve_entity_type(
+        &self,
+        entity_type: &str,
+    ) -> Result<Option<String>, WenlanError> {
+        let lower = entity_type.to_lowercase();
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT canonical FROM entity_type_vocabulary WHERE canonical = ?1",
+                libsql::params![lower.clone()],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("resolve_entity_type canonical: {e}")))?;
+        if rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("resolve_entity_type row: {e}")))?
+            .is_some()
+        {
+            return Ok(Some(lower));
+        }
+        drop(rows);
+        // Deterministic order so resolution can't flip between runs.
+        let mut rows = conn
+            .query(
+                "SELECT canonical, aliases FROM entity_type_vocabulary WHERE aliases IS NOT NULL ORDER BY canonical",
+                libsql::params![],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("resolve_entity_type aliases: {e}")))?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("resolve_entity_type alias row: {e}")))?
+        {
+            let canonical = row.get::<String>(0).unwrap_or_default();
+            let aliases_json = row.get::<String>(1).unwrap_or_default();
+            if let Ok(serde_json::Value::Array(arr)) = serde_json::from_str(&aliases_json) {
+                for v in &arr {
+                    if v.as_str().map(|a| a.to_lowercase()) == Some(lower.clone()) {
+                        return Ok(Some(canonical));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Increment usage count for a canonical entity type.
+    pub async fn increment_entity_type_count(&self, canonical: &str) -> Result<(), WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "UPDATE entity_type_vocabulary SET count = count + 1 WHERE canonical = ?1",
+            libsql::params![canonical.to_string()],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("increment_entity_type_count: {e}")))?;
         Ok(())
     }
 
@@ -43349,6 +43439,34 @@ pub(crate) mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn entity_type_vocabulary_seeded_and_resolves() {
+        let (db, _tmp) = test_db().await;
+        // Canonical resolves to itself.
+        assert_eq!(
+            db.resolve_entity_type("concept").await.unwrap(),
+            Some("concept".into())
+        );
+        // Case-insensitive canonical.
+        assert_eq!(
+            db.resolve_entity_type("Concept").await.unwrap(),
+            Some("concept".into())
+        );
+        // Unknown type is not in the vocabulary.
+        assert_eq!(db.resolve_entity_type("interest").await.unwrap(), None);
+        // Seed count is exactly the 6 live types.
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT COUNT(*) FROM entity_type_vocabulary", ())
+            .await
+            .unwrap();
+        let n: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(
+            n, 6,
+            "entity_type_vocabulary should seed exactly the 6 live canonicals"
+        );
+    }
+
     // ==================== Topic-key upsert feature tests ====================
 
     // ---- link_page_source + get_page_sources ----
@@ -50852,7 +50970,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 69);
+        assert_eq!(uv, 70);
     }
 
     #[tokio::test]
@@ -50869,7 +50987,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 69,
+            uv, 70,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -50903,7 +51021,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 69);
+        assert_eq!(uv, 70);
     }
 
     #[tokio::test]
@@ -50920,7 +51038,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 69,
+            uv, 70,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -50969,8 +51087,8 @@ pub(crate) mod tests {
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
         assert_eq!(
-            uv, 69,
-            "terminal version is 69 after derived sweep receipts"
+            uv, 70,
+            "terminal version is 70 after entity_type_vocabulary"
         );
     }
 
@@ -50988,7 +51106,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 69,
+            uv, 70,
             "user_version restored to current terminal version after idempotent re-run"
         );
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -411,6 +411,81 @@ impl MemoryDB {
         }
         Ok(folded)
     }
+
+    /// All canonical entity types (lowercase), for safe-transform matching.
+    pub async fn entity_canonicals(&self) -> Result<Vec<String>, WenlanError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT canonical FROM entity_type_vocabulary ORDER BY canonical",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("entity_canonicals: {e}")))?;
+        let mut out = Vec::new();
+        while let Some(r) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+        {
+            out.push(r.get::<String>(0).unwrap_or_default());
+        }
+        Ok(out)
+    }
+
+    /// Fold every entity of `old_type` into `canonical`. Plain rewrite: unlike
+    /// relations, there's no unique constraint on `entities.entity_type`, so no
+    /// collision handling is needed. Every folded row's pre-image is recorded
+    /// to the ledger so the fold is reversible. Returns the number of rows folded.
+    pub async fn fold_entity_type(
+        &self,
+        old_type: &str,
+        canonical: &str,
+    ) -> Result<usize, WenlanError> {
+        // Snapshot the affected ids for the ledger, then rewrite. No unique
+        // constraint on entities.entity_type, so no collision handling needed.
+        let (pre_json, ids) = {
+            let conn = self.conn.lock().await;
+            let mut rows = conn
+                .query(
+                    "SELECT id FROM entities WHERE entity_type = ?1",
+                    libsql::params![old_type],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+            let mut ids = Vec::new();
+            while let Some(r) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                ids.push(r.get::<String>(0).unwrap_or_default());
+            }
+            let pre: Vec<serde_json::Value> = ids
+                .iter()
+                .map(|id| serde_json::json!({"id": id, "entity_type": old_type}))
+                .collect();
+            (
+                serde_json::to_string(&pre).unwrap_or_else(|_| "[]".into()),
+                ids,
+            )
+        };
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        {
+            let conn = self.conn.lock().await;
+            conn.execute(
+                "UPDATE entities SET entity_type = ?1 WHERE entity_type = ?2",
+                libsql::params![canonical.to_string(), old_type.to_string()],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("fold_entity_type: {e}")))?;
+        }
+        self.insert_vocab_ledger_entry("entity", old_type, canonical, &pre_json)
+            .await?;
+        Ok(ids.len())
+    }
 }
 
 /// Embedding dimension — must match the model (GTE-Base-EN-v1.5-Q = 768).

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -15470,7 +15470,7 @@ impl MemoryDB {
         // Scan aliases JSON arrays for a case-insensitive match.
         let mut rows = conn
             .query(
-                "SELECT canonical, aliases FROM relation_type_vocabulary WHERE aliases IS NOT NULL",
+                "SELECT canonical, aliases FROM relation_type_vocabulary WHERE aliases IS NOT NULL ORDER BY canonical",
                 libsql::params![],
             )
             .await
@@ -43805,6 +43805,17 @@ pub(crate) mod tests {
             Some("works_on".to_string())
         );
         assert_eq!(db.resolve_relation_type("custom_type").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn promote_rejects_value_colliding_with_existing_alias() {
+        let (db, _tmp) = test_db().await;
+        // 'wrote' is a seeded alias of 'authored'. Promoting it as a NEW canonical
+        // would be shadowed by resolve's canonical-first lookup -> must be rejected.
+        let err = db
+            .promote_vocabulary_canonical("relation", "wrote", None)
+            .await;
+        assert!(err.is_err(), "promoting an existing alias must be rejected");
     }
 
     #[tokio::test]

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -278,106 +278,130 @@ impl MemoryDB {
         old_type: &str,
         canonical: &str,
     ) -> Result<usize, WenlanError> {
+        // Self-fold would collide every row with itself and DELETE it: guard first.
+        if old_type == canonical {
+            return Ok(0);
+        }
         let conn = self.conn.lock().await;
         conn.execute("BEGIN", ())
             .await
             .map_err(|e| WenlanError::VectorDb(format!("fold begin: {e}")))?;
 
-        // Snapshot every row of old_type (the pre-image, for the ledger + undo).
-        let mut rows = conn
-            .query(
-                "SELECT id, from_entity, to_entity, confidence, explanation, source_memory_id, source_agent, created_at FROM relations WHERE relation_type = ?1",
-                libsql::params![old_type],
-            )
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("fold snapshot: {e}")))?;
-        let mut pre_image: Vec<serde_json::Value> = Vec::new();
-        #[allow(clippy::type_complexity)]
-        let mut ids: Vec<(
-            String,
-            String,
-            String,
-            Option<f64>,
-            Option<String>,
-            Option<String>,
-        )> = Vec::new();
-        while let Some(r) = rows
-            .next()
-            .await
-            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
-        {
-            let id: String = r.get(0).unwrap_or_default();
-            let from: String = r.get(1).unwrap_or_default();
-            let to: String = r.get(2).unwrap_or_default();
-            let conf: Option<f64> = r.get(3).ok();
-            let expl: Option<String> = r.get(4).ok();
-            let smid: Option<String> = r.get(5).ok();
-            pre_image.push(serde_json::json!({
-                "id": id, "from_entity": from, "to_entity": to, "relation_type": old_type,
-                "confidence": conf, "explanation": expl, "source_memory_id": smid,
-            }));
-            ids.push((id, from, to, conf, expl, smid));
-        }
-        drop(rows);
-
-        let mut folded = 0usize;
-        for (id, from, to, conf, expl, smid) in &ids {
-            // Does a canonical edge already exist for this pair?
-            let mut ex = conn
+        // Run the snapshot + mutation loop in an inner block so any early Err
+        // routes through ROLLBACK below instead of leaking an open transaction
+        // on the shared connection (mirrors the migration-50 pattern).
+        let result: Result<(usize, Vec<serde_json::Value>), WenlanError> = async {
+            // Snapshot every row of old_type (the pre-image, for the ledger + undo).
+            let mut rows = conn
                 .query(
-                    "SELECT id, confidence, explanation, source_memory_id FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
-                    libsql::params![from.clone(), to.clone(), canonical.to_string()],
+                    "SELECT id, from_entity, to_entity, confidence, explanation, source_memory_id, source_agent, created_at FROM relations WHERE relation_type = ?1",
+                    libsql::params![old_type],
                 )
                 .await
-                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
-            if let Some(sr) = ex
+                .map_err(|e| WenlanError::VectorDb(format!("fold snapshot: {e}")))?;
+            let mut pre_image: Vec<serde_json::Value> = Vec::new();
+            #[allow(clippy::type_complexity)]
+            let mut ids: Vec<(
+                String,
+                String,
+                String,
+                Option<f64>,
+                Option<String>,
+                Option<String>,
+            )> = Vec::new();
+            while let Some(r) = rows
                 .next()
                 .await
                 .map_err(|e| WenlanError::VectorDb(e.to_string()))?
             {
-                let s_conf: Option<f64> = sr.get(1).ok();
-                let s_expl: Option<String> = sr.get(2).ok();
-                let s_smid: Option<String> = sr.get(3).ok();
-                drop(ex);
-                // Merge provenance into the survivor: higher confidence wins; fill nulls.
-                let merged_conf = match (s_conf, conf) {
-                    (Some(a), Some(b)) => Some(a.max(*b)),
-                    (a, b) => a.or(*b),
-                };
-                let merged_expl = s_expl.or_else(|| expl.clone());
-                let merged_smid = s_smid.or_else(|| smid.clone());
-                conn.execute(
-                    "UPDATE relations SET confidence = ?1, explanation = ?2, source_memory_id = ?3 WHERE from_entity = ?4 AND to_entity = ?5 AND relation_type = ?6",
-                    libsql::params![
-                        merged_conf.map(libsql::Value::Real).unwrap_or(libsql::Value::Null),
-                        merged_expl.map(libsql::Value::Text).unwrap_or(libsql::Value::Null),
-                        merged_smid.map(libsql::Value::Text).unwrap_or(libsql::Value::Null),
-                        from.clone(), to.clone(), canonical.to_string()],
-                )
-                .await
-                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
-                // Delete the loser (its pre-image is already captured above).
-                conn.execute(
-                    "DELETE FROM relations WHERE id = ?1",
-                    libsql::params![id.clone()],
-                )
-                .await
-                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
-            } else {
-                drop(ex);
-                conn.execute(
-                    "UPDATE relations SET relation_type = ?1 WHERE id = ?2",
-                    libsql::params![canonical.to_string(), id.clone()],
-                )
-                .await
-                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                let id: String = r.get(0).unwrap_or_default();
+                let from: String = r.get(1).unwrap_or_default();
+                let to: String = r.get(2).unwrap_or_default();
+                let conf: Option<f64> = r.get(3).ok();
+                let expl: Option<String> = r.get(4).ok();
+                let smid: Option<String> = r.get(5).ok();
+                let sagent: Option<String> = r.get(6).ok();
+                let created: Option<i64> = r.get(7).ok();
+                pre_image.push(serde_json::json!({
+                    "id": id, "from_entity": from, "to_entity": to, "relation_type": old_type,
+                    "confidence": conf, "explanation": expl, "source_memory_id": smid,
+                    "source_agent": sagent, "created_at": created,
+                }));
+                ids.push((id, from, to, conf, expl, smid));
             }
-            folded += 1;
-        }
+            drop(rows);
 
-        conn.execute("COMMIT", ())
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("fold commit: {e}")))?;
+            let mut folded = 0usize;
+            for (id, from, to, conf, expl, smid) in &ids {
+                // Does a canonical edge already exist for this pair?
+                let mut ex = conn
+                    .query(
+                        "SELECT id, confidence, explanation, source_memory_id FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
+                        libsql::params![from.clone(), to.clone(), canonical.to_string()],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                if let Some(sr) = ex
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+                {
+                    let s_conf: Option<f64> = sr.get(1).ok();
+                    let s_expl: Option<String> = sr.get(2).ok();
+                    let s_smid: Option<String> = sr.get(3).ok();
+                    drop(ex);
+                    // Merge provenance into the survivor: higher confidence wins; fill nulls.
+                    let merged_conf = match (s_conf, conf) {
+                        (Some(a), Some(b)) => Some(a.max(*b)),
+                        (a, b) => a.or(*b),
+                    };
+                    let merged_expl = s_expl.or_else(|| expl.clone());
+                    let merged_smid = s_smid.or_else(|| smid.clone());
+                    conn.execute(
+                        "UPDATE relations SET confidence = ?1, explanation = ?2, source_memory_id = ?3 WHERE from_entity = ?4 AND to_entity = ?5 AND relation_type = ?6",
+                        libsql::params![
+                            merged_conf.map(libsql::Value::Real).unwrap_or(libsql::Value::Null),
+                            merged_expl.map(libsql::Value::Text).unwrap_or(libsql::Value::Null),
+                            merged_smid.map(libsql::Value::Text).unwrap_or(libsql::Value::Null),
+                            from.clone(), to.clone(), canonical.to_string()],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                    // Delete the loser (its pre-image is already captured above).
+                    conn.execute(
+                        "DELETE FROM relations WHERE id = ?1",
+                        libsql::params![id.clone()],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                } else {
+                    drop(ex);
+                    conn.execute(
+                        "UPDATE relations SET relation_type = ?1 WHERE id = ?2",
+                        libsql::params![canonical.to_string(), id.clone()],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                }
+                folded += 1;
+            }
+
+            Ok((folded, pre_image))
+        }
+        .await;
+
+        let (folded, pre_image) = match result {
+            Ok(v) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("fold commit: {e}")))?;
+                v
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
         drop(conn);
 
         if !pre_image.is_empty() {

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -493,7 +493,7 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 71;
+pub const SCHEMA_VERSION: u32 = 72;
 
 /// Shared embedder reference. Pass to [`MemoryDB::new_with_shared_embedder`] to
 /// reuse a single embedder across many `MemoryDB` instances. Created via
@@ -6964,6 +6964,27 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("migration 71 bump: {e}")))?;
                 log::info!("[migration] Migration 71 applied: vocab_heal_ledger table for reversible auto-heal");
+            }
+
+            // Migration 72: retire dedup_merge. One-time dismiss of any legacy
+            // dedup_merge rows still pending/awaiting_review; nothing produces
+            // them anymore (the ProposalAction::DedupMerge parse arms stay for
+            // historical deserialize).
+            if version < 72 {
+                let conn = self.conn.lock().await;
+                conn.execute(
+                    "UPDATE refinement_queue SET status = 'dismissed' \
+                     WHERE action = 'dedup_merge' AND status IN ('pending', 'awaiting_review')",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("migration 72 dismiss: {e}")))?;
+                conn.execute("PRAGMA user_version = 72", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("migration 72 bump: {e}")))?;
+                log::info!(
+                    "[migration] Migration 72 applied: dismissed deprecated dedup_merge rows"
+                );
             }
         }
 
@@ -51498,7 +51519,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 71);
+        assert_eq!(uv, 72);
     }
 
     #[tokio::test]
@@ -51515,7 +51536,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 71,
+            uv, 72,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -51549,7 +51570,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 71);
+        assert_eq!(uv, 72);
     }
 
     #[tokio::test]
@@ -51566,7 +51587,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 71,
+            uv, 72,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -51614,7 +51635,10 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 71, "terminal version is 71 after vocab_heal_ledger");
+        assert_eq!(
+            uv, 72,
+            "terminal version is 72 after dedup_merge retirement"
+        );
     }
 
     #[tokio::test]
@@ -51631,7 +51655,7 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 71,
+            uv, 72,
             "user_version restored to current terminal version after idempotent re-run"
         );
 
@@ -53402,6 +53426,27 @@ pub(crate) mod tests {
             .await
             .unwrap()
             .contains(&"p1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn dedup_merge_rows_are_dismissed_by_migration() {
+        let (db, _tmp) = test_db().await;
+        // A migration cannot see rows inserted after it runs, so assert the SQL
+        // directly: insert a legacy row, run the same dismiss statement, verify.
+        {
+            let conn = db.conn.lock().await;
+            conn.execute("INSERT INTO refinement_queue (id, action, source_ids, payload, confidence, status) VALUES ('legacy-1', 'dedup_merge', '[\"a\",\"b\"]', NULL, 0.5, 'pending')", ()).await.unwrap();
+            conn.execute("UPDATE refinement_queue SET status = 'dismissed' WHERE action = 'dedup_merge' AND status IN ('pending','awaiting_review')", ()).await.unwrap();
+            let mut rows = conn
+                .query(
+                    "SELECT status FROM refinement_queue WHERE id = 'legacy-1'",
+                    (),
+                )
+                .await
+                .unwrap();
+            let status: String = rows.next().await.unwrap().unwrap().get(0).unwrap();
+            assert_eq!(status, "dismissed");
+        }
     }
 
     #[test]

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -43877,6 +43877,36 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn prompt_entity_types_match_vocabulary_seed() {
+        let (db, _tmp) = test_db().await;
+        // Entity types named in the extraction prompt.
+        let prompt_types: std::collections::BTreeSet<String> = [
+            "person",
+            "project",
+            "technology",
+            "organization",
+            "place",
+            "concept",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT canonical FROM entity_type_vocabulary", ())
+            .await
+            .unwrap();
+        let mut db_types = std::collections::BTreeSet::new();
+        while let Some(r) = rows.next().await.unwrap() {
+            db_types.insert(r.get::<String>(0).unwrap());
+        }
+        assert_eq!(
+            prompt_types, db_types,
+            "prompt entity types must match entity_type_vocabulary seed exactly"
+        );
+    }
+
+    #[tokio::test]
     async fn create_relation_coerces_unknown_type_to_related_to() {
         let (db, _tmp) = test_db().await;
         let e1 = db.create_entity("Alice", "person", None).await.unwrap();

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -21077,7 +21077,8 @@ impl MemoryDB {
 
     /// Stable fingerprint for a vocab proposal — keyed on (kind, old_value) ONLY,
     /// never the suggested target. One human dismissal of a value is permanent.
-    fn vocab_proposal_fingerprint(kind: &str, old_value: &str) -> String {
+    /// `pub(crate)` so the refinement_queue tests can reconstruct the id.
+    pub(crate) fn vocab_proposal_fingerprint(kind: &str, old_value: &str) -> String {
         format!("vocab_promote::{kind}::{}", old_value.to_lowercase())
     }
 
@@ -21107,6 +21108,48 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("insert_vocab_promote: {e}")))?;
         Ok(affected > 0)
+    }
+
+    /// Promote a value to a new canonical in the entity/relation vocabulary.
+    /// Rejects a value that collides (casefold) with an existing canonical or alias.
+    pub async fn promote_vocabulary_canonical(
+        &self,
+        kind: &str,
+        old_value: &str,
+        category: Option<&str>,
+    ) -> Result<(), WenlanError> {
+        // Cross-canonical uniqueness guard (Task 11 extends the alias half).
+        // Resolve BEFORE taking the conn lock — `resolve_*` lock `self.conn`
+        // internally and the Mutex is not reentrant.
+        let already = match kind {
+            "entity" => self.resolve_entity_type(old_value).await?,
+            _ => self.resolve_relation_type(old_value).await?,
+        };
+        if already.is_some() {
+            return Err(WenlanError::Validation(format!(
+                "'{old_value}' already resolves to a canonical; cannot promote"
+            )));
+        }
+        let table = if kind == "entity" {
+            "entity_type_vocabulary"
+        } else {
+            "relation_type_vocabulary"
+        };
+        let conn = self.conn.lock().await;
+        conn.execute(
+            &format!(
+                "INSERT OR IGNORE INTO {table} (canonical, aliases, category, count) VALUES (?1, '[]', ?2, 0)"
+            ),
+            libsql::params![
+                old_value.to_lowercase(),
+                category
+                    .map(|c| libsql::Value::Text(c.to_string()))
+                    .unwrap_or(libsql::Value::Null)
+            ],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("promote_vocabulary_canonical: {e}")))?;
+        Ok(())
     }
 
     /// Get all pending/awaiting_review refinement proposals.

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -96,6 +96,8 @@ pub struct RethinkReport {
     pub merge_candidates: usize,
     pub relations_healed: usize,
     pub relations_queued: usize,
+    pub entities_healed: usize,
+    pub entities_queued: usize,
     pub embeddings_refreshed: usize,
     pub stale_relations_flagged: usize,
     pub contradictions_found: usize,
@@ -116,10 +118,13 @@ pub async fn run_rethink(
     _config: &RefineryConfig,
 ) -> Result<RethinkReport, WenlanError> {
     let rel = heal_relation_vocabulary(db).await?;
+    let ent = heal_entity_vocabulary(db).await?;
     let report = RethinkReport {
         merge_candidates: find_merge_candidates(db).await?,
         relations_healed: rel.healed,
         relations_queued: rel.queued,
+        entities_healed: ent.healed,
+        entities_queued: ent.queued,
         embeddings_refreshed: refresh_stale_entity_embeddings(db).await?,
         stale_relations_flagged: detect_stale_relations(db).await?,
         contradictions_found: scan_contradictions(db).await?,
@@ -332,6 +337,74 @@ pub async fn heal_relation_vocabulary(db: &MemoryDB) -> Result<VocabHealCounts, 
         // Band B: semantic / new -> queue one promote candidate.
         if db
             .insert_vocab_promote_proposal("relation", rel_type, None)
+            .await?
+        {
+            counts.queued += 1;
+        }
+    }
+    Ok(counts)
+}
+
+/// Heal non-canonical entity types: auto-fold the deterministically safe ones
+/// (known aliases + safe transforms), queue everything else as a promote candidate.
+pub async fn heal_entity_vocabulary(db: &MemoryDB) -> Result<VocabHealCounts, WenlanError> {
+    // First, read all distinct entity types.
+    let types_to_check: Vec<String> = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT DISTINCT entity_type FROM entities", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("distinct entity types: {}", e)))?;
+        let mut types = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("entity type row: {}", e)))?
+        {
+            types.push(row.get::<String>(0).unwrap_or_default());
+        }
+        types
+    };
+
+    let canonicals = db.entity_canonicals().await?;
+    let mut counts = VocabHealCounts::default();
+    for entity_type in &types_to_check {
+        if entity_type.is_empty() {
+            continue;
+        }
+        // Already canonical? nothing to do.
+        if canonicals.iter().any(|c| c == entity_type) {
+            continue;
+        }
+        // Band A1: known alias in the vocabulary -> deterministic fold.
+        if let Some(canonical) = db.resolve_entity_type(entity_type).await? {
+            let folded = db.fold_entity_type(entity_type, &canonical).await?;
+            counts.healed += folded;
+            log::info!(
+                "[rethink] folded '{}' -> '{}' ({} entities, ledgered)",
+                entity_type,
+                canonical,
+                folded
+            );
+            continue;
+        }
+        // Band A2: deterministic safe transform toward an existing canonical.
+        if let Some(canonical) =
+            crate::vocab::safe_transform::safe_transform(entity_type, &canonicals)
+        {
+            let folded = db.fold_entity_type(entity_type, &canonical).await?;
+            counts.healed += folded;
+            log::info!(
+                "[rethink] folded '{}' -> '{}' ({} entities, ledgered)",
+                entity_type,
+                canonical,
+                folded
+            );
+            continue;
+        }
+        // Band B: semantic / new -> queue one promote candidate.
+        if db
+            .insert_vocab_promote_proposal("entity", entity_type, None)
             .await?
         {
             counts.queued += 1;
@@ -1210,5 +1283,31 @@ mod tests {
                 .as_deref()
                 .unwrap_or("")
                 .contains("design_inspiration")));
+    }
+
+    #[tokio::test]
+    async fn heal_entity_vocabulary_folds_plural_and_queues_semantic() {
+        let (db, _dir) = test_db().await;
+        db.store_entity("X", "concepts", None, Some("t"), None)
+            .await
+            .unwrap(); // safe: concepts->concept
+        db.store_entity("Y", "interest", None, Some("t"), None)
+            .await
+            .unwrap(); // semantic: queue
+        let counts = super::heal_entity_vocabulary(&db).await.unwrap();
+        assert!(counts.healed >= 1);
+        assert!(counts.queued >= 1);
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT entity_type FROM entities ORDER BY entity_type", ())
+            .await
+            .unwrap();
+        let mut types = vec![];
+        while let Some(r) = rows.next().await.unwrap() {
+            types.push(r.get::<String>(0).unwrap());
+        }
+        assert!(types.contains(&"concept".to_string()));
+        assert!(!types.contains(&"concepts".to_string()));
+        assert!(types.contains(&"interest".to_string())); // unchanged, awaiting human
     }
 }

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -1003,6 +1003,15 @@ mod tests {
             pre_image.contains("created_at"),
             "pre-image must include created_at so undo can restore the NOT-NULL column, got {pre_image}"
         );
+        // Spec §2.5: the SURVIVOR is mutated too (provenance COALESCE-merge), so its
+        // pre-image must also be ledgered before the UPDATE, else undo cannot restore
+        // its pre-merge confidence/explanation. `rel-canon` is the survivor's id and
+        // appears in NO loser pre-image (loser id is `rel-alias`), so its presence
+        // proves the survivor pre-image was captured.
+        assert!(
+            pre_image.contains("rel-canon"),
+            "survivor pre-image must be ledgered so undo can restore the mutated survivor, got {pre_image}"
+        );
     }
 
     // ── hallucination_guard ──────────────────────────────────────────────

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -290,40 +290,13 @@ pub async fn normalize_non_vocabulary_relations(db: &MemoryDB) -> Result<usize, 
             continue;
         };
         if canonical != *rel_type {
-            let conn = db.conn.lock().await;
-            // Use UPDATE OR IGNORE to skip rows that would violate the unique
-            // constraint (from_entity, to_entity, relation_type). Then delete
-            // the orphaned rows that couldn't be updated (they're now duplicates
-            // of the canonical relation that already existed).
-            let affected = conn
-                .execute(
-                    "UPDATE OR IGNORE relations SET relation_type = ?1 WHERE relation_type = ?2",
-                    libsql::params![canonical.clone(), rel_type.clone()],
-                )
-                .await
-                .map_err(|e| WenlanError::VectorDb(format!("normalize relations: {}", e)))?;
-            // Clean up rows that couldn't be updated (still have old type, but
-            // a canonical relation already exists for the same entity pair).
-            let deleted = conn
-                .execute(
-                    "DELETE FROM relations WHERE relation_type = ?1",
-                    libsql::params![rel_type.clone()],
-                )
-                .await
-                .map_err(|e| WenlanError::VectorDb(format!("cleanup dup relations: {}", e)))?;
-            if deleted > 0 {
-                log::info!(
-                    "[rethink] cleaned up {} duplicate relations after normalizing '{}'",
-                    deleted,
-                    rel_type
-                );
-            }
-            normalized += affected as usize;
+            let folded = db.fold_relation_type(rel_type, &canonical).await?;
+            normalized += folded;
             log::info!(
-                "[rethink] normalized '{}' -> '{}' ({} relations)",
+                "[rethink] folded '{}' -> '{}' ({} relations, ledgered)",
                 rel_type,
                 canonical,
-                affected
+                folded
             );
         }
     }
@@ -844,12 +817,11 @@ mod tests {
         }
     }
 
-    // ── Fix 3: normalize_non_vocabulary_relations handles UNIQUE conflicts ─
+    // ── Fix 3: fold_relation_type merges provenance + ledgers the loser ────
 
     #[tokio::test]
-    async fn test_normalize_handles_unique_conflict() {
+    async fn fold_relation_type_merges_provenance_and_ledgers_the_loser() {
         let (db, _dir) = test_db().await;
-
         let e1 = db
             .store_entity("EntityA", "person", None, Some("test"), None)
             .await
@@ -858,67 +830,50 @@ mod tests {
             .store_entity("EntityB", "project", None, Some("test"), None)
             .await
             .unwrap();
-
-        // Insert two relations directly via SQL, bypassing normalization:
-        // one with canonical type "works_on" and one with alias "working_at".
-        // Normalizing "working_at" -> "works_on" would cause a UNIQUE violation
-        // on (from_entity, to_entity, relation_type).
+        let now = chrono::Utc::now().timestamp();
         {
             let conn = db.conn.lock().await;
-            let now = chrono::Utc::now().timestamp();
+            // Survivor: canonical works_on, confidence 0.9.
             conn.execute(
-                "INSERT INTO relations (id, from_entity, to_entity, relation_type, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                libsql::params![
-                    "rel-canonical".to_string(),
-                    e1.clone(),
-                    e2.clone(),
-                    "works_on".to_string(),
-                    now
-                ],
+                "INSERT INTO relations (id, from_entity, to_entity, relation_type, confidence, created_at) VALUES ('rel-canon', ?1, ?2, 'works_on', 0.9, ?3)",
+                libsql::params![e1.clone(), e2.clone(), now]).await.unwrap();
+            // Loser: alias working_at, confidence 0.5, has an explanation.
+            conn.execute(
+                "INSERT INTO relations (id, from_entity, to_entity, relation_type, confidence, explanation, created_at) VALUES ('rel-alias', ?1, ?2, 'working_at', 0.5, 'employed since 2020', ?3)",
+                libsql::params![e1.clone(), e2.clone(), now]).await.unwrap();
+        }
+
+        let folded = db
+            .fold_relation_type("working_at", "works_on")
+            .await
+            .unwrap();
+        assert_eq!(folded, 1);
+
+        let conn = db.conn.lock().await;
+        // Exactly one A->B row survives, canonical, confidence preserved at 0.9,
+        // and the loser's explanation was merged in (survivor had none).
+        let mut rows = conn.query(
+            "SELECT COUNT(*), MAX(confidence) FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
+            libsql::params![e1.clone(), e2.clone()]).await.unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let cnt: i64 = row.get(0).unwrap();
+        let conf: f64 = row.get(1).unwrap();
+        assert_eq!(cnt, 1, "collision must not leave two rows");
+        assert!(
+            (conf - 0.9).abs() < 1e-6,
+            "survivor keeps the higher confidence"
+        );
+        drop(rows);
+        // The absorbed edge's pre-image is in the ledger (undo is possible).
+        let mut led = conn
+            .query(
+                "SELECT COUNT(*) FROM vocab_heal_ledger WHERE old_value = 'working_at'",
+                (),
             )
             .await
             .unwrap();
-            conn.execute(
-                "INSERT INTO relations (id, from_entity, to_entity, relation_type, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                libsql::params![
-                    "rel-alias".to_string(),
-                    e1.clone(),
-                    e2.clone(),
-                    "working_at".to_string(),
-                    now
-                ],
-            )
-            .await
-            .unwrap();
-        }
-
-        // normalize_non_vocabulary_relations should succeed without panicking
-        normalize_non_vocabulary_relations(&db).await.unwrap();
-
-        // After normalization, only 1 relation should remain for A->B
-        {
-            let conn = db.conn.lock().await;
-            let mut rows = conn
-                .query(
-                    "SELECT COUNT(*), relation_type FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
-                    libsql::params![e1.clone(), e2.clone()],
-                )
-                .await
-                .unwrap();
-            let row = rows.next().await.unwrap().expect("should have a row");
-            let cnt: i64 = row.get::<i64>(0).unwrap();
-            let rel_type: String = row.get::<String>(1).unwrap();
-            assert_eq!(
-                cnt, 1,
-                "only 1 relation should remain after normalization resolved the UNIQUE conflict, got {cnt}"
-            );
-            assert_eq!(
-                rel_type, "works_on",
-                "surviving relation should have canonical type 'works_on', got '{rel_type}'"
-            );
-        }
+        let n: i64 = led.next().await.unwrap().unwrap().get(0).unwrap();
+        assert!(n >= 1, "the folded loser must be recorded in the ledger");
     }
 
     // ── hallucination_guard ──────────────────────────────────────────────

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -130,6 +130,17 @@ pub async fn run_rethink(
         contradictions_found: scan_contradictions(db).await?,
     };
 
+    let receipt = serde_json::json!({
+        "relations_healed": report.relations_healed,
+        "relations_queued": report.relations_queued,
+        "entities_healed": report.entities_healed,
+        "entities_queued": report.entities_queued,
+    })
+    .to_string();
+    let _ = db
+        .log_agent_activity("daemon", "vocab_heal_receipt", &[], None, &receipt)
+        .await;
+
     Ok(report)
 }
 
@@ -1309,5 +1320,37 @@ mod tests {
         assert!(types.contains(&"concept".to_string()));
         assert!(!types.contains(&"concepts".to_string()));
         assert!(types.contains(&"interest".to_string())); // unchanged, awaiting human
+    }
+
+    #[tokio::test]
+    async fn run_rethink_emits_a_vocab_heal_receipt() {
+        let (db, _dir) = test_db().await;
+        // Seed one queue-able dirty relation.
+        let e1 = db
+            .store_entity("A", "person", None, Some("t"), None)
+            .await
+            .unwrap();
+        let e2 = db
+            .store_entity("B", "project", None, Some("t"), None)
+            .await
+            .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute("INSERT INTO relations (id, from_entity, to_entity, relation_type, created_at) VALUES ('r1', ?1, ?2, 'design_inspiration', 0)",
+                libsql::params![e1, e2]).await.unwrap();
+        }
+        let cfg = crate::tuning::RefineryConfig::default();
+        super::run_rethink(&db, None, &cfg).await.unwrap();
+        // A vocab-heal receipt activity row exists.
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM agent_activity WHERE action = 'vocab_heal_receipt'",
+                (),
+            )
+            .await
+            .unwrap();
+        let n: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert!(n >= 1, "run_rethink must emit a counted vocab-heal receipt");
     }
 }

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -864,16 +864,24 @@ mod tests {
             "survivor keeps the higher confidence"
         );
         drop(rows);
-        // The absorbed edge's pre-image is in the ledger (undo is possible).
+        // The absorbed edge's pre-image is in the ledger (undo is possible),
+        // and the pre-image is COMPLETE: it carries created_at so a NOT-NULL
+        // restore is possible on undo.
         let mut led = conn
             .query(
-                "SELECT COUNT(*) FROM vocab_heal_ledger WHERE old_value = 'working_at'",
+                "SELECT COUNT(*), MAX(pre_image) FROM vocab_heal_ledger WHERE old_value = 'working_at'",
                 (),
             )
             .await
             .unwrap();
-        let n: i64 = led.next().await.unwrap().unwrap().get(0).unwrap();
+        let led_row = led.next().await.unwrap().unwrap();
+        let n: i64 = led_row.get(0).unwrap();
+        let pre_image: String = led_row.get(1).unwrap();
         assert!(n >= 1, "the folded loser must be recorded in the ledger");
+        assert!(
+            pre_image.contains("created_at"),
+            "pre-image must include created_at so undo can restore the NOT-NULL column, got {pre_image}"
+        );
     }
 
     // ── hallucination_guard ──────────────────────────────────────────────

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -94,7 +94,8 @@ pub async fn verify_page(
 #[derive(Debug, Default, serde::Serialize)]
 pub struct RethinkReport {
     pub merge_candidates: usize,
-    pub types_normalized: usize,
+    pub relations_healed: usize,
+    pub relations_queued: usize,
     pub embeddings_refreshed: usize,
     pub stale_relations_flagged: usize,
     pub contradictions_found: usize,
@@ -113,9 +114,11 @@ pub async fn run_rethink(
     _llm: Option<&Arc<dyn LlmProvider>>,
     _config: &RefineryConfig,
 ) -> Result<RethinkReport, WenlanError> {
+    let rel = heal_relation_vocabulary(db).await?;
     let report = RethinkReport {
         merge_candidates: find_merge_candidates(db).await?,
-        types_normalized: normalize_non_vocabulary_relations(db).await?,
+        relations_healed: rel.healed,
+        relations_queued: rel.queued,
         embeddings_refreshed: refresh_stale_entity_embeddings(db).await?,
         stale_relations_flagged: detect_stale_relations(db).await?,
         contradictions_found: scan_contradictions(db).await?,
@@ -262,7 +265,15 @@ async fn surface_minhash_merge_candidates(db: &MemoryDB) -> Result<usize, Wenlan
 
 /// Normalize relations whose type isn't canonical in the vocabulary.
 /// Uses `resolve_relation_type` to map aliases to canonical forms.
-pub async fn normalize_non_vocabulary_relations(db: &MemoryDB) -> Result<usize, WenlanError> {
+#[derive(Debug, Default, Clone, Copy)]
+pub struct VocabHealCounts {
+    pub healed: usize,
+    pub queued: usize,
+}
+
+/// Heal non-canonical relation types: auto-fold the deterministically safe ones
+/// (known aliases + safe transforms), queue everything else as a promote candidate.
+pub async fn heal_relation_vocabulary(db: &MemoryDB) -> Result<VocabHealCounts, WenlanError> {
     // First, read all distinct relation types.
     let types_to_check: Vec<String> = {
         let conn = db.conn.lock().await;
@@ -281,26 +292,50 @@ pub async fn normalize_non_vocabulary_relations(db: &MemoryDB) -> Result<usize, 
         types
     };
 
-    let mut normalized = 0usize;
+    let canonicals = db.relation_canonicals().await?;
+    let mut counts = VocabHealCounts::default();
     for rel_type in &types_to_check {
         if rel_type.is_empty() {
             continue;
         }
-        let Some(canonical) = db.resolve_relation_type(rel_type).await? else {
+        // Already canonical? nothing to do.
+        if canonicals.iter().any(|c| c == rel_type) {
             continue;
-        };
-        if canonical != *rel_type {
+        }
+        // Band A1: known alias in the vocabulary -> deterministic fold.
+        if let Some(canonical) = db.resolve_relation_type(rel_type).await? {
             let folded = db.fold_relation_type(rel_type, &canonical).await?;
-            normalized += folded;
+            counts.healed += folded;
             log::info!(
                 "[rethink] folded '{}' -> '{}' ({} relations, ledgered)",
                 rel_type,
                 canonical,
                 folded
             );
+            continue;
+        }
+        // Band A2: deterministic safe transform toward an existing canonical.
+        if let Some(canonical) = crate::vocab::safe_transform::safe_transform(rel_type, &canonicals)
+        {
+            let folded = db.fold_relation_type(rel_type, &canonical).await?;
+            counts.healed += folded;
+            log::info!(
+                "[rethink] folded '{}' -> '{}' ({} relations, ledgered)",
+                rel_type,
+                canonical,
+                folded
+            );
+            continue;
+        }
+        // Band B: semantic / new -> queue one promote candidate.
+        if db
+            .insert_vocab_promote_proposal("relation", rel_type, None)
+            .await?
+        {
+            counts.queued += 1;
         }
     }
-    Ok(normalized)
+    Ok(counts)
 }
 
 /// Refresh embeddings for entities that have accumulated 5+ new observations
@@ -566,9 +601,9 @@ mod tests {
 
         // Rethink should have normalized "working_at" -> "works_on"
         assert!(
-            report.types_normalized >= 1,
+            report.relations_healed >= 1,
             "expected at least 1 type normalized, got {}",
-            report.types_normalized
+            report.relations_healed
         );
 
         // Verify the relation now has the canonical type
@@ -592,7 +627,7 @@ mod tests {
         let report = run_rethink(&db, None, &config).await.unwrap();
         // All zero is fine; the point is it runs without error.
         assert_eq!(report.merge_candidates, 0);
-        assert_eq!(report.types_normalized, 0);
+        assert_eq!(report.relations_healed, 0);
         assert_eq!(report.stale_relations_flagged, 0);
     }
 
@@ -707,7 +742,7 @@ mod tests {
         // Nothing to normalize (already canonical); no duplicates;
         // embedding_refreshed and stale counts should be 0.
         assert_eq!(report.merge_candidates, 0);
-        assert_eq!(report.types_normalized, 0);
+        assert_eq!(report.relations_healed, 0);
     }
 
     // ── Fix 1: Case-insensitive relation resolution ────────────────────────
@@ -1116,5 +1151,62 @@ mod tests {
             );
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn heal_relation_vocabulary_folds_aliases_and_queues_semantics() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .store_entity("A", "person", None, Some("t"), None)
+            .await
+            .unwrap();
+        let e2 = db
+            .store_entity("B", "project", None, Some("t"), None)
+            .await
+            .unwrap();
+        let now = chrono::Utc::now().timestamp();
+        {
+            let conn = db.conn.lock().await;
+            // Known alias -> auto-fold to works_on.
+            conn.execute("INSERT INTO relations (id, from_entity, to_entity, relation_type, created_at) VALUES ('r1', ?1, ?2, 'working_at', ?3)",
+                libsql::params![e1.clone(), e2.clone(), now]).await.unwrap();
+            // Semantic new type -> queue promote.
+            conn.execute("INSERT INTO relations (id, from_entity, to_entity, relation_type, created_at) VALUES ('r2', ?1, ?2, 'design_inspiration', ?3)",
+                libsql::params![e1.clone(), e2.clone(), now]).await.unwrap();
+        }
+        let counts = super::heal_relation_vocabulary(&db).await.unwrap();
+        assert!(
+            counts.healed >= 1,
+            "working_at is a known alias, must auto-fold"
+        );
+        assert!(
+            counts.queued >= 1,
+            "design_inspiration must be queued as promote"
+        );
+        // working_at is gone (folded); design_inspiration still present (awaiting human).
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT relation_type FROM relations ORDER BY relation_type",
+                (),
+            )
+            .await
+            .unwrap();
+        let mut types = vec![];
+        while let Some(r) = rows.next().await.unwrap() {
+            types.push(r.get::<String>(0).unwrap());
+        }
+        assert!(types.contains(&"works_on".to_string()));
+        assert!(types.contains(&"design_inspiration".to_string()));
+        assert!(!types.contains(&"working_at".to_string()));
+        drop(rows);
+        drop(conn); // release before get_pending_refinements re-locks conn (non-reentrant mutex)
+                    // And a promote proposal exists for design_inspiration.
+        let pending = db.get_pending_refinements().await.unwrap();
+        assert!(pending.iter().any(|p| p.action == "vocab_promote"
+            && p.payload
+                .as_deref()
+                .unwrap_or("")
+                .contains("design_inspiration")));
     }
 }

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -105,7 +105,8 @@ pub struct RethinkReport {
 ///
 /// Phases:
 /// 1. Entity merge candidates -- find duplicates with identical lowercase names
-/// 2. Relation type normalization -- rewrite non-canonical types to canonical
+/// 2. Relation vocabulary heal -- auto-fold safe non-canonical types (known
+///    aliases + deterministic transforms) to canonical, queue the rest for review
 /// 3. Entity embedding refresh -- re-embed entities with many new observations
 /// 4. Stale relation detection -- relations whose source memory was deleted
 /// 5. Contradiction scan -- log entities with many observations for review
@@ -263,8 +264,9 @@ async fn surface_minhash_merge_candidates(db: &MemoryDB) -> Result<usize, Wenlan
     Ok(enqueued)
 }
 
-/// Normalize relations whose type isn't canonical in the vocabulary.
-/// Uses `resolve_relation_type` to map aliases to canonical forms.
+/// Counts returned by a vocabulary heal pass: how many relations were
+/// auto-folded to a canonical, and how many distinct new types were queued
+/// for human review as promote candidates.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct VocabHealCounts {
     pub healed: usize,

--- a/crates/wenlan-core/src/lib.rs
+++ b/crates/wenlan-core/src/lib.rs
@@ -68,6 +68,7 @@ pub mod tags;
 pub(crate) mod temporal_query;
 pub mod topic_match;
 pub mod tuning;
+pub mod vocab;
 
 // Re-exports for convenience.
 pub use error::WenlanError;

--- a/crates/wenlan-core/src/lint/operations/query/refinement.rs
+++ b/crates/wenlan-core/src/lint/operations/query/refinement.rs
@@ -11,6 +11,7 @@ enum Action {
     PageMerge,
     RelationConflict,
     SuggestEntity,
+    VocabPromote,
 }
 
 impl Action {
@@ -25,12 +26,15 @@ impl Action {
             "page_merge" => Some(Self::PageMerge),
             "relation_conflict" => Some(Self::RelationConflict),
             "suggest_entity" => Some(Self::SuggestEntity),
+            "vocab_promote" => Some(Self::VocabPromote),
             _ => None,
         }
     }
 
     fn valid_cardinality(self, count: usize) -> bool {
         match self {
+            // source_ids is empty — the payload carries the value.
+            Self::VocabPromote => true,
             Self::CrossSpaceDiscovery => count >= 2,
             Self::PageKeepOrArchive | Self::SuggestEntity => count == 1,
             Self::ConsolidateDuplicate
@@ -73,7 +77,8 @@ impl Action {
             | Self::EntityMerge
             | Self::PageKeepOrArchive
             | Self::PageMerge
-            | Self::RelationConflict => match status {
+            | Self::RelationConflict
+            | Self::VocabPromote => match status {
                 Status::Pending | Status::AwaitingReview | Status::Resolved | Status::Dismissed => {
                     true
                 }

--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -1092,17 +1092,20 @@ pub async fn run_periodic_steep_with_api(
                 let report = crate::kg_quality::run_rethink(db_ref, llm, tuning).await?;
                 let total = report.merge_candidates
                     + report.relations_healed
+                    + report.entities_healed
                     + report.embeddings_refreshed
                     + report.stale_relations_flagged
                     + report.contradictions_found;
                 log::info!(
-                    "[refinery] kg_rethink: {} merges, {} healed, {} queued, {} refreshed, {} stale, {} contradictions",
+                    "[refinery] kg_rethink: {} merges, {} healed, {} queued, {} refreshed, {} stale, {} contradictions, {} entities_healed, {} entities_queued",
                     report.merge_candidates,
                     report.relations_healed,
                     report.relations_queued,
                     report.embeddings_refreshed,
                     report.stale_relations_flagged,
                     report.contradictions_found,
+                    report.entities_healed,
+                    report.entities_queued,
                 );
                 let (nudge, headline) = classify_backfill(total);
                 Ok(PhaseOutput {

--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -1091,14 +1091,15 @@ pub async fn run_periodic_steep_with_api(
             let phase = run_phase(Phase::KgRethink, || async {
                 let report = crate::kg_quality::run_rethink(db_ref, llm, tuning).await?;
                 let total = report.merge_candidates
-                    + report.types_normalized
+                    + report.relations_healed
                     + report.embeddings_refreshed
                     + report.stale_relations_flagged
                     + report.contradictions_found;
                 log::info!(
-                    "[refinery] kg_rethink: {} merges, {} normalized, {} refreshed, {} stale, {} contradictions",
+                    "[refinery] kg_rethink: {} merges, {} healed, {} queued, {} refreshed, {} stale, {} contradictions",
                     report.merge_candidates,
-                    report.types_normalized,
+                    report.relations_healed,
+                    report.relations_queued,
                     report.embeddings_refreshed,
                     report.stale_relations_flagged,
                     report.contradictions_found,

--- a/crates/wenlan-core/src/synthesis/refinement_queue.rs
+++ b/crates/wenlan-core/src/synthesis/refinement_queue.rs
@@ -217,6 +217,19 @@ pub async fn apply_refinement_with_decision(
                 ));
             }
         },
+        "vocab_promote" => {
+            let payload = prop
+                .payload
+                .as_deref()
+                .ok_or_else(|| WenlanError::Validation("vocab_promote missing payload".into()))?;
+            let v: serde_json::Value = serde_json::from_str(payload)
+                .map_err(|e| WenlanError::Validation(format!("vocab_promote payload: {e}")))?;
+            let kind = v["kind"].as_str().unwrap_or_default();
+            let old_value = v["old_value"].as_str().unwrap_or_default();
+            let category = v["category"].as_str();
+            db.promote_vocabulary_canonical(kind, old_value, category)
+                .await?;
+        }
         other => {
             return Err(WenlanError::Validation(format!("unknown action: {other}")));
         }
@@ -818,6 +831,24 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn apply_refinement_vocab_promote_adds_canonical() {
+        let (db, _tmp) = test_db().await;
+        // A dirty relation type exists in the queue as a promote candidate.
+        db.insert_vocab_promote_proposal("relation", "design_inspiration", None)
+            .await
+            .unwrap();
+        let id = crate::db::MemoryDB::vocab_proposal_fingerprint("relation", "design_inspiration");
+        apply_refinement(&db, &id, "test").await.unwrap();
+        // It is now canonical: resolve returns itself.
+        assert_eq!(
+            db.resolve_relation_type("design_inspiration")
+                .await
+                .unwrap(),
+            Some("design_inspiration".into())
+        );
     }
 
     #[tokio::test]

--- a/crates/wenlan-core/src/vocab/mod.rs
+++ b/crates/wenlan-core/src/vocab/mod.rs
@@ -1,0 +1,1 @@
+pub mod safe_transform;

--- a/crates/wenlan-core/src/vocab/safe_transform.rs
+++ b/crates/wenlan-core/src/vocab/safe_transform.rs
@@ -28,22 +28,21 @@ fn candidate_forms(value: &str) -> Vec<String> {
 /// Returns `Some(canonical)` iff a deterministic transform maps `value` to
 /// exactly one member of `canonicals`. The output is ALWAYS in `canonicals`.
 pub fn safe_transform(value: &str, canonicals: &[String]) -> Option<String> {
-    let canon_lower: std::collections::HashSet<String> =
-        canonicals.iter().map(|c| c.to_lowercase()).collect();
     // An already-canonical value (exact, case-sensitive match) is not "dirty"
-    // — nothing to transform. Compare against the literal list, not the
+    // — nothing to transform. Compare against the literal list, not a
     // casefolded set, so a differently-cased variant (e.g. "Concept") still
     // falls through to the transform below instead of short-circuiting here.
     if canonicals.iter().any(|c| c == value) {
         return None;
     }
-    let hits: Vec<String> = candidate_forms(value)
-        .into_iter()
-        .filter(|f| canon_lower.contains(f))
+    let forms = candidate_forms(value);
+    let hits: Vec<&String> = canonicals
+        .iter()
+        .filter(|c| forms.contains(&c.to_lowercase()))
         .collect();
     // Exactly one canonical target, or refuse (ambiguous or none).
     match hits.as_slice() {
-        [only] => Some(only.clone()),
+        [only] => Some((*only).clone()),
         _ => None,
     }
 }
@@ -85,8 +84,8 @@ mod tests {
 
     #[test]
     fn rejects_ambiguous_singularize() {
-        // If two canonicals could be the singular target, refuse (ambiguous).
-        let c: Vec<String> = ["bus", "buses"].iter().map(|s| s.to_string()).collect();
-        assert_eq!(safe_transform("busses", &c), None);
+        // Genuine ambiguity: "Dogs" -> forms {"dogs","dog"}, both are canonicals.
+        let c: Vec<String> = ["dog", "dogs"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(safe_transform("Dogs", &c), None);
     }
 }

--- a/crates/wenlan-core/src/vocab/safe_transform.rs
+++ b/crates/wenlan-core/src/vocab/safe_transform.rs
@@ -1,0 +1,92 @@
+//! Deterministic, provably-safe vocabulary transforms — the auto-heal band.
+//!
+//! A transform may ONLY rewrite a value toward an existing canonical. Anything
+//! that touches meaning (tense, role, direction, opposites) has no rule here and
+//! falls through to `None`, i.e. the review queue. ponytail: three rules only —
+//! casefold, separator-normalize, unique trailing-s singularize. Grow this set
+//! only with a matching rejection test.
+
+/// Normalize case and separators: lowercase, and map `-`/space to `_`.
+fn normalize_shape(value: &str) -> String {
+    value.trim().to_lowercase().replace([' ', '-'], "_")
+}
+
+/// Candidate forms of `value` that a safe transform could produce.
+fn candidate_forms(value: &str) -> Vec<String> {
+    let base = normalize_shape(value);
+    let mut forms = vec![base.clone()];
+    // Unique trailing-s singularize (concepts -> concept). Only the simple
+    // trailing 's'; never 'ies'->'y' or irregulars (too semantic to be "safe").
+    if let Some(singular) = base.strip_suffix('s') {
+        if !singular.is_empty() {
+            forms.push(singular.to_string());
+        }
+    }
+    forms
+}
+
+/// Returns `Some(canonical)` iff a deterministic transform maps `value` to
+/// exactly one member of `canonicals`. The output is ALWAYS in `canonicals`.
+pub fn safe_transform(value: &str, canonicals: &[String]) -> Option<String> {
+    let canon_lower: std::collections::HashSet<String> =
+        canonicals.iter().map(|c| c.to_lowercase()).collect();
+    // An already-canonical value (exact, case-sensitive match) is not "dirty"
+    // — nothing to transform. Compare against the literal list, not the
+    // casefolded set, so a differently-cased variant (e.g. "Concept") still
+    // falls through to the transform below instead of short-circuiting here.
+    if canonicals.iter().any(|c| c == value) {
+        return None;
+    }
+    let hits: Vec<String> = candidate_forms(value)
+        .into_iter()
+        .filter(|f| canon_lower.contains(f))
+        .collect();
+    // Exactly one canonical target, or refuse (ambiguous or none).
+    match hits.as_slice() {
+        [only] => Some(only.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::safe_transform;
+
+    fn canon() -> Vec<String> {
+        ["concept", "technology", "project", "works_on", "member_of"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn casefold_and_singularize_to_existing_canonical() {
+        assert_eq!(safe_transform("concepts", &canon()), Some("concept".into()));
+        assert_eq!(safe_transform("Concept", &canon()), Some("concept".into()));
+        assert_eq!(
+            safe_transform("works-on", &canon()),
+            Some("works_on".into())
+        );
+        assert_eq!(
+            safe_transform("works on", &canon()),
+            Some("works_on".into())
+        );
+    }
+
+    #[test]
+    fn rejects_when_target_is_not_canonical() {
+        // No canonical `aw`; must fail closed to review, never mint `aw`.
+        assert_eq!(safe_transform("aws", &canon()), None);
+        // Semantic / role / tense words never match a deterministic transform.
+        assert_eq!(safe_transform("owns", &canon()), None);
+        assert_eq!(safe_transform("design_inspiration", &canon()), None);
+        assert_eq!(safe_transform("generates", &canon()), None);
+    }
+
+    #[test]
+    fn rejects_ambiguous_singularize() {
+        // If two canonicals could be the singular target, refuse (ambiguous).
+        let c: Vec<String> = ["bus", "buses"].iter().map(|s| s.to_string()).collect();
+        assert_eq!(safe_transform("busses", &c), None);
+    }
+}

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -2281,7 +2281,7 @@ impl WenlanMcpServer {
     // --- Review proposal tools ---
 
     #[tool(
-        description = "List pending review proposals from Wenlan's daemon-side queue. Use when the user wants to audit what the daemon has queued for review — phrases like 'pending proposals', 'what's queued', 'check review queue'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge/vocab_promote), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
+        description = "List pending review proposals from Wenlan's daemon-side queue. Use when the user wants to audit what the daemon has queued for review. Phrases like 'pending proposals', 'what's queued', 'check review queue'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge/vocab_promote), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
         annotations(
             title = "List review proposals",
             read_only_hint = true,

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -5016,4 +5016,51 @@ mod tests {
             "space field must be present in capture schema when WENLAN_SPACE is not locked"
         );
     }
+
+    /// Collect `properties.<name>` entries whose schema is a bare boolean.
+    fn boolean_property_schemas(node: &serde_json::Value, path: &str, out: &mut Vec<String>) {
+        match node {
+            serde_json::Value::Object(map) => {
+                if let Some(serde_json::Value::Object(props)) = map.get("properties") {
+                    for (name, schema) in props {
+                        if schema.is_boolean() {
+                            out.push(format!("{path}.{name}"));
+                        }
+                    }
+                }
+                for value in map.values() {
+                    boolean_property_schemas(value, path, out);
+                }
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    boolean_property_schemas(item, path, out);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// No tool may expose a bare-boolean property schema.
+    ///
+    /// `#[schemars(with = "serde_json::Value")]` renders as the schema `true`. That is
+    /// legal JSON Schema 2020-12, but MCP clients that validate with Zod (Claude Code
+    /// among them) reject it. `tools/list` is all-or-nothing, so ONE such property makes
+    /// the whole listing fail and every tool disappears from the client — the server
+    /// still connects, which is why it presents as "tools fetch failed" rather than a
+    /// crash. Use `serde_json::Map<String, serde_json::Value>` instead: it renders as
+    /// `{"type": "object", "additionalProperties": true}` and validates.
+    #[test]
+    fn tool_schemas_have_no_boolean_property_schemas() {
+        let mut offenders = Vec::new();
+        for tool in WenlanMcpServer::tool_router().list_all() {
+            let schema = serde_json::Value::Object((*tool.input_schema).clone());
+            boolean_property_schemas(&schema, &tool.name, &mut offenders);
+        }
+        assert!(
+            offenders.is_empty(),
+            "bare-boolean property schemas would make Claude Code reject tools/list \
+             entirely, hiding EVERY tool: {offenders:?}"
+        );
+    }
 }

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -367,7 +367,7 @@ pub struct ConfirmMemoryParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct ListRefinementsParams {
     #[schemars(
-        description = "Optional action filter. One of: entity_merge, relation_conflict, detect_contradiction, suggest_entity, dedup_merge."
+        description = "Optional action filter. One of: entity_merge, relation_conflict, detect_contradiction, suggest_entity, dedup_merge, vocab_promote."
     )]
     #[serde(default)]
     pub action: Option<String>,
@@ -2281,7 +2281,7 @@ impl WenlanMcpServer {
     // --- Review proposal tools ---
 
     #[tool(
-        description = "List pending review proposals from Wenlan's daemon-side queue. Use when the user wants to audit what the daemon has queued for review — phrases like 'pending proposals', 'what's queued', 'check review queue'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
+        description = "List pending review proposals from Wenlan's daemon-side queue. Use when the user wants to audit what the daemon has queued for review — phrases like 'pending proposals', 'what's queued', 'check review queue'. Returns proposals with action (entity_merge/relation_conflict/detect_contradiction/suggest_entity/dedup_merge/vocab_promote), source ids, confidence, and typed payload. Filter by action with optional `action` param. Pair with `reject_refinement` to dismiss noise.",
         annotations(
             title = "List review proposals",
             read_only_hint = true,
@@ -4205,6 +4205,21 @@ mod tests {
         assert!(
             ctx.contains("how the user thinks"),
             "context description must frame the result as modeling how the user thinks, got: {ctx}"
+        );
+    }
+
+    #[test]
+    fn list_refinements_description_mentions_vocab_promote() {
+        // Closed-set contract (spec §2.4): the list_refinements action enumeration
+        // must include vocab_promote, or the action ships half-wired (Task 6 wired
+        // the enum/parse/apply but missed this doc string).
+        let descriptions = tool_descriptions();
+        let list = descriptions
+            .get("list_refinements")
+            .expect("list_refinements tool exists");
+        assert!(
+            list.contains("vocab_promote"),
+            "list_refinements description must enumerate vocab_promote, got: {list}"
         );
     }
 

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -2318,6 +2318,7 @@ impl WenlanMcpServer {
             relation_conflict: new relation supersedes. \
             detect_contradiction: previously-stored memory flagged for revision. \
             cross_space_discovery: pass `space` to choose the destination space. \
+            vocab_promote: promote a non-canonical entity or relation type to a first-class vocabulary type. \
             Returns 422 for suggest_entity (no producer) and dedup_merge (deprecated). \
             Not available over remote HTTP MCP transport (local stdio only).",
         annotations(

--- a/crates/wenlan-server/src/refinery_routes.rs
+++ b/crates/wenlan-server/src/refinery_routes.rs
@@ -132,6 +132,7 @@ fn parse_action(s: &str) -> Option<ProposalAction> {
         "page_merge" => Some(ProposalAction::PageMerge),
         "cross_space_discovery" => Some(ProposalAction::CrossSpaceDiscovery),
         "page_keep_or_archive" => Some(ProposalAction::PageKeepOrArchive),
+        "vocab_promote" => Some(ProposalAction::VocabPromote),
         _ => None,
     }
 }
@@ -171,6 +172,10 @@ fn parse_payload(payload: Option<&str>, action: &str) -> Option<RefinementPayloa
             return Some(RefinementPayload::SuggestEntity {
                 name_hint: payload.map(|s| s.to_string()),
             });
+        }
+        "vocab_promote" => {
+            let raw = payload?;
+            return serde_json::from_str::<RefinementPayload>(raw).ok();
         }
         _ => {}
     }

--- a/crates/wenlan-types/src/responses.rs
+++ b/crates/wenlan-types/src/responses.rs
@@ -692,6 +692,7 @@ pub enum ProposalAction {
     PageMerge,
     CrossSpaceDiscovery,
     PageKeepOrArchive,
+    VocabPromote,
     /// ponytail: deserialize-only catch-all. Lets a stale client decode a
     /// newer daemon's action tag instead of failing the whole list. NEVER
     /// constructed or serialized by the daemon (it only ever holds real
@@ -753,6 +754,12 @@ pub enum RefinementPayload {
         source_count: usize,
         allowed_actions: Vec<RefinementCardAction>,
     },
+    VocabPromote {
+        kind: String,
+        old_value: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        category: Option<String>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -805,6 +812,7 @@ mod refinement_wire_tests {
                 "\"page_keep_or_archive\"",
                 ProposalAction::PageKeepOrArchive,
             ),
+            ("\"vocab_promote\"", ProposalAction::VocabPromote),
         ];
         for (json, expected) in cases {
             let parsed: ProposalAction = serde_json::from_str(json).unwrap();
@@ -815,10 +823,23 @@ mod refinement_wire_tests {
     }
 
     #[test]
+    fn vocab_promote_payload_round_trips() {
+        let p = RefinementPayload::VocabPromote {
+            kind: "relation".into(),
+            old_value: "design_inspiration".into(),
+            category: None,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        let back: RefinementPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
+        assert!(json.contains("\"action\":\"vocab_promote\""));
+    }
+
+    #[test]
     fn proposal_action_unknown_future_variant_deserializes() {
         // A stale client must decode a NEWER daemon's action tag to Unknown,
         // never error the whole ListRefinementsResponse.
-        let parsed: ProposalAction = serde_json::from_str("\"vocab_promote\"").unwrap();
+        let parsed: ProposalAction = serde_json::from_str("\"future_unshipped_action\"").unwrap();
         assert_eq!(parsed, ProposalAction::Unknown);
         let parsed2: ProposalAction = serde_json::from_str("\"totally_new_action\"").unwrap();
         assert_eq!(parsed2, ProposalAction::Unknown);

--- a/crates/wenlan-types/src/responses.rs
+++ b/crates/wenlan-types/src/responses.rs
@@ -692,6 +692,12 @@ pub enum ProposalAction {
     PageMerge,
     CrossSpaceDiscovery,
     PageKeepOrArchive,
+    /// ponytail: deserialize-only catch-all. Lets a stale client decode a
+    /// newer daemon's action tag instead of failing the whole list. NEVER
+    /// constructed or serialized by the daemon (it only ever holds real
+    /// variants), so serialize-of-Unknown never happens in practice.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -806,6 +812,16 @@ mod refinement_wire_tests {
             let back = serde_json::to_string(&expected).unwrap();
             assert_eq!(back, json, "serialize {expected:?}");
         }
+    }
+
+    #[test]
+    fn proposal_action_unknown_future_variant_deserializes() {
+        // A stale client must decode a NEWER daemon's action tag to Unknown,
+        // never error the whole ListRefinementsResponse.
+        let parsed: ProposalAction = serde_json::from_str("\"vocab_promote\"").unwrap();
+        assert_eq!(parsed, ProposalAction::Unknown);
+        let parsed2: ProposalAction = serde_json::from_str("\"totally_new_action\"").unwrap();
+        assert_eq!(parsed2, ProposalAction::Unknown);
     }
 
     #[test]


### PR DESCRIPTION
## What

Tier 1 vocabulary auto-heal: a 3-band gate that rides the weekly `KgRethink` pass (no feature flag) and normalizes drifting entity-type and relation-type vocabulary as it accumulates.

- **Auto**: deterministic-safe folds toward an *existing* canonical, applied silently, collision-aware, with a full pre-image ledger entry written before every mutation.
- **Review**: semantic or ambiguous values become one deduped `vocab_promote` proposal, surfaced for human accept/dismiss via `/api/refinery/queue` and the MCP `list_refinements` tool.
- **Leave**: freeform noise is left untouched.

A counted `vocab_heal_receipt` activity row plus the refinery INFO line make each pass legible (anti-dark-flag tooth).

## Wire compatibility (release-relevant)

This adds `VocabPromote` and an `Unknown` `#[serde(other)]` catch-all to `wenlan_types::ProposalAction`. Once the daemon lists `vocab_promote`, a client built against an *older* `wenlan-types` (no catch-all) fails to decode the entire review-queue response, not just the vocab rows. Everything shipped from this monorepo (daemon, `wenlan-mcp`, CLI, types) moves together and is safe by construction. The one external consumer is **wenlan-app** (separate repo, pulls `wenlan-types` from crates.io).

Single-release path chosen deliberately: ship this, then fast-follow with a `wenlan-app` `wenlan-types` bump. That closes the only exposure, which is narrow (an old wenlan-app desktop client pointed at a separately-installed newer standalone daemon; a normal wenlan-app install has client and bundled daemon matched).

## Reversibility

Every mutated or absorbed row gets a full pre-image entry in `vocab_heal_ledger` before it changes, inside the fold transaction. Collision survivors are captured too, so a fold that rewrites both the absorbed row and the surviving canonical is fully reversible.

## How it was built and reviewed

Subagent-driven development: 15 tasks, per-task spec + quality review, one broad whole-branch review on the top model, one bundled fix wave, then an independent re-review that came back APPROVED. The final review caught and closed a dark-feature gap (the Review band was inserting proposals as `pending`, which no surface lists; fixed to self-promote to `awaiting_review`) and an incomplete-ledger gap (collision survivor was not captured).

## Tests

- `cargo test --workspace --lib`: 2773 passed, 0 failed, 26 ignored.
- `cargo fmt --all --check` clean; clippy `-D warnings` clean.
- Deterministic daemon smoke: boot plus migrations (`user_version=72`), coercion (`design_inspiration` -> `related_to`), exactly one `vocab_promote` proposal, no panic.

## Note on commit 769294c5

`test: guard tools/list against bare-boolean property schemas` predates the vocab work and is unrelated (an MCP `tools/list` schema guard). It rides along on this branch; flagging it so it is not a surprise in the squashed history.

## Merge note

Squash-merge; the `feat:` PR title drives the intended 0.13.2 -> 0.14.0 minor bump via release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xebizyUk1ccGztc2S8FHX
