### PR TITLE
fix: Page Map v1 daemon — schema, accessors, routes, improve pass

### DIFF
--- a/crates/wenlan-core/src/config.rs
+++ b/crates/wenlan-core/src/config.rs
@@ -86,6 +86,15 @@ pub struct Config {
     /// is set). Selects the SOURCE only. Absent → auto chain.
     #[serde(default)]
     pub synthesis_source: Option<String>,
+    /// Gates ONLY the proactive Page-Map suggestion phase in the refinery
+    /// scheduler (`Phase::PageMaps`). The explicit `POST /api/pages/{id}/map/improve`
+    /// route is NEVER gated by this flag. Default true (via serde on a missing
+    /// field); note `Config::default()` yields `false` — same quirk as
+    /// `private_browsing_detection`, since a derived `Default` ignores the serde
+    /// attribute. Fresh installs read config through `load_config`, which returns
+    /// `Config::default()` only when no file exists.
+    #[serde(default = "default_true")]
+    pub page_map_auto_suggest: bool,
 }
 
 /// Generate a source ID slug from a directory path (last component, lowercased, sanitized).
@@ -387,6 +396,32 @@ mod tests {
 
         let old: Config = serde_json::from_str(r#"{"anthropic_api_key": "sk-test"}"#).unwrap();
         assert_eq!(old.reranker_mode, None);
+    }
+
+    #[test]
+    fn page_map_auto_suggest_defaults_true_on_missing_field() {
+        // A config file without the field deserializes to true (serde default).
+        let config: Config = serde_json::from_str(r#"{"clipboard_enabled": true}"#).unwrap();
+        assert!(config.page_map_auto_suggest);
+    }
+
+    #[test]
+    fn page_map_auto_suggest_roundtrip_false() {
+        let config = Config {
+            page_map_auto_suggest: false,
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert!(!restored.page_map_auto_suggest);
+    }
+
+    #[test]
+    fn page_map_auto_suggest_tolerates_unknown_fields() {
+        // Unknown/adjacent fields don't disturb the flag's serde default.
+        let json = r#"{"page_map_auto_suggest": false, "some_future_field": 42}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(!config.page_map_auto_suggest);
     }
 
     // --- New sources/knowledge_path tests ---

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -51683,7 +51683,6 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 72);
     }
 
     #[tokio::test]
@@ -51700,7 +51699,8 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 72,
+            uv as u32,
+            crate::db::SCHEMA_VERSION,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -51734,7 +51734,6 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(uv, 72);
     }
 
     #[tokio::test]
@@ -51751,7 +51750,8 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 72,
+            uv as u32,
+            crate::db::SCHEMA_VERSION,
             "user_version restored to current terminal version after idempotent re-run"
         );
     }
@@ -51799,10 +51799,6 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
-        assert_eq!(
-            uv, 72,
-            "terminal version is 72 after dedup_merge retirement"
-        );
     }
 
     #[tokio::test]
@@ -51819,7 +51815,8 @@ pub(crate) mod tests {
         let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
         let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
         assert_eq!(
-            uv, 72,
+            uv as u32,
+            crate::db::SCHEMA_VERSION,
             "user_version restored to current terminal version after idempotent re-run"
         );
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -530,7 +530,7 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 73;
+pub const SCHEMA_VERSION: u32 = 75;
 
 /// Shared embedder reference. Pass to [`MemoryDB::new_with_shared_embedder`] to
 /// reuse a single embedder across many `MemoryDB` instances. Created via
@@ -7024,7 +7024,11 @@ impl MemoryDB {
                 );
             }
 
-            // Migration 73 (Page Map v1): page_maps / page_map_nodes / page_map_edges.
+            // Migration 75 (Page Map v1): page_maps / page_map_nodes / page_map_edges.
+            // Numbered 75, not 73: versions 73/74 were already claimed on live
+            // user DBs by the in-flight wiki-spaces branch (page_evidence /
+            // document_enrichment_queue / derived_artifact_sweeps), and a
+            // `< 73` guard silently skips on any DB those daemons touched.
             // Presentation-only per-page mind map: page_maps carries the
             // optimistic-concurrency revision + viewport, page_map_nodes is the
             // parent_id spine (the flextree input, dedup+tombstone keyed by
@@ -7032,7 +7036,7 @@ impl MemoryDB {
             // suggested links (tree edges are derived from the spine, never
             // stored). See
             // docs/superpowers/plans/2026-07-18-page-map-api-spec.md.
-            if version < 73 {
+            if version < 75 {
                 let conn = self.conn.lock().await;
                 conn.execute_batch(
                     "CREATE TABLE IF NOT EXISTS page_maps (
@@ -7083,12 +7087,12 @@ impl MemoryDB {
                     );",
                 )
                 .await
-                .map_err(|e| WenlanError::VectorDb(format!("m73 create page_map tables: {e}")))?;
-                conn.execute("PRAGMA user_version = 73", ())
+                .map_err(|e| WenlanError::VectorDb(format!("m75 create page_map tables: {e}")))?;
+                conn.execute("PRAGMA user_version = 75", ())
                     .await
-                    .map_err(|e| WenlanError::VectorDb(format!("m73 bump: {e}")))?;
+                    .map_err(|e| WenlanError::VectorDb(format!("m75 bump: {e}")))?;
                 log::info!(
-                    "[migration] Migration 73 applied: page_maps + page_map_nodes + page_map_edges (Page Map v1)"
+                    "[migration] Migration 75 applied: page_maps + page_map_nodes + page_map_edges (Page Map v1)"
                 );
             }
         }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -18,6 +18,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 mod count;
+pub mod page_map;
 mod scoped_entities;
 mod scoped_pages;
 
@@ -529,7 +530,7 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 72;
+pub const SCHEMA_VERSION: u32 = 73;
 
 /// Shared embedder reference. Pass to [`MemoryDB::new_with_shared_embedder`] to
 /// reuse a single embedder across many `MemoryDB` instances. Created via
@@ -7020,6 +7021,74 @@ impl MemoryDB {
                     .map_err(|e| WenlanError::VectorDb(format!("migration 72 bump: {e}")))?;
                 log::info!(
                     "[migration] Migration 72 applied: dismissed deprecated dedup_merge rows"
+                );
+            }
+
+            // Migration 73 (Page Map v1): page_maps / page_map_nodes / page_map_edges.
+            // Presentation-only per-page mind map: page_maps carries the
+            // optimistic-concurrency revision + viewport, page_map_nodes is the
+            // parent_id spine (the flextree input, dedup+tombstone keyed by
+            // `fingerprint`), page_map_edges holds only cross-links and
+            // suggested links (tree edges are derived from the spine, never
+            // stored). See
+            // docs/superpowers/plans/2026-07-18-page-map-api-spec.md.
+            if version < 73 {
+                let conn = self.conn.lock().await;
+                conn.execute_batch(
+                    "CREATE TABLE IF NOT EXISTS page_maps (
+                        page_id     TEXT PRIMARY KEY REFERENCES pages(id),
+                        revision    INTEGER NOT NULL DEFAULT 0,
+                        map_schema  INTEGER NOT NULL DEFAULT 1,
+                        viewport    TEXT,
+                        generated_at TEXT,
+                        created_at  TEXT DEFAULT (datetime('now')),
+                        updated_at  TEXT DEFAULT (datetime('now'))
+                    );
+
+                    CREATE TABLE IF NOT EXISTS page_map_nodes (
+                        id          TEXT PRIMARY KEY,
+                        page_id     TEXT NOT NULL REFERENCES page_maps(page_id) ON DELETE CASCADE,
+                        parent_id   TEXT REFERENCES page_map_nodes(id),
+                        rank        REAL NOT NULL DEFAULT 0,
+                        ref_kind    TEXT NOT NULL CHECK (ref_kind IN ('memory','entity','page','section')),
+                        ref_id      TEXT NOT NULL,
+                        label       TEXT,
+                        status      TEXT NOT NULL DEFAULT 'active'
+                                    CHECK (status IN ('suggested','active','dismissed')),
+                        pinned      INTEGER NOT NULL DEFAULT 0,
+                        placed      INTEGER NOT NULL DEFAULT 0,
+                        collapsed   INTEGER NOT NULL DEFAULT 0,
+                        x REAL, y REAL, width REAL, height REAL,
+                        fingerprint TEXT NOT NULL,
+                        provenance  TEXT,
+                        created_at  TEXT DEFAULT (datetime('now')),
+                        updated_at  TEXT DEFAULT (datetime('now'))
+                    );
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_pmn_fp ON page_map_nodes(page_id, fingerprint);
+                    CREATE INDEX IF NOT EXISTS idx_pmn_page ON page_map_nodes(page_id, status);
+
+                    CREATE TABLE IF NOT EXISTS page_map_edges (
+                        id         TEXT PRIMARY KEY,
+                        page_id    TEXT NOT NULL REFERENCES page_maps(page_id) ON DELETE CASCADE,
+                        from_node  TEXT NOT NULL REFERENCES page_map_nodes(id) ON DELETE CASCADE,
+                        to_node    TEXT NOT NULL REFERENCES page_map_nodes(id) ON DELETE CASCADE,
+                        kind       TEXT NOT NULL DEFAULT 'link' CHECK (kind IN ('link','suggested')),
+                        label      TEXT,
+                        status     TEXT NOT NULL DEFAULT 'active'
+                                   CHECK (status IN ('suggested','active','dismissed')),
+                        provenance TEXT,
+                        created_at TEXT DEFAULT (datetime('now')),
+                        CHECK (from_node <> to_node),
+                        UNIQUE (page_id, from_node, to_node, kind)
+                    );",
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m73 create page_map tables: {e}")))?;
+                conn.execute("PRAGMA user_version = 73", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m73 bump: {e}")))?;
+                log::info!(
+                    "[migration] Migration 73 applied: page_maps + page_map_nodes + page_map_edges (Page Map v1)"
                 );
             }
         }

--- a/crates/wenlan-core/src/db/page_map.rs
+++ b/crates/wenlan-core/src/db/page_map.rs
@@ -1,0 +1,1173 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Page Map (mind-map) v1 — db-layer types + accessors over migration 73's
+// `page_maps` / `page_map_nodes` / `page_map_edges` tables. See
+// docs/superpowers/plans/2026-07-18-page-map-api-spec.md for the full
+// contract (data model, identity/tombstone rule, state machine, graph
+// invariants). This module implements only the data layer: routes and wire
+// DTOs are a later stage and live outside `wenlan-core`.
+//
+// Declared `pub mod page_map` (unlike the private `mod count` /
+// `scoped_pages` siblings) because stage 2 needs `PageMapNode` /
+// `PageMapEdge` / the create outcomes as real cross-crate types, not just
+// methods on `MemoryDB`.
+
+use super::MemoryDB;
+use crate::WenlanError;
+
+/// A `page_maps` row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageMap {
+    pub page_id: String,
+    pub revision: i64,
+    pub map_schema: i64,
+    pub viewport: Option<String>,
+    pub generated_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A `page_map_nodes` row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageMapNode {
+    pub id: String,
+    pub page_id: String,
+    /// `None` only for the root.
+    pub parent_id: Option<String>,
+    pub rank: f64,
+    pub ref_kind: String,
+    pub ref_id: String,
+    /// Map-local display override; `None` = render from the backing object.
+    pub label: Option<String>,
+    pub status: String,
+    pub pinned: bool,
+    pub placed: bool,
+    pub collapsed: bool,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub fingerprint: String,
+    pub provenance: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A `page_map_edges` row.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageMapEdge {
+    pub id: String,
+    pub page_id: String,
+    pub from_node: String,
+    pub to_node: String,
+    pub kind: String,
+    pub label: Option<String>,
+    pub status: String,
+    pub provenance: Option<String>,
+    pub created_at: String,
+}
+
+/// Full map read (`get_page_map` / `init_page_map` / any mutation that
+/// returns the whole map).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PageMapData {
+    pub map: PageMap,
+    pub nodes: Vec<PageMapNode>,
+    pub edges: Vec<PageMapEdge>,
+}
+
+/// Fields a node PATCH may touch. `None` = leave unchanged. `label` is a
+/// nested `Option` so a patch can distinguish "don't touch the label" from
+/// "clear the override back to NULL" (render from the backing object).
+#[derive(Debug, Clone, Default)]
+pub struct NodePatch {
+    pub label: Option<Option<String>>,
+    pub pinned: Option<bool>,
+    pub status: Option<String>,
+    pub rank: Option<f64>,
+    /// Re-parent target node id.
+    pub parent_id: Option<String>,
+}
+
+/// Fields an edge PATCH may touch (accept/dismiss/relabel per the spec's
+/// route table — no from/to/kind changes).
+#[derive(Debug, Clone, Default)]
+pub struct EdgePatch {
+    pub label: Option<Option<String>>,
+    pub status: Option<String>,
+}
+
+/// One placed node in a layout write.
+#[derive(Debug, Clone)]
+pub struct NodeLayout {
+    pub node_id: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub collapsed: bool,
+}
+
+/// Outcome of `create_map_node`. The fingerprint unique index is both the
+/// dedup AND tombstone key: a conflicting row with `status = 'dismissed'`
+/// means the fingerprint was previously dismissed (a fresh uuid cannot
+/// bypass that tombstone — nothing is inserted), while a conflicting row in
+/// any other status is a plain live duplicate.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CreateNodeOutcome {
+    Created(PageMapNode),
+    Duplicate(PageMapNode),
+    Tombstoned,
+}
+
+/// Outcome of `create_map_edge`, mirroring `CreateNodeOutcome` for the
+/// `UNIQUE(page_id, from_node, to_node, kind)` key.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CreateEdgeOutcome {
+    Created(PageMapEdge),
+    Duplicate(PageMapEdge),
+    Tombstoned,
+}
+
+const NODE_COLUMNS: &str = "id, page_id, parent_id, rank, ref_kind, ref_id, label, status, \
+     pinned, placed, collapsed, x, y, width, height, fingerprint, provenance, created_at, updated_at";
+const EDGE_COLUMNS: &str =
+    "id, page_id, from_node, to_node, kind, label, status, provenance, created_at";
+
+fn row_to_page_map(row: &libsql::Row) -> Result<PageMap, WenlanError> {
+    Ok(PageMap {
+        page_id: row
+            .get(0)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.page_id: {e}")))?,
+        revision: row
+            .get(1)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.revision: {e}")))?,
+        map_schema: row
+            .get(2)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.map_schema: {e}")))?,
+        viewport: row
+            .get(3)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.viewport: {e}")))?,
+        generated_at: row
+            .get(4)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.generated_at: {e}")))?,
+        created_at: row
+            .get(5)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.created_at: {e}")))?,
+        updated_at: row
+            .get(6)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map.updated_at: {e}")))?,
+    })
+}
+
+fn row_to_map_node(row: &libsql::Row) -> Result<PageMapNode, WenlanError> {
+    Ok(PageMapNode {
+        id: row
+            .get(0)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.id: {e}")))?,
+        page_id: row
+            .get(1)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.page_id: {e}")))?,
+        parent_id: row
+            .get(2)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.parent_id: {e}")))?,
+        rank: row
+            .get(3)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.rank: {e}")))?,
+        ref_kind: row
+            .get(4)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.ref_kind: {e}")))?,
+        ref_id: row
+            .get(5)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.ref_id: {e}")))?,
+        label: row
+            .get(6)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.label: {e}")))?,
+        status: row
+            .get(7)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.status: {e}")))?,
+        pinned: row
+            .get::<i64>(8)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.pinned: {e}")))?
+            != 0,
+        placed: row
+            .get::<i64>(9)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.placed: {e}")))?
+            != 0,
+        collapsed: row
+            .get::<i64>(10)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.collapsed: {e}")))?
+            != 0,
+        x: row
+            .get(11)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.x: {e}")))?,
+        y: row
+            .get(12)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.y: {e}")))?,
+        width: row
+            .get(13)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.width: {e}")))?,
+        height: row
+            .get(14)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.height: {e}")))?,
+        fingerprint: row
+            .get(15)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.fingerprint: {e}")))?,
+        provenance: row
+            .get(16)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.provenance: {e}")))?,
+        created_at: row
+            .get(17)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.created_at: {e}")))?,
+        updated_at: row
+            .get(18)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_node.updated_at: {e}")))?,
+    })
+}
+
+fn row_to_map_edge(row: &libsql::Row) -> Result<PageMapEdge, WenlanError> {
+    Ok(PageMapEdge {
+        id: row
+            .get(0)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.id: {e}")))?,
+        page_id: row
+            .get(1)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.page_id: {e}")))?,
+        from_node: row
+            .get(2)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.from_node: {e}")))?,
+        to_node: row
+            .get(3)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.to_node: {e}")))?,
+        kind: row
+            .get(4)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.kind: {e}")))?,
+        label: row
+            .get(5)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.label: {e}")))?,
+        status: row
+            .get(6)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.status: {e}")))?,
+        provenance: row
+            .get(7)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.provenance: {e}")))?,
+        created_at: row
+            .get(8)
+            .map_err(|e| WenlanError::VectorDb(format!("page_map_edge.created_at: {e}")))?,
+    })
+}
+
+/// `fingerprint = "{ref_kind}:{ref_id}@{parent_ref}"` (spec: Identity &
+/// tombstones). The root's own fingerprint is `fingerprint_for("page",
+/// page_id, "~")`.
+fn fingerprint_for(ref_kind: &str, ref_id: &str, parent_ref: &str) -> String {
+    format!("{ref_kind}:{ref_id}@{parent_ref}")
+}
+
+/// A node's own `"{ref_kind}:{ref_id}"` token as used in a *child's*
+/// fingerprint — `"~"` when the node itself is the root.
+fn parent_ref_token(node: &PageMapNode) -> String {
+    if node.parent_id.is_none() {
+        "~".to_string()
+    } else {
+        format!("{}:{}", node.ref_kind, node.ref_id)
+    }
+}
+
+fn revision_conflict(page_id: &str, current: i64, expected: i64) -> WenlanError {
+    WenlanError::Conflict(format!(
+        "page_map for {page_id} is at revision {current}, expected {expected}"
+    ))
+}
+
+async fn read_page_map_revision(
+    conn: &libsql::Connection,
+    page_id: &str,
+) -> Result<Option<i64>, WenlanError> {
+    let mut rows = conn
+        .query(
+            "SELECT revision FROM page_maps WHERE page_id = ?1",
+            libsql::params![page_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_page_map_revision: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_page_map_revision row: {e}")))?
+    {
+        Some(row) => Ok(Some(row.get(0).map_err(|e| {
+            WenlanError::VectorDb(format!("read_page_map_revision col: {e}"))
+        })?)),
+        None => Ok(None),
+    }
+}
+
+async fn read_page_map(
+    conn: &libsql::Connection,
+    page_id: &str,
+) -> Result<Option<PageMap>, WenlanError> {
+    let mut rows = conn
+        .query(
+            "SELECT page_id, revision, map_schema, viewport, generated_at, created_at, updated_at \
+             FROM page_maps WHERE page_id = ?1",
+            libsql::params![page_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_page_map: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_page_map row: {e}")))?
+    {
+        Some(row) => Ok(Some(row_to_page_map(&row)?)),
+        None => Ok(None),
+    }
+}
+
+async fn read_map_nodes(
+    conn: &libsql::Connection,
+    page_id: &str,
+    include_dismissed: bool,
+) -> Result<Vec<PageMapNode>, WenlanError> {
+    let sql = if include_dismissed {
+        format!("SELECT {NODE_COLUMNS} FROM page_map_nodes WHERE page_id = ?1 ORDER BY rank")
+    } else {
+        format!(
+            "SELECT {NODE_COLUMNS} FROM page_map_nodes WHERE page_id = ?1 AND status != 'dismissed' ORDER BY rank"
+        )
+    };
+    let mut rows = conn
+        .query(&sql, libsql::params![page_id])
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_nodes: {e}")))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_nodes row: {e}")))?
+    {
+        out.push(row_to_map_node(&row)?);
+    }
+    Ok(out)
+}
+
+async fn read_map_edges(
+    conn: &libsql::Connection,
+    page_id: &str,
+    include_dismissed: bool,
+) -> Result<Vec<PageMapEdge>, WenlanError> {
+    let sql = if include_dismissed {
+        format!("SELECT {EDGE_COLUMNS} FROM page_map_edges WHERE page_id = ?1 ORDER BY created_at")
+    } else {
+        format!(
+            "SELECT {EDGE_COLUMNS} FROM page_map_edges WHERE page_id = ?1 AND status != 'dismissed' ORDER BY created_at"
+        )
+    };
+    let mut rows = conn
+        .query(&sql, libsql::params![page_id])
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_edges: {e}")))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_edges row: {e}")))?
+    {
+        out.push(row_to_map_edge(&row)?);
+    }
+    Ok(out)
+}
+
+async fn load_page_map_data(
+    conn: &libsql::Connection,
+    page_id: &str,
+    include_dismissed: bool,
+) -> Result<Option<PageMapData>, WenlanError> {
+    let map = match read_page_map(conn, page_id).await? {
+        Some(m) => m,
+        None => return Ok(None),
+    };
+    let nodes = read_map_nodes(conn, page_id, include_dismissed).await?;
+    let edges = read_map_edges(conn, page_id, include_dismissed).await?;
+    Ok(Some(PageMapData { map, nodes, edges }))
+}
+
+async fn read_map_node(
+    conn: &libsql::Connection,
+    page_id: &str,
+    node_id: &str,
+) -> Result<Option<PageMapNode>, WenlanError> {
+    let sql = format!("SELECT {NODE_COLUMNS} FROM page_map_nodes WHERE page_id = ?1 AND id = ?2");
+    let mut rows = conn
+        .query(&sql, libsql::params![page_id, node_id])
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_node: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_node row: {e}")))?
+    {
+        Some(row) => Ok(Some(row_to_map_node(&row)?)),
+        None => Ok(None),
+    }
+}
+
+async fn read_map_node_by_fingerprint(
+    conn: &libsql::Connection,
+    page_id: &str,
+    fingerprint: &str,
+) -> Result<Option<PageMapNode>, WenlanError> {
+    let sql = format!(
+        "SELECT {NODE_COLUMNS} FROM page_map_nodes WHERE page_id = ?1 AND fingerprint = ?2"
+    );
+    let mut rows = conn
+        .query(&sql, libsql::params![page_id, fingerprint])
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_node_by_fingerprint: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_node_by_fingerprint row: {e}")))?
+    {
+        Some(row) => Ok(Some(row_to_map_node(&row)?)),
+        None => Ok(None),
+    }
+}
+
+async fn read_map_edge(
+    conn: &libsql::Connection,
+    page_id: &str,
+    edge_id: &str,
+) -> Result<Option<PageMapEdge>, WenlanError> {
+    let sql = format!("SELECT {EDGE_COLUMNS} FROM page_map_edges WHERE page_id = ?1 AND id = ?2");
+    let mut rows = conn
+        .query(&sql, libsql::params![page_id, edge_id])
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_edge: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_edge row: {e}")))?
+    {
+        Some(row) => Ok(Some(row_to_map_edge(&row)?)),
+        None => Ok(None),
+    }
+}
+
+async fn read_map_edge_by_key(
+    conn: &libsql::Connection,
+    page_id: &str,
+    from_node: &str,
+    to_node: &str,
+    kind: &str,
+) -> Result<Option<PageMapEdge>, WenlanError> {
+    let sql = format!(
+        "SELECT {EDGE_COLUMNS} FROM page_map_edges \
+         WHERE page_id = ?1 AND from_node = ?2 AND to_node = ?3 AND kind = ?4"
+    );
+    let mut rows = conn
+        .query(&sql, libsql::params![page_id, from_node, to_node, kind])
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_edge_by_key: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("read_map_edge_by_key row: {e}")))?
+    {
+        Some(row) => Ok(Some(row_to_map_edge(&row)?)),
+        None => Ok(None),
+    }
+}
+
+/// Distinguishes "doesn't exist anywhere" (404 NotFound) from "exists, but
+/// in a different page's map" (422 graph-invariant violation — spec: parent
+/// / edge endpoints must resolve within the same map) for a referenced node
+/// id that wasn't found scoped to `page_id`.
+async fn missing_node_error(
+    conn: &libsql::Connection,
+    node_id: &str,
+) -> Result<WenlanError, WenlanError> {
+    let exists_elsewhere = conn
+        .query(
+            "SELECT 1 FROM page_map_nodes WHERE id = ?1 LIMIT 1",
+            libsql::params![node_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("missing_node_error lookup: {e}")))?
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("missing_node_error row: {e}")))?
+        .is_some();
+    Ok(if exists_elsewhere {
+        WenlanError::Validation(format!("node {node_id} is not part of this page's map"))
+    } else {
+        WenlanError::NotFound(format!("node {node_id} not found"))
+    })
+}
+
+/// Walk-to-root cycle check (spec: maps are small, so a straight walk is
+/// sufficient): true if re-parenting `node_id` under `new_parent_id` would
+/// make `node_id` its own ancestor. A depth cap guards a corrupted spine
+/// from looping forever; a runaway walk is conservatively treated as a
+/// cycle.
+async fn node_would_cycle(
+    conn: &libsql::Connection,
+    page_id: &str,
+    node_id: &str,
+    new_parent_id: &str,
+) -> Result<bool, WenlanError> {
+    let mut current = new_parent_id.to_string();
+    for _ in 0..10_000 {
+        if current == node_id {
+            return Ok(true);
+        }
+        match read_map_node(conn, page_id, &current).await? {
+            Some(n) => match n.parent_id {
+                Some(p) => current = p,
+                None => return Ok(false), // reached the root
+            },
+            None => return Ok(false),
+        }
+    }
+    Ok(true)
+}
+
+/// The bump-and-check helper: atomically bumps `page_maps.revision` from
+/// `base_revision` to `base_revision + 1`. `rows_affected == 0` means
+/// `base_revision` was stale (someone else wrote first) → `Conflict`.
+async fn bump_revision(
+    conn: &libsql::Connection,
+    page_id: &str,
+    base_revision: i64,
+) -> Result<i64, WenlanError> {
+    let rows = conn
+        .execute(
+            "UPDATE page_maps SET revision = revision + 1, updated_at = datetime('now') \
+             WHERE page_id = ?1 AND revision = ?2",
+            libsql::params![page_id, base_revision],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("bump_revision: {e}")))?;
+    if rows == 0 {
+        return Err(WenlanError::Conflict(format!(
+            "page_map for {page_id} changed concurrently (expected revision {base_revision})"
+        )));
+    }
+    Ok(base_revision + 1)
+}
+
+impl MemoryDB {
+    /// Full map read. Non-dismissed nodes/edges by default; pass
+    /// `include_dismissed = true` for the `?include=dismissed` audit view.
+    /// Returns `None` when no `page_maps` row exists yet — the API layer's
+    /// "revision 0, empty map" response is synthesized there, never stored.
+    pub async fn get_page_map(
+        &self,
+        page_id: &str,
+        include_dismissed: bool,
+    ) -> Result<Option<PageMapData>, WenlanError> {
+        let conn = self.conn.lock().await;
+        load_page_map_data(&conn, page_id, include_dismissed).await
+    }
+
+    /// Idempotent: creates the `page_maps` row + root node
+    /// (`ref_kind='page'`, `ref_id=page_id`, `parent_id=NULL`, fingerprint
+    /// `"page:{page_id}@~"`) in one transaction when no map exists yet, then
+    /// returns the current map state either way. Root creation counts as
+    /// the first write, so a freshly-initialized map's `revision` is 1 — 0
+    /// is reserved for "no `page_maps` row at all" (spec: whole-map
+    /// lifecycle).
+    pub async fn init_page_map(&self, page_id: &str) -> Result<PageMapData, WenlanError> {
+        let conn = self.conn.lock().await;
+        if let Some(existing) = load_page_map_data(&conn, page_id, true).await? {
+            return Ok(existing);
+        }
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("init_page_map begin: {e}")))?;
+
+        let result: Result<(), WenlanError> = async {
+            let root_id = uuid::Uuid::new_v4().to_string();
+            let fingerprint = fingerprint_for("page", page_id, "~");
+            conn.execute(
+                "INSERT INTO page_maps (page_id, revision) VALUES (?1, 0)",
+                libsql::params![page_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("init_page_map insert page_maps: {e}")))?;
+            conn.execute(
+                "INSERT INTO page_map_nodes (id, page_id, parent_id, rank, ref_kind, ref_id, status, fingerprint) \
+                 VALUES (?1, ?2, NULL, 0, 'page', ?2, 'active', ?3)",
+                libsql::params![root_id, page_id, fingerprint],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("init_page_map insert root: {e}")))?;
+            conn.execute(
+                "UPDATE page_maps SET revision = 1, updated_at = datetime('now') WHERE page_id = ?1",
+                libsql::params![page_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("init_page_map bump: {e}")))?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(e) = result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(e);
+        }
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("init_page_map commit: {e}")))?;
+
+        load_page_map_data(&conn, page_id, true)
+            .await?
+            .ok_or_else(|| {
+                WenlanError::VectorDb(format!("init_page_map: {page_id} missing after insert"))
+            })
+    }
+
+    /// Creates a node under `parent_id`. Requires an existing `page_maps`
+    /// row (call `init_page_map` first on an uninitialized page — the root
+    /// node's id becomes the natural first `parent_id`). Computes
+    /// `fingerprint` and relies on the unique index for dedup/tombstone
+    /// detection: see `CreateNodeOutcome`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_map_node(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        parent_id: &str,
+        ref_kind: &str,
+        ref_id: &str,
+        label: Option<&str>,
+        rank: f64,
+    ) -> Result<CreateNodeOutcome, WenlanError> {
+        if !matches!(ref_kind, "memory" | "entity" | "page" | "section") {
+            return Err(WenlanError::Validation(format!(
+                "unknown ref_kind '{ref_kind}'"
+            )));
+        }
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_map_node begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+
+            let parent = match read_map_node(&conn, page_id, parent_id).await? {
+                Some(p) => p,
+                None => return Err(missing_node_error(&conn, parent_id).await?),
+            };
+            let parent_ref = parent_ref_token(&parent);
+            let fingerprint = fingerprint_for(ref_kind, ref_id, &parent_ref);
+
+            let node_id = uuid::Uuid::new_v4().to_string();
+            let inserted = conn
+                .execute(
+                    "INSERT INTO page_map_nodes \
+                     (id, page_id, parent_id, rank, ref_kind, ref_id, label, status, fingerprint) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active', ?8) \
+                     ON CONFLICT(page_id, fingerprint) DO NOTHING",
+                    libsql::params![
+                        node_id.clone(),
+                        page_id,
+                        parent_id,
+                        rank,
+                        ref_kind,
+                        ref_id,
+                        label,
+                        fingerprint.clone()
+                    ],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("create_map_node insert: {e}")))?;
+
+            if inserted == 0 {
+                let existing = read_map_node_by_fingerprint(&conn, page_id, &fingerprint)
+                    .await?
+                    .ok_or_else(|| {
+                        WenlanError::VectorDb(
+                            "create_map_node: conflicting row vanished".to_string(),
+                        )
+                    })?;
+                return Ok(if existing.status == "dismissed" {
+                    CreateNodeOutcome::Tombstoned
+                } else {
+                    CreateNodeOutcome::Duplicate(existing)
+                });
+            }
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            let created = read_map_node(&conn, page_id, &node_id)
+                .await?
+                .ok_or_else(|| {
+                    WenlanError::VectorDb("create_map_node: row missing after insert".to_string())
+                })?;
+            Ok(CreateNodeOutcome::Created(created))
+        }
+        .await;
+
+        match result {
+            Ok(outcome) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("create_map_node commit: {e}")))?;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Applies `patch` to a node. Any touched field (`label`, `status`,
+    /// `rank`, `parent_id`) sets `pinned = 1` unless the same patch also
+    /// gives `pinned` explicitly. Status transitions are restricted to
+    /// `suggested->active`, `suggested->dismissed`, `active->dismissed`.
+    /// Root (`parent_id IS NULL`) cannot be dismissed or re-parented.
+    /// Re-parenting rejects cycles (walk-to-root) and recomputes
+    /// `fingerprint`, which must not collide with another node's.
+    pub async fn patch_map_node(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        node_id: &str,
+        patch: NodePatch,
+    ) -> Result<PageMapNode, WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("patch_map_node begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+            let node = read_map_node(&conn, page_id, node_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("node {node_id} not found")))?;
+            let is_root = node.parent_id.is_none();
+
+            if let Some(new_status) = &patch.status {
+                if is_root && new_status == "dismissed" {
+                    return Err(WenlanError::Validation(
+                        "root node cannot be dismissed".to_string(),
+                    ));
+                }
+                let allowed = matches!(
+                    (node.status.as_str(), new_status.as_str()),
+                    ("suggested", "active") | ("suggested", "dismissed") | ("active", "dismissed")
+                );
+                if !allowed {
+                    return Err(WenlanError::Validation(format!(
+                        "invalid status transition {} -> {new_status}",
+                        node.status
+                    )));
+                }
+            }
+            if patch.parent_id.is_some() && is_root {
+                return Err(WenlanError::Validation(
+                    "root node cannot be re-parented".to_string(),
+                ));
+            }
+
+            let mut new_fingerprint = node.fingerprint.clone();
+            let mut new_parent_id = node.parent_id.clone();
+            if let Some(target_parent_id) = &patch.parent_id {
+                if target_parent_id == node_id {
+                    return Err(WenlanError::Validation(
+                        "node cannot be its own parent".to_string(),
+                    ));
+                }
+                let target_parent = match read_map_node(&conn, page_id, target_parent_id).await? {
+                    Some(p) => p,
+                    None => return Err(missing_node_error(&conn, target_parent_id).await?),
+                };
+                if node_would_cycle(&conn, page_id, node_id, target_parent_id).await? {
+                    return Err(WenlanError::Validation(
+                        "re-parent would create a cycle".to_string(),
+                    ));
+                }
+                let parent_ref = parent_ref_token(&target_parent);
+                new_fingerprint = fingerprint_for(&node.ref_kind, &node.ref_id, &parent_ref);
+                if new_fingerprint != node.fingerprint {
+                    if let Some(collision) =
+                        read_map_node_by_fingerprint(&conn, page_id, &new_fingerprint).await?
+                    {
+                        if collision.id != node.id {
+                            return Err(WenlanError::Validation(
+                                "re-parent collides with an existing node under the new parent"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+                new_parent_id = Some(target_parent_id.clone());
+            }
+
+            let new_label = match &patch.label {
+                Some(inner) => inner.clone(),
+                None => node.label.clone(),
+            };
+            let new_rank = patch.rank.unwrap_or(node.rank);
+            let new_status = patch.status.clone().unwrap_or_else(|| node.status.clone());
+            let touched_other_field = patch.label.is_some()
+                || patch.status.is_some()
+                || patch.rank.is_some()
+                || patch.parent_id.is_some();
+            let new_pinned = patch.pinned.unwrap_or(touched_other_field || node.pinned);
+
+            conn.execute(
+                "UPDATE page_map_nodes \
+                 SET parent_id = ?1, rank = ?2, label = ?3, status = ?4, pinned = ?5, \
+                     fingerprint = ?6, updated_at = datetime('now') \
+                 WHERE page_id = ?7 AND id = ?8",
+                libsql::params![
+                    new_parent_id,
+                    new_rank,
+                    new_label,
+                    new_status,
+                    new_pinned as i64,
+                    new_fingerprint,
+                    page_id,
+                    node_id
+                ],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("patch_map_node update: {e}")))?;
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            read_map_node(&conn, page_id, node_id)
+                .await?
+                .ok_or_else(|| {
+                    WenlanError::VectorDb("patch_map_node: row missing after update".to_string())
+                })
+        }
+        .await;
+
+        match result {
+            Ok(node) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("patch_map_node commit: {e}")))?;
+                Ok(node)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Tombstones a node (`status = 'dismissed'`) — the DELETE route's
+    /// semantics. Reuses `patch_map_node` so root protection and the status
+    /// state machine stay in one place.
+    pub async fn delete_map_node(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        node_id: &str,
+    ) -> Result<PageMapNode, WenlanError> {
+        self.patch_map_node(
+            page_id,
+            base_revision,
+            node_id,
+            NodePatch {
+                status: Some("dismissed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// Creates a user cross-link or suggested edge between two nodes in the
+    /// same map. Same fingerprint-style dedup/tombstone handling as
+    /// `create_map_node`, keyed on `UNIQUE(page_id, from_node, to_node,
+    /// kind)`.
+    pub async fn create_map_edge(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        from_node: &str,
+        to_node: &str,
+        kind: &str,
+        label: Option<&str>,
+    ) -> Result<CreateEdgeOutcome, WenlanError> {
+        if !matches!(kind, "link" | "suggested") {
+            return Err(WenlanError::Validation(format!(
+                "unknown edge kind '{kind}'"
+            )));
+        }
+        if from_node == to_node {
+            return Err(WenlanError::Validation(
+                "edge cannot connect a node to itself".to_string(),
+            ));
+        }
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_map_edge begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+            if read_map_node(&conn, page_id, from_node).await?.is_none() {
+                return Err(missing_node_error(&conn, from_node).await?);
+            }
+            if read_map_node(&conn, page_id, to_node).await?.is_none() {
+                return Err(missing_node_error(&conn, to_node).await?);
+            }
+
+            let edge_id = uuid::Uuid::new_v4().to_string();
+            let inserted = conn
+                .execute(
+                    "INSERT INTO page_map_edges (id, page_id, from_node, to_node, kind, label, status) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'active') \
+                     ON CONFLICT(page_id, from_node, to_node, kind) DO NOTHING",
+                    libsql::params![edge_id.clone(), page_id, from_node, to_node, kind, label],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("create_map_edge insert: {e}")))?;
+
+            if inserted == 0 {
+                let existing = read_map_edge_by_key(&conn, page_id, from_node, to_node, kind)
+                    .await?
+                    .ok_or_else(|| {
+                        WenlanError::VectorDb(
+                            "create_map_edge: conflicting row vanished".to_string(),
+                        )
+                    })?;
+                return Ok(if existing.status == "dismissed" {
+                    CreateEdgeOutcome::Tombstoned
+                } else {
+                    CreateEdgeOutcome::Duplicate(existing)
+                });
+            }
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            let created = read_map_edge(&conn, page_id, &edge_id).await?.ok_or_else(|| {
+                WenlanError::VectorDb("create_map_edge: row missing after insert".to_string())
+            })?;
+            Ok(CreateEdgeOutcome::Created(created))
+        }
+        .await;
+
+        match result {
+            Ok(outcome) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("create_map_edge commit: {e}")))?;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Applies `patch` (status/label only) to an edge. Same status state
+    /// machine as nodes; edges have no root-equivalent invariant.
+    pub async fn patch_map_edge(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        edge_id: &str,
+        patch: EdgePatch,
+    ) -> Result<PageMapEdge, WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("patch_map_edge begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+            let edge = read_map_edge(&conn, page_id, edge_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("edge {edge_id} not found")))?;
+
+            if let Some(new_status) = &patch.status {
+                let allowed = matches!(
+                    (edge.status.as_str(), new_status.as_str()),
+                    ("suggested", "active") | ("suggested", "dismissed") | ("active", "dismissed")
+                );
+                if !allowed {
+                    return Err(WenlanError::Validation(format!(
+                        "invalid status transition {} -> {new_status}",
+                        edge.status
+                    )));
+                }
+            }
+
+            let new_label = match &patch.label {
+                Some(inner) => inner.clone(),
+                None => edge.label.clone(),
+            };
+            let new_status = patch.status.clone().unwrap_or_else(|| edge.status.clone());
+
+            conn.execute(
+                "UPDATE page_map_edges SET label = ?1, status = ?2 WHERE page_id = ?3 AND id = ?4",
+                libsql::params![new_label, new_status, page_id, edge_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("patch_map_edge update: {e}")))?;
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            read_map_edge(&conn, page_id, edge_id)
+                .await?
+                .ok_or_else(|| {
+                    WenlanError::VectorDb("patch_map_edge: row missing after update".to_string())
+                })
+        }
+        .await;
+
+        match result {
+            Ok(edge) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("patch_map_edge commit: {e}")))?;
+                Ok(edge)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Tombstones an edge (`status = 'dismissed'`) — the DELETE route's
+    /// semantics. Reuses `patch_map_edge`.
+    pub async fn delete_map_edge(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        edge_id: &str,
+    ) -> Result<PageMapEdge, WenlanError> {
+        self.patch_map_edge(
+            page_id,
+            base_revision,
+            edge_id,
+            EdgePatch {
+                status: Some("dismissed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    /// Writes viewport + per-node positions/sizes/collapsed state in one
+    /// transaction, setting `placed = 1` on every positioned node. Every
+    /// `node_id` in `positions` must already belong to this map.
+    pub async fn put_page_map_layout(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        viewport: Option<&str>,
+        positions: &[NodeLayout],
+    ) -> Result<PageMapData, WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("put_page_map_layout begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+
+            for pos in positions {
+                let rows = conn
+                    .execute(
+                        "UPDATE page_map_nodes \
+                         SET x = ?1, y = ?2, width = ?3, height = ?4, collapsed = ?5, placed = 1, \
+                             updated_at = datetime('now') \
+                         WHERE page_id = ?6 AND id = ?7",
+                        libsql::params![
+                            pos.x,
+                            pos.y,
+                            pos.width,
+                            pos.height,
+                            pos.collapsed as i64,
+                            page_id,
+                            pos.node_id.clone()
+                        ],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("put_page_map_layout node: {e}")))?;
+                if rows == 0 {
+                    return Err(missing_node_error(&conn, &pos.node_id).await?);
+                }
+            }
+            conn.execute(
+                "UPDATE page_maps SET viewport = ?1, updated_at = datetime('now') WHERE page_id = ?2",
+                libsql::params![viewport, page_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("put_page_map_layout viewport: {e}")))?;
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            load_page_map_data(&conn, page_id, true).await?.ok_or_else(|| {
+                WenlanError::VectorDb("put_page_map_layout: map missing after update".to_string())
+            })
+        }
+        .await;
+
+        match result {
+            Ok(data) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("put_page_map_layout commit: {e}"))
+                })?;
+                Ok(data)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Full reset: deletes the `page_maps` row; `ON DELETE CASCADE` clears
+    /// `page_map_nodes` / `page_map_edges` INCLUDING tombstones (spec:
+    /// reset means "start clean"). No `base_revision` — this is the escape
+    /// hatch, not a conditional write. Idempotent: a page with no map row
+    /// is a no-op.
+    pub async fn reset_page_map(&self, page_id: &str) -> Result<(), WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "DELETE FROM page_maps WHERE page_id = ?1",
+            libsql::params![page_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("reset_page_map: {e}")))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "page_map_test.rs"]
+mod tests;

--- a/crates/wenlan-core/src/db/page_map.rs
+++ b/crates/wenlan-core/src/db/page_map.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Page Map (mind-map) v1 — db-layer types + accessors over migration 73's
+// Page Map (mind-map) v1 — db-layer types + accessors over migration 75's
 // `page_maps` / `page_map_nodes` / `page_map_edges` tables. See
 // docs/superpowers/plans/2026-07-18-page-map-api-spec.md for the full
 // contract (data model, identity/tombstone rule, state machine, graph

--- a/crates/wenlan-core/src/db/page_map.rs
+++ b/crates/wenlan-core/src/db/page_map.rs
@@ -1044,6 +1044,11 @@ impl MemoryDB {
                     Some(p) => p,
                     None => return Err(missing_node_error(&conn, target_parent_id).await?),
                 };
+                if target_parent.status == "dismissed" {
+                    return Err(WenlanError::Validation(format!(
+                        "parent {target_parent_id} is dismissed"
+                    )));
+                }
                 if node_would_cycle(&conn, page_id, node_id, target_parent_id).await? {
                     return Err(WenlanError::Validation(
                         "re-parent would create a cycle".to_string(),

--- a/crates/wenlan-core/src/db/page_map.rs
+++ b/crates/wenlan-core/src/db/page_map.rs
@@ -571,6 +571,45 @@ impl MemoryDB {
         load_page_map_data(&conn, page_id, include_dismissed).await
     }
 
+    /// Reads `page_maps.generated_at` — the server-internal watermark stamped
+    /// by the improve pass (the last time suggestions were generated for this
+    /// page). `None` when no map row exists or it has never been generated.
+    /// Not part of the client wire shape; the proactive scheduler uses it to
+    /// skip pages whose `last_modified` hasn't advanced past it.
+    pub async fn page_map_generated_at(
+        &self,
+        page_id: &str,
+    ) -> Result<Option<String>, WenlanError> {
+        let conn = self.conn.lock().await;
+        Ok(read_page_map(&conn, page_id)
+            .await?
+            .and_then(|m| m.generated_at))
+    }
+
+    /// Stamps `page_maps.generated_at` to now WITHOUT bumping the revision — it
+    /// is a server-internal watermark, not a client-visible map change, so
+    /// bumping would raise spurious 409s against in-flight client edits. No-op
+    /// when no map row exists.
+    ///
+    /// Stored as an RFC3339 UTC string (`chrono::Utc::now().to_rfc3339()`) —
+    /// the SAME clock and format as `pages.last_modified` (see
+    /// `post_write::create_page_with_tuning`). This matters: the proactive
+    /// scheduler compares the two, and SQLite's `datetime('now')` ("YYYY-MM-DD
+    /// HH:MM:SS") both truncates to whole seconds and uses a space separator,
+    /// so a lexical or same-second compare against RFC3339 `last_modified`
+    /// would be wrong. One format on both sides keeps the compare honest.
+    pub async fn stamp_page_map_generated_at(&self, page_id: &str) -> Result<(), WenlanError> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let conn = self.conn.lock().await;
+        conn.execute(
+            "UPDATE page_maps SET generated_at = ?2 WHERE page_id = ?1",
+            libsql::params![page_id, now],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("stamp_page_map_generated_at: {e}")))?;
+        Ok(())
+    }
+
     /// Idempotent: creates the `page_maps` row + root node
     /// (`ref_kind='page'`, `ref_id=page_id`, `parent_id=NULL`, fingerprint
     /// `"page:{page_id}@~"`) in one transaction when no map exists yet, then
@@ -721,6 +760,116 @@ impl MemoryDB {
                 conn.execute("COMMIT", ())
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("create_map_node commit: {e}")))?;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Suggestion-path sibling of [`MemoryDB::create_map_node`]: inserts a node
+    /// with `status = 'suggested'` and a `provenance` stamp, used by the
+    /// improve pass. INSERT-ONLY by construction — the same `ON CONFLICT(page_id,
+    /// fingerprint) DO NOTHING` makes re-proposing an existing OR dismissed
+    /// fingerprint a no-op (`Duplicate` / `Tombstoned`), so a suggestion pass
+    /// can never modify, resurrect, or overwrite a pinned/active/dismissed row.
+    /// Kept a separate accessor (rather than parameterizing `create_map_node`)
+    /// so the tested active-node write path stays byte-for-byte untouched.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_suggested_map_node(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        parent_id: &str,
+        ref_kind: &str,
+        ref_id: &str,
+        label: Option<&str>,
+        rank: f64,
+        provenance: &str,
+    ) -> Result<CreateNodeOutcome, WenlanError> {
+        if !matches!(ref_kind, "memory" | "entity" | "page" | "section") {
+            return Err(WenlanError::Validation(format!(
+                "unknown ref_kind '{ref_kind}'"
+            )));
+        }
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_suggested_map_node begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+
+            let parent = match read_map_node(&conn, page_id, parent_id).await? {
+                Some(p) => p,
+                None => return Err(missing_node_error(&conn, parent_id).await?),
+            };
+            let parent_ref = parent_ref_token(&parent);
+            let fingerprint = fingerprint_for(ref_kind, ref_id, &parent_ref);
+
+            let node_id = uuid::Uuid::new_v4().to_string();
+            let inserted = conn
+                .execute(
+                    "INSERT INTO page_map_nodes \
+                     (id, page_id, parent_id, rank, ref_kind, ref_id, label, status, fingerprint, provenance) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'suggested', ?8, ?9) \
+                     ON CONFLICT(page_id, fingerprint) DO NOTHING",
+                    libsql::params![
+                        node_id.clone(),
+                        page_id,
+                        parent_id,
+                        rank,
+                        ref_kind,
+                        ref_id,
+                        label,
+                        fingerprint.clone(),
+                        provenance
+                    ],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("create_suggested_map_node insert: {e}"))
+                })?;
+
+            if inserted == 0 {
+                let existing = read_map_node_by_fingerprint(&conn, page_id, &fingerprint)
+                    .await?
+                    .ok_or_else(|| {
+                        WenlanError::VectorDb(
+                            "create_suggested_map_node: conflicting row vanished".to_string(),
+                        )
+                    })?;
+                return Ok(if existing.status == "dismissed" {
+                    CreateNodeOutcome::Tombstoned
+                } else {
+                    CreateNodeOutcome::Duplicate(existing)
+                });
+            }
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            let created = read_map_node(&conn, page_id, &node_id)
+                .await?
+                .ok_or_else(|| {
+                    WenlanError::VectorDb(
+                        "create_suggested_map_node: row missing after insert".to_string(),
+                    )
+                })?;
+            Ok(CreateNodeOutcome::Created(created))
+        }
+        .await;
+
+        match result {
+            Ok(outcome) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("create_suggested_map_node commit: {e}"))
+                })?;
                 Ok(outcome)
             }
             Err(e) => {
@@ -974,6 +1123,114 @@ impl MemoryDB {
                 conn.execute("COMMIT", ())
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("create_map_edge commit: {e}")))?;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Suggestion-path sibling of [`MemoryDB::create_map_edge`]: inserts an
+    /// edge with `status = 'suggested'` and a `provenance` stamp. INSERT-ONLY on
+    /// the `UNIQUE(page_id, from_node, to_node, kind)` key — re-proposing an
+    /// existing or dismissed edge is a no-op (`Duplicate` / `Tombstoned`),
+    /// mirroring the node sibling. Existing `create_map_edge` stays untouched.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn create_suggested_map_edge(
+        &self,
+        page_id: &str,
+        base_revision: i64,
+        from_node: &str,
+        to_node: &str,
+        kind: &str,
+        label: Option<&str>,
+        provenance: &str,
+    ) -> Result<CreateEdgeOutcome, WenlanError> {
+        if !matches!(kind, "link" | "suggested") {
+            return Err(WenlanError::Validation(format!(
+                "unknown edge kind '{kind}'"
+            )));
+        }
+        if from_node == to_node {
+            return Err(WenlanError::Validation(
+                "edge cannot connect a node to itself".to_string(),
+            ));
+        }
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_suggested_map_edge begin: {e}")))?;
+
+        let result = async {
+            let current_revision = read_page_map_revision(&conn, page_id)
+                .await?
+                .ok_or_else(|| WenlanError::NotFound(format!("no page_map for page {page_id}")))?;
+            if current_revision != base_revision {
+                return Err(revision_conflict(page_id, current_revision, base_revision));
+            }
+            if read_map_node(&conn, page_id, from_node).await?.is_none() {
+                return Err(missing_node_error(&conn, from_node).await?);
+            }
+            if read_map_node(&conn, page_id, to_node).await?.is_none() {
+                return Err(missing_node_error(&conn, to_node).await?);
+            }
+
+            let edge_id = uuid::Uuid::new_v4().to_string();
+            let inserted = conn
+                .execute(
+                    "INSERT INTO page_map_edges \
+                     (id, page_id, from_node, to_node, kind, label, status, provenance) \
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'suggested', ?7) \
+                     ON CONFLICT(page_id, from_node, to_node, kind) DO NOTHING",
+                    libsql::params![
+                        edge_id.clone(),
+                        page_id,
+                        from_node,
+                        to_node,
+                        kind,
+                        label,
+                        provenance
+                    ],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("create_suggested_map_edge insert: {e}"))
+                })?;
+
+            if inserted == 0 {
+                let existing = read_map_edge_by_key(&conn, page_id, from_node, to_node, kind)
+                    .await?
+                    .ok_or_else(|| {
+                        WenlanError::VectorDb(
+                            "create_suggested_map_edge: conflicting row vanished".to_string(),
+                        )
+                    })?;
+                return Ok(if existing.status == "dismissed" {
+                    CreateEdgeOutcome::Tombstoned
+                } else {
+                    CreateEdgeOutcome::Duplicate(existing)
+                });
+            }
+
+            bump_revision(&conn, page_id, current_revision).await?;
+            let created = read_map_edge(&conn, page_id, &edge_id)
+                .await?
+                .ok_or_else(|| {
+                    WenlanError::VectorDb(
+                        "create_suggested_map_edge: row missing after insert".to_string(),
+                    )
+                })?;
+            Ok(CreateEdgeOutcome::Created(created))
+        }
+        .await;
+
+        match result {
+            Ok(outcome) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("create_suggested_map_edge commit: {e}"))
+                })?;
                 Ok(outcome)
             }
             Err(e) => {

--- a/crates/wenlan-core/src/db/page_map.rs
+++ b/crates/wenlan-core/src/db/page_map.rs
@@ -257,20 +257,67 @@ fn row_to_map_edge(row: &libsql::Row) -> Result<PageMapEdge, WenlanError> {
     })
 }
 
-/// `fingerprint = "{ref_kind}:{ref_id}@{parent_ref}"` (spec: Identity &
-/// tombstones). The root's own fingerprint is `fingerprint_for("page",
+/// ASCII Unit Separator — joins fingerprint components unambiguously, since
+/// `validate_ref_component` rejects it from ever appearing inside a
+/// `ref_kind`/`ref_id`. Replaces the old `"{kind}:{id}@{parent}"` encoding,
+/// where a ref_id containing `:` or `@` could inject a fake component
+/// boundary and collide with an unrelated node's fingerprint.
+const FINGERPRINT_SEP: char = '\u{1f}';
+
+/// `fingerprint = "{ref_kind}<SEP>{ref_id}<SEP>{parent_ref}"` (spec: Identity
+/// & tombstones). The root's own fingerprint is `fingerprint_for("page",
 /// page_id, "~")`.
 fn fingerprint_for(ref_kind: &str, ref_id: &str, parent_ref: &str) -> String {
-    format!("{ref_kind}:{ref_id}@{parent_ref}")
+    format!("{ref_kind}{FINGERPRINT_SEP}{ref_id}{FINGERPRINT_SEP}{parent_ref}")
 }
 
-/// A node's own `"{ref_kind}:{ref_id}"` token as used in a *child's*
+/// A node's own `"{ref_kind}<SEP>{ref_id}"` token as used in a *child's*
 /// fingerprint — `"~"` when the node itself is the root.
 fn parent_ref_token(node: &PageMapNode) -> String {
     if node.parent_id.is_none() {
         "~".to_string()
     } else {
-        format!("{}:{}", node.ref_kind, node.ref_id)
+        format!("{}{FINGERPRINT_SEP}{}", node.ref_kind, node.ref_id)
+    }
+}
+
+/// Rejects a `ref_kind`/`ref_id` containing the fingerprint separator — it
+/// would otherwise let a crafted ref inject a fake component boundary into
+/// `fingerprint_for`'s encoding.
+fn validate_ref_component(ref_kind: &str, ref_id: &str) -> Result<(), WenlanError> {
+    if ref_kind.contains(FINGERPRINT_SEP) || ref_id.contains(FINGERPRINT_SEP) {
+        return Err(WenlanError::Validation(
+            "ref_kind/ref_id must not contain the fingerprint separator".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Count of non-dismissed direct children of `node_id` — used to block a
+/// dismissal (or delete, which dismisses) that would orphan live descendants
+/// (spec: dismissal cannot orphan).
+async fn count_live_children(
+    conn: &libsql::Connection,
+    page_id: &str,
+    node_id: &str,
+) -> Result<i64, WenlanError> {
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM page_map_nodes \
+             WHERE page_id = ?1 AND parent_id = ?2 AND status != 'dismissed'",
+            libsql::params![page_id, node_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("count_live_children: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("count_live_children row: {e}")))?
+    {
+        Some(row) => row
+            .get(0)
+            .map_err(|e| WenlanError::VectorDb(format!("count_live_children col: {e}"))),
+        None => Ok(0),
     }
 }
 
@@ -586,24 +633,30 @@ impl MemoryDB {
             .and_then(|m| m.generated_at))
     }
 
-    /// Stamps `page_maps.generated_at` to now WITHOUT bumping the revision — it
-    /// is a server-internal watermark, not a client-visible map change, so
-    /// bumping would raise spurious 409s against in-flight client edits. No-op
-    /// when no map row exists.
+    /// Stamps `page_maps.generated_at` to `generated_at` WITHOUT bumping the
+    /// revision — it is a server-internal watermark, not a client-visible map
+    /// change, so bumping would raise spurious 409s against in-flight client
+    /// edits. No-op when no map row exists.
     ///
-    /// Stored as an RFC3339 UTC string (`chrono::Utc::now().to_rfc3339()`) —
-    /// the SAME clock and format as `pages.last_modified` (see
-    /// `post_write::create_page_with_tuning`). This matters: the proactive
-    /// scheduler compares the two, and SQLite's `datetime('now')` ("YYYY-MM-DD
-    /// HH:MM:SS") both truncates to whole seconds and uses a space separator,
-    /// so a lexical or same-second compare against RFC3339 `last_modified`
-    /// would be wrong. One format on both sides keeps the compare honest.
-    pub async fn stamp_page_map_generated_at(&self, page_id: &str) -> Result<(), WenlanError> {
-        let now = chrono::Utc::now().to_rfc3339();
+    /// The caller passes `page.last_modified` captured at the START of an
+    /// improve pass, not `now()` — otherwise an edit made DURING the pass
+    /// (bumping `last_modified` after the watermark would be stamped) could
+    /// land between capture and stamp and be silently missed by the next
+    /// proactive tick. Same clock and format as `pages.last_modified` (see
+    /// `post_write::create_page_with_tuning`): an RFC3339 UTC string. This
+    /// matters because SQLite's `datetime('now')` ("YYYY-MM-DD HH:MM:SS")
+    /// both truncates to whole seconds and uses a space separator, so a
+    /// lexical or same-second compare against RFC3339 `last_modified` would
+    /// be wrong. One format on both sides keeps the compare honest.
+    pub async fn stamp_page_map_generated_at(
+        &self,
+        page_id: &str,
+        generated_at: &str,
+    ) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
         conn.execute(
             "UPDATE page_maps SET generated_at = ?2 WHERE page_id = ?1",
-            libsql::params![page_id, now],
+            libsql::params![page_id, generated_at],
         )
         .await
         .map_err(|e| WenlanError::VectorDb(format!("stamp_page_map_generated_at: {e}")))?;
@@ -612,30 +665,47 @@ impl MemoryDB {
 
     /// Idempotent: creates the `page_maps` row + root node
     /// (`ref_kind='page'`, `ref_id=page_id`, `parent_id=NULL`, fingerprint
-    /// `"page:{page_id}@~"`) in one transaction when no map exists yet, then
-    /// returns the current map state either way. Root creation counts as
-    /// the first write, so a freshly-initialized map's `revision` is 1 — 0
-    /// is reserved for "no `page_maps` row at all" (spec: whole-map
-    /// lifecycle).
-    pub async fn init_page_map(&self, page_id: &str) -> Result<PageMapData, WenlanError> {
+    /// `fingerprint_for("page", page_id, "~")`) in one transaction when no
+    /// map exists yet, then returns the current map state either way. Root
+    /// creation counts as the first write, so a freshly-initialized map's
+    /// `revision` is 1 — 0 is reserved for "no `page_maps` row at all"
+    /// (spec: whole-map lifecycle).
+    ///
+    /// The returned `bool` is `true` only when THIS call performed the
+    /// insert, decided atomically from the INSERT's own `rows_affected`
+    /// (`ON CONFLICT(page_id) DO NOTHING`) rather than from a separate,
+    /// non-atomic pre-check — a caller (e.g. `handle_create_map_node`) must
+    /// use this flag, not an earlier `get_page_map` read, to decide whether
+    /// to substitute the freshly-initialized revision for a client's
+    /// `base_revision`; substituting on a stale earlier read let a genuinely
+    /// stale `base_revision` silently succeed instead of 409ing.
+    pub async fn init_page_map(&self, page_id: &str) -> Result<(PageMapData, bool), WenlanError> {
         let conn = self.conn.lock().await;
         if let Some(existing) = load_page_map_data(&conn, page_id, true).await? {
-            return Ok(existing);
+            return Ok((existing, false));
         }
 
         conn.execute("BEGIN", ())
             .await
             .map_err(|e| WenlanError::VectorDb(format!("init_page_map begin: {e}")))?;
 
-        let result: Result<(), WenlanError> = async {
+        let result: Result<bool, WenlanError> = async {
             let root_id = uuid::Uuid::new_v4().to_string();
             let fingerprint = fingerprint_for("page", page_id, "~");
-            conn.execute(
-                "INSERT INTO page_maps (page_id, revision) VALUES (?1, 0)",
-                libsql::params![page_id],
-            )
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("init_page_map insert page_maps: {e}")))?;
+            let inserted = conn
+                .execute(
+                    "INSERT INTO page_maps (page_id, revision) VALUES (?1, 0) \
+                     ON CONFLICT(page_id) DO NOTHING",
+                    libsql::params![page_id],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("init_page_map insert page_maps: {e}"))
+                })?;
+            if inserted == 0 {
+                // Someone else's insert won; nothing left for us to do.
+                return Ok(false);
+            }
             conn.execute(
                 "INSERT INTO page_map_nodes (id, page_id, parent_id, rank, ref_kind, ref_id, status, fingerprint) \
                  VALUES (?1, ?2, NULL, 0, 'page', ?2, 'active', ?3)",
@@ -649,23 +719,27 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("init_page_map bump: {e}")))?;
-            Ok(())
+            Ok(true)
         }
         .await;
 
-        if let Err(e) = result {
-            let _ = conn.execute("ROLLBACK", ()).await;
-            return Err(e);
-        }
+        let created = match result {
+            Ok(created) => created,
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
         conn.execute("COMMIT", ())
             .await
             .map_err(|e| WenlanError::VectorDb(format!("init_page_map commit: {e}")))?;
 
-        load_page_map_data(&conn, page_id, true)
+        let data = load_page_map_data(&conn, page_id, true)
             .await?
             .ok_or_else(|| {
                 WenlanError::VectorDb(format!("init_page_map: {page_id} missing after insert"))
-            })
+            })?;
+        Ok((data, created))
     }
 
     /// Creates a node under `parent_id`. Requires an existing `page_maps`
@@ -689,6 +763,7 @@ impl MemoryDB {
                 "unknown ref_kind '{ref_kind}'"
             )));
         }
+        validate_ref_component(ref_kind, ref_id)?;
         let conn = self.conn.lock().await;
         conn.execute("BEGIN", ())
             .await
@@ -706,6 +781,11 @@ impl MemoryDB {
                 Some(p) => p,
                 None => return Err(missing_node_error(&conn, parent_id).await?),
             };
+            if parent.status == "dismissed" {
+                return Err(WenlanError::Validation(format!(
+                    "parent {parent_id} is dismissed"
+                )));
+            }
             let parent_ref = parent_ref_token(&parent);
             let fingerprint = fingerprint_for(ref_kind, ref_id, &parent_ref);
 
@@ -794,6 +874,7 @@ impl MemoryDB {
                 "unknown ref_kind '{ref_kind}'"
             )));
         }
+        validate_ref_component(ref_kind, ref_id)?;
         let conn = self.conn.lock().await;
         conn.execute("BEGIN", ())
             .await
@@ -811,6 +892,11 @@ impl MemoryDB {
                 Some(p) => p,
                 None => return Err(missing_node_error(&conn, parent_id).await?),
             };
+            if parent.status == "dismissed" {
+                return Err(WenlanError::Validation(format!(
+                    "parent {parent_id} is dismissed"
+                )));
+            }
             let parent_ref = parent_ref_token(&parent);
             let fingerprint = fingerprint_for(ref_kind, ref_id, &parent_ref);
 
@@ -908,6 +994,11 @@ impl MemoryDB {
             let node = read_map_node(&conn, page_id, node_id)
                 .await?
                 .ok_or_else(|| WenlanError::NotFound(format!("node {node_id} not found")))?;
+            if node.status == "dismissed" {
+                return Err(WenlanError::Validation(
+                    "node is dismissed and cannot be modified".to_string(),
+                ));
+            }
             let is_root = node.parent_id.is_none();
 
             if let Some(new_status) = &patch.status {
@@ -925,6 +1016,14 @@ impl MemoryDB {
                         "invalid status transition {} -> {new_status}",
                         node.status
                     )));
+                }
+                if new_status == "dismissed" {
+                    let live_children = count_live_children(&conn, page_id, node_id).await?;
+                    if live_children > 0 {
+                        return Err(WenlanError::Validation(
+                            "node has live children and cannot be dismissed".to_string(),
+                        ));
+                    }
                 }
             }
             if patch.parent_id.is_some() && is_root {
@@ -1077,11 +1176,23 @@ impl MemoryDB {
             if current_revision != base_revision {
                 return Err(revision_conflict(page_id, current_revision, base_revision));
             }
-            if read_map_node(&conn, page_id, from_node).await?.is_none() {
-                return Err(missing_node_error(&conn, from_node).await?);
+            let from = match read_map_node(&conn, page_id, from_node).await? {
+                Some(n) => n,
+                None => return Err(missing_node_error(&conn, from_node).await?),
+            };
+            if from.status == "dismissed" {
+                return Err(WenlanError::Validation(format!(
+                    "node {from_node} is dismissed"
+                )));
             }
-            if read_map_node(&conn, page_id, to_node).await?.is_none() {
-                return Err(missing_node_error(&conn, to_node).await?);
+            let to = match read_map_node(&conn, page_id, to_node).await? {
+                Some(n) => n,
+                None => return Err(missing_node_error(&conn, to_node).await?),
+            };
+            if to.status == "dismissed" {
+                return Err(WenlanError::Validation(format!(
+                    "node {to_node} is dismissed"
+                )));
             }
 
             let edge_id = uuid::Uuid::new_v4().to_string();
@@ -1170,11 +1281,23 @@ impl MemoryDB {
             if current_revision != base_revision {
                 return Err(revision_conflict(page_id, current_revision, base_revision));
             }
-            if read_map_node(&conn, page_id, from_node).await?.is_none() {
-                return Err(missing_node_error(&conn, from_node).await?);
+            let from = match read_map_node(&conn, page_id, from_node).await? {
+                Some(n) => n,
+                None => return Err(missing_node_error(&conn, from_node).await?),
+            };
+            if from.status == "dismissed" {
+                return Err(WenlanError::Validation(format!(
+                    "node {from_node} is dismissed"
+                )));
             }
-            if read_map_node(&conn, page_id, to_node).await?.is_none() {
-                return Err(missing_node_error(&conn, to_node).await?);
+            let to = match read_map_node(&conn, page_id, to_node).await? {
+                Some(n) => n,
+                None => return Err(missing_node_error(&conn, to_node).await?),
+            };
+            if to.status == "dismissed" {
+                return Err(WenlanError::Validation(format!(
+                    "node {to_node} is dismissed"
+                )));
             }
 
             let edge_id = uuid::Uuid::new_v4().to_string();
@@ -1264,6 +1387,11 @@ impl MemoryDB {
             let edge = read_map_edge(&conn, page_id, edge_id)
                 .await?
                 .ok_or_else(|| WenlanError::NotFound(format!("edge {edge_id} not found")))?;
+            if edge.status == "dismissed" {
+                return Err(WenlanError::Validation(
+                    "edge is dismissed and cannot be modified".to_string(),
+                ));
+            }
 
             if let Some(new_status) = &patch.status {
                 let allowed = matches!(
@@ -1335,8 +1463,10 @@ impl MemoryDB {
     }
 
     /// Writes viewport + per-node positions/sizes/collapsed state in one
-    /// transaction, setting `placed = 1` on every positioned node. Every
-    /// `node_id` in `positions` must already belong to this map.
+    /// transaction, setting `placed = 1` AND `pinned = 1` on every positioned
+    /// node (spec: moving a node with placement is a user mutation, so it
+    /// pins the same way any other user edit does). Every `node_id` in
+    /// `positions` must already belong to this map.
     pub async fn put_page_map_layout(
         &self,
         page_id: &str,
@@ -1362,7 +1492,7 @@ impl MemoryDB {
                     .execute(
                         "UPDATE page_map_nodes \
                          SET x = ?1, y = ?2, width = ?3, height = ?4, collapsed = ?5, placed = 1, \
-                             updated_at = datetime('now') \
+                             pinned = 1, updated_at = datetime('now') \
                          WHERE page_id = ?6 AND id = ?7",
                         libsql::params![
                             pos.x,

--- a/crates/wenlan-core/src/db/page_map_test.rs
+++ b/crates/wenlan-core/src/db/page_map_test.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::tests::test_db;
-use super::{CreateNodeOutcome, MemoryDB, NodePatch};
+use super::{CreateEdgeOutcome, CreateNodeOutcome, EdgePatch, MemoryDB, NodeLayout, NodePatch};
 
 async fn seed_page(db: &MemoryDB, page_id: &str) {
     let conn = db.conn.lock().await;
@@ -28,17 +28,19 @@ async fn init_page_map_idempotent() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
 
-    let first = db.init_page_map("page-1").await.unwrap();
+    let (first, created_first) = db.init_page_map("page-1").await.unwrap();
+    assert!(created_first, "first call must report created = true");
     assert_eq!(first.map.revision, 1);
     assert_eq!(first.nodes.len(), 1);
     let root = &first.nodes[0];
     assert!(root.parent_id.is_none());
     assert_eq!(root.ref_kind, "page");
     assert_eq!(root.ref_id, "page-1");
-    assert_eq!(root.fingerprint, "page:page-1@~");
+    assert_eq!(root.fingerprint, "page\u{1f}page-1\u{1f}~");
 
     // Second call is a no-op: same revision, same single root, no new row.
-    let second = db.init_page_map("page-1").await.unwrap();
+    let (second, created_second) = db.init_page_map("page-1").await.unwrap();
+    assert!(!created_second, "second call must report created = false");
     assert_eq!(second.map.revision, 1);
     assert_eq!(second.nodes.len(), 1);
     assert_eq!(second.nodes[0].id, root.id);
@@ -48,7 +50,7 @@ async fn init_page_map_idempotent() {
 async fn create_map_node_fingerprint_dedup() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
     let root = root_id(&map.nodes);
 
     let first = db
@@ -67,7 +69,7 @@ async fn create_map_node_fingerprint_dedup() {
         CreateNodeOutcome::Created(node) => node,
         other => panic!("expected Created, got {other:?}"),
     };
-    assert_eq!(created.fingerprint, "memory:mem-1@~");
+    assert_eq!(created.fingerprint, "memory\u{1f}mem-1\u{1f}~");
 
     // Same (ref_kind, ref_id, parent) proposed again -> Duplicate, no revision bump.
     let revision_after_first = db
@@ -113,7 +115,7 @@ async fn create_map_node_fingerprint_dedup() {
 async fn dismissed_tombstone_blocks_reproposal() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
     let root = root_id(&map.nodes);
 
     let created = match db
@@ -164,7 +166,7 @@ async fn dismissed_tombstone_blocks_reproposal() {
         after
             .nodes
             .iter()
-            .filter(|n| n.fingerprint == "memory:mem-1@~")
+            .filter(|n| n.fingerprint == "memory\u{1f}mem-1\u{1f}~")
             .count(),
         1
     );
@@ -174,7 +176,7 @@ async fn dismissed_tombstone_blocks_reproposal() {
 async fn revision_bumps_on_every_write_and_stale_base_rejected() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
     let root = root_id(&map.nodes);
     let stale_revision = map.map.revision;
 
@@ -218,7 +220,7 @@ async fn revision_bumps_on_every_write_and_stale_base_rejected() {
 async fn root_invariants_reject_dismiss_delete_and_reparent() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
     let root = root_id(&map.nodes);
 
     let child = match db
@@ -267,7 +269,7 @@ async fn root_invariants_reject_dismiss_delete_and_reparent() {
 async fn reparent_rejects_cycle() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
     let root = root_id(&map.nodes);
 
     let a = match db
@@ -329,7 +331,7 @@ async fn reparent_rejects_cycle() {
 async fn reset_page_map_clears_tombstones() {
     let (db, _tmp) = test_db().await;
     seed_page(&db, "page-1").await;
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
     let root = root_id(&map.nodes);
 
     let created = match db
@@ -363,7 +365,8 @@ async fn reset_page_map_clears_tombstones() {
     assert!(db.get_page_map("page-1", true).await.unwrap().is_none());
 
     // Fresh init + the same fingerprint must succeed as Created, not Tombstoned.
-    let map = db.init_page_map("page-1").await.unwrap();
+    let (map, created_after_reset) = db.init_page_map("page-1").await.unwrap();
+    assert!(created_after_reset);
     let root = root_id(&map.nodes);
     let outcome = db
         .create_map_node(
@@ -378,4 +381,500 @@ async fn reset_page_map_clears_tombstones() {
         .await
         .unwrap();
     assert!(matches!(outcome, CreateNodeOutcome::Created(_)));
+}
+
+// Dismissed rows are terminal: no patch, of any shape, can touch them — not
+// even one that only re-parents (which would otherwise recompute the
+// fingerprint and free the old tombstone key, letting a dismissed suggestion
+// resurface under a different parent).
+#[tokio::test]
+async fn patch_on_dismissed_node_rejected_and_tombstone_holds() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let other_parent = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-other-parent",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let created = match db
+        .create_map_node("page-1", rev, &root, "memory", "mem-1", None, 0.0)
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_node("page-1", rev, &created.id)
+        .await
+        .unwrap();
+    let fingerprint_before = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .nodes
+        .into_iter()
+        .find(|n| n.id == created.id)
+        .unwrap()
+        .fingerprint;
+
+    // A patch touching only parent_id (no status change) must still be
+    // rejected — dismissed is terminal regardless of patch contents.
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .patch_map_node(
+            "page-1",
+            rev,
+            &created.id,
+            NodePatch {
+                parent_id: Some(other_parent.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+
+    // Fingerprint must be unchanged in the DB.
+    let after = db.get_page_map("page-1", true).await.unwrap().unwrap();
+    let node_after = after.nodes.iter().find(|n| n.id == created.id).unwrap();
+    assert_eq!(node_after.fingerprint, fingerprint_before);
+
+    // A subsequent create under the original parent still tombstones.
+    let rev = after.map.revision;
+    let outcome = db
+        .create_map_node("page-1", rev, &root, "memory", "mem-1", None, 0.0)
+        .await
+        .unwrap();
+    assert_eq!(outcome, CreateNodeOutcome::Tombstoned);
+}
+
+#[tokio::test]
+async fn patch_on_dismissed_edge_rejected() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let a = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-a",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let b = match db
+        .create_map_node("page-1", rev, &root, "memory", "mem-b", None, 0.0)
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let edge = match db
+        .create_map_edge("page-1", rev, &a.id, &b.id, "link", None)
+        .await
+        .unwrap()
+    {
+        CreateEdgeOutcome::Created(edge) => edge,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_edge("page-1", rev, &edge.id).await.unwrap();
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .patch_map_edge(
+            "page-1",
+            rev,
+            &edge.id,
+            EdgePatch {
+                label: Some(Some("relabel".to_string())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}
+
+// Dismissal cannot orphan: dismissing a node with a live child is rejected.
+#[tokio::test]
+async fn dismiss_with_live_child_rejected() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let parent = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-parent",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.create_map_node("page-1", rev, &parent.id, "memory", "mem-child", None, 0.0)
+        .await
+        .unwrap();
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .delete_map_node("page-1", rev, &parent.id)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}
+
+// Creating a node under a dismissed parent is rejected.
+#[tokio::test]
+async fn create_under_dismissed_parent_rejected() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let parent = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-parent",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_node("page-1", rev, &parent.id).await.unwrap();
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .create_map_node("page-1", rev, &parent.id, "memory", "mem-child", None, 0.0)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}
+
+// Creating an edge to a dismissed endpoint is rejected.
+#[tokio::test]
+async fn edge_to_dismissed_endpoint_rejected() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let a = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-a",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let b = match db
+        .create_map_node("page-1", rev, &root, "memory", "mem-b", None, 0.0)
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_node("page-1", rev, &b.id).await.unwrap();
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .create_map_edge("page-1", rev, &a.id, &b.id, "link", None)
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}
+
+#[tokio::test]
+async fn fingerprint_uses_unit_separator_and_rejects_it_in_ref_components() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    // A ref_id containing the fingerprint separator itself is rejected.
+    let err = db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "a\u{1f}b",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+
+    // ref_ids that would have collided under the OLD "{kind}:{id}@{parent}"
+    // scheme (colliding on '@'/':' in the ref_id) now insert as distinct rows.
+    let first = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "a@b",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    assert_eq!(first.fingerprint, "memory\u{1f}a@b\u{1f}~");
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let second = match db
+        .create_map_node("page-1", rev, &root, "memory", "a:b", None, 0.0)
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    assert_eq!(second.fingerprint, "memory\u{1f}a:b\u{1f}~");
+    assert_ne!(first.fingerprint, second.fingerprint);
+}
+
+#[tokio::test]
+async fn init_page_map_created_flag_reflects_atomic_insert() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+
+    let (first, created_first) = db.init_page_map("page-1").await.unwrap();
+    assert!(created_first, "first call must report created = true");
+    assert_eq!(first.map.revision, 1);
+
+    let (second, created_second) = db.init_page_map("page-1").await.unwrap();
+    assert!(
+        !created_second,
+        "second call must report created = false (idempotent no-op)"
+    );
+    assert_eq!(second.map.revision, 1);
+}
+
+#[tokio::test]
+async fn put_page_map_layout_round_trip_pins_and_places_positioned_nodes() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let child = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let viewport = r#"{"x":1.0,"y":2.0,"zoom":1.5}"#;
+    let positions = vec![NodeLayout {
+        node_id: child.id.clone(),
+        x: 10.0,
+        y: 20.0,
+        width: 100.0,
+        height: 50.0,
+        collapsed: true,
+    }];
+    let data = db
+        .put_page_map_layout("page-1", rev, Some(viewport), &positions)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        data.map.revision,
+        rev + 1,
+        "layout write must bump the revision"
+    );
+    assert_eq!(data.map.viewport.as_deref(), Some(viewport));
+
+    let updated = data.nodes.iter().find(|n| n.id == child.id).unwrap();
+    assert_eq!(updated.x, Some(10.0));
+    assert_eq!(updated.y, Some(20.0));
+    assert_eq!(updated.width, Some(100.0));
+    assert_eq!(updated.height, Some(50.0));
+    assert!(updated.placed, "positioned node must be marked placed");
+    assert!(
+        updated.pinned,
+        "positioned node must be pinned (move with placement)"
+    );
+    assert!(updated.collapsed);
+
+    // Stale base_revision is rejected.
+    let err = db
+        .put_page_map_layout("page-1", rev, None, &[])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Conflict(_)));
 }

--- a/crates/wenlan-core/src/db/page_map_test.rs
+++ b/crates/wenlan-core/src/db/page_map_test.rs
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::tests::test_db;
+use super::{CreateNodeOutcome, MemoryDB, NodePatch};
+
+async fn seed_page(db: &MemoryDB, page_id: &str) {
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO pages (id, title, content, created_at, last_compiled, last_modified) \
+         VALUES (?1, 'Test Page', 'body', datetime('now'), datetime('now'), datetime('now'))",
+        libsql::params![page_id],
+    )
+    .await
+    .unwrap();
+}
+
+fn root_id(nodes: &[super::PageMapNode]) -> String {
+    nodes
+        .iter()
+        .find(|n| n.parent_id.is_none())
+        .expect("root node")
+        .id
+        .clone()
+}
+
+#[tokio::test]
+async fn init_page_map_idempotent() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+
+    let first = db.init_page_map("page-1").await.unwrap();
+    assert_eq!(first.map.revision, 1);
+    assert_eq!(first.nodes.len(), 1);
+    let root = &first.nodes[0];
+    assert!(root.parent_id.is_none());
+    assert_eq!(root.ref_kind, "page");
+    assert_eq!(root.ref_id, "page-1");
+    assert_eq!(root.fingerprint, "page:page-1@~");
+
+    // Second call is a no-op: same revision, same single root, no new row.
+    let second = db.init_page_map("page-1").await.unwrap();
+    assert_eq!(second.map.revision, 1);
+    assert_eq!(second.nodes.len(), 1);
+    assert_eq!(second.nodes[0].id, root.id);
+}
+
+#[tokio::test]
+async fn create_map_node_fingerprint_dedup() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let first = db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap();
+    let created = match first {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    assert_eq!(created.fingerprint, "memory:mem-1@~");
+
+    // Same (ref_kind, ref_id, parent) proposed again -> Duplicate, no revision bump.
+    let revision_after_first = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let second = db
+        .create_map_node(
+            "page-1",
+            revision_after_first,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            1.0,
+        )
+        .await
+        .unwrap();
+    match second {
+        CreateNodeOutcome::Duplicate(node) => assert_eq!(node.id, created.id),
+        other => panic!("expected Duplicate, got {other:?}"),
+    }
+    let revision_after_second = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    assert_eq!(revision_after_second, revision_after_first);
+}
+
+// Mutation-proof note: this test only has teeth against the tombstone branch
+// in `create_map_node` (`if existing.status == "dismissed" { Tombstoned }
+// else { Duplicate(existing) }`). Flipping that branch to always return
+// `Duplicate(existing)` makes this test fail on the `Tombstoned` assert
+// below (the mutation was applied locally to confirm the failure, then
+// reverted — it is not left in the shipped code).
+#[tokio::test]
+async fn dismissed_tombstone_blocks_reproposal() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let created = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_node("page-1", rev, &created.id)
+        .await
+        .unwrap();
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let outcome = db
+        .create_map_node("page-1", rev, &root, "memory", "mem-1", None, 0.0)
+        .await
+        .unwrap();
+    assert_eq!(outcome, CreateNodeOutcome::Tombstoned);
+
+    // Tombstoned outcome must not have inserted a second row or bumped the revision.
+    let after = db.get_page_map("page-1", true).await.unwrap().unwrap();
+    assert_eq!(after.map.revision, rev);
+    assert_eq!(
+        after
+            .nodes
+            .iter()
+            .filter(|n| n.fingerprint == "memory:mem-1@~")
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn revision_bumps_on_every_write_and_stale_base_rejected() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+    let stale_revision = map.map.revision;
+
+    db.create_map_node(
+        "page-1",
+        stale_revision,
+        &root,
+        "memory",
+        "mem-1",
+        None,
+        0.0,
+    )
+    .await
+    .unwrap();
+    let bumped = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    assert_eq!(bumped, stale_revision + 1);
+
+    // Reusing the now-stale base_revision must be rejected as a conflict.
+    let err = db
+        .create_map_node(
+            "page-1",
+            stale_revision,
+            &root,
+            "memory",
+            "mem-2",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Conflict(_)));
+}
+
+#[tokio::test]
+async fn root_invariants_reject_dismiss_delete_and_reparent() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let child = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db.delete_map_node("page-1", rev, &root).await.unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+
+    let err = db
+        .patch_map_node(
+            "page-1",
+            rev,
+            &root,
+            NodePatch {
+                parent_id: Some(child.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}
+
+#[tokio::test]
+async fn reparent_rejects_cycle() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let a = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-a",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let b = match db
+        .create_map_node("page-1", rev, &a.id, "memory", "mem-b", None, 0.0)
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+
+    // a -> root, b -> a. Re-parenting a under b would make a its own ancestor.
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .patch_map_node(
+            "page-1",
+            rev,
+            &a.id,
+            NodePatch {
+                parent_id: Some(b.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}
+
+#[tokio::test]
+async fn reset_page_map_clears_tombstones() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let created = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_node("page-1", rev, &created.id)
+        .await
+        .unwrap();
+
+    db.reset_page_map("page-1").await.unwrap();
+    assert!(db.get_page_map("page-1", true).await.unwrap().is_none());
+
+    // Fresh init + the same fingerprint must succeed as Created, not Tombstoned.
+    let map = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+    let outcome = db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-1",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap();
+    assert!(matches!(outcome, CreateNodeOutcome::Created(_)));
+}

--- a/crates/wenlan-core/src/db/page_map_test.rs
+++ b/crates/wenlan-core/src/db/page_map_test.rs
@@ -878,3 +878,74 @@ async fn put_page_map_layout_round_trip_pins_and_places_positioned_nodes() {
         .unwrap_err();
     assert!(matches!(err, crate::WenlanError::Conflict(_)));
 }
+
+// Re-parenting onto a dismissed target parent is rejected — the same
+// cannot-orphan rule as create-under-dismissed-parent, on the patch path.
+#[tokio::test]
+async fn reparent_onto_dismissed_parent_rejected() {
+    let (db, _tmp) = test_db().await;
+    seed_page(&db, "page-1").await;
+    let (map, _created) = db.init_page_map("page-1").await.unwrap();
+    let root = root_id(&map.nodes);
+
+    let a = match db
+        .create_map_node(
+            "page-1",
+            map.map.revision,
+            &root,
+            "memory",
+            "mem-a",
+            None,
+            0.0,
+        )
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let b = match db
+        .create_map_node("page-1", rev, &root, "memory", "mem-b", None, 1.0)
+        .await
+        .unwrap()
+    {
+        CreateNodeOutcome::Created(node) => node,
+        other => panic!("expected Created, got {other:?}"),
+    };
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    db.delete_map_node("page-1", rev, &b.id).await.unwrap();
+
+    let rev = db
+        .get_page_map("page-1", true)
+        .await
+        .unwrap()
+        .unwrap()
+        .map
+        .revision;
+    let err = db
+        .patch_map_node(
+            "page-1",
+            rev,
+            &a.id,
+            NodePatch {
+                parent_id: Some(b.id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(err, crate::WenlanError::Validation(_)));
+}

--- a/crates/wenlan-core/src/lib.rs
+++ b/crates/wenlan-core/src/lib.rs
@@ -47,6 +47,7 @@ pub mod migrations;
 pub mod narrative;
 pub mod on_device_models;
 pub mod onboarding;
+pub mod page_map_improve;
 pub mod page_projection_tracker;
 pub mod pages;
 pub mod post_ingest;

--- a/crates/wenlan-core/src/lint/serving/routes/pages.rs
+++ b/crates/wenlan-core/src/lint/serving/routes/pages.rs
@@ -21,4 +21,5 @@ pub(super) const ROUTES: &[SensitiveReadRoute] = &[
     row!(Get,"/api/pages/{id}/sources","page_sources",HeaderOnly,UnauthenticatedLocal,PageWorkspace,ParentCollectionFiltered,Rejected,Forbidden),
     row!(Get,"/api/pages/{id}/links","page_links",HeaderOnly,UnauthenticatedLocal,PageWorkspace,ParentCollectionFiltered,Rejected,Forbidden),
     row!(Get,"/api/pages/{id}/revisions","page_revisions",HeaderOnly,UnauthenticatedLocal,PageWorkspace,ParentCollectionFiltered,Rejected,Forbidden),
+    row!(Get,"/api/pages/{id}/map","page_map",HeaderOnly,UnauthenticatedLocal,PageWorkspace,ParentCollectionFiltered,Rejected,Forbidden),
 ];

--- a/crates/wenlan-core/src/lint/serving_review_test.rs
+++ b/crates/wenlan-core/src/lint/serving_review_test.rs
@@ -108,6 +108,7 @@ fn route_catalog_freezes_exact_global_and_scoped_keys() {
         (Method::Get, "/api/pages/{id}/sources"),
         (Method::Get, "/api/pages/{id}/links"),
         (Method::Get, "/api/pages/{id}/revisions"),
+        (Method::Get, "/api/pages/{id}/map"),
         (Method::Post, "/api/memory/entities/list"),
         (Method::Post, "/api/memory/entities/search"),
         (Method::Get, "/api/memory/entities/{entity_id}"),
@@ -131,8 +132,8 @@ fn route_catalog_freezes_exact_global_and_scoped_keys() {
         .map(|row| (row.method, row.path))
         .collect::<BTreeSet<_>>();
 
-    assert_eq!(rows.len(), 57);
-    assert_eq!(keys.len(), 57, "duplicate sensitive route key");
+    assert_eq!(rows.len(), 58);
+    assert_eq!(keys.len(), 58, "duplicate sensitive route key");
     assert_eq!(global, GLOBAL.iter().copied().collect());
     assert_eq!(scoped, SCOPED.iter().copied().collect());
 }

--- a/crates/wenlan-core/src/page_map_improve.rs
+++ b/crates/wenlan-core/src/page_map_improve.rs
@@ -31,6 +31,15 @@ use crate::WenlanError;
 /// the page's own `source_memory_ids` order.
 const MAX_MEMORY_NODES: usize = 20;
 
+/// Upper bound on section nodes proposed for one page, mirroring
+/// `MAX_MEMORY_NODES` — a page with many headings shouldn't produce an
+/// unusable hairball either. The first N in document order.
+const MAX_SECTION_NODES: usize = 20;
+
+/// Upper bound on wikilink nodes proposed for one page, mirroring
+/// `MAX_MEMORY_NODES`. The first N in first-seen order.
+const MAX_WIKILINK_NODES: usize = 20;
+
 /// How many active pages the proactive pass scans per tick (most-recently-
 /// modified first). Bounded so an idle tick is cheap on a large corpus.
 const PROACTIVE_SCAN_LIMIT: i64 = 200;
@@ -51,7 +60,11 @@ fn improve_provenance(basis: &str) -> String {
 
 /// ATX markdown headings (`#`..`######`), de-duplicated case-insensitively in
 /// first-seen order. Setext (`===`/`---`) headings are intentionally ignored.
-fn extract_headings(content: &str) -> Vec<String> {
+///
+/// `pub` (not crate-private) so `wenlan-server`'s `compute_ref_state` can reuse
+/// this exact extraction when checking whether a `section` node's heading
+/// still exists in the page, instead of duplicating the slug logic.
+pub fn extract_headings(content: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut seen = std::collections::HashSet::new();
     for line in content.lines() {
@@ -199,9 +212,15 @@ pub async fn improve_page_map(db: &MemoryDB, page_id: &str) -> Result<ImproveOut
         .get_page(page_id)
         .await?
         .ok_or_else(|| WenlanError::NotFound(format!("page {page_id} not found")))?;
+    // Captured BEFORE sourcing starts: the watermark must reflect the page's
+    // state at the moment the pass began reading it, not wall-clock time when
+    // it finishes. An edit landing during the pass bumps `last_modified` past
+    // this captured value, so the proactive scheduler still sees the page as
+    // eligible next tick instead of wrongly treating it as caught up.
+    let last_modified = page.last_modified.clone();
 
     // Ensure the map + root exist (idempotent); capture root id + revision.
-    let map = db.init_page_map(page_id).await?;
+    let (map, _created) = db.init_page_map(page_id).await?;
     let root_id = map
         .nodes
         .iter()
@@ -215,14 +234,22 @@ pub async fn improve_page_map(db: &MemoryDB, page_id: &str) -> Result<ImproveOut
     // A concurrent client write between our reads flips a create to Conflict;
     // `source` returns early on it (a graceful stop, not an error). Any real
     // error propagates via `?`.
-    source_suggestions(db, page_id, &page, &root_id, &mut revision, &mut outcome).await?;
+    let completed =
+        source_suggestions(db, page_id, &page, &root_id, &mut revision, &mut outcome).await?;
 
-    // Watermark regardless of an early conflict stop, so the proactive
-    // scheduler doesn't re-pick the same page every tick.
-    db.stamp_page_map_generated_at(page_id).await?;
+    // Only watermark a pass that ran to completion. A conflict-stop leaves
+    // generated_at untouched so the next tick's idempotent re-run resumes
+    // cheaply instead of being wrongly marked done.
+    if completed {
+        db.stamp_page_map_generated_at(page_id, &last_modified)
+            .await?;
+    }
     Ok(outcome)
 }
 
+/// Returns whether the pass ran to completion (`true`) or stopped early on a
+/// revision conflict (`false`) — the caller uses this to decide whether to
+/// stamp the watermark (spec: only a completed pass is watermarked).
 async fn source_suggestions(
     db: &MemoryDB,
     page_id: &str,
@@ -230,7 +257,7 @@ async fn source_suggestions(
     root_id: &str,
     revision: &mut i64,
     outcome: &mut ImproveOutcome,
-) -> Result<(), WenlanError> {
+) -> Result<bool, WenlanError> {
     // Ranks give newly-suggested siblings a stable order under the root.
     let mut rank = 1.0f64;
 
@@ -241,13 +268,16 @@ async fn source_suggestions(
         )
         .await?
         {
-            return Ok(());
+            return Ok(false);
         }
         rank += 1.0;
     }
 
-    // 2. The page's own markdown sections.
-    for heading in extract_headings(&page.content) {
+    // 2. The page's own markdown sections (bounded).
+    for heading in extract_headings(&page.content)
+        .into_iter()
+        .take(MAX_SECTION_NODES)
+    {
         let ref_id = format!("{page_id}#{}", crate::export::obsidian::slugify(&heading));
         if let NodeStep::Conflict = add_suggested_node(
             db,
@@ -263,7 +293,7 @@ async fn source_suggestions(
         )
         .await?
         {
-            return Ok(());
+            return Ok(false);
         }
         rank += 1.0;
     }
@@ -275,13 +305,16 @@ async fn source_suggestions(
         )
         .await?
         {
-            return Ok(());
+            return Ok(false);
         }
         rank += 1.0;
     }
 
-    // 4. Wikilinks → a linked-page node + a suggested cross-link edge.
-    for title in extract_wikilinks(&page.content) {
+    // 4. Wikilinks → a linked-page node + a suggested cross-link edge (bounded).
+    for title in extract_wikilinks(&page.content)
+        .into_iter()
+        .take(MAX_WIKILINK_NODES)
+    {
         let Some(linked_id) = db.find_active_page_id_by_title(&title).await? else {
             continue; // unresolved title — stay grounded, propose nothing
         };
@@ -307,17 +340,17 @@ async fn source_suggestions(
                 rank += 1.0;
                 continue;
             }
-            NodeStep::Conflict => return Ok(()),
+            NodeStep::Conflict => return Ok(false),
         };
         rank += 1.0;
         if let EdgeStep::Conflict =
             add_suggested_edge(db, page_id, revision, root_id, &node_id, outcome).await?
         {
-            return Ok(());
+            return Ok(false);
         }
     }
 
-    Ok(())
+    Ok(true)
 }
 
 /// Bounded proactive pass: improves up to `budget` active pages whose content
@@ -330,6 +363,9 @@ pub async fn run_proactive_page_maps(db: &MemoryDB, budget: usize) -> Result<usi
     }
     // Most-recently-modified first — those most likely to want fresh
     // suggestions. A single bounded window suffices for an idle tick.
+    // ponytail: fixed 200-newest scan window; pages beyond it rely on
+    // explicit POST improve — add a persistent cursor if large corpora make
+    // proactive coverage matter.
     let pages = db.list_pages("active", PROACTIVE_SCAN_LIMIT, 0).await?;
     let mut improved = 0usize;
     for page in pages {
@@ -505,7 +541,7 @@ mod tests {
         )
         .await;
 
-        let map = db.init_page_map(&page_id).await.unwrap();
+        let (map, _created) = db.init_page_map(&page_id).await.unwrap();
         let root = map
             .nodes
             .iter()
@@ -612,7 +648,7 @@ mod tests {
         let dismissed_rows: Vec<_> = after
             .nodes
             .iter()
-            .filter(|n| n.fingerprint == "memory:mem-dismissed@~")
+            .filter(|n| n.fingerprint == "memory\u{1f}mem-dismissed\u{1f}~")
             .collect();
         assert_eq!(dismissed_rows.len(), 1);
         assert_eq!(dismissed_rows[0].status, "dismissed");
@@ -678,6 +714,107 @@ mod tests {
         let (db, _tmp) = test_db().await;
         let err = improve_page_map(&db, "no-such-page").await.unwrap_err();
         assert!(matches!(err, WenlanError::NotFound(_)));
+    }
+
+    // A conflict-stop must not stamp generated_at, so the next tick's
+    // idempotent re-run resumes rather than being wrongly marked done. Forces
+    // the conflict deterministically by calling the private `source_suggestions`
+    // helper directly with a stale revision (the same pattern this file already
+    // uses to test private helpers, e.g. `extract_headings_parses_atx_and_dedups`),
+    // rather than via true concurrency, which would be flaky.
+    #[tokio::test]
+    async fn improve_conflict_stop_leaves_generated_at_unchanged() {
+        let (db, _tmp) = test_db().await;
+        let page_id = seed_page(&db, "Conflict Stop", "body", vec!["mem-1".to_string()]).await;
+        let page = db.get_page(&page_id).await.unwrap().unwrap();
+
+        let (map, _created) = db.init_page_map(&page_id).await.unwrap();
+        let root_id = map
+            .nodes
+            .iter()
+            .find(|n| n.parent_id.is_none())
+            .unwrap()
+            .id
+            .clone();
+
+        // A deliberately-stale revision forces the very first candidate write
+        // to hit a revision conflict.
+        let mut stale_revision = map.map.revision + 999;
+        let mut outcome = ImproveOutcome::default();
+        let completed = source_suggestions(
+            &db,
+            &page_id,
+            &page,
+            &root_id,
+            &mut stale_revision,
+            &mut outcome,
+        )
+        .await
+        .unwrap();
+        assert!(!completed, "stale revision must stop the pass early");
+
+        // improve_page_map only stamps when `completed`; since it's false here,
+        // generated_at must still be unset.
+        assert!(
+            db.page_map_generated_at(&page_id).await.unwrap().is_none(),
+            "conflict-stop must leave generated_at unstamped"
+        );
+    }
+
+    // The watermark must reflect the page's last_modified as it was AT THE
+    // START of the pass, not wall-clock time when the pass finishes — so an
+    // edit that happens after generation still leaves the page eligible for
+    // the next proactive tick.
+    #[tokio::test]
+    async fn improve_stamps_captured_last_modified_and_page_stays_eligible_after_later_edit() {
+        let (db, _tmp) = test_db().await;
+        let page_id = seed_page(&db, "Watermark Capture", "body", vec!["mem-1".to_string()]).await;
+
+        let page_before = db.get_page(&page_id).await.unwrap().unwrap();
+        let captured = page_before.last_modified.clone();
+
+        improve_page_map(&db, &page_id).await.unwrap();
+
+        let generated_at = db
+            .page_map_generated_at(&page_id)
+            .await
+            .unwrap()
+            .expect("stamped");
+        assert_eq!(
+            generated_at, captured,
+            "must stamp with page.last_modified captured at pass start, not now()"
+        );
+
+        // Bump last_modified AFTER generation captured its value (simulating an
+        // edit that happened during/after the pass) — sleep past the RFC3339
+        // one-second resolution so the compare in run_proactive_page_maps is
+        // unambiguous.
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        db.update_page_summary(&page_id, Some("edited during pass"))
+            .await
+            .unwrap();
+
+        let improved = run_proactive_page_maps(&db, 5).await.unwrap();
+        assert_eq!(
+            improved, 1,
+            "page whose last_modified advanced past the captured watermark stays eligible"
+        );
+    }
+
+    #[tokio::test]
+    async fn improve_caps_section_suggestions_at_twenty() {
+        let (db, _tmp) = test_db().await;
+        let content: String = (1..=25).map(|i| format!("# Heading {i}\n")).collect();
+        let page_id = seed_page(&db, "Many Headings", &content, vec!["mem-1".to_string()]).await;
+
+        improve_page_map(&db, &page_id).await.unwrap();
+
+        let map = db.get_page_map(&page_id, true).await.unwrap().unwrap();
+        let section_nodes = map.nodes.iter().filter(|n| n.ref_kind == "section").count();
+        assert_eq!(
+            section_nodes, 20,
+            "must cap section suggestions at MAX_SECTION_NODES"
+        );
     }
 
     // --- Proactive runner ---

--- a/crates/wenlan-core/src/page_map_improve.rs
+++ b/crates/wenlan-core/src/page_map_improve.rs
@@ -1,0 +1,720 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Page Map "improve" pass (stage 3) — generates `status = 'suggested'`
+//! nodes/edges for one page's map. See
+//! docs/superpowers/plans/2026-07-18-page-map-api-spec.md.
+//!
+//! Design invariants, held BY CONSTRUCTION:
+//! - **Insert-only.** Every write goes through
+//!   [`MemoryDB::create_suggested_map_node`] /
+//!   [`MemoryDB::create_suggested_map_edge`], whose `ON CONFLICT ... DO NOTHING`
+//!   makes a re-proposal of an existing fingerprint a `Duplicate` and of a
+//!   dismissed fingerprint a `Tombstoned` — both no-ops. The pass therefore
+//!   never updates, deletes, resurrects, or overwrites any existing row
+//!   (pinned / active / dismissed alike).
+//! - **Grounded.** Every candidate node references a REAL object read straight
+//!   from the page row: its entity, its own markdown sections, its source
+//!   memories, and the pages its wikilinks resolve to. There are no free-text
+//!   nodes, so grounding needs no separate existence check.
+//! - **Deterministic-first.** The whole pass is deterministic db reads +
+//!   string parsing; no LLM is invoked. (This is the central judgment call —
+//!   see the module's report notes.)
+//! - **Watermarked, not revision-bumped.** After sourcing, the pass stamps
+//!   `page_maps.generated_at` WITHOUT a revision bump, so the proactive
+//!   scheduler can skip unchanged pages without spawning 409s at clients.
+
+use crate::db::page_map::{CreateEdgeOutcome, CreateNodeOutcome};
+use crate::db::MemoryDB;
+use crate::WenlanError;
+
+/// Upper bound on memory nodes proposed for one page, so a page distilled from
+/// hundreds of memories doesn't produce an unusable hairball. The first N by
+/// the page's own `source_memory_ids` order.
+const MAX_MEMORY_NODES: usize = 20;
+
+/// How many active pages the proactive pass scans per tick (most-recently-
+/// modified first). Bounded so an idle tick is cheap on a large corpus.
+const PROACTIVE_SCAN_LIMIT: i64 = 200;
+
+/// What one improve pass did. `*_skipped` counts fingerprints that were already
+/// present (duplicate) or tombstoned (dismissed) — the insert-only no-ops.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImproveOutcome {
+    pub nodes_created: usize,
+    pub edges_created: usize,
+    pub nodes_skipped: usize,
+    pub edges_skipped: usize,
+}
+
+fn improve_provenance(basis: &str) -> String {
+    serde_json::json!({ "pass": "improve", "basis": basis }).to_string()
+}
+
+/// ATX markdown headings (`#`..`######`), de-duplicated case-insensitively in
+/// first-seen order. Setext (`===`/`---`) headings are intentionally ignored.
+fn extract_headings(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            let heading = trimmed.trim_start_matches('#').trim();
+            if !heading.is_empty() && seen.insert(heading.to_lowercase()) {
+                out.push(heading.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// `[[Wikilink]]` targets, de-duplicated case-insensitively in first-seen
+/// order. `[[Title|alias]]` keeps `Title`; `[[Title#section]]` keeps `Title`.
+/// Byte offsets from `find` land on the ASCII `[[` / `]]` delimiters, so the
+/// slicing is UTF-8 safe.
+fn extract_wikilinks(content: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut rest = content;
+    while let Some(open) = rest.find("[[") {
+        let after = &rest[open + 2..];
+        let Some(close) = after.find("]]") else { break };
+        let inner = &after[..close];
+        let title = inner
+            .split('|')
+            .next()
+            .unwrap_or("")
+            .split('#')
+            .next()
+            .unwrap_or("")
+            .trim();
+        if !title.is_empty() && seen.insert(title.to_lowercase()) {
+            out.push(title.to_string());
+        }
+        rest = &after[close + 2..];
+    }
+    out
+}
+
+/// Result of one node proposal.
+enum NodeStep {
+    /// Node exists after the call (freshly created or already present) — carries
+    /// the live node id for wiring an edge to it.
+    Present(String),
+    /// Fingerprint is tombstoned (dismissed); nothing to link.
+    Tombstoned,
+    /// The map's revision moved under the pass; stop gracefully.
+    Conflict,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn add_suggested_node(
+    db: &MemoryDB,
+    page_id: &str,
+    revision: &mut i64,
+    parent_id: &str,
+    ref_kind: &str,
+    ref_id: &str,
+    label: Option<&str>,
+    rank: f64,
+    basis: &str,
+    outcome: &mut ImproveOutcome,
+) -> Result<NodeStep, WenlanError> {
+    match db
+        .create_suggested_map_node(
+            page_id,
+            *revision,
+            parent_id,
+            ref_kind,
+            ref_id,
+            label,
+            rank,
+            &improve_provenance(basis),
+        )
+        .await
+    {
+        Ok(CreateNodeOutcome::Created(node)) => {
+            *revision += 1;
+            outcome.nodes_created += 1;
+            Ok(NodeStep::Present(node.id))
+        }
+        Ok(CreateNodeOutcome::Duplicate(node)) => {
+            outcome.nodes_skipped += 1;
+            Ok(NodeStep::Present(node.id))
+        }
+        Ok(CreateNodeOutcome::Tombstoned) => {
+            outcome.nodes_skipped += 1;
+            Ok(NodeStep::Tombstoned)
+        }
+        Err(WenlanError::Conflict(_)) => Ok(NodeStep::Conflict),
+        Err(e) => Err(e),
+    }
+}
+
+/// Whether the edge step hit a revision conflict (stop) or completed.
+enum EdgeStep {
+    Done,
+    Conflict,
+}
+
+async fn add_suggested_edge(
+    db: &MemoryDB,
+    page_id: &str,
+    revision: &mut i64,
+    from_node: &str,
+    to_node: &str,
+    outcome: &mut ImproveOutcome,
+) -> Result<EdgeStep, WenlanError> {
+    match db
+        .create_suggested_map_edge(
+            page_id,
+            *revision,
+            from_node,
+            to_node,
+            "suggested",
+            None,
+            &improve_provenance("wikilink"),
+        )
+        .await
+    {
+        Ok(CreateEdgeOutcome::Created(_)) => {
+            *revision += 1;
+            outcome.edges_created += 1;
+            Ok(EdgeStep::Done)
+        }
+        Ok(CreateEdgeOutcome::Duplicate(_)) | Ok(CreateEdgeOutcome::Tombstoned) => {
+            outcome.edges_skipped += 1;
+            Ok(EdgeStep::Done)
+        }
+        Err(WenlanError::Conflict(_)) => Ok(EdgeStep::Conflict),
+        Err(e) => Err(e),
+    }
+}
+
+/// Runs the improve pass for one page: proposes `status = 'suggested'` nodes
+/// (entity, sections, memories, wikilinked pages) plus suggested cross-link
+/// edges for wikilinks, then stamps `generated_at`. Idempotent — re-running is
+/// a no-op except for genuinely new content, because the fingerprint unique key
+/// dedups. 404s if the page doesn't exist.
+pub async fn improve_page_map(db: &MemoryDB, page_id: &str) -> Result<ImproveOutcome, WenlanError> {
+    let page = db
+        .get_page(page_id)
+        .await?
+        .ok_or_else(|| WenlanError::NotFound(format!("page {page_id} not found")))?;
+
+    // Ensure the map + root exist (idempotent); capture root id + revision.
+    let map = db.init_page_map(page_id).await?;
+    let root_id = map
+        .nodes
+        .iter()
+        .find(|n| n.parent_id.is_none())
+        .map(|n| n.id.clone())
+        .ok_or_else(|| WenlanError::VectorDb(format!("page_map {page_id} has no root node")))?;
+
+    let mut revision = map.map.revision;
+    let mut outcome = ImproveOutcome::default();
+
+    // A concurrent client write between our reads flips a create to Conflict;
+    // `source` returns early on it (a graceful stop, not an error). Any real
+    // error propagates via `?`.
+    source_suggestions(db, page_id, &page, &root_id, &mut revision, &mut outcome).await?;
+
+    // Watermark regardless of an early conflict stop, so the proactive
+    // scheduler doesn't re-pick the same page every tick.
+    db.stamp_page_map_generated_at(page_id).await?;
+    Ok(outcome)
+}
+
+async fn source_suggestions(
+    db: &MemoryDB,
+    page_id: &str,
+    page: &wenlan_types::pages::Page,
+    root_id: &str,
+    revision: &mut i64,
+    outcome: &mut ImproveOutcome,
+) -> Result<(), WenlanError> {
+    // Ranks give newly-suggested siblings a stable order under the root.
+    let mut rank = 1.0f64;
+
+    // 1. Entity this page is about.
+    if let Some(entity_id) = page.entity_id.as_deref() {
+        if let NodeStep::Conflict = add_suggested_node(
+            db, page_id, revision, root_id, "entity", entity_id, None, rank, "entity", outcome,
+        )
+        .await?
+        {
+            return Ok(());
+        }
+        rank += 1.0;
+    }
+
+    // 2. The page's own markdown sections.
+    for heading in extract_headings(&page.content) {
+        let ref_id = format!("{page_id}#{}", crate::export::obsidian::slugify(&heading));
+        if let NodeStep::Conflict = add_suggested_node(
+            db,
+            page_id,
+            revision,
+            root_id,
+            "section",
+            &ref_id,
+            Some(&heading),
+            rank,
+            "section",
+            outcome,
+        )
+        .await?
+        {
+            return Ok(());
+        }
+        rank += 1.0;
+    }
+
+    // 3. Source memories that compose the page (bounded).
+    for source_id in page.source_memory_ids.iter().take(MAX_MEMORY_NODES) {
+        if let NodeStep::Conflict = add_suggested_node(
+            db, page_id, revision, root_id, "memory", source_id, None, rank, "memory", outcome,
+        )
+        .await?
+        {
+            return Ok(());
+        }
+        rank += 1.0;
+    }
+
+    // 4. Wikilinks → a linked-page node + a suggested cross-link edge.
+    for title in extract_wikilinks(&page.content) {
+        let Some(linked_id) = db.find_active_page_id_by_title(&title).await? else {
+            continue; // unresolved title — stay grounded, propose nothing
+        };
+        if linked_id == page_id {
+            continue; // self-link would collide with the root fingerprint
+        }
+        let node_id = match add_suggested_node(
+            db,
+            page_id,
+            revision,
+            root_id,
+            "page",
+            &linked_id,
+            Some(&title),
+            rank,
+            "wikilink",
+            outcome,
+        )
+        .await?
+        {
+            NodeStep::Present(id) => id,
+            NodeStep::Tombstoned => {
+                rank += 1.0;
+                continue;
+            }
+            NodeStep::Conflict => return Ok(()),
+        };
+        rank += 1.0;
+        if let EdgeStep::Conflict =
+            add_suggested_edge(db, page_id, revision, root_id, &node_id, outcome).await?
+        {
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+/// Bounded proactive pass: improves up to `budget` active pages whose content
+/// changed since their map was last generated (or was never generated).
+/// Returns the number of pages improved. Config-gated by the caller (the
+/// refinery `Phase::PageMaps`), never gating the explicit improve route.
+pub async fn run_proactive_page_maps(db: &MemoryDB, budget: usize) -> Result<usize, WenlanError> {
+    if budget == 0 {
+        return Ok(0);
+    }
+    // Most-recently-modified first — those most likely to want fresh
+    // suggestions. A single bounded window suffices for an idle tick.
+    let pages = db.list_pages("active", PROACTIVE_SCAN_LIMIT, 0).await?;
+    let mut improved = 0usize;
+    for page in pages {
+        if improved >= budget {
+            break;
+        }
+        // Skip pages unchanged since their last generation. Both timestamps are
+        // RFC3339 UTC strings written off the same clock (`pages.last_modified`
+        // in `create_page_with_tuning`, `page_maps.generated_at` in
+        // `stamp_page_map_generated_at`), but we compare them as parsed instants
+        // rather than lexically — RFC3339's variable fractional-second precision
+        // makes string order unreliable near equal times. An unparseable
+        // timestamp fails safe to eligible (a redundant improve is idempotent;
+        // wrongly skipping a changed page is not).
+        let eligible = match db.page_map_generated_at(&page.id).await? {
+            None => true,
+            Some(generated_at) => {
+                match (
+                    chrono::DateTime::parse_from_rfc3339(&page.last_modified),
+                    chrono::DateTime::parse_from_rfc3339(&generated_at),
+                ) {
+                    (Ok(modified), Ok(generated)) => modified > generated,
+                    _ => true,
+                }
+            }
+        };
+        if !eligible {
+            continue;
+        }
+        improve_page_map(db, &page.id).await?;
+        improved += 1;
+    }
+    Ok(improved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::page_map::{CreateNodeOutcome, NodePatch};
+    use crate::db::tests::test_db;
+    use wenlan_types::requests::CreateConceptRequest;
+
+    // --- Pure parsing helpers ---
+
+    #[test]
+    fn extract_headings_parses_atx_and_dedups() {
+        let content =
+            "# Overview\n\nsome text\n## Details\n### Details\ntext\n#NoSpace\nplain line";
+        let headings = extract_headings(content);
+        // "### Details" dedups against "## Details" (case-insensitive);
+        // "#NoSpace" trims to "NoSpace".
+        assert_eq!(headings, vec!["Overview", "Details", "NoSpace"]);
+    }
+
+    #[test]
+    fn extract_wikilinks_parses_alias_section_and_dedups() {
+        let content =
+            "See [[Rust]] and [[Rust]] again, [[Tokio|the runtime]], [[Async#Futures]], [[]].";
+        let links = extract_wikilinks(content);
+        assert_eq!(links, vec!["Rust", "Tokio", "Async"]);
+    }
+
+    // --- DB-backed improve pass ---
+
+    async fn seed_memory_doc(db: &MemoryDB, source_id: &str, content: &str) {
+        let doc = crate::sources::RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: format!("memory-{source_id}"),
+            content: content.to_string(),
+            memory_type: Some("fact".to_string()),
+            space: Some("default".to_string()),
+            source_agent: Some("test-agent".to_string()),
+            confidence: Some(0.9),
+            confirmed: Some(true),
+            ..Default::default()
+        };
+        db.upsert_documents(vec![doc]).await.unwrap();
+    }
+
+    async fn seed_page(
+        db: &MemoryDB,
+        title: &str,
+        content: &str,
+        source_memory_ids: Vec<String>,
+    ) -> String {
+        // A distilled page must cite >= 1 source memory whose text matches the
+        // body — `create_page_with_tuning`'s quality gate rejects an empty
+        // citation list and a body that diverges from its sources (cos sim <
+        // 0.6). Seed each cited memory with the page's own content, and
+        // synthesize one when the caller passed none, so the gate passes
+        // deterministically regardless of whether the embedding model is loaded.
+        let source_memory_ids = if source_memory_ids.is_empty() {
+            vec![format!("auto-src-{title}")]
+        } else {
+            source_memory_ids
+        };
+        for sid in &source_memory_ids {
+            seed_memory_doc(db, sid, content).await;
+        }
+        let result = crate::post_write::create_page_with_tuning(
+            db,
+            CreateConceptRequest {
+                title: title.to_string(),
+                content: content.to_string(),
+                summary: None,
+                entity_id: None,
+                source_memory_ids,
+                creation_kind: Some("distilled".to_string()),
+                space: Some("default".to_string()),
+                workspace: Some("default".to_string()),
+            },
+            "test",
+            None,
+            1,
+            1.1, // high threshold forces a fresh page instead of clustering
+        )
+        .await
+        .unwrap();
+        result.id
+    }
+
+    #[tokio::test]
+    async fn improve_creates_suggested_memory_nodes() {
+        let (db, _tmp) = test_db().await;
+        let page_id = seed_page(&db, "Improve Basics", "body", vec!["mem-x".to_string()]).await;
+
+        let outcome = improve_page_map(&db, &page_id).await.unwrap();
+        assert!(
+            outcome.nodes_created >= 1,
+            "expected at least the memory node"
+        );
+
+        let map = db.get_page_map(&page_id, true).await.unwrap().unwrap();
+        let mem = map
+            .nodes
+            .iter()
+            .find(|n| n.ref_kind == "memory" && n.ref_id == "mem-x")
+            .expect("suggested memory node for mem-x");
+        assert_eq!(mem.status, "suggested");
+        assert!(
+            mem.provenance
+                .as_deref()
+                .is_some_and(|p| p.contains("improve")),
+            "suggested node must carry an improve provenance stamp, got {:?}",
+            mem.provenance
+        );
+
+        // generated_at watermark was stamped.
+        assert!(db.page_map_generated_at(&page_id).await.unwrap().is_some());
+    }
+
+    // Mutation-proof note: this test's teeth are on the INSERT-ONLY contract of
+    // `create_suggested_map_node` / `create_suggested_map_edge` — specifically
+    // the `ON CONFLICT(page_id, fingerprint) DO NOTHING`. Changing that clause
+    // to `DO UPDATE SET status = 'suggested', provenance = excluded.provenance`
+    // makes the improve pass overwrite the pre-existing pinned/active row, so
+    // the "byte-identical" asserts below fail (status flips to 'suggested',
+    // provenance stops being NULL). Applied that mutation locally, confirmed the
+    // test fails, then reverted — it is NOT left in the shipped code.
+    #[tokio::test]
+    async fn improve_is_insert_only_never_touches_existing_rows() {
+        let (db, _tmp) = test_db().await;
+        let page_id = seed_page(
+            &db,
+            "Insert Only",
+            "body",
+            vec![
+                "mem-active".to_string(),
+                "mem-dismissed".to_string(),
+                "mem-new".to_string(),
+            ],
+        )
+        .await;
+
+        let map = db.init_page_map(&page_id).await.unwrap();
+        let root = map
+            .nodes
+            .iter()
+            .find(|n| n.parent_id.is_none())
+            .unwrap()
+            .id
+            .clone();
+
+        // Pre-seed an ACTIVE, PINNED node for mem-active (fingerprint the pass
+        // will re-propose).
+        let rev = db
+            .get_page_map(&page_id, true)
+            .await
+            .unwrap()
+            .unwrap()
+            .map
+            .revision;
+        let active = match db
+            .create_map_node(&page_id, rev, &root, "memory", "mem-active", None, 0.0)
+            .await
+            .unwrap()
+        {
+            CreateNodeOutcome::Created(n) => n,
+            other => panic!("expected Created, got {other:?}"),
+        };
+        let rev = db
+            .get_page_map(&page_id, true)
+            .await
+            .unwrap()
+            .unwrap()
+            .map
+            .revision;
+        db.patch_map_node(
+            &page_id,
+            rev,
+            &active.id,
+            NodePatch {
+                pinned: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // Pre-seed a DISMISSED (tombstoned) node for mem-dismissed.
+        let rev = db
+            .get_page_map(&page_id, true)
+            .await
+            .unwrap()
+            .unwrap()
+            .map
+            .revision;
+        let dismissed = match db
+            .create_map_node(&page_id, rev, &root, "memory", "mem-dismissed", None, 0.0)
+            .await
+            .unwrap()
+        {
+            CreateNodeOutcome::Created(n) => n,
+            other => panic!("expected Created, got {other:?}"),
+        };
+        let rev = db
+            .get_page_map(&page_id, true)
+            .await
+            .unwrap()
+            .unwrap()
+            .map
+            .revision;
+        db.delete_map_node(&page_id, rev, &dismissed.id)
+            .await
+            .unwrap();
+
+        // Snapshot the pre-existing active row for a byte-identical comparison.
+        let before = db.get_page_map(&page_id, true).await.unwrap().unwrap();
+        let active_before = before
+            .nodes
+            .iter()
+            .find(|n| n.id == active.id)
+            .cloned()
+            .unwrap();
+
+        // Run the pass.
+        improve_page_map(&db, &page_id).await.unwrap();
+
+        let after = db.get_page_map(&page_id, true).await.unwrap().unwrap();
+
+        // The pinned/active row is byte-identical (status, pinned, provenance,
+        // rank, label, updated_at all unchanged) — the pass never touched it.
+        let active_after = after
+            .nodes
+            .iter()
+            .find(|n| n.id == active.id)
+            .cloned()
+            .expect("active node still present");
+        assert_eq!(
+            active_after, active_before,
+            "insert-only violated: active row changed"
+        );
+        assert_eq!(active_after.status, "active");
+        assert!(active_after.pinned);
+        assert!(active_after.provenance.is_none());
+
+        // The dismissed fingerprint was NOT resurrected: still exactly one row,
+        // still dismissed.
+        let dismissed_rows: Vec<_> = after
+            .nodes
+            .iter()
+            .filter(|n| n.fingerprint == "memory:mem-dismissed@~")
+            .collect();
+        assert_eq!(dismissed_rows.len(), 1);
+        assert_eq!(dismissed_rows[0].status, "dismissed");
+
+        // Non-vacuous: the pass DID add a fresh suggestion for mem-new.
+        let new_node = after
+            .nodes
+            .iter()
+            .find(|n| n.ref_kind == "memory" && n.ref_id == "mem-new")
+            .expect("suggested node for mem-new");
+        assert_eq!(new_node.status, "suggested");
+    }
+
+    #[tokio::test]
+    async fn improve_creates_wikilink_node_and_edge() {
+        let (db, _tmp) = test_db().await;
+        // Target page must exist for the wikilink to resolve (grounding).
+        let _target = seed_page(&db, "Tokio", "runtime", vec![]).await;
+        let source = seed_page(&db, "Rust Async", "See [[Tokio]] for details.", vec![]).await;
+
+        let outcome = improve_page_map(&db, &source).await.unwrap();
+        assert!(outcome.nodes_created >= 1);
+        assert!(
+            outcome.edges_created >= 1,
+            "wikilink must yield a cross-link edge"
+        );
+
+        let map = db.get_page_map(&source, true).await.unwrap().unwrap();
+        let linked = map
+            .nodes
+            .iter()
+            .find(|n| n.ref_kind == "page" && n.ref_id == _target)
+            .expect("suggested page node for the wikilink");
+        assert_eq!(linked.status, "suggested");
+        let edge = map
+            .edges
+            .iter()
+            .find(|e| e.to_node == linked.id)
+            .expect("suggested edge to the linked page node");
+        assert_eq!(edge.status, "suggested");
+        assert_eq!(edge.kind, "suggested");
+        assert!(edge
+            .provenance
+            .as_deref()
+            .is_some_and(|p| p.contains("improve")));
+    }
+
+    #[tokio::test]
+    async fn improve_is_idempotent_second_pass_creates_nothing() {
+        let (db, _tmp) = test_db().await;
+        let page_id = seed_page(&db, "Idempotent", "body", vec!["mem-1".to_string()]).await;
+
+        let first = improve_page_map(&db, &page_id).await.unwrap();
+        assert!(first.nodes_created >= 1);
+
+        let second = improve_page_map(&db, &page_id).await.unwrap();
+        assert_eq!(second.nodes_created, 0, "re-proposals must all dedup");
+        assert_eq!(second.edges_created, 0);
+    }
+
+    #[tokio::test]
+    async fn improve_page_map_404s_for_unknown_page() {
+        let (db, _tmp) = test_db().await;
+        let err = improve_page_map(&db, "no-such-page").await.unwrap_err();
+        assert!(matches!(err, WenlanError::NotFound(_)));
+    }
+
+    // --- Proactive runner ---
+
+    #[tokio::test]
+    async fn run_proactive_respects_budget() {
+        let (db, _tmp) = test_db().await;
+        let p1 = seed_page(&db, "Proactive One", "body", vec!["m1".to_string()]).await;
+        let p2 = seed_page(&db, "Proactive Two", "body", vec!["m2".to_string()]).await;
+        let p3 = seed_page(&db, "Proactive Three", "body", vec!["m3".to_string()]).await;
+
+        let improved = run_proactive_page_maps(&db, 2).await.unwrap();
+        assert_eq!(improved, 2, "budget of 2 must improve exactly 2 pages");
+
+        // Exactly two of the three pages now carry a generated_at watermark.
+        let mut stamped = 0;
+        for id in [&p1, &p2, &p3] {
+            if db.page_map_generated_at(id).await.unwrap().is_some() {
+                stamped += 1;
+            }
+        }
+        assert_eq!(stamped, 2);
+    }
+
+    #[tokio::test]
+    async fn run_proactive_skips_already_generated_pages() {
+        let (db, _tmp) = test_db().await;
+        let _p = seed_page(&db, "Once Only", "body", vec!["m1".to_string()]).await;
+
+        let first = run_proactive_page_maps(&db, 5).await.unwrap();
+        assert_eq!(first, 1);
+
+        // Nothing changed the page since; a second tick improves nothing.
+        let second = run_proactive_page_maps(&db, 5).await.unwrap();
+        assert_eq!(
+            second, 0,
+            "unchanged page must be skipped by the generated_at watermark"
+        );
+    }
+}

--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -2344,6 +2344,7 @@ mod tests {
             "re-distill",
             "overview",
             "decision_logs",
+            "page_maps",
         ];
         for &exp in expected {
             assert!(
@@ -2502,6 +2503,7 @@ mod tests {
             "overview",
             "refinement_queue",
             "decision_logs",
+            "page_maps",
             "prune_rejections",
             "kg_rethink",
         ];

--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -397,6 +397,7 @@ impl TriggerKind {
                     | Phase::ReDistill
                     | Phase::Overview
                     | Phase::DecisionLogs
+                    | Phase::PageMaps
             ),
             Self::Daily => matches!(
                 phase,
@@ -611,10 +612,12 @@ pub async fn run_periodic_steep_with_api(
 ) -> Result<SteepResult, WenlanError> {
     let steep_start = std::time::Instant::now();
     let deadline = trigger.deadline_secs(tuning.steep_deadline_secs);
-    // Per-job everyday source pin — read once per cycle from config; drives both
-    // the recap and entity-extraction phases below. Absent/unknown → auto chain.
-    let everyday_pin =
-        EverydaySource::parse(crate::config::load_config().everyday_source.as_deref());
+    // Config read once per cycle. `everyday_pin` drives the recap and
+    // entity-extraction phases (absent/unknown → auto chain);
+    // `page_map_auto_suggest` gates the proactive Page-Map phase below.
+    let cfg = crate::config::load_config();
+    let everyday_pin = EverydaySource::parse(cfg.everyday_source.as_deref());
+    let page_map_auto_suggest = cfg.page_map_auto_suggest;
     let mut phases: Vec<PhaseResult> = Vec::new();
     #[allow(unused_assignments)]
     let mut deadline_hit = false; // track if we've logged the first skip
@@ -1007,6 +1010,26 @@ pub async fn run_periodic_steep_with_api(
             let (nudge, headline) = crate::synthesis::decision_logs::classify_decision_logs(count);
             Ok(PhaseOutput {
                 items_processed: count,
+                nudge,
+                headline,
+            })
+        })
+        .await;
+        phases.push(phase);
+    }
+
+    // Phase: proactive Page-Map suggestions (Idle only; config-gated).
+    // Generates `status='suggested'` nodes/edges for recently-changed pages,
+    // insert-only. The explicit `POST /api/pages/{id}/map/improve` route runs
+    // the SAME pass but is NEVER gated by `page_map_auto_suggest` — only this
+    // background phase is. Bounded to 5 pages per pass. Always Silent (no
+    // user-facing nudge; suggestions surface in the map UI, not as a toast).
+    if page_map_auto_suggest && trigger.runs_phase(Phase::PageMaps) {
+        let phase = run_phase(Phase::PageMaps, || async {
+            let improved = crate::page_map_improve::run_proactive_page_maps(db_ref, 5).await?;
+            let (nudge, headline) = classify_backfill(improved);
+            Ok(PhaseOutput {
+                items_processed: improved,
                 nudge,
                 headline,
             })

--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -2307,7 +2307,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_idle_trigger_runs_only_synthesis_phases() {
+        // The page_maps phase is gated on `config.page_map_auto_suggest`,
+        // which the steep reads via `load_config()` — pin WENLAN_DATA_DIR to
+        // a temp config so the phase list doesn't depend on the host's
+        // config.json (absent on CI → gate off → phase missing).
+        let _env_serial = COMPILE_ROUTING_ENV_LOCK.lock().await;
         let (db, _dir) = test_db().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        let data_dir_var = data_dir.path().to_string_lossy().to_string();
 
         db.upsert_documents(vec![make_memory(
             "idle_test",
@@ -2318,21 +2325,31 @@ mod tests {
         .await
         .unwrap();
 
-        let result = run_periodic_steep_with_api(
-            &db,
-            None,
-            None,
-            None,
-            None,
-            &PromptRegistry::default(),
-            &crate::tuning::RefineryConfig::default(),
-            &crate::tuning::ConfidenceConfig::default(),
-            &crate::tuning::DistillationConfig::default(),
-            None,
-            TriggerKind::Idle,
-        )
-        .await
-        .unwrap();
+        let result =
+            temp_env::async_with_vars([("WENLAN_DATA_DIR", Some(data_dir_var.as_str()))], async {
+                let config = crate::config::Config {
+                    page_map_auto_suggest: true,
+                    ..crate::config::Config::default()
+                };
+                crate::config::save_config(&config).unwrap();
+
+                run_periodic_steep_with_api(
+                    &db,
+                    None,
+                    None,
+                    None,
+                    None,
+                    &PromptRegistry::default(),
+                    &crate::tuning::RefineryConfig::default(),
+                    &crate::tuning::ConfidenceConfig::default(),
+                    &crate::tuning::DistillationConfig::default(),
+                    None,
+                    TriggerKind::Idle,
+                )
+                .await
+            })
+            .await
+            .unwrap();
 
         let phase_names: Vec<&str> = result.phases.iter().map(|p| p.name.as_str()).collect();
 
@@ -2455,9 +2472,16 @@ mod tests {
     async fn test_backstop_trigger_runs_all_phases() {
         // Backstop always runs the Evict phase gate and this test asserts
         // an EXACT phase count — same ambient-`WENLAN_ENABLE_EVICTION`
-        // dependency as the Daily test above, same lock required.
+        // dependency as the Daily test above, same lock required. The
+        // page_maps phase is additionally gated on
+        // `config.page_map_auto_suggest` read via `load_config()`, so pin
+        // WENLAN_DATA_DIR to a temp config (host config.json is absent on
+        // CI → gate off → phase missing).
         let _serial = EVICT_ENV_LOCK.lock().await;
+        let _env_serial = COMPILE_ROUTING_ENV_LOCK.lock().await;
         let (db, _dir) = test_db().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        let data_dir_var = data_dir.path().to_string_lossy().to_string();
 
         db.upsert_documents(vec![make_memory(
             "backstop_test",
@@ -2468,21 +2492,31 @@ mod tests {
         .await
         .unwrap();
 
-        let result = run_periodic_steep_with_api(
-            &db,
-            None,
-            None,
-            None,
-            None,
-            &PromptRegistry::default(),
-            &crate::tuning::RefineryConfig::default(),
-            &crate::tuning::ConfidenceConfig::default(),
-            &crate::tuning::DistillationConfig::default(),
-            None,
-            TriggerKind::Backstop,
-        )
-        .await
-        .unwrap();
+        let result =
+            temp_env::async_with_vars([("WENLAN_DATA_DIR", Some(data_dir_var.as_str()))], async {
+                let config = crate::config::Config {
+                    page_map_auto_suggest: true,
+                    ..crate::config::Config::default()
+                };
+                crate::config::save_config(&config).unwrap();
+
+                run_periodic_steep_with_api(
+                    &db,
+                    None,
+                    None,
+                    None,
+                    None,
+                    &PromptRegistry::default(),
+                    &crate::tuning::RefineryConfig::default(),
+                    &crate::tuning::ConfidenceConfig::default(),
+                    &crate::tuning::DistillationConfig::default(),
+                    None,
+                    TriggerKind::Backstop,
+                )
+                .await
+            })
+            .await
+            .unwrap();
 
         let phase_names: Vec<&str> = result.phases.iter().map(|p| p.name.as_str()).collect();
 

--- a/crates/wenlan-core/src/refinery/phase.rs
+++ b/crates/wenlan-core/src/refinery/phase.rs
@@ -24,6 +24,7 @@ pub enum Phase {
     PruneRejections,
     Evict,
     KgRethink,
+    PageMaps,
 }
 
 impl Phase {
@@ -46,6 +47,7 @@ impl Phase {
         Phase::PruneRejections,
         Phase::Evict,
         Phase::KgRethink,
+        Phase::PageMaps,
     ];
 
     /// Stable string identifier — preserved across the refactor for log
@@ -69,6 +71,7 @@ impl Phase {
             Phase::PruneRejections => "prune_rejections",
             Phase::Evict => "evict",
             Phase::KgRethink => "kg_rethink",
+            Phase::PageMaps => "page_maps",
         }
     }
 }

--- a/crates/wenlan-server/src/config_routes.rs
+++ b/crates/wenlan-server/src/config_routes.rs
@@ -32,6 +32,7 @@ fn config_to_response(cfg: &config::Config) -> ConfigResponse {
             .unwrap_or(false),
         everyday_source: cfg.everyday_source.clone(),
         synthesis_source: cfg.synthesis_source.clone(),
+        page_map_auto_suggest: cfg.page_map_auto_suggest,
     }
 }
 
@@ -103,6 +104,9 @@ pub async fn handle_update_config(
     }
     if let Some(v) = req.synthesis_source {
         cfg.synthesis_source = validate_synthesis_source(&v)?;
+    }
+    if let Some(v) = req.page_map_auto_suggest {
+        cfg.page_map_auto_suggest = v;
     }
     config::save_config(&cfg).map_err(|e| ServerError::Internal(e.to_string()))?;
     if external_touched {
@@ -1181,6 +1185,49 @@ mod config_model_fields_tests {
             Some("http://localhost:11434/v1")
         );
         assert_eq!(cfg.external_llm_model.as_deref(), Some("llama3"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn put_config_toggles_page_map_auto_suggest_and_preserves_when_omitted() {
+        let _lock = crate::TEST_DATA_DIR_LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        let _env = DataDirGuard::new();
+        let state = std::sync::Arc::new(RwLock::new(ServerState::default()));
+        let app = crate::router::build_router(state);
+
+        async fn put(app: &crate::router::AppRouter, body: serde_json::Value) -> Value {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("PUT")
+                        .uri("/api/config")
+                        .header("content-type", "application/json")
+                        .body(Body::from(body.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            response_json(resp).await
+        }
+
+        // Set true explicitly — response echoes it and it persists.
+        let body = put(&app, serde_json::json!({"page_map_auto_suggest": true})).await;
+        assert_eq!(body["page_map_auto_suggest"], true);
+        assert!(config::load_config().page_map_auto_suggest);
+
+        // Omitting the field preserves the stored value.
+        let body = put(&app, serde_json::json!({"clipboard_enabled": true})).await;
+        assert_eq!(body["page_map_auto_suggest"], true);
+        assert!(config::load_config().page_map_auto_suggest);
+
+        // Flip to false — response echoes it and it persists.
+        let body = put(&app, serde_json::json!({"page_map_auto_suggest": false})).await;
+        assert_eq!(body["page_map_auto_suggest"], false);
+        assert!(!config::load_config().page_map_auto_suggest);
     }
 }
 

--- a/crates/wenlan-server/src/lib.rs
+++ b/crates/wenlan-server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod knowledge_routes;
 pub mod lint_routes;
 pub mod memory_routes;
 pub mod onboarding_routes;
+pub mod page_map_routes;
 pub mod read_scope;
 pub mod refinery_routes;
 pub mod reflection_debounce;

--- a/crates/wenlan-server/src/page_map_routes.rs
+++ b/crates/wenlan-server/src/page_map_routes.rs
@@ -1,0 +1,822 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Page Map (mind-map) v1 HTTP routes — stage 2 of the daemon feature. See
+//! docs/superpowers/plans/2026-07-18-page-map-api-spec.md for the full
+//! contract; this module wires the wenlan-core data layer
+//! (`db::page_map`) to HTTP, staying thin per the crate boundary rule (no
+//! business logic here). `POST .../map/improve` (stage 3) is out of scope.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+use wenlan_core::db::page_map::{
+    CreateEdgeOutcome, CreateNodeOutcome, EdgePatch, NodeLayout, NodePatch, PageMapData,
+    PageMapEdge as CoreEdge, PageMapNode as CoreNode,
+};
+use wenlan_core::db::MemoryDB;
+use wenlan_types::page_map::{
+    CreateMapEdgeRequest, CreateMapNodeRequest, DeleteMapEdgeRequest, DeleteMapNodeRequest,
+    EdgeMutationResponse, NodeMutationResponse, PageMapEdge as WireEdge, PageMapNode as WireNode,
+    PageMapResponse, PageMapViewport, PatchMapEdgeRequest, PatchMapNodeRequest,
+    PutPageMapLayoutRequest, RefState,
+};
+
+use crate::error::ServerError;
+use crate::state::ServerState;
+
+async fn ensure_page_exists(db: &MemoryDB, page_id: &str) -> Result<(), ServerError> {
+    db.get_page(page_id)
+        .await?
+        .ok_or_else(|| ServerError::NotFound(format!("page {page_id} not found")))?;
+    Ok(())
+}
+
+fn root_node_id(nodes: &[CoreNode]) -> Option<String> {
+    nodes
+        .iter()
+        .find(|n| n.parent_id.is_none())
+        .map(|n| n.id.clone())
+}
+
+/// `ref_state` is computed at read time, never stored: live iff the node's
+/// backing object still resolves. `section` refs are simplified to "live
+/// iff the parent page exists" (the full heading-existence check is
+/// deferred; `ref_id` is `"{page_id}#{heading-slug}"`, so the page id is
+/// everything before the first `#`).
+async fn compute_ref_state(
+    db: &MemoryDB,
+    ref_kind: &str,
+    ref_id: &str,
+) -> Result<RefState, ServerError> {
+    let live = match ref_kind {
+        "memory" => db.get_memory_type(ref_id).await?.is_some(),
+        "entity" => db.get_entity_name_type(ref_id).await?.is_some(),
+        "page" => db.get_page(ref_id).await?.is_some(),
+        "section" => match ref_id.split_once('#') {
+            Some((page_id, _heading_slug)) => db.get_page(page_id).await?.is_some(),
+            None => false,
+        },
+        _ => false,
+    };
+    Ok(if live {
+        RefState::Live
+    } else {
+        RefState::Dangling
+    })
+}
+
+async fn wire_node(db: &MemoryDB, node: CoreNode) -> Result<WireNode, ServerError> {
+    let ref_state = compute_ref_state(db, &node.ref_kind, &node.ref_id).await?;
+    Ok(WireNode {
+        id: node.id,
+        parent_id: node.parent_id,
+        rank: node.rank,
+        ref_kind: node.ref_kind,
+        ref_id: node.ref_id,
+        label: node.label,
+        status: node.status,
+        pinned: node.pinned,
+        placed: node.placed,
+        collapsed: node.collapsed,
+        x: node.x,
+        y: node.y,
+        width: node.width,
+        height: node.height,
+        ref_state,
+    })
+}
+
+fn wire_edge(edge: CoreEdge) -> WireEdge {
+    WireEdge {
+        id: edge.id,
+        from_node: edge.from_node,
+        to_node: edge.to_node,
+        kind: edge.kind,
+        label: edge.label,
+        status: edge.status,
+    }
+}
+
+async fn build_map_response(
+    db: &MemoryDB,
+    page_id: &str,
+    data: PageMapData,
+) -> Result<PageMapResponse, ServerError> {
+    let viewport = data
+        .map
+        .viewport
+        .as_deref()
+        .and_then(|v| serde_json::from_str::<PageMapViewport>(v).ok());
+    let mut nodes = Vec::with_capacity(data.nodes.len());
+    for node in data.nodes {
+        nodes.push(wire_node(db, node).await?);
+    }
+    let edges = data.edges.into_iter().map(wire_edge).collect();
+    Ok(PageMapResponse {
+        page_id: page_id.to_string(),
+        revision: data.map.revision,
+        map_schema: data.map.map_schema,
+        viewport,
+        nodes,
+        edges,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MapIncludeQuery {
+    #[serde(default)]
+    pub include: Option<String>,
+}
+
+/// GET /api/pages/{id}/map
+///
+/// 200 always for an existing page: an absent map synthesizes the empty
+/// shape (`revision: 0`, no nodes/edges) rather than 404ing or
+/// auto-creating a `page_maps` row. 404 only when the page itself doesn't
+/// exist.
+pub async fn handle_get_page_map(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(page_id): Path<String>,
+    Query(query): Query<MapIncludeQuery>,
+) -> Result<Json<PageMapResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let include_dismissed = query.include.as_deref() == Some("dismissed");
+    let data = db.get_page_map(&page_id, include_dismissed).await?;
+    let response = match data {
+        Some(data) => build_map_response(&db, &page_id, data).await?,
+        None => PageMapResponse {
+            page_id,
+            revision: 0,
+            map_schema: 1,
+            viewport: None,
+            nodes: vec![],
+            edges: vec![],
+        },
+    };
+    Ok(Json(response))
+}
+
+/// PUT /api/pages/{id}/map/layout
+pub async fn handle_put_page_map_layout(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(page_id): Path<String>,
+    Json(req): Json<PutPageMapLayoutRequest>,
+) -> Result<Json<PageMapResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let viewport_json = req
+        .viewport
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|e| ServerError::BadRequest(format!("invalid viewport: {e}")))?;
+    let positions: Vec<NodeLayout> = req
+        .positions
+        .into_iter()
+        .map(|p| NodeLayout {
+            node_id: p.node_id,
+            x: p.x,
+            y: p.y,
+            width: p.width,
+            height: p.height,
+            collapsed: p.collapsed,
+        })
+        .collect();
+
+    let data = db
+        .put_page_map_layout(
+            &page_id,
+            req.base_revision,
+            viewport_json.as_deref(),
+            &positions,
+        )
+        .await?;
+    Ok(Json(build_map_response(&db, &page_id, data).await?))
+}
+
+/// POST /api/pages/{id}/map/nodes
+///
+/// First mutation against a never-initialized map: `init_page_map` runs
+/// (idempotent) before the create. When the map was absent, the client's
+/// `base_revision` is necessarily a guess (GET synthesizes `revision: 0`
+/// for an absent map — a sentinel, not a real CAS token, since no
+/// `page_maps` row ever existed to be stale against), so the freshly
+/// initialized revision is used instead of trusting it; once a map
+/// exists, `base_revision` reverts to a normal conditional write. A
+/// `parent_id` of `None` attaches under the map's root, resolved here so
+/// the very first node can be created without the client already knowing
+/// the root's freshly-minted id.
+pub async fn handle_create_map_node(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(page_id): Path<String>,
+    Json(req): Json<CreateMapNodeRequest>,
+) -> Result<Json<NodeMutationResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let ref_kind = req
+        .ref_kind
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("ref_kind is required".to_string()))?;
+    let ref_id = req
+        .ref_id
+        .as_deref()
+        .ok_or_else(|| ServerError::BadRequest("ref_id is required".to_string()))?;
+
+    let was_absent = db.get_page_map(&page_id, true).await?.is_none();
+    let map = db.init_page_map(&page_id).await?;
+    let parent_id = match req.parent_id.clone() {
+        Some(id) => id,
+        None => root_node_id(&map.nodes)
+            .ok_or_else(|| ServerError::Internal("page map has no root node".to_string()))?,
+    };
+    let base_revision = if was_absent {
+        map.map.revision
+    } else {
+        req.base_revision
+    };
+
+    let outcome = db
+        .create_map_node(
+            &page_id,
+            base_revision,
+            &parent_id,
+            ref_kind,
+            ref_id,
+            req.label.as_deref(),
+            req.rank,
+        )
+        .await?;
+
+    match outcome {
+        CreateNodeOutcome::Created(node) => Ok(Json(NodeMutationResponse {
+            revision: base_revision + 1,
+            node: wire_node(&db, node).await?,
+        })),
+        CreateNodeOutcome::Duplicate(node) => Ok(Json(NodeMutationResponse {
+            revision: base_revision,
+            node: wire_node(&db, node).await?,
+        })),
+        CreateNodeOutcome::Tombstoned => Err(ServerError::Conflict(format!(
+            "node for {ref_kind}:{ref_id} was previously dismissed under this parent"
+        ))),
+    }
+}
+
+/// PATCH /api/pages/{id}/map/nodes/{node_id}
+pub async fn handle_patch_map_node(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path((page_id, node_id)): Path<(String, String)>,
+    Json(req): Json<PatchMapNodeRequest>,
+) -> Result<Json<NodeMutationResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let base_revision = req.base_revision;
+    let patch = NodePatch {
+        label: req.label,
+        pinned: req.pinned,
+        status: req.status,
+        rank: req.rank,
+        parent_id: req.parent_id,
+    };
+    let node = db
+        .patch_map_node(&page_id, base_revision, &node_id, patch)
+        .await?;
+    Ok(Json(NodeMutationResponse {
+        revision: base_revision + 1,
+        node: wire_node(&db, node).await?,
+    }))
+}
+
+/// DELETE /api/pages/{id}/map/nodes/{node_id}
+pub async fn handle_delete_map_node(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path((page_id, node_id)): Path<(String, String)>,
+    Json(req): Json<DeleteMapNodeRequest>,
+) -> Result<Json<NodeMutationResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let node = db
+        .delete_map_node(&page_id, req.base_revision, &node_id)
+        .await?;
+    Ok(Json(NodeMutationResponse {
+        revision: req.base_revision + 1,
+        node: wire_node(&db, node).await?,
+    }))
+}
+
+/// POST /api/pages/{id}/map/edges
+///
+/// Unlike node creation, edges never need init-if-absent: an edge always
+/// references existing node ids, which cannot exist unless the map was
+/// already initialized (by an earlier node create) — so a genuinely
+/// absent map surfaces its natural 404 here.
+pub async fn handle_create_map_edge(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(page_id): Path<String>,
+    Json(req): Json<CreateMapEdgeRequest>,
+) -> Result<Json<EdgeMutationResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let outcome = db
+        .create_map_edge(
+            &page_id,
+            req.base_revision,
+            &req.from_node,
+            &req.to_node,
+            &req.kind,
+            req.label.as_deref(),
+        )
+        .await?;
+
+    match outcome {
+        CreateEdgeOutcome::Created(edge) => Ok(Json(EdgeMutationResponse {
+            revision: req.base_revision + 1,
+            edge: wire_edge(edge),
+        })),
+        CreateEdgeOutcome::Duplicate(edge) => Ok(Json(EdgeMutationResponse {
+            revision: req.base_revision,
+            edge: wire_edge(edge),
+        })),
+        CreateEdgeOutcome::Tombstoned => Err(ServerError::Conflict(format!(
+            "edge {} -> {} ({}) was previously dismissed",
+            req.from_node, req.to_node, req.kind
+        ))),
+    }
+}
+
+/// PATCH /api/pages/{id}/map/edges/{edge_id}
+pub async fn handle_patch_map_edge(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path((page_id, edge_id)): Path<(String, String)>,
+    Json(req): Json<PatchMapEdgeRequest>,
+) -> Result<Json<EdgeMutationResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let base_revision = req.base_revision;
+    let patch = EdgePatch {
+        label: req.label,
+        status: req.status,
+    };
+    let edge = db
+        .patch_map_edge(&page_id, base_revision, &edge_id, patch)
+        .await?;
+    Ok(Json(EdgeMutationResponse {
+        revision: base_revision + 1,
+        edge: wire_edge(edge),
+    }))
+}
+
+/// DELETE /api/pages/{id}/map/edges/{edge_id}
+pub async fn handle_delete_map_edge(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path((page_id, edge_id)): Path<(String, String)>,
+    Json(req): Json<DeleteMapEdgeRequest>,
+) -> Result<Json<EdgeMutationResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    let edge = db
+        .delete_map_edge(&page_id, req.base_revision, &edge_id)
+        .await?;
+    Ok(Json(EdgeMutationResponse {
+        revision: req.base_revision + 1,
+        edge: wire_edge(edge),
+    }))
+}
+
+/// DELETE /api/pages/{id}/map (reset)
+pub async fn handle_reset_page_map(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(page_id): Path<String>,
+) -> Result<Json<serde_json::Value>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    db.reset_page_map(&page_id).await?;
+    Ok(Json(serde_json::json!({"status": "reset"})))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn new_test_db() -> (Arc<MemoryDB>, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().unwrap();
+        let emitter: Arc<dyn wenlan_core::events::EventEmitter> =
+            Arc::new(wenlan_core::events::NoopEmitter);
+        let db = MemoryDB::new(tmp.path(), emitter).await.unwrap();
+        (Arc::new(db), tmp)
+    }
+
+    async fn seed_test_page(db: &MemoryDB, title: &str) -> String {
+        let source_id = format!("src-{title}");
+        let source = wenlan_core::sources::RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.clone(),
+            title: format!("memory-{source_id}"),
+            content: format!("{title} body content for testing"),
+            memory_type: Some("fact".to_string()),
+            space: Some("default".to_string()),
+            source_agent: Some("test-agent".to_string()),
+            confidence: Some(0.9),
+            confirmed: Some(true),
+            ..Default::default()
+        };
+        db.upsert_documents(vec![source]).await.unwrap();
+        let result = wenlan_core::post_write::create_page_with_tuning(
+            db,
+            wenlan_types::requests::CreateConceptRequest {
+                title: title.to_string(),
+                content: format!("{title} body content for testing"),
+                summary: None,
+                entity_id: None,
+                source_memory_ids: vec![source_id],
+                creation_kind: Some("distilled".to_string()),
+                space: Some("default".to_string()),
+                workspace: Some("default".to_string()),
+            },
+            "test",
+            None,
+            1,
+            1.1, // forces a new page rather than clustering into an existing one
+        )
+        .await
+        .unwrap();
+        result.id
+    }
+
+    async fn seed_memory(db: &MemoryDB, source_id: &str) {
+        let mem = wenlan_core::sources::RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.to_string(),
+            title: format!("memory-{source_id}"),
+            content: "test memory content".to_string(),
+            memory_type: Some("fact".to_string()),
+            space: Some("default".to_string()),
+            source_agent: Some("test-agent".to_string()),
+            confidence: Some(0.9),
+            confirmed: Some(true),
+            ..Default::default()
+        };
+        db.upsert_documents(vec![mem]).await.unwrap();
+    }
+
+    fn state_with_db(db: Arc<MemoryDB>) -> Arc<RwLock<ServerState>> {
+        Arc::new(RwLock::new(ServerState {
+            db: Some(db),
+            ..Default::default()
+        }))
+    }
+
+    fn create_node_request(ref_id: &str, base_revision: i64) -> CreateMapNodeRequest {
+        CreateMapNodeRequest {
+            base_revision,
+            parent_id: None,
+            ref_kind: Some("memory".to_string()),
+            ref_id: Some(ref_id.to_string()),
+            label: None,
+            rank: 0.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_page_map_returns_empty_shape_for_absent_map() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Absent Map Page").await;
+        let state = state_with_db(db);
+
+        let Json(response) = handle_get_page_map(
+            State(state),
+            Path(page_id.clone()),
+            Query(MapIncludeQuery { include: None }),
+        )
+        .await
+        .expect("absent map should return 200, not 404");
+
+        assert_eq!(response.page_id, page_id);
+        assert_eq!(response.revision, 0);
+        assert!(response.nodes.is_empty());
+        assert!(response.edges.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_page_map_returns_404_for_unknown_page() {
+        let (db, _tmp) = new_test_db().await;
+        let state = state_with_db(db);
+
+        let result = handle_get_page_map(
+            State(state),
+            Path("nonexistent-page".to_string()),
+            Query(MapIncludeQuery { include: None }),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::NotFound(_)) => {}
+            _ => panic!("expected NotFound for unknown page"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_map_node_rejects_missing_ref_kind_with_400() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Node 400 Page").await;
+        let state = state_with_db(db);
+
+        let result = handle_create_map_node(
+            State(state),
+            Path(page_id),
+            Json(CreateMapNodeRequest {
+                base_revision: 0,
+                parent_id: None,
+                ref_kind: None,
+                ref_id: Some("mem-1".to_string()),
+                label: None,
+                rank: 0.0,
+            }),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::BadRequest(_)) => {}
+            _ => panic!("expected BadRequest for missing ref_kind"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_map_node_returns_404_for_unknown_page() {
+        let (db, _tmp) = new_test_db().await;
+        let state = state_with_db(db);
+
+        let result = handle_create_map_node(
+            State(state),
+            Path("nonexistent-page".to_string()),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::NotFound(_)) => {}
+            _ => panic!("expected NotFound for unknown page"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_map_node_succeeds_as_first_mutation_against_absent_map() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "First Mutation Page").await;
+        seed_memory(&db, "mem-1").await;
+        let state = state_with_db(db);
+
+        // The client would have seen revision 0 from a GET on the
+        // never-initialized map (the "absent map" contract) and naturally
+        // sends that back as base_revision.
+        let Json(response) = handle_create_map_node(
+            State(state),
+            Path(page_id),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await
+        .expect("first node creation against an absent map should succeed, not conflict");
+
+        // init_page_map bumps an absent map to revision 1, then the create bumps to 2.
+        assert_eq!(response.revision, 2);
+        assert_eq!(response.node.ref_kind, "memory");
+        assert_eq!(response.node.ref_state, RefState::Live);
+    }
+
+    #[tokio::test]
+    async fn create_map_node_duplicate_returns_200_with_existing_row() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Duplicate Page").await;
+        seed_memory(&db, "mem-1").await;
+        let state = state_with_db(db);
+
+        let Json(first) = handle_create_map_node(
+            State(state.clone()),
+            Path(page_id.clone()),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await
+        .unwrap();
+
+        let Json(second) = handle_create_map_node(
+            State(state),
+            Path(page_id),
+            Json(create_node_request("mem-1", first.revision)),
+        )
+        .await
+        .expect("duplicate proposal should succeed as 200, not error");
+
+        assert_eq!(second.node.id, first.node.id);
+        assert_eq!(
+            second.revision, first.revision,
+            "duplicate never bumps revision"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_map_node_tombstoned_returns_409() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Tombstone Page").await;
+        seed_memory(&db, "mem-1").await;
+        let state = state_with_db(db);
+
+        let Json(created) = handle_create_map_node(
+            State(state.clone()),
+            Path(page_id.clone()),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await
+        .unwrap();
+
+        let Json(deleted) = handle_delete_map_node(
+            State(state.clone()),
+            Path((page_id.clone(), created.node.id.clone())),
+            Json(DeleteMapNodeRequest {
+                base_revision: created.revision,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let result = handle_create_map_node(
+            State(state),
+            Path(page_id),
+            Json(create_node_request("mem-1", deleted.revision)),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::Conflict(_)) => {}
+            _ => panic!("expected Conflict (409) for a tombstoned fingerprint"),
+        }
+    }
+
+    #[tokio::test]
+    async fn patch_map_node_rejects_stale_base_revision_with_409() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Stale Revision Page").await;
+        seed_memory(&db, "mem-1").await;
+        let state = state_with_db(db);
+
+        let Json(created) = handle_create_map_node(
+            State(state.clone()),
+            Path(page_id.clone()),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await
+        .unwrap();
+        let stale_revision = created.revision;
+
+        let Json(patched) = handle_patch_map_node(
+            State(state.clone()),
+            Path((page_id.clone(), created.node.id.clone())),
+            Json(PatchMapNodeRequest {
+                base_revision: stale_revision,
+                label: None,
+                pinned: None,
+                status: None,
+                rank: Some(5.0),
+                parent_id: None,
+            }),
+        )
+        .await
+        .expect("patch with the correct base_revision should succeed");
+        assert_eq!(
+            patched.revision,
+            stale_revision + 1,
+            "base_revision round-trips to revision + 1"
+        );
+
+        let result = handle_patch_map_node(
+            State(state),
+            Path((page_id, created.node.id)),
+            Json(PatchMapNodeRequest {
+                base_revision: stale_revision,
+                label: None,
+                pinned: None,
+                status: None,
+                rank: Some(9.0),
+                parent_id: None,
+            }),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::Conflict(_)) => {}
+            _ => panic!("expected Conflict (409) for stale base_revision"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_map_node_rejects_root_dismissal_with_422() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Root Protect Page").await;
+        let map = db.init_page_map(&page_id).await.unwrap();
+        let root_id = map.nodes[0].id.clone();
+        let base_revision = map.map.revision;
+        let state = state_with_db(db);
+
+        let result = handle_delete_map_node(
+            State(state),
+            Path((page_id, root_id)),
+            Json(DeleteMapNodeRequest { base_revision }),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::ValidationError(_)) => {}
+            _ => panic!("expected ValidationError (422) for root dismissal"),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_page_map_include_dismissed_toggles_visibility() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Include Dismissed Page").await;
+        seed_memory(&db, "mem-1").await;
+        let state = state_with_db(db);
+
+        let Json(created) = handle_create_map_node(
+            State(state.clone()),
+            Path(page_id.clone()),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await
+        .unwrap();
+        let _ = handle_delete_map_node(
+            State(state.clone()),
+            Path((page_id.clone(), created.node.id.clone())),
+            Json(DeleteMapNodeRequest {
+                base_revision: created.revision,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let Json(without) = handle_get_page_map(
+            State(state.clone()),
+            Path(page_id.clone()),
+            Query(MapIncludeQuery { include: None }),
+        )
+        .await
+        .unwrap();
+        assert!(
+            without.nodes.iter().all(|n| n.id != created.node.id),
+            "dismissed node must be excluded by default"
+        );
+
+        let Json(with) = handle_get_page_map(
+            State(state),
+            Path(page_id),
+            Query(MapIncludeQuery {
+                include: Some("dismissed".to_string()),
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(
+            with.nodes.iter().any(|n| n.id == created.node.id),
+            "?include=dismissed must surface the dismissed node"
+        );
+    }
+}

--- a/crates/wenlan-server/src/page_map_routes.rs
+++ b/crates/wenlan-server/src/page_map_routes.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Page Map (mind-map) v1 HTTP routes — stage 2 of the daemon feature. See
+//! Page Map (mind-map) v1 HTTP routes. See
 //! docs/superpowers/plans/2026-07-18-page-map-api-spec.md for the full
 //! contract; this module wires the wenlan-core data layer
 //! (`db::page_map`) to HTTP, staying thin per the crate boundary rule (no
-//! business logic here). `POST .../map/improve` (stage 3) is out of scope.
+//! business logic here). The improve pass itself lives in
+//! `wenlan_core::page_map_improve`; `handle_improve_page_map` only invokes it.
 
 use std::sync::Arc;
 
@@ -434,6 +435,47 @@ pub async fn handle_reset_page_map(
     Ok(Json(serde_json::json!({"status": "reset"})))
 }
 
+/// POST /api/pages/{id}/map/improve
+///
+/// Synchronous (mirrors `POST /api/steep`): runs the improve pass for this one
+/// page inline, then returns the refreshed map. INSERT-ONLY — the pass appends
+/// `status = 'suggested'` nodes/edges grounded in the page's real objects
+/// (entity, markdown sections, source memories, resolved wikilinks) and never
+/// touches an existing row; see `wenlan_core::page_map_improve`. This route is
+/// NEVER gated by the `page_map_auto_suggest` config flag — that flag gates only
+/// the background scheduler phase (`refinery::Phase::PageMaps`). Returns the
+/// full `PageMapResponse` (excluding dismissed rows) so the client reuses the
+/// same render path as GET; the freshly-suggested nodes surface with
+/// `status = "suggested"`.
+pub async fn handle_improve_page_map(
+    State(state): State<Arc<RwLock<ServerState>>>,
+    Path(page_id): Path<String>,
+) -> Result<Json<PageMapResponse>, ServerError> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone().ok_or(ServerError::DbNotInitialized)?
+    };
+    ensure_page_exists(&db, &page_id).await?;
+
+    wenlan_core::page_map_improve::improve_page_map(&db, &page_id).await?;
+
+    // The pass always init's the map, so `get_page_map` returns Some here; the
+    // None arm is defensive and mirrors GET's empty-map shape.
+    let data = db.get_page_map(&page_id, false).await?;
+    let response = match data {
+        Some(data) => build_map_response(&db, &page_id, data).await?,
+        None => PageMapResponse {
+            page_id,
+            revision: 0,
+            map_schema: 1,
+            viewport: None,
+            nodes: vec![],
+            edges: vec![],
+        },
+    };
+    Ok(Json(response))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -817,6 +859,101 @@ mod tests {
         assert!(
             with.nodes.iter().any(|n| n.id == created.node.id),
             "?include=dismissed must surface the dismissed node"
+        );
+    }
+
+    #[tokio::test]
+    async fn improve_page_map_suggests_and_bumps_revision() {
+        let (db, _tmp) = new_test_db().await;
+        // seed_test_page attaches one source memory (`src-{title}`), which the
+        // improve pass turns into a suggested memory node.
+        let page_id = seed_test_page(&db, "Improve Route Page").await;
+        let state = state_with_db(db);
+
+        let Json(response) = handle_improve_page_map(State(state), Path(page_id.clone()))
+            .await
+            .expect("improve should return 200 for an existing page");
+
+        assert_eq!(response.page_id, page_id);
+        // init_page_map lifts the absent-map sentinel (0) to revision 1, then
+        // the suggested memory node bumps it again.
+        assert!(
+            response.revision >= 1,
+            "improve must bump the revision off the absent-map sentinel, got {}",
+            response.revision
+        );
+        assert!(
+            response.nodes.iter().any(|n| n.status == "suggested"),
+            "improve must surface at least one suggested node"
+        );
+    }
+
+    #[tokio::test]
+    async fn improve_page_map_404s_for_unknown_page() {
+        let (db, _tmp) = new_test_db().await;
+        let state = state_with_db(db);
+
+        let result =
+            handle_improve_page_map(State(state), Path("nonexistent-page".to_string())).await;
+
+        match result {
+            Err(ServerError::NotFound(_)) => {}
+            _ => panic!("expected NotFound for unknown page"),
+        }
+    }
+
+    // Regression guard: the explicit improve route must NEVER be gated by the
+    // `page_map_auto_suggest` config flag (that flag gates only the background
+    // `refinery::Phase::PageMaps` scheduler phase). We write a config with the
+    // flag OFF into a temp data dir, then confirm the handler still produces
+    // suggestions. Because the handler does not read config at all, this test
+    // is race-safe under cargo's parallel test threads (a concurrently-set
+    // `WENLAN_DATA_DIR` cannot change the handler's behavior); its teeth are on
+    // a *future* regression that wrongly wires the flag into this route.
+    #[tokio::test]
+    async fn improve_page_map_runs_when_auto_suggest_disabled() {
+        struct DataDirGuard {
+            _tmp: tempfile::TempDir,
+            previous: Option<std::ffi::OsString>,
+        }
+        impl DataDirGuard {
+            fn new() -> Self {
+                let tmp = tempfile::tempdir().unwrap();
+                let previous = std::env::var_os("WENLAN_DATA_DIR");
+                std::env::set_var("WENLAN_DATA_DIR", tmp.path());
+                Self {
+                    _tmp: tmp,
+                    previous,
+                }
+            }
+        }
+        impl Drop for DataDirGuard {
+            fn drop(&mut self) {
+                match &self.previous {
+                    Some(value) => std::env::set_var("WENLAN_DATA_DIR", value),
+                    None => std::env::remove_var("WENLAN_DATA_DIR"),
+                }
+            }
+        }
+
+        let _env = DataDirGuard::new();
+        // Empty temp data dir → load_config returns defaults; set the flag OFF
+        // explicitly and persist it, so a hypothetical future gating of this
+        // route on the flag would read `false`.
+        let mut cfg = wenlan_core::config::load_config();
+        cfg.page_map_auto_suggest = false;
+        wenlan_core::config::save_config(&cfg).unwrap();
+
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Disabled Flag Page").await;
+        let state = state_with_db(db);
+
+        let Json(response) = handle_improve_page_map(State(state), Path(page_id))
+            .await
+            .expect("explicit improve must run even with auto_suggest disabled");
+        assert!(
+            response.nodes.iter().any(|n| n.status == "suggested"),
+            "explicit improve route must suggest regardless of the config flag"
         );
     }
 }

--- a/crates/wenlan-server/src/page_map_routes.rs
+++ b/crates/wenlan-server/src/page_map_routes.rs
@@ -43,10 +43,11 @@ fn root_node_id(nodes: &[CoreNode]) -> Option<String> {
 }
 
 /// `ref_state` is computed at read time, never stored: live iff the node's
-/// backing object still resolves. `section` refs are simplified to "live
-/// iff the parent page exists" (the full heading-existence check is
-/// deferred; `ref_id` is `"{page_id}#{heading-slug}"`, so the page id is
-/// everything before the first `#`).
+/// backing object still resolves. `section` refs additionally check that the
+/// heading itself is still present in the page's content (`ref_id` is
+/// `"{page_id}#{heading-slug}"`), reusing `wenlan_core::page_map_improve`'s
+/// exact heading extraction + slug function so this never duplicates that
+/// logic.
 async fn compute_ref_state(
     db: &MemoryDB,
     ref_kind: &str,
@@ -57,7 +58,12 @@ async fn compute_ref_state(
         "entity" => db.get_entity_name_type(ref_id).await?.is_some(),
         "page" => db.get_page(ref_id).await?.is_some(),
         "section" => match ref_id.split_once('#') {
-            Some((page_id, _heading_slug)) => db.get_page(page_id).await?.is_some(),
+            Some((page_id, heading_slug)) => match db.get_page(page_id).await? {
+                Some(page) => wenlan_core::page_map_improve::extract_headings(&page.content)
+                    .iter()
+                    .any(|h| wenlan_core::export::obsidian::slugify(h) == heading_slug),
+                None => false,
+            },
             None => false,
         },
         _ => false,
@@ -210,15 +216,17 @@ pub async fn handle_put_page_map_layout(
 /// POST /api/pages/{id}/map/nodes
 ///
 /// First mutation against a never-initialized map: `init_page_map` runs
-/// (idempotent) before the create. When the map was absent, the client's
-/// `base_revision` is necessarily a guess (GET synthesizes `revision: 0`
-/// for an absent map — a sentinel, not a real CAS token, since no
-/// `page_maps` row ever existed to be stale against), so the freshly
-/// initialized revision is used instead of trusting it; once a map
-/// exists, `base_revision` reverts to a normal conditional write. A
-/// `parent_id` of `None` attaches under the map's root, resolved here so
-/// the very first node can be created without the client already knowing
-/// the root's freshly-minted id.
+/// (idempotent) before the create. When THIS call's `init_page_map` is the
+/// one that atomically performed the insert (`created == true`, decided from
+/// the INSERT's own `rows_affected`, not a separate pre-check), the client's
+/// `base_revision` is necessarily a guess (GET synthesizes `revision: 0` for
+/// an absent map — a sentinel, not a real CAS token, since no `page_maps` row
+/// ever existed to be stale against), so the freshly initialized revision is
+/// used instead of trusting it; otherwise `base_revision` is enforced as a
+/// normal conditional write (a stale `base_revision` 409s even though the map
+/// already existed before this request). A `parent_id` of `None` attaches
+/// under the map's root, resolved here so the very first node can be created
+/// without the client already knowing the root's freshly-minted id.
 pub async fn handle_create_map_node(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(page_id): Path<String>,
@@ -239,14 +247,13 @@ pub async fn handle_create_map_node(
         .as_deref()
         .ok_or_else(|| ServerError::BadRequest("ref_id is required".to_string()))?;
 
-    let was_absent = db.get_page_map(&page_id, true).await?.is_none();
-    let map = db.init_page_map(&page_id).await?;
+    let (map, created) = db.init_page_map(&page_id).await?;
     let parent_id = match req.parent_id.clone() {
         Some(id) => id,
         None => root_node_id(&map.nodes)
             .ok_or_else(|| ServerError::Internal("page map has no root node".to_string()))?,
     };
-    let base_revision = if was_absent {
+    let base_revision = if created {
         map.map.revision
     } else {
         req.base_revision
@@ -508,6 +515,43 @@ mod tests {
             wenlan_types::requests::CreateConceptRequest {
                 title: title.to_string(),
                 content: format!("{title} body content for testing"),
+                summary: None,
+                entity_id: None,
+                source_memory_ids: vec![source_id],
+                creation_kind: Some("distilled".to_string()),
+                space: Some("default".to_string()),
+                workspace: Some("default".to_string()),
+            },
+            "test",
+            None,
+            1,
+            1.1, // forces a new page rather than clustering into an existing one
+        )
+        .await
+        .unwrap();
+        result.id
+    }
+
+    async fn seed_page_with_content(db: &MemoryDB, title: &str, content: &str) -> String {
+        let source_id = format!("src-{title}");
+        let source = wenlan_core::sources::RawDocument {
+            source: "memory".to_string(),
+            source_id: source_id.clone(),
+            title: format!("memory-{source_id}"),
+            content: content.to_string(),
+            memory_type: Some("fact".to_string()),
+            space: Some("default".to_string()),
+            source_agent: Some("test-agent".to_string()),
+            confidence: Some(0.9),
+            confirmed: Some(true),
+            ..Default::default()
+        };
+        db.upsert_documents(vec![source]).await.unwrap();
+        let result = wenlan_core::post_write::create_page_with_tuning(
+            db,
+            wenlan_types::requests::CreateConceptRequest {
+                title: title.to_string(),
+                content: content.to_string(),
                 summary: None,
                 entity_id: None,
                 source_memory_ids: vec![source_id],
@@ -793,7 +837,7 @@ mod tests {
     async fn delete_map_node_rejects_root_dismissal_with_422() {
         let (db, _tmp) = new_test_db().await;
         let page_id = seed_test_page(&db, "Root Protect Page").await;
-        let map = db.init_page_map(&page_id).await.unwrap();
+        let (map, _created) = db.init_page_map(&page_id).await.unwrap();
         let root_id = map.nodes[0].id.clone();
         let base_revision = map.map.revision;
         let state = state_with_db(db);
@@ -954,6 +998,54 @@ mod tests {
         assert!(
             response.nodes.iter().any(|n| n.status == "suggested"),
             "explicit improve route must suggest regardless of the config flag"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_map_node_rejects_stale_zero_base_revision_once_map_exists() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_test_page(&db, "Existing Map Page").await;
+        seed_memory(&db, "mem-1").await;
+
+        // Simulate an actor that already initialized the map before this
+        // request's own init call runs.
+        let (_pre, created) = db.init_page_map(&page_id).await.unwrap();
+        assert!(created);
+
+        let state = state_with_db(db);
+        let result = handle_create_map_node(
+            State(state),
+            Path(page_id),
+            Json(create_node_request("mem-1", 0)),
+        )
+        .await;
+
+        match result {
+            Err(ServerError::Conflict(_)) => {}
+            _ => panic!("expected 409 for stale base_revision=0 once the map already exists"),
+        }
+    }
+
+    #[tokio::test]
+    async fn compute_ref_state_section_dangles_when_heading_removed() {
+        let (db, _tmp) = new_test_db().await;
+        let page_id = seed_page_with_content(&db, "Section Removal Page", "# Overview\nbody").await;
+        let slug = wenlan_core::export::obsidian::slugify("Overview");
+        let ref_id = format!("{page_id}#{slug}");
+
+        assert_eq!(
+            compute_ref_state(&db, "section", &ref_id).await.unwrap(),
+            RefState::Live
+        );
+
+        // Heading removed from the page's own content.
+        db.update_page_content(&page_id, "no headings here anymore", &[], "test")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            compute_ref_state(&db, "section", &ref_id).await.unwrap(),
+            RefState::Dangling
         );
     }
 }

--- a/crates/wenlan-server/src/route_registry.rs
+++ b/crates/wenlan-server/src/route_registry.rs
@@ -33,6 +33,7 @@ enum RegisteredMethod {
     Post,
     Put,
     Delete,
+    Patch,
 }
 
 impl RegisteredMethod {
@@ -40,7 +41,7 @@ impl RegisteredMethod {
         match self {
             Self::Get => Some(Method::Get),
             Self::Post => Some(Method::Post),
-            Self::Put | Self::Delete => None,
+            Self::Put | Self::Delete | Self::Patch => None,
         }
     }
 }
@@ -65,6 +66,7 @@ top_level_method!(get, Get);
 top_level_method!(post, Post);
 top_level_method!(put, Put);
 top_level_method!(delete, Delete);
+top_level_method!(patch, Patch);
 
 impl<S> TrackedMethodRouter<S>
 where
@@ -191,6 +193,8 @@ const NON_SENSITIVE_PATHS: &[&str] = &[
     "/api/memory/{id}/correct", "/api/profile/narrative/regenerate", "/api/memory/{id}/pin", "/api/memory/{id}/unpin",
     "/api/snapshots/{id}/delete", "/api/memory/{id}/update-page", "/api/knowledge/path",
     "/api/onboarding/milestones/{id}/acknowledge", "/api/onboarding/reset", "/ws/updates",
+    "/api/pages/{id}/map/layout", "/api/pages/{id}/map/nodes", "/api/pages/{id}/map/edges",
+    "/api/pages/{id}/map/nodes/{node_id}", "/api/pages/{id}/map/edges/{edge_id}",
 ];
 
 const NON_SENSITIVE_MIXED_ROUTES: &[(RegisteredMethod, &str)] = &[
@@ -204,6 +208,7 @@ const NON_SENSITIVE_MIXED_ROUTES: &[(RegisteredMethod, &str)] = &[
     (RegisteredMethod::Put, "/api/pages/{id}"),
     (RegisteredMethod::Delete, "/api/pages/{id}"),
     (RegisteredMethod::Post, "/api/sources"),
+    (RegisteredMethod::Delete, "/api/pages/{id}/map"),
 ];
 
 #[cfg(test)]

--- a/crates/wenlan-server/src/route_registry.rs
+++ b/crates/wenlan-server/src/route_registry.rs
@@ -195,6 +195,7 @@ const NON_SENSITIVE_PATHS: &[&str] = &[
     "/api/onboarding/milestones/{id}/acknowledge", "/api/onboarding/reset", "/ws/updates",
     "/api/pages/{id}/map/layout", "/api/pages/{id}/map/nodes", "/api/pages/{id}/map/edges",
     "/api/pages/{id}/map/nodes/{node_id}", "/api/pages/{id}/map/edges/{edge_id}",
+    "/api/pages/{id}/map/improve",
 ];
 
 const NON_SENSITIVE_MIXED_ROUTES: &[(RegisteredMethod, &str)] = &[

--- a/crates/wenlan-server/src/router.rs
+++ b/crates/wenlan-server/src/router.rs
@@ -272,6 +272,10 @@ pub fn build_router(state: SharedState) -> AppRouter {
                 .delete(page_map_routes::handle_delete_map_edge),
         )
         .route(
+            "/api/pages/{id}/map/improve",
+            post(page_map_routes::handle_improve_page_map),
+        )
+        .route(
             "/api/memory/{id}/revisions",
             get(memory_routes::handle_get_memory_revisions),
         )

--- a/crates/wenlan-server/src/router.rs
+++ b/crates/wenlan-server/src/router.rs
@@ -2,11 +2,12 @@
 //! Axum router construction — wires all HTTP and WebSocket routes.
 
 pub use crate::route_registry::AppRouter;
-use crate::route_registry::{delete, get, post, put, TrackedRouter};
+use crate::route_registry::{delete, get, patch, post, put, TrackedRouter};
 use crate::state::SharedState;
 use crate::{
     config_routes, import_routes, ingest_routes, knowledge_routes, lint_routes, memory_routes,
-    onboarding_routes, refinery_routes, routes, security, source_routes, websocket,
+    onboarding_routes, page_map_routes, refinery_routes, routes, security, source_routes,
+    websocket,
 };
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
@@ -241,6 +242,34 @@ pub fn build_router(state: SharedState) -> AppRouter {
         .route(
             "/api/pages/{id}/revisions",
             get(memory_routes::handle_get_page_revisions),
+        )
+        // Page Map (mind-map v1, stage 2)
+        .route(
+            "/api/pages/{id}/map",
+            get(page_map_routes::handle_get_page_map)
+                .delete(page_map_routes::handle_reset_page_map),
+        )
+        .route(
+            "/api/pages/{id}/map/layout",
+            put(page_map_routes::handle_put_page_map_layout),
+        )
+        .route(
+            "/api/pages/{id}/map/nodes",
+            post(page_map_routes::handle_create_map_node),
+        )
+        .route(
+            "/api/pages/{id}/map/nodes/{node_id}",
+            patch(page_map_routes::handle_patch_map_node)
+                .delete(page_map_routes::handle_delete_map_node),
+        )
+        .route(
+            "/api/pages/{id}/map/edges",
+            post(page_map_routes::handle_create_map_edge),
+        )
+        .route(
+            "/api/pages/{id}/map/edges/{edge_id}",
+            patch(page_map_routes::handle_patch_map_edge)
+                .delete(page_map_routes::handle_delete_map_edge),
         )
         .route(
             "/api/memory/{id}/revisions",

--- a/crates/wenlan-server/src/sensitive_read_routes/tests.rs
+++ b/crates/wenlan-server/src/sensitive_read_routes/tests.rs
@@ -125,6 +125,7 @@ fn canonical_matrix_freezes_exact_global_and_scoped_keys() {
         (Method::Get, "/api/pages/{id}/sources"),
         (Method::Get, "/api/pages/{id}/links"),
         (Method::Get, "/api/pages/{id}/revisions"),
+        (Method::Get, "/api/pages/{id}/map"),
         (Method::Post, "/api/memory/entities/list"),
         (Method::Post, "/api/memory/entities/search"),
         (Method::Get, "/api/memory/entities/{entity_id}"),
@@ -148,8 +149,8 @@ fn canonical_matrix_freezes_exact_global_and_scoped_keys() {
         .map(|row| (row.method, row.path))
         .collect::<BTreeSet<_>>();
 
-    assert_eq!(rows.len(), 57);
-    assert_eq!(keys.len(), 57, "duplicate sensitive route key");
+    assert_eq!(rows.len(), 58);
+    assert_eq!(keys.len(), 58, "duplicate sensitive route key");
     assert_eq!(global, GLOBAL.iter().copied().collect());
     assert_eq!(scoped, SCOPED.iter().copied().collect());
     assert_eq!(

--- a/crates/wenlan-server/tests/space_scoping/case_runner.rs
+++ b/crates/wenlan-server/tests/space_scoping/case_runner.rs
@@ -370,7 +370,7 @@ pub fn assert_wave_4_knowledge_catalog_contract() {
     }
 
     let rows = wenlan_server::sensitive_read_routes::sensitive_read_routes().collect::<Vec<_>>();
-    assert_eq!(rows.len(), 57);
+    assert_eq!(rows.len(), 58);
     assert_eq!(
         rows.iter()
             .filter(|row| row.scope_binding == ScopeBinding::Global)
@@ -381,7 +381,7 @@ pub fn assert_wave_4_knowledge_catalog_contract() {
         rows.iter()
             .filter(|row| row.scope_binding != ScopeBinding::Global)
             .count(),
-        42
+        43
     );
     assert_eq!(
         rows.iter()

--- a/crates/wenlan-types/src/lib.rs
+++ b/crates/wenlan-types/src/lib.rs
@@ -15,6 +15,7 @@ pub mod memory;
 pub mod memory_type;
 pub mod narrative;
 pub mod onboarding;
+pub mod page_map;
 pub mod pages;
 pub mod requests;
 pub mod responses;

--- a/crates/wenlan-types/src/page_map.rs
+++ b/crates/wenlan-types/src/page_map.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wire types for the Page Map API (stage 2). See
+//! docs/superpowers/plans/2026-07-18-page-map-api-spec.md for the full
+//! contract. Mirrors the row shapes in
+//! `crates/wenlan-core/src/db/page_map.rs`, adding the read-time computed
+//! `ref_state` field the daemon derives at GET time (never stored).
+
+use serde::{Deserialize, Serialize};
+
+/// Whether a node's backing object (memory/entity/page/section) still
+/// resolves. Computed at read time by the server; never persisted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefState {
+    Live,
+    Dangling,
+}
+
+/// `page_maps.viewport`, wire shape (stored server-side as a JSON string).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct PageMapViewport {
+    pub x: f64,
+    pub y: f64,
+    pub zoom: f64,
+}
+
+/// A node in the map, as returned to clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageMapNode {
+    pub id: String,
+    /// `None` only for the root.
+    pub parent_id: Option<String>,
+    pub rank: f64,
+    pub ref_kind: String,
+    pub ref_id: String,
+    /// Map-local display override; `None` = render from the backing object.
+    pub label: Option<String>,
+    pub status: String,
+    pub pinned: bool,
+    pub placed: bool,
+    pub collapsed: bool,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub ref_state: RefState,
+}
+
+/// An edge in the map, as returned to clients.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageMapEdge {
+    pub id: String,
+    pub from_node: String,
+    pub to_node: String,
+    pub kind: String,
+    pub label: Option<String>,
+    pub status: String,
+}
+
+/// Full map read: `GET /api/pages/{id}/map` and `PUT .../map/layout`, which
+/// also returns the whole (now-updated) map.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageMapResponse {
+    pub page_id: String,
+    pub revision: i64,
+    pub map_schema: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewport: Option<PageMapViewport>,
+    pub nodes: Vec<PageMapNode>,
+    pub edges: Vec<PageMapEdge>,
+}
+
+/// `POST /api/pages/{id}/map/nodes`. `ref_kind`/`ref_id` are `Option` on the
+/// wire (rather than required strings) so a missing ref can be reported as a
+/// 400 by the handler rather than whatever status axum's own JSON-rejection
+/// happens to pick for a missing field.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateMapNodeRequest {
+    pub base_revision: i64,
+    /// `None` = attach under the map's root (resolved server-side; lets the
+    /// very first node on a brand-new map be created without the client
+    /// already knowing the root's freshly-minted id).
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    #[serde(default)]
+    pub ref_kind: Option<String>,
+    #[serde(default)]
+    pub ref_id: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub rank: f64,
+}
+
+/// `PATCH /api/pages/{id}/map/nodes/{node_id}`. `label` is a nested
+/// `Option` so a patch can distinguish "don't touch the label" (key absent)
+/// from "clear the override back to NULL" (key present, value `null`) —
+/// see `deserialize_double_option` below.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchMapNodeRequest {
+    pub base_revision: i64,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub label: Option<Option<String>>,
+    #[serde(default)]
+    pub pinned: Option<bool>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub rank: Option<f64>,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+}
+
+/// `DELETE /api/pages/{id}/map/nodes/{node_id}` (and the edge equivalent
+/// below) — a conditional write like every other map mutation, so it still
+/// carries `base_revision` even though it has no other fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteMapNodeRequest {
+    pub base_revision: i64,
+}
+
+/// The shared mutation envelope for node writes: the new revision plus the
+/// touched row, so the client can chain edits without a round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeMutationResponse {
+    pub revision: i64,
+    pub node: PageMapNode,
+}
+
+fn default_edge_kind() -> String {
+    "link".to_string()
+}
+
+/// `POST /api/pages/{id}/map/edges`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateMapEdgeRequest {
+    pub base_revision: i64,
+    pub from_node: String,
+    pub to_node: String,
+    #[serde(default = "default_edge_kind")]
+    pub kind: String,
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+/// `PATCH /api/pages/{id}/map/edges/{edge_id}` — accept/dismiss/relabel only
+/// (no from/to/kind changes, per the route table).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PatchMapEdgeRequest {
+    pub base_revision: i64,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    pub label: Option<Option<String>>,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteMapEdgeRequest {
+    pub base_revision: i64,
+}
+
+/// The shared mutation envelope for edge writes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EdgeMutationResponse {
+    pub revision: i64,
+    pub edge: PageMapEdge,
+}
+
+/// One placed node in a `PUT .../map/layout` write.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageMapNodeLayout {
+    pub node_id: String,
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    #[serde(default)]
+    pub collapsed: bool,
+}
+
+/// `PUT /api/pages/{id}/map/layout`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PutPageMapLayoutRequest {
+    pub base_revision: i64,
+    #[serde(default)]
+    pub viewport: Option<PageMapViewport>,
+    #[serde(default)]
+    pub positions: Vec<PageMapNodeLayout>,
+}
+
+/// Distinguishes "field omitted" (`None`, leave unchanged) from "field
+/// present with value `null`" (`Some(None)`, clear the override) for a
+/// `label` PATCH — serde's derived `Option<Option<T>>` collapses both to
+/// `None` by default (a JSON `null` short-circuits at the outer `Option`),
+/// so the nested option is deserialized by hand here. This is the same ~3
+/// line recipe the `serde_with::rust::double_option` crate ships; hand-
+/// rolled so wenlan-types stays serde + serde_json + anyhow only.
+fn deserialize_double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Ok(Some(Option::deserialize(deserializer)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ref_state_serializes_snake_case() {
+        assert_eq!(serde_json::to_string(&RefState::Live).unwrap(), "\"live\"");
+        assert_eq!(
+            serde_json::to_string(&RefState::Dangling).unwrap(),
+            "\"dangling\""
+        );
+    }
+
+    #[test]
+    fn double_option_label_distinguishes_absent_null_and_value() {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_double_option")]
+            label: Option<Option<String>>,
+        }
+
+        let absent: Wrapper = serde_json::from_str("{}").unwrap();
+        assert_eq!(absent.label, None);
+
+        let cleared: Wrapper = serde_json::from_str(r#"{"label": null}"#).unwrap();
+        assert_eq!(cleared.label, Some(None));
+
+        let set: Wrapper = serde_json::from_str(r#"{"label": "custom"}"#).unwrap();
+        assert_eq!(set.label, Some(Some("custom".to_string())));
+    }
+
+    #[test]
+    fn patch_map_node_request_label_field_uses_double_option() {
+        let req: PatchMapNodeRequest =
+            serde_json::from_str(r#"{"base_revision": 1, "label": null}"#).unwrap();
+        assert_eq!(req.label, Some(None));
+
+        let req: PatchMapNodeRequest = serde_json::from_str(r#"{"base_revision": 1}"#).unwrap();
+        assert_eq!(req.label, None);
+    }
+
+    #[test]
+    fn create_map_edge_request_defaults_kind_to_link() {
+        let req: CreateMapEdgeRequest =
+            serde_json::from_str(r#"{"base_revision": 1, "from_node": "a", "to_node": "b"}"#)
+                .unwrap();
+        assert_eq!(req.kind, "link");
+    }
+
+    #[test]
+    fn page_map_response_omits_absent_viewport() {
+        let response = PageMapResponse {
+            page_id: "p1".to_string(),
+            revision: 0,
+            map_schema: 1,
+            viewport: None,
+            nodes: vec![],
+            edges: vec![],
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(!json.contains("viewport"));
+    }
+}

--- a/crates/wenlan-types/src/requests.rs
+++ b/crates/wenlan-types/src/requests.rs
@@ -386,6 +386,10 @@ pub struct UpdateConfigRequest {
     /// `""` = clear; validated by the config route.
     #[serde(default)]
     pub synthesis_source: Option<String>,
+    /// Gates the proactive Page-Map suggestion phase in the scheduler. Omitted =
+    /// preserve stored value; present = set. Never gates the explicit improve route.
+    #[serde(default)]
+    pub page_map_auto_suggest: Option<bool>,
 }
 
 // ===== Chunks / indexed files =====

--- a/crates/wenlan-types/src/responses.rs
+++ b/crates/wenlan-types/src/responses.rs
@@ -432,6 +432,9 @@ pub struct ConfigResponse {
     /// `"external"`, or absent/null when unpinned.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub synthesis_source: Option<String>,
+    /// Whether the proactive Page-Map suggestion phase is enabled. Default true.
+    #[serde(default)]
+    pub page_map_auto_suggest: bool,
 }
 
 // ===== On-device model =====


### PR DESCRIPTION
Implements the daemon side of the Page Map (per-page mind map) feature, per the API spec in `7xuanlu/wenlan-app` `docs/superpowers/plans/2026-07-18-page-map-api-spec.md` (PR wenlan-app#94). Companion pieces: layout spike wenlan-app#93, plan doc on wenlan-app#90.

All four stages landed:

- [x] **Stage 1 — data layer** (`bb14ccb5`): migration 75 (renumbered from 73 in `1224a3c4`; versions 73/74 were already claimed on live user DBs by the in-flight wiki-spaces branch — `page_maps` / `page_map_nodes` / `page_map_edges`), `db/page_map.rs` accessors — optimistic `base_revision` check-and-bump on every mutation, fingerprint `{ref_kind}:{ref_id}@{parent_ref}` as dedup **and** tombstone key, root invariants, cycle-rejecting re-parent, layout write, reset. 7 unit tests.
- [x] **Stage 2 — HTTP surface** (`af503141`): `page_map_routes.rs` + wire DTOs in `wenlan-types` — GET map (`?include=dismissed`), PUT layout, node/edge POST/PATCH/DELETE, DELETE map (reset); 409 on stale revision and tombstoned fingerprints; 422 on invariant violations. Added the missing `Patch` verb to the route registry. 10 handler tests + 5 DTO tests.
- [x] **Stage 3 — improve pass** (`a97bdefa`): deterministic, **insert-only** suggestion generation (entity, ATX-heading sections, source memories capped at 20, resolved `[[wikilinks]]` as page nodes + cross-link edges) — never touches pinned rows; tombstones respected by construction. Synchronous `POST .../map/improve` (per the `/api/steep` precedent) + `Phase::PageMaps` on the Idle trigger, budget 5 pages/pass, watermarked by `generated_at` (RFC3339, instant-parsed comparison — fixed a lexical-compare bug that would have made every page perpetually eligible). No LLM in v1; an LLM enrichment step can layer behind the same insert-only accessors later.
- [x] **Stage 4 — config** (`a97bdefa`): `page_map_auto_suggest` (missing-field default true, same serde idiom as `private_browsing_detection`) through the existing `/api/config` partial merge. Gates only the proactive phase — explicit POST improve always runs.

Design invariants (from the spec): tree edges derive from the `parent_id` spine and are never stored; a dismissed fingerprint is a tombstone a fresh uuid cannot bypass; any user mutation pins the row; `suggested → active → dismissed` only; every node references a real object (no free-text nodes).

Gate evidence (full run on the final tree): wenlan-core page_map 19 passed; wenlan-server 323 passed (16 suites); `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVoky9SGNauqSnTyzhQaUn
