### PR TITLE
fix: define Page draft wire contract

### DIFF
--- a/crates/wenlan-types/src/lib.rs
+++ b/crates/wenlan-types/src/lib.rs
@@ -39,14 +39,17 @@ pub use memory::{
 pub use memory_type::{MEMORY_TYPE_CAPTURE_DESCRIPTION, MEMORY_TYPE_FILTER_DESCRIPTION};
 pub use narrative::NarrativeResponse;
 pub use pages::{Page, PageEvidence};
-pub use requests::AcceptRefinementRequest;
+pub use requests::{
+    AcceptRefinementRequest, CreatePageDraftRequest, PageDraftVersionRequest,
+    UpdatePageDraftRequest,
+};
 pub use responses::{
     ContradictionDismissResponse, ExportStats, ListMemoryRevisionsResponse,
     ListPageRevisionsResponse, ListRefinementsResponse, MemoryDetail, MemoryRevisionEntry,
     OnDeviceModelEntry, OnDeviceModelResponse, OrphanLink, OrphanLinksResponse, PageChangelogEntry,
-    PageWriteResponse, PendingRevision, PendingRevisionItem, ProposalAction, RefinementCardAction,
-    RefinementPayload, RefinementProposalSummary, RejectRefinementResponse, RevisionAcceptResponse,
-    RevisionDismissResponse,
+    PageDraftResponse, PageWriteResponse, PendingRevision, PendingRevisionItem, ProposalAction,
+    RefinementCardAction, RefinementPayload, RefinementProposalSummary, RejectRefinementResponse,
+    RevisionAcceptResponse, RevisionDismissResponse,
 };
 pub use sources::{MemoryType, RawDocument, SourceType, StabilityTier, SyncStatus};
 

--- a/crates/wenlan-types/src/requests.rs
+++ b/crates/wenlan-types/src/requests.rs
@@ -260,6 +260,148 @@ pub struct CreateConceptRequest {
     pub workspace: Option<String>,
 }
 
+/// First durable snapshot for a human-authored Page draft.
+///
+/// The client only sends this request once either `title` or `content` is
+/// meaningful. Both fields default to empty so title-first and body-first
+/// writing flows share one wire shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreatePageDraftRequest {
+    /// Stable client-generated id used to make an ambiguous create retry safe.
+    pub draft_id: String,
+    pub title: String,
+    pub content: String,
+    pub space: Option<String>,
+    space_provided: bool,
+}
+
+impl CreatePageDraftRequest {
+    /// Build a request with an explicit `space` value.
+    ///
+    /// Passing `None` serializes as `"space": null`.
+    pub fn new(draft_id: String, title: String, content: String, space: Option<String>) -> Self {
+        Self {
+            draft_id,
+            title,
+            content,
+            space,
+            space_provided: true,
+        }
+    }
+
+    /// Build a request that omits `space`, allowing the server to inherit the
+    /// `X-Wenlan-Space` request header.
+    pub fn new_inheriting_header_space(draft_id: String, title: String, content: String) -> Self {
+        Self {
+            draft_id,
+            title,
+            content,
+            space: None,
+            space_provided: false,
+        }
+    }
+
+    /// Whether the JSON body contained a `space` key.
+    ///
+    /// This distinguishes an omitted key (inherit the request header) from an
+    /// explicit `null` (clear the header-provided Space).
+    pub fn space_was_provided(&self) -> bool {
+        self.space_provided
+    }
+}
+
+impl Serialize for CreatePageDraftRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let field_count = if self.space_provided { 4 } else { 3 };
+        let mut state = serializer.serialize_struct("CreatePageDraftRequest", field_count)?;
+        state.serialize_field("draft_id", &self.draft_id)?;
+        state.serialize_field("title", &self.title)?;
+        state.serialize_field("content", &self.content)?;
+        if self.space_provided {
+            state.serialize_field("space", &self.space)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CreatePageDraftRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            draft_id: String,
+            #[serde(default)]
+            title: String,
+            #[serde(default)]
+            content: String,
+            #[serde(default, deserialize_with = "double_option")]
+            space: Option<Option<String>>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let (space_provided, space) = match wire.space {
+            Some(space) => (true, space),
+            None => (false, None),
+        };
+        Ok(Self {
+            draft_id: wire.draft_id,
+            title: wire.title,
+            content: wire.content,
+            space,
+            space_provided,
+        })
+    }
+}
+
+/// Complete replacement snapshot for an existing Page draft.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct UpdatePageDraftRequest {
+    pub expected_version: i64,
+    pub title: String,
+    pub content: String,
+    pub space: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for UpdatePageDraftRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            expected_version: i64,
+            title: String,
+            content: String,
+            #[serde(default, deserialize_with = "double_option")]
+            space: Option<Option<String>>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let space = wire
+            .space
+            .ok_or_else(|| serde::de::Error::missing_field("space"))?;
+        Ok(Self {
+            expected_version: wire.expected_version,
+            title: wire.title,
+            content: wire.content,
+            space,
+        })
+    }
+}
+
+/// Optimistic-concurrency body shared by draft publish and discard.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PageDraftVersionRequest {
+    pub expected_version: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum AcceptRefinementRequest {
@@ -331,7 +473,7 @@ pub struct AddSourceRequest {
 // ===== Config =====
 
 /// Distinguishes an omitted JSON field (outer None) from an explicit `null`
-/// (Some(None)). Used for tri-state secret updates.
+/// (Some(None)). Used for presence-sensitive wire fields.
 fn double_option<'de, T, D>(de: D) -> Result<Option<Option<T>>, D::Error>
 where
     T: serde::Deserialize<'de>,

--- a/crates/wenlan-types/src/responses.rs
+++ b/crates/wenlan-types/src/responses.rs
@@ -490,6 +490,12 @@ pub struct PageWriteResponse {
     pub gated: bool,
 }
 
+/// Page draft create, update, and publish response envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageDraftResponse {
+    pub page: Page,
+}
+
 // ===== Memory detail =====
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/wenlan-types/tests/page_draft_wire.rs
+++ b/crates/wenlan-types/tests/page_draft_wire.rs
@@ -1,0 +1,185 @@
+use serde_json::json;
+use wenlan_types::{
+    CreatePageDraftRequest, PageDraftResponse, PageDraftVersionRequest, UpdatePageDraftRequest,
+};
+
+#[test]
+fn create_requires_client_id() {
+    assert!(serde_json::from_value::<CreatePageDraftRequest>(json!({
+        "title": "Missing stable id"
+    }))
+    .is_err());
+}
+
+#[test]
+fn create_preserves_partial_snapshot_defaults() {
+    let title_first: CreatePageDraftRequest = serde_json::from_value(json!({
+        "draft_id": "page_00000000-0000-4000-8000-000000000001",
+        "title": "Working title"
+    }))
+    .unwrap();
+
+    assert_eq!(title_first.content, "");
+    assert_eq!(title_first.space, None);
+    assert!(!title_first.space_was_provided());
+
+    let content_first: CreatePageDraftRequest = serde_json::from_value(json!({
+        "draft_id": "page_00000000-0000-4000-8000-000000000002",
+        "content": "Opening paragraph"
+    }))
+    .unwrap();
+
+    assert_eq!(content_first.title, "");
+    assert_eq!(content_first.content, "Opening paragraph");
+    assert!(!content_first.space_was_provided());
+}
+
+#[test]
+fn create_round_trips_omitted_null_and_named_space_distinctly() {
+    let omitted = json!({
+        "draft_id": "page_00000000-0000-4000-8000-000000000001",
+        "title": "Inherit request header",
+        "content": ""
+    });
+    let omitted_request: CreatePageDraftRequest = serde_json::from_value(omitted.clone()).unwrap();
+
+    assert!(!omitted_request.space_was_provided());
+    assert_eq!(serde_json::to_value(omitted_request).unwrap(), omitted);
+
+    let explicit_null = json!({
+        "draft_id": "page_00000000-0000-4000-8000-000000000002",
+        "title": "Unscoped",
+        "content": "",
+        "space": null
+    });
+    let explicit_null_request: CreatePageDraftRequest =
+        serde_json::from_value(explicit_null.clone()).unwrap();
+
+    assert!(explicit_null_request.space_was_provided());
+    assert_eq!(
+        serde_json::to_value(explicit_null_request).unwrap(),
+        explicit_null
+    );
+
+    let named = json!({
+        "draft_id": "page_00000000-0000-4000-8000-000000000003",
+        "title": "",
+        "content": "Opening paragraph",
+        "space": "work"
+    });
+    let named_request: CreatePageDraftRequest = serde_json::from_value(named.clone()).unwrap();
+
+    assert!(named_request.space_was_provided());
+    assert_eq!(named_request.space.as_deref(), Some("work"));
+    assert_eq!(serde_json::to_value(named_request).unwrap(), named);
+}
+
+#[test]
+fn create_constructors_choose_header_inheritance_or_explicit_space() {
+    let inherited = CreatePageDraftRequest::new_inheriting_header_space(
+        "page_00000000-0000-4000-8000-000000000004".into(),
+        "Inherited".into(),
+        String::new(),
+    );
+    assert_eq!(
+        serde_json::to_value(inherited).unwrap(),
+        json!({
+            "draft_id": "page_00000000-0000-4000-8000-000000000004",
+            "title": "Inherited",
+            "content": ""
+        })
+    );
+
+    let unscoped = CreatePageDraftRequest::new(
+        "page_00000000-0000-4000-8000-000000000005".into(),
+        "Unscoped".into(),
+        String::new(),
+        None,
+    );
+    assert_eq!(
+        serde_json::to_value(unscoped).unwrap(),
+        json!({
+            "draft_id": "page_00000000-0000-4000-8000-000000000005",
+            "title": "Unscoped",
+            "content": "",
+            "space": null
+        })
+    );
+}
+
+#[test]
+fn update_request_round_trips_exactly() {
+    let update = json!({
+        "expected_version": 4,
+        "title": "Working title",
+        "content": "Revised paragraph",
+        "space": null
+    });
+
+    let parsed: UpdatePageDraftRequest = serde_json::from_value(update.clone()).unwrap();
+
+    assert_eq!(serde_json::to_value(parsed).unwrap(), update);
+}
+
+#[test]
+fn update_requires_a_complete_snapshot() {
+    for incomplete in [
+        json!({
+            "expected_version": 4,
+            "content": "Revised paragraph",
+            "space": null
+        }),
+        json!({
+            "expected_version": 4,
+            "title": "Working title",
+            "space": null
+        }),
+        json!({
+            "expected_version": 4,
+            "title": "Working title",
+            "content": "Revised paragraph"
+        }),
+    ] {
+        assert!(serde_json::from_value::<UpdatePageDraftRequest>(incomplete).is_err());
+    }
+}
+
+#[test]
+fn version_request_round_trips_exactly() {
+    let version = json!({ "expected_version": 7 });
+
+    let parsed: PageDraftVersionRequest = serde_json::from_value(version.clone()).unwrap();
+
+    assert_eq!(serde_json::to_value(parsed).unwrap(), version);
+}
+
+#[test]
+fn response_envelope_deserializes_an_existing_page() {
+    let payload = json!({
+        "page": {
+            "id": "page_draft_1",
+            "title": "Working title",
+            "summary": null,
+            "content": "Opening paragraph",
+            "entity_id": null,
+            "space": null,
+            "source_memory_ids": [],
+            "version": 3,
+            "status": "draft",
+            "created_at": "2026-07-16T00:00:00Z",
+            "last_compiled": "2026-07-16T00:00:00Z",
+            "last_modified": "2026-07-16T00:00:00Z",
+            "sources_updated_count": 0,
+            "stale_reason": null,
+            "user_edited": true,
+            "workspace": null,
+            "creation_kind": "authored",
+            "review_status": "unconfirmed"
+        }
+    });
+
+    let response: PageDraftResponse = serde_json::from_value(payload).unwrap();
+
+    assert_eq!(response.page.id, "page_draft_1");
+    assert_eq!(response.page.status, "draft");
+}


### PR DESCRIPTION
## What changed

- add shared serde DTOs for Page draft create, update, publish, discard, and responses
- preserve the three distinct create-time Space states: omitted, explicit `null`, and named Space
- require update requests to carry a complete replacement snapshot
- export the DTOs from `wenlan-types`

## Why

The desktop Page editor and daemon need one stable wire contract before database or HTTP behavior is introduced. Splitting this contract out keeps the first review bounded and prevents fixture-only app behavior from being mistaken for a live daemon capability.

## Impact

This is types-only. It does not add database persistence, routes, projection behavior, or enable the app editor.

## Verification

- `cargo test -p wenlan-types` — 113 passed
- `cargo clippy -p wenlan-types --all-targets -- -D warnings`
- `cargo fmt --check --all`
- independent review: READY after fixing tri-state create Space and required update Space
