### PR TITLE
fix: preserve exact canonical page source

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -25704,12 +25704,10 @@ impl MemoryDB {
         workspace: Option<&str>,
         citations_json: Option<&str>,
     ) -> Result<(), WenlanError> {
-        // Sanitize daemon-reserved Sources delimiters from client content so
-        // persisted `Page.content` never carries them (symmetric with the
-        // watcher's egress canonicalization). Shadows `content` so both the
-        // INSERT and the wikilink refresh below see the sanitized value.
-        let sanitized_content = crate::export::provenance::sanitize_ingress_content(content);
-        let content: &str = &sanitized_content;
+        // Canonical storage is exact source. Projection-owned delimiters are
+        // rejected rather than rewritten, and every consumer below sees the
+        // same caller-supplied representation.
+        let content = crate::export::provenance::validate_canonical_page_content(content)?;
         let source_ids_json = serde_json::to_string(&source_memory_ids)
             .map_err(|e| WenlanError::VectorDb(format!("serialize source_memory_ids: {e}")))?;
 
@@ -25835,10 +25833,10 @@ impl MemoryDB {
         source_memory_ids: &[&str],
         link_reason: &str,
     ) -> Result<bool, WenlanError> {
-        let sanitized_content = crate::export::provenance::sanitize_ingress_content(content);
+        let content = crate::export::provenance::validate_canonical_page_content(content)?;
         let source_ids_json = serde_json::to_string(source_memory_ids)
             .map_err(|e| WenlanError::VectorDb(format!("serialize source_memory_ids: {e}")))?;
-        let embed_text = crate::pages::page_embedding_text(title, summary, &sanitized_content);
+        let embed_text = crate::pages::page_embedding_text(title, summary, content);
         let embedding_sql = match self.generate_embeddings(&[embed_text]) {
             Ok(mut vectors) if !vectors.is_empty() => {
                 vectors.pop().map(|embedding| Self::vec_to_sql(&embedding))
@@ -25872,7 +25870,7 @@ impl MemoryDB {
                         libsql::params![
                             title,
                             summary,
-                            sanitized_content.as_str(),
+                            content,
                             source_ids_json.as_str(),
                             now.as_str(),
                             embedding,
@@ -25892,7 +25890,7 @@ impl MemoryDB {
                         libsql::params![
                             title,
                             summary,
-                            sanitized_content.as_str(),
+                            content,
                             source_ids_json.as_str(),
                             now.as_str(),
                             id
@@ -25961,7 +25959,7 @@ impl MemoryDB {
             )));
         }
         drop(conn);
-        if let Err(error) = self.refresh_page_wikilinks(id, &sanitized_content).await {
+        if let Err(error) = self.refresh_page_wikilinks(id, content).await {
             log::warn!("[page-links] source Page refresh failed for {id}: {error}");
         }
         Ok(true)
@@ -26475,14 +26473,10 @@ impl MemoryDB {
             ));
         }
         let citations_bind: &str = citations_json.unwrap_or("[]");
-        // Sanitize daemon-reserved Sources delimiters from client content so
-        // persisted `Page.content` never carries them (symmetric with the
-        // watcher's egress canonicalization). Shadows `content` so both the
-        // UPDATE and the wikilink refresh below see the sanitized value. The
-        // watcher's apply path already passes a canonicalized body, so this is
-        // an idempotent no-op there.
-        let sanitized_content = crate::export::provenance::sanitize_ingress_content(content);
-        let content: &str = &sanitized_content;
+        // Canonical storage is exact source. The watcher already decodes its
+        // projection before this boundary; all other callers must supply
+        // delimiter-free source, which is stored without transformation.
+        let content = crate::export::provenance::validate_canonical_page_content(content)?;
         let source_ids_json = serde_json::to_string(&source_memory_ids)
             .map_err(|e| WenlanError::VectorDb(format!("serialize source_memory_ids: {e}")))?;
         let now = chrono::Utc::now().to_rfc3339();
@@ -43955,18 +43949,20 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn insert_page_strips_daemon_sources_delimiters_from_client_content() {
-        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+    async fn insert_page_preserves_delimiter_free_content_exactly() {
         let (db, _dir) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
-        let content = format!(
-            "## Overview\nReal prose.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_99]]\n{SOURCES_BLOCK_END}\n"
+        let content = "\u{feff}\r\n  ## Overview  \r\nReal prose.\t \r\n\r\n";
+        assert_ne!(
+            content.trim_end(),
+            content,
+            "positive control: trimming must change this fixture"
         );
         db.insert_page(
             "page_ingress",
             "Ingress",
             None,
-            &content,
+            content,
             None,
             None,
             &[],
@@ -43975,52 +43971,92 @@ pub(crate) mod tests {
         .await
         .unwrap();
         let stored = db.get_page("page_ingress").await.unwrap().unwrap();
-        assert!(!stored.content.contains(SOURCES_BLOCK_START));
-        assert!(!stored.content.contains(SOURCES_BLOCK_END));
-        assert!(!stored.content.contains("## Sources"));
-        assert!(!stored.content.contains("[[mem_99]]"));
-        assert!(stored.content.contains("Real prose."));
+        assert_eq!(stored.content, content);
+        let history = db.list_page_history("page_ingress", 10).await.unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].content, content);
     }
 
     #[tokio::test]
-    async fn update_page_content_strips_daemon_sources_delimiters_from_client_content() {
-        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+    async fn update_page_content_preserves_delimiter_free_content_exactly() {
         let (db, _dir) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
         db.insert_page("page_upd", "Upd", None, "seed", None, None, &[], &now)
             .await
             .unwrap();
-        let content = format!(
-            "Updated prose.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_7]]\n{SOURCES_BLOCK_END}\n"
-        );
-        db.update_page_content("page_upd", &content, &[], "manual_edit")
+        let content = "\r\n  Updated prose.\t \r\n\r\n";
+        db.update_page_content("page_upd", content, &[], "manual_edit")
             .await
             .unwrap();
         let stored = db.get_page("page_upd").await.unwrap().unwrap();
-        assert!(!stored.content.contains(SOURCES_BLOCK_START));
-        assert!(!stored.content.contains(SOURCES_BLOCK_END));
-        assert!(!stored.content.contains("## Sources"));
-        assert!(!stored.content.contains("[[mem_7]]"));
-        assert!(stored.content.contains("Updated prose."));
+        assert_eq!(stored.content, content);
+        let history = db.list_page_history("page_upd", 10).await.unwrap();
+        assert_eq!(history[0].content, content);
     }
 
     #[tokio::test]
-    async fn insert_page_stray_start_delimiter_does_not_truncate_prose() {
-        // Data-loss regression: a lone START token (no matching END) must not
-        // cause the prose after it to be dropped. Both halves must survive and
-        // the delimiter token must be removed.
+    async fn insert_page_rejects_reserved_sources_delimiter_without_mutation() {
         use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
         let (db, _dir) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
-        let content = format!("prose A {SOURCES_BLOCK_START} prose B");
-        db.insert_page("page_stray", "Stray", None, &content, None, None, &[], &now)
+        let content =
+            format!("prose A {SOURCES_BLOCK_START} daemon block {SOURCES_BLOCK_END} prose B");
+        let error = db
+            .insert_page(
+                "page_rejected",
+                "Rejected",
+                None,
+                &content,
+                None,
+                None,
+                &[],
+                &now,
+            )
             .await
-            .unwrap();
-        let stored = db.get_page("page_stray").await.unwrap().unwrap();
-        assert!(stored.content.contains("prose A"));
-        assert!(stored.content.contains("prose B"));
-        assert!(!stored.content.contains(SOURCES_BLOCK_START));
-        assert!(!stored.content.contains(SOURCES_BLOCK_END));
+            .unwrap_err();
+        assert!(matches!(error, WenlanError::Validation(_)));
+        assert!(db.get_page("page_rejected").await.unwrap().is_none());
+        assert!(db
+            .list_page_history("page_rejected", 10)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn update_page_content_rejects_reserved_sources_delimiter_without_mutation() {
+        use crate::export::provenance::SOURCES_BLOCK_START;
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_rejected_upd",
+            "Upd",
+            None,
+            "seed",
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+        let before = db.get_page("page_rejected_upd").await.unwrap().unwrap();
+        let history_before = db.list_page_history("page_rejected_upd", 10).await.unwrap();
+        let error = db
+            .update_page_content(
+                "page_rejected_upd",
+                &format!("prose A {SOURCES_BLOCK_START} prose B"),
+                &[],
+                "manual_edit",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, WenlanError::Validation(_)));
+        let after = db.get_page("page_rejected_upd").await.unwrap().unwrap();
+        let history_after = db.list_page_history("page_rejected_upd", 10).await.unwrap();
+        assert_eq!(after.content, before.content);
+        assert_eq!(after.version, before.version);
+        assert_eq!(history_after.len(), history_before.len());
     }
 
     // ---- page_links / wikilink graph ----
@@ -46851,6 +46887,7 @@ pub(crate) mod tests {
     async fn replace_source_page_advances_source_revision_with_exact_provenance() {
         let (db, _dir) = test_db().await;
         let now = chrono::Utc::now().to_rfc3339();
+        let replacement = "\u{feff}\r\n  Updated body  \r\n\r\n";
         db.insert_page_with_kind(
             "page-source-replace",
             "Source page",
@@ -46873,7 +46910,7 @@ pub(crate) mod tests {
                 "page-source-replace",
                 "Source page",
                 Some("Updated summary"),
-                "Updated body",
+                replacement,
                 &["source-new-a", "source-new-b"],
                 "source_refresh",
             )
@@ -46888,6 +46925,7 @@ pub(crate) mod tests {
             1
         );
         let page = db.get_page("page-source-replace").await.unwrap().unwrap();
+        assert_eq!(page.content, replacement);
         assert_eq!(
             page.source_memory_ids,
             vec!["source-new-a".to_string(), "source-new-b".to_string()]
@@ -46903,6 +46941,79 @@ pub(crate) mod tests {
             sources,
             HashSet::from(["source-new-a".to_string(), "source-new-b".to_string()])
         );
+        let history = db
+            .list_page_history("page-source-replace", 10)
+            .await
+            .unwrap();
+        assert_eq!(history[0].content, replacement);
+    }
+
+    #[tokio::test]
+    async fn replace_source_page_rejects_reserved_delimiter_without_mutation() {
+        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page_with_kind(
+            "page-source-rejected",
+            "Source page",
+            None,
+            "Original body",
+            None,
+            None,
+            &["source-old"],
+            &now,
+            "source",
+            "confirmed",
+            None,
+            Some("[]"),
+        )
+        .await
+        .unwrap();
+        let before = db.get_page("page-source-rejected").await.unwrap().unwrap();
+        let history_before = db
+            .list_page_history("page-source-rejected", 10)
+            .await
+            .unwrap();
+        let sources_before: HashSet<_> = db
+            .get_page_sources("page-source-rejected")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|source| source.memory_source_id)
+            .collect();
+
+        let error = db
+            .replace_source_page(
+                "page-source-rejected",
+                "Changed title",
+                Some("Changed summary"),
+                &format!("{SOURCES_BLOCK_START}\nowned\n{SOURCES_BLOCK_END}"),
+                &["source-new"],
+                "source_refresh",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, WenlanError::Validation(_)));
+
+        let after = db.get_page("page-source-rejected").await.unwrap().unwrap();
+        let history_after = db
+            .list_page_history("page-source-rejected", 10)
+            .await
+            .unwrap();
+        let sources_after: HashSet<_> = db
+            .get_page_sources("page-source-rejected")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|source| source.memory_source_id)
+            .collect();
+        assert_eq!(after.title, before.title);
+        assert_eq!(after.summary, before.summary);
+        assert_eq!(after.content, before.content);
+        assert_eq!(after.version, before.version);
+        assert_eq!(history_after.len(), history_before.len());
+        assert_eq!(sources_after, sources_before);
     }
 
     #[tokio::test]

--- a/crates/wenlan-core/src/db/page_drafts.rs
+++ b/crates/wenlan-core/src/db/page_drafts.rs
@@ -20,8 +20,8 @@ fn ensure_meaningful_snapshot(title: &str, content: &str) -> Result<(), WenlanEr
 }
 
 fn ensure_meaningful_draft_snapshot(title: &str, content: &str) -> Result<(), WenlanError> {
-    let canonical_content = crate::export::provenance::sanitize_ingress_content(content);
-    ensure_meaningful_snapshot(title, &canonical_content)
+    let content = crate::export::provenance::validate_canonical_page_content(content)?;
+    ensure_meaningful_snapshot(title, content)
 }
 
 fn ensure_client_page_draft_id(id: &str) -> Result<(), WenlanError> {

--- a/crates/wenlan-core/src/db/page_drafts_test.rs
+++ b/crates/wenlan-core/src/db/page_drafts_test.rs
@@ -346,8 +346,12 @@ async fn simultaneous_same_id_creates_are_idempotent_or_conflict_by_snapshot() {
 #[tokio::test]
 async fn create_preserves_bytes_null_embedding_and_has_no_derived_rows() {
     let (db, _tmp) = test_db().await;
-    let content =
-        "Before\n<!-- origin:sources:start -->\nowned\n<!-- origin:sources:end -->\nAfter  \n";
+    let content = "\u{feff}\r\n  Before  \r\nAfter\t \r\n\r\n";
+    assert_ne!(
+        content.trim_end(),
+        content,
+        "positive control: trimming must change this fixture"
+    );
     let page = db
         .create_page_draft("  Draft  ", content, None, None)
         .await
@@ -374,6 +378,65 @@ async fn create_preserves_bytes_null_embedding_and_has_no_derived_rows() {
             }
         );
         assert_eq!(scalar_i64(&db, &sql, &page.id).await, 0);
+    }
+}
+
+#[tokio::test]
+async fn create_and_update_reject_reserved_delimiters_without_mutation() {
+    use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+
+    let (db, _tmp) = test_db().await;
+    let cases = [
+        format!("before {SOURCES_BLOCK_START} after"),
+        format!("before {SOURCES_BLOCK_END} after"),
+        format!("{SOURCES_BLOCK_START}\nowned\n{SOURCES_BLOCK_END}"),
+        format!(
+            "{SOURCES_BLOCK_START}\none\n{SOURCES_BLOCK_END}\n\
+             {SOURCES_BLOCK_START}\ntwo\n{SOURCES_BLOCK_END}"
+        ),
+        format!("```md\n{SOURCES_BLOCK_START}\n```\nkept prose"),
+    ];
+
+    let rejected_id = "page_00000000-0000-4000-8000-000000000099";
+    for content in &cases {
+        assert!(matches!(
+            db.create_page_draft_with_id(rejected_id, "Draft", content, None, None)
+                .await,
+            Err(WenlanError::Validation(_))
+        ));
+        assert!(db.get_page(rejected_id).await.unwrap().is_none());
+        assert_eq!(
+            scalar_i64(
+                &db,
+                "SELECT COUNT(*) FROM page_draft_create_requests WHERE page_id=?1",
+                rejected_id,
+            )
+            .await,
+            0
+        );
+    }
+
+    let draft = db
+        .create_page_draft("Original title", "Original body  \n", None, None)
+        .await
+        .unwrap();
+    for content in &cases {
+        assert!(matches!(
+            db.update_page_draft(
+                &draft.id,
+                draft.version,
+                "Changed title",
+                content,
+                None,
+                None,
+            )
+            .await,
+            Err(WenlanError::Validation(_))
+        ));
+        let after = db.get_page(&draft.id).await.unwrap().unwrap();
+        assert_eq!(after.title, draft.title);
+        assert_eq!(after.content, draft.content);
+        assert_eq!(after.version, draft.version);
     }
 }
 

--- a/crates/wenlan-core/src/export/provenance.rs
+++ b/crates/wenlan-core/src/export/provenance.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Provenance projection helpers: delimiter-owned Sources block, the shared
-//! ingress canonicalizer, and `_sources/` stub projection + GC.
+//! Provenance projection helpers: delimiter-owned Sources block, canonical
+//! storage validation, and `_sources/` stub projection + GC.
+
+use crate::error::WenlanError;
 
 /// Opening delimiter for the export-only `## Sources` block. The block is
 /// generated from DB truth at projection time and stripped at ingress; it is
@@ -39,15 +41,28 @@ pub fn canonicalize_page_body(body: &str) -> String {
     out.trim_end().to_string()
 }
 
-/// Strip daemon-reserved Sources-block delimiters from CLIENT-supplied page
-/// content before persistence. The exporter owns these delimiters; persisted
-/// `Page.content` must never carry them, or the watcher's egress
-/// canonicalization becomes asymmetric (mismatched-pair `user_edited` storm or
-/// stray-delimiter prose truncation). Strips a delimiter-owned block (via
-/// `canonicalize_page_body`) AND removes any residual lone START/END tokens
-/// (a stray delimiter with no matching pair, which `canonicalize_page_body`
-/// leaves untouched). Idempotent: delimiter-free content only gets trailing
-/// whitespace trimmed, so re-sanitizing already-stored content is a no-op.
+/// Validate CLIENT-supplied canonical Page source without rewriting it.
+///
+/// The exporter owns both Sources delimiters. Persisting either token would
+/// make vault projection decoding ambiguous, so canonical ingress rejects the
+/// whole write instead of silently deleting user bytes. Delimiter-free source
+/// is returned as the same borrowed string so every later storage consumer
+/// sees the exact representation the caller supplied.
+pub fn validate_canonical_page_content(content: &str) -> Result<&str, WenlanError> {
+    if content.contains(SOURCES_BLOCK_START) || content.contains(SOURCES_BLOCK_END) {
+        return Err(WenlanError::Validation(
+            "Page content contains a daemon-reserved Sources delimiter".to_string(),
+        ));
+    }
+    Ok(content)
+}
+
+/// Compatibility projection decoder retained for downstream callers that used
+/// the pre-0.14.1 ingress helper directly.
+///
+/// Canonical storage paths must use [`validate_canonical_page_content`].
+/// This function intentionally preserves its historical lossy behavior for
+/// callers decoding daemon-owned projection text.
 pub fn sanitize_ingress_content(content: &str) -> String {
     let stripped = canonicalize_page_body(content);
     let cleaned = stripped
@@ -431,39 +446,43 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_ingress_strips_full_block_preserving_prose() {
-        let content = format!(
-            "## Overview\nReal prose here.\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_1]]\n{SOURCES_BLOCK_END}\n\ntail prose"
+    fn canonical_content_validation_preserves_delimiter_free_source_exactly() {
+        let content = "\u{feff}\r\n  ## Overview  \r\nNormal prose.\t \r\n\r\n";
+        assert_ne!(
+            content.trim_end(),
+            content,
+            "positive control: trimming must change this fixture"
         );
-        let out = sanitize_ingress_content(&content);
-        assert!(!out.contains(SOURCES_BLOCK_START));
-        assert!(!out.contains(SOURCES_BLOCK_END));
-        assert!(!out.contains("[[mem_1]]"));
-        assert!(out.contains("Real prose here."));
-        assert!(out.contains("tail prose"));
+        let validated = validate_canonical_page_content(content).unwrap();
+        assert_eq!(validated, content);
+        assert_eq!(validated.as_ptr(), content.as_ptr());
     }
 
     #[test]
-    fn sanitize_ingress_strips_stray_start_without_truncating_prose() {
-        // A lone START token with prose after it. canonicalize_page_body leaves
-        // it untouched (no matching END), so sanitize must remove the token AND
-        // keep BOTH prose halves — no truncation (the data-loss case).
-        let content = format!("prose A {SOURCES_BLOCK_START} prose B");
-        let out = sanitize_ingress_content(&content);
-        assert!(!out.contains(SOURCES_BLOCK_START));
-        assert!(!out.contains(SOURCES_BLOCK_END));
-        assert!(out.contains("prose A"));
-        assert!(out.contains("prose B"));
+    fn canonical_content_validation_rejects_reserved_delimiters_without_rewriting() {
+        let cases = [
+            format!("before {SOURCES_BLOCK_START} after"),
+            format!("before {SOURCES_BLOCK_END} after"),
+            format!("{SOURCES_BLOCK_START}\nowned\n{SOURCES_BLOCK_END}"),
+            format!("```md\n{SOURCES_BLOCK_START}\n```\nkept prose"),
+        ];
+        for content in cases {
+            let error = validate_canonical_page_content(&content).unwrap_err();
+            assert!(matches!(error, WenlanError::Validation(_)));
+            assert!(
+                content.contains("before")
+                    || content.contains("owned")
+                    || content.contains("kept prose")
+            );
+        }
     }
 
     #[test]
-    fn sanitize_ingress_is_noop_on_delimiter_free_content() {
-        let content =
-            "## Overview\nJust normal prose.\n\n## Sources\nuser-typed, not the daemon block.";
-        let out = sanitize_ingress_content(content);
-        assert_eq!(out, content.trim_end());
-        // Idempotent: re-sanitizing already-stored content changes nothing.
-        assert_eq!(sanitize_ingress_content(&out), out);
+    fn compatibility_ingress_sanitizer_keeps_its_projection_decoding_behavior() {
+        let content = format!(
+            "head\n\n{SOURCES_BLOCK_START}\n## Sources\n- [[mem_1]]\n{SOURCES_BLOCK_END}\n\ntail"
+        );
+        assert_eq!(sanitize_ingress_content(&content), "head\n\ntail");
     }
 
     #[test]

--- a/crates/wenlan-core/src/post_write.rs
+++ b/crates/wenlan-core/src/post_write.rs
@@ -1833,6 +1833,7 @@ async fn replace_source_page_impl(
             "source Page replacement requires title, content, and source ids".into(),
         ));
     }
+    let content = crate::export::provenance::validate_canonical_page_content(content)?;
     let current = db
         .get_page(page_id)
         .await?
@@ -1849,9 +1850,8 @@ async fn replace_source_page_impl(
     // a byte-identical stub body on every retry, and without this each retry
     // would bump the version and append another identical history row.
     //
-    // Compared against the *sanitized* body because that is the form the row
-    // holds; comparing the raw one would report a spurious change forever.
-    let sanitized = crate::export::provenance::sanitize_ingress_content(content);
+    // Canonical storage is exact source, so compare the validated incoming
+    // representation directly with the stored representation.
     let stored_sources: HashSet<&str> = current
         .source_memory_ids
         .iter()
@@ -1860,7 +1860,7 @@ async fn replace_source_page_impl(
     let incoming_sources: HashSet<&str> = source_memory_ids.iter().map(String::as_str).collect();
     if current.title == title
         && current.summary.as_deref() == summary
-        && current.content == sanitized
+        && current.content == content
         && stored_sources == incoming_sources
     {
         return Ok(WriteResult {
@@ -2483,6 +2483,7 @@ async fn create_page_impl(
             "page content must not be empty".into(),
         ));
     }
+    crate::export::provenance::validate_canonical_page_content(&req.content)?;
     let creation_kind = req.creation_kind.as_deref().unwrap_or("distilled");
     if creation_kind == "distilled" && req.source_memory_ids.is_empty() {
         return Err(WenlanError::Validation(
@@ -2643,7 +2644,7 @@ async fn create_page_impl(
                 );
             }
         }
-        return Err(WenlanError::VectorDb(e.to_string()));
+        return Err(e);
     }
     drop(projection);
 
@@ -2821,6 +2822,8 @@ pub async fn stage_page_revision_card(
     source_memory_ids: &[String],
     edited_by: &str,
 ) -> Result<WriteResult, WenlanError> {
+    crate::export::provenance::validate_canonical_page_content(content)?;
+
     let revision_card_id = format!(
         "mem_{}",
         uuid::Uuid::new_v4()
@@ -3094,11 +3097,6 @@ async fn update_page_impl(
         }
     }
 
-    let source_refs: Vec<&str> = req.source_memory_ids.iter().map(|s| s.as_str()).collect();
-    let projection = knowledge_path.map(|path| {
-        crate::export::knowledge::KnowledgeProjectionWrite::new(path.to_path_buf(), db)
-    });
-
     // ── Retry identity ──────────────────────────────────────────────────────
     // A caller that sends both ids gets exactly-once semantics. The same pair
     // with the same request replays the recorded response without writing
@@ -3129,6 +3127,16 @@ async fn update_page_impl(
             });
         }
     }
+
+    // Preserve receipt replay/collision precedence, then reject daemon-owned
+    // projection delimiters before ownership gating, revision-card staging, or
+    // any canonical page/projection mutation.
+    crate::export::provenance::validate_canonical_page_content(&req.content)?;
+
+    let source_refs: Vec<&str> = req.source_memory_ids.iter().map(|s| s.as_str()).collect();
+    let projection = knowledge_path.map(|path| {
+        crate::export::knowledge::KnowledgeProjectionWrite::new(path.to_path_buf(), db)
+    });
 
     // ── Load, decide ownership, and write under one version CAS ─────────────
     // The ownership decision is made from a loaded row, and the write CASes on
@@ -4493,6 +4501,113 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_page_rejects_reserved_delimiter_before_projection_or_db_mutation() {
+        use crate::export::provenance::SOURCES_BLOCK_START;
+
+        let (db, _dir) = test_db().await;
+        let knowledge = tempfile::tempdir().unwrap();
+        let req = CreateConceptRequest {
+            title: "Rejected authored page".to_string(),
+            content: format!("before {SOURCES_BLOCK_START} after"),
+            summary: None,
+            entity_id: None,
+            space: None,
+            source_memory_ids: Vec::new(),
+            creation_kind: Some("authored".to_string()),
+            workspace: None,
+        };
+
+        let error = create_page(&db, req, "test", Some(knowledge.path()))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, WenlanError::Validation(_)));
+        assert!(db.list_pages("active", 10, 0).await.unwrap().is_empty());
+        assert!(
+            std::fs::read_dir(knowledge.path())
+                .unwrap()
+                .next()
+                .is_none(),
+            "validation must happen before projection creates any artifact"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_page_rejects_reserved_delimiter_before_distilled_dedup_attachment() {
+        use crate::export::provenance::SOURCES_BLOCK_END;
+
+        let (db, _dir) = test_db().await;
+        let existing_source = "mem-reserved-dedup-existing";
+        let candidate_source = "mem-reserved-dedup-candidate";
+        let grounded = "Rust workspace members share package metadata and one dependency lockfile";
+        seed_memory(&db, existing_source, grounded).await;
+        seed_memory(&db, candidate_source, grounded).await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page_with_kind(
+            "page_reserved_dedup_existing",
+            "Rust Workspace",
+            None,
+            grounded,
+            None,
+            Some("work"),
+            &[existing_source],
+            &now,
+            "distilled",
+            "confirmed",
+            Some("work"),
+            None,
+        )
+        .await
+        .unwrap();
+        let before = db
+            .get_page("page_reserved_dedup_existing")
+            .await
+            .unwrap()
+            .unwrap();
+        let evidence_before = db
+            .get_page_evidence("page_reserved_dedup_existing")
+            .await
+            .unwrap();
+        let history_before = db
+            .list_page_history("page_reserved_dedup_existing", 10)
+            .await
+            .unwrap();
+        let req = CreateConceptRequest {
+            title: "Rust Workspace".to_string(),
+            content: format!("{grounded}\n\n{SOURCES_BLOCK_END}"),
+            summary: None,
+            entity_id: None,
+            space: Some("work".to_string()),
+            source_memory_ids: vec![candidate_source.to_string()],
+            creation_kind: Some("distilled".to_string()),
+            workspace: Some("work".to_string()),
+        };
+
+        let error = create_page_with_tuning(&db, req, "test", None, 1, -1.0)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, WenlanError::Validation(_)));
+        let after = db
+            .get_page("page_reserved_dedup_existing")
+            .await
+            .unwrap()
+            .unwrap();
+        let evidence_after = db
+            .get_page_evidence("page_reserved_dedup_existing")
+            .await
+            .unwrap();
+        let history_after = db
+            .list_page_history("page_reserved_dedup_existing", 10)
+            .await
+            .unwrap();
+        assert_eq!(after.content, before.content);
+        assert_eq!(after.version, before.version);
+        assert_eq!(after.source_memory_ids, before.source_memory_ids);
+        assert_eq!(after.stale_reason, before.stale_reason);
+        assert_eq!(evidence_after.len(), evidence_before.len());
+        assert_eq!(history_after.len(), history_before.len());
+    }
+
+    #[tokio::test]
     async fn create_page_borns_distilled_unconfirmed() {
         let (db, _dir) = test_db().await;
         let docs = [
@@ -5689,6 +5804,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn page_write_update_rejects_reserved_delimiter_before_revision_staging() {
+        use crate::export::provenance::SOURCES_BLOCK_START;
+
+        let (db, _dir) = test_db().await;
+        let mem_id = "mem-pagewrite-reserved-staging";
+        let source_content = "Rust ownership keeps memory safety rules explicit in systems code";
+        seed_memory(&db, mem_id, source_content).await;
+        let now = chrono::Utc::now().to_rfc3339();
+        let page_id = "page_pagewrite_reserved_staging";
+        db.insert_page_with_kind(
+            page_id,
+            "Rust Ownership",
+            None,
+            source_content,
+            None,
+            None,
+            &[mem_id],
+            &now,
+            "authored",
+            "confirmed",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let before = db.get_page(page_id).await.unwrap().unwrap();
+        let history_before = db.list_page_history(page_id, 10).await.unwrap();
+        assert!(db.list_pending_revisions(10).await.unwrap().is_empty());
+
+        let error = page_write(
+            &db,
+            PageWrite::Update {
+                page_id,
+                req: UpdatePageRequest {
+                    content: format!("{source_content}\n\n{SOURCES_BLOCK_START}"),
+                    source_memory_ids: vec![mem_id.to_string()],
+                    expected_version: Some(before.version),
+                    caller_id: None,
+                    operation_id: None,
+                },
+                edited_by: "re_distill",
+                require_stale: false,
+                expected_source_revision: None,
+                knowledge_path: None,
+                citations: None,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, WenlanError::Validation(_)));
+
+        let after = db.get_page(page_id).await.unwrap().unwrap();
+        let history_after = db.list_page_history(page_id, 10).await.unwrap();
+        assert_eq!(after.content, before.content);
+        assert_eq!(after.version, before.version);
+        assert_eq!(after.source_memory_ids, before.source_memory_ids);
+        assert_eq!(history_after, history_before);
+        assert!(
+            db.list_pending_revisions(10).await.unwrap().is_empty(),
+            "rejected source must not survive as a pending revision card"
+        );
+    }
+
+    #[tokio::test]
     async fn gated_refresh_does_not_clear_a_newer_source_revision() {
         let (db, _dir) = test_db().await;
         for (source_id, content) in [
@@ -6014,8 +6194,12 @@ mod tests {
             "a freshly created source page must already have its v1 history row"
         );
 
-        let v2 = "A source page is the machine-owned projection of one ingested document, \
-                  rewritten whenever that document is enriched again";
+        let v2 = "\u{feff}\r\n  A source page keeps exact source  \r\n\r\n";
+        assert_ne!(
+            v2.trim_end(),
+            v2,
+            "positive control: trimming must change this fixture"
+        );
         let result = page_write(
             &db,
             PageWrite::ReplaceSource {
@@ -6070,8 +6254,7 @@ mod tests {
         let (mem_id, _v1) = seed_source_page(&db, page_id).await;
         let sources = [mem_id.to_string()];
 
-        let body = "A source page is the machine-owned projection of one ingested document, \
-                    rebuilt identically on every retry while the analysis LLM stays down";
+        let body = "\u{feff}\r\n  A source page retry stays byte-identical  \t\r\n\r\n";
         let replace = |content: &'static str| {
             page_write(
                 &db,
@@ -6118,6 +6301,68 @@ mod tests {
             vec![2, 1],
             "no version means no history row — the retry appends nothing"
         );
+    }
+
+    #[tokio::test]
+    async fn replace_source_page_rejects_reserved_delimiters_without_mutation() {
+        use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+
+        let (db, _dir) = test_db().await;
+        let page_id = "page_source_reserved";
+        let (mem_id, _v1) = seed_source_page(&db, page_id).await;
+        let sources = [mem_id.to_string()];
+        let before = db.get_page(page_id).await.unwrap().unwrap();
+        let history_before = db.list_page_history(page_id, 10).await.unwrap();
+        let source_ids_before: HashSet<_> = db
+            .get_page_sources(page_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|source| source.memory_source_id)
+            .collect();
+        let cases = [
+            format!("before {SOURCES_BLOCK_START} after"),
+            format!("before {SOURCES_BLOCK_END} after"),
+            format!("{SOURCES_BLOCK_START}\nowned\n{SOURCES_BLOCK_END}"),
+            format!(
+                "{SOURCES_BLOCK_START}\none\n{SOURCES_BLOCK_END}\n\
+                 {SOURCES_BLOCK_START}\ntwo\n{SOURCES_BLOCK_END}"
+            ),
+            format!("```md\n{SOURCES_BLOCK_START}\n```\nkept prose"),
+        ];
+
+        for content in cases {
+            let error = page_write(
+                &db,
+                PageWrite::ReplaceSource {
+                    page_id,
+                    title: "Changed title",
+                    summary: Some("Changed summary"),
+                    content: &content,
+                    source_memory_ids: &sources,
+                    agent: "doc-enrich",
+                },
+            )
+            .await
+            .unwrap_err();
+            assert!(matches!(error, WenlanError::Validation(_)));
+
+            let after = db.get_page(page_id).await.unwrap().unwrap();
+            let history_after = db.list_page_history(page_id, 10).await.unwrap();
+            let source_ids_after: HashSet<_> = db
+                .get_page_sources(page_id)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|source| source.memory_source_id)
+                .collect();
+            assert_eq!(after.title, before.title);
+            assert_eq!(after.summary, before.summary);
+            assert_eq!(after.content, before.content);
+            assert_eq!(after.version, before.version);
+            assert_eq!(history_after.len(), history_before.len());
+            assert_eq!(source_ids_after, source_ids_before);
+        }
     }
 
     /// Seed a page and return `(db, tempdir, page_id, memory_id)` for the
@@ -6209,6 +6454,8 @@ mod tests {
     /// their new text was saved when it never was, so refuse instead.
     #[tokio::test]
     async fn page_write_same_operation_id_with_different_body_is_a_conflict() {
+        use crate::export::provenance::SOURCES_BLOCK_START;
+
         let (db, _dir, page_id, mem_id) = receipt_fixture("page_receipt_conflict").await;
 
         update_page(
@@ -6227,15 +6474,15 @@ mod tests {
         .await
         .unwrap();
         let after_first = db.get_page(page_id).await.unwrap().unwrap();
+        let changed_body = format!(
+            "A retried write must not become a second version of the page — \
+             different text\n\n{SOURCES_BLOCK_START}"
+        );
 
         let err = update_page(
             &db,
             page_id,
-            retry_req(
-                "A retried write must not become a second version of the page — different text",
-                mem_id,
-                "op-1",
-            ),
+            retry_req(&changed_body, mem_id, "op-1"),
             "re_distill",
             false,
             None,
@@ -6245,7 +6492,7 @@ mod tests {
         .expect_err("reusing an operation id for a different write must be refused");
         assert!(
             matches!(err, WenlanError::Conflict(_)),
-            "expected a conflict, got {err:?}"
+            "receipt collision must win before canonical-content validation; got {err:?}"
         );
 
         let unchanged = db.get_page(page_id).await.unwrap().unwrap();

--- a/crates/wenlan-server/src/memory_routes.rs
+++ b/crates/wenlan-server/src/memory_routes.rs
@@ -3572,6 +3572,8 @@ pub async fn handle_refresh_page(
                 .into(),
         ));
     }
+    wenlan_core::export::provenance::validate_canonical_page_content(&req.content)
+        .map_err(ServerError::from)?;
 
     let db = {
         let s = state.read().await;
@@ -3597,7 +3599,7 @@ pub async fn handle_refresh_page(
             "agent_refresh",
         )
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
         return Ok(Json(wenlan_types::responses::PageWriteResponse {
             ok: true,
             revision_card_id: result.revision_card_id,
@@ -3727,7 +3729,7 @@ pub async fn handle_refresh_page(
                     rb
                 );
             }
-            return Err(ServerError::IngestFailed(e.to_string()));
+            return Err(ServerError::from(e));
         }
     };
 

--- a/crates/wenlan-server/tests/page_manual_edit_gate.rs
+++ b/crates/wenlan-server/tests/page_manual_edit_gate.rs
@@ -7,9 +7,10 @@
 
 mod common;
 
-use axum::body::Body;
+use axum::body::{to_bytes, Body};
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
+use wenlan_core::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
 
 fn post_page(id: &str, body: serde_json::Value) -> Request<Body> {
     Request::builder()
@@ -18,6 +19,19 @@ fn post_page(id: &str, body: serde_json::Value) -> Request<Body> {
         .header("content-type", "application/json")
         .body(Body::from(body.to_string()))
         .unwrap()
+}
+
+fn get_page(id: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(format!("/api/pages/{id}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn response_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
 }
 
 /// A manual edit must leave a changelog entry and a history row — the trail a
@@ -209,4 +223,186 @@ async fn manual_edit_of_zero_source_authored_page_is_allowed() {
     assert_eq!(response.status(), StatusCode::OK);
     let after = db.get_page(&page_id).await.unwrap().unwrap();
     assert_eq!(after.content, "Things I am still thinking about.");
+}
+
+#[tokio::test]
+async fn manual_edit_round_trips_exact_source_through_post_then_get() {
+    let (app, _tmp, db) = common::test_app().await;
+    let page_id =
+        common::create_page_fixture(&db, "Exact source", "old body", None, &[], "authored").await;
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let exact = "\u{feff}\r\n  # Exact source  \r\n\r\nBody with terminal bytes\t \r\n\r\n";
+    assert_ne!(
+        exact.trim_end(),
+        exact,
+        "positive control: trimming must change this fixture"
+    );
+
+    let response = app
+        .clone()
+        .oneshot(post_page(
+            &page_id,
+            serde_json::json!({
+                "content": exact,
+                "expected_version": before.version,
+                "caller_id": "wenlan-app",
+                "operation_id": "exact-source-round-trip",
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app.oneshot(get_page(&page_id)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(
+        body["page"]["content"].as_str(),
+        Some(exact),
+        "GET must return the exact source accepted by POST"
+    );
+}
+
+#[tokio::test]
+async fn identical_operation_replays_without_a_second_version_or_history_row() {
+    let (app, _tmp, db) = common::test_app().await;
+    let page_id =
+        common::create_page_fixture(&db, "Retry receipt", "old body", None, &[], "authored").await;
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let history_before = db.list_page_history(&page_id, 10).await.unwrap();
+    let request = serde_json::json!({
+        "content": "one exact operation",
+        "expected_version": before.version,
+        "caller_id": "wenlan-app",
+        "operation_id": "receipt-replay",
+    });
+
+    let first = app
+        .clone()
+        .oneshot(post_page(&page_id, request.clone()))
+        .await
+        .unwrap();
+    let second = app.oneshot(post_page(&page_id, request)).await.unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(second.status(), StatusCode::OK);
+
+    let after = db.get_page(&page_id).await.unwrap().unwrap();
+    let history_after = db.list_page_history(&page_id, 10).await.unwrap();
+    assert_eq!(after.version, before.version + 1);
+    assert_eq!(history_after.len(), history_before.len() + 1);
+    assert!(
+        db.get_operation_receipt("wenlan-app", "receipt-replay")
+            .await
+            .unwrap()
+            .is_some(),
+        "the successful mutation and its receipt must commit together"
+    );
+}
+
+#[tokio::test]
+async fn reused_operation_with_one_byte_change_conflicts_without_mutation() {
+    let (app, _tmp, db) = common::test_app().await;
+    let page_id =
+        common::create_page_fixture(&db, "Receipt conflict", "old body", None, &[], "authored")
+            .await;
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let first = serde_json::json!({
+        "content": "landed body",
+        "expected_version": before.version,
+        "caller_id": "wenlan-app",
+        "operation_id": "receipt-conflict",
+    });
+    let changed = serde_json::json!({
+        "content": "landed body ",
+        "expected_version": before.version,
+        "caller_id": "wenlan-app",
+        "operation_id": "receipt-conflict",
+    });
+
+    let response = app
+        .clone()
+        .oneshot(post_page(&page_id, first))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let landed = db.get_page(&page_id).await.unwrap().unwrap();
+    let history_landed = db.list_page_history(&page_id, 10).await.unwrap();
+
+    let response = app.oneshot(post_page(&page_id, changed)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let unchanged = db.get_page(&page_id).await.unwrap().unwrap();
+    let history_unchanged = db.list_page_history(&page_id, 10).await.unwrap();
+    assert_eq!(unchanged.content, landed.content);
+    assert_eq!(unchanged.version, landed.version);
+    assert_eq!(history_unchanged.len(), history_landed.len());
+}
+
+#[tokio::test]
+async fn canonical_page_write_rejects_every_reserved_sources_marker_shape() {
+    let cases = [
+        ("start-only", format!("before {SOURCES_BLOCK_START} after")),
+        ("end-only", format!("before {SOURCES_BLOCK_END} after")),
+        (
+            "paired",
+            format!("{SOURCES_BLOCK_START}\nowned\n{SOURCES_BLOCK_END}"),
+        ),
+        (
+            "duplicate",
+            format!(
+                "{SOURCES_BLOCK_START}\none\n{SOURCES_BLOCK_END}\n\
+                 {SOURCES_BLOCK_START}\ntwo\n{SOURCES_BLOCK_END}"
+            ),
+        ),
+        (
+            "inside-fence",
+            format!("```md\n{SOURCES_BLOCK_START}\n```\nkept prose"),
+        ),
+    ];
+
+    for (case, content) in cases {
+        let (app, _tmp, db) = common::test_app().await;
+        let page_id = common::create_page_fixture(
+            &db,
+            &format!("Reserved marker {case}"),
+            "unchanged body",
+            None,
+            &[],
+            "authored",
+        )
+        .await;
+        let before = db.get_page(&page_id).await.unwrap().unwrap();
+        let history_before = db.list_page_history(&page_id, 10).await.unwrap();
+        let operation_id = format!("reserved-marker-{case}");
+
+        let response = app
+            .oneshot(post_page(
+                &page_id,
+                serde_json::json!({
+                    "content": content,
+                    "expected_version": before.version,
+                    "caller_id": "wenlan-app",
+                    "operation_id": operation_id,
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "{case} must fail closed"
+        );
+
+        let after = db.get_page(&page_id).await.unwrap().unwrap();
+        let history_after = db.list_page_history(&page_id, 10).await.unwrap();
+        assert_eq!(after.content, before.content, "{case}");
+        assert_eq!(after.version, before.version, "{case}");
+        assert_eq!(history_after.len(), history_before.len(), "{case}");
+        assert!(
+            db.get_operation_receipt("wenlan-app", &operation_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "{case} must not record a receipt for a rejected write"
+        );
+    }
 }

--- a/crates/wenlan-server/tests/route_convergence.rs
+++ b/crates/wenlan-server/tests/route_convergence.rs
@@ -6,11 +6,9 @@
 //! mapping) stays in sync with the origin-types wire shapes and
 //! post_write capability signatures.
 //!
-//! create_page integration is deferred: it requires a memory seeded via
-//! /api/memory/store (FastEmbed) before the hallucination guard can run,
-//! which adds significant setup cost. The post_write::create_page unit
-//! tests in origin-core already cover the logic; the HTTP shim is smoke-
-//! tested via the manual smoke test. See task notes for rationale.
+//! Authored create-page coverage uses its supported zero-source path, while
+//! distilled fixtures seed their source memories directly. This keeps route
+//! validation and error mapping covered without a separate TCP server.
 
 use axum::body::Body;
 use axum::http::{header, Method, Request, StatusCode};
@@ -353,6 +351,92 @@ async fn json_put(
     (status, val)
 }
 
+fn reserved_marker_cases() -> Vec<(&'static str, String)> {
+    use wenlan_core::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
+
+    vec![
+        (
+            "start-only",
+            format!("before\n{SOURCES_BLOCK_START}\nafter"),
+        ),
+        ("end-only", format!("before\n{SOURCES_BLOCK_END}\nafter")),
+        (
+            "paired",
+            format!("before\n{SOURCES_BLOCK_START}\nowned\n{SOURCES_BLOCK_END}\nafter"),
+        ),
+        (
+            "duplicate",
+            format!("{SOURCES_BLOCK_START}\n{SOURCES_BLOCK_START}"),
+        ),
+        (
+            "fenced",
+            format!("```markdown\n{SOURCES_BLOCK_START}\n```\nordinary prose"),
+        ),
+    ]
+}
+
+fn knowledge_snapshot(root: &std::path::Path) -> Vec<(String, Vec<u8>)> {
+    fn visit(root: &std::path::Path, current: &std::path::Path, out: &mut Vec<(String, Vec<u8>)>) {
+        let mut entries = std::fs::read_dir(current)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        entries.sort_by_key(std::fs::DirEntry::file_name);
+        for entry in entries {
+            let path = entry.path();
+            let relative = path.strip_prefix(root).unwrap().to_string_lossy();
+            if path.is_dir() {
+                out.push((format!("{relative}/"), Vec::new()));
+                visit(root, &path, out);
+            } else {
+                out.push((relative.into_owned(), std::fs::read(path).unwrap()));
+            }
+        }
+    }
+
+    let mut snapshot = Vec::new();
+    visit(root, root, &mut snapshot);
+    snapshot
+}
+
+#[tokio::test]
+async fn authored_create_rejects_reserved_markers_before_projection_or_db_mutation() {
+    let _guard = data_dir_lock().lock().await;
+    let config = WritableKnowledgeConfig::new();
+    let (app, db, _dir) = test_app_with_db().await;
+    let projection_before = knowledge_snapshot(&config.pages_dir());
+
+    for (case, content) in reserved_marker_cases() {
+        let (status, body) = json_post(
+            &app,
+            "/api/pages",
+            Some("test-agent"),
+            serde_json::json!({
+                "title": format!("Rejected {case}"),
+                "content": content,
+                "source_memory_ids": [],
+                "creation_kind": "authored"
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "{case} must map to HTTP 422; body: {body}"
+        );
+        assert!(
+            db.list_pages("active", 100, 0).await.unwrap().is_empty(),
+            "{case} must not create a DB page"
+        );
+        assert_eq!(
+            knowledge_snapshot(&config.pages_dir()),
+            projection_before,
+            "{case} must be rejected before projection mutation"
+        );
+    }
+}
+
 /// A refresh that does not land must leave no projection claiming a version
 /// ahead of the DB.
 ///
@@ -564,6 +648,89 @@ async fn refresh_page_machine_owned_page_goes_through_page_write_changelog() {
         has_agent_refresh_entry,
         "HTTP refresh must route through PageWrite changelog, got {changelog}"
     );
+}
+
+#[tokio::test]
+async fn refresh_rejects_reserved_markers_before_card_page_or_projection_mutation() {
+    let _guard = data_dir_lock().lock().await;
+    let config = WritableKnowledgeConfig::new();
+    let (app, db, _dir) = test_app_with_db().await;
+    let mem_id = "mem_route_reserved_refresh";
+    let source_content =
+        "Rust async refresh content stays grounded in its source memory and exact source bytes";
+    db.upsert_documents(vec![RawDocument {
+        source: "memory".to_string(),
+        source_id: mem_id.to_string(),
+        title: "Reserved refresh source".to_string(),
+        content: source_content.to_string(),
+        last_modified: chrono::Utc::now().timestamp(),
+        memory_type: Some("fact".to_string()),
+        source_agent: Some("test".to_string()),
+        confirmed: Some(true),
+        ..Default::default()
+    }])
+    .await
+    .unwrap();
+
+    let authored_id =
+        create_authored_page_fixture(&db, "Human-owned exact source", source_content).await;
+    let distilled_id =
+        create_distilled_page_fixture(&db, "Machine-owned exact source", source_content, &[mem_id])
+            .await;
+    let projection_before = knowledge_snapshot(&config.pages_dir());
+    let pending_before = db.list_pending_revisions(100).await.unwrap();
+
+    for (ownership, page_id) in [("human", authored_id), ("machine", distilled_id)] {
+        let page_before = db.get_page(&page_id).await.unwrap().unwrap();
+        let history_before = db.list_page_history(&page_id, 100).await.unwrap();
+
+        for (case, marker_content) in reserved_marker_cases() {
+            let content = format!("{source_content}\n\n{marker_content}");
+            let (status, body) = json_put(
+                &app,
+                &format!("/api/pages/{page_id}"),
+                serde_json::json!({
+                    "content": content,
+                    "source_memory_ids": [mem_id]
+                }),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{ownership}-owned {case} must map to HTTP 422; body: {body}"
+            );
+            let page_after = db.get_page(&page_id).await.unwrap().unwrap();
+            assert_eq!(
+                page_after.content, page_before.content,
+                "{ownership} {case}"
+            );
+            assert_eq!(
+                page_after.version, page_before.version,
+                "{ownership} {case}"
+            );
+            assert_eq!(
+                page_after.source_memory_ids, page_before.source_memory_ids,
+                "{ownership} {case}"
+            );
+            assert_eq!(
+                db.list_page_history(&page_id, 100).await.unwrap(),
+                history_before,
+                "{ownership} {case} must not append page history"
+            );
+            assert_eq!(
+                db.list_pending_revisions(100).await.unwrap().len(),
+                pending_before.len(),
+                "{ownership} {case} must not stage a revision card"
+            );
+            assert_eq!(
+                knowledge_snapshot(&config.pages_dir()),
+                projection_before,
+                "{ownership} {case} must not mutate projection files"
+            );
+        }
+    }
 }
 
 /// Non-existent source_id uses the same static 404 as a scope mismatch.


### PR DESCRIPTION
## What this PR does
Preserves delimiter-free canonical Page content byte-for-byte across create, draft, source replacement, and CAS update paths. Reserved projection delimiters now fail closed before page, history, source, revision-card, receipt, or projection mutation while watcher-side projection decoding and the existing public sanitizer API remain compatible.

## How to test
- `cargo test --workspace` — 60 suites, 3527 passed, 29 ignored, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check --all`
- Focused exact-source contracts: provenance 20/20, reserved delimiters 7/7, page watcher 13/13, manual HTTP gate 9/9, route convergence 16/16
- Two independent release reviews completed; all functional and compatibility holds resolved

## Checklist
- [x] Tests pass (`cargo test --workspace`)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet
- [x] No secrets or credentials committed