### PR TITLE
fix: M2 unified edges — schema expand + dual-write shadow (PR-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5648,6 +5648,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "toml",
+ "unicode-normalization",
  "uuid",
  "wenlan-types",
  "zip",

--- a/crates/wenlan-core/Cargo.toml
+++ b/crates/wenlan-core/Cargo.toml
@@ -73,6 +73,13 @@ env_logger = "0.11"
 # eval modules are not feature-gated, so their deps are regular deps.
 tiktoken-rs = "0.6"
 futures = { workspace = true }
+# Unicode NFC normalization for provenance-root content canonicalization
+# (Q6-locked recipe: NFC + line-ending + whitespace, nothing semantic).
+# Already present transitively (text-splitter -> ... -> unicode-normalization
+# 0.1.25), so this pins it as a direct dep rather than growing the resolved
+# graph. Root Cargo.toml is release-please-locked, so this is a per-crate
+# dep like text-splitter/tiktoken-rs above rather than a workspace one.
+unicode-normalization = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 llama-cpp-2 = { version = "0.1", features = ["metal", "sampler"] }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -7952,13 +7952,18 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("m81 migration state: {e}")))?;
 
             // Fence created AFTER every backfill INSERT above -- see the
-            // "ordering matters" note on this function's doc comment. Sole
-            // exemption (besides `lineage='legacy'`): `cites` to an external
-            // URI, which has no space to check (spec §2).
+            // "ordering matters" note on this function's doc comment.
+            // Exemptions: `lineage='legacy'` (whole edge, WHEN clause) and the
+            // DESTINATION endpoint of a `cites`->external URI (which has no
+            // space to check, spec §2). The external exemption is scoped to
+            // the destination ONLY -- the source page is still fenced, so a
+            // page in space A cannot mint a `cites`->external edge stamped
+            // space B. (An earlier WHEN clause disabled the whole trigger body
+            // for `cites`->external, skipping the source check too.)
             conn.execute_batch(
                 "CREATE TRIGGER IF NOT EXISTS edges_space_fence
                  AFTER INSERT ON edges
-                 WHEN NEW.lineage != 'legacy' AND NOT (NEW.edge_type = 'cites' AND NEW.dst_kind = 'external')
+                 WHEN NEW.lineage != 'legacy'
                  BEGIN
                      SELECT RAISE(ABORT, 'edges_space_fence: cross-space edge rejected')
                      WHERE (
@@ -7970,13 +7975,16 @@ impl MemoryDB {
                          END
                      ) IS NOT NEW.space
                      OR (
-                         CASE NEW.dst_kind
-                             WHEN 'page' THEN (SELECT space FROM pages WHERE id = NEW.dst_id)
-                             WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = NEW.dst_id)
-                             WHEN 'entity' THEN (SELECT space FROM entities WHERE id = NEW.dst_id)
-                             ELSE NULL
-                         END
-                     ) IS NOT NEW.space;
+                         NOT (NEW.edge_type = 'cites' AND NEW.dst_kind = 'external')
+                         AND (
+                             CASE NEW.dst_kind
+                                 WHEN 'page' THEN (SELECT space FROM pages WHERE id = NEW.dst_id)
+                                 WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = NEW.dst_id)
+                                 WHEN 'entity' THEN (SELECT space FROM entities WHERE id = NEW.dst_id)
+                                 ELSE NULL
+                             END
+                         ) IS NOT NEW.space
+                     );
                  END;",
             )
             .await
@@ -8120,11 +8128,39 @@ impl MemoryDB {
             discriminator,
         );
         let now = chrono::Utc::now().timestamp();
+        // ON CONFLICT resolves two things deterministically, so the shadow
+        // edge is independent of dual-write CALL ORDER:
+        //   1. Reactivation -- a soft-invalidated edge (`valid_until` set) is
+        //      un-retracted (the "delete a link then add it back" case).
+        //   2. Lineage precedence -- one content-addressed `edge_id` can be
+        //      dual-written by several legacy stores for the same (page,
+        //      memory) fact: `page_evidence` writes `evidence`, a
+        //      `pages.citations` entry writes `synthesis`. Without a rule the
+        //      lineage would be whichever store happened to write first (the
+        //      old `DO UPDATE` never touched `lineage`). We pin
+        //      `evidence` > `synthesis` -- the same precedence the migration-81
+        //      backfill already yields by running `page_sources`/`page_evidence`
+        //      before `page_citations` (`DO NOTHING`, first writer wins), so a
+        //      live edge and its backfilled twin agree.
+        // This is FENCE-SAFE: for a given `edge_id` every writer resolves the
+        // identical page/memory spaces, so they agree same-space vs cross-space
+        // -- `evidence`/`synthesis` occur only same-space (fence already passed
+        // at insert), `legacy` only cross-space; the CASE therefore only ever
+        // moves `synthesis`->`evidence` within one space and never crosses the
+        // `legacy` boundary, so the row stays fence-valid (and the fence is an
+        // AFTER INSERT trigger that does not re-fire on this UPDATE regardless).
         conn.execute(
             "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL, ?8, NULL, NULL, NULL, ?9, ?10, NULL, NULL)
-             ON CONFLICT(edge_id) DO UPDATE SET valid_until = NULL, superseded_by = NULL
-             WHERE valid_until IS NOT NULL",
+             ON CONFLICT(edge_id) DO UPDATE SET
+                 valid_until = NULL,
+                 superseded_by = NULL,
+                 lineage = CASE
+                     WHEN excluded.lineage = 'evidence' AND edges.lineage = 'synthesis' THEN 'evidence'
+                     ELSE edges.lineage
+                 END
+             WHERE valid_until IS NOT NULL
+                OR (excluded.lineage = 'evidence' AND edges.lineage = 'synthesis')",
             libsql::params![
                 edge_id.clone(),
                 src_id.to_string(),
@@ -8321,15 +8357,29 @@ impl MemoryDB {
     }
 
     /// `page_sources` → `cites` edges (matrix row 2). `page_id` FK cascades
-    /// to `pages`, so every row is classifiable: `pages.space` is always
-    /// present (NOT NULL since M1).
+    /// to `pages`, so `pages.space` is always present (NOT NULL since M1). The
+    /// cited memory's space is resolved by a scalar subquery: a `source_id`'s
+    /// space is single-valued by construction (`update_memory_space_opt`
+    /// mutates every chunk of a `source_id` together; ingest stamps one space
+    /// per document), so `LIMIT 1` is deterministic -- the same resolution the
+    /// live fence trigger and `resolve_memory_space` use. A memory in a
+    /// DIFFERENT space (the `cross_space_discovery` feature mints exactly this
+    /// shape -- a page in one space citing memories in another) or an absent
+    /// memory downgrades to `lineage='legacy'`, mirroring
+    /// `backfill_edges_from_page_evidence`. Without this, a cross-space
+    /// page_sources row would backfill as a non-legacy `evidence` edge that
+    /// the live fence does NOT exempt (only `cites`->`external` is), so the
+    /// backfilled shadow and the live dual-write of the same row would
+    /// disagree, and the backfilled non-legacy cross-space edge would persist
+    /// because the backfill predates the fence.
     async fn backfill_edges_from_page_sources(
         conn: &libsql::Connection,
     ) -> Result<EdgeBackfillCounts, WenlanError> {
         let mut counts = EdgeBackfillCounts::default();
         let mut rows = conn
             .query(
-                "SELECT ps.page_id, ps.memory_source_id, p.space \
+                "SELECT ps.page_id, ps.memory_source_id, p.space, \
+                        (SELECT m.space FROM memories m WHERE m.source_id = ps.memory_source_id LIMIT 1) \
                  FROM page_sources ps JOIN pages p ON p.id = ps.page_id",
                 (),
             )
@@ -8343,7 +8393,14 @@ impl MemoryDB {
             let page_id: String = row.get(0).unwrap_or_default();
             let memory_source_id: String = row.get(1).unwrap_or_default();
             let space: String = row.get(2).unwrap_or_default();
-            counts.classifiable += 1;
+            let memory_space: Option<String> = row.get(3).unwrap_or(None);
+            let lineage = if memory_space.as_deref() == Some(space.as_str()) {
+                counts.classifiable += 1;
+                "evidence"
+            } else {
+                counts.unknown_inserted += 1;
+                "legacy"
+            };
             Self::insert_backfilled_edge(
                 conn,
                 "cites",
@@ -8352,7 +8409,7 @@ impl MemoryDB {
                 "memory",
                 &memory_source_id,
                 &memory_source_id,
-                "evidence",
+                lineage,
                 &space,
                 "page_sources",
             )
@@ -8370,20 +8427,31 @@ impl MemoryDB {
         conn: &libsql::Connection,
     ) -> Result<EdgeBackfillCounts, WenlanError> {
         let mut counts = EdgeBackfillCounts::default();
-        // LEFT JOIN memories on the memory-kind locator so a memory-kind
-        // citation's classification can check space agreement -- a page in
-        // one space citing a memory in another is a real legacy shape (the
-        // old `page_evidence` schema never enforced same-space), and the
-        // fence trigger does NOT exempt `cites`->`memory` edges (only
-        // `cites`->`external` is space-exempt), so an unmatched space must
-        // downgrade to `legacy` or a live dual-write of the same row would
-        // be fence-rejected.
+        // Resolve the cited memory's space by a SCALAR SUBQUERY (not a JOIN)
+        // so a memory-kind citation's classification can check space
+        // agreement -- a page in one space citing a memory in another is a
+        // real legacy shape (the old `page_evidence` schema never enforced
+        // same-space), and the fence trigger does NOT exempt `cites`->`memory`
+        // edges (only `cites`->`external` is space-exempt), so an unmatched
+        // space must downgrade to `legacy` or a live dual-write of the same
+        // row would be fence-rejected.
+        //
+        // A `LEFT JOIN memories` here fans out: a memory has one row PER CHUNK
+        // sharing its `source_id`, so an N-chunk memory would yield N rows for
+        // one `page_evidence` row -- N identical classifications (space is
+        // single-valued per `source_id`; see `resolve_memory_space`) that
+        // inflate `classifiable`/`unknown_inserted` N-fold in the migration
+        // report while `insert_backfilled_edge`'s `ON CONFLICT DO NOTHING`
+        // still lands one edge. The scalar subquery + `LIMIT 1` yields exactly
+        // one row per `page_evidence` row, so the report counts one citation
+        // as one. For an external locator the subquery finds no memory and
+        // returns NULL, which the `external_*` branches never read.
         let mut rows = conn
             .query(
-                "SELECT pe.page_id, pe.source_kind, pe.locator, p.space, m.space \
+                "SELECT pe.page_id, pe.source_kind, pe.locator, p.space, \
+                        (SELECT m.space FROM memories m WHERE m.source_id = pe.locator LIMIT 1) \
                  FROM page_evidence pe \
-                 JOIN pages p ON p.id = pe.page_id \
-                 LEFT JOIN memories m ON m.source_id = pe.locator AND pe.source_kind = 'memory'",
+                 JOIN pages p ON p.id = pe.page_id",
                 (),
             )
             .await
@@ -8679,64 +8747,99 @@ impl MemoryDB {
         let bands = crate::provenance::content_minhash_bands(&canonical);
 
         let conn = self.conn.lock().await;
-        // Overlay match wins over the structural signal key -- a near-dup
-        // catches groups the structural signal alone would keep apart (e.g.
-        // two distinct import batches containing byte-similar content); the
-        // structural key is the fallback when no near-dup is found, and a
-        // fresh id is the last resort when neither signal establishes a group.
-        let overlay_match = Self::query_provenance_roots_by_band(&conn, &bands)
-            .await?
-            .into_iter()
-            .next();
-        let group_id = overlay_match
-            .or_else(|| crate::provenance::base_independence_key(signals))
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
-        let root_id = uuid::Uuid::new_v4().to_string();
-        let now = chrono::Utc::now().timestamp();
-        let mut rows = conn
-            .query(
-                "INSERT INTO provenance_roots (root_id, identity_version, identity_digest, root_kind, independence_group_id, status, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6)
-                 ON CONFLICT(identity_version, identity_digest) DO UPDATE SET root_id = root_id
-                 RETURNING root_id",
-                libsql::params![
-                    root_id.clone(),
-                    crate::provenance::IDENTITY_VERSION,
-                    digest,
-                    root_kind.to_string(),
-                    group_id,
-                    now
-                ],
-            )
+        // The root row and its MinHash bands must land ATOMICALLY. They are
+        // two statements; without a transaction the root INSERT autocommits and
+        // a crash before the band INSERTs leaves a durable root with no bands
+        // -- permanently invisible to LSH near-dup lookup, so later near-dups
+        // mint separate independence groups forever. Wrapping both (plus the
+        // band read they depend on) in one transaction makes the root durable
+        // only once its bands are too; a crash mid-way rolls the whole thing
+        // back. It also closes the query-then-insert near-dup race under the
+        // single-writer connection: because a winning writer's bands commit
+        // atomically with its root, the next (serialized) acquirer's band read
+        // sees them and converges on the same group rather than minting a new
+        // one. (A genuinely concurrent multi-connection deployment would
+        // reintroduce the race; the daemon is single-writer, so this holds.)
+        conn.execute("BEGIN", ())
             .await
-            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root: {e}")))?;
-        let winning_root_id: String = rows
-            .next()
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root row: {e}")))?
-            .ok_or_else(|| {
-                WenlanError::VectorDb(
-                    "acquire_provenance_root: INSERT..RETURNING produced no row".to_string(),
-                )
-            })?
-            .get(0)
-            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root col: {e}")))?;
-        drop(rows);
+            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root begin: {e}")))?;
 
-        // Only index this root's own bands when it actually won (the
-        // conflict branch already has bands indexed from its own insert).
-        if winning_root_id == root_id {
-            for band in &bands {
-                conn.execute(
-                    "INSERT OR IGNORE INTO provenance_root_minhash_bands (band_key, root_id) VALUES (?1, ?2)",
-                    libsql::params![*band as i64, winning_root_id.clone()],
+        let acquired: Result<String, WenlanError> = async {
+            // Overlay match wins over the structural signal key -- a near-dup
+            // catches groups the structural signal alone would keep apart (e.g.
+            // two distinct import batches containing byte-similar content); the
+            // structural key is the fallback when no near-dup is found, and a
+            // fresh id is the last resort when neither signal establishes a group.
+            let overlay_match = Self::query_provenance_roots_by_band(&conn, &bands)
+                .await?
+                .into_iter()
+                .next();
+            let group_id = overlay_match
+                .or_else(|| crate::provenance::base_independence_key(signals))
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+            let root_id = uuid::Uuid::new_v4().to_string();
+            let now = chrono::Utc::now().timestamp();
+            let mut rows = conn
+                .query(
+                    "INSERT INTO provenance_roots (root_id, identity_version, identity_digest, root_kind, independence_group_id, status, created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6)
+                     ON CONFLICT(identity_version, identity_digest) DO UPDATE SET root_id = root_id
+                     RETURNING root_id",
+                    libsql::params![
+                        root_id.clone(),
+                        crate::provenance::IDENTITY_VERSION,
+                        digest,
+                        root_kind.to_string(),
+                        group_id,
+                        now
+                    ],
                 )
                 .await
-                .map_err(|e| WenlanError::VectorDb(format!("provenance_root_minhash_bands: {e}")))?;
-            }
-        }
+                .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root: {e}")))?;
+            let winning_root_id: String = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root row: {e}")))?
+                .ok_or_else(|| {
+                    WenlanError::VectorDb(
+                        "acquire_provenance_root: INSERT..RETURNING produced no row".to_string(),
+                    )
+                })?
+                .get(0)
+                .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root col: {e}")))?;
+            drop(rows);
 
+            // Only index this root's own bands when it actually won (the
+            // conflict branch already has bands indexed from its own insert).
+            if winning_root_id == root_id {
+                for band in &bands {
+                    conn.execute(
+                        "INSERT OR IGNORE INTO provenance_root_minhash_bands (band_key, root_id) VALUES (?1, ?2)",
+                        libsql::params![*band as i64, winning_root_id.clone()],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("provenance_root_minhash_bands: {e}")))?;
+                }
+            }
+
+            Ok(winning_root_id)
+        }
+        .await;
+
+        let winning_root_id = match acquired {
+            Ok(id) => id,
+            Err(error) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(error);
+            }
+        };
+        if let Err(error) = conn.execute("COMMIT", ()).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(WenlanError::VectorDb(format!(
+                "acquire_provenance_root commit: {error}"
+            )));
+        }
         Ok(winning_root_id)
     }
 
@@ -27096,6 +27199,21 @@ impl MemoryDB {
         // same edge_id a backfill would produce for the same row. This is
         // the ONE fix site for every `insert_resolved_page_evidence` caller,
         // same rationale as `resolve_source_kinds`'s doc comment.
+        //
+        // The single-transaction dual-write contract (spec v3 §2: the legacy
+        // write and its shadow edge commit or roll back together) requires the
+        // CALLER to have opened a transaction. On an autocommit connection the
+        // `page_evidence` INSERT below would commit before the edge INSERT, so
+        // a fence-rejected or otherwise failing edge write could not roll the
+        // legacy write back. Assert the invariant so any caller that forgets a
+        // `BEGIN` fails loudly in tests rather than silently splitting the two
+        // writes across commits.
+        debug_assert!(
+            !conn.is_autocommit(),
+            "insert_resolved_page_evidence must run inside a caller-opened transaction \
+             (single-transaction dual-write); autocommit would commit the page_evidence write \
+             before the edge write, breaking atomicity"
+        );
         let mut space_rows = conn
             .query(
                 "SELECT space FROM pages WHERE id = ?1",
@@ -60882,6 +61000,62 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn migration_81_page_evidence_backfill_counts_multichunk_memory_once() {
+        // A memory is stored as one row PER CHUNK sharing a `source_id`. A
+        // memory-kind `page_evidence` row citing it must count as ONE
+        // classifiable citation, not once per chunk. Regression for the
+        // `LEFT JOIN memories` fan-out that inflated the migration report's
+        // classifiable count N-fold for an N-chunk memory (the edge itself was
+        // always deduped by `ON CONFLICT DO NOTHING`; only the count lied).
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_multi", "chunk zero", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            // Second chunk of the SAME source_id (distinct primary-key id).
+            conn.execute(
+                "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                                        last_modified, chunk_type, source_agent, space, confidence, \
+                                        confirmed, memory_type, pending_revision) \
+                 VALUES ('mem_multi_c1', 'chunk one', 'memory', 'mem_multi', 'test', 1, 1712707200, 'text', NULL, 'space_a', 1.0, 0, 'fact', 0)",
+                (),
+            )
+            .await
+            .unwrap();
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason) \
+                 VALUES ('page_1', 'memory', 'mem_multi', NULL, 1712707200, NULL)",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        // Exactly one edge (dedup was never the bug).
+        let edge_present = edge_row(&conn, "cites", "page_1", "mem_multi").await;
+        assert!(edge_present.is_some(), "the single cites edge must exist");
+        // And the report counts the citation once, not once per chunk.
+        let report_json: String = {
+            let mut rows = conn
+                .query(
+                    "SELECT report_json FROM edges_migration_state WHERE id = 1",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        let report: serde_json::Value = serde_json::from_str(&report_json).unwrap();
+        let classifiable = report["page_evidence"]["classifiable"].as_i64().unwrap();
+        assert_eq!(
+            classifiable, 1,
+            "a 2-chunk memory cited once must count as 1 classifiable, not 2 (LEFT JOIN fan-out)"
+        );
+    }
+
+    #[tokio::test]
     async fn migration_81_backfills_relations_same_space_as_assertion() {
         let (db, _dir) = test_db().await;
         let e1 = db
@@ -60945,6 +61119,40 @@ pub(crate) mod tests {
         let conn = db.conn.lock().await;
         let (lineage, grounded, space) = edge_row(&conn, "cites", "page_1", "mem_1").await.unwrap();
         assert_eq!(lineage, "evidence");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_cross_space_page_source_as_legacy() {
+        // A page in space_a citing a memory in space_b (the shape the
+        // cross_space_discovery feature mints). The backfilled `cites` edge
+        // takes the page's space, but its provenance is cross-space -- the
+        // live fence would reject a non-legacy `cites`->memory edge across
+        // spaces, so the backfill must classify it honestly as `lineage`
+        // 'legacy', NOT 'evidence'. Regression for the page_sources backfill
+        // stamping every row 'evidence' without resolving the cited memory's
+        // space.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_x", "source content", "space_b").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_sources (page_id, memory_source_id, linked_at, link_reason) VALUES ('page_1', 'mem_x', 1712707200, 'distill')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) = edge_row(&conn, "cites", "page_1", "mem_x").await.unwrap();
+        assert_eq!(
+            lineage, "legacy",
+            "a cross-space page_source must backfill as legacy, not evidence"
+        );
         assert_eq!(grounded, 0);
         assert_eq!(space, "space_a");
     }
@@ -61210,7 +61418,30 @@ pub(crate) mod tests {
             (),
         )
         .await
-        .expect("cites-to-external is exempt from the fence (no space to check)");
+        .expect("cites-to-external is exempt from the fence on its destination (source page still matches)");
+    }
+
+    #[tokio::test]
+    async fn migration_81_fence_trigger_rejects_cites_external_with_mismatched_source_space() {
+        // The external DESTINATION is exempt (no space to check), but the
+        // SOURCE page is still fenced: a page in space_a cannot mint a
+        // cites->external edge stamped space_b. Regression for the WHEN clause
+        // that used to disable the entire fence body for cites->external.
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_src", "space_a").await;
+        let result = conn
+            .execute(
+                "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until) \
+                 VALUES ('test-edge-ext-mismatch', 'page_src', 'page', 'https://example.com/z', 'external', 'cites', 'evidence', 0, NULL, 'space_b', NULL, NULL, NULL, NULL, 0, NULL, NULL)",
+                (),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a cites->external edge whose SOURCE page is in a different space than the edge \
+             must be rejected -- the external exemption covers only the destination endpoint"
+        );
     }
 
     #[tokio::test]
@@ -61647,5 +61878,217 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_ne!(root_1, root_2);
+    }
+
+    #[tokio::test]
+    async fn acquire_provenance_root_indexes_bands_on_success() {
+        // A successfully-acquired new root must have its MinHash bands
+        // indexed in the same call -- otherwise it is invisible to LSH
+        // near-dup lookup. Guards the happy-path half of the atomic
+        // root+bands write.
+        let (db, _dir) = test_db().await;
+        let signals = crate::provenance::IndependenceSignals {
+            source_identity: Some("file:///a.txt"),
+            agent_turn: None,
+            import_batch: None,
+        };
+        let root = db
+            .acquire_provenance_root(
+                "document_ingest",
+                "a document long enough to produce content shingles and bands",
+                &signals,
+            )
+            .await
+            .unwrap();
+        let conn = db.conn.lock().await;
+        let band_count: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM provenance_root_minhash_bands WHERE root_id = ?1",
+                    libsql::params![root.clone()],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert!(
+            band_count > 0,
+            "a committed root must carry its bands (atomic root+bands index)"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_provenance_root_rolls_back_root_when_band_index_fails() {
+        // Force the band INSERT to fail AFTER the root row is written (a
+        // trigger, so the overlay SELECT on the same table still succeeds).
+        // With the atomic root+bands transaction the root must roll back;
+        // the pre-fix code autocommitted the root before the band write, so
+        // the root would survive -- exactly the durable-unindexed-root gap.
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "CREATE TRIGGER test_reject_band_insert \
+                 BEFORE INSERT ON provenance_root_minhash_bands \
+                 BEGIN SELECT RAISE(ABORT, 'test: band insert rejected'); END",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        let signals = crate::provenance::IndependenceSignals {
+            source_identity: Some("file:///a.txt"),
+            agent_turn: None,
+            import_batch: None,
+        };
+        let result = db
+            .acquire_provenance_root(
+                "document_ingest",
+                "a document whose band-index write is forced to fail mid-acquire",
+                &signals,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a band-index failure must fail the whole acquire"
+        );
+        let conn = db.conn.lock().await;
+        let root_count: i64 = {
+            let mut rows = conn
+                .query("SELECT COUNT(*) FROM provenance_roots", ())
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            root_count, 0,
+            "the root must roll back when its band-index write fails -- \
+             atomic root+bands, not two independent autocommit writes"
+        );
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_lineage_evidence_wins_over_synthesis_regardless_of_order() {
+        // One content-addressed edge_id can be dual-written by several legacy
+        // stores for the same (page, memory) fact: page_evidence -> evidence,
+        // a pages.citations entry -> synthesis. The resolved lineage must be
+        // deterministic (evidence > synthesis) no matter which store writes
+        // first, so a live edge and its migration-81 backfilled twin agree.
+        // Regression for the ON CONFLICT that never merged lineage (first
+        // writer's lineage stuck).
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_1", "c", "space_a").await;
+        seed_memory_with_source_id_and_space(&db, "mem_2", "c", "space_a").await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+        insert_raw_page_for_m81_test(&conn, "page_2", "space_a").await;
+
+        // synthesis first, evidence second -> evidence wins (upgrade).
+        MemoryDB::dual_write_edge(
+            &conn,
+            "cites",
+            "page",
+            "page_1",
+            "memory",
+            "mem_1",
+            "mem_1",
+            "synthesis",
+            "space_a",
+            None,
+        )
+        .await
+        .unwrap();
+        MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_1", "memory", "mem_1", "mem_1", "evidence", "space_a",
+            None,
+        )
+        .await
+        .unwrap();
+        let (lineage_1, _, _) = edge_row(&conn, "cites", "page_1", "mem_1").await.unwrap();
+        assert_eq!(
+            lineage_1, "evidence",
+            "evidence written after synthesis must win"
+        );
+
+        // evidence first, synthesis second -> evidence retained (no downgrade).
+        MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_2", "memory", "mem_2", "mem_2", "evidence", "space_a",
+            None,
+        )
+        .await
+        .unwrap();
+        MemoryDB::dual_write_edge(
+            &conn,
+            "cites",
+            "page",
+            "page_2",
+            "memory",
+            "mem_2",
+            "mem_2",
+            "synthesis",
+            "space_a",
+            None,
+        )
+        .await
+        .unwrap();
+        let (lineage_2, _, _) = edge_row(&conn, "cites", "page_2", "mem_2").await.unwrap();
+        assert_eq!(
+            lineage_2, "evidence",
+            "evidence must not be downgraded to synthesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn replace_page_sources_dual_write_rolls_back_page_evidence_on_edge_failure() {
+        // End-to-end proof that `insert_resolved_page_evidence` runs inside the
+        // caller's transaction (the invariant its `debug_assert!` guards): with
+        // the `edges` table dropped, the dual-write edge INSERT fails, and the
+        // page_sources + page_evidence legacy writes in the same transaction
+        // must roll back -- not two independent autocommit writes.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_1", "content", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute("DROP TABLE edges", ()).await.unwrap();
+        }
+
+        let result = db
+            .replace_page_sources("page_1", &["mem_1"], "distill")
+            .await;
+        assert!(
+            result.is_err(),
+            "a same-transaction edge-write failure must fail the whole call"
+        );
+
+        let conn = db.conn.lock().await;
+        let pe_count: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM page_evidence WHERE page_id = 'page_1'",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            pe_count, 0,
+            "the page_evidence write must roll back when the same-transaction edge write fails"
+        );
+        let ps_count: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM page_sources WHERE page_id = 'page_1'",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            ps_count, 0,
+            "the page_sources write must roll back too -- single-transaction dual-write"
+        );
     }
 }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -8151,6 +8151,24 @@ impl MemoryDB {
         discriminator: &str,
         lineage: &str,
         space: &str,
+        // Whether this write is a genuine cross-space (or indeterminate-space)
+        // DOWNGRADE, supplied by the producer from its OWN space resolution --
+        // never inferred here from `(lineage, dst_kind)`. Each caller sets it
+        // from the same destination-space comparison that chose `lineage`
+        // (`resolved_space_downgrades` for a resolved single destination; the
+        // two-endpoint compare for `relates`), so a same-space determinate
+        // destination is `false` even if some producer labelled it `legacy`,
+        // and a cross-space/indeterminate destination is `true`. External
+        // destinations are fence-exempt and always pass `false` (their `legacy`
+        // is an unknown-KIND label, not a downgrade). This marker lets the
+        // conflict rule reconcile the row to `legacy` even when the stored space
+        // stamp (which tracks the SOURCE endpoint) is unchanged by a DESTINATION
+        // move -- the round-3 SQL-only discriminant compared stamps and so
+        // missed destination moves, producing a fence abort (round-4
+        // regression). Passing it explicitly (round-5) removes the reconstructed
+        // proxy, which could not prove a producer never emits same-space
+        // non-external `legacy`.
+        cross_space_downgrade: bool,
         operation_id: Option<&str>,
     ) -> Result<String, libsql::Error> {
         let edge_id = crate::provenance::compute_edge_id(
@@ -8162,19 +8180,6 @@ impl MemoryDB {
             discriminator,
         );
         let now = chrono::Utc::now().timestamp();
-        // Whether this write is a genuine cross-space (or indeterminate-space)
-        // DOWNGRADE, resolved in Rust where the reason is explicit rather than
-        // inferred from the space stamp. Callers pass `lineage = 'legacy'` for a
-        // fence-applicable destination (memory / entity / page) ONLY when they
-        // detected the destination is not in the source's space (or its space is
-        // indeterminate); an external destination is fence-exempt, so its
-        // `legacy` is an unknown-KIND classification, never a cross-space
-        // downgrade. This marker lets the conflict rule reconcile the row to
-        // `legacy` even when the stored space stamp (which tracks the SOURCE
-        // endpoint) is unchanged by a DESTINATION move -- the round-3 SQL-only
-        // discriminant compared stamps and so missed destination moves,
-        // producing a fence abort (round-4 regression).
-        let cross_space_downgrade = lineage == "legacy" && dst_kind != "external";
         // ON CONFLICT resolves the shadow edge independent of dual-write CALL
         // ORDER, reconciling three things a re-write can change:
         //   1. Reactivation -- a soft-invalidated edge (`valid_until` set) is
@@ -8323,6 +8328,26 @@ impl MemoryDB {
         }
     }
 
+    /// Whether a dual-write edge to a fence-applicable (non-external)
+    /// destination is a genuine cross-space -- or space-indeterminate --
+    /// DOWNGRADE, i.e. the reason it carries `lineage='legacy'`. This is the
+    /// single seam that turns a RESOLVED destination space into the downgrade
+    /// reason `dual_write_edge` needs, so no caller and `dual_write_edge` itself
+    /// reconstruct it from the lineage label:
+    ///   - `Some(s)` where `s == edge_space` (same determinate space) -> `false`
+    ///     -- NOT a downgrade; a `legacy` here (if any) must lose to a typed
+    ///     edge through ranking, never bypass it.
+    ///   - `Some(_)` differing space (cross-space) -> `true`.
+    ///   - `None` (unresolved / conflicting / absent, per `resolve_memory_space`
+    ///     and the `page_sources` subquery) -> `true` -- indeterminate downgrades
+    ///     for the same fence-safety reason a cross-space one does.
+    ///
+    /// External destinations are fence-exempt and never call this (their
+    /// `legacy` is an unknown-KIND label); their callers pass `false` directly.
+    fn resolved_space_downgrades(resolved_dst_space: Option<&str>, edge_space: &str) -> bool {
+        resolved_dst_space != Some(edge_space)
+    }
+
     /// Dual-write (M2 PR-1) for a `pages.citations` blob write: reasserts
     /// one `cites` edge per citation in the new blob, mirroring
     /// `backfill_edges_from_page_citations`'s classification exactly. Does
@@ -8363,22 +8388,27 @@ impl MemoryDB {
         };
 
         for citation in citations {
-            let (dst_kind, lineage) = match citation.source_kind.as_str() {
+            let (dst_kind, lineage, cross_space_downgrade) = match citation.source_kind.as_str() {
                 "memory" => {
-                    let resolves = Self::resolve_memory_space(conn, &citation.locator).await?
-                        == Some(space.clone());
-                    ("memory", if resolves { "synthesis" } else { "legacy" })
+                    let resolved = Self::resolve_memory_space(conn, &citation.locator).await?;
+                    let downgrades = Self::resolved_space_downgrades(resolved.as_deref(), &space);
+                    (
+                        "memory",
+                        if downgrades { "legacy" } else { "synthesis" },
+                        downgrades,
+                    )
                 }
                 // A distiller-authored citation to an external URI is
                 // `synthesis` (matrix row 6), NOT `legacy`: its external
                 // destination is fence-exempt, so there is no cross-space
                 // reason to downgrade. Writing `legacy` would collide with
-                // `page_evidence`'s `evidence` on the same external edge_id and
-                // make the resolved lineage order-dependent (round-2 item #2).
-                // Unknown/unresolved kinds can't classify a real destination
-                // and stay `legacy`.
-                "external_url" | "external_file" => ("external", "synthesis"),
-                _ => ("external", "legacy"),
+                // `page_evidence`'s `evidence` on the same external edge_id
+                // and make the resolved lineage order-dependent (round-2
+                // item #2). Unknown/unresolved kinds can't classify a real
+                // destination and stay `legacy` -- an unknown-KIND label,
+                // never a cross-space downgrade (external is fence-exempt).
+                "external_url" | "external_file" => ("external", "synthesis", false),
+                _ => ("external", "legacy", false),
             };
             Self::dual_write_edge(
                 conn,
@@ -8390,6 +8420,7 @@ impl MemoryDB {
                 &citation.locator,
                 lineage,
                 &space,
+                cross_space_downgrade,
                 None,
             )
             .await?;
@@ -15960,11 +15991,14 @@ impl MemoryDB {
                     };
                     drop(space_rows);
                     if let Some(page_space) = page_space {
-                        let lineage = if new_memory_space.as_deref() == Some(page_space.as_str())
-                        {
-                            "evidence"
-                        } else {
+                        let cross_space_downgrade = Self::resolved_space_downgrades(
+                            new_memory_space.as_deref(),
+                            &page_space,
+                        );
+                        let lineage = if cross_space_downgrade {
                             "legacy"
+                        } else {
+                            "evidence"
                         };
                         Self::dual_write_edge(
                             &conn,
@@ -15976,6 +16010,7 @@ impl MemoryDB {
                             new_source_id,
                             lineage,
                             &page_space,
+                            cross_space_downgrade,
                             None,
                         )
                         .await
@@ -18999,13 +19034,20 @@ impl MemoryDB {
                     None => (None, None),
                 };
             drop(space_rows);
-            let (lineage, space) = match (&from_space, &to_space) {
-                (Some(fs), Some(ts)) if fs == ts => ("assertion", fs.clone()),
+            // `relates` resolves two endpoints, not one destination, so it does
+            // not go through `resolved_space_downgrades`: SAME-SPACE requires
+            // both entity spaces present and equal; anything else (differing, or
+            // either unresolved) is a cross-space/indeterminate downgrade. dst
+            // is always `entity` (never fence-exempt external). Mirrors
+            // `backfill_edges_from_relations`.
+            let (lineage, space, cross_space_downgrade) = match (&from_space, &to_space) {
+                (Some(fs), Some(ts)) if fs == ts => ("assertion", fs.clone(), false),
                 _ => (
                     "legacy",
                     from_space
                         .or(to_space)
                         .unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
+                    true,
                 ),
             };
             Self::dual_write_edge(
@@ -19018,6 +19060,7 @@ impl MemoryDB {
                 &canonical,
                 lineage,
                 &space,
+                cross_space_downgrade,
                 None,
             )
             .await?;
@@ -27436,21 +27479,41 @@ impl MemoryDB {
             .await?;
 
             if let Some(space) = &page_space {
-                let (dst_kind, classifiable) = match source_kind.as_str() {
+                let (dst_kind, lineage, cross_space_downgrade) = match source_kind.as_str() {
                     // A `memory` citation is only fence-safe when the memory
                     // shares the page's space -- `cites`->`memory` is NOT
                     // exempt from the space fence (only `cites`->`external`
-                    // is), mirroring `backfill_edges_from_page_evidence`.
-                    "memory" => (
-                        "memory",
-                        Self::resolve_memory_space(conn, sid).await? == Some(space.clone()),
-                    ),
-                    "external_url" | "external_file" => ("external", true),
-                    _ => ("external", false),
+                    // is), mirroring `backfill_edges_from_page_evidence`. A
+                    // differing / unresolved memory space is the cross-space
+                    // (indeterminate) downgrade.
+                    "memory" => {
+                        let resolved = Self::resolve_memory_space(conn, sid).await?;
+                        let downgrades =
+                            Self::resolved_space_downgrades(resolved.as_deref(), space);
+                        (
+                            "memory",
+                            if downgrades { "legacy" } else { "evidence" },
+                            downgrades,
+                        )
+                    }
+                    // External destinations are fence-exempt: `evidence` for a
+                    // real URI, `legacy` for an unknown KIND -- neither a
+                    // cross-space downgrade.
+                    "external_url" | "external_file" => ("external", "evidence", false),
+                    _ => ("external", "legacy", false),
                 };
-                let lineage = if classifiable { "evidence" } else { "legacy" };
                 Self::dual_write_edge(
-                    conn, "cites", "page", page_id, dst_kind, sid, sid, lineage, space, None,
+                    conn,
+                    "cites",
+                    "page",
+                    page_id,
+                    dst_kind,
+                    sid,
+                    sid,
+                    lineage,
+                    space,
+                    cross_space_downgrade,
+                    None,
                 )
                 .await?;
             }
@@ -29653,10 +29716,12 @@ impl MemoryDB {
                     None => None,
                 };
                 drop(dst_rows);
-                let lineage = if dst_space.as_deref() == Some(space.as_str()) {
-                    "synthesis"
-                } else {
+                let cross_space_downgrade =
+                    Self::resolved_space_downgrades(dst_space.as_deref(), &space);
+                let lineage = if cross_space_downgrade {
                     "legacy"
+                } else {
+                    "synthesis"
                 };
                 Self::dual_write_edge(
                     &conn,
@@ -29668,6 +29733,7 @@ impl MemoryDB {
                     &label_key,
                     lineage,
                     &space,
+                    cross_space_downgrade,
                     None,
                 )
                 .await?;
@@ -30689,18 +30755,35 @@ impl MemoryDB {
                 };
                 drop(rows);
                 if let Some(space) = space {
-                    let (dst_kind, classifiable) = match source_kind {
-                        "memory" => (
-                            "memory",
-                            Self::resolve_memory_space(&conn, locator).await? == Some(space.clone()),
-                        ),
-                        "external_url" | "external_file" => ("external", true),
-                        _ => ("external", false),
+                    let (dst_kind, lineage, cross_space_downgrade) = match source_kind {
+                        "memory" => {
+                            let resolved = Self::resolve_memory_space(&conn, locator).await?;
+                            let downgrades =
+                                Self::resolved_space_downgrades(resolved.as_deref(), &space);
+                            (
+                                "memory",
+                                if downgrades { "legacy" } else { "evidence" },
+                                downgrades,
+                            )
+                        }
+                        // External destinations are fence-exempt: `evidence` for
+                        // a real URI, `legacy` for an unknown KIND -- neither a
+                        // cross-space downgrade.
+                        "external_url" | "external_file" => ("external", "evidence", false),
+                        _ => ("external", "legacy", false),
                     };
-                    let lineage = if classifiable { "evidence" } else { "legacy" };
                     Self::dual_write_edge(
-                        &conn, "cites", "page", page_id, dst_kind, locator, locator, lineage,
-                        &space, None,
+                        &conn,
+                        "cites",
+                        "page",
+                        page_id,
+                        dst_kind,
+                        locator,
+                        locator,
+                        lineage,
+                        &space,
+                        cross_space_downgrade,
+                        None,
                     )
                     .await?;
                 }
@@ -62197,13 +62280,14 @@ pub(crate) mod tests {
             "mem_1",
             "synthesis",
             "space_a",
+            false,
             None,
         )
         .await
         .unwrap();
         MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_1", "memory", "mem_1", "mem_1", "evidence", "space_a",
-            None,
+            false, None,
         )
         .await
         .unwrap();
@@ -62216,7 +62300,7 @@ pub(crate) mod tests {
         // evidence first, synthesis second -> evidence retained (no downgrade).
         MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_2", "memory", "mem_2", "mem_2", "evidence", "space_a",
-            None,
+            false, None,
         )
         .await
         .unwrap();
@@ -62230,6 +62314,7 @@ pub(crate) mod tests {
             "mem_2",
             "synthesis",
             "space_a",
+            false,
             None,
         )
         .await
@@ -62370,7 +62455,8 @@ pub(crate) mod tests {
                 .await
                 .unwrap();
             MemoryDB::dual_write_edge(
-                &conn, "cites", "page", "page_a", "external", loc, loc, "evidence", "space_a", None,
+                &conn, "cites", "page", "page_a", "external", loc, loc, "evidence", "space_a",
+                false, None,
             )
             .await
             .unwrap();
@@ -62386,7 +62472,8 @@ pub(crate) mod tests {
             let conn = db.conn.lock().await;
             insert_raw_page_for_m81_test(&conn, "page_b", "space_a").await;
             MemoryDB::dual_write_edge(
-                &conn, "cites", "page", "page_b", "external", loc, loc, "evidence", "space_a", None,
+                &conn, "cites", "page", "page_b", "external", loc, loc, "evidence", "space_a",
+                false, None,
             )
             .await
             .unwrap();
@@ -62430,7 +62517,7 @@ pub(crate) mod tests {
             );
             MemoryDB::dual_write_edge(
                 &conn, "cites", "page", "page_u1", "external", loc, loc, "evidence", "space_a",
-                None,
+                false, None,
             )
             .await
             .unwrap();
@@ -62447,7 +62534,7 @@ pub(crate) mod tests {
             insert_raw_page_for_m81_test(&conn, "page_u2", "space_a").await;
             MemoryDB::dual_write_edge(
                 &conn, "cites", "page", "page_u2", "external", loc, loc, "evidence", "space_a",
-                None,
+                false, None,
             )
             .await
             .unwrap();
@@ -62475,7 +62562,8 @@ pub(crate) mod tests {
             let conn = db.conn.lock().await;
             insert_raw_page_for_m81_test(&conn, "page_s1", "space_a").await;
             MemoryDB::dual_write_edge(
-                &conn, "cites", "page", "page_s1", "external", loc, loc, "legacy", "space_a", None,
+                &conn, "cites", "page", "page_s1", "external", loc, loc, "legacy", "space_a",
+                false, None,
             )
             .await
             .unwrap();
@@ -62489,6 +62577,7 @@ pub(crate) mod tests {
                 loc,
                 "synthesis",
                 "space_a",
+                false,
                 None,
             )
             .await
@@ -62514,12 +62603,14 @@ pub(crate) mod tests {
                 loc,
                 "synthesis",
                 "space_a",
+                false,
                 None,
             )
             .await
             .unwrap();
             MemoryDB::dual_write_edge(
-                &conn, "cites", "page", "page_s2", "external", loc, loc, "legacy", "space_a", None,
+                &conn, "cites", "page", "page_s2", "external", loc, loc, "legacy", "space_a",
+                false, None,
             )
             .await
             .unwrap();
@@ -62546,7 +62637,7 @@ pub(crate) mod tests {
         insert_raw_page_for_m81_test(&conn, "page_dm", "space_a").await;
         MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_dm", "memory", "mem_dm", "mem_dm", "evidence", "space_a",
-            None,
+            false, None,
         )
         .await
         .expect("same-space evidence edge inserts");
@@ -62561,7 +62652,7 @@ pub(crate) mod tests {
         // 'legacy'; the source-space stamp it passes is still 'space_a'.
         let result = MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_dm", "memory", "mem_dm", "mem_dm", "legacy", "space_a",
-            None,
+            true, None,
         )
         .await;
         assert!(
@@ -62601,6 +62692,7 @@ pub(crate) mod tests {
             "knows",
             "assertion",
             "space_a",
+            false,
             None,
         )
         .await
@@ -62613,7 +62705,7 @@ pub(crate) mod tests {
         .unwrap();
         let result = MemoryDB::dual_write_edge(
             &conn, "relates", "entity", "ent_src", "entity", "ent_dst", "knows", "legacy",
-            "space_a", None,
+            "space_a", true, None,
         )
         .await;
         assert!(
@@ -62645,6 +62737,7 @@ pub(crate) mod tests {
             "see-also",
             "synthesis",
             "space_a",
+            false,
             None,
         )
         .await
@@ -62657,7 +62750,7 @@ pub(crate) mod tests {
         .unwrap();
         let result = MemoryDB::dual_write_edge(
             &conn, "links", "page", "page_ls", "page", "page_ld", "see-also", "legacy", "space_a",
-            None,
+            true, None,
         )
         .await;
         assert!(
@@ -62668,6 +62761,80 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(lineage, "legacy", "links row must reconcile to legacy");
+    }
+
+    #[tokio::test]
+    async fn resolved_space_downgrades_gates_lineage_through_real_resolver() {
+        // Round-5: the cross-space downgrade reason MUST come from the
+        // destination's RESOLVED space, never be reconstructed from
+        // `(lineage, dst_kind)`. This is the reviewer's negative test: a
+        // same-space, DETERMINATE, non-external destination through the REAL
+        // resolver must NOT downgrade (its edge stays typed, never `legacy`);
+        // a differing space (cross-space) or an unresolved one (indeterminate)
+        // MUST. Nothing here trusts the lineage label to infer the reason.
+
+        // The pure seam every producer feeds the resolver's output through.
+        assert!(
+            !MemoryDB::resolved_space_downgrades(Some("space_a"), "space_a"),
+            "same determinate space must NOT be a downgrade"
+        );
+        assert!(
+            MemoryDB::resolved_space_downgrades(Some("space_b"), "space_a"),
+            "a differing space (cross-space) must be a downgrade"
+        );
+        assert!(
+            MemoryDB::resolved_space_downgrades(None, "space_a"),
+            "an unresolved / indeterminate space must be a downgrade"
+        );
+
+        // The REAL resolver (`resolve_memory_space`) feeds the same seam.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_same", "content", "space_a").await;
+        seed_memory_with_source_id_and_space(&db, "mem_cross", "content", "space_b").await;
+        {
+            let conn = db.conn.lock().await;
+            let same = MemoryDB::resolve_memory_space(&conn, "mem_same")
+                .await
+                .unwrap();
+            assert_eq!(same.as_deref(), Some("space_a"));
+            assert!(
+                !MemoryDB::resolved_space_downgrades(same.as_deref(), "space_a"),
+                "a same-space memory resolved through the REAL resolver must not downgrade"
+            );
+            let cross = MemoryDB::resolve_memory_space(&conn, "mem_cross")
+                .await
+                .unwrap();
+            assert!(
+                MemoryDB::resolved_space_downgrades(cross.as_deref(), "space_a"),
+                "a cross-space memory resolved through the REAL resolver must downgrade"
+            );
+            let absent = MemoryDB::resolve_memory_space(&conn, "mem_ghost")
+                .await
+                .unwrap();
+            assert_eq!(absent, None, "an absent memory resolves to None");
+            assert!(
+                MemoryDB::resolved_space_downgrades(absent.as_deref(), "space_a"),
+                "an unresolvable memory must downgrade (indeterminate)"
+            );
+            insert_raw_page_for_m81_test(&conn, "page_rr", "space_a").await;
+        }
+
+        // End-to-end: a same-space memory citation through the REAL producer
+        // (`link_page_evidence` -> `resolve_memory_space` -> `dual_write_edge`)
+        // must land `evidence`, never `legacy`. This is the property the proxy
+        // could not guarantee: a non-external destination is legacy ONLY on a
+        // genuine cross-space/indeterminate resolution.
+        db.link_page_evidence("page_rr", "memory", Some("mem_same"), None, "test")
+            .await
+            .unwrap();
+        let conn = db.conn.lock().await;
+        let (lineage, _, _) = edge_row(&conn, "cites", "page_rr", "mem_same")
+            .await
+            .unwrap();
+        assert_eq!(
+            lineage, "evidence",
+            "a same-space memory citation through the real producer must be 'evidence', never 'legacy'"
+        );
     }
 
     #[tokio::test]
@@ -62683,7 +62850,7 @@ pub(crate) mod tests {
         insert_raw_page_for_m81_test(&conn, "page_r", "space_a").await;
         let edge_id = MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_r", "memory", "mem_r", "mem_r", "evidence", "space_a",
-            None,
+            false, None,
         )
         .await
         .unwrap();
@@ -62698,7 +62865,8 @@ pub(crate) mod tests {
         .await
         .unwrap();
         MemoryDB::dual_write_edge(
-            &conn, "cites", "page", "page_r", "memory", "mem_r", "mem_r", "legacy", "space_a", None,
+            &conn, "cites", "page", "page_r", "memory", "mem_r", "mem_r", "legacy", "space_a",
+            true, None,
         )
         .await
         .unwrap();
@@ -62731,7 +62899,7 @@ pub(crate) mod tests {
         insert_raw_page_for_m81_test(&conn, "page_f", "space_a").await;
         let edge_id = MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_f", "memory", "mem_f", "mem_f", "evidence", "space_a",
-            None,
+            false, None,
         )
         .await
         .unwrap();
@@ -62747,7 +62915,7 @@ pub(crate) mod tests {
         // Buggy reassert: keeps evidence/space_a though the memory is now cross-space.
         let result = MemoryDB::dual_write_edge(
             &conn, "cites", "page", "page_f", "memory", "mem_f", "mem_f", "evidence", "space_a",
-            None,
+            false, None,
         )
         .await;
         assert!(
@@ -62867,7 +63035,7 @@ pub(crate) mod tests {
             conn.execute("BEGIN", ()).await.unwrap();
             MemoryDB::dual_write_edge(
                 &conn, "cites", "page", "page_cl", "memory", "ghost", "ghost", "legacy", "space_a",
-                None,
+                true, None,
             )
             .await
             .unwrap();

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -8175,16 +8175,32 @@ impl MemoryDB {
         //   3. Lineage -- one content-addressed `edge_id` can be dual-written
         //      by several legacy stores for the same fact (`page_evidence`/
         //      `page_sources` -> `evidence`; a `pages.citations` entry ->
-        //      `synthesis`), and a reactivation can arrive with a fresh
-        //      classification (e.g. its memory moved cross-space, so the caller
-        //      now passes `legacy`). The CASE is a TOTAL rule over all four
-        //      lineages: `legacy` (a cross-space downgrade) always wins;
-        //      `evidence` outranks `synthesis` (the precedence the migration-81
-        //      backfill already yields by ordering `page_sources`/`page_evidence`
-        //      before `page_citations`); otherwise the fresh (`excluded`) typed
-        //      value is adopted (assertion/synthesis reactivation, or a
-        //      legacy->typed same-space upgrade). So a live edge and its
-        //      backfilled twin agree regardless of which store wrote first.
+        //      `synthesis`, or `legacy` for an unknown citation kind), and a
+        //      reactivation can arrive with a fresh classification (e.g. its
+        //      memory moved cross-space, so the caller now passes `legacy`). The
+        //      CASE resolves lineage in three cases, split so the same-space
+        //      concurrent case is COMMUTATIVE (round-3 item 2c):
+        //        a. Reactivation (`edges.valid_until IS NOT NULL`) adopts the
+        //           FRESH (`excluded`) value -- a retracted-then-readded edge
+        //           takes its current classification (evidence can honestly
+        //           become legacy when the memory moved cross-space). Item 4.
+        //        b. A cross-space re-write of an ACTIVE edge
+        //           (`edges.space IS NOT excluded.space`) likewise adopts the
+        //           fresh value -- the caller passes `legacy` on a genuine
+        //           cross-space move; the AFTER UPDATE fence re-validates any
+        //           typed result. This is the item-4 fence downgrade, and it is
+        //           a time-ordered move, NOT an ordering violation.
+        //        c. Two concurrent ACTIVE, SAME-SPACE writes of one fact from
+        //           different stores resolve by a TOTAL, COMMUTATIVE rank so the
+        //           result is independent of which store wrote first:
+        //           `evidence` > `synthesis` > `legacy`. (`assertion`, from
+        //           `relates`/`mentions`, never shares a same-space active
+        //           edge_id with these -- distinct `edge_type` -- so its rank is
+        //           immaterial, but it is ranked above `legacy` for a total
+        //           order.) An unknown-kind citation's same-space `legacy` can
+        //           no longer clobber an active `evidence`/`synthesis`.
+        //      So a live edge and its backfilled twin agree regardless of which
+        //      store wrote first.
         // FENCE-SAFE: the AFTER UPDATE twin of the space fence re-validates any
         // update that keeps the edge active and typed, so a reactivation that
         // reconciles to a cross-space typed row is rejected here just as the
@@ -8198,10 +8214,12 @@ impl MemoryDB {
                  superseded_by = NULL,
                  space = excluded.space,
                  lineage = CASE
-                     WHEN excluded.lineage = 'legacy' THEN 'legacy'
-                     WHEN excluded.lineage = 'evidence' THEN 'evidence'
-                     WHEN edges.lineage = 'evidence' AND excluded.lineage = 'synthesis' THEN 'evidence'
-                     ELSE excluded.lineage
+                     WHEN edges.valid_until IS NOT NULL THEN excluded.lineage
+                     WHEN edges.space IS NOT excluded.space THEN excluded.lineage
+                     WHEN (CASE excluded.lineage WHEN 'evidence' THEN 3 WHEN 'synthesis' THEN 2 WHEN 'assertion' THEN 1 ELSE 0 END)
+                        > (CASE edges.lineage WHEN 'evidence' THEN 3 WHEN 'synthesis' THEN 2 WHEN 'assertion' THEN 1 ELSE 0 END)
+                     THEN excluded.lineage
+                     ELSE edges.lineage
                  END
              WHERE edges.valid_until IS NOT NULL
                 OR edges.space IS NOT excluded.space
@@ -62359,6 +62377,135 @@ pub(crate) mod tests {
             assert_eq!(
                 lineage, "evidence",
                 "evidence must not be downgraded when synthesis writes after"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_unknown_citation_and_evidence_commute() {
+        // Item 2c (round-3): an unknown-kind pages.citations entry writes
+        // lineage='legacy' SAME-SPACE (the external destination is fence-exempt,
+        // so 'legacy' here is an unknown-KIND classification, not a cross-space
+        // downgrade). It shares one content-addressed edge_id with a
+        // page_evidence 'evidence' write for the same external locator. The
+        // resolved lineage must be 'evidence' regardless of which store wrote
+        // first: a same-space 'legacy' must never overwrite an active 'evidence'.
+        let loc = "https://example.com/unknown-kind";
+        let citations = format!(
+            r#"[{{"occurrence":1,"marker":1,"source_kind":"external_pdf","locator":"{loc}","score":0.0,"status":"unverified","scope":"paragraph"}}]"#
+        );
+        // Order A: unknown-kind citation (legacy) first, then page_evidence (evidence).
+        {
+            let (db, _dir) = test_db().await;
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_u1", "space_a").await;
+            MemoryDB::dual_write_page_citations(&conn, "page_u1", Some(&citations))
+                .await
+                .unwrap();
+            let (l0, _, _) = edge_row(&conn, "cites", "page_u1", loc).await.unwrap();
+            assert_eq!(
+                l0, "legacy",
+                "an unknown citation kind must classify same-space legacy"
+            );
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_u1", "external", loc, loc, "evidence", "space_a",
+                None,
+            )
+            .await
+            .unwrap();
+            let (lineage, _, _) = edge_row(&conn, "cites", "page_u1", loc).await.unwrap();
+            assert_eq!(
+                lineage, "evidence",
+                "evidence must win when legacy wrote first"
+            );
+        }
+        // Order B: page_evidence (evidence) first, then unknown-kind citation (legacy).
+        {
+            let (db, _dir) = test_db().await;
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_u2", "space_a").await;
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_u2", "external", loc, loc, "evidence", "space_a",
+                None,
+            )
+            .await
+            .unwrap();
+            MemoryDB::dual_write_page_citations(&conn, "page_u2", Some(&citations))
+                .await
+                .unwrap();
+            let (lineage, _, _) = edge_row(&conn, "cites", "page_u2", loc).await.unwrap();
+            assert_eq!(
+                lineage, "evidence",
+                "active evidence must not be downgraded when legacy writes after"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_synthesis_and_legacy_commute() {
+        // Item 2c (round-3): synthesis and legacy on the same active, same-space
+        // external edge_id must resolve to 'synthesis' in BOTH write orders --
+        // the same-space total order is evidence > synthesis > legacy, commutative
+        // across every pair, not just evidence/synthesis.
+        let loc = "https://example.com/syn-legacy";
+        // Order A: legacy first, then synthesis.
+        {
+            let (db, _dir) = test_db().await;
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_s1", "space_a").await;
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_s1", "external", loc, loc, "legacy", "space_a", None,
+            )
+            .await
+            .unwrap();
+            MemoryDB::dual_write_edge(
+                &conn,
+                "cites",
+                "page",
+                "page_s1",
+                "external",
+                loc,
+                loc,
+                "synthesis",
+                "space_a",
+                None,
+            )
+            .await
+            .unwrap();
+            let (lineage, _, _) = edge_row(&conn, "cites", "page_s1", loc).await.unwrap();
+            assert_eq!(
+                lineage, "synthesis",
+                "synthesis must win when legacy wrote first"
+            );
+        }
+        // Order B: synthesis first, then legacy.
+        {
+            let (db, _dir) = test_db().await;
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_s2", "space_a").await;
+            MemoryDB::dual_write_edge(
+                &conn,
+                "cites",
+                "page",
+                "page_s2",
+                "external",
+                loc,
+                loc,
+                "synthesis",
+                "space_a",
+                None,
+            )
+            .await
+            .unwrap();
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_s2", "external", loc, loc, "legacy", "space_a", None,
+            )
+            .await
+            .unwrap();
+            let (lineage, _, _) = edge_row(&conn, "cites", "page_s2", loc).await.unwrap();
+            assert_eq!(
+                lineage, "synthesis",
+                "active synthesis must not be downgraded when legacy writes after"
             );
         }
     }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -533,7 +533,7 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 80;
+pub const SCHEMA_VERSION: u32 = 81;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -7465,6 +7465,19 @@ impl MemoryDB {
             if version < 80 {
                 self.migrate_80_page_scope_fold().await?;
             }
+
+            // Migration 81 (M2 PR-1 "unified edges", stage a+b): expand
+            // schema with `edges` (spec v3 §2, one typed store replacing
+            // `relations`/`page_sources`/`page_evidence`/`pages.citations`/
+            // `page_links`) and `provenance_roots` (spec v3 §1). Backfills
+            // the five legacy stores into `edges` once, then creates the
+            // NULL-safe space-fence trigger so it only binds on writes AFTER
+            // the backfill. Extracted (like 73/74/80) -- see
+            // migrate_81_unified_edges and
+            // docs/plans/2026-07-21-m2-edge-assignment-matrix.md.
+            if version < 81 {
+                self.migrate_81_unified_edges().await?;
+            }
         }
 
         Ok(())
@@ -7810,6 +7823,960 @@ impl MemoryDB {
             ));
         }
         Ok(())
+    }
+
+    // Migration 81 (M2 PR-1 "unified edges"). Spec v3 §2 replaces five
+    // legacy edge/link stores (`relations`, `page_sources`, `page_evidence`,
+    // the `pages.citations` JSON blob, `page_links`) with one typed `edges`
+    // table; §1 adds `provenance_roots`, the content-addressed identity
+    // substrate `edges.root_id` will reference once M3+ roots the corpus.
+    //
+    // Legacy honesty (spec §2): M2 has no span-validation pipeline, so every
+    // edge this migration writes is honestly `grounded = 0` -- a real
+    // computed function that returns false for all M2 inputs, not a stub.
+    // `root_id` is NULL on every M2 edge; corpus-wide root attachment is
+    // explicitly deferred (M3+/M6, per the goal prompt's stop-and-confirm on
+    // "confidently rooting the full memory corpus"). `provenance_roots`
+    // itself is built and tested here (`acquire_provenance_root`), proven by
+    // a direct two-writer convergence test, not by corpus attachment.
+    //
+    // Ordering matters: the backfill INSERTs run BEFORE `edges_space_fence`
+    // exists, so they never trip it (AFTER INSERT triggers only fire on
+    // inserts issued after CREATE TRIGGER runs) -- "backfill shadows predate
+    // the fence". A killed-and-rerun migration stays replay-safe without a
+    // ledger: `edges.edge_id` is content-addressed and every insert is
+    // `ON CONFLICT(edge_id) DO NOTHING`, so a resumed backfill re-attempts
+    // identical inserts that either land once or no-op forever after --
+    // no partial-apply state to track. See the full per-store
+    // lineage/edge_type table and fence-exemption rationale in
+    // docs/plans/2026-07-21-m2-edge-assignment-matrix.md.
+    //
+    // ponytail: one BEGIN/COMMIT for the whole backfill, not M1's
+    // rowid-batched multi-transaction dance -- `edges` is a brand-new empty
+    // table with no concurrent readers depending on it yet (unlike M1's
+    // in-place NOT NULL fold of the live `pages` table), so the lock-duration
+    // risk that motivated M1's batching doesn't apply here. Add batching if a
+    // real corpus makes single-transaction backfill measurably slow.
+    //
+    // Bulk-insert/trigger benchmark (M2 index contract, spec v3 §2), measured
+    // 2026-07-21 on this machine: 10,000 live dual-writes through
+    // `create_relation` (relations INSERT + `edges_space_fence`-gated edges
+    // INSERT, one BEGIN/COMMIT each) = 3.88s (387.8µs/row). See
+    // `m81_bulk_insert_trigger_benchmark` (`#[ignore]`, manual-only).
+    async fn migrate_81_unified_edges(&self) -> Result<(), WenlanError> {
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 begin: {e}")))?;
+
+        let result: Result<(), WenlanError> = async {
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS provenance_roots (
+                    root_id TEXT PRIMARY KEY,
+                    identity_version INTEGER NOT NULL,
+                    identity_digest TEXT NOT NULL,
+                    root_kind TEXT NOT NULL CHECK(root_kind IN ('document_ingest','human_capture','human_edit_delta','generated')),
+                    independence_group_id TEXT NOT NULL,
+                    status TEXT NOT NULL CHECK(status IN ('ingesting','active','failed')) DEFAULT 'active',
+                    created_at INTEGER NOT NULL,
+                    UNIQUE(identity_version, identity_digest)
+                );
+                CREATE TABLE IF NOT EXISTS provenance_root_minhash_bands (
+                    band_key INTEGER NOT NULL,
+                    root_id TEXT NOT NULL REFERENCES provenance_roots(root_id) ON DELETE CASCADE
+                );
+                CREATE INDEX IF NOT EXISTS idx_provenance_root_minhash_band
+                    ON provenance_root_minhash_bands(band_key);
+                CREATE TABLE IF NOT EXISTS edges (
+                    edge_id TEXT PRIMARY KEY,
+                    src_id TEXT NOT NULL,
+                    src_kind TEXT NOT NULL CHECK(src_kind IN ('page','memory','entity','external')),
+                    dst_id TEXT NOT NULL,
+                    dst_kind TEXT NOT NULL CHECK(dst_kind IN ('page','memory','entity','external')),
+                    edge_type TEXT NOT NULL CHECK(edge_type IN ('mentions','relates','cites','supports','links')),
+                    lineage TEXT NOT NULL CHECK(lineage IN ('assertion','evidence','synthesis','legacy')),
+                    grounded INTEGER NOT NULL CHECK(grounded IN (0,1)),
+                    root_id TEXT REFERENCES provenance_roots(root_id),
+                    space TEXT NOT NULL,
+                    weight REAL,
+                    payload TEXT,
+                    provenance TEXT,
+                    operation_id TEXT,
+                    created_at INTEGER NOT NULL,
+                    superseded_by TEXT REFERENCES edges(edge_id),
+                    valid_until INTEGER
+                );
+                CREATE INDEX IF NOT EXISTS idx_edges_src ON edges(src_kind, src_id);
+                CREATE INDEX IF NOT EXISTS idx_edges_dst ON edges(dst_kind, dst_id);
+                CREATE INDEX IF NOT EXISTS idx_edges_root ON edges(root_id) WHERE root_id IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS idx_edges_operation ON edges(operation_id) WHERE operation_id IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS idx_edges_superseded ON edges(superseded_by) WHERE superseded_by IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS idx_edges_active_grounded_space_type
+                    ON edges(space, edge_type) WHERE valid_until IS NULL AND grounded = 1;
+                CREATE TABLE IF NOT EXISTS edges_migration_state (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    stage TEXT NOT NULL,
+                    cursor TEXT,
+                    batch_checksum TEXT,
+                    epoch INTEGER NOT NULL DEFAULT 1,
+                    completed_at INTEGER,
+                    report_json TEXT
+                );",
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 DDL: {e}")))?;
+
+            let relations = Self::backfill_edges_from_relations(&conn).await?;
+            let page_sources = Self::backfill_edges_from_page_sources(&conn).await?;
+            let page_evidence = Self::backfill_edges_from_page_evidence(&conn).await?;
+            let page_links = Self::backfill_edges_from_page_links(&conn).await?;
+            let citations = Self::backfill_edges_from_page_citations(&conn).await?;
+            let audit = Self::audit_legacy_cross_space_links(&conn).await?;
+
+            let report = serde_json::json!({
+                "relations": relations.to_json(),
+                "page_sources": page_sources.to_json(),
+                "page_evidence": page_evidence.to_json(),
+                "page_links": page_links.to_json(),
+                "pages_citations": citations.to_json(),
+                "cross_space_audit": audit,
+            });
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "INSERT INTO edges_migration_state (id, stage, cursor, batch_checksum, epoch, completed_at, report_json)
+                 VALUES (1, 'backfilled', NULL, NULL, 1, ?1, ?2)
+                 ON CONFLICT(id) DO UPDATE SET stage='backfilled', completed_at=?1, report_json=?2",
+                libsql::params![now, report.to_string()],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 migration state: {e}")))?;
+
+            // Fence created AFTER every backfill INSERT above -- see the
+            // "ordering matters" note on this function's doc comment. Sole
+            // exemption (besides `lineage='legacy'`): `cites` to an external
+            // URI, which has no space to check (spec §2).
+            conn.execute_batch(
+                "CREATE TRIGGER IF NOT EXISTS edges_space_fence
+                 AFTER INSERT ON edges
+                 WHEN NEW.lineage != 'legacy' AND NOT (NEW.edge_type = 'cites' AND NEW.dst_kind = 'external')
+                 BEGIN
+                     SELECT RAISE(ABORT, 'edges_space_fence: cross-space edge rejected')
+                     WHERE (
+                         CASE NEW.src_kind
+                             WHEN 'page' THEN (SELECT space FROM pages WHERE id = NEW.src_id)
+                             WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = NEW.src_id)
+                             WHEN 'entity' THEN (SELECT space FROM entities WHERE id = NEW.src_id)
+                             ELSE NULL
+                         END
+                     ) IS NOT NEW.space
+                     OR (
+                         CASE NEW.dst_kind
+                             WHEN 'page' THEN (SELECT space FROM pages WHERE id = NEW.dst_id)
+                             WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = NEW.dst_id)
+                             WHEN 'entity' THEN (SELECT space FROM entities WHERE id = NEW.dst_id)
+                             ELSE NULL
+                         END
+                     ) IS NOT NEW.space;
+                 END;",
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 fence trigger: {e}")))?;
+
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m81 commit: {e}")))?;
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        }
+        drop(conn);
+
+        let conn = self.conn.lock().await;
+        conn.execute("PRAGMA user_version = 81", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 bump: {e}")))?;
+        log::info!("[migration] Migration 81 applied: unified edges + provenance_roots (M2 PR-1)");
+        Ok(())
+    }
+}
+
+/// Per-store backfill tally for the M2 PR-1 migration report (spec §2
+/// "legacy honesty": a report of classifiable vs unknown counts).
+/// `unknown_inserted` counts unknown rows still written as `lineage='legacy'`
+/// edges (real src/dst values, ambiguous provenance); `unknown_skipped`
+/// counts rows with no determinable destination at all (e.g. an orphan
+/// wikilink -- "no page→page edge exists yet") that never become an edges
+/// row.
+#[derive(Default)]
+struct EdgeBackfillCounts {
+    classifiable: u64,
+    unknown_inserted: u64,
+    unknown_skipped: u64,
+}
+
+impl EdgeBackfillCounts {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "classifiable": self.classifiable,
+            "unknown_inserted": self.unknown_inserted,
+            "unknown_skipped": self.unknown_skipped,
+        })
+    }
+}
+
+impl MemoryDB {
+    /// Insert one backfilled edge (`ON CONFLICT(edge_id) DO NOTHING` --
+    /// content-addressed retry identity, spec §6.1). `grounded=0`, `root_id`
+    /// NULL, `operation_id` NULL on every M2-backfilled row (legacy
+    /// honesty). `provenance` records which legacy store produced the row,
+    /// for audit.
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_backfilled_edge(
+        conn: &libsql::Connection,
+        edge_type: &str,
+        src_kind: &str,
+        src_id: &str,
+        dst_kind: &str,
+        dst_id: &str,
+        discriminator: &str,
+        lineage: &str,
+        space: &str,
+        backfilled_from: &str,
+    ) -> Result<(), WenlanError> {
+        let edge_id = crate::provenance::compute_edge_id(
+            edge_type,
+            src_kind,
+            src_id,
+            dst_kind,
+            dst_id,
+            discriminator,
+        );
+        let provenance = serde_json::json!({"backfilled_from": backfilled_from}).to_string();
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL, ?8, NULL, NULL, ?9, NULL, ?10, NULL, NULL)
+             ON CONFLICT(edge_id) DO NOTHING",
+            libsql::params![
+                edge_id,
+                src_id.to_string(),
+                src_kind.to_string(),
+                dst_id.to_string(),
+                dst_kind.to_string(),
+                edge_type.to_string(),
+                lineage.to_string(),
+                space.to_string(),
+                provenance,
+                now
+            ],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("m81 insert edge ({edge_type}): {e}")))?;
+        Ok(())
+    }
+
+    /// Live dual-write counterpart to `insert_backfilled_edge` (M2 PR-1
+    /// stage b): mints, or retry-converges onto via content-addressed
+    /// `edge_id`, one edge row in the SAME transaction as the caller's
+    /// legacy-store write. Uses the identical `(edge_type, src_kind,
+    /// src_id, dst_kind, dst_id, discriminator)` inputs the migration-81
+    /// backfill uses for the same logical row, so a freshly-written edge
+    /// and a backfilled edge for the same fact converge on one `edge_id`
+    /// by construction. `ON CONFLICT` reactivates a previously
+    /// soft-invalidated edge (the "delete a link then add it back" case)
+    /// rather than leaving it stuck invalid. M2 PR-1 has no
+    /// span-validation pipeline, so every dual-written edge is honestly
+    /// `grounded=false`, `root_id=NULL` -- same legacy-honesty ceiling as
+    /// the backfill (spec v3 §2). Returns `libsql::Error` so callers whose
+    /// existing transaction block is already typed that way (the common
+    /// case in this file) can `.await?` it directly.
+    #[allow(clippy::too_many_arguments)]
+    async fn dual_write_edge(
+        conn: &libsql::Connection,
+        edge_type: &str,
+        src_kind: &str,
+        src_id: &str,
+        dst_kind: &str,
+        dst_id: &str,
+        discriminator: &str,
+        lineage: &str,
+        space: &str,
+        operation_id: Option<&str>,
+    ) -> Result<String, libsql::Error> {
+        let edge_id = crate::provenance::compute_edge_id(
+            edge_type,
+            src_kind,
+            src_id,
+            dst_kind,
+            dst_id,
+            discriminator,
+        );
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL, ?8, NULL, NULL, NULL, ?9, ?10, NULL, NULL)
+             ON CONFLICT(edge_id) DO UPDATE SET valid_until = NULL, superseded_by = NULL
+             WHERE valid_until IS NOT NULL",
+            libsql::params![
+                edge_id.clone(),
+                src_id.to_string(),
+                src_kind.to_string(),
+                dst_id.to_string(),
+                dst_kind.to_string(),
+                edge_type.to_string(),
+                lineage.to_string(),
+                space.to_string(),
+                operation_id.map(|s| s.to_string()),
+                now
+            ],
+        )
+        .await?;
+        Ok(edge_id)
+    }
+
+    /// Soft-invalidate a dual-written edge on legacy-store
+    /// deletion/supersession (spec v3 §2: "Deleting a memory/page/claim
+    /// retracts its incident active edges in the same transaction" --
+    /// append-only-with-soft-supersession, never a hard delete). A no-op
+    /// when no such edge exists (legacy data predating dual-write) or it
+    /// is already invalidated.
+    async fn dual_write_invalidate_edge(
+        conn: &libsql::Connection,
+        edge_id: &str,
+        superseded_by: Option<&str>,
+    ) -> Result<(), libsql::Error> {
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "UPDATE edges SET valid_until = ?1, superseded_by = ?2 WHERE edge_id = ?3 AND valid_until IS NULL",
+            libsql::params![now, superseded_by.map(|s| s.to_string()), edge_id],
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Look up a memory's space by `source_id`, for the page_evidence
+    /// dual-write's memory-kind space check (the fence trigger does not
+    /// exempt `cites`->`memory` edges, unlike `cites`->`external`).
+    async fn resolve_memory_space(
+        conn: &libsql::Connection,
+        source_id: &str,
+    ) -> Result<Option<String>, libsql::Error> {
+        let mut rows = conn
+            .query(
+                "SELECT space FROM memories WHERE source_id = ?1 LIMIT 1",
+                libsql::params![source_id],
+            )
+            .await?;
+        match rows.next().await? {
+            Some(row) => Ok(row.get(0).unwrap_or(None)),
+            None => Ok(None),
+        }
+    }
+
+    /// Dual-write (M2 PR-1) for a `pages.citations` blob write: reasserts
+    /// one `cites` edge per citation in the new blob, mirroring
+    /// `backfill_edges_from_page_citations`'s classification exactly. Does
+    /// NOT invalidate edges for citations that dropped out of the blob --
+    /// `page_evidence` can independently back the same (page, locator) pair
+    /// and computes the identical content-addressed edge_id, so blindly
+    /// invalidating "this store's" edges here risks retracting one still
+    /// backed by an active `page_evidence` row. Reads stay legacy in PR-1
+    /// (dual-write is shadow-only), so this conservative "never wrongly
+    /// retract" choice costs nothing today; re-derivation semantics are a
+    /// PR-2 (reader cutover) concern.
+    async fn dual_write_page_citations(
+        conn: &libsql::Connection,
+        page_id: &str,
+        citations_json: Option<&str>,
+    ) -> Result<(), libsql::Error> {
+        let Some(citations_json) = citations_json else {
+            return Ok(());
+        };
+        let Ok(citations) =
+            serde_json::from_str::<Vec<wenlan_types::pages::PageCitation>>(citations_json)
+        else {
+            return Ok(());
+        };
+        let mut space_rows = conn
+            .query(
+                "SELECT space FROM pages WHERE id = ?1",
+                libsql::params![page_id],
+            )
+            .await?;
+        let space: Option<String> = match space_rows.next().await? {
+            Some(row) => row.get(0).unwrap_or(None),
+            None => None,
+        };
+        drop(space_rows);
+        let Some(space) = space else {
+            return Ok(());
+        };
+
+        for citation in citations {
+            if citation.source_kind == "memory" {
+                let resolves = Self::resolve_memory_space(conn, &citation.locator).await?
+                    == Some(space.clone());
+                let lineage = if resolves { "synthesis" } else { "legacy" };
+                Self::dual_write_edge(
+                    conn,
+                    "cites",
+                    "page",
+                    page_id,
+                    "memory",
+                    &citation.locator,
+                    &citation.locator,
+                    lineage,
+                    &space,
+                    None,
+                )
+                .await?;
+            } else {
+                Self::dual_write_edge(
+                    conn,
+                    "cites",
+                    "page",
+                    page_id,
+                    "external",
+                    &citation.locator,
+                    &citation.locator,
+                    "legacy",
+                    &space,
+                    None,
+                )
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// `relations` → `relates` edges (matrix row 1). entity→entity FK
+    /// cascades make a dangling endpoint unreachable via normal writes
+    /// (`crates/wenlan-core/src/lint/kg_test.rs` constructs one only by
+    /// disabling `PRAGMA foreign_keys`), so `unknown` is a defensive branch,
+    /// not a live case on this schema -- still counted per the matrix.
+    async fn backfill_edges_from_relations(
+        conn: &libsql::Connection,
+    ) -> Result<EdgeBackfillCounts, WenlanError> {
+        let mut counts = EdgeBackfillCounts::default();
+        let mut rows = conn
+            .query(
+                "SELECT r.from_entity, r.to_entity, r.relation_type, \
+                        fe.space, te.space \
+                 FROM relations r \
+                 LEFT JOIN entities fe ON fe.id = r.from_entity \
+                 LEFT JOIN entities te ON te.id = r.to_entity",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 select relations: {e}")))?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 relations row: {e}")))?
+        {
+            let from_entity: String = row.get(0).unwrap_or_default();
+            let to_entity: String = row.get(1).unwrap_or_default();
+            let relation_type: String = row.get(2).unwrap_or_default();
+            let from_space: Option<String> = row.get(3).unwrap_or(None);
+            let to_space: Option<String> = row.get(4).unwrap_or(None);
+
+            let (lineage, space) = match (&from_space, &to_space) {
+                (Some(fs), Some(ts)) if fs == ts => {
+                    counts.classifiable += 1;
+                    ("assertion", fs.clone())
+                }
+                _ => {
+                    counts.unknown_inserted += 1;
+                    (
+                        "legacy",
+                        from_space
+                            .or(to_space)
+                            .unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
+                    )
+                }
+            };
+            Self::insert_backfilled_edge(
+                conn,
+                "relates",
+                "entity",
+                &from_entity,
+                "entity",
+                &to_entity,
+                &relation_type,
+                lineage,
+                &space,
+                "relations",
+            )
+            .await?;
+        }
+        Ok(counts)
+    }
+
+    /// `page_sources` → `cites` edges (matrix row 2). `page_id` FK cascades
+    /// to `pages`, so every row is classifiable: `pages.space` is always
+    /// present (NOT NULL since M1).
+    async fn backfill_edges_from_page_sources(
+        conn: &libsql::Connection,
+    ) -> Result<EdgeBackfillCounts, WenlanError> {
+        let mut counts = EdgeBackfillCounts::default();
+        let mut rows = conn
+            .query(
+                "SELECT ps.page_id, ps.memory_source_id, p.space \
+                 FROM page_sources ps JOIN pages p ON p.id = ps.page_id",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 select page_sources: {e}")))?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 page_sources row: {e}")))?
+        {
+            let page_id: String = row.get(0).unwrap_or_default();
+            let memory_source_id: String = row.get(1).unwrap_or_default();
+            let space: String = row.get(2).unwrap_or_default();
+            counts.classifiable += 1;
+            Self::insert_backfilled_edge(
+                conn,
+                "cites",
+                "page",
+                &page_id,
+                "memory",
+                &memory_source_id,
+                &memory_source_id,
+                "evidence",
+                &space,
+                "page_sources",
+            )
+            .await?;
+        }
+        Ok(counts)
+    }
+
+    /// `page_evidence` → `cites` edges (matrix rows 3-4). `source_kind`
+    /// `memory`/`external_url`/`external_file` with a non-NULL `locator` are
+    /// classifiable; `authored` or a NULL locator can't resolve to a real
+    /// destination and are backfilled as `lineage='legacy'` (still a real
+    /// locator-shaped dst_id when one exists, else skipped).
+    async fn backfill_edges_from_page_evidence(
+        conn: &libsql::Connection,
+    ) -> Result<EdgeBackfillCounts, WenlanError> {
+        let mut counts = EdgeBackfillCounts::default();
+        // LEFT JOIN memories on the memory-kind locator so a memory-kind
+        // citation's classification can check space agreement -- a page in
+        // one space citing a memory in another is a real legacy shape (the
+        // old `page_evidence` schema never enforced same-space), and the
+        // fence trigger does NOT exempt `cites`->`memory` edges (only
+        // `cites`->`external` is space-exempt), so an unmatched space must
+        // downgrade to `legacy` or a live dual-write of the same row would
+        // be fence-rejected.
+        let mut rows = conn
+            .query(
+                "SELECT pe.page_id, pe.source_kind, pe.locator, p.space, m.space \
+                 FROM page_evidence pe \
+                 JOIN pages p ON p.id = pe.page_id \
+                 LEFT JOIN memories m ON m.source_id = pe.locator AND pe.source_kind = 'memory'",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 select page_evidence: {e}")))?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 page_evidence row: {e}")))?
+        {
+            let page_id: String = row.get(0).unwrap_or_default();
+            let source_kind: String = row.get(1).unwrap_or_default();
+            let locator: Option<String> = row.get(2).unwrap_or(None);
+            let space: String = row.get(3).unwrap_or_default();
+            let memory_space: Option<String> = row.get(4).unwrap_or(None);
+
+            let Some(locator) = locator else {
+                counts.unknown_skipped += 1;
+                continue;
+            };
+            let (dst_kind, classifiable) = match source_kind.as_str() {
+                "memory" => ("memory", memory_space.as_deref() == Some(space.as_str())),
+                "external_url" | "external_file" => ("external", true),
+                _ => ("external", false),
+            };
+            let lineage = if classifiable {
+                counts.classifiable += 1;
+                "evidence"
+            } else {
+                counts.unknown_inserted += 1;
+                "legacy"
+            };
+            Self::insert_backfilled_edge(
+                conn,
+                "cites",
+                "page",
+                &page_id,
+                dst_kind,
+                &locator,
+                &locator,
+                lineage,
+                &space,
+                "page_evidence",
+            )
+            .await?;
+        }
+        Ok(counts)
+    }
+
+    /// `page_links` → `links` edges (matrix row 5). A NULL `target_page_id`
+    /// (orphan wikilink) has no destination at all -- "no page→page edge
+    /// exists yet" -- so it is counted, never inserted.
+    async fn backfill_edges_from_page_links(
+        conn: &libsql::Connection,
+    ) -> Result<EdgeBackfillCounts, WenlanError> {
+        let mut counts = EdgeBackfillCounts::default();
+        let mut rows = conn
+            .query(
+                "SELECT pl.source_page_id, pl.target_page_id, pl.label_key, \
+                        sp.space, tp.space \
+                 FROM page_links pl \
+                 JOIN pages sp ON sp.id = pl.source_page_id \
+                 LEFT JOIN pages tp ON tp.id = pl.target_page_id",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 select page_links: {e}")))?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 page_links row: {e}")))?
+        {
+            let source_page_id: String = row.get(0).unwrap_or_default();
+            let target_page_id: Option<String> = row.get(1).unwrap_or(None);
+            let label_key: String = row.get(2).unwrap_or_default();
+            let src_space: String = row.get(3).unwrap_or_default();
+            let dst_space: Option<String> = row.get(4).unwrap_or(None);
+
+            let Some(target_page_id) = target_page_id else {
+                counts.unknown_skipped += 1;
+                continue;
+            };
+            let (lineage, space) = if dst_space.as_deref() == Some(src_space.as_str()) {
+                counts.classifiable += 1;
+                ("synthesis", src_space)
+            } else {
+                counts.unknown_inserted += 1;
+                ("legacy", src_space)
+            };
+            Self::insert_backfilled_edge(
+                conn,
+                "links",
+                "page",
+                &source_page_id,
+                "page",
+                &target_page_id,
+                &label_key,
+                lineage,
+                &space,
+                "page_links",
+            )
+            .await?;
+        }
+        Ok(counts)
+    }
+
+    /// `pages.citations` blob → `cites` edges (matrix row 6, `synthesis`
+    /// lineage -- distinct from `page_evidence`'s `evidence`). A page whose
+    /// `citations` column doesn't parse as `Vec<PageCitation>` contributes no
+    /// per-record data and is counted once as `unknown_skipped` for the
+    /// whole page. Content-addressing dedupes repeated `[N]` occurrences of
+    /// the same source onto one edge without an explicit unique-set pass.
+    async fn backfill_edges_from_page_citations(
+        conn: &libsql::Connection,
+    ) -> Result<EdgeBackfillCounts, WenlanError> {
+        let mut counts = EdgeBackfillCounts::default();
+        let mut rows = conn
+            .query(
+                "SELECT id, space, citations FROM pages WHERE citations IS NOT NULL",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 select pages citations: {e}")))?;
+        let mut pages: Vec<(String, String, String)> = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m81 pages citations row: {e}")))?
+        {
+            let page_id: String = row.get(0).unwrap_or_default();
+            let space: String = row.get(1).unwrap_or_default();
+            let citations_json: String = row.get::<String>(2).unwrap_or_default();
+            pages.push((page_id, space, citations_json));
+        }
+        drop(rows);
+
+        for (page_id, space, citations_json) in pages {
+            let Ok(citations) =
+                serde_json::from_str::<Vec<wenlan_types::pages::PageCitation>>(&citations_json)
+            else {
+                counts.unknown_skipped += 1;
+                continue;
+            };
+            for citation in citations {
+                if citation.source_kind == "memory" {
+                    // Same-space check, not just existence: the fence
+                    // trigger does not exempt `cites`->`memory` edges, so a
+                    // citation resolving to a memory in a different space
+                    // must downgrade to `legacy` (mirrors
+                    // `backfill_edges_from_page_evidence`'s memory-kind fix).
+                    let resolves = Self::resolve_memory_space(conn, &citation.locator)
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("m81 citations resolve: {e}"))
+                        })?
+                        == Some(space.clone());
+                    let lineage = if resolves {
+                        counts.classifiable += 1;
+                        "synthesis"
+                    } else {
+                        counts.unknown_inserted += 1;
+                        "legacy"
+                    };
+                    Self::insert_backfilled_edge(
+                        conn,
+                        "cites",
+                        "page",
+                        &page_id,
+                        "memory",
+                        &citation.locator,
+                        &citation.locator,
+                        lineage,
+                        &space,
+                        "pages.citations",
+                    )
+                    .await?;
+                } else {
+                    counts.unknown_inserted += 1;
+                    Self::insert_backfilled_edge(
+                        conn,
+                        "cites",
+                        "page",
+                        &page_id,
+                        "external",
+                        &citation.locator,
+                        &citation.locator,
+                        "legacy",
+                        &space,
+                        "pages.citations",
+                    )
+                    .await?;
+                }
+            }
+        }
+        Ok(counts)
+    }
+
+    /// Pre-migration audit (spec §2: "A pre-migration audit reports legacy
+    /// cross-space links"). Per store, how many links are same-space /
+    /// cross-space / NULL-space *before* the fence trigger binds -- read
+    /// straight from the legacy tables, independent of backfill outcome.
+    /// Reported, never gated on: if this surfaced a live path minting
+    /// genuine cross-space links the fence would newly reject, that's the
+    /// M2 goal prompt's stop condition, not something to guess around here.
+    async fn audit_legacy_cross_space_links(
+        conn: &libsql::Connection,
+    ) -> Result<serde_json::Value, WenlanError> {
+        async fn tally(
+            conn: &libsql::Connection,
+            sql: &str,
+        ) -> Result<serde_json::Value, WenlanError> {
+            let mut rows = conn
+                .query(sql, ())
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m81 audit: {e}")))?;
+            match rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m81 audit row: {e}")))?
+            {
+                Some(row) => Ok(serde_json::json!({
+                    "same_space": row.get::<i64>(0).unwrap_or(0),
+                    "cross_space": row.get::<i64>(1).unwrap_or(0),
+                    "null_space": row.get::<i64>(2).unwrap_or(0),
+                })),
+                None => Ok(serde_json::json!({"same_space": 0, "cross_space": 0, "null_space": 0})),
+            }
+        }
+
+        let relations = tally(
+            conn,
+            "SELECT \
+                SUM(CASE WHEN fe.space IS NOT NULL AND fe.space = te.space THEN 1 ELSE 0 END), \
+                SUM(CASE WHEN fe.space IS NOT NULL AND te.space IS NOT NULL AND fe.space != te.space THEN 1 ELSE 0 END), \
+                SUM(CASE WHEN fe.space IS NULL OR te.space IS NULL THEN 1 ELSE 0 END) \
+             FROM relations r \
+             LEFT JOIN entities fe ON fe.id = r.from_entity \
+             LEFT JOIN entities te ON te.id = r.to_entity",
+        )
+        .await?;
+
+        let page_links = tally(
+            conn,
+            "SELECT \
+                SUM(CASE WHEN tp.space IS NOT NULL AND tp.space = sp.space THEN 1 ELSE 0 END), \
+                SUM(CASE WHEN tp.space IS NOT NULL AND tp.space != sp.space THEN 1 ELSE 0 END), \
+                SUM(CASE WHEN pl.target_page_id IS NULL THEN 1 ELSE 0 END) \
+             FROM page_links pl \
+             JOIN pages sp ON sp.id = pl.source_page_id \
+             LEFT JOIN pages tp ON tp.id = pl.target_page_id",
+        )
+        .await?;
+
+        Ok(serde_json::json!({
+            "relations": relations,
+            "page_links": page_links,
+        }))
+    }
+
+    /// Acquire (get-or-create) a `provenance_roots` row for `raw_content`,
+    /// per spec §1: "Root acquisition is `INSERT … ON CONFLICT … RETURNING
+    /// root_id` ... never check-then-insert (two concurrent imports of one
+    /// file must converge on one root at the database, not in application
+    /// code)." `DO UPDATE SET root_id = root_id` is a no-op update that
+    /// exists only to make `RETURNING` fire on the conflict branch too, so
+    /// this single statement returns the winning `root_id` whether it
+    /// inserted or found an existing row -- proven by
+    /// `acquire_provenance_root_two_writers_converge_on_same_root`.
+    ///
+    /// `independence_group_id` resolution (Q6 decision C): a fresh
+    /// LSH band lookup against `provenance_root_minhash_bands` adopts an
+    /// existing near-dup group when one is found, else mints a new group id.
+    /// This work happens before the INSERT unconditionally (never
+    /// check-then-insert), so on the conflict path it is simply discarded --
+    /// the existing row's group is untouched, matching `grounded`/`root_id`/
+    /// `lineage` immutability elsewhere in the spec.
+    ///
+    /// ponytail: band-match only, no exact-Jaccard re-verification pass (the
+    /// entity_minhash cascade re-fetches the candidate's `name` to confirm;
+    /// `provenance_roots` doesn't store raw/canonical content, only its
+    /// digest, so there is nothing to re-fetch). Lower stakes than entity
+    /// resolution -- independence grouping is a derived floor-counting
+    /// signal (M6), not identity -- so trusting LSH banding directly is a
+    /// reasonable ceiling; add content storage + re-verification if a real
+    /// corpus shows false-positive group merges matter.
+    pub async fn acquire_provenance_root(
+        &self,
+        root_kind: &str,
+        raw_content: &str,
+        signals: &crate::provenance::IndependenceSignals<'_>,
+    ) -> Result<String, WenlanError> {
+        let canonical = crate::provenance::canonicalize_content(raw_content);
+        let digest = crate::provenance::identity_digest(root_kind, raw_content);
+        let bands = crate::provenance::content_minhash_bands(&canonical);
+
+        let conn = self.conn.lock().await;
+        // Overlay match wins over the structural signal key -- a near-dup
+        // catches groups the structural signal alone would keep apart (e.g.
+        // two distinct import batches containing byte-similar content); the
+        // structural key is the fallback when no near-dup is found, and a
+        // fresh id is the last resort when neither signal establishes a group.
+        let overlay_match = Self::query_provenance_roots_by_band(&conn, &bands)
+            .await?
+            .into_iter()
+            .next();
+        let group_id = overlay_match
+            .or_else(|| crate::provenance::base_independence_key(signals))
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+        let root_id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().timestamp();
+        let mut rows = conn
+            .query(
+                "INSERT INTO provenance_roots (root_id, identity_version, identity_digest, root_kind, independence_group_id, status, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6)
+                 ON CONFLICT(identity_version, identity_digest) DO UPDATE SET root_id = root_id
+                 RETURNING root_id",
+                libsql::params![
+                    root_id.clone(),
+                    crate::provenance::IDENTITY_VERSION,
+                    digest,
+                    root_kind.to_string(),
+                    group_id,
+                    now
+                ],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root: {e}")))?;
+        let winning_root_id: String = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root row: {e}")))?
+            .ok_or_else(|| {
+                WenlanError::VectorDb(
+                    "acquire_provenance_root: INSERT..RETURNING produced no row".to_string(),
+                )
+            })?
+            .get(0)
+            .map_err(|e| WenlanError::VectorDb(format!("acquire_provenance_root col: {e}")))?;
+        drop(rows);
+
+        // Only index this root's own bands when it actually won (the
+        // conflict branch already has bands indexed from its own insert).
+        if winning_root_id == root_id {
+            for band in &bands {
+                conn.execute(
+                    "INSERT OR IGNORE INTO provenance_root_minhash_bands (band_key, root_id) VALUES (?1, ?2)",
+                    libsql::params![*band as i64, winning_root_id.clone()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("provenance_root_minhash_bands: {e}")))?;
+            }
+        }
+
+        Ok(winning_root_id)
+    }
+
+    /// Return the distinct `independence_group_id`s of roots sharing at
+    /// least one of `band_keys` (LSH candidate lookup, mirrors
+    /// `query_entities_by_band` for `entity_minhash_bands`).
+    async fn query_provenance_roots_by_band(
+        conn: &libsql::Connection,
+        band_keys: &[u64],
+    ) -> Result<Vec<String>, WenlanError> {
+        if band_keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = (1..=band_keys.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT DISTINCT pr.independence_group_id \
+             FROM provenance_root_minhash_bands b \
+             JOIN provenance_roots pr ON pr.root_id = b.root_id \
+             WHERE b.band_key IN ({placeholders})"
+        );
+        let params: Vec<libsql::Value> = band_keys
+            .iter()
+            .map(|&k| libsql::Value::Integer(k as i64))
+            .collect();
+        let mut rows = conn
+            .query(&sql, libsql::params_from_iter(params))
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("query_provenance_roots_by_band: {e}")))?;
+        let mut groups = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|e| {
+            WenlanError::VectorDb(format!("query_provenance_roots_by_band row: {e}"))
+        })? {
+            if let Ok(g) = row.get::<String>(0) {
+                groups.push(g);
+            }
+        }
+        Ok(groups)
     }
 
     async fn migrate_73_schema_collision_reconciliation(
@@ -14582,6 +15549,33 @@ impl MemoryDB {
                 }
                 drop(page_rows);
 
+                // Dual-write (M2 PR-1): capture which pages currently cite
+                // `old_source_id` (via either legacy store) before the
+                // remap below runs, so the corresponding edges can move
+                // too -- invalidate the old edge_id, reassert one for
+                // `new_source_id` per affected page.
+                let mut edge_affected_pages: Vec<String> = Vec::new();
+                {
+                    let mut rows = conn
+                        .query(
+                            "SELECT DISTINCT page_id FROM page_sources WHERE memory_source_id = ?1
+                             UNION
+                             SELECT DISTINCT page_id FROM page_evidence WHERE source_kind = 'memory' AND locator = ?1",
+                            libsql::params![old_source_id],
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("rebind_source_id edge scan: {e}"))
+                        })?;
+                    while let Some(row) = rows.next().await.map_err(|e| {
+                        WenlanError::VectorDb(format!("rebind_source_id edge scan row: {e}"))
+                    })? {
+                        edge_affected_pages.push(row.get::<String>(0).map_err(|e| {
+                            WenlanError::VectorDb(format!("rebind_source_id edge scan id: {e}"))
+                        })?);
+                    }
+                }
+
                 conn.execute(
                     "INSERT OR IGNORE INTO page_sources
                          (page_id, memory_source_id, linked_at, link_reason)
@@ -14631,6 +15625,64 @@ impl MemoryDB {
                     .map_err(|e| {
                         WenlanError::VectorDb(format!("rebind_source_id page JSON update: {e}"))
                     })?;
+                }
+
+                // Dual-write (M2 PR-1), continued: move the edges.
+                let new_memory_space = Self::resolve_memory_space(&conn, new_source_id)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("rebind_source_id new memory space: {e}"))
+                    })?;
+                for page_id in &edge_affected_pages {
+                    let old_edge_id = crate::provenance::compute_edge_id(
+                        "cites", "page", page_id, "memory", old_source_id, old_source_id,
+                    );
+                    Self::dual_write_invalidate_edge(&conn, &old_edge_id, None)
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("rebind_source_id edge invalidate: {e}"))
+                        })?;
+
+                    let mut space_rows = conn
+                        .query(
+                            "SELECT space FROM pages WHERE id = ?1",
+                            libsql::params![page_id.as_str()],
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("rebind_source_id page space: {e}"))
+                        })?;
+                    let page_space: Option<String> = match space_rows.next().await.map_err(|e| {
+                        WenlanError::VectorDb(format!("rebind_source_id page space row: {e}"))
+                    })? {
+                        Some(row) => row.get(0).unwrap_or(None),
+                        None => None,
+                    };
+                    drop(space_rows);
+                    if let Some(page_space) = page_space {
+                        let lineage = if new_memory_space.as_deref() == Some(page_space.as_str())
+                        {
+                            "evidence"
+                        } else {
+                            "legacy"
+                        };
+                        Self::dual_write_edge(
+                            &conn,
+                            "cites",
+                            "page",
+                            page_id,
+                            "memory",
+                            new_source_id,
+                            new_source_id,
+                            lineage,
+                            &page_space,
+                            None,
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("rebind_source_id edge reassert: {e}"))
+                        })?;
+                    }
                 }
             }
 
@@ -17449,22 +18501,21 @@ impl MemoryDB {
             ));
         }
         let conn = self.conn.lock().await;
-
-        let mut rows = conn
-            .query(
-                "SELECT id, from_entity, to_entity, relation_type, source_agent, \
-                        confidence, explanation, source_memory_id, created_at \
-                 FROM relations WHERE id = ?1",
-                libsql::params![loser_id],
-            )
+        conn.execute("BEGIN", ())
             .await
-            .map_err(|e| WenlanError::VectorDb(format!("supersede_relation select: {e}")))?;
+            .map_err(|e| WenlanError::VectorDb(format!("supersede_relation begin: {e}")))?;
 
-        let snapshot = rows
-            .next()
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("supersede_relation row: {e}")))?
-            .map(|row| {
+        let exec = async {
+            let mut rows = conn
+                .query(
+                    "SELECT id, from_entity, to_entity, relation_type, source_agent, \
+                            confidence, explanation, source_memory_id, created_at \
+                     FROM relations WHERE id = ?1",
+                    libsql::params![loser_id],
+                )
+                .await?;
+
+            let snapshot = rows.next().await?.map(|row| {
                 serde_json::json!({
                     "id":               row.get::<String>(0).ok(),
                     "from_entity":      row.get::<String>(1).ok(),
@@ -17477,15 +18528,47 @@ impl MemoryDB {
                     "created_at":       row.get::<i64>(8).ok(),
                 })
             });
-        drop(rows);
+            drop(rows);
 
-        conn.execute(
-            "DELETE FROM relations WHERE id = ?1",
-            libsql::params![loser_id],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("supersede_relation: {e}")))?;
-        Ok(snapshot)
+            conn.execute(
+                "DELETE FROM relations WHERE id = ?1",
+                libsql::params![loser_id],
+            )
+            .await?;
+
+            // Dual-write (M2 PR-1): soft-invalidate the corresponding edge
+            // rather than hard-delete it (append-only-with-soft-supersession,
+            // spec v3 §2). Same-id computation as the live create_relation
+            // dual-write and the migration-81 relations backfill.
+            if let Some(snap) = &snapshot {
+                if let (Some(fe), Some(te), Some(rt)) = (
+                    snap["from_entity"].as_str(),
+                    snap["to_entity"].as_str(),
+                    snap["relation_type"].as_str(),
+                ) {
+                    let edge_id = crate::provenance::compute_edge_id(
+                        "relates", "entity", fe, "entity", te, rt,
+                    );
+                    Self::dual_write_invalidate_edge(&conn, &edge_id, None).await?;
+                }
+            }
+
+            Ok::<_, libsql::Error>(snapshot)
+        }
+        .await;
+
+        match exec {
+            Ok(snapshot) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("supersede_relation commit: {e}"))
+                })?;
+                Ok(snapshot)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(WenlanError::VectorDb(format!("supersede_relation: {e}")))
+            }
+        }
     }
 
     /// Set `pending_revision = 1` on all chunks matching `source_id`. Idempotent
@@ -17553,61 +18636,120 @@ impl MemoryDB {
         let now = chrono::Utc::now().timestamp();
 
         let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_relation begin: {e}")))?;
 
-        // Upsert: insert new or update existing if new confidence is higher.
-        let affected = conn.execute(
-            "INSERT INTO relations (id, from_entity, to_entity, relation_type, source_agent, confidence, explanation, source_memory_id, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-             ON CONFLICT(from_entity, to_entity, relation_type) DO UPDATE SET
-                 confidence = CASE
-                     WHEN EXCLUDED.confidence IS NOT NULL AND (confidence IS NULL OR EXCLUDED.confidence > confidence)
-                     THEN EXCLUDED.confidence ELSE confidence END,
-                 explanation = CASE
-                     WHEN EXCLUDED.confidence IS NOT NULL AND (confidence IS NULL OR EXCLUDED.confidence > confidence)
-                     THEN COALESCE(EXCLUDED.explanation, explanation) ELSE explanation END,
-                 source_memory_id = COALESCE(EXCLUDED.source_memory_id, source_memory_id)",
-            libsql::params![
-                id.clone(),
-                from_entity.to_string(),
-                to_entity.to_string(),
-                canonical.clone(),
-                source_agent.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
-                confidence.map(libsql::Value::Real).unwrap_or(libsql::Value::Null),
-                explanation.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
-                source_memory_id.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
-                now
-            ],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("create_relation: {}", e)))?;
+        let exec = async {
+            // Upsert: insert new or update existing if new confidence is higher.
+            let affected = conn.execute(
+                "INSERT INTO relations (id, from_entity, to_entity, relation_type, source_agent, confidence, explanation, source_memory_id, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+                 ON CONFLICT(from_entity, to_entity, relation_type) DO UPDATE SET
+                     confidence = CASE
+                         WHEN EXCLUDED.confidence IS NOT NULL AND (confidence IS NULL OR EXCLUDED.confidence > confidence)
+                         THEN EXCLUDED.confidence ELSE confidence END,
+                     explanation = CASE
+                         WHEN EXCLUDED.confidence IS NOT NULL AND (confidence IS NULL OR EXCLUDED.confidence > confidence)
+                         THEN COALESCE(EXCLUDED.explanation, explanation) ELSE explanation END,
+                     source_memory_id = COALESCE(EXCLUDED.source_memory_id, source_memory_id)",
+                libsql::params![
+                    id.clone(),
+                    from_entity.to_string(),
+                    to_entity.to_string(),
+                    canonical.clone(),
+                    source_agent.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
+                    confidence.map(libsql::Value::Real).unwrap_or(libsql::Value::Null),
+                    explanation.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
+                    source_memory_id.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
+                    now
+                ],
+            )
+            .await?;
 
-        // Only increment vocabulary count for genuinely new relations.
-        if affected > 0 {
+            if affected == 0 {
+                return Ok::<Option<String>, libsql::Error>(None);
+            }
+
             // Check if this was an insert (the id we generated exists) vs an update.
             let mut rows = conn
                 .query(
                     "SELECT id FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
                     libsql::params![from_entity.to_string(), to_entity.to_string(), canonical.clone()],
                 )
-                .await
-                .map_err(|e| WenlanError::VectorDb(format!("create_relation check: {}", e)))?;
-            let existing_id = match rows.next().await {
-                Ok(Some(row)) => row.get::<String>(0).unwrap_or(id.clone()),
-                _ => id.clone(),
+                .await?;
+            let existing_id = match rows.next().await? {
+                Some(row) => row.get::<String>(0).unwrap_or(id.clone()),
+                None => id.clone(),
             };
             drop(rows);
-            drop(conn);
 
-            // Only count new inserts (our generated id matches the stored id).
-            if existing_id == id {
-                self.increment_relation_type_count(&canonical).await.ok();
-            }
+            // Dual-write (M2 PR-1): mirror `backfill_edges_from_relations`'s
+            // classification exactly so a live-written edge and a backfilled
+            // edge for the same fact converge on the same edge_id.
+            let mut space_rows = conn
+                .query(
+                    "SELECT fe.space, te.space FROM entities fe, entities te WHERE fe.id = ?1 AND te.id = ?2",
+                    libsql::params![from_entity.to_string(), to_entity.to_string()],
+                )
+                .await?;
+            let (from_space, to_space): (Option<String>, Option<String>) =
+                match space_rows.next().await? {
+                    Some(row) => (row.get(0).unwrap_or(None), row.get(1).unwrap_or(None)),
+                    None => (None, None),
+                };
+            drop(space_rows);
+            let (lineage, space) = match (&from_space, &to_space) {
+                (Some(fs), Some(ts)) if fs == ts => ("assertion", fs.clone()),
+                _ => (
+                    "legacy",
+                    from_space
+                        .or(to_space)
+                        .unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
+                ),
+            };
+            Self::dual_write_edge(
+                &conn,
+                "relates",
+                "entity",
+                from_entity,
+                "entity",
+                to_entity,
+                &canonical,
+                lineage,
+                &space,
+                None,
+            )
+            .await?;
 
-            return Ok(existing_id);
+            Ok(Some(existing_id))
         }
+        .await;
 
-        drop(conn);
-        Ok(id)
+        match exec {
+            Ok(Some(existing_id)) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("create_relation commit: {e}")))?;
+                drop(conn);
+                // Only count new inserts (our generated id matches the stored id).
+                if existing_id == id {
+                    self.increment_relation_type_count(&canonical).await.ok();
+                }
+                Ok(existing_id)
+            }
+            Ok(None) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("create_relation commit: {e}")))?;
+                drop(conn);
+                Ok(id)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(WenlanError::VectorDb(format!("create_relation: {e}")))
+            }
+        }
     }
 
     pub async fn list_relations_between(
@@ -25947,14 +27089,53 @@ impl MemoryDB {
         linked_at: i64,
         link_reason: &str,
     ) -> Result<(), libsql::Error> {
+        // Dual-write (M2 PR-1): one SELECT for the page's space, then per
+        // source id mirror `backfill_edges_from_page_evidence`'s
+        // classification (memory/external_url/external_file -> evidence;
+        // anything else -> legacy) so a live-written edge converges on the
+        // same edge_id a backfill would produce for the same row. This is
+        // the ONE fix site for every `insert_resolved_page_evidence` caller,
+        // same rationale as `resolve_source_kinds`'s doc comment.
+        let mut space_rows = conn
+            .query(
+                "SELECT space FROM pages WHERE id = ?1",
+                libsql::params![page_id],
+            )
+            .await?;
+        let page_space: Option<String> = match space_rows.next().await? {
+            Some(row) => row.get(0).unwrap_or(None),
+            None => None,
+        };
+        drop(space_rows);
+
         for sid in source_ids {
             let source_kind = Self::resolve_one_source_kind(conn, sid).await?;
             conn.execute(
                 "INSERT OR IGNORE INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason)
                  VALUES (?1, ?2, ?3, NULL, ?4, ?5)",
-                libsql::params![page_id, source_kind, *sid, linked_at, link_reason],
+                libsql::params![page_id, source_kind.clone(), *sid, linked_at, link_reason],
             )
             .await?;
+
+            if let Some(space) = &page_space {
+                let (dst_kind, classifiable) = match source_kind.as_str() {
+                    // A `memory` citation is only fence-safe when the memory
+                    // shares the page's space -- `cites`->`memory` is NOT
+                    // exempt from the space fence (only `cites`->`external`
+                    // is), mirroring `backfill_edges_from_page_evidence`.
+                    "memory" => (
+                        "memory",
+                        Self::resolve_memory_space(conn, sid).await? == Some(space.clone()),
+                    ),
+                    "external_url" | "external_file" => ("external", true),
+                    _ => ("external", false),
+                };
+                let lineage = if classifiable { "evidence" } else { "legacy" };
+                Self::dual_write_edge(
+                    conn, "cites", "page", page_id, dst_kind, sid, sid, lineage, space, None,
+                )
+                .await?;
+            }
         }
         Ok(())
     }
@@ -28085,11 +29266,26 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("replace_page_links begin: {e}")))?;
         let exec = async {
+            // Dual-write (M2 PR-1): invalidate every active `links` edge
+            // from this page up front; the loop below re-asserts (or
+            // reactivates, via `dual_write_edge`'s upsert) an edge for each
+            // link still present, so a link dropped from the new set stays
+            // invalidated and a link that survives round-trips back to
+            // active within this same transaction.
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "UPDATE edges SET valid_until = ?2, superseded_by = NULL \
+                 WHERE edge_type = 'links' AND src_id = ?1 AND valid_until IS NULL",
+                libsql::params![source_page_id, now],
+            )
+            .await?;
+
             conn.execute(
                 "DELETE FROM page_links WHERE source_page_id = ?1",
                 libsql::params![source_page_id],
             )
             .await?;
+            let mut src_space: Option<Option<String>> = None;
             for link in links {
                 let label_key = link.label.to_lowercase();
                 conn.execute(
@@ -28098,9 +29294,63 @@ impl MemoryDB {
                     libsql::params![
                         source_page_id,
                         link.target_page_id.clone(),
-                        label_key,
+                        label_key.clone(),
                         link.label.clone(),
                     ],
+                )
+                .await?;
+
+                let Some(target_page_id) = &link.target_page_id else {
+                    continue; // orphan wikilink: no destination, no edge (matrix row 5)
+                };
+                let space = match &src_space {
+                    Some(s) => s.clone(),
+                    None => {
+                        let mut rows = conn
+                            .query(
+                                "SELECT space FROM pages WHERE id = ?1",
+                                libsql::params![source_page_id],
+                            )
+                            .await?;
+                        let s: Option<String> = match rows.next().await? {
+                            Some(row) => row.get(0).unwrap_or(None),
+                            None => None,
+                        };
+                        drop(rows);
+                        src_space = Some(s.clone());
+                        s
+                    }
+                };
+                let Some(space) = space else {
+                    continue; // source page unresolvable: skip (shouldn't happen, FK-backed)
+                };
+                let mut dst_rows = conn
+                    .query(
+                        "SELECT space FROM pages WHERE id = ?1",
+                        libsql::params![target_page_id.clone()],
+                    )
+                    .await?;
+                let dst_space: Option<String> = match dst_rows.next().await? {
+                    Some(row) => row.get(0).unwrap_or(None),
+                    None => None,
+                };
+                drop(dst_rows);
+                let lineage = if dst_space.as_deref() == Some(space.as_str()) {
+                    "synthesis"
+                } else {
+                    "legacy"
+                };
+                Self::dual_write_edge(
+                    &conn,
+                    "links",
+                    "page",
+                    source_page_id,
+                    "page",
+                    target_page_id,
+                    &label_key,
+                    lineage,
+                    &space,
+                    None,
                 )
                 .await?;
             }
@@ -28994,13 +30244,31 @@ impl MemoryDB {
     ) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
         Self::reject_page_draft_on_conn(&conn, page_id).await?;
-        conn.execute(
-            "UPDATE pages SET citations = ?1 WHERE id = ?2",
-            libsql::params![citations_json, page_id],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("set_page_citations: {e}")))?;
-        Ok(())
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("set_page_citations begin: {e}")))?;
+        let exec = async {
+            conn.execute(
+                "UPDATE pages SET citations = ?1 WHERE id = ?2",
+                libsql::params![citations_json, page_id],
+            )
+            .await?;
+            Self::dual_write_page_citations(&conn, page_id, citations_json).await?;
+            Ok::<_, libsql::Error>(())
+        }
+        .await;
+        match exec {
+            Ok(()) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("set_page_citations commit: {e}"))
+                })?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(WenlanError::VectorDb(format!("set_page_citations: {e}")))
+            }
+        }
     }
 
     /// Atomically write `citations` + `changelog` WITHOUT touching `content`,
@@ -29018,13 +30286,33 @@ impl MemoryDB {
     ) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
         Self::reject_page_draft_on_conn(&conn, page_id).await?;
-        conn.execute(
-            "UPDATE pages SET citations = ?1, changelog = ?2 WHERE id = ?3",
-            libsql::params![citations_json, changelog_json, page_id],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("set_page_citations_with_changelog: {e}")))?;
-        Ok(())
+        conn.execute("BEGIN", ()).await.map_err(|e| {
+            WenlanError::VectorDb(format!("set_page_citations_with_changelog begin: {e}"))
+        })?;
+        let exec = async {
+            conn.execute(
+                "UPDATE pages SET citations = ?1, changelog = ?2 WHERE id = ?3",
+                libsql::params![citations_json, changelog_json, page_id],
+            )
+            .await?;
+            Self::dual_write_page_citations(&conn, page_id, citations_json).await?;
+            Ok::<_, libsql::Error>(())
+        }
+        .await;
+        match exec {
+            Ok(()) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("set_page_citations_with_changelog commit: {e}"))
+                })?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(WenlanError::VectorDb(format!(
+                    "set_page_citations_with_changelog: {e}"
+                )))
+            }
+        }
     }
 
     /// Test-only: overwrite a page's `citations` column directly, bypassing the
@@ -29058,12 +30346,63 @@ impl MemoryDB {
         let now = chrono::Utc::now().timestamp();
         let conn = self.conn.lock().await;
         Self::reject_page_draft_on_conn(&conn, page_id).await?;
-        conn.execute(
-            "INSERT OR IGNORE INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            libsql::params![page_id, source_kind, locator, title, now, link_reason],
-        ).await.map_err(|e| WenlanError::VectorDb(format!("link_page_evidence: {e}")))?;
-        Ok(())
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("link_page_evidence begin: {e}")))?;
+
+        let exec = async {
+            conn.execute(
+                "INSERT OR IGNORE INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                libsql::params![page_id, source_kind, locator, title, now, link_reason],
+            )
+            .await?;
+
+            // Dual-write (M2 PR-1): a NULL locator (e.g. `authored`) has no
+            // destination value -- no edge is minted, matching
+            // `backfill_edges_from_page_evidence`'s NULL-locator skip.
+            if let Some(locator) = locator {
+                let mut rows = conn
+                    .query("SELECT space FROM pages WHERE id = ?1", libsql::params![page_id])
+                    .await?;
+                let space: Option<String> = match rows.next().await? {
+                    Some(row) => row.get(0).unwrap_or(None),
+                    None => None,
+                };
+                drop(rows);
+                if let Some(space) = space {
+                    let (dst_kind, classifiable) = match source_kind {
+                        "memory" => (
+                            "memory",
+                            Self::resolve_memory_space(&conn, locator).await? == Some(space.clone()),
+                        ),
+                        "external_url" | "external_file" => ("external", true),
+                        _ => ("external", false),
+                    };
+                    let lineage = if classifiable { "evidence" } else { "legacy" };
+                    Self::dual_write_edge(
+                        &conn, "cites", "page", page_id, dst_kind, locator, locator, lineage,
+                        &space, None,
+                    )
+                    .await?;
+                }
+            }
+            Ok::<_, libsql::Error>(())
+        }
+        .await;
+
+        match exec {
+            Ok(()) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!("link_page_evidence commit: {e}"))
+                })?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(WenlanError::VectorDb(format!("link_page_evidence: {e}")))
+            }
+        }
     }
 
     /// Stamp `last_distilled_at` on the given memories (keyed by `source_id`).
@@ -29342,6 +30681,26 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("cleanup_orphaned_page_evidence: {e}")))?;
+
+            // Dual-write (M2 PR-1): soft-invalidate the edges the two
+            // deletes above just orphaned. Both `page_sources` and
+            // `page_evidence` dual-write onto the identical content-addressed
+            // edge_id for the same (page, memory) pair, so one invalidation
+            // pass covers whichever store originally produced the edge.
+            for (page_id, removed_locators) in &affected_pages {
+                for locator in removed_locators {
+                    let edge_id = crate::provenance::compute_edge_id(
+                        "cites", "page", page_id, "memory", locator, locator,
+                    );
+                    Self::dual_write_invalidate_edge(&conn, &edge_id, None)
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!(
+                                "cleanup_orphaned_page_sources edge invalidate: {e}"
+                            ))
+                        })?;
+                }
+            }
 
             let now = chrono::Utc::now().to_rfc3339();
             let removed_count: usize = affected_pages.values().map(HashSet::len).sum();
@@ -49493,6 +50852,15 @@ pub(crate) mod tests {
             let conn = db.conn.lock().await;
 
             conn.execute("PRAGMA foreign_keys = OFF", ()).await.unwrap();
+            // legacy_alter_table: the RENAME below reparses every trigger in
+            // the schema to fix up table references, and briefly chokes on
+            // `edges_space_fence` (migration 81) since it names `pages` while
+            // the old `pages` is dropped and the new one isn't renamed in yet.
+            // The legacy behavior skips that dependent-object fixup, which
+            // this rename doesn't need (no trigger references `pages_pre49`).
+            conn.execute("PRAGMA legacy_alter_table = ON", ())
+                .await
+                .unwrap();
             // Migration 50 renamed pages.domain → pages.space; use the current
             // column name here so the table copy does not crash on post-50 DBs.
             // Recreate with an explicit schema (PRIMARY KEY on id) rather than
@@ -49527,6 +50895,9 @@ pub(crate) mod tests {
             )
             .await
             .expect("recreate pages without changelog should succeed");
+            conn.execute("PRAGMA legacy_alter_table = OFF", ())
+                .await
+                .unwrap();
             conn.execute("PRAGMA foreign_keys = ON", ()).await.unwrap();
 
             // Roll back to version 47 so migration 49 re-fires.
@@ -59364,5 +60735,917 @@ pub(crate) mod tests {
             err.to_string().contains("m80"),
             "error should identify migration 80: {err}"
         );
+    }
+
+    // -- M2 PR-1 migration 81: unified edges + provenance_roots --
+
+    async fn insert_raw_page_for_m81_test(conn: &libsql::Connection, id: &str, space: &str) {
+        conn.execute(
+            "INSERT INTO pages (id, title, content, created_at, last_compiled, last_modified, space, workspace) \
+             VALUES (?1, ?2, 'content', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', ?3, ?3)",
+            libsql::params![id, format!("title {id}"), space],
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn seed_memory_with_source_id_and_space(
+        db: &MemoryDB,
+        source_id: &str,
+        content: &str,
+        space: &str,
+    ) {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                                    last_modified, chunk_type, source_agent, space, confidence, \
+                                    confirmed, memory_type, pending_revision) \
+             VALUES (?1, ?2, 'memory', ?3, 'test', 0, 1712707200, 'text', NULL, ?4, 1.0, 0, 'fact', 0)",
+            libsql::params![
+                source_id.to_string(),
+                content.to_string(),
+                source_id.to_string(),
+                space.to_string()
+            ],
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Roll `user_version` back to 80 and re-run migrations so
+    /// `migrate_81_unified_edges` re-fires over rows inserted after the
+    /// initial `test_db()` migration pass -- mirrors the M1
+    /// relax-then-re-run pattern (`migration_80_fresh_and_upgraded_schema_agree`).
+    async fn rerun_migration_81(db: &MemoryDB) {
+        {
+            let conn = db.conn.lock().await;
+            conn.execute("PRAGMA user_version = 80", ()).await.unwrap();
+        }
+        db.run_migrations(&crate::events::NoopEmitter)
+            .await
+            .expect("migration 81 re-fires");
+    }
+
+    async fn edges_count(conn: &libsql::Connection) -> i64 {
+        let mut rows = conn.query("SELECT COUNT(*) FROM edges", ()).await.unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    }
+
+    async fn edge_row(
+        conn: &libsql::Connection,
+        edge_type: &str,
+        src_id: &str,
+        dst_id: &str,
+    ) -> Option<(String, i64, String)> {
+        // (lineage, grounded, space)
+        let mut rows = conn
+            .query(
+                "SELECT lineage, grounded, space FROM edges WHERE edge_type = ?1 AND src_id = ?2 AND dst_id = ?3",
+                libsql::params![edge_type, src_id, dst_id],
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().map(|row| {
+            (
+                row.get(0).unwrap(),
+                row.get(1).unwrap(),
+                row.get(2).unwrap(),
+            )
+        })
+    }
+
+    #[tokio::test]
+    async fn migration_81_creates_edges_and_provenance_schema() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        for table in [
+            "edges",
+            "provenance_roots",
+            "provenance_root_minhash_bands",
+            "edges_migration_state",
+        ] {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    libsql::params![table],
+                )
+                .await
+                .unwrap();
+            let present: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+            assert_eq!(present, 1, "{table} table should exist after migration 81");
+        }
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='trigger' AND name='edges_space_fence'",
+                (),
+            )
+            .await
+            .unwrap();
+        let present: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(present, 1, "edges_space_fence trigger should exist");
+
+        let uv: i64 = {
+            let mut rows = conn.query("PRAGMA user_version", ()).await.unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(uv as u32, crate::db::SCHEMA_VERSION);
+    }
+
+    #[tokio::test]
+    async fn migration_81_migration_state_row_records_report() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT stage, completed_at, report_json FROM edges_migration_state WHERE id = 1",
+                (),
+            )
+            .await
+            .unwrap();
+        let row = rows
+            .next()
+            .await
+            .unwrap()
+            .expect("durable migration state row must exist");
+        let stage: String = row.get(0).unwrap();
+        let completed_at: Option<i64> = row.get(1).unwrap();
+        let report_json: String = row.get(2).unwrap();
+        assert_eq!(stage, "backfilled");
+        assert!(completed_at.is_some());
+        let report: serde_json::Value = serde_json::from_str(&report_json).unwrap();
+        assert!(report.get("relations").is_some());
+        assert!(report.get("page_sources").is_some());
+        assert!(report.get("page_evidence").is_some());
+        assert!(report.get("page_links").is_some());
+        assert!(report.get("pages_citations").is_some());
+        assert!(report.get("cross_space_audit").is_some());
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_relations_same_space_as_assertion() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_a"))
+            .await
+            .unwrap();
+        db.create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await
+            .unwrap();
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) = edge_row(&conn, "relates", &e1, &e2).await.unwrap();
+        assert_eq!(lineage, "assertion");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_relations_cross_space_as_legacy() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_b"))
+            .await
+            .unwrap();
+        db.create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await
+            .unwrap();
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, _space) = edge_row(&conn, "relates", &e1, &e2).await.unwrap();
+        assert_eq!(lineage, "legacy");
+        assert_eq!(grounded, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_page_sources_as_evidence() {
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_1", "source content", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_sources (page_id, memory_source_id, linked_at, link_reason) VALUES ('page_1', 'mem_1', 1712707200, 'distill')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) = edge_row(&conn, "cites", "page_1", "mem_1").await.unwrap();
+        assert_eq!(lineage, "evidence");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_page_evidence_external_url_as_evidence() {
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason) \
+                 VALUES ('page_1', 'external_url', 'https://example.com/a', NULL, 1712707200, NULL)",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) =
+            edge_row(&conn, "cites", "page_1", "https://example.com/a")
+                .await
+                .unwrap();
+        assert_eq!(lineage, "evidence");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+        let dst_kind: String = {
+            let mut rows = conn
+                .query(
+                    "SELECT dst_kind FROM edges WHERE edge_type='cites' AND src_id='page_1' AND dst_id='https://example.com/a'",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(dst_kind, "external");
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_page_evidence_null_locator_is_skipped() {
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason) \
+                 VALUES ('page_1', 'authored', NULL, 'An Author', 1712707200, NULL)",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        let before = {
+            let conn = db.conn.lock().await;
+            edges_count(&conn).await
+        };
+        rerun_migration_81(&db).await;
+        let conn = db.conn.lock().await;
+        let after = edges_count(&conn).await;
+        assert_eq!(
+            before, after,
+            "a NULL-locator evidence row must not mint an edge"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_page_links_orphan_is_skipped_not_inserted() {
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_links (source_page_id, target_page_id, label_key, label) VALUES ('page_1', NULL, 'missing-page', 'Missing Page')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        let before = {
+            let conn = db.conn.lock().await;
+            edges_count(&conn).await
+        };
+        rerun_migration_81(&db).await;
+        let conn = db.conn.lock().await;
+        let after = edges_count(&conn).await;
+        assert_eq!(
+            before, after,
+            "an orphan wikilink has no destination -- no edge is minted"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_page_links_resolved_as_synthesis() {
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            insert_raw_page_for_m81_test(&conn, "page_2", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_links (source_page_id, target_page_id, label_key, label) VALUES ('page_1', 'page_2', 'page-2', 'Page 2')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) =
+            edge_row(&conn, "links", "page_1", "page_2").await.unwrap();
+        assert_eq!(lineage, "synthesis");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_citations_memory_resolved_as_synthesis() {
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_cited", "cited content", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            let citations = serde_json::json!([{
+                "occurrence": 1, "marker": 1, "source_kind": "memory",
+                "locator": "mem_cited", "score": 0.9, "status": "verified", "scope": "sentence"
+            }]);
+            conn.execute(
+                "UPDATE pages SET citations = ?1 WHERE id = 'page_1'",
+                libsql::params![citations.to_string()],
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) = edge_row(&conn, "cites", "page_1", "mem_cited")
+            .await
+            .unwrap();
+        assert_eq!(lineage, "synthesis");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfills_citations_unresolved_source_kind_as_legacy() {
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_1", "space_a").await;
+            let citations = serde_json::json!([{
+                "occurrence": 1, "marker": 1, "source_kind": "external",
+                "locator": "https://example.com/x", "score": 0.9, "status": "verified", "scope": "sentence"
+            }]);
+            conn.execute(
+                "UPDATE pages SET citations = ?1 WHERE id = 'page_1'",
+                libsql::params![citations.to_string()],
+            )
+            .await
+            .unwrap();
+        }
+        rerun_migration_81(&db).await;
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, _space) =
+            edge_row(&conn, "cites", "page_1", "https://example.com/x")
+                .await
+                .unwrap();
+        assert_eq!(lineage, "legacy");
+        assert_eq!(grounded, 0);
+    }
+
+    #[tokio::test]
+    async fn migration_81_backfill_replay_is_idempotent() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_a"))
+            .await
+            .unwrap();
+        db.create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await
+            .unwrap();
+        rerun_migration_81(&db).await;
+        let first_count = {
+            let conn = db.conn.lock().await;
+            edges_count(&conn).await
+        };
+
+        rerun_migration_81(&db).await;
+        let second_count = {
+            let conn = db.conn.lock().await;
+            edges_count(&conn).await
+        };
+
+        assert_eq!(
+            first_count, second_count,
+            "a killed-and-rerun backfill must not duplicate edges (content-addressed retry identity)"
+        );
+        assert!(first_count > 0);
+    }
+
+    #[tokio::test]
+    async fn migration_81_fence_trigger_rejects_cross_space_typed_edge() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_b"))
+            .await
+            .unwrap();
+        let conn = db.conn.lock().await;
+        let result = conn
+            .execute(
+                "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until) \
+                 VALUES ('test-edge-1', ?1, 'entity', ?2, 'entity', 'relates', 'assertion', 0, NULL, 'space_a', NULL, NULL, NULL, NULL, 0, NULL, NULL)",
+                libsql::params![e1, e2],
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a typed edge whose dst endpoint is in a different space must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_fence_trigger_allows_legacy_edge_despite_space_mismatch() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_b"))
+            .await
+            .unwrap();
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until) \
+             VALUES ('test-edge-2', ?1, 'entity', ?2, 'entity', 'relates', 'legacy', 0, NULL, 'space_a', NULL, NULL, NULL, NULL, 0, NULL, NULL)",
+            libsql::params![e1, e2],
+        )
+        .await
+        .expect("lineage='legacy' is exempt from the fence");
+    }
+
+    #[tokio::test]
+    async fn migration_81_fence_trigger_allows_cites_external_regardless_of_space() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_x", "space_a").await;
+        conn.execute(
+            "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until) \
+             VALUES ('test-edge-3', 'page_x', 'page', 'https://example.com/y', 'external', 'cites', 'evidence', 0, NULL, 'space_a', NULL, NULL, NULL, NULL, 0, NULL, NULL)",
+            (),
+        )
+        .await
+        .expect("cites-to-external is exempt from the fence (no space to check)");
+    }
+
+    #[tokio::test]
+    async fn migration_81_fresh_and_upgraded_schema_agree() {
+        let (fresh_db, _fresh_dir) = test_db().await;
+        let fresh_sql: String = {
+            let conn = fresh_db.conn.lock().await;
+            let mut rows = conn
+                .query(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='edges'",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+
+        let (upgraded_db, _upgraded_dir) = test_db().await;
+        rerun_migration_81(&upgraded_db).await;
+        let upgraded_sql: String = {
+            let conn = upgraded_db.conn.lock().await;
+            let mut rows = conn
+                .query(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='edges'",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+
+        assert_eq!(
+            fresh_sql, upgraded_sql,
+            "fresh-DB and upgraded-DB edges DDL must agree byte-for-byte"
+        );
+    }
+
+    async fn query_plan_detail(conn: &libsql::Connection, sql: &str) -> String {
+        let mut rows = conn
+            .query(&format!("EXPLAIN QUERY PLAN {sql}"), ())
+            .await
+            .unwrap();
+        let mut details = Vec::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            let detail: String = row.get(3).unwrap_or_default();
+            details.push(detail);
+        }
+        details.join(" | ")
+    }
+
+    #[tokio::test]
+    async fn migration_81_index_contract_endpoint_lookups_use_index() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        let src_plan = query_plan_detail(
+            &conn,
+            "SELECT * FROM edges WHERE src_kind='page' AND src_id='p1'",
+        )
+        .await;
+        assert!(
+            src_plan.to_uppercase().contains("INDEX"),
+            "src lookup should use an index: {src_plan}"
+        );
+
+        let dst_plan = query_plan_detail(
+            &conn,
+            "SELECT * FROM edges WHERE dst_kind='page' AND dst_id='p1'",
+        )
+        .await;
+        assert!(
+            dst_plan.to_uppercase().contains("INDEX"),
+            "dst lookup should use an index: {dst_plan}"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_index_contract_root_id_lookup_uses_index() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        let plan = query_plan_detail(&conn, "SELECT * FROM edges WHERE root_id = 'r1'").await;
+        assert!(
+            plan.to_uppercase().contains("INDEX"),
+            "root_id lookup should use an index: {plan}"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_index_contract_operation_id_lookup_uses_index() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        let plan = query_plan_detail(&conn, "SELECT * FROM edges WHERE operation_id = 'op1'").await;
+        assert!(
+            plan.to_uppercase().contains("INDEX"),
+            "operation_id lookup should use an index: {plan}"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_index_contract_supersession_chain_lookup_uses_index() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        let plan = query_plan_detail(&conn, "SELECT * FROM edges WHERE superseded_by = 'e1'").await;
+        assert!(
+            plan.to_uppercase().contains("INDEX"),
+            "supersession chain lookup should use an index: {plan}"
+        );
+    }
+
+    #[tokio::test]
+    async fn migration_81_index_contract_active_grounded_space_type_scan_uses_index() {
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        let plan = query_plan_detail(
+            &conn,
+            "SELECT * FROM edges WHERE space='space_a' AND edge_type='relates' AND valid_until IS NULL AND grounded = 1",
+        )
+        .await;
+        assert!(
+            plan.to_uppercase().contains("INDEX"),
+            "active-grounded scan by space/type should use an index: {plan}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_provenance_root_two_writers_converge_on_same_root() {
+        let (db, _dir) = test_db().await;
+        let signals = crate::provenance::IndependenceSignals {
+            source_identity: Some("file:///a.txt"),
+            agent_turn: None,
+            import_batch: None,
+        };
+        let root_1 = db
+            .acquire_provenance_root("document_ingest", "identical content", &signals)
+            .await
+            .unwrap();
+        let root_2 = db
+            .acquire_provenance_root("document_ingest", "identical content", &signals)
+            .await
+            .unwrap();
+        assert_eq!(
+            root_1, root_2,
+            "two writers of byte-identical content must converge on the same root"
+        );
+
+        let conn = db.conn.lock().await;
+        let count = {
+            let mut rows = conn
+                .query("SELECT COUNT(*) FROM provenance_roots", ())
+                .await
+                .unwrap();
+            let n: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+            n
+        };
+        assert_eq!(count, 1, "convergence must not mint a second row");
+    }
+
+    // -- M2 PR-1 dual-write acceptance: single-transaction rollback,
+    // retry idempotency, soft-supersession (spec v3 §2, goal-prompt stage b) --
+
+    #[tokio::test]
+    async fn create_relation_dual_write_rolls_back_both_stores_on_edge_failure() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_a"))
+            .await
+            .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute("DROP TABLE edges", ()).await.unwrap();
+        }
+
+        let result = db
+            .create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await;
+        assert!(
+            result.is_err(),
+            "a same-transaction dual-write failure must fail the whole call"
+        );
+
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
+                libsql::params![e1.clone(), e2.clone()],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(
+            count, 0,
+            "the relations write must roll back when the same-transaction edge write fails -- \
+             proves single-transaction atomicity, not two independent autocommit writes"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_relation_dual_write_retry_is_idempotent_no_duplicate_edge() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_a"))
+            .await
+            .unwrap();
+        db.create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await
+            .unwrap();
+        // Retry / replay: same logical write submitted again.
+        db.create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await
+            .unwrap();
+
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM edges WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?2",
+                libsql::params![e1, e2],
+            )
+            .await
+            .unwrap();
+        let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(
+            count, 1,
+            "retrying the same create_relation call must converge onto one edge (content-addressed \
+             edge_id + ON CONFLICT), not mint a duplicate voter"
+        );
+    }
+
+    #[tokio::test]
+    async fn supersede_relation_dual_write_soft_invalidates_edge_not_hard_deletes() {
+        let (db, _dir) = test_db().await;
+        let e1 = db
+            .create_entity("Alice", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e2 = db
+            .create_entity("Bob", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let e3 = db
+            .create_entity("Carol", "person", Some("space_a"))
+            .await
+            .unwrap();
+        let loser_id = db
+            .create_relation(&e1, &e2, "knows", None, None, None, None)
+            .await
+            .unwrap();
+        let winner_id = db
+            .create_relation(&e1, &e3, "knows", None, None, None, None)
+            .await
+            .unwrap();
+        db.supersede_relation(&loser_id, &winner_id).await.unwrap();
+
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT valid_until FROM edges WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?2",
+                libsql::params![e1, e2],
+            )
+            .await
+            .unwrap();
+        let valid_until: Option<i64> = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert!(
+            valid_until.is_some(),
+            "supersede_relation must soft-invalidate (valid_until set), not hard-delete the edge row \
+             -- append-only-with-soft-supersession, spec v3 §2"
+        );
+    }
+
+    #[tokio::test]
+    async fn link_page_source_dual_writes_cites_edge_via_page_evidence_chokepoint() {
+        // page_sources has no single chokepoint of its own, but every
+        // production write site also calls insert_resolved_page_evidence
+        // for the same (page, memory) pair with the identical
+        // content-addressed edge_id -- this proves that transitive
+        // coverage holds for `link_page_source`, one of page_sources's
+        // ~9 scattered write sites.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_x", "content", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_x", "space_a").await;
+        }
+        db.link_page_source("page_x", "mem_x", "distill")
+            .await
+            .unwrap();
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) = edge_row(&conn, "cites", "page_x", "mem_x").await.unwrap();
+        assert_eq!(lineage, "evidence");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+    }
+
+    #[tokio::test]
+    async fn replace_page_links_dual_writes_and_invalidates_removed_links() {
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "src_page", "space_a").await;
+            insert_raw_page_for_m81_test(&conn, "tgt_page", "space_a").await;
+        }
+        db.replace_page_links(
+            "src_page",
+            &[crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("tgt_page".to_string()),
+                label: "Tgt Page".to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            let (lineage, grounded, space) = edge_row(&conn, "links", "src_page", "tgt_page")
+                .await
+                .unwrap();
+            assert_eq!(lineage, "synthesis");
+            assert_eq!(grounded, 0);
+            assert_eq!(space, "space_a");
+        }
+
+        // Replace with an empty link set -- the edge must be invalidated,
+        // not left dangling active with no backing page_links row.
+        db.replace_page_links("src_page", &[]).await.unwrap();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT valid_until FROM edges WHERE edge_type = 'links' AND src_id = 'src_page' AND dst_id = 'tgt_page'",
+                (),
+            )
+            .await
+            .unwrap();
+        let valid_until: Option<i64> = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert!(
+            valid_until.is_some(),
+            "a link dropped from the new set must be invalidated, not left active"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_page_citations_dual_writes_memory_and_external_citations() {
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_cited", "content", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_c", "space_a").await;
+        }
+        let citations = serde_json::json!([
+            {"occurrence": 1, "marker": 1, "source_kind": "memory", "locator": "mem_cited",
+             "score": 0.9, "status": "verified", "scope": "sentence"},
+            {"occurrence": 2, "marker": 2, "source_kind": "external_url", "locator": "https://example.com/z",
+             "score": 0.8, "status": "verified", "scope": "sentence"}
+        ]);
+        db.set_page_citations("page_c", Some(&citations.to_string()))
+            .await
+            .unwrap();
+
+        let conn = db.conn.lock().await;
+        let (lineage, grounded, space) = edge_row(&conn, "cites", "page_c", "mem_cited")
+            .await
+            .unwrap();
+        assert_eq!(lineage, "synthesis");
+        assert_eq!(grounded, 0);
+        assert_eq!(space, "space_a");
+        let (ext_lineage, ext_grounded, _) =
+            edge_row(&conn, "cites", "page_c", "https://example.com/z")
+                .await
+                .unwrap();
+        assert_eq!(ext_lineage, "legacy");
+        assert_eq!(ext_grounded, 0);
+    }
+
+    /// Bulk-insert/trigger benchmark for the M2 index contract (spec v3 §2:
+    /// "bulk-insert trigger benchmarks in the acceptance gate"). Manual-only
+    /// (like the GPU evals) since it is a timing measurement, not a
+    /// pass/fail correctness check; run with
+    /// `cargo test -p wenlan-core --lib m81_bulk_insert_trigger_benchmark -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore]
+    async fn m81_bulk_insert_trigger_benchmark() {
+        let (db, _dir) = test_db().await;
+        const N: usize = 10_000;
+        let mut entity_ids = Vec::with_capacity(N + 1);
+        for i in 0..=N {
+            entity_ids.push(
+                db.create_entity(&format!("Entity {i}"), "thing", Some("space_a"))
+                    .await
+                    .unwrap(),
+            );
+        }
+        let start = std::time::Instant::now();
+        for i in 0..N {
+            db.create_relation(
+                &entity_ids[i],
+                &entity_ids[i + 1],
+                "related_to",
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        let elapsed = start.elapsed();
+        println!(
+            "[m81_bulk_insert_trigger_benchmark] {N} live dual-writes (relations INSERT + \
+             edges_space_fence-gated edges INSERT, one BEGIN/COMMIT each) in {elapsed:?} \
+             ({:.1}µs/row)",
+            elapsed.as_micros() as f64 / N as f64
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_provenance_root_different_content_gets_different_root() {
+        let (db, _dir) = test_db().await;
+        let signals = crate::provenance::IndependenceSignals {
+            source_identity: Some("file:///a.txt"),
+            agent_turn: None,
+            import_batch: None,
+        };
+        let root_1 = db
+            .acquire_provenance_root("document_ingest", "content one", &signals)
+            .await
+            .unwrap();
+        let root_2 = db
+            .acquire_provenance_root("document_ingest", "content two", &signals)
+            .await
+            .unwrap();
+        assert_ne!(root_1, root_2);
     }
 }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -7960,10 +7960,44 @@ impl MemoryDB {
             // page in space A cannot mint a `cites`->external edge stamped
             // space B. (An earlier WHEN clause disabled the whole trigger body
             // for `cites`->external, skipping the source check too.)
+            // Two triggers with the IDENTICAL body: one AFTER INSERT (first
+            // write) and one AFTER UPDATE (reactivation / lineage-precedence /
+            // space reconciliation via `dual_write_edge`'s ON CONFLICT DO
+            // UPDATE). The UPDATE twin additionally guards on
+            // `NEW.valid_until IS NULL` so a SOFT-INVALIDATE (which sets
+            // valid_until on an edge whose endpoint may since have moved) is
+            // never blocked -- only an update that keeps the edge ACTIVE and
+            // typed is re-fenced. Without the UPDATE twin a reactivation could
+            // resurrect a typed row against a now-cross-space endpoint.
             conn.execute_batch(
                 "CREATE TRIGGER IF NOT EXISTS edges_space_fence
                  AFTER INSERT ON edges
                  WHEN NEW.lineage != 'legacy'
+                 BEGIN
+                     SELECT RAISE(ABORT, 'edges_space_fence: cross-space edge rejected')
+                     WHERE (
+                         CASE NEW.src_kind
+                             WHEN 'page' THEN (SELECT space FROM pages WHERE id = NEW.src_id)
+                             WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = NEW.src_id)
+                             WHEN 'entity' THEN (SELECT space FROM entities WHERE id = NEW.src_id)
+                             ELSE NULL
+                         END
+                     ) IS NOT NEW.space
+                     OR (
+                         NOT (NEW.edge_type = 'cites' AND NEW.dst_kind = 'external')
+                         AND (
+                             CASE NEW.dst_kind
+                                 WHEN 'page' THEN (SELECT space FROM pages WHERE id = NEW.dst_id)
+                                 WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = NEW.dst_id)
+                                 WHEN 'entity' THEN (SELECT space FROM entities WHERE id = NEW.dst_id)
+                                 ELSE NULL
+                             END
+                         ) IS NOT NEW.space
+                     );
+                 END;
+                 CREATE TRIGGER IF NOT EXISTS edges_space_fence_update
+                 AFTER UPDATE ON edges
+                 WHEN NEW.lineage != 'legacy' AND NEW.valid_until IS NULL
                  BEGIN
                      SELECT RAISE(ABORT, 'edges_space_fence: cross-space edge rejected')
                      WHERE (
@@ -8128,39 +8162,53 @@ impl MemoryDB {
             discriminator,
         );
         let now = chrono::Utc::now().timestamp();
-        // ON CONFLICT resolves two things deterministically, so the shadow
-        // edge is independent of dual-write CALL ORDER:
+        // ON CONFLICT resolves the shadow edge independent of dual-write CALL
+        // ORDER, reconciling three things a re-write can change:
         //   1. Reactivation -- a soft-invalidated edge (`valid_until` set) is
         //      un-retracted (the "delete a link then add it back" case).
-        //   2. Lineage precedence -- one content-addressed `edge_id` can be
-        //      dual-written by several legacy stores for the same (page,
-        //      memory) fact: `page_evidence` writes `evidence`, a
-        //      `pages.citations` entry writes `synthesis`. Without a rule the
-        //      lineage would be whichever store happened to write first (the
-        //      old `DO UPDATE` never touched `lineage`). We pin
-        //      `evidence` > `synthesis` -- the same precedence the migration-81
-        //      backfill already yields by running `page_sources`/`page_evidence`
-        //      before `page_citations` (`DO NOTHING`, first writer wins), so a
-        //      live edge and its backfilled twin agree.
-        // This is FENCE-SAFE: for a given `edge_id` every writer resolves the
-        // identical page/memory spaces, so they agree same-space vs cross-space
-        // -- `evidence`/`synthesis` occur only same-space (fence already passed
-        // at insert), `legacy` only cross-space; the CASE therefore only ever
-        // moves `synthesis`->`evidence` within one space and never crosses the
-        // `legacy` boundary, so the row stays fence-valid (and the fence is an
-        // AFTER INSERT trigger that does not re-fire on this UPDATE regardless).
+        //   2. Space -- `space` is adopted from the fresh write (`excluded`).
+        //      An endpoint can move between spaces (a memory re-spaced, a page
+        //      renamed), so a reactivated/re-written edge must carry the CURRENT
+        //      space, not the space frozen at first insert -- otherwise the
+        //      space fence would validate against stale coordinates. The AFTER
+        //      UPDATE fence (below) re-checks endpoints against this new space.
+        //   3. Lineage -- one content-addressed `edge_id` can be dual-written
+        //      by several legacy stores for the same fact (`page_evidence`/
+        //      `page_sources` -> `evidence`; a `pages.citations` entry ->
+        //      `synthesis`), and a reactivation can arrive with a fresh
+        //      classification (e.g. its memory moved cross-space, so the caller
+        //      now passes `legacy`). The CASE is a TOTAL rule over all four
+        //      lineages: `legacy` (a cross-space downgrade) always wins;
+        //      `evidence` outranks `synthesis` (the precedence the migration-81
+        //      backfill already yields by ordering `page_sources`/`page_evidence`
+        //      before `page_citations`); otherwise the fresh (`excluded`) typed
+        //      value is adopted (assertion/synthesis reactivation, or a
+        //      legacy->typed same-space upgrade). So a live edge and its
+        //      backfilled twin agree regardless of which store wrote first.
+        // FENCE-SAFE: the AFTER UPDATE twin of the space fence re-validates any
+        // update that keeps the edge active and typed, so a reactivation that
+        // reconciles to a cross-space typed row is rejected here just as the
+        // AFTER INSERT fence rejects it on first write (an earlier version only
+        // fenced INSERTs, letting a stale-space reactivation slip through).
         conn.execute(
             "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, grounded, root_id, space, weight, payload, provenance, operation_id, created_at, superseded_by, valid_until)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL, ?8, NULL, NULL, NULL, ?9, ?10, NULL, NULL)
              ON CONFLICT(edge_id) DO UPDATE SET
                  valid_until = NULL,
                  superseded_by = NULL,
+                 space = excluded.space,
                  lineage = CASE
-                     WHEN excluded.lineage = 'evidence' AND edges.lineage = 'synthesis' THEN 'evidence'
-                     ELSE edges.lineage
+                     WHEN excluded.lineage = 'legacy' THEN 'legacy'
+                     WHEN excluded.lineage = 'evidence' THEN 'evidence'
+                     WHEN edges.lineage = 'evidence' AND excluded.lineage = 'synthesis' THEN 'evidence'
+                     ELSE excluded.lineage
                  END
-             WHERE valid_until IS NOT NULL
-                OR (excluded.lineage = 'evidence' AND edges.lineage = 'synthesis')",
+             WHERE edges.valid_until IS NOT NULL
+                OR edges.space IS NOT excluded.space
+                OR (excluded.lineage = 'evidence' AND edges.lineage != 'evidence')
+                OR (excluded.lineage = 'legacy' AND edges.lineage != 'legacy')
+                OR (excluded.lineage = 'synthesis' AND edges.lineage NOT IN ('evidence', 'synthesis'))
+                OR (excluded.lineage = 'assertion' AND edges.lineage != 'assertion')",
             libsql::params![
                 edge_id.clone(),
                 src_id.to_string(),
@@ -8198,22 +8246,41 @@ impl MemoryDB {
         Ok(())
     }
 
-    /// Look up a memory's space by `source_id`, for the page_evidence
-    /// dual-write's memory-kind space check (the fence trigger does not
-    /// exempt `cites`->`memory` edges, unlike `cites`->`external`).
+    /// Resolve a memory's space by `source_id` for the `cites`->`memory`
+    /// dual-write's space check (the fence does not exempt `cites`->`memory`,
+    /// unlike `cites`->`external`). A `source_id`'s chunks are stamped one
+    /// space together in normal operation (`update_memory_space_opt` mutates
+    /// every chunk of a `source_id`; ingest stamps one space per document),
+    /// but nothing at the SCHEMA enforces it -- so this resolves
+    /// DETERMINISTICALLY rather than trusting a `LIMIT 1` coin flip over
+    /// possibly-conflicting chunks: `Some(space)` only when every chunk agrees
+    /// on one non-NULL space, else `None` (no rows, any NULL-space chunk, or
+    /// chunks in conflicting spaces). `None` routes the caller to
+    /// `lineage='legacy'` (fence-exempt), so an ambiguous `source_id` can never
+    /// mint a typed cross-space edge off an indeterminate pick.
     async fn resolve_memory_space(
         conn: &libsql::Connection,
         source_id: &str,
     ) -> Result<Option<String>, libsql::Error> {
         let mut rows = conn
             .query(
-                "SELECT space FROM memories WHERE source_id = ?1 LIMIT 1",
+                "SELECT COUNT(*), COUNT(space), COUNT(DISTINCT space), MIN(space) \
+                 FROM memories WHERE source_id = ?1",
                 libsql::params![source_id],
             )
             .await?;
-        match rows.next().await? {
-            Some(row) => Ok(row.get(0).unwrap_or(None)),
-            None => Ok(None),
+        let Some(row) = rows.next().await? else {
+            return Ok(None);
+        };
+        let total: i64 = row.get(0).unwrap_or(0);
+        let non_null: i64 = row.get(1).unwrap_or(0);
+        let distinct: i64 = row.get(2).unwrap_or(0);
+        // Exactly one distinct, non-NULL space across every chunk resolves;
+        // zero rows / any NULL-space chunk / conflicting spaces resolve to None.
+        if total > 0 && non_null == total && distinct == 1 {
+            Ok(row.get(3).unwrap_or(None))
+        } else {
+            Ok(None)
         }
     }
 
@@ -8257,38 +8324,36 @@ impl MemoryDB {
         };
 
         for citation in citations {
-            if citation.source_kind == "memory" {
-                let resolves = Self::resolve_memory_space(conn, &citation.locator).await?
-                    == Some(space.clone());
-                let lineage = if resolves { "synthesis" } else { "legacy" };
-                Self::dual_write_edge(
-                    conn,
-                    "cites",
-                    "page",
-                    page_id,
-                    "memory",
-                    &citation.locator,
-                    &citation.locator,
-                    lineage,
-                    &space,
-                    None,
-                )
-                .await?;
-            } else {
-                Self::dual_write_edge(
-                    conn,
-                    "cites",
-                    "page",
-                    page_id,
-                    "external",
-                    &citation.locator,
-                    &citation.locator,
-                    "legacy",
-                    &space,
-                    None,
-                )
-                .await?;
-            }
+            let (dst_kind, lineage) = match citation.source_kind.as_str() {
+                "memory" => {
+                    let resolves = Self::resolve_memory_space(conn, &citation.locator).await?
+                        == Some(space.clone());
+                    ("memory", if resolves { "synthesis" } else { "legacy" })
+                }
+                // A distiller-authored citation to an external URI is
+                // `synthesis` (matrix row 6), NOT `legacy`: its external
+                // destination is fence-exempt, so there is no cross-space
+                // reason to downgrade. Writing `legacy` would collide with
+                // `page_evidence`'s `evidence` on the same external edge_id and
+                // make the resolved lineage order-dependent (round-2 item #2).
+                // Unknown/unresolved kinds can't classify a real destination
+                // and stay `legacy`.
+                "external_url" | "external_file" => ("external", "synthesis"),
+                _ => ("external", "legacy"),
+            };
+            Self::dual_write_edge(
+                conn,
+                "cites",
+                "page",
+                page_id,
+                dst_kind,
+                &citation.locator,
+                &citation.locator,
+                lineage,
+                &space,
+                None,
+            )
+            .await?;
         }
         Ok(())
     }
@@ -8358,20 +8423,20 @@ impl MemoryDB {
 
     /// `page_sources` → `cites` edges (matrix row 2). `page_id` FK cascades
     /// to `pages`, so `pages.space` is always present (NOT NULL since M1). The
-    /// cited memory's space is resolved by a scalar subquery: a `source_id`'s
-    /// space is single-valued by construction (`update_memory_space_opt`
-    /// mutates every chunk of a `source_id` together; ingest stamps one space
-    /// per document), so `LIMIT 1` is deterministic -- the same resolution the
-    /// live fence trigger and `resolve_memory_space` use. A memory in a
+    /// cited memory's space is resolved DETERMINISTICALLY by a scalar subquery
+    /// that returns the single distinct non-NULL space shared by every chunk
+    /// of the `source_id`, else NULL when chunks are absent / NULL-spaced /
+    /// conflicting (never a `LIMIT 1` pick over disagreeing chunks) -- the same
+    /// rule `resolve_memory_space` applies on the live path, so the backfilled
+    /// shadow and a live dual-write of the same row agree. A memory in a
     /// DIFFERENT space (the `cross_space_discovery` feature mints exactly this
-    /// shape -- a page in one space citing memories in another) or an absent
-    /// memory downgrades to `lineage='legacy'`, mirroring
+    /// shape -- a page in one space citing memories in another) or an absent /
+    /// ambiguous memory downgrades to `lineage='legacy'`, mirroring
     /// `backfill_edges_from_page_evidence`. Without this, a cross-space
     /// page_sources row would backfill as a non-legacy `evidence` edge that
     /// the live fence does NOT exempt (only `cites`->`external` is), so the
-    /// backfilled shadow and the live dual-write of the same row would
-    /// disagree, and the backfilled non-legacy cross-space edge would persist
-    /// because the backfill predates the fence.
+    /// backfilled non-legacy cross-space edge would persist because the
+    /// backfill predates the fence.
     async fn backfill_edges_from_page_sources(
         conn: &libsql::Connection,
     ) -> Result<EdgeBackfillCounts, WenlanError> {
@@ -8379,7 +8444,9 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT ps.page_id, ps.memory_source_id, p.space, \
-                        (SELECT m.space FROM memories m WHERE m.source_id = ps.memory_source_id LIMIT 1) \
+                        (SELECT CASE WHEN COUNT(*) > 0 AND COUNT(m.space) = COUNT(*) AND COUNT(DISTINCT m.space) = 1 \
+                                     THEN MIN(m.space) ELSE NULL END \
+                           FROM memories m WHERE m.source_id = ps.memory_source_id) \
                  FROM page_sources ps JOIN pages p ON p.id = ps.page_id",
                 (),
             )
@@ -8438,18 +8505,22 @@ impl MemoryDB {
         //
         // A `LEFT JOIN memories` here fans out: a memory has one row PER CHUNK
         // sharing its `source_id`, so an N-chunk memory would yield N rows for
-        // one `page_evidence` row -- N identical classifications (space is
-        // single-valued per `source_id`; see `resolve_memory_space`) that
-        // inflate `classifiable`/`unknown_inserted` N-fold in the migration
-        // report while `insert_backfilled_edge`'s `ON CONFLICT DO NOTHING`
-        // still lands one edge. The scalar subquery + `LIMIT 1` yields exactly
-        // one row per `page_evidence` row, so the report counts one citation
-        // as one. For an external locator the subquery finds no memory and
-        // returns NULL, which the `external_*` branches never read.
+        // one `page_evidence` row -- N classifications that inflate
+        // `classifiable`/`unknown_inserted` N-fold in the migration report
+        // while `insert_backfilled_edge`'s `ON CONFLICT DO NOTHING` still lands
+        // one edge. The scalar subquery collapses each `page_evidence` row to
+        // exactly one memory-space value, resolved DETERMINISTICALLY (the single
+        // distinct non-NULL space every chunk agrees on, else NULL for
+        // absent/conflicting chunks -- never a `LIMIT 1` pick), matching
+        // `resolve_memory_space` on the live path. For an external locator the
+        // subquery finds no memory and returns NULL, which the `external_*`
+        // branches never read.
         let mut rows = conn
             .query(
                 "SELECT pe.page_id, pe.source_kind, pe.locator, p.space, \
-                        (SELECT m.space FROM memories m WHERE m.source_id = pe.locator LIMIT 1) \
+                        (SELECT CASE WHEN COUNT(*) > 0 AND COUNT(m.space) = COUNT(*) AND COUNT(DISTINCT m.space) = 1 \
+                                     THEN MIN(m.space) ELSE NULL END \
+                           FROM memories m WHERE m.source_id = pe.locator) \
                  FROM page_evidence pe \
                  JOIN pages p ON p.id = pe.page_id",
                 (),
@@ -8595,54 +8666,55 @@ impl MemoryDB {
                 continue;
             };
             for citation in citations {
-                if citation.source_kind == "memory" {
-                    // Same-space check, not just existence: the fence
-                    // trigger does not exempt `cites`->`memory` edges, so a
-                    // citation resolving to a memory in a different space
-                    // must downgrade to `legacy` (mirrors
-                    // `backfill_edges_from_page_evidence`'s memory-kind fix).
-                    let resolves = Self::resolve_memory_space(conn, &citation.locator)
-                        .await
-                        .map_err(|e| {
-                            WenlanError::VectorDb(format!("m81 citations resolve: {e}"))
-                        })?
-                        == Some(space.clone());
-                    let lineage = if resolves {
+                let (dst_kind, lineage) = match citation.source_kind.as_str() {
+                    "memory" => {
+                        // Same-space check, not just existence: the fence does
+                        // not exempt `cites`->`memory`, so a citation resolving
+                        // to a memory in a different space downgrades to
+                        // `legacy` (mirrors `backfill_edges_from_page_evidence`).
+                        let resolves = Self::resolve_memory_space(conn, &citation.locator)
+                            .await
+                            .map_err(|e| {
+                                WenlanError::VectorDb(format!("m81 citations resolve: {e}"))
+                            })?
+                            == Some(space.clone());
+                        if resolves {
+                            counts.classifiable += 1;
+                            ("memory", "synthesis")
+                        } else {
+                            counts.unknown_inserted += 1;
+                            ("memory", "legacy")
+                        }
+                    }
+                    // A distiller-authored external-URI citation is `synthesis`
+                    // (matrix row 6, fence-exempt destination), agreeing with
+                    // the live `dual_write_page_citations` classification and
+                    // resolving to `evidence` under the `evidence`>`synthesis`
+                    // precedence when `page_evidence` also backs the same
+                    // external edge_id -- writing `legacy` here made that shared
+                    // edge order-dependent (round-2 item #2).
+                    "external_url" | "external_file" => {
                         counts.classifiable += 1;
-                        "synthesis"
-                    } else {
+                        ("external", "synthesis")
+                    }
+                    _ => {
                         counts.unknown_inserted += 1;
-                        "legacy"
-                    };
-                    Self::insert_backfilled_edge(
-                        conn,
-                        "cites",
-                        "page",
-                        &page_id,
-                        "memory",
-                        &citation.locator,
-                        &citation.locator,
-                        lineage,
-                        &space,
-                        "pages.citations",
-                    )
-                    .await?;
-                } else {
-                    counts.unknown_inserted += 1;
-                    Self::insert_backfilled_edge(
-                        conn,
-                        "cites",
-                        "page",
-                        &page_id,
-                        "external",
-                        &citation.locator,
-                        &citation.locator,
-                        "legacy",
-                        &space,
-                        "pages.citations",
-                    )
-                    .await?;
-                }
+                        ("external", "legacy")
+                    }
+                };
+                Self::insert_backfilled_edge(
+                    conn,
+                    "cites",
+                    "page",
+                    &page_id,
+                    dst_kind,
+                    &citation.locator,
+                    &citation.locator,
+                    lineage,
+                    &space,
+                    "pages.citations",
+                )
+                .await?;
             }
         }
         Ok(counts)
@@ -8704,9 +8776,76 @@ impl MemoryDB {
         )
         .await?;
 
+        // The remaining three legacy stores the matrix claims coverage for.
+        // Each resolves the cited memory's space DETERMINISTICALLY (the single
+        // distinct non-NULL space every chunk agrees on, else NULL) via the
+        // same subquery the backfill/live paths use -- no `LIMIT 1` fanout --
+        // so the tally counts one citation as one link. `page_evidence` and
+        // `pages.citations` are tallied for their MEMORY-kind entries only:
+        // their `external_*` entries are fence-EXEMPT (external destination),
+        // so they cannot be cross-space in the fence's sense.
+        let mem_space_subquery = "SELECT CASE WHEN COUNT(*) > 0 AND COUNT(m.space) = COUNT(*) \
+                                              AND COUNT(DISTINCT m.space) = 1 \
+                                         THEN MIN(m.space) ELSE NULL END FROM memories m";
+
+        let page_sources = tally(
+            conn,
+            &format!(
+                "SELECT \
+                    SUM(CASE WHEN msp IS NOT NULL AND msp = pspace THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN msp IS NOT NULL AND msp != pspace THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN msp IS NULL THEN 1 ELSE 0 END) \
+                 FROM ( \
+                    SELECT p.space AS pspace, \
+                           ({mem_space_subquery} WHERE m.source_id = ps.memory_source_id) AS msp \
+                    FROM page_sources ps JOIN pages p ON p.id = ps.page_id \
+                 )"
+            ),
+        )
+        .await?;
+
+        let page_evidence = tally(
+            conn,
+            &format!(
+                "SELECT \
+                    SUM(CASE WHEN msp IS NOT NULL AND msp = pspace THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN msp IS NOT NULL AND msp != pspace THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN msp IS NULL THEN 1 ELSE 0 END) \
+                 FROM ( \
+                    SELECT p.space AS pspace, \
+                           ({mem_space_subquery} WHERE m.source_id = pe.locator) AS msp \
+                    FROM page_evidence pe JOIN pages p ON p.id = pe.page_id \
+                    WHERE pe.source_kind = 'memory' \
+                 )"
+            ),
+        )
+        .await?;
+
+        let pages_citations = tally(
+            conn,
+            &format!(
+                "SELECT \
+                    SUM(CASE WHEN msp IS NOT NULL AND msp = pspace THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN msp IS NOT NULL AND msp != pspace THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN msp IS NULL THEN 1 ELSE 0 END) \
+                 FROM ( \
+                    SELECT p.space AS pspace, \
+                           ({mem_space_subquery} WHERE m.source_id = json_extract(c.value, '$.locator')) AS msp \
+                    FROM pages p, \
+                         json_each(CASE WHEN json_valid(p.citations) AND json_type(p.citations) = 'array' \
+                                        THEN p.citations ELSE '[]' END) c \
+                    WHERE json_extract(c.value, '$.source_kind') = 'memory' \
+                 )"
+            ),
+        )
+        .await?;
+
         Ok(serde_json::json!({
             "relations": relations,
             "page_links": page_links,
+            "page_sources": page_sources,
+            "page_evidence": page_evidence,
+            "pages_citations": pages_citations,
         }))
     }
 
@@ -8720,13 +8859,16 @@ impl MemoryDB {
     /// inserted or found an existing row -- proven by
     /// `acquire_provenance_root_two_writers_converge_on_same_root`.
     ///
-    /// `independence_group_id` resolution (Q6 decision C): a fresh
-    /// LSH band lookup against `provenance_root_minhash_bands` adopts an
-    /// existing near-dup group when one is found, else mints a new group id.
-    /// This work happens before the INSERT unconditionally (never
-    /// check-then-insert), so on the conflict path it is simply discarded --
-    /// the existing row's group is untouched, matching `grounded`/`root_id`/
-    /// `lineage` immutability elsewhere in the spec.
+    /// `independence_group_id` resolution (Q6 decision C), in precedence
+    /// order: an LSH band lookup against `provenance_root_minhash_bands`
+    /// adopts an existing near-dup group when one is found; else the base
+    /// independence-signal key (source / agent-turn / import-batch); else the
+    /// independence is un-establishable and the call ROUTES TO HUMAN REVIEW
+    /// (returns `Err`) per Q6 B.4 -- it never mints a random group (that would
+    /// silently inflate independent-support counts). This work happens before
+    /// the INSERT unconditionally (never check-then-insert), so on the conflict
+    /// path it is simply discarded -- the existing row's group is untouched,
+    /// matching `grounded`/`root_id`/`lineage` immutability elsewhere in the spec.
     ///
     /// ponytail: band-match only, no exact-Jaccard re-verification pass (the
     /// entity_minhash cascade re-fetches the candidate's `name` to confirm;
@@ -8774,9 +8916,25 @@ impl MemoryDB {
                 .await?
                 .into_iter()
                 .next();
-            let group_id = overlay_match
+            let group_id = match overlay_match
                 .or_else(|| crate::provenance::base_independence_key(signals))
-                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            {
+                Some(id) => id,
+                // Q6 B.4: un-establishable independence (no near-dup overlay
+                // AND no source/turn/batch signal) routes to human review,
+                // NEVER auto-genesis. Minting a fresh UUID group here would
+                // silently manufacture a distinct independence group and
+                // inflate independent-support counts (round-2 item #6). Fail
+                // loud instead -- the inner block's Err rolls the txn back.
+                None => {
+                    return Err(WenlanError::VectorDb(
+                        "acquire_provenance_root: independence un-establishable (no near-dup, no \
+                         source/turn/batch signal); routing to human review per Q6 B.4 rather than \
+                         auto-generating a group"
+                            .to_string(),
+                    ));
+                }
+            };
 
             let root_id = uuid::Uuid::new_v4().to_string();
             let now = chrono::Utc::now().timestamp();
@@ -27205,15 +27363,18 @@ impl MemoryDB {
         // CALLER to have opened a transaction. On an autocommit connection the
         // `page_evidence` INSERT below would commit before the edge INSERT, so
         // a fence-rejected or otherwise failing edge write could not roll the
-        // legacy write back. Assert the invariant so any caller that forgets a
-        // `BEGIN` fails loudly in tests rather than silently splitting the two
+        // legacy write back. Enforce this at RUNTIME (not `debug_assert!`,
+        // which compiles out of release) so a caller that forgets a `BEGIN`
+        // fails loudly in every build rather than silently splitting the two
         // writes across commits.
-        debug_assert!(
-            !conn.is_autocommit(),
-            "insert_resolved_page_evidence must run inside a caller-opened transaction \
-             (single-transaction dual-write); autocommit would commit the page_evidence write \
-             before the edge write, breaking atomicity"
-        );
+        if conn.is_autocommit() {
+            return Err(libsql::Error::Misuse(
+                "insert_resolved_page_evidence must run inside a caller-opened transaction \
+                 (single-transaction dual-write); an autocommit connection would commit the \
+                 page_evidence write before the edge write, breaking atomicity"
+                    .to_string(),
+            ));
+        }
         let mut space_rows = conn
             .query(
                 "SELECT space FROM pages WHERE id = ?1",
@@ -61816,7 +61977,10 @@ pub(crate) mod tests {
             edge_row(&conn, "cites", "page_c", "https://example.com/z")
                 .await
                 .unwrap();
-        assert_eq!(ext_lineage, "legacy");
+        // A distiller-authored external-URI citation is `synthesis` (matrix
+        // row 6, fence-exempt destination), not `legacy` -- see the round-2
+        // item #2 fix in `dual_write_page_citations`.
+        assert_eq!(ext_lineage, "synthesis");
         assert_eq!(ext_grounded, 0);
     }
 
@@ -62089,6 +62253,342 @@ pub(crate) mod tests {
         assert_eq!(
             ps_count, 0,
             "the page_sources write must roll back too -- single-transaction dual-write"
+        );
+    }
+
+    // ---- Round-2 rework: M2 PR-1 edge dual-write hardening ----
+
+    #[tokio::test]
+    async fn resolve_memory_space_conflicting_chunks_resolve_to_none() {
+        // Item 1: a source_id spanning two distinct spaces must resolve to
+        // None (deterministic), not an arbitrary `LIMIT 1` pick. None routes
+        // the caller to lineage='legacy' (fence-exempt), so an ambiguous
+        // source can never mint a typed cross-space edge.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "src_conflict", "chunk zero", "space_a").await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                    last_modified, chunk_type, source_agent, space, confidence, confirmed, \
+                    memory_type, pending_revision) \
+                 VALUES ('src_conflict-1', 'chunk one', 'memory', 'src_conflict', 'test', 1, \
+                    1712707200, 'text', NULL, 'space_b', 1.0, 0, 'fact', 0)",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        let conn = db.conn.lock().await;
+        let resolved = MemoryDB::resolve_memory_space(&conn, "src_conflict")
+            .await
+            .unwrap();
+        assert_eq!(
+            resolved, None,
+            "a source_id spanning two spaces must resolve to None, not a LIMIT-1 coin flip"
+        );
+    }
+
+    #[tokio::test]
+    async fn dual_write_page_citations_external_uses_synthesis_not_legacy() {
+        // Item 2c: a pages.citations external_url/external_file entry is
+        // synthesis-authored (the distiller wrote it) and its external
+        // destination is fence-exempt, so it carries lineage='synthesis'
+        // (matrix row 6), NOT 'legacy'. Writing 'legacy' collides with
+        // page_evidence's 'evidence' for the same external edge_id and makes
+        // the resolved lineage order-dependent.
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_ext", "space_a").await;
+        let citations = r#"[{"occurrence":1,"marker":1,"source_kind":"external_url","locator":"https://example.com/a","score":0.0,"status":"unverified","scope":"paragraph"}]"#;
+        MemoryDB::dual_write_page_citations(&conn, "page_ext", Some(citations))
+            .await
+            .unwrap();
+        let (lineage, _, _) = edge_row(&conn, "cites", "page_ext", "https://example.com/a")
+            .await
+            .expect("external citation edge must exist");
+        assert_eq!(
+            lineage, "synthesis",
+            "a pages.citations external_url entry must be synthesis (fence-exempt), not legacy"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_external_citation_edge_lineage_is_order_independent() {
+        // Item 2c: page_evidence external (evidence) and pages.citations
+        // external_url (synthesis, after the fix) share one content-addressed
+        // edge_id; the resolved lineage must be 'evidence' regardless of order.
+        let loc = "https://example.com/shared";
+        let citations = format!(
+            r#"[{{"occurrence":1,"marker":1,"source_kind":"external_url","locator":"{loc}","score":0.0,"status":"unverified","scope":"paragraph"}}]"#
+        );
+        // Order A: citation (synthesis) first, then page_evidence (evidence).
+        {
+            let (db, _dir) = test_db().await;
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_a", "space_a").await;
+            MemoryDB::dual_write_page_citations(&conn, "page_a", Some(&citations))
+                .await
+                .unwrap();
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_a", "external", loc, loc, "evidence", "space_a", None,
+            )
+            .await
+            .unwrap();
+            let (lineage, _, _) = edge_row(&conn, "cites", "page_a", loc).await.unwrap();
+            assert_eq!(
+                lineage, "evidence",
+                "evidence must win when synthesis wrote first"
+            );
+        }
+        // Order B: page_evidence (evidence) first, then citation (synthesis).
+        {
+            let (db, _dir) = test_db().await;
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_b", "space_a").await;
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_b", "external", loc, loc, "evidence", "space_a", None,
+            )
+            .await
+            .unwrap();
+            let citations_b = citations.clone();
+            MemoryDB::dual_write_page_citations(&conn, "page_b", Some(&citations_b))
+                .await
+                .unwrap();
+            let (lineage, _, _) = edge_row(&conn, "cites", "page_b", loc).await.unwrap();
+            assert_eq!(
+                lineage, "evidence",
+                "evidence must not be downgraded when synthesis writes after"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_reactivation_adopts_fresh_lineage() {
+        // Item 4: reactivating a soft-invalidated edge must adopt the fresh
+        // classification, not resurrect a stale lineage. An edge written
+        // 'evidence' (same-space), invalidated, then reasserted after its
+        // memory moved cross-space (caller passes 'legacy') must come back
+        // 'legacy', not stale 'evidence'.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_r", "content", "space_a").await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_r", "space_a").await;
+        let edge_id = MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_r", "memory", "mem_r", "mem_r", "evidence", "space_a",
+            None,
+        )
+        .await
+        .unwrap();
+        MemoryDB::dual_write_invalidate_edge(&conn, &edge_id, None)
+            .await
+            .unwrap();
+        // The memory moved cross-space, so the caller now classifies 'legacy'.
+        conn.execute(
+            "UPDATE memories SET space = 'space_b' WHERE source_id = 'mem_r'",
+            (),
+        )
+        .await
+        .unwrap();
+        MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_r", "memory", "mem_r", "mem_r", "legacy", "space_a", None,
+        )
+        .await
+        .unwrap();
+        let (lineage, _, _) = edge_row(&conn, "cites", "page_r", "mem_r").await.unwrap();
+        assert_eq!(
+            lineage, "legacy",
+            "reactivation must adopt fresh 'legacy', not stale 'evidence'"
+        );
+        let valid_until: Option<i64> = {
+            let mut rows = conn
+                .query(
+                    "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id.clone()],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(valid_until, None, "reactivation must clear valid_until");
+    }
+
+    #[tokio::test]
+    async fn edges_after_update_fence_rejects_cross_space_reactivation() {
+        // Item 4: the fence must validate UPDATEs, not only INSERTs. A buggy
+        // caller that reactivates a typed edge whose endpoint has moved to a
+        // different space must be rejected by the AFTER UPDATE fence.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_f", "content", "space_a").await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_f", "space_a").await;
+        let edge_id = MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_f", "memory", "mem_f", "mem_f", "evidence", "space_a",
+            None,
+        )
+        .await
+        .unwrap();
+        MemoryDB::dual_write_invalidate_edge(&conn, &edge_id, None)
+            .await
+            .unwrap();
+        conn.execute(
+            "UPDATE memories SET space = 'space_b' WHERE source_id = 'mem_f'",
+            (),
+        )
+        .await
+        .unwrap();
+        // Buggy reassert: keeps evidence/space_a though the memory is now cross-space.
+        let result = MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_f", "memory", "mem_f", "mem_f", "evidence", "space_a",
+            None,
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "AFTER UPDATE fence must reject reactivating a typed edge whose dst is now cross-space"
+        );
+    }
+
+    #[tokio::test]
+    async fn audit_legacy_cross_space_links_covers_all_five_stores() {
+        // Item 5: the pre-migration cross-space audit must report every store
+        // the matrix claims coverage for, not just relations + page_links, and
+        // tally a cross-space page_source correctly.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_ps", "content", "space_b").await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_ps", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_sources (page_id, memory_source_id, linked_at, link_reason) \
+                 VALUES ('page_ps', 'mem_ps', 1, 'test')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        let conn = db.conn.lock().await;
+        let audit = MemoryDB::audit_legacy_cross_space_links(&conn)
+            .await
+            .unwrap();
+        for store in [
+            "relations",
+            "page_links",
+            "page_sources",
+            "page_evidence",
+            "pages_citations",
+        ] {
+            assert!(
+                audit.get(store).is_some(),
+                "cross-space audit must include store {store}: {audit}"
+            );
+        }
+        assert_eq!(
+            audit["page_sources"]["cross_space"],
+            serde_json::json!(1),
+            "a page in space_a citing a memory in space_b is one cross-space page_source: {audit}"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_provenance_root_unestablishable_independence_routes_to_review() {
+        // Item 6: with no near-dup and no source/turn/batch signal, the
+        // contract (Q6 B.4) routes to human review -- it must NOT auto-genesis
+        // a random active group.
+        let (db, _dir) = test_db().await;
+        let signals = crate::provenance::IndependenceSignals {
+            source_identity: None,
+            agent_turn: None,
+            import_batch: None,
+        };
+        let result = db
+            .acquire_provenance_root("generated", "some ungrounded content", &signals)
+            .await;
+        assert!(
+            result.is_err(),
+            "unestablishable independence must fail loud (route to review), not auto-genesis"
+        );
+        let conn = db.conn.lock().await;
+        let count: i64 = {
+            let mut rows = conn
+                .query("SELECT COUNT(*) FROM provenance_roots", ())
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            count, 0,
+            "no root row may be minted when independence is unestablishable"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_resolved_page_evidence_rejects_autocommit_connection() {
+        // Item 3: the single-transaction dual-write invariant must be enforced
+        // in RELEASE too (debug_assert! compiles out). Calling on an autocommit
+        // connection must return an error, not silently split the writes.
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_ac", "space_a").await;
+        let result =
+            MemoryDB::insert_resolved_page_evidence(&conn, "page_ac", &["mem_ac"], 1, "test").await;
+        assert!(
+            result.is_err(),
+            "must reject an autocommit connection (release-enforced, not debug_assert)"
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_orphaned_page_sources_rolls_back_edge_invalidate_on_failure() {
+        // Item 3: cleanup owns its BEGIN/COMMIT, so a mid-transaction fault
+        // rolls back the edge soft-invalidate together with the legacy delete
+        // -- not two independent autocommit writes.
+        let edge_id = crate::provenance::compute_edge_id(
+            "cites", "page", "page_cl", "memory", "ghost", "ghost",
+        );
+        let (db, _dir) = test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            insert_raw_page_for_m81_test(&conn, "page_cl", "space_a").await;
+            conn.execute(
+                "INSERT INTO page_sources (page_id, memory_source_id, linked_at, link_reason) \
+                 VALUES ('page_cl', 'ghost', 1, 'test')",
+                (),
+            )
+            .await
+            .unwrap();
+            conn.execute("BEGIN", ()).await.unwrap();
+            MemoryDB::dual_write_edge(
+                &conn, "cites", "page", "page_cl", "memory", "ghost", "ghost", "legacy", "space_a",
+                None,
+            )
+            .await
+            .unwrap();
+            conn.execute("COMMIT", ()).await.unwrap();
+            conn.execute(
+                "CREATE TRIGGER test_abort_pages_update BEFORE UPDATE ON pages \
+                 BEGIN SELECT RAISE(ABORT, 'test: pages update blocked'); END",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        let result = db.cleanup_orphaned_page_sources().await;
+        assert!(result.is_err(), "the injected fault must fail the cleanup");
+        let conn = db.conn.lock().await;
+        let valid_until: Option<i64> = {
+            let mut rows = conn
+                .query(
+                    "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            valid_until, None,
+            "the edge invalidate must roll back with the legacy delete (single transaction)"
         );
     }
 }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -8162,6 +8162,19 @@ impl MemoryDB {
             discriminator,
         );
         let now = chrono::Utc::now().timestamp();
+        // Whether this write is a genuine cross-space (or indeterminate-space)
+        // DOWNGRADE, resolved in Rust where the reason is explicit rather than
+        // inferred from the space stamp. Callers pass `lineage = 'legacy'` for a
+        // fence-applicable destination (memory / entity / page) ONLY when they
+        // detected the destination is not in the source's space (or its space is
+        // indeterminate); an external destination is fence-exempt, so its
+        // `legacy` is an unknown-KIND classification, never a cross-space
+        // downgrade. This marker lets the conflict rule reconcile the row to
+        // `legacy` even when the stored space stamp (which tracks the SOURCE
+        // endpoint) is unchanged by a DESTINATION move -- the round-3 SQL-only
+        // discriminant compared stamps and so missed destination moves,
+        // producing a fence abort (round-4 regression).
+        let cross_space_downgrade = lineage == "legacy" && dst_kind != "external";
         // ON CONFLICT resolves the shadow edge independent of dual-write CALL
         // ORDER, reconciling three things a re-write can change:
         //   1. Reactivation -- a soft-invalidated edge (`valid_until` set) is
@@ -8184,21 +8197,27 @@ impl MemoryDB {
         //           FRESH (`excluded`) value -- a retracted-then-readded edge
         //           takes its current classification (evidence can honestly
         //           become legacy when the memory moved cross-space). Item 4.
-        //        b. A cross-space re-write of an ACTIVE edge
-        //           (`edges.space IS NOT excluded.space`) likewise adopts the
-        //           fresh value -- the caller passes `legacy` on a genuine
-        //           cross-space move; the AFTER UPDATE fence re-validates any
-        //           typed result. This is the item-4 fence downgrade, and it is
-        //           a time-ordered move, NOT an ordering violation.
-        //        c. Two concurrent ACTIVE, SAME-SPACE writes of one fact from
+        //        b. A cross-space DOWNGRADE (`cross_space_downgrade`, bound as
+        //           ?11) reconciles to `legacy` and wins. This covers a genuine
+        //           cross-space (or indeterminate-space) re-assert of a
+        //           fence-applicable destination -- INCLUDING a DESTINATION move
+        //           that leaves the source-space stamp unchanged, which a
+        //           stamp-only comparison misses (round-4 regression). The
+        //           resulting `legacy` row is fence-exempt, so the AFTER UPDATE
+        //           fence does not abort the dual-write txn.
+        //        c. A SOURCE move (`edges.space IS NOT excluded.space`) adopts
+        //           the fresh value -- the edge follows its re-spaced source; the
+        //           AFTER UPDATE fence re-validates any typed result.
+        //        d. Two concurrent ACTIVE, SAME-SPACE writes of one fact from
         //           different stores resolve by a TOTAL, COMMUTATIVE rank so the
         //           result is independent of which store wrote first:
         //           `evidence` > `synthesis` > `legacy`. (`assertion`, from
         //           `relates`/`mentions`, never shares a same-space active
         //           edge_id with these -- distinct `edge_type` -- so its rank is
         //           immaterial, but it is ranked above `legacy` for a total
-        //           order.) An unknown-kind citation's same-space `legacy` can
-        //           no longer clobber an active `evidence`/`synthesis`.
+        //           order.) An unknown-kind citation's same-space `legacy` (which
+        //           is NOT a `cross_space_downgrade`) can no longer clobber an
+        //           active `evidence`/`synthesis`.
         //      So a live edge and its backfilled twin agree regardless of which
         //      store wrote first.
         // FENCE-SAFE: the AFTER UPDATE twin of the space fence re-validates any
@@ -8215,6 +8234,7 @@ impl MemoryDB {
                  space = excluded.space,
                  lineage = CASE
                      WHEN edges.valid_until IS NOT NULL THEN excluded.lineage
+                     WHEN ?11 = 1 THEN 'legacy'
                      WHEN edges.space IS NOT excluded.space THEN excluded.lineage
                      WHEN (CASE excluded.lineage WHEN 'evidence' THEN 3 WHEN 'synthesis' THEN 2 WHEN 'assertion' THEN 1 ELSE 0 END)
                         > (CASE edges.lineage WHEN 'evidence' THEN 3 WHEN 'synthesis' THEN 2 WHEN 'assertion' THEN 1 ELSE 0 END)
@@ -8237,7 +8257,8 @@ impl MemoryDB {
                 lineage.to_string(),
                 space.to_string(),
                 operation_id.map(|s| s.to_string()),
-                now
+                now,
+                cross_space_downgrade as i64
             ],
         )
         .await?;
@@ -62508,6 +62529,145 @@ pub(crate) mod tests {
                 "active synthesis must not be downgraded when legacy writes after"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_cites_destination_move_downgrades_to_legacy() {
+        // Round-4 regression: an ACTIVE, same-space typed edge whose DESTINATION
+        // endpoint later moves to another space (incident edges NOT invalidated)
+        // must accept a fresh 'legacy' downgrade re-assert and reconcile to
+        // 'legacy' -- the whole dual-write must SUCCEED, not abort. The round-3
+        // discriminant compared the SOURCE-space stamp (unchanged by a
+        // destination move), misread this as a same-space conflict, kept the
+        // stale 'evidence', and the AFTER UPDATE fence then aborted the txn.
+        let (db, _dir) = test_db().await;
+        seed_memory_with_source_id_and_space(&db, "mem_dm", "content", "space_a").await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_dm", "space_a").await;
+        MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_dm", "memory", "mem_dm", "mem_dm", "evidence", "space_a",
+            None,
+        )
+        .await
+        .expect("same-space evidence edge inserts");
+        // Destination memory moves cross-space; the edge is NOT invalidated.
+        conn.execute(
+            "UPDATE memories SET space = 'space_b' WHERE source_id = 'mem_dm'",
+            (),
+        )
+        .await
+        .unwrap();
+        // Caller detects the cross-space move (classifiable=false) and re-asserts
+        // 'legacy'; the source-space stamp it passes is still 'space_a'.
+        let result = MemoryDB::dual_write_edge(
+            &conn, "cites", "page", "page_dm", "memory", "mem_dm", "mem_dm", "legacy", "space_a",
+            None,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "cross-space destination-move downgrade must succeed, not abort the txn: {result:?}"
+        );
+        let (lineage, _, _) = edge_row(&conn, "cites", "page_dm", "mem_dm").await.unwrap();
+        assert_eq!(
+            lineage, "legacy",
+            "row must reconcile to legacy after the destination moved"
+        );
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_relates_destination_move_downgrades_to_legacy() {
+        // Round-4 regression, `relates`->entity kind: same shape as the cites
+        // case -- an active same-space assertion edge whose destination entity
+        // moves cross-space must accept a fresh legacy downgrade and succeed.
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        for (id, space) in [("ent_src", "space_a"), ("ent_dst", "space_a")] {
+            conn.execute(
+                "INSERT INTO entities (id, name, entity_type, space, confirmed, created_at, updated_at) \
+                 VALUES (?1, ?1, 'Topic', ?2, 0, 0, 0)",
+                libsql::params![id, space],
+            )
+            .await
+            .unwrap();
+        }
+        MemoryDB::dual_write_edge(
+            &conn,
+            "relates",
+            "entity",
+            "ent_src",
+            "entity",
+            "ent_dst",
+            "knows",
+            "assertion",
+            "space_a",
+            None,
+        )
+        .await
+        .expect("same-space assertion edge inserts");
+        conn.execute(
+            "UPDATE entities SET space = 'space_b' WHERE id = 'ent_dst'",
+            (),
+        )
+        .await
+        .unwrap();
+        let result = MemoryDB::dual_write_edge(
+            &conn, "relates", "entity", "ent_src", "entity", "ent_dst", "knows", "legacy",
+            "space_a", None,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "relates destination-move downgrade must succeed, not abort: {result:?}"
+        );
+        let (lineage, _, _) = edge_row(&conn, "relates", "ent_src", "ent_dst")
+            .await
+            .unwrap();
+        assert_eq!(lineage, "legacy", "relates row must reconcile to legacy");
+    }
+
+    #[tokio::test]
+    async fn dual_write_edge_links_destination_move_downgrades_to_legacy() {
+        // Round-4 regression, `links`->page kind: an active same-space synthesis
+        // edge whose destination page moves cross-space must accept a fresh
+        // legacy downgrade and succeed.
+        let (db, _dir) = test_db().await;
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_ls", "space_a").await;
+        insert_raw_page_for_m81_test(&conn, "page_ld", "space_a").await;
+        MemoryDB::dual_write_edge(
+            &conn,
+            "links",
+            "page",
+            "page_ls",
+            "page",
+            "page_ld",
+            "see-also",
+            "synthesis",
+            "space_a",
+            None,
+        )
+        .await
+        .expect("same-space synthesis link edge inserts");
+        conn.execute(
+            "UPDATE pages SET space = 'space_b' WHERE id = 'page_ld'",
+            (),
+        )
+        .await
+        .unwrap();
+        let result = MemoryDB::dual_write_edge(
+            &conn, "links", "page", "page_ls", "page", "page_ld", "see-also", "legacy", "space_a",
+            None,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "links destination-move downgrade must succeed, not abort: {result:?}"
+        );
+        let (lineage, _, _) = edge_row(&conn, "links", "page_ls", "page_ld")
+            .await
+            .unwrap();
+        assert_eq!(lineage, "legacy", "links row must reconcile to legacy");
     }
 
     #[tokio::test]

--- a/crates/wenlan-core/src/lib.rs
+++ b/crates/wenlan-core/src/lib.rs
@@ -54,6 +54,7 @@ pub mod post_ingest;
 pub mod post_write;
 pub mod privacy;
 pub mod prompts;
+pub mod provenance;
 pub mod quality_gate;
 pub mod read_scope;
 pub mod reconcile;

--- a/crates/wenlan-core/src/provenance.rs
+++ b/crates/wenlan-core/src/provenance.rs
@@ -160,9 +160,15 @@ pub fn base_independence_key(signals: &IndependenceSignals) -> Option<String> {
 /// `sha256(edge_type, src_kind, src_id, dst_kind, dst_id, discriminator)`.
 /// A retried write recomputes the same `edge_id`; `INSERT ... ON
 /// CONFLICT(edge_id) DO NOTHING` converges on the one edge -- no duplicate
-/// voter, exactly the §6.1 retry-identity guarantee at the edge grain. Parts
-/// are null-byte-separated so no two distinct tuples can collide by
-/// concatenation ambiguity (e.g. ("ab", "c") vs ("a", "bc")).
+/// voter, exactly the §6.1 retry-identity guarantee at the edge grain.
+///
+/// Each part is **length-prefixed** (its byte length as a u64 LE, then the
+/// bytes) so no two distinct tuples can collide by concatenation ambiguity.
+/// A bare NUL *separator* is not enough: a part may itself contain a NUL byte
+/// (Rust `&str` is arbitrary UTF-8, and locators/labels are unvalidated), so
+/// `("x\0", "y")` and `("x", "\0y")` would hash identically under a
+/// separator-only scheme. Length-prefixing removes the separator's meaning
+/// entirely -- the boundary is the declared length, not a sentinel byte.
 pub fn compute_edge_id(
     edge_type: &str,
     src_kind: &str,
@@ -173,8 +179,9 @@ pub fn compute_edge_id(
 ) -> String {
     let mut hasher = Sha256::new();
     for part in [edge_type, src_kind, src_id, dst_kind, dst_id, discriminator] {
-        hasher.update(part.as_bytes());
-        hasher.update(b"\0");
+        let bytes = part.as_bytes();
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
     }
     format!("{:x}", hasher.finalize())
 }
@@ -340,5 +347,18 @@ mod tests {
         let a = compute_edge_id("cites", "page", "ab", "memory", "c", "loc");
         let b = compute_edge_id("cites", "page", "a", "memory", "bc", "loc");
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_edge_id_embedded_nul_no_collision() {
+        // A part may itself contain a NUL byte, so a NUL *separator* alone
+        // would let ("x\0", "y") and ("x", "\0y") hash identically. The
+        // length-prefix must keep them distinct.
+        let a = compute_edge_id("cites", "page", "p", "memory", "x\0", "y");
+        let b = compute_edge_id("cites", "page", "p", "memory", "x", "\0y");
+        assert_ne!(
+            a, b,
+            "an embedded NUL must not collide with a shifted split -- length-prefix, not separator"
+        );
     }
 }

--- a/crates/wenlan-core/src/provenance.rs
+++ b/crates/wenlan-core/src/provenance.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Provenance root identity & independence grouping (KG unified-model M2,
+//! spec v3 §1, Q6-locked recipe).
+//!
+//! Pure, deterministic helpers for `provenance_roots` -- the content-addressed
+//! substrate `edges.root_id` references. Two concerns, cleanly split per the
+//! Q6 decision draft:
+//!
+//! - **Identity** ([`identity_digest`]): exact/near-exact content equivalence,
+//!   deterministic and replica-convergent -- nothing semantic. Source-instance
+//!   identity (file path, fetch time, importing agent) never enters this, so
+//!   two byte-identical imports converge on one root (spec §1, §6.7).
+//! - **Independence** ([`base_independence_key`], [`content_minhash_bands`]):
+//!   fuzzy-mergeable grouping by source signal, with a mandatory near-dup
+//!   MinHash/LSH overlay reusing `retrieval::dedup` (T16), re-pointed from
+//!   entity names to root content. The overlay itself (band-table lookup,
+//!   union into an existing group) needs DB access and lives in `db.rs`,
+//!   mirroring the existing split between this crate's pure `dedup.rs` and
+//!   its `db.rs` accessors (`minhash_resolve_candidate` et al.).
+//!
+//! `edge_id` content-addressing ([`compute_edge_id`]) lives here too -- it is
+//! the same "pure deterministic identity hash" concern, just for edges
+//! instead of roots (assignment-matrix "Retry identity" section,
+//! `docs/plans/2026-07-21-m2-edge-assignment-matrix.md`).
+
+use crate::retrieval::dedup;
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use unicode_normalization::UnicodeNormalization;
+
+/// Q6-locked: the root digest's version tag. Bump only alongside a
+/// deliberate canonicalization-recipe change -- a version bump changes every
+/// digest, so old and new roots never collide and replica convergence never
+/// silently breaks across a canonicalization change (mirrors spec §6.6's "a
+/// model upgrade re-derives before it re-judges", applied to content
+/// identity instead of model scores).
+pub const IDENTITY_VERSION: i64 = 1;
+
+/// Character shingle width for content near-dup detection. Wider than the
+/// entity-name default (`SHINGLE_K = 3` in `retrieval::dedup`) because
+/// content is much longer than a name -- a k=3 shingle set over a whole
+/// document is dominated by common short substrings and would over-match.
+const CONTENT_SHINGLE_K: usize = 8;
+
+/// Q6-locked canonicalization: Unicode NFC + line-ending normalization +
+/// trailing/collapsed-whitespace trim. **Nothing semantic** -- this is what
+/// keeps replica convergence trivially safe; a whitespace-tweaked mirror is a
+/// DISTINCT root (re-unified only by the independence-group near-dup
+/// overlay, never by identity itself).
+pub fn canonicalize_content(raw: &str) -> String {
+    // Line-ending normalization first (CRLF/CR -> LF) so NFC never has to
+    // reason about carriage returns.
+    let unix_lines = raw.replace("\r\n", "\n").replace('\r', "\n");
+    // Unicode NFC.
+    let nfc: String = unix_lines.nfc().collect();
+    // Per-line trailing-whitespace trim + collapse of internal whitespace
+    // runs to a single space, then trim the whole document. `split_whitespace`
+    // already drops leading/trailing whitespace per line as a side effect.
+    let collapsed: String = nfc
+        .lines()
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect::<Vec<_>>()
+        .join("\n");
+    collapsed.trim().to_string()
+}
+
+/// `canonical_content_digest` -- the content-only half of the root digest
+/// (spec §1: "hash(identity_version, root_kind, canonical_content_digest)").
+/// Exposed separately from [`identity_digest`] because it is the honest
+/// canonicalized counterpart to `memories.content_hash` (migration 65's
+/// whole-file SHA-256 over raw bytes, which does NOT canonicalize).
+pub fn canonical_content_digest(raw_content: &str) -> String {
+    let canonical = canonicalize_content(raw_content);
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Root digest = `hash(identity_version, root_kind, canonical_content_digest)`
+/// (Q6, spec §1). Source-instance identity is excluded, so two
+/// byte-identical imports converge on one root via `INSERT ... ON CONFLICT
+/// ... RETURNING` (§6.7) -- same content, same root, regardless of file path,
+/// fetch time, or importing agent.
+pub fn identity_digest(root_kind: &str, raw_content: &str) -> String {
+    let content_digest = canonical_content_digest(raw_content);
+    let mut hasher = Sha256::new();
+    hasher.update(IDENTITY_VERSION.to_le_bytes());
+    hasher.update(b":");
+    hasher.update(root_kind.as_bytes());
+    hasher.update(b":");
+    hasher.update(content_digest.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Content near-dup shingle set, reusing `retrieval::dedup::char_shingles`
+/// re-pointed from entity names ([`CONTENT_SHINGLE_K`] instead of the
+/// name-tuned trigram width).
+pub fn content_shingles(canonical_content: &str) -> HashSet<String> {
+    dedup::char_shingles(canonical_content, CONTENT_SHINGLE_K)
+}
+
+/// LSH band keys for a root's canonicalized content -- the same
+/// MinHash-signature-then-band pipeline `retrieval::dedup` already uses for
+/// entity names, applied to content shingles instead. The DB-side overlay
+/// (persisting bands, looking up candidates, confirming with exact Jaccard)
+/// lives in `db.rs` alongside the existing entity-minhash accessors.
+pub fn content_minhash_bands(canonical_content: &str) -> Vec<u64> {
+    let shingles = content_shingles(canonical_content);
+    let sig = dedup::minhash_signature(&shingles);
+    dedup::lsh_bands(&sig)
+}
+
+/// Q6-locked near-dup threshold, reused verbatim from `retrieval::dedup`
+/// ("high threshold = near-identical only, never topical").
+pub const CONTENT_NEAR_DUP_THRESHOLD: f64 = dedup::FUZZY_JACCARD_THRESHOLD;
+
+/// Exact-Jaccard confirmation between two roots' content, reusing
+/// `retrieval::dedup::jaccard` over content shingles rather than name
+/// shingles. Callers pass already-canonicalized content (the DB layer
+/// canonicalizes once per root and reuses that string for both the identity
+/// digest and this overlay, rather than canonicalizing twice).
+pub fn content_jaccard(canonical_a: &str, canonical_b: &str) -> f64 {
+    dedup::jaccard(
+        &content_shingles(canonical_a),
+        &content_shingles(canonical_b),
+    )
+}
+
+/// The four independence signals in Q6's precedence order (spec Q6 decision
+/// draft, part B): distinct external source identity > agent turn/session >
+/// import batch/container (fallback only when per-item source identity is
+/// absent). The near-dup MinHash overlay is a separate, DB-backed union step
+/// (`db.rs`) applied on top of this base key -- it is not a signal an
+/// implementer of this pure function can see.
+pub struct IndependenceSignals<'a> {
+    /// Distinct external source identity: URL/domain, distinct file origin,
+    /// or distinct author. Highest precedence.
+    pub source_identity: Option<&'a str>,
+    /// Agent turn/session id, for generated or captured content. Second
+    /// precedence -- used only when `source_identity` is absent.
+    pub agent_turn: Option<&'a str>,
+    /// Import batch/container id. Fallback only, used only when both of the
+    /// above are absent.
+    pub import_batch: Option<&'a str>,
+}
+
+/// Base independence-group key by Q6's precedence rule. Returns `None` when
+/// no signal is establishable -- per Q6 B.4 ("un-establishable independence
+/// routes to human review, never auto-genesis"), a `None` here is a signal
+/// to the caller to route to human review rather than mint a group.
+pub fn base_independence_key(signals: &IndependenceSignals) -> Option<String> {
+    signals
+        .source_identity
+        .map(|s| format!("src:{s}"))
+        .or_else(|| signals.agent_turn.map(|s| format!("turn:{s}")))
+        .or_else(|| signals.import_batch.map(|s| format!("batch:{s}")))
+}
+
+/// Content-addressed `edge_id` (assignment-matrix "Retry identity" section):
+/// `sha256(edge_type, src_kind, src_id, dst_kind, dst_id, discriminator)`.
+/// A retried write recomputes the same `edge_id`; `INSERT ... ON
+/// CONFLICT(edge_id) DO NOTHING` converges on the one edge -- no duplicate
+/// voter, exactly the §6.1 retry-identity guarantee at the edge grain. Parts
+/// are null-byte-separated so no two distinct tuples can collide by
+/// concatenation ambiguity (e.g. ("ab", "c") vs ("a", "bc")).
+pub fn compute_edge_id(
+    edge_type: &str,
+    src_kind: &str,
+    src_id: &str,
+    dst_kind: &str,
+    dst_id: &str,
+    discriminator: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    for part in [edge_type, src_kind, src_id, dst_kind, dst_id, discriminator] {
+        hasher.update(part.as_bytes());
+        hasher.update(b"\0");
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonicalize_normalizes_line_endings() {
+        assert_eq!(canonicalize_content("a\r\nb\rc\nd"), "a\nb\nc\nd");
+    }
+
+    #[test]
+    fn canonicalize_collapses_and_trims_whitespace() {
+        assert_eq!(
+            canonicalize_content("  hello   world  \n\n  foo\tbar  "),
+            "hello world\n\nfoo bar"
+        );
+    }
+
+    #[test]
+    fn canonicalize_applies_nfc() {
+        // "e" + combining acute accent (NFD) canonicalizes to precomposed "é" (NFC).
+        let nfd = "e\u{0301}";
+        let nfc = "\u{00e9}";
+        assert_eq!(canonicalize_content(nfd), canonicalize_content(nfc));
+    }
+
+    #[test]
+    fn identity_digest_is_deterministic() {
+        let a = identity_digest("document_ingest", "hello world");
+        let b = identity_digest("document_ingest", "hello world");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn identity_digest_same_content_different_whitespace_converges() {
+        // Byte-identical-after-canonicalization content must produce the
+        // same digest (source instance excluded, spec §1).
+        let a = identity_digest("document_ingest", "hello   world");
+        let b = identity_digest("document_ingest", "hello world");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn identity_digest_differs_by_root_kind() {
+        // A byte-identical human_capture and document_ingest must NOT
+        // converge -- root_kind is part of the digest input.
+        let a = identity_digest("document_ingest", "hello world");
+        let b = identity_digest("human_capture", "hello world");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn identity_digest_differs_by_content() {
+        let a = identity_digest("document_ingest", "hello world");
+        let b = identity_digest("document_ingest", "goodbye world");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn identity_digest_formatting_mirror_is_distinct_from_source_root() {
+        // A formatting-tweaked mirror (adds semantic markup, not just
+        // whitespace) is a DISTINCT root by identity -- re-unified only by
+        // the independence-group near-dup overlay, never by the digest
+        // itself (Q6 equivalence matrix row 2).
+        let a = identity_digest("document_ingest", "# Title\n\nBody text.");
+        let b = identity_digest("document_ingest", "Title\n\nBody text.");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn base_independence_key_precedence_source_over_turn_over_batch() {
+        let all_three = IndependenceSignals {
+            source_identity: Some("https://example.com/doc"),
+            agent_turn: Some("turn-1"),
+            import_batch: Some("batch-1"),
+        };
+        assert_eq!(
+            base_independence_key(&all_three),
+            Some("src:https://example.com/doc".to_string())
+        );
+
+        let turn_and_batch = IndependenceSignals {
+            source_identity: None,
+            agent_turn: Some("turn-1"),
+            import_batch: Some("batch-1"),
+        };
+        assert_eq!(
+            base_independence_key(&turn_and_batch),
+            Some("turn:turn-1".to_string())
+        );
+
+        let batch_only = IndependenceSignals {
+            source_identity: None,
+            agent_turn: None,
+            import_batch: Some("batch-1"),
+        };
+        assert_eq!(
+            base_independence_key(&batch_only),
+            Some("batch:batch-1".to_string())
+        );
+    }
+
+    #[test]
+    fn base_independence_key_none_when_unestablishable() {
+        let none = IndependenceSignals {
+            source_identity: None,
+            agent_turn: None,
+            import_batch: None,
+        };
+        assert_eq!(base_independence_key(&none), None);
+    }
+
+    #[test]
+    fn content_jaccard_near_identical_above_threshold() {
+        // b = a with a short suffix appended: every shingle of `a` is also
+        // a shingle of `b` at the same offset (b has a as a verbatim
+        // prefix), so intersection = |shingles(a)| exactly and the only new
+        // shingles come from the short suffix + boundary. `a` is long,
+        // non-repeating prose (a repeated short phrase would collapse to a
+        // handful of distinct shingles via the HashSet dedup, understating
+        // the shared-shingle count), so the boundary addition is a small
+        // fraction of the total -- a near-dup mirror, precisely bounded
+        // rather than hand-guessed.
+        let a = "the annual harvest festival draws visitors from every \
+                 nearby town to admire the painted carts, sample the \
+                 preserved fruits, and watch the evening lantern parade \
+                 wind slowly through the cobblestone streets past the old \
+                 mill and the riverside market stalls selling wool, honey, \
+                 and hand carved wooden toys to children waiting eagerly \
+                 near the fountain square";
+        let b = format!("{a} and then everyone walked home together");
+        assert!(content_jaccard(a, &b) >= CONTENT_NEAR_DUP_THRESHOLD);
+    }
+
+    #[test]
+    fn content_jaccard_unrelated_below_threshold() {
+        let a = "the quick brown fox jumps over the lazy dog";
+        let b = "completely different subject matter about astronomy";
+        assert!(content_jaccard(a, b) < CONTENT_NEAR_DUP_THRESHOLD);
+    }
+
+    #[test]
+    fn compute_edge_id_is_deterministic_and_retry_safe() {
+        let a = compute_edge_id("relates", "entity", "e1", "entity", "e2", "friend_of");
+        let b = compute_edge_id("relates", "entity", "e1", "entity", "e2", "friend_of");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn compute_edge_id_differs_by_discriminator() {
+        let a = compute_edge_id("relates", "entity", "e1", "entity", "e2", "friend_of");
+        let b = compute_edge_id("relates", "entity", "e1", "entity", "e2", "enemy_of");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn compute_edge_id_no_concatenation_ambiguity() {
+        // ("ab", "c") vs ("a", "bc") must not collide despite concatenating
+        // to the same string without a separator.
+        let a = compute_edge_id("cites", "page", "ab", "memory", "c", "loc");
+        let b = compute_edge_id("cites", "page", "a", "memory", "bc", "loc");
+        assert_ne!(a, b);
+    }
+}

--- a/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
+++ b/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
@@ -118,8 +118,74 @@ guessed around.
 `edge_id` is content-addressed: `sha256(edge_type, src_kind, src_id, dst_kind,
 dst_id, discriminator)` (sha2 is already the crate's hasher, used for
 `memories.content_hash`) where the discriminator is the store's natural-key tail
-(relation_type / locator / label_key / cited_id). A retried write recomputes the
-same `edge_id`; `INSERT … ON CONFLICT(edge_id) DO NOTHING` converges on the one
-edge — no duplicate voter — exactly the §6.1 retry-identity guarantee, at the
-edge grain. Every edge still carries its `operation_id` for audit/receipt
-linkage.
+(relation_type / locator / label_key / cited_id). Each part is **length-prefixed**
+before hashing (its byte length, then its bytes) so no two distinct tuples can
+collide by concatenation ambiguity even if a part itself contains the separator
+byte (locators/labels are unvalidated UTF-8). A retried write recomputes the
+same `edge_id`; `INSERT … ON CONFLICT(edge_id) DO NOTHING` (backfill) /
+`DO UPDATE` (live) converges on the one edge — no duplicate voter — exactly the
+§6.1 retry-identity guarantee, at the edge grain. Every edge still carries its
+`operation_id` for audit/receipt linkage.
+
+### Shared edge_id lineage precedence (evidence > synthesis)
+
+One content-addressed `edge_id` can be produced by more than one legacy store
+for the same `(page, memory)` fact: `page_evidence` (and `page_sources`) →
+`evidence`, a `pages.citations` entry → `synthesis`. The resolved `lineage` is
+**deterministic and order-independent**: `evidence` outranks `synthesis`.
+
+- **Backfill** already yields this: migration 81 runs `page_sources` /
+  `page_evidence` (→ `evidence`) *before* `page_citations` (→ `synthesis`), and
+  `insert_backfilled_edge` is `ON CONFLICT DO NOTHING`, so the first (evidence)
+  writer wins.
+- **Live** dual-write's `ON CONFLICT DO UPDATE` upgrades `synthesis`→`evidence`
+  (and never downgrades), so a live edge and its backfilled twin agree
+  regardless of which store's write fired first.
+
+This is fence-safe because, for a given `edge_id`, every writer resolves the
+identical page/memory spaces: `evidence`/`synthesis` occur only same-space (the
+fence already passed at insert), `legacy` only cross-space, so the precedence
+never crosses the `legacy` boundary and the row stays fence-valid.
+
+## Open design question (M2 PR-1 review): cross-space live typed writes
+
+The "Two *fenced* endpoints in different non-NULL spaces is always rejected"
+clause above is in tension with the live dual-write code as shipped, and the
+resolution is a **design decision deferred out of PR-1** (documented here, not
+silently resolved).
+
+**The tension.** A genuinely *new* live write can present two fenced endpoints
+in different non-NULL spaces — e.g. `create_relation` over two entities the
+agent created in different spaces (entity identity is global, so resolution
+crosses spaces), or the `cross_space_discovery` feature minting a page in one
+space that cites memories in another. The live dual-write classifies such a
+cross-space pair as `lineage='legacy'` (fence-exempt) rather than as its typed
+lineage, so the edge is **written as legacy, not rejected**.
+
+**Why the code does this (Option B, shipped).** PR-1's prime directive is that
+the shadow dual-write must **not change legacy write behavior** (never weaken an
+existing check; no user-visible change). Because the edge write shares the
+legacy write's single transaction, classifying the cross-space pair as a *typed*
+edge would make the fence **reject** it and thereby **roll back the legacy
+write** — a cross-space relation/citation that succeeds today would start
+failing. Downgrading to `legacy` keeps the legacy write intact and the shadow
+faithful.
+
+**The fork.**
+- **Option A — honor the matrix literally (reject cross-space typed writes).**
+  Consequence: the single-transaction dual-write rolls back the legacy write, so
+  a currently-successful cross-space `create_relation` / cross-space citation
+  begins to fail. This *changes legacy behavior* — outside PR-1's contract and
+  the goal-prompt's stop condition ("if the audit surfaced a new-write path
+  minting genuine cross-space fenced links the fence would newly reject, that is
+  the stop condition — report rather than guess around").
+- **Option B — downgrade cross-space typed writes to `legacy` (current code).**
+  Consequence: legacy behavior is preserved and atomicity holds, but the
+  matrix's "always rejected" clause is inaccurate for these new-write paths; the
+  clause should be amended to "downgraded to `legacy`" once the design owner
+  confirms.
+
+Both options either change legacy behavior (A) or amend the matrix (B); neither
+is a pure implementation fix, so PR-1 ships Option B and flags the matrix clause
+for the design owner. `audit_legacy_cross_space_links` reports the pre-fence
+cross-space counts per store so the blast radius is measured, not guessed.

--- a/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
+++ b/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
@@ -158,32 +158,42 @@ same `edge_id`; `INSERT … ON CONFLICT(edge_id) DO NOTHING` (backfill) /
 
 One content-addressed `edge_id` can be produced by more than one legacy store
 for the same fact: `page_evidence` / `page_sources` → `evidence`, a
-`pages.citations` entry → `synthesis`. This holds for BOTH destinations —
-`(page, memory)` AND `(page, external)` — because a `pages.citations`
-external-URI entry is now `synthesis` (matrix row 6, fence-exempt destination),
-not `legacy`; writing it `legacy` made the shared external edge order-dependent
-(round-2 item #2). The resolved `lineage` is **deterministic and
-order-independent** under a TOTAL conflict rule over all four lineages:
+`pages.citations` entry → `synthesis` (external-URI kind) or `legacy` (unknown
+citation kind). This holds for BOTH destinations — `(page, memory)` AND
+`(page, external)` — and the external `legacy` case is SAME-SPACE (the external
+destination is fence-exempt), so `legacy` is NOT exclusively a cross-space
+marker (round-3 item #2c corrected the round-2 claim that it was). The resolved
+`lineage` is **deterministic and order-independent**, resolved in three cases so
+the same-space concurrent case is genuinely commutative:
 
-- `legacy` (a cross-space downgrade) always wins — a genuinely cross-space
-  reassertion of any pair reconciles the shadow row to `legacy`.
-- `evidence` outranks `synthesis`.
-- otherwise the fresh (`excluded`) typed value is adopted — an `assertion` /
-  `synthesis` reactivation, or a `legacy`→typed same-space upgrade.
+- **Reactivation** (the conflicting row was soft-invalidated): adopt the FRESH
+  (`excluded`) value. A retracted-then-readded edge takes its current
+  classification — `evidence` can honestly become `legacy` when its memory moved
+  cross-space. This is a time-ordered move, not a concurrent-write ordering.
+- **Cross-space re-write of an active edge** (`edges.space ≠ excluded.space`):
+  adopt the fresh value. The caller passes `legacy` on a genuine cross-space
+  move; the AFTER UPDATE fence re-validates any typed result. This is the
+  item-4 fence downgrade.
+- **Concurrent same-space active writes**: a TOTAL, COMMUTATIVE rank —
+  `evidence` > `synthesis` > `legacy` — so the result is independent of which
+  store wrote first. (`assertion`, from `relates`/`mentions`, never shares a
+  same-space active `edge_id` with these — distinct `edge_type` — so its rank is
+  immaterial; it sits above `legacy` for totality.) An unknown-kind citation's
+  same-space `legacy` can no longer overwrite an active `evidence`/`synthesis`.
 
 - **Backfill** already yields the `evidence` > `synthesis` case: migration 81
   runs `page_sources` / `page_evidence` before `page_citations`, and
   `insert_backfilled_edge` is `ON CONFLICT DO NOTHING`, so the first (evidence)
   writer wins.
-- **Live** dual-write's `ON CONFLICT DO UPDATE` applies the total rule above and
-  reconciles `space = excluded.space`, so a live edge and its backfilled twin
+- **Live** dual-write's `ON CONFLICT DO UPDATE` applies the three-case rule above
+  and reconciles `space = excluded.space`, so a live edge and its backfilled twin
   agree regardless of which store's write fired first, and a reactivation adopts
   the CURRENT classification rather than a stale one.
 
-Fence-safe: `evidence`/`synthesis` occur only same-space (or fence-exempt
-external), `legacy` only cross-space, and the AFTER UPDATE fence twin
-re-validates every active-and-typed reconciliation, so the row stays
-fence-valid.
+Fence-safe: `evidence`/`synthesis`/`assertion` occur only same-space (or the
+fence-exempt external destination); a genuinely cross-space reassertion arrives
+as `legacy` (fence-exempt); and the AFTER UPDATE fence twin re-validates every
+active-and-typed reconciliation, so the row stays fence-valid.
 
 ### Ownership / re-derivation of shared edges (PR-1 conservative, M3 gate)
 

--- a/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
+++ b/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
@@ -50,7 +50,7 @@ endpoint (the page for page-incident edges; the source entity for `relates`).
 | `page_evidence` (source_kind=`memory`) | `cites` | page → memory | `evidence` | false | NULL | (`cites`, page_id, locator) |
 | `page_evidence` (source_kind=`external_url`/`external_file`) | `cites` | page → external | `evidence` | false | NULL (external) | (`cites`, page_id, locator) |
 | `page_links` (target resolved) | `links` | page → page | `synthesis` | false | NULL | (`links`, source_page_id, label_key) |
-| `pages.citations` blob (per entry) | `cites` | page → memory | `synthesis` | false | NULL | (`cites`, page_id, cited_id) |
+| `pages.citations` blob (per entry) | `cites` | page → memory \| external | `synthesis` | false | NULL | (`cites`, page_id, cited_id) |
 
 `lineage` records the *immediate author* and is display/audit only in M2
 (grounded is the load-bearing bit; all M2 edges are non-voting). Choices:
@@ -74,7 +74,11 @@ unknown counts", each backfilled row is classified deterministically:
   - `relations` with a dangling endpoint (from/to entity absent),
   - `page_links` with `target_page_id IS NULL` (orphan wikilink — no page→page
     edge exists yet),
-  - `pages.citations` entries that don't parse / don't resolve to a memory.
+  - `pages.citations` entries that don't parse, resolve to a memory in a
+    different space, or carry an unknown `source_kind`. (A `memory` entry
+    resolving same-space → `synthesis`; an `external_url`/`external_file` entry
+    → `synthesis` with a fence-exempt external destination — both classifiable,
+    NOT `legacy`.)
 
 Counts land in the durable `edges_migration_state` row (`report_json`) and are
 cited in the PR body.
@@ -103,15 +107,38 @@ user-visible change) or the single-transaction atomicity proof. Resolution
   memory/entity not yet normalized) → the edge is written as `lineage='legacy'`
   (fence-exempt), grounded=false. **The edge is always written in the same
   transaction** → atomicity holds, the legacy write is never blocked, and the
-  shadow stays faithful. Two *fenced* endpoints in different non-NULL spaces is
-  always rejected.
+  shadow stays faithful.
+- **Two *fenced* endpoints in different non-NULL spaces — phase-scoped rule (PR-1 shadow exception, M3 enforcement gate).**
+  A pair the fence *would* reject is **not** rejected during the PR-1 shadow
+  phase: the live dual-write **downgrades it to `lineage='legacy'`** (fence-exempt)
+  so the shared legacy write is never rolled back (full rationale in "Open design
+  question" below — Option B, shipped). This is the deliberate shadow-phase
+  behavior, not the literal-matrix "always rejected". Strict rejection /
+  reclassification to the typed lineage is deferred to the **M3 reader-cutover
+  gate**: when a reader begins trusting `edges`, that cutover MUST (a) re-derive
+  these downgraded rows against normalized `memories`/`entities` spaces, and
+  (b) enforce the fence on live typed writes (reject, or route cross-space pairs
+  to review) rather than silently downgrading. Until that gate, "always rejected"
+  reads as "downgraded to `legacy` in shadow, enforced at cutover".
+- The fence is enforced by **two triggers with an identical body** —
+  `edges_space_fence` (AFTER INSERT) and `edges_space_fence_update`
+  (AFTER UPDATE, additionally guarded on `NEW.valid_until IS NULL` so a
+  soft-invalidate is never blocked). The UPDATE twin re-validates a
+  `dual_write_edge` reactivation / lineage-precedence / space-reconciliation
+  upsert, so a reactivated edge cannot resurrect a typed row against an endpoint
+  that has since moved cross-space.
 
-A pre-migration audit (`audit_legacy_cross_space_links`) reports, per store, how
-many legacy links are same-space / cross-space / NULL-space **before** the fence
-binds; those counts are in the PR body. If the audit surfaced a *new-write* path
-minting genuine cross-space fenced links the fence would newly reject, that is
-the goal prompt's stop condition — the audit result is reported rather than
-guessed around.
+A pre-migration audit (`audit_legacy_cross_space_links`) reports same-space /
+cross-space / NULL-space counts for **all five legacy stores** — `relations`,
+`page_links`, `page_sources`, memory-kind `page_evidence`, and memory-kind
+`pages.citations` (the `external_*` entries of the latter two are fence-EXEMPT,
+so they cannot be cross-space in the fence's sense and are not tallied) —
+**before** the fence binds; those counts are in the PR body. Each store resolves
+the cited memory's space DETERMINISTICALLY (the single distinct non-NULL space
+every chunk agrees on, else NULL), never a `LIMIT 1` pick over conflicting
+chunks. If the audit surfaced a *new-write* path minting genuine cross-space
+fenced links the fence would newly reject, that is the goal prompt's stop
+condition — the audit result is reported rather than guessed around.
 
 ## Retry identity / idempotency
 
@@ -127,25 +154,60 @@ same `edge_id`; `INSERT … ON CONFLICT(edge_id) DO NOTHING` (backfill) /
 §6.1 retry-identity guarantee, at the edge grain. Every edge still carries its
 `operation_id` for audit/receipt linkage.
 
-### Shared edge_id lineage precedence (evidence > synthesis)
+### Shared edge_id lineage precedence (total, order-independent)
 
 One content-addressed `edge_id` can be produced by more than one legacy store
-for the same `(page, memory)` fact: `page_evidence` (and `page_sources`) →
-`evidence`, a `pages.citations` entry → `synthesis`. The resolved `lineage` is
-**deterministic and order-independent**: `evidence` outranks `synthesis`.
+for the same fact: `page_evidence` / `page_sources` → `evidence`, a
+`pages.citations` entry → `synthesis`. This holds for BOTH destinations —
+`(page, memory)` AND `(page, external)` — because a `pages.citations`
+external-URI entry is now `synthesis` (matrix row 6, fence-exempt destination),
+not `legacy`; writing it `legacy` made the shared external edge order-dependent
+(round-2 item #2). The resolved `lineage` is **deterministic and
+order-independent** under a TOTAL conflict rule over all four lineages:
 
-- **Backfill** already yields this: migration 81 runs `page_sources` /
-  `page_evidence` (→ `evidence`) *before* `page_citations` (→ `synthesis`), and
+- `legacy` (a cross-space downgrade) always wins — a genuinely cross-space
+  reassertion of any pair reconciles the shadow row to `legacy`.
+- `evidence` outranks `synthesis`.
+- otherwise the fresh (`excluded`) typed value is adopted — an `assertion` /
+  `synthesis` reactivation, or a `legacy`→typed same-space upgrade.
+
+- **Backfill** already yields the `evidence` > `synthesis` case: migration 81
+  runs `page_sources` / `page_evidence` before `page_citations`, and
   `insert_backfilled_edge` is `ON CONFLICT DO NOTHING`, so the first (evidence)
   writer wins.
-- **Live** dual-write's `ON CONFLICT DO UPDATE` upgrades `synthesis`→`evidence`
-  (and never downgrades), so a live edge and its backfilled twin agree
-  regardless of which store's write fired first.
+- **Live** dual-write's `ON CONFLICT DO UPDATE` applies the total rule above and
+  reconciles `space = excluded.space`, so a live edge and its backfilled twin
+  agree regardless of which store's write fired first, and a reactivation adopts
+  the CURRENT classification rather than a stale one.
 
-This is fence-safe because, for a given `edge_id`, every writer resolves the
-identical page/memory spaces: `evidence`/`synthesis` occur only same-space (the
-fence already passed at insert), `legacy` only cross-space, so the precedence
-never crosses the `legacy` boundary and the row stays fence-valid.
+Fence-safe: `evidence`/`synthesis` occur only same-space (or fence-exempt
+external), `legacy` only cross-space, and the AFTER UPDATE fence twin
+re-validates every active-and-typed reconciliation, so the row stays
+fence-valid.
+
+### Ownership / re-derivation of shared edges (PR-1 conservative, M3 gate)
+
+Because one `edge_id` is content-addressed and shared across stores, removal
+from ONE legacy store cannot safely retract the shared edge without a refcount /
+derivation record (another store may still back it). PR-1 takes the conservative
+side deliberately, and it is invisible in the shadow phase (reads are 100%
+legacy):
+
+- `dual_write_page_citations` does **not** invalidate citations dropped from a
+  re-written blob — `page_evidence`/`page_sources` may still back the same
+  `edge_id`. So a dropped-but-still-backed edge is never wrongly retracted; a
+  dropped-and-unbacked edge may linger **active** in the shadow (harmless while
+  reads are legacy).
+- `cleanup_orphaned_page_sources` **does** invalidate the shared edge, but only
+  for links whose **destination memory no longer exists** (its orphan predicate
+  is `NOT EXISTS (SELECT 1 FROM memories …)`). Every store citing a deleted
+  memory is equally dangling, so this retracts no surviving store's support.
+
+Full re-derivation on single-store removal (a refcount or per-store derivation
+record) is the **M3 reader-cutover gate**, not a PR-1 fix: when a reader begins
+trusting `edges`, the cutover MUST reconcile lingering-active and multi-backed
+edges. Until then the shadow's conservative "never wrongly retract" is correct
+and cheap.
 
 ## Open design question (M2 PR-1 review): cross-space live typed writes
 

--- a/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
+++ b/docs/plans/2026-07-21-m2-edge-assignment-matrix.md
@@ -1,0 +1,125 @@
+# M2 edge assignment matrix (PR-1, stage a)
+
+Status: committed **before** the `edges` schema code, per the M2 goal prompt
+("The assignment matrix is the FIRST artifact, committed before schema code").
+It pins, for every one of the five legacy stores and every new typed write,
+which `edge_type` the row becomes and what `lineage`, `root_id`, and `grounded`
+it gets. Source of truth: spec v3 §2 (edges) and the Q6 decision draft.
+
+## The one grounding rule (spec §2)
+
+> Only edges whose derivation bottoms out in captured external reality vote.
+
+`grounded` is computed at write time from the derivation chain and is then
+immutable. **M2 has no span-validation pipeline and does not root the existing
+corpus** (both are M3+ / deferred, per the goal prompt's out-of-scope list and
+its "confidently rooting the full memory corpus" stop-and-confirm clause).
+Therefore, honestly, **every edge M2 writes is `grounded = false`** — a typo-safe
+extraction edge cannot claim grounding without the span validator, and a `cites`
+edge cannot claim it without a rooted, external memory. `grounded` is a real
+computed function (`grounded_at_write`) that returns `false` for all M2 inputs
+because no M2 input can satisfy the rule yet; M3+ extends it. This is "legacy
+honesty" applied uniformly, not a stub.
+
+## root_id in M2
+
+`provenance_roots` (the table, the Q6 digest, `ON CONFLICT … RETURNING`
+convergence, independence grouping) is **built and tested** in M2. But
+**attaching roots to the existing memory corpus is deferred** (the goal prompt's
+explicit stop-and-confirm: rooting the full corpus balloons the rung; building
+`genesis_candidate_roots` / the floor's consumption is M6). So in M2 every edge
+carries `root_id = NULL`. The root machinery is proven by a direct two-writer
+convergence test, not by corpus attachment. When M3+ roots memories, edge
+`root_id` back-references land then.
+
+## Node kinds and the space of an edge
+
+`src_kind` / `dst_kind` ∈ `{page, memory, entity, external}`.
+Endpoint space lookups (`pages.space`, `memories.space`, `entities.space`):
+`pages.space` is NOT NULL since M1 (migration 80); `memories.space` and
+`entities.space` are **nullable** (migration 50 renamed `domain→space`; only
+pages were normalized in M1). An edge's `space` is derived from a fenced
+endpoint (the page for page-incident edges; the source entity for `relates`).
+
+## Assignment matrix
+
+| Legacy store | → edge_type | src_kind → dst_kind | New-write `lineage` | `grounded` | `root_id` | Natural key (→ content-addressed `edge_id`) |
+|---|---|---|---|---|---|---|
+| `relations` | `relates` | entity → entity | `assertion` | false | NULL | (`relates`, from_entity, to_entity, relation_type) |
+| `page_sources` | `cites` | page → memory | `evidence` | false | NULL | (`cites`, page_id, memory_source_id) |
+| `page_evidence` (source_kind=`memory`) | `cites` | page → memory | `evidence` | false | NULL | (`cites`, page_id, locator) |
+| `page_evidence` (source_kind=`external_url`/`external_file`) | `cites` | page → external | `evidence` | false | NULL (external) | (`cites`, page_id, locator) |
+| `page_links` (target resolved) | `links` | page → page | `synthesis` | false | NULL | (`links`, source_page_id, label_key) |
+| `pages.citations` blob (per entry) | `cites` | page → memory | `synthesis` | false | NULL | (`cites`, page_id, cited_id) |
+
+`lineage` records the *immediate author* and is display/audit only in M2
+(grounded is the load-bearing bit; all M2 edges are non-voting). Choices:
+`relates` from extraction = `assertion` (the extractor asserts the relation);
+`cites` from page provenance = `evidence` (the page's evidentiary basis);
+`links` = `synthesis` (distill-generated cross-reference). These are refined
+when M3+ adds span validation and real grounding.
+
+## Backfill classification (legacy honesty) → the classifiable-vs-unknown report
+
+Existing rows are mirrored into `edges` once, by migration 81's backfill. Per the
+spec's legacy-honesty rule and the goal prompt's "report of classifiable vs
+unknown counts", each backfilled row is classified deterministically:
+
+- **classifiable** — the store + row fields unambiguously resolve to a real
+  edge (both endpoints resolvable, semantics unambiguous): stamped with the
+  matrix `lineage` above, `grounded=false`, `root_id=NULL`, fence **exempt**
+  (backfill shadows predate the fence — see below).
+- **unknown** → `lineage = 'legacy'` — the row is ambiguous or dangling and its
+  authorship can't be confidently classified:
+  - `relations` with a dangling endpoint (from/to entity absent),
+  - `page_links` with `target_page_id IS NULL` (orphan wikilink — no page→page
+    edge exists yet),
+  - `pages.citations` entries that don't parse / don't resolve to a memory.
+
+Counts land in the durable `edges_migration_state` row (`report_json`) and are
+cited in the PR body.
+
+## The fence, NULL-safety, and the lineage='legacy' exemption
+
+Spec §2: a trigger with **NULL-safe (`IS NOT`) comparisons** enforces both
+endpoints in the edge's `space`; sole spec exemption is `cites` to an external
+URI. `IS NOT` is SQLite's null-safe distinct operator, so a NULL-space endpoint
+against a non-NULL `edge.space` is **caught (rejected)**, never silently passed —
+which is the whole point (a `!=` trigger silently passes NULL rows).
+
+Because `memories.space` / `entities.space` are still nullable (not normalized
+until a later rung), a strict fence would reject a *new* internal edge whose
+memory/entity endpoint is a legacy NULL-space row — which would either break the
+authoritative legacy write (unacceptable: never weaken an existing check, no
+user-visible change) or the single-transaction atomicity proof. Resolution
+(assume-and-announce; not a wire-contract or user-visible-data change):
+
+- The fence trigger is exempt for `lineage='legacy'` edges **and** external-URI
+  `cites`, and binds (`IS NOT`) on every other (typed) edge.
+- Dual-write derives `edge.space` from the page endpoint (always fenced) and
+  checks the other endpoint's space in Rust *before* the insert. If both
+  endpoints are fenceable and co-spaced → the edge is typed (real `lineage`) and
+  the fence passes. If the other endpoint is NULL-spaced / unfenceable (a legacy
+  memory/entity not yet normalized) → the edge is written as `lineage='legacy'`
+  (fence-exempt), grounded=false. **The edge is always written in the same
+  transaction** → atomicity holds, the legacy write is never blocked, and the
+  shadow stays faithful. Two *fenced* endpoints in different non-NULL spaces is
+  always rejected.
+
+A pre-migration audit (`audit_legacy_cross_space_links`) reports, per store, how
+many legacy links are same-space / cross-space / NULL-space **before** the fence
+binds; those counts are in the PR body. If the audit surfaced a *new-write* path
+minting genuine cross-space fenced links the fence would newly reject, that is
+the goal prompt's stop condition — the audit result is reported rather than
+guessed around.
+
+## Retry identity / idempotency
+
+`edge_id` is content-addressed: `sha256(edge_type, src_kind, src_id, dst_kind,
+dst_id, discriminator)` (sha2 is already the crate's hasher, used for
+`memories.content_hash`) where the discriminator is the store's natural-key tail
+(relation_type / locator / label_key / cited_id). A retried write recomputes the
+same `edge_id`; `INSERT … ON CONFLICT(edge_id) DO NOTHING` converges on the one
+edge — no duplicate voter — exactly the §6.1 retry-identity guarantee, at the
+edge grain. Every edge still carries its `operation_id` for audit/receipt
+linkage.


### PR DESCRIPTION
# M2 PR-1 — unified edges: schema expand + dual-write shadow

Rung **M2** (stages a+b) of the unified knowledge-model spec v3. One typed
`edges` store is born alongside the five legacy link stores (`relations`,
`page_sources`, `page_evidence`, `page_links`, `pages.citations`), backfilled
from them, and dual-written on every mutation — **as a write-only shadow**.
Reads stay entirely on the legacy stores; the cutover behind an epoch + parity
watermark is PR-2 (`kg-m2-reader-cutover`). Q6 identity decisions (locked
2026-07-20) ship here as `provenance_roots` + the digest recipe.

## Acceptance checklist — stage (a) schema expand

| # | Requirement (goal-prompt / spec §2) | Evidence |
|---|---|---|
| 1 | `edges` table with §2's exact columns; `edge_type ∈ {mentions, relates, cites, supports, links}`; `lineage ∈ {assertion, evidence, synthesis, legacy}`; `grounded` computed at write, immutable | migration 81 (`db.rs`); `migration_81_creates_edges_and_provenance_schema`; `migration_81_fresh_and_upgraded_schema_agree` |
| 2 | `provenance_roots` `UNIQUE(identity_version, identity_digest)`, Q6 digest, `independence_group_id`, `ingesting/active/failed` lifecycle; acquisition via `INSERT … ON CONFLICT … RETURNING` in the attaching txn | `acquire_provenance_root`; two-writer convergence proof `acquire_provenance_root_two_writers_converge_on_same_root`; distinct-content test |
| 3 | **Assignment matrix committed FIRST**, `(writer × origin × operation) → (lineage, root_id, grounded)` for all five stores + new writes | `docs/plans/2026-07-21-m2-edge-assignment-matrix.md`, commit `79deca61` — landed before any schema code |
| 4 | **Index contract**: active-grounded space/type scans, both endpoint directions, `root_id`, supersession chains, `operation_id` — proven by `EXPLAIN QUERY PLAN`, not hoped | 5 EQP assertion tests: `migration_81_index_contract_{active_grounded_space_type_scan, endpoint_lookups, root_id_lookup, supersession_chain_lookup, operation_id_lookup}_uses_index` |
| 5 | Bulk-insert + trigger benchmark | `m81_bulk_insert_trigger_benchmark` (#[ignore]d, run manually): **10,000 live dual-writes (relations INSERT + fence-gated edges INSERT, one BEGIN/COMMIT each) in 3.73s = 373µs/row** |
| 6 | **Space fence as constraint**: NULL-safe (`IS NOT`) trigger, both endpoints in edge's space; external-URI `cites` exempt | `migration_81_fence_trigger_rejects_cross_space_typed_edge`; `…_allows_cites_external_regardless_of_space`; `…_allows_legacy_edge_despite_space_mismatch` |
| 7 | Q6 recipe exact: digest = `hash(identity_version, root_kind, canonical_content)`, source instance excluded; canonicalization = NFC + line-endings + whitespace only; independence base-key precedence + content-MinHash bands | `provenance.rs` (344 lines): `identity_digest_{is_deterministic, differs_by_content, differs_by_root_kind, same_content_different_whitespace_converges, formatting_mirror_is_distinct…}`; `canonicalize_{applies_nfc, normalizes_line_endings, collapses_and_trims_whitespace}`; `base_independence_key_precedence_source_over_turn_over_batch`; `…_none_when_unestablishable`; `content_jaccard_{near_identical_above, unrelated_below}_threshold` |

## Acceptance checklist — stage (b) dual-write

| # | Requirement | Evidence |
|---|---|---|
| 8 | Every legacy-store mutation also writes `edges` in **ONE transaction** — never eventual | `create_relation_dual_write_rolls_back_both_stores_on_edge_failure` (both directions); 9 call sites below |
| 9 | Retry converges on the same edge, never a duplicate voter | deterministic `edge_id` (`compute_edge_id_{is_deterministic_and_retry_safe, differs_by_discriminator, no_concatenation_ambiguity}`); `create_relation_dual_write_retry_is_idempotent_no_duplicate_edge` |
| 10 | Durable migration-state row (stage, cursor, checksum, epoch, completion); batches commit with cursor | `edges_migration_state` in migration 81; `migration_81_migration_state_row_records_report` |
| 11 | **Replay-safe DDL + backfill**: kill/rerun converges, no duplicate edges | `migration_81_backfill_replay_is_idempotent`; `rerun_migration_81` harness; `CREATE TABLE IF NOT EXISTS` throughout |
| 12 | **Legacy honesty**: unclassifiable rows backfill `lineage=legacy, grounded=false`; classifiable-vs-unknown counts reported | per-store backfill tests (`migration_81_backfills_{relations_same_space_as_assertion, relations_cross_space_as_legacy, page_sources_as_evidence, page_evidence_external_url_as_evidence, page_evidence_null_locator_is_skipped, page_links_resolved_as_synthesis, page_links_orphan_is_skipped_not_inserted, citations_memory_resolved_as_synthesis, citations_unresolved_source_kind_as_legacy}`); tally recorded in the state row |
| 13 | Pre-migration cross-space audit before the fence binds | `audit_legacy_cross_space_links` (report; legacy rows enter as `lineage=legacy`, fence-exempt) |
| 14 | Reads stay on legacy stores; zero wire-contract change | no read-path edits in the diff; `edges` referenced only by writers, backfill, and tests |

### Dual-write call sites (all 9)

`create_relation`, `supersede_relation` (soft-invalidates the edge, no hard
delete), `replace_page_links` (writes + invalidates removed links),
`insert_resolved_page_evidence`, `link_page_evidence` (chokepoint — covers
`page_sources` cites), `set_page_citations`,
`set_page_citations_with_changelog`, `cleanup_orphaned_page_sources`,
`rebind_source_id`.

## Test evidence (all local gates green)

- `cargo test -p wenlan-core --lib` — **2668 passed / 0 failed / 27 ignored**
- `cargo test -p wenlan-server --no-fail-fast` — **403 passed, all 18 suites, 0 failed** (known flock flake did not fire)
- `cargo test -p wenlan-mcp` — green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check --all` — clean
- ~30 new tests; mutation checks on the fence trigger and root-conflict path

## Disclosures

- **New direct dependency: `unicode-normalization = "0.1"`** in wenlan-core —
  required for the Q6-locked NFC canonicalization. Already present
  transitively in the resolved graph, so no new crates compile; this pins the
  direct edge.
- **§6.9 pre-migration backup + restore drill: DEFERRED to PR-2.** No backup
  machinery exists anywhere in the repo today. PR-1 is purely additive — the
  five legacy stores are never mutated, so rollback is "stop writing / drop
  the shadow" with zero data loss (the goal-prompt's own PR-1 rollback
  contract). The backup + restore drill becomes load-bearing at reader
  cutover, and lands with PR-2.
- **Fence memory-endpoint lookup keys `memories` by `source_id`** — the
  pre-existing KG edge convention (relations/citations reference memories by
  `source_id`, not rowid `id`). Flagged for review.
- **Pre-existing test touched:** `test_migration_49_pages_changelog_column`
  gained a `PRAGMA legacy_alter_table = ON/OFF` bracket around its
  DROP+RENAME schema simulation — SQLite reparses all triggers on
  `ALTER TABLE RENAME`, and the new `edges_space_fence` (which names `pages`)
  transiently fails resolution mid-rename. Mirrors the test's existing
  `PRAGMA foreign_keys` bracket; the test's assertions are unchanged.
- **`grounded` is `false` for every edge this PR writes or backfills** — no
  span-validation pipeline exists yet (M3+ promotes `mentions`/`relates`);
  new edges mirror legacy semantics and stay honestly ungrounded.

## Out of scope (PR-2 / later)

- Reader cutover, epoch + parity watermark, reconciliation soak at 100k/5k
  scale — PR-2 (`kg-m2-reader-cutover`, stacks on this branch).
- Stage (e) legacy-store retirement — deferred past the rollback window.
- `genesis_candidate_roots` / floor counting (M6); span-validation promotion
  (M3+).

Draft PR: description IS the acceptance checklist above.

## Post-review fixes (cross-family gate)

Codex (gpt-5.6-sol, HIGH, diff-only) blind review returned **FIX-FIRST** with 8
blockers. Each was verified against the code before any change; confirmed ones
fixed TDD red-first (mutation-checked where load-bearing), the rest refuted or
disclosed with file:line evidence. Two follow-up commits on this branch:
`83532032` (#5, provenance.rs), `39b09518` (#1/#3/#4/#6/#7/#8 db.rs + matrix).

| # | Verdict | Evidence (file:line) | Resolution |
|---|---|---|---|
| 1 | **CONFIRMED** | `db.rs` fence trigger — old WHEN `AND NOT (cites AND external)` disabled the whole body, skipping the source-page check | `39b09518`: WHEN is `lineage != 'legacy'`; external exemption scoped to the destination endpoint only. Red test `migration_81_fence_trigger_rejects_cites_external_with_mismatched_source_space` |
| 2 | **BLOCKED-ON-DESIGN** | live dual-write classifies cross-space new writes as `lineage='legacy'` (fence-exempt) — `insert_resolved_page_evidence` `db.rs:27155`, `dual_write_page_citations` `db.rs:8235`; reachable via global entity identity (`create_relation`) + `cross_space_discovery` (`maintenance.rs:383`) | Code unchanged. Fork documented in the matrix doc "Open design question" section: Option A (reject) changes legacy behavior; Option B (downgrade, shipped) contradicts the matrix's "always rejected" clause. Deferred to the design owner |
| 3 | **REFUTED** (nondeterminism) + narrow fix | every `memories.space` write is by `source_id` or by old-space value, never per-chunk-id (`db.rs:10335`, `16600`, `9433/9520/9616/9738`); space is single-valued per `source_id`, so `LIMIT 1` is deterministic | Lineage cannot be nondeterministic. The page_evidence backfill's LEFT JOIN did fan out an N-chunk memory N-fold in the report count → `39b09518` switches it to a scalar subquery. Red test `migration_81_page_evidence_backfill_counts_multichunk_memory_once` |
| 4 | **CONFIRMED** | `backfill_edges_from_page_sources` stamped every row `evidence` with no memory-space check | `39b09518`: scalar-subquery space resolution; cross-space/absent → `lineage='legacy'`, mirroring the page_evidence backfill. Red test `migration_81_backfills_cross_space_page_source_as_legacy` |
| 5 | **CONFIRMED** | `provenance.rs::compute_edge_id` NUL-separator aliased embedded-NUL parts: `("x\0","y")` == `("x","\0y")` | `83532032`: length-prefix each part. Red test `compute_edge_id_embedded_nul_no_collision` |
| 6 | **CONFIRMED** (lineage) + REFUTED/DISCLOSED (invalidation) | `dual_write_edge` ON CONFLICT never merged `lineage` (`db.rs:8134`, order-dependent); invalidation is memory-existence-keyed / orphan-only (`db.rs:30621/30703`), and dropped-but-alive citation non-invalidation is the documented PR-1 "never wrongly retract" deferral (`db.rs:8195`) | `39b09518`: pin `evidence > synthesis` in ON CONFLICT (fence-safe: same-space only, never crosses the legacy boundary). Mutation-checked red test `dual_write_edge_lineage_evidence_wins_over_synthesis_regardless_of_order`. Invalidation left as-is (correct); reduced-citation re-derivation stays a PR-2 concern |
| 7 | **CONFIRMED** | `acquire_provenance_root` root INSERT (`db.rs:8728`) + band INSERTs (`db.rs:8760`) were separate autocommit statements → crash between them leaves a durable unindexed root | `39b09518`: wrap root + bands (+ the band read) in one BEGIN/COMMIT; also closes the query-then-insert near-dup race under the single-writer connection. Mutation-proof `acquire_provenance_root_rolls_back_root_when_band_index_fails` + `..._indexes_bands_on_success` |
| 8 | **CONFIRMED** | `insert_resolved_page_evidence` writes page_evidence (`db.rs:27142`) then the edge (`db.rs:27163`) with no local BEGIN; autocommit would split the two | `39b09518`: `debug_assert!(!conn.is_autocommit())` — the whole lib suite now verifies all six callers hold a transaction. End-to-end rollback test `replace_page_sources_dual_write_rolls_back_page_evidence_on_edge_failure` |

### #2 design fork (for the owner)

Cross-space live typed writes are genuinely reachable (global entity identity;
`cross_space_discovery`). Every resolution either changes legacy write behavior
(reject → single-transaction rollback of the legacy write) or amends the
matrix's "always rejected" clause (downgrade to `legacy`, the shipped code).
Neither is a pure implementation fix, so PR-1 ships the behavior-preserving
downgrade and flags the matrix clause. `audit_legacy_cross_space_links` reports
pre-fence per-store cross-space counts so the blast radius is measured.

### Gates re-run after the fixes (all green)

- `cargo test -p wenlan-core --lib` — **2676 passed / 0 failed / 27 ignored** (`target/gate-logs/gate1_core_lib.log`)
- `cargo test -p wenlan-server --no-fail-fast` — **403 passed, 0 failed** (known flock flake did not fire) (`target/gate-logs/gate2_server.log`)
- `cargo test -p wenlan-mcp` — **288 passed** (`target/gate-logs/gate3_mcp.log`)
- `cargo clippy --workspace --all-targets -- -D warnings` — **No issues found** (`target/gate-logs/gate4_clippy.log`)
- `cargo fmt --all -- --check` — clean (`target/gate-logs/gate5_fmt.log`)
- 8 new tests; mutation-checked the lineage-precedence (#6) fix by revert (fails `synthesis`≠`evidence` without it) and the root-atomicity (#7) fix by forced band-insert failure

## Round-2 rework (Sol re-review)

Codex (gpt-5.6-sol, HIGH, diff-only) round-2 re-review returned **FIX-FIRST** with
a 7-item blocking list (`target/gate-logs/codex_review_2.md`). Each was verified
against the current code before any change. Six code findings confirmed and fixed;
the compound items (2, 3) split into confirmed-and-fixed parts plus refuted/deferred
parts with file:line evidence. Two commits on this branch: `21b67e00` (db.rs code +
tests), `9a6920f5` (matrix doc). Shadow-phase reads stay 100% legacy, so no legacy
write semantics change — only the shadow `edges` table gains correctness/enforcement.

| # | Verdict | Evidence (file:line) | Resolution + test |
|---|---|---|---|
| 1 | **CONFIRMED** | `resolve_memory_space` and both migration-81 backfill subqueries picked an arbitrary chunk with `LIMIT 1` (`db.rs:8210`, `8382`, `8452`); no constraint makes a `source_id`'s space single-valued, so conflicting chunks are indeterminate | `21b67e00`: resolve DETERMINISTICALLY — the single distinct non-NULL space every chunk agrees on, else `None`; `None` routes to fence-exempt `lineage='legacy'`. Red test `resolve_memory_space_conflicting_chunks_resolve_to_none` |
| 2 | **SPLIT** | 2c order-dependence: `pages.citations` external entry wrote `legacy` (`db.rs:8286`) colliding with `page_evidence`'s `evidence` on the same content-addressed external `edge_id`; 2a: cleanup invalidates only orphaned edges (`db.rs:30710-30715` predicate `NOT EXISTS … memories`); 2b: dropped-but-still-backed citations (`db.rs:8223-8230`) | **2c CONFIRMED → fixed** `21b67e00`: external-URI citations → `synthesis` (live + backfill) and a TOTAL conflict rule makes every shared combination order-independent. Tests `dual_write_page_citations_external_uses_synthesis_not_legacy`, `shared_external_citation_edge_lineage_is_order_independent`. **2a REFUTED**: cleanup only invalidates edges whose destination memory is orphaned (gone), so no surviving store's support is retracted. **2b DEFERRED**: content-addressed shared edges have no refcount; single-store removal can't safely invalidate; shadow reads are legacy so zero impact — documented as the M3 reader-cutover gate (`9a6920f5`) |
| 3 | **SPLIT** | `insert_resolved_page_evidence` enforced the txn only with `debug_assert!` (`db.rs:27211`, compiles out of release); `rebind_source_id` owns BEGIN/COMMIT (`db.rs:15590`/`15829`); `cleanup_orphaned_page_sources` owns BEGIN/COMMIT/ROLLBACK (`db.rs:30700`/`30935`/`30930`) | **insert_resolved_page_evidence CONFIRMED → fixed** `21b67e00`: runtime `libsql::Error::Misuse` on an autocommit connection. Red test `insert_resolved_page_evidence_rejects_autocommit_connection`. **rebind + cleanup REFUTED** (structurally atomic): existing `rebind_source_id_rolls_back_when_checkpoint_rebind_fails` (`db.rs:36430`) + new `cleanup_orphaned_page_sources_rolls_back_edge_invalidate_on_failure`. NOTE: the reviewer's `cleanup_orphaned_page_evidence` does not exist — the real fn is `cleanup_orphaned_page_sources` |
| 4 | **CONFIRMED** | the space fence was AFTER INSERT only; `dual_write_edge`'s ON CONFLICT reactivation cleared `valid_until` without updating `space`/`lineage` (`db.rs:8155-8163`) — a reactivated typed row could carry stale coordinates unfenced | `21b67e00`: ON CONFLICT is a TOTAL lineage rule + `space = excluded.space`; new `edges_space_fence_update` AFTER UPDATE trigger (guarded on `valid_until IS NULL` so soft-invalidate is never blocked) re-validates reactivations. Tests `dual_write_edge_reactivation_adopts_fresh_lineage`, `edges_after_update_fence_rejects_cross_space_reactivation` |
| 5 | **CONFIRMED** | `audit_legacy_cross_space_links` reported only `relations` + `page_links` (`db.rs:8683-8710`), omitting 3 of 5 stores the matrix claims coverage for | `21b67e00`: adds `page_sources`, memory-kind `page_evidence`, and memory-kind `pages.citations` (external entries are fence-exempt), each with the same deterministic memory-space resolution. Red test `audit_legacy_cross_space_links_covers_all_five_stores` |
| 6 | **CONFIRMED** | `acquire_provenance_root` minted a fresh active UUID group when independence was un-establishable (`db.rs:8777-8779` `unwrap_or_else(uuid)`), contradicting the Q6 B.4 route-to-review contract (`provenance.rs:147-150`) | `21b67e00`: `None` → `Err` (route to human review), never auto-genesis. No production caller today (tests only). Red test `acquire_provenance_root_unestablishable_independence_routes_to_review` |
| 7 | **CONFIRMED** (doc) | matrix "Two fenced endpoints in different non-NULL spaces is always rejected" (`matrix:106-107`) contradicts the shipped Option-B downgrade | `9a6920f5`: amended to a phase-scoped rule — PR-1 shadow downgrades to `lineage='legacy'`; strict rejection/reclassification is an explicit M3 reader-cutover enforcement gate. New "Ownership / re-derivation of shared edges" section records the 2b deferral |

### Gates re-run after the fixes (all green)

- `cargo test -p wenlan-core --lib` — **2685 passed / 0 failed / 27 ignored** (`target/gate-logs/rework_core.log`)
- `cargo test -p wenlan-server --no-fail-fast` — **403 passed / 0 failed across all 18 suites** (48.95s) — full green, no failures (`target/gate-logs/rework_server.log`). Note: `bind_addr_tests::data_root_lock_excludes_a_second_daemon_for_the_same_root` (`main.rs`) is a known parallel-run flock flake (`os error 35`, resource temporarily unavailable) that fired on an earlier interleaving; it passed in this full-suite run and passes 3/3 in isolation, and is unrelated to the wenlan-core edge changes
- `cargo test -p wenlan-mcp` — **288 passed** (`target/gate-logs/rework_mcp.log`)
- `cargo clippy --workspace --all-targets -- -D warnings` — **No issues found** (`target/gate-logs/rework_clippy.log`)
- `cargo fmt --all -- --check` — clean (`target/gate-logs/rework_fmt.log`)
- 9 new tests + 1 existing assertion updated (`set_page_citations_dual_writes_memory_and_external_citations`: external now `synthesis`, the concrete round→round behavior-change witness for #2c)

### Round-3 addendum (2026-07-21 evening)

Sol round-3: 6/7 SATISFIED; one residual (2c) — unknown-citation-kind `evidence ↔ legacy` non-commutativity. Fixed: conflict resolution is now three-case (reactivation adopts the fresh classification; live same-space conflicts resolve by the commutative total order evidence > synthesis > legacy; cross-space reassertion still downgrades to `legacy` per the fence rule). Matrix doc corrected (external `legacy` is same-space, not only a cross-space marker). Both write orders proven identical by new tests (`citations` unknown-kind + `page_evidence`, both orders → `evidence`; synthesis ↔ legacy likewise). Gates: core 2687/0/27, server 403/0 (18 suites), mcp 288, clippy -D warnings clean, fmt clean.

### Round-4/5 addendum (2026-07-21 late evening)

Sol round-4: 2c SATISFIED, but a NEW regression — the round-3 space-equality
discriminant misread destination-side space moves (the stamp tracks the source),
so a legitimate `evidence → legacy` downgrade on a destination move hit the
AFTER-UPDATE space fence and aborted the WHOLE dual-write transaction, legacy
write included (live SQL repro). Fixed in `5307f251` via an update-path marker.

Sol round-5: the round-4 marker flagged as an *inferred proxy* — the reviewer's
stated merge condition: "pass an explicit downgrade-reason from the space-aware
resolver, plus a resolver-level negative test." Fixed in `48a8bb42`:

- `dual_write_edge` takes an explicit `cross_space_downgrade: bool` (the proxy
  is deleted); `CASE WHEN ?11 = 1 THEN 'legacy'` routes the lineage downgrade
  only on a producer-supplied reason.
- Pure helper `resolved_space_downgrades(resolved_dst_space, edge_space)`
  computes that reason from the REAL space resolution (`resolve_memory_space` /
  the `page_sources` subquery) at all 6 production call sites. `None`
  (unresolved/conflicting) downgrades — fence-safe default. External
  destinations are fence-exempt and pass `false` directly.
- Resolver-level negative test
  `resolved_space_downgrades_gates_lineage_through_real_resolver`.

Gates on `48a8bb42` (all green): core lib full pass, server 403/0 across 18
suites (`--no-fail-fast`), mcp 288, clippy `-D warnings` clean, fmt clean
(`target/gate-logs/r5_*.log`, `r5_clippy2.log`).
