### PR TITLE
ci: make differential routing fail closed

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,20 +3,6 @@
 #
 # https://nexte.st/docs/configuration/
 
-# Serialize all wenlan-core tests. Many of them instantiate the fastembed
-# embedder which holds a process-level lock on
-# `<cache>/models--Qdrant--bge-base-en-v1.5-onnx-Q/blobs/*.lock`. nextest
-# defaults to one process per test, so without serialization parallel tests
-# race on the cache lock and panic with "Lock acquisition failed". Serial
-# execution mirrors cargo test's in-process behavior and gives the embedder
-# init a clean window.
-[test-groups]
-wenlan-core = { max-threads = 1 }
-
-[[profile.default.overrides]]
-filter = 'package(wenlan-core)'
-test-group = 'wenlan-core'
-
 # The folder-ingest pipeline is normally well under a minute (23s in the
 # focused local run). If its queue stops making progress, fail with evidence
 # instead of occupying a CI runner for an hour.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,12 @@ jobs:
       docs:    ${{ steps.filter.outputs.docs }}
       plugin:  ${{ steps.filter.outputs.plugin }}
       npm:     ${{ steps.filter.outputs.npm }}
+      macos:   ${{ steps.filter.outputs.macos }}
       windows: ${{ steps.filter.outputs.windows }}
-      # Test matrix OSes as a JSON array. Windows is included only when
-      # Windows-affecting files changed (saves ~30min per PR otherwise).
+      windows-lint: ${{ steps.filter.outputs.windows-lint }}
+      windows-release: ${{ steps.filter.outputs.windows-release }}
+      # Test matrix OSes as a JSON array. On PRs, Windows is included only when
+      # Windows-affecting files changed. Non-PR runs keep the full backstop.
       test-oses: ${{ steps.matrix.outputs.json }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -47,21 +50,27 @@ jobs:
               # `some` quantifier, a negative glob like `!crates/*/npm/**`
               # makes README-only PRs match this filter.
               - 'crates/**/*.rs'
+              # Native sources bootstrap the drift guard that verifies their
+              # platform route; otherwise a new file could skip its own check.
+              - 'crates/**/*.c'
+              - 'crates/**/*.cc'
+              - 'crates/**/*.cpp'
+              - 'crates/**/*.cxx'
+              - 'crates/**/*.h'
+              - 'crates/**/*.hh'
+              - 'crates/**/*.hpp'
+              - 'crates/**/*.hxx'
+              - 'crates/**/*.m'
+              - 'crates/**/*.mm'
               - 'crates/**/Cargo.toml'
               - 'crates/*/resources/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
-              - 'scripts/lint-scale-gate.sh'
-              - 'scripts/stabilize-rust-cache-toolchains.sh'
-              - 'scripts/stabilize-rust-cache-toolchains.test.sh'
-              - 'scripts/stage-onnxruntime-windows.ps1'
-              - 'scripts/smoke-windows.ps1'
-              - 'scripts/smoke-windows-llm.ps1'
-              - 'scripts/smoke-windows-llm.test.ps1'
-              - 'scripts/verify-ort-source-pin.py'
-              - 'scripts/verify-ort-source-pin.test.py'
+              - '.github/workflows/release.yml'
+              - 'docker/**'
+              - 'scripts/**'
               # Release PRs must run the drift guard: 0.10.1 merged with
               # version drift precisely because these two files don't match
               # any glob above, so the rust tests (incl. drift_guard) skipped
@@ -99,15 +108,72 @@ jobs:
               - '.github/workflows/release.yml'
             npm:
               - 'crates/*/npm/**'
+            macos:
+              # macOS owns launchd/host-activity behavior and its native build
+              # surface. Every current Rust file with a macOS cfg marker is
+              # covered here; drift_guard fails if a future one is not.
+              - 'crates/wenlan-cli/src/**'
+              - 'crates/wenlan-cli/tests/**'
+              - 'crates/wenlan-core/src/drift_guard.rs'
+              - 'crates/wenlan-core/src/config.rs'
+              - 'crates/wenlan-core/src/export/knowledge.rs'
+              - 'crates/wenlan-core/src/lint/**'
+              - 'crates/wenlan-core/src/llm_provider.rs'
+              - 'crates/wenlan-core/src/repair.rs'
+              - 'crates/wenlan-core/src/repair/**'
+              - 'crates/wenlan-core/src/repair_plan/**'
+              - 'crates/wenlan-core/src/sources/directory.rs'
+              - 'crates/**/*.c'
+              - 'crates/**/*.cc'
+              - 'crates/**/*.cpp'
+              - 'crates/**/*.cxx'
+              - 'crates/**/*.h'
+              - 'crates/**/*.hh'
+              - 'crates/**/*.hpp'
+              - 'crates/**/*.hxx'
+              - 'crates/**/*.m'
+              - 'crates/**/*.mm'
+              - 'crates/wenlan-mcp/src/**'
+              - 'crates/wenlan-server/src/**'
+              - 'crates/wenlan-server/tests/**'
+              - 'scripts/install-macos-app.sh'
+              - 'scripts/test-install-macos-app.sh'
+              - 'install.sh'
+              - 'crates/**/Cargo.toml'
+              - 'crates/**/build.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'version.txt'
+              - '.release-please-manifest.json'
+              - 'CHANGELOG.md'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
             windows:
-              # Files that change Windows-specific behavior. PRs not
-              # touching any of these skip the Windows test job entirely.
-              - 'crates/wenlan-cli/src/commands/service.rs'
-              - 'crates/wenlan-cli/src/commands/mcp.rs'
-              - 'crates/wenlan-cli/tests/cli_integration.rs'
-              - 'crates/wenlan-cli/tests/distribution.rs'
-              - 'crates/wenlan-server/src/main.rs'
+              # Windows owns CLI/service/runtime portability, native ORT, and
+              # packaging. drift_guard scans cfg-bearing Rust + PowerShell
+              # paths so this list cannot silently miss a new Windows surface.
+              - 'crates/wenlan-cli/src/**'
+              - 'crates/wenlan-cli/tests/**'
+              - 'crates/wenlan-server/src/**'
+              - 'crates/wenlan-server/tests/**'
               - 'crates/wenlan-mcp/npm/install.js'
+              - 'crates/wenlan-mcp/src/**'
+              - 'crates/wenlan-core/src/config.rs'
+              - 'crates/wenlan-core/src/drift_guard.rs'
+              - 'crates/wenlan-core/src/export/knowledge.rs'
+              - 'crates/wenlan-core/src/repair.rs'
+              - 'crates/wenlan-core/src/repair/**'
+              - 'crates/wenlan-core/src/repair_plan/**'
+              - 'crates/wenlan-core/src/sources/directory.rs'
+              - 'crates/**/*.c'
+              - 'crates/**/*.cc'
+              - 'crates/**/*.cpp'
+              - 'crates/**/*.cxx'
+              - 'crates/**/*.h'
+              - 'crates/**/*.hh'
+              - 'crates/**/*.hpp'
+              - 'crates/**/*.hxx'
               - 'scripts/stage-onnxruntime-windows.ps1'
               - 'scripts/smoke-windows.ps1'
               - 'scripts/smoke-windows-llm.ps1'
@@ -119,30 +185,83 @@ jobs:
               - 'crates/wenlan-core/src/engine.rs'
               - 'crates/wenlan-core/src/llm_provider.rs'
               - 'crates/wenlan-core/src/bin/model_probe.rs'
+              # Exact entry retained for the ORT feature-manifest contract;
+              # the broader manifest glob below covers future crates too.
               - 'crates/wenlan-core/Cargo.toml'
+              - 'crates/**/Cargo.toml'
+              - 'crates/**/build.rs'
+              - 'crates/*/npm/**'
               - 'install.sh'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - 'version.txt'
+              - '.release-please-manifest.json'
+              - 'CHANGELOG.md'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+            windows-lint:
+              # The Windows functional lint-scale proof is useful only when
+              # its implementation or harness changes.
+              - 'crates/wenlan-core/src/lint/**'
+              - 'scripts/lint-scale-gate.sh'
+            windows-release:
+              # Expensive release-profile proof is required only when a PR can
+              # change native linkage, Cargo/build inputs, or packaged output.
+              # Non-PR backstops run it regardless of this filter.
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - 'crates/**/Cargo.toml'
+              - 'crates/**/build.rs'
+              - 'crates/**/*.c'
+              - 'crates/**/*.cc'
+              - 'crates/**/*.cpp'
+              - 'crates/**/*.cxx'
+              - 'crates/**/*.h'
+              - 'crates/**/*.hh'
+              - 'crates/**/*.hpp'
+              - 'crates/**/*.hxx'
+              - 'crates/*/npm/**'
+              - 'crates/wenlan-core/src/engine.rs'
+              - 'crates/wenlan-core/src/llm_provider.rs'
+              - 'crates/wenlan-core/src/bin/model_probe.rs'
+              - 'crates/wenlan-server/src/main.rs'
+              - 'crates/wenlan-mcp/npm/install.js'
+              - 'install.sh'
+              - 'scripts/stage-onnxruntime-windows.ps1'
+              - 'scripts/smoke-windows.ps1'
+              - 'scripts/smoke-windows-llm.ps1'
+              - 'scripts/smoke-windows-llm.test.ps1'
+              - 'version.txt'
+              - '.release-please-manifest.json'
+              - 'CHANGELOG.md'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
 
       - id: matrix
         run: |
-          if [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
             echo 'json=["ubuntu-24.04", "macos-14", "windows-2022"]' >> "$GITHUB_OUTPUT"
-          else
+          elif [ "${{ steps.filter.outputs.macos }}" = "true" ] && [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+            echo 'json=["ubuntu-24.04", "macos-14", "windows-2022"]' >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.filter.outputs.macos }}" = "true" ]; then
             echo 'json=["ubuntu-24.04", "macos-14"]' >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+            echo 'json=["ubuntu-24.04", "windows-2022"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'json=["ubuntu-24.04"]' >> "$GITHUB_OUTPUT"
           fi
 
-  # Rust fmt + lint only run when Rust-affecting paths changed. Docs/image-only
-  # PRs should still get the required aggregate `conclusion` check, but they
-  # should not spend runners on Cargo jobs. The fail-open surface is closed by
-  # `conclusion`, which explicitly fails if `detect-changes` itself fails.
+  # On PRs, Rust fmt + lint only run when Rust-affecting paths changed.
+  # Docs/image-only PRs should still get the required aggregate `conclusion`
+  # check, but they should not spend runners on Cargo jobs. Non-PR runs keep the
+  # full backstop. The fail-open surface is closed by `conclusion`, which
+  # explicitly fails if `detect-changes` itself fails.
   fmt:
     name: fmt
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(main): release')"
+    if: "needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request'"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -154,8 +273,8 @@ jobs:
 
   lint:
     name: lint
-    needs: [detect-changes, fmt]
-    if: "needs.detect-changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(main): release')"
+    needs: [detect-changes]
+    if: "needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request'"
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -185,8 +304,8 @@ jobs:
 
   test:
     name: test (${{ matrix.os }})
-    needs: [detect-changes, fmt, lint]
-    if: "needs.detect-changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(main): release')"
+    needs: [detect-changes]
+    if: "needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request'"
     runs-on: ${{ matrix.os }}
     strategy:
       # Cancel the rest of the matrix when one OS fails. Saves ~20-30min
@@ -292,7 +411,7 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         run: bash scripts/lint-scale-gate.sh "$RUNNER_TEMP/task-19-memory-lint-debugger-linux.txt"
       - name: Page lint scale gate (Windows functional)
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-lint == 'true')
         shell: pwsh
         run: |
           # Functional portability only; the Linux leg owns time and RSS thresholds.
@@ -322,7 +441,7 @@ jobs:
           "exit_code=$gateCode" | Add-Content -Path $receipt
           if ($gateCode -ne 0) { throw "Windows functional scale gate failed" }
       - name: Upload Page lint scale receipt
-        if: always() && (matrix.os == 'ubuntu-24.04' || matrix.os == 'windows-2022')
+        if: always() && (matrix.os == 'ubuntu-24.04' || (matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-lint == 'true')))
         uses: actions/upload-artifact@v4
         with:
           name: task-19-lint-scale-${{ matrix.os }}-${{ github.sha }}
@@ -340,6 +459,12 @@ jobs:
       # sync/enrich/delete lifecycle in-process).
       - name: Integration tests wenlan-cli + wenlan-server
         run: cargo nextest run -p wenlan -p wenlan-server
+      # The MCP runtime has platform-specific token/transport code, while its
+      # test suite remains quarantined below. Compile every target on the
+      # platform owners so cfg-only breakage cannot hide behind Ubuntu clippy.
+      - name: Compile platform-owned MCP runtime
+        if: matrix.os == 'macos-14' || matrix.os == 'windows-2022'
+        run: cargo check -p wenlan-mcp --all-targets
       - name: Run integration tests (core) (Linux)
         if: matrix.os == 'ubuntu-24.04'
         # nextest process-per-test sidesteps the macOS SIGSEGV root cause
@@ -414,14 +539,24 @@ jobs:
       - name: E2E folder ingest over HTTP (Linux)
         if: matrix.os == 'ubuntu-24.04'
         run: bash scripts/smoke-folder-ingest.sh
-      # The Windows release-profile smoke is intentionally PR-gated to the
-      # windows-affecting path filter above. It proves the dynamically loaded
-      # ORT DLL before a release tag can publish an unusable backend.
-      - name: Build Windows release binaries
+      # Ordinary Windows PR proof uses debug artifacts already warmed by the
+      # integration suite. Stage the pinned DLL next to the daemon because the
+      # scheduled task does not inherit ORT_DYLIB_PATH from this runner shell.
+      - name: Build Windows contract binaries
         if: matrix.os == 'windows-2022'
         shell: pwsh
         run: |
-          cargo build --release -p wenlan -p wenlan-server
+          cargo build -p wenlan -p wenlan-server
+          & scripts/stage-onnxruntime-windows.ps1 `
+            -DestinationDirectory "target\debug"
+
+      # Release-profile proof remains on every non-PR backstop and on PRs whose
+      # diff can change native linkage, Cargo/build inputs, or packaging.
+      - name: Build Windows release binaries
+        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')
+        shell: pwsh
+        run: |
+          cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp
           cargo build --release -p wenlan-core --bin model_probe
 
       - name: Validate Windows LLM probe and smoke harness
@@ -444,7 +579,7 @@ jobs:
           & scripts/smoke-windows-llm.test.ps1
 
       - name: Native ORT smoke (Windows; release profile)
-        if: matrix.os == 'windows-2022'
+        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')
         shell: pwsh
         run: |
           & scripts/stage-onnxruntime-windows.ps1 `
@@ -463,7 +598,7 @@ jobs:
         run: |
           $ErrorActionPreference = "Stop"
           try {
-            $backgroundOnOut = & target\release\wenlan.exe background on 2>&1
+            $backgroundOnOut = & target\debug\wenlan.exe background on 2>&1
             $backgroundOnCode = $LASTEXITCODE
             Write-Host "background on exit=$backgroundOnCode out=$backgroundOnOut"
             if ($backgroundOnCode -ne 0) { throw "background on failed: $backgroundOnOut" }
@@ -487,7 +622,7 @@ jobs:
             }
             Write-Host "    daemon healthy under scheduled task"
 
-            $backgroundOffOut = & target\release\wenlan.exe background off 2>&1
+            $backgroundOffOut = & target\debug\wenlan.exe background off 2>&1
             $backgroundOffCode = $LASTEXITCODE
             Write-Host "background off exit=$backgroundOffCode out=$backgroundOffOut"
             if ($backgroundOffCode -ne 0) { throw "background off failed: $backgroundOffOut" }
@@ -539,7 +674,7 @@ jobs:
   test-quarantine:
     name: test-quarantine
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.rust == 'true' && !startsWith(github.event.head_commit.message, 'chore(main): release')"
+    if: "needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request'"
     runs-on: ubuntu-24.04
     continue-on-error: true
     env:
@@ -597,28 +732,45 @@ jobs:
   # of stalling forever on a never-run required check.
   #
   # detect-changes.result is checked explicitly: if the path filter itself
-  # fails, downstream jobs would be skipped silently and this gate would
-  # otherwise pass. fmt/lint/test/plugin/npm are path-filtered, so `skipped`
-  # is their normal state on PRs not touching those surfaces.
+  # fails, downstream jobs would be skipped silently. Every filtered job also
+  # has an expected-vs-actual assertion: expected jobs must succeed and jobs
+  # with no matching diff must be skipped.
   conclusion:
     name: conclusion
     needs: [detect-changes, fmt, lint, test, docs, plugin, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
-      - name: Aggregate
+      - name: Aggregate expected CI results
         run: |
+          expect_job() {
+            name="$1"
+            expected="$2"
+            actual="$3"
+            if [ "$expected" = "true" ]; then
+              if [ "$actual" != "success" ]; then
+                echo "$name was required but result was $actual"
+                exit 1
+              fi
+            elif [ "$actual" != "skipped" ]; then
+              echo "$name was not required but result was $actual"
+              exit 1
+            fi
+          }
+
           dc='${{ needs.detect-changes.result }}'
           if [ "$dc" != 'success' ]; then
             echo "detect-changes did not succeed: $dc"
             exit 1
           fi
-          for r in '${{ needs.fmt.result }}' '${{ needs.lint.result }}' '${{ needs.test.result }}' '${{ needs.docs.result }}' '${{ needs.plugin.result }}' '${{ needs.npm.result }}'; do
-            case "$r" in
-              success|skipped) ;;
-              *) echo "Upstream job failed: $r"; exit 1 ;;
-            esac
-          done
+
+          run_rust='${{ needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request' }}'
+          expect_job fmt "$run_rust" '${{ needs.fmt.result }}'
+          expect_job lint "$run_rust" '${{ needs.lint.result }}'
+          expect_job test "$run_rust" '${{ needs.test.result }}'
+          expect_job docs '${{ needs.detect-changes.outputs.docs == 'true' }}' '${{ needs.docs.result }}'
+          expect_job plugin '${{ needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'
+          expect_job npm '${{ needs.detect-changes.outputs.npm == 'true' }}' '${{ needs.npm.result }}'
 
   plugin:
     needs: detect-changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
       windows: ${{ steps.filter.outputs.windows }}
       windows-lint: ${{ steps.filter.outputs.windows-lint }}
       windows-release: ${{ steps.filter.outputs.windows-release }}
+      mcp-platform: ${{ steps.filter.outputs.mcp-platform }}
       # Test matrix OSes as a JSON array. On PRs, Windows is included only when
       # Windows-affecting files changed. Non-PR runs keep the full backstop.
       test-oses: ${{ steps.matrix.outputs.json }}
@@ -67,7 +68,9 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
+              - '.github/workflows/coverage.yml'
               - '.github/workflows/release.yml'
               - 'docker/**'
               - 'scripts/**'
@@ -134,11 +137,17 @@ jobs:
               - 'crates/**/*.m'
               - 'crates/**/*.mm'
               - 'crates/wenlan-mcp/src/**'
+              - 'crates/wenlan-mcp/Cargo.toml'
+              - 'crates/wenlan-mcp/build.rs'
+              - 'crates/wenlan-types/src/**'
+              - 'crates/wenlan-types/Cargo.toml'
+              - 'crates/wenlan-types/build.rs'
               - 'crates/wenlan-server/src/**'
               - 'crates/wenlan-server/tests/**'
               - 'scripts/install-macos-app.sh'
               - 'scripts/test-install-macos-app.sh'
               - 'install.sh'
+              - '.config/nextest.toml'
               - 'crates/**/Cargo.toml'
               - 'crates/**/build.rs'
               - 'Cargo.toml'
@@ -159,6 +168,11 @@ jobs:
               - 'crates/wenlan-server/tests/**'
               - 'crates/wenlan-mcp/npm/install.js'
               - 'crates/wenlan-mcp/src/**'
+              - 'crates/wenlan-mcp/Cargo.toml'
+              - 'crates/wenlan-mcp/build.rs'
+              - 'crates/wenlan-types/src/**'
+              - 'crates/wenlan-types/Cargo.toml'
+              - 'crates/wenlan-types/build.rs'
               - 'crates/wenlan-core/src/config.rs'
               - 'crates/wenlan-core/src/drift_guard.rs'
               - 'crates/wenlan-core/src/export/knowledge.rs'
@@ -182,6 +196,7 @@ jobs:
               - 'scripts/stabilize-rust-cache-toolchains.test.sh'
               - 'scripts/lint-scale-gate.sh'
               - 'crates/wenlan-core/src/lint/**'
+              - '.config/nextest.toml'
               - 'crates/wenlan-core/src/engine.rs'
               - 'crates/wenlan-core/src/llm_provider.rs'
               - 'crates/wenlan-core/src/bin/model_probe.rs'
@@ -236,6 +251,21 @@ jobs:
               - 'version.txt'
               - '.release-please-manifest.json'
               - 'CHANGELOG.md'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+            mcp-platform:
+              # The MCP runtime owns Unix/non-Unix cfg branches. Compile all
+              # shipped targets on both platform owners only when its source,
+              # runtime dependency graph, toolchain, or workflow changes.
+              - 'crates/wenlan-mcp/src/**'
+              - 'crates/wenlan-mcp/Cargo.toml'
+              - 'crates/wenlan-mcp/build.rs'
+              - 'crates/wenlan-types/src/**'
+              - 'crates/wenlan-types/Cargo.toml'
+              - 'crates/wenlan-types/build.rs'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
 
@@ -320,14 +350,11 @@ jobs:
         # and pay the ~30min Windows tax anyway today.
         os: ${{ fromJSON(needs.detect-changes.outputs.test-oses) }}
     env:
-      # Drop debuginfo from test artifacts. CI has no debugger attached and the
-      # build cache stays warm via rust-cache. Trims linker time + cache size.
+      # Keep dev/test dependency fingerprints aligned and drop debuginfo. CI
+      # has no debugger attached; this lets nextest and later debug binary
+      # builds reuse more artifacts while trimming linker time + cache size.
+      CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
-      # sccache wraps rustc and caches compile outputs to GHA, including
-      # C/C++ from build scripts (ring, openssl-src, llama-cpp-sys). Bigger
-      # win than rust-cache alone on cold cache.
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
       FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -346,7 +373,14 @@ jobs:
         shell: bash
         run: bash scripts/stabilize-rust-cache-toolchains.sh
       - name: Set up sccache
+        if: matrix.os == 'ubuntu-24.04'
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: Enable sccache (Linux)
+        if: matrix.os == 'ubuntu-24.04'
+        shell: bash
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: test
@@ -402,11 +436,12 @@ jobs:
       - name: Workspace lib tests (Linux)
         if: matrix.os == 'ubuntu-24.04'
         run: cargo nextest run --workspace --lib
-      - name: Workspace lib tests (macOS, single-threaded)
+      - name: Workspace lib tests (macOS)
         if: matrix.os == 'macos-14'
         # nextest spawns one process per test by default — sidesteps the
         # ONNX atexit FFI race that required --test-threads=1 with cargo test.
-        run: cargo nextest run --workspace --lib --test-threads=1
+        # .config/nextest.toml still serializes wenlan-core's model/cache tests.
+        run: cargo nextest run --workspace --lib
       - name: Page lint scale gate (Linux time + RSS)
         if: matrix.os == 'ubuntu-24.04'
         run: bash scripts/lint-scale-gate.sh "$RUNNER_TEMP/task-19-memory-lint-debugger-linux.txt"
@@ -448,6 +483,27 @@ jobs:
           path: ${{ runner.temp }}/task-19-memory-lint-debugger-*.txt
           retention-days: 30
           if-no-files-found: error
+      # Syntax and stub-behavior checks are cheap and independent of Rust
+      # compilation. Run them before the long Windows Cargo steps so a broken
+      # release harness fails in seconds rather than near the end of the job.
+      - name: Validate Windows smoke harness
+        if: matrix.os == 'windows-2022'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $tokens = $null
+          $parseErrors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path "scripts\smoke-windows-llm.ps1"),
+            [ref]$tokens,
+            [ref]$parseErrors
+          ) | Out-Null
+          if ($parseErrors.Count -ne 0) {
+            $parseErrors | Format-List | Out-String | Write-Error
+            throw "scripts\smoke-windows-llm.ps1 has PowerShell parse errors"
+          }
+          & scripts/smoke-windows-llm.test.ps1
+
       # Integration tests for wenlan-cli + wenlan-server. We deliberately do
       # NOT use `--workspace --tests` because that pulls in wenlan-core's
       # `eval_harness.rs` which requires `ANTHROPIC_API_KEY` (not in CI).
@@ -459,12 +515,22 @@ jobs:
       # sync/enrich/delete lifecycle in-process).
       - name: Integration tests wenlan-cli + wenlan-server
         run: cargo nextest run -p wenlan -p wenlan-server
+      # Release-profile proof remains on every non-PR backstop and on PRs whose
+      # diff can change native linkage, Cargo/build inputs, or packaging. Run
+      # functional integration first, then prioritize release-only failures
+      # ahead of the MCP runtime and debug artifact builds.
+      - name: Build Windows release binaries
+        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')
+        shell: pwsh
+        run: |
+          cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp
+          cargo build --release -p wenlan-core --bin model_probe
       # The MCP runtime has platform-specific token/transport code, while its
-      # test suite remains quarantined below. Compile every target on the
-      # platform owners so cfg-only breakage cannot hide behind Ubuntu clippy.
+      # test suite remains quarantined below. Compile the shipped lib/bin on
+      # both platform owners; Linux quarantine owns test/dev-dependency targets.
       - name: Compile platform-owned MCP runtime
-        if: matrix.os == 'macos-14' || matrix.os == 'windows-2022'
-        run: cargo check -p wenlan-mcp --all-targets
+        if: (matrix.os == 'macos-14' || matrix.os == 'windows-2022') && (github.event_name != 'pull_request' || needs.detect-changes.outputs.mcp-platform == 'true')
+        run: cargo check -p wenlan-mcp --lib --bins
       - name: Run integration tests (core) (Linux)
         if: matrix.os == 'ubuntu-24.04'
         # nextest process-per-test sidesteps the macOS SIGSEGV root cause
@@ -550,33 +616,10 @@ jobs:
           & scripts/stage-onnxruntime-windows.ps1 `
             -DestinationDirectory "target\debug"
 
-      # Release-profile proof remains on every non-PR backstop and on PRs whose
-      # diff can change native linkage, Cargo/build inputs, or packaging.
-      - name: Build Windows release binaries
-        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')
-        shell: pwsh
-        run: |
-          cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp
-          cargo build --release -p wenlan-core --bin model_probe
-
-      - name: Validate Windows LLM probe and smoke harness
+      - name: Validate Windows LLM probe
         if: matrix.os == 'windows-2022'
         shell: pwsh
-        run: |
-          cargo test -p wenlan-core --bin model_probe
-
-          $tokens = $null
-          $parseErrors = $null
-          [System.Management.Automation.Language.Parser]::ParseFile(
-            (Resolve-Path "scripts\smoke-windows-llm.ps1"),
-            [ref]$tokens,
-            [ref]$parseErrors
-          ) | Out-Null
-          if ($parseErrors.Count -ne 0) {
-            $parseErrors | Format-List | Out-String | Write-Error
-            throw "scripts\smoke-windows-llm.ps1 has PowerShell parse errors"
-          }
-          & scripts/smoke-windows-llm.test.ps1
+        run: cargo test -p wenlan-core --bin model_probe
 
       - name: Native ORT smoke (Windows; release profile)
         if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
               - 'crates/*/resources/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
+              - 'clippy.toml'
               - 'rust-toolchain.toml'
               - '.config/nextest.toml'
               - '.github/workflows/ci.yml'
@@ -337,6 +338,7 @@ jobs:
     needs: [detect-changes]
     if: "needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request'"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       # Cancel the rest of the matrix when one OS fails. Saves ~20-30min
       # per PR when a real bug breaks all platforms — Linux/macOS catch
@@ -372,6 +374,17 @@ jobs:
         if: matrix.os == 'windows-2022'
         shell: bash
         run: bash scripts/stabilize-rust-cache-toolchains.sh
+      - name: Configure rust-lld linker (Windows tests)
+        if: matrix.os == 'windows-2022'
+        shell: pwsh
+        run: |
+          $sysroot = (rustc --print sysroot).Trim()
+          $lld = Join-Path $sysroot "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          if (-not (Test-Path $lld)) {
+            throw "rust-lld.exe missing at $lld"
+          }
+          "RUSTFLAGS=-C linker=$lld -C linker-flavor=lld-link" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
       - name: Set up sccache
         if: matrix.os == 'ubuntu-24.04'
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -431,8 +444,8 @@ jobs:
       # Workspace lib tests skipped on Windows — Linux + macOS catch the
       # same cross-platform unit logic in ~5-15min vs 25min on Windows.
       # Windows-specific behavior (paths, mcp_add, schtasks) is covered
-      # by `Integration tests wenlan-cli + wenlan-server` + the schtasks
-      # install round-trip E2E further down.
+      # by the Windows CLI/server integration step + the schtasks install
+      # round-trip E2E further down.
       - name: Workspace lib tests (Linux)
         if: matrix.os == 'ubuntu-24.04'
         run: cargo nextest run --workspace --lib
@@ -440,7 +453,7 @@ jobs:
         if: matrix.os == 'macos-14'
         # nextest spawns one process per test by default — sidesteps the
         # ONNX atexit FFI race that required --test-threads=1 with cargo test.
-        # .config/nextest.toml still serializes wenlan-core's model/cache tests.
+        # FastEmbed initialization has its own cross-process file lock.
         run: cargo nextest run --workspace --lib
       - name: Page lint scale gate (Linux time + RSS)
         if: matrix.os == 'ubuntu-24.04'
@@ -513,18 +526,12 @@ jobs:
       # three carry the cross-workspace-leak security tests and the P3
       # demotion regression; folder_ingest_e2e covers the full folder
       # sync/enrich/delete lifecycle in-process).
-      - name: Integration tests wenlan-cli + wenlan-server
+      - name: Integration tests wenlan-cli + wenlan-server (shared integration only)
+        if: matrix.os != 'windows-2022'
+        run: cargo nextest run -p wenlan -p wenlan-server -E 'kind(test)'
+      - name: Integration tests wenlan-cli + wenlan-server (Windows)
+        if: matrix.os == 'windows-2022'
         run: cargo nextest run -p wenlan -p wenlan-server
-      # Release-profile proof remains on every non-PR backstop and on PRs whose
-      # diff can change native linkage, Cargo/build inputs, or packaging. Run
-      # functional integration first, then prioritize release-only failures
-      # ahead of the MCP runtime and debug artifact builds.
-      - name: Build Windows release binaries
-        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')
-        shell: pwsh
-        run: |
-          cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp
-          cargo build --release -p wenlan-core --bin model_probe
       # The MCP runtime has platform-specific token/transport code, while its
       # test suite remains quarantined below. Compile the shipped lib/bin on
       # both platform owners; Linux quarantine owns test/dev-dependency targets.
@@ -621,15 +628,6 @@ jobs:
         shell: pwsh
         run: cargo test -p wenlan-core --bin model_probe
 
-      - name: Native ORT smoke (Windows; release profile)
-        if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true')
-        shell: pwsh
-        run: |
-          & scripts/stage-onnxruntime-windows.ps1 `
-            -DestinationDirectory "target\release"
-          & scripts/smoke-windows.ps1 `
-            -ExePath "target\release\wenlan-server.exe"
-
       # `wenlan background on` on Windows registers a per-user Task Scheduler
       # ONLOGON entry via schtasks.exe and triggers it immediately. We
       # verify the full round-trip: background on registers the task, daemon
@@ -709,6 +707,60 @@ jobs:
             $global:LASTEXITCODE = 0
           }
 
+  # Release-profile proof runs beside the ordinary Windows contract instead of
+  # adding ~25-30 minutes to its critical path. It is required for native,
+  # Cargo/build, packaging, and release workflow diffs, plus every non-PR
+  # backstop. A read-only restore may make it faster, but correctness never
+  # depends on another parallel job winning a cache write race.
+  windows-release-proof:
+    name: windows-release-proof
+    needs: [detect-changes]
+    if: "github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true'"
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - name: Stabilize Windows Rust cache toolchain inputs
+        shell: bash
+        run: bash scripts/stabilize-rust-cache-toolchains.sh
+      - name: Configure rust-lld linker (Windows release)
+        shell: pwsh
+        run: |
+          $sysroot = (rustc --print sysroot).Trim()
+          $lld = Join-Path $sysroot "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          if (-not (Test-Path $lld)) {
+            throw "rust-lld.exe missing at $lld"
+          }
+          "RUSTFLAGS=-C linker=$lld -C linker-flavor=lld-link" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Restore Rust cache (read-only)
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: test
+          cache-all-crates: "true"
+          save-if: "false"
+      - name: Install sqlite3 (Windows only)
+        shell: pwsh
+        run: |
+          vcpkg install sqlite3:x64-windows-static-md
+          "LIB=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md\lib;$env:LIB" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Build Windows release binaries
+        shell: pwsh
+        run: |
+          cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp
+          cargo build --release -p wenlan-core --bin model_probe
+      - name: Native ORT smoke (Windows; release profile)
+        shell: pwsh
+        run: |
+          & scripts/stage-onnxruntime-windows.ps1 `
+            -DestinationDirectory "target\release"
+          & scripts/smoke-windows.ps1 `
+            -ExePath "target\release\wenlan-server.exe"
+
   # Quarantine lane: exercises test files present in the tree but not wired
   # into the required `test` job (dormant wenlan-mcp / wenlan-types
   # integration suites). Excluded from `conclusion.needs` so it can never
@@ -780,7 +832,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, fmt, lint, test, docs, plugin, npm]
+    needs: [detect-changes, fmt, lint, test, windows-release-proof, docs, plugin, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -811,6 +863,7 @@ jobs:
           expect_job fmt "$run_rust" '${{ needs.fmt.result }}'
           expect_job lint "$run_rust" '${{ needs.lint.result }}'
           expect_job test "$run_rust" '${{ needs.test.result }}'
+          expect_job windows-release-proof '${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true' }}' '${{ needs.windows-release-proof.result }}'
           expect_job docs '${{ needs.detect-changes.outputs.docs == 'true' }}' '${{ needs.docs.result }}'
           expect_job plugin '${{ needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'
           expect_job npm '${{ needs.detect-changes.outputs.npm == 'true' }}' '${{ needs.npm.result }}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,8 @@
 name: Coverage (informational)
 
-# Non-blocking coverage report posted to PRs. Pre-push and the main CI lane
-# both skip coverage; this workflow exists to give visibility without slowing
-# the merge gate. See AGENTS.md "Local vs CI test responsibilities".
+# Non-blocking coverage report for main and manual runs. Pre-push and the main
+# CI lane both skip instrumentation; this workflow keeps visibility without
+# slowing the merge gate. See AGENTS.md "Local vs CI test responsibilities".
 
 on:
   # Coverage was running on every PR (~7 min). Coverage is informational
@@ -21,8 +21,7 @@ on:
 permissions:
   contents: read
 
-# Don't run on every push — only PRs and manual triggers.
-# Cancel in-flight runs when a new commit lands on the PR.
+# Cancel a superseded manual/main run for the same ref.
 concurrency:
   group: coverage-${{ github.ref }}
   cancel-in-progress: true
@@ -40,6 +39,10 @@ jobs:
     # Informational: never blocks merges. Failing this job is a warning, not a
     # gate. Required-status-checks should NOT include this job.
     continue-on-error: true
+    env:
+      # Match ci.yml exactly so actions/cache computes the same cache version;
+      # a cache miss may download the model but never changes correctness.
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -57,13 +60,10 @@ jobs:
           # interchangeable with the `clippy` or `test` caches in ci.yml.
           shared-key: coverage
 
-      - name: Cache FastEmbed ONNX model
+      - name: Cache fastembed model (Linux)
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          # Wenlan's `resolve_fastembed_cache_dir` writes to
-          # `dirs::data_dir()/wenlan/memorydb/fastembed_cache` on Linux when
-          # no per-DB path or WENLAN_TEST_FASTEMBED_CACHE override is given.
-          path: ~/.local/share/wenlan/memorydb/fastembed_cache
+          path: ${{ env.FASTEMBED_CACHE_DIR }}
           key: fastembed-bge-base-en-v1.5-q-v2
           restore-keys: |
             fastembed-bge-base-en-v1.5-q-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,11 +195,6 @@ jobs:
           toolchain: 1.95.0
           targets: ${{ matrix.target }}
 
-      # sccache caches rustc + build-script outputs to GHA. Big win on the
-      # C/C++-heavy crates we pull (openssl-src, ring, llama-cpp-sys).
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-
       # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
       # time and does not bundle SQLite on Windows. Mirrors ci.yml's test
       # step. GitHub `windows-2022` runner ships vcpkg preinstalled.
@@ -242,9 +237,6 @@ jobs:
       # entire class of openssl-sys/system-OpenSSL/container-version traps
       # that consumed several PRs for v0.7.0.
       - name: Build
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
         run: cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp --target ${{ matrix.target }}
 
       - name: Smoke

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "fastembed::TextEmbedding::try_new", reason = "all FastEmbed text initialization must hold the shared cross-process cache lock", replacement = "crate::db::init_text_embedding" },
+]

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -664,6 +664,24 @@ fn acquire_embedder_init_file_lock(cache_dir: Option<&std::path::Path>) -> Optio
     Some(file)
 }
 
+/// Construct a FastEmbed text model behind the shared process + filesystem
+/// locks. Every `TextEmbedding` initializer in this crate must use this seam:
+/// nextest runs tests in separate processes, so a process-local singleton does
+/// not protect a cold shared model cache.
+#[allow(clippy::disallowed_methods)]
+pub(crate) fn init_text_embedding(options: InitOptions) -> anyhow::Result<TextEmbedding> {
+    // fastembed 5.13.1 gives HF_HOME precedence over options.cache_dir in
+    // pull_from_hf(). Derive the lock domain from the same inputs here so a
+    // caller cannot accidentally lock one directory while hf-hub mutates
+    // another.
+    let effective_cache_dir = std::env::var_os("HF_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| options.cache_dir.clone());
+    let _file_lock = acquire_embedder_init_file_lock(Some(&effective_cache_dir));
+    let _guard = EMBEDDER_INIT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    TextEmbedding::try_new(options)
+}
+
 /// Known-client registry — maps canonical technical IDs (what clients send in
 /// `x-agent-name`) to human-friendly display names (what users see in UI).
 ///
@@ -2913,23 +2931,16 @@ impl MemoryDB {
                 .unwrap_or_else(|| "<default>".into())
         );
         let (embed_tx, embed_rx) = tokio::sync::oneshot::channel();
-        let embed_cache_for_lock = embed_cache_dir.clone();
         std::thread::Builder::new()
             .name("embedder-init".into())
             .spawn(move || {
-                // Cross-process serialization first (covers nextest forked test
-                // processes). Process-local mutex second (covers parallel inits
-                // within the same process). Lock-ordering: outer file lock,
-                // inner process mutex — both protect the same try_new call.
-                let _file_lock = acquire_embedder_init_file_lock(embed_cache_for_lock.as_deref());
-                let _guard = EMBEDDER_INIT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
                 log::info!("[memory_db] embedder thread: loading ONNX model...");
                 let mut opts = InitOptions::new(EmbeddingModel::BGEBaseENV15Q)
                     .with_show_download_progress(true);
                 if let Some(cache) = embed_cache_dir {
                     opts = opts.with_cache_dir(cache);
                 }
-                let result = TextEmbedding::try_new(opts);
+                let result = init_text_embedding(opts);
                 let _ = embed_tx.send(result);
             })
             .map_err(|e| WenlanError::Embedding(format!("spawn embedder thread: {}", e)))?;
@@ -3049,15 +3060,9 @@ impl MemoryDB {
         std::thread::Builder::new()
             .name("embedder-init-shared".into())
             .spawn(move || {
-                // Cross-process serialization first (covers nextest forked test
-                // processes). Process-local mutex second. No `embed_cache_dir`
-                // here — caller doesn't supply one, so the lock falls back to
-                // `dirs::data_dir()/wenlan/memorydb/.embedder_init.lock`.
-                let _file_lock = acquire_embedder_init_file_lock(None);
-                let _guard = EMBEDDER_INIT_LOCK.lock().unwrap_or_else(|p| p.into_inner());
                 let opts = InitOptions::new(EmbeddingModel::BGEBaseENV15Q)
                     .with_show_download_progress(true);
-                let result = TextEmbedding::try_new(opts);
+                let result = init_text_embedding(opts);
                 let _ = tx.send(result);
             })
             .map_err(|e| WenlanError::Embedding(format!("spawn embedder: {}", e)))?;
@@ -39652,12 +39657,12 @@ pub(crate) mod tests {
                 // empty) and walk the env + shared-host candidates.
                 let mut opts = InitOptions::new(EmbeddingModel::BGEBaseENV15Q)
                     .with_show_download_progress(false);
-                if let Some(cache) =
-                    resolve_fastembed_cache_dir(std::path::Path::new(".nonexistent"))
-                {
-                    opts = opts.with_cache_dir(cache);
+                let cache_dir =
+                    resolve_fastembed_cache_dir(std::path::Path::new(".nonexistent"));
+                if let Some(cache) = &cache_dir {
+                    opts = opts.with_cache_dir(cache.clone());
                 }
-                let emb = TextEmbedding::try_new(opts).expect(
+                let emb = init_text_embedding(opts).expect(
                     "failed to init embedder for tests (set WENLAN_TEST_FASTEMBED_CACHE or run the daemon once to populate the shared cache)",
                 );
                 Arc::new(std::sync::Mutex::new(emb))

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -103,6 +103,7 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
     const CACHE_STEP: &str = "Cache fastembed model (Linux)";
     const CACHE_DIR: &str = "${{ github.workspace }}/.fastembed_cache";
     const CACHE_PATH: &str = "${{ env.FASTEMBED_CACHE_DIR }}";
+    const CACHE_KEY: &str = "fastembed-bge-base-en-v1.5-q-v2";
     const JOBS: &[(&str, &str)] = &[
         ("test", "Workspace lib tests (Linux)"),
         (
@@ -157,6 +158,12 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
                 "job {job_name} caches {actual_path:?}, expected {CACHE_PATH:?}"
             ));
         }
+        let actual_key = steps[cache_index]["with"]["key"].as_str();
+        if actual_key != Some(CACHE_KEY) {
+            violations.push(format!(
+                "job {job_name} uses FastEmbed cache key {actual_key:?}, expected {CACHE_KEY:?}"
+            ));
+        }
 
         let consumer_index = steps
             .iter()
@@ -175,6 +182,117 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
     violations
 }
 
+fn coverage_fastembed_cache_violations(workflow: &str) -> Vec<String> {
+    const CACHE_STEP: &str = "Cache fastembed model (Linux)";
+    const CACHE_DIR: &str = "${{ github.workspace }}/.fastembed_cache";
+    const CACHE_PATH: &str = "${{ env.FASTEMBED_CACHE_DIR }}";
+    const CACHE_KEY: &str = "fastembed-bge-base-en-v1.5-q-v2";
+
+    let parsed: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse coverage.yml");
+    let mut violations = Vec::new();
+    let actual_cache_dir = parsed["jobs"]["coverage"]["env"]["FASTEMBED_CACHE_DIR"].as_str();
+    if actual_cache_dir != Some(CACHE_DIR) {
+        violations.push(format!(
+            "coverage sets FASTEMBED_CACHE_DIR={actual_cache_dir:?}, expected {CACHE_DIR:?}"
+        ));
+    }
+
+    let Some(steps) = parsed["jobs"]["coverage"]["steps"].as_sequence() else {
+        violations.push("coverage job has no steps".into());
+        return violations;
+    };
+    let cache_steps: Vec<&serde_yaml::Value> = steps
+        .iter()
+        .filter(|step| step["name"].as_str() == Some(CACHE_STEP))
+        .collect();
+    if cache_steps.len() != 1 {
+        violations.push(format!(
+            "coverage has {} {CACHE_STEP:?} steps, expected 1",
+            cache_steps.len()
+        ));
+        return violations;
+    }
+    let cache_step = cache_steps[0];
+    let actual_path = cache_step["with"]["path"].as_str();
+    if actual_path != Some(CACHE_PATH) {
+        violations.push(format!(
+            "coverage caches {actual_path:?}, expected {CACHE_PATH:?}"
+        ));
+    }
+    let actual_key = cache_step["with"]["key"].as_str();
+    if actual_key != Some(CACHE_KEY) {
+        violations.push(format!(
+            "coverage uses FastEmbed cache key {actual_key:?}, expected {CACHE_KEY:?}"
+        ));
+    }
+
+    violations
+}
+
+fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
+    let parsed: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse release.yml");
+    let mut violations = Vec::new();
+    let Some(steps) = parsed["jobs"]["release"]["steps"].as_sequence() else {
+        return vec!["release job has no steps".into()];
+    };
+
+    if steps.iter().any(|step| {
+        step["uses"]
+            .as_str()
+            .is_some_and(|uses| uses.contains("sccache-action"))
+    }) {
+        violations.push(
+            "release tag builds install sccache despite near-zero cross-tag cache reuse".into(),
+        );
+    }
+    let build = steps
+        .iter()
+        .find(|step| step["name"].as_str() == Some("Build"));
+    if build.is_none_or(|step| {
+        step["env"]["RUSTC_WRAPPER"].as_str() == Some("sccache")
+            || step["env"]["SCCACHE_GHA_ENABLED"].as_str() == Some("true")
+    }) {
+        violations.push("release Build still depends on sccache GHA state".into());
+    }
+    if !steps.iter().any(|step| {
+        step["uses"]
+            .as_str()
+            .is_some_and(|uses| uses.contains("Swatinem/rust-cache"))
+    }) {
+        violations.push("release job removed its target-level rust-cache fallback".into());
+    }
+
+    violations
+}
+
+fn nextest_core_serialization_violations(config: &str) -> Vec<String> {
+    let parsed: toml::Value = toml::from_str(config).expect("parse nextest.toml");
+    let mut violations = Vec::new();
+    let max_threads = parsed["test-groups"]["wenlan-core"]["max-threads"].as_integer();
+    if max_threads != Some(1) {
+        violations.push(format!(
+            "wenlan-core nextest group max-threads={max_threads:?}, expected 1"
+        ));
+    }
+
+    let has_override = parsed["profile"]["default"]["overrides"]
+        .as_array()
+        .is_some_and(|overrides| {
+            overrides.iter().any(|override_| {
+                override_["filter"].as_str() == Some("package(wenlan-core)")
+                    && override_["test-group"].as_str() == Some("wenlan-core")
+            })
+        });
+    if !has_override {
+        violations.push(
+            "nextest default profile does not assign package(wenlan-core) to its serialized group"
+                .into(),
+        );
+    }
+
+    violations
+}
+
 #[test]
 fn fastembed_ci_cache_is_restored_before_model_consumers() {
     let workflow =
@@ -185,6 +303,115 @@ fn fastembed_ci_cache_is_restored_before_model_consumers() {
         "FastEmbed CI cache contract drift:\n{}",
         violations.join("\n")
     );
+}
+
+#[test]
+fn coverage_and_ci_share_the_fastembed_cache_contract() {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/coverage.yml"))
+        .expect("read coverage.yml");
+    let violations = coverage_fastembed_cache_violations(&workflow);
+    assert!(
+        violations.is_empty(),
+        "Coverage FastEmbed cache contract drift:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn coverage_fastembed_cache_contract_detects_non_sharing_path() {
+    let workflow = r#"
+jobs:
+  coverage:
+    env: {}
+    steps:
+      - name: Cache fastembed model (Linux)
+        with:
+          path: ~/.local/share/wenlan/memorydb/fastembed_cache
+          key: fastembed-bge-base-en-v1.5-q-v1
+"#;
+    let violations = coverage_fastembed_cache_violations(workflow);
+    for expected in ["FASTEMBED_CACHE_DIR", "coverage caches", "cache key"] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
+#[test]
+fn release_uses_target_cache_without_tag_scoped_sccache_writes() {
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/release.yml"))
+        .expect("read release.yml");
+    let violations = release_rust_cache_violations(&workflow);
+    assert!(
+        violations.is_empty(),
+        "Release cache contract drift:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn release_cache_contract_rejects_sccache_only_fixture() {
+    let workflow = r#"
+jobs:
+  release:
+    steps:
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@sha
+      - name: Build
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
+        run: cargo build --release
+"#;
+    let violations = release_rust_cache_violations(workflow);
+    for expected in [
+        "install sccache",
+        "depends on sccache",
+        "rust-cache fallback",
+    ] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
+#[test]
+fn nextest_keeps_core_isolated_while_other_macos_tests_parallelize() {
+    let config = std::fs::read_to_string(repo_root().join(".config/nextest.toml"))
+        .expect("read nextest.toml");
+    let violations = nextest_core_serialization_violations(&config);
+    assert!(
+        violations.is_empty(),
+        "nextest core serialization contract drift:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn nextest_core_serialization_contract_rejects_missing_group() {
+    let config = r#"
+[test-groups]
+wenlan-core = { max-threads = 3 }
+
+[[profile.default.overrides]]
+filter = 'package(other)'
+test-group = 'wenlan-core'
+"#;
+    let violations = nextest_core_serialization_violations(config);
+    for expected in ["max-threads", "package(wenlan-core)"] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
+        );
+    }
 }
 
 #[test]
@@ -227,6 +454,12 @@ jobs:
             .iter()
             .any(|violation| violation.contains("WENLAN_TEST_FASTEMBED_CACHE")),
         "fixture must reject per-step cache overrides: {violations:?}"
+    );
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("cache key")),
+        "fixture must reject a missing or stale cache key: {violations:?}"
     );
 }
 
@@ -1032,7 +1265,13 @@ fn ci_routing_contract_violations(
     let ci: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse ci.yml");
     let mut violations = Vec::new();
 
-    for output in ["macos", "windows", "windows-lint", "windows-release"] {
+    for output in [
+        "macos",
+        "windows",
+        "windows-lint",
+        "windows-release",
+        "mcp-platform",
+    ] {
         if ci["jobs"]["detect-changes"]["outputs"][output]
             .as_str()
             .is_none()
@@ -1046,6 +1285,11 @@ fn ci_routing_contract_violations(
         violations.push(
             "Linux canonical routing is not a fail-closed catch-all for tracked Rust sources"
                 .into(),
+        );
+    }
+    if !rust_paths.contains(".github/workflows/coverage.yml") {
+        violations.push(
+            "coverage workflow cannot bootstrap its FastEmbed cache contract through rust".into(),
         );
     }
     for (path, platform, filter) in platform_sensitive_paths {
@@ -1072,6 +1316,17 @@ fn ci_routing_contract_violations(
     }
     let windows_paths = detect_change_filter_paths(&ci, "windows");
     let macos_paths = detect_change_filter_paths(&ci, "macos");
+    for (filter, paths) in [
+        ("rust", &rust_paths),
+        ("macos", &macos_paths),
+        ("windows", &windows_paths),
+    ] {
+        if !paths.contains(".config/nextest.toml") {
+            violations.push(format!(
+                "{filter} routing omits nextest config that guards macOS core-test isolation"
+            ));
+        }
+    }
     for extension in ["c", "cc", "cpp", "cxx", "h", "hh", "hpp", "hxx"] {
         let path = format!("crates/**/*.{extension}");
         for (filter, paths) in [
@@ -1168,6 +1423,35 @@ fn ci_routing_contract_violations(
             }
         }
     }
+    let mcp_platform = detect_change_filter_paths(&ci, "mcp-platform");
+    for path in [
+        "crates/wenlan-mcp/src/**",
+        "crates/wenlan-mcp/Cargo.toml",
+        "crates/wenlan-mcp/build.rs",
+        "crates/wenlan-types/src/**",
+        "crates/wenlan-types/Cargo.toml",
+        "crates/wenlan-types/build.rs",
+        "Cargo.toml",
+        "Cargo.lock",
+        "rust-toolchain.toml",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+    ] {
+        if !mcp_platform.contains(path) {
+            violations.push(format!(
+                "mcp-platform routing omits platform-compile-sensitive path {path}"
+            ));
+        }
+    }
+    for path in &mcp_platform {
+        for (platform, platform_paths) in [("macos", &macos_paths), ("windows", &windows_paths)] {
+            if !filter_routes_path(platform_paths, path) {
+                violations.push(format!(
+                    "mcp-platform path does not also schedule {platform}: {path}"
+                ));
+            }
+        }
+    }
 
     for job in ["lint", "test"] {
         let actual = job_needs(&ci, job);
@@ -1176,6 +1460,36 @@ fn ci_routing_contract_violations(
                 "{job} is unnecessarily serialized; needs={actual:?}, expected [\"detect-changes\"]"
             ));
         }
+    }
+    for profile in ["DEV", "TEST"] {
+        let key = format!("CARGO_PROFILE_{profile}_DEBUG");
+        let actual = ci["jobs"]["test"]["env"][&key].as_str();
+        if actual != Some("0") {
+            violations.push(format!(
+                "test job sets {key}={actual:?}, expected \"0\" for dev/test artifact reuse"
+            ));
+        }
+    }
+    let setup_sccache = job_step(&ci, "test", "Set up sccache");
+    let setup_condition = setup_sccache
+        .and_then(|step| step["if"].as_str())
+        .unwrap_or_default();
+    let enable_sccache = job_step(&ci, "test", "Enable sccache (Linux)");
+    let enable_condition = enable_sccache
+        .and_then(|step| step["if"].as_str())
+        .unwrap_or_default();
+    let enable_run = enable_sccache
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if setup_condition != "matrix.os == 'ubuntu-24.04'"
+        || enable_condition != "matrix.os == 'ubuntu-24.04'"
+        || !enable_run.contains("SCCACHE_GHA_ENABLED=true")
+        || !enable_run.contains("RUSTC_WRAPPER=sccache")
+        || ci["jobs"]["test"]["env"]["RUSTC_WRAPPER"].as_str() == Some("sccache")
+    {
+        violations.push(
+            "test matrix does not restrict sccache reads/writes to the proven Linux lane".into(),
+        );
     }
     for job in ["fmt", "lint", "test", "test-quarantine"] {
         let condition = ci["jobs"][job]["if"].as_str().unwrap_or_default();
@@ -1334,9 +1648,57 @@ fn ci_routing_contract_violations(
         .unwrap_or_default();
     if !mcp_condition.contains("matrix.os == 'macos-14'")
         || !mcp_condition.contains("matrix.os == 'windows-2022'")
-        || !mcp_run.contains("cargo check -p wenlan-mcp --all-targets")
+        || !mcp_condition.contains("needs.detect-changes.outputs.mcp-platform == 'true'")
+        || !mcp_condition.contains("github.event_name != 'pull_request'")
+        || !mcp_run.contains("cargo check -p wenlan-mcp --lib --bins")
+        || mcp_run.contains("--all-targets")
     {
-        violations.push("macOS/Windows ownership does not compile every wenlan-mcp target".into());
+        violations.push(
+            "macOS/Windows ownership does not differentially compile every wenlan-mcp target"
+                .into(),
+        );
+    }
+
+    let macos_lib = job_step(&ci, "test", "Workspace lib tests (macOS)");
+    let macos_lib_run = macos_lib
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if !macos_lib_run.contains("cargo nextest run --workspace --lib")
+        || macos_lib_run.contains("--test-threads=1")
+    {
+        violations.push("macOS nextest workspace proof is unnecessarily single-threaded".into());
+    }
+
+    let Some(test_steps) = ci["jobs"]["test"]["steps"].as_sequence() else {
+        violations.push("test job has no steps for fail-fast ordering".into());
+        return violations;
+    };
+    let step_index = |name: &str| {
+        test_steps
+            .iter()
+            .position(|step| step["name"].as_str() == Some(name))
+    };
+    let integration_index = step_index("Integration tests wenlan-cli + wenlan-server");
+    match (
+        step_index("Validate Windows smoke harness"),
+        integration_index,
+    ) {
+        (Some(harness), Some(integration)) if harness < integration => {}
+        _ => violations
+            .push("Validate Windows smoke harness does not fail fast before integration".into()),
+    }
+    match (
+        integration_index,
+        step_index("Build Windows release binaries"),
+        step_index("Compile platform-owned MCP runtime"),
+        step_index("Build Windows contract binaries"),
+    ) {
+        (Some(integration), Some(release), Some(mcp), Some(debug))
+            if integration < release && release < mcp && release < debug => {}
+        _ => violations.push(
+            "Windows steps do not prioritize integration then release proof before later compilation"
+                .into(),
+        ),
     }
 
     violations
@@ -1391,6 +1753,12 @@ jobs:
       - name: Native ORT smoke (Windows; release profile)
         if: matrix.os == 'windows-2022'
         run: smoke
+      - name: Workspace lib tests (macOS, single-threaded)
+        if: matrix.os == 'macos-14'
+        run: cargo nextest run --workspace --lib --test-threads=1
+      - name: Compile platform-owned MCP runtime
+        if: matrix.os == 'macos-14' || matrix.os == 'windows-2022'
+        run: cargo check -p wenlan-mcp --all-targets
   conclusion:
     steps:
       - name: Aggregate
@@ -1416,13 +1784,21 @@ jobs:
         "bootstrap the CI contract",
         "expected-vs-actual",
         "unnecessarily serialized",
+        "dev/test artifact reuse",
+        "proven Linux lane",
         "condition omits CI scheduling trigger",
+        "coverage workflow",
+        "nextest config",
         "release-profile-sensitive",
         "release-sensitive",
         "wenlan-mcp artifact",
         "does not also schedule",
         "debug runtime artifacts",
-        "compile every wenlan-mcp target",
+        "differentially compile every wenlan-mcp target",
+        "mcp-platform routing",
+        "single-threaded",
+        "fail fast before integration",
+        "release proof before later compilation",
         "root installer",
     ] {
         assert!(

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -622,6 +622,818 @@ jobs:
     );
 }
 
+// ── Teeth #8: differential CI routing stays fail-closed ──
+
+fn detect_change_filter_paths(workflow: &serde_yaml::Value, filter_name: &str) -> BTreeSet<String> {
+    let Some(steps) = workflow["jobs"]["detect-changes"]["steps"].as_sequence() else {
+        return BTreeSet::new();
+    };
+    let Some(filters_yaml) = steps
+        .iter()
+        .find(|step| step["id"].as_str() == Some("filter"))
+        .and_then(|step| step["with"]["filters"].as_str())
+    else {
+        return BTreeSet::new();
+    };
+    let Ok(filters) = serde_yaml::from_str::<serde_yaml::Value>(filters_yaml) else {
+        return BTreeSet::new();
+    };
+    filters[filter_name]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_yaml::Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+fn job_needs(workflow: &serde_yaml::Value, job_name: &str) -> Vec<String> {
+    let needs = &workflow["jobs"][job_name]["needs"];
+    if let Some(single) = needs.as_str() {
+        return vec![single.to_string()];
+    }
+    needs
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_yaml::Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+fn job_step<'a>(
+    workflow: &'a serde_yaml::Value,
+    job_name: &str,
+    step_name: &str,
+) -> Option<&'a serde_yaml::Value> {
+    workflow["jobs"][job_name]["steps"]
+        .as_sequence()?
+        .iter()
+        .find(|step| step["name"].as_str() == Some(step_name))
+}
+
+fn native_platform_markers() -> Vec<(&'static str, &'static str, regex::Regex)> {
+    vec![
+        (
+            "windows",
+            "windows",
+            regex::Regex::new(r#"\b(?:_WIN32|_WIN64|WIN32)\b"#).unwrap(),
+        ),
+        (
+            "macos",
+            "macos",
+            regex::Regex::new(r#"\b(?:__APPLE__|__MACH__|TARGET_OS_OSX)\b"#).unwrap(),
+        ),
+        (
+            "linux",
+            "rust",
+            regex::Regex::new(r#"\b__linux__\b"#).unwrap(),
+        ),
+        (
+            "unix",
+            "macos",
+            regex::Regex::new(r#"\b(?:__unix__|__unix)\b"#).unwrap(),
+        ),
+        (
+            "unix",
+            "windows",
+            regex::Regex::new(r#"\b(?:__unix__|__unix)\b"#).unwrap(),
+        ),
+    ]
+}
+
+fn rust_cfg_expression_ranges(contents: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut search_from = 0;
+    while let Some(relative) = contents[search_from..].find("cfg") {
+        let start = search_from + relative;
+        let previous_is_identifier = contents[..start]
+            .bytes()
+            .next_back()
+            .is_some_and(|byte| byte.is_ascii_alphanumeric() || byte == b'_');
+        if previous_is_identifier {
+            search_from = start + 3;
+            continue;
+        }
+
+        let mut cursor = start + 3;
+        if contents[cursor..].starts_with("_attr") {
+            cursor += "_attr".len();
+        } else if contents[cursor..].starts_with('!') {
+            cursor += 1;
+        }
+        while contents
+            .as_bytes()
+            .get(cursor)
+            .is_some_and(u8::is_ascii_whitespace)
+        {
+            cursor += 1;
+        }
+        if contents.as_bytes().get(cursor) != Some(&b'(') {
+            search_from = start + 3;
+            continue;
+        }
+
+        let expression_start = cursor + 1;
+        let mut depth = 0_u32;
+        let mut in_string = false;
+        let mut escaped = false;
+        let mut expression_end = None;
+        for (relative, character) in contents[cursor..].char_indices() {
+            let absolute = cursor + relative;
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if character == '\\' {
+                    escaped = true;
+                } else if character == '"' {
+                    in_string = false;
+                }
+                continue;
+            }
+            if character == '"' {
+                in_string = true;
+                continue;
+            }
+            match character {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        expression_end = Some(absolute);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(end) = expression_end {
+            ranges.push((expression_start, end));
+            search_from = end + 1;
+        } else {
+            search_from = start + 3;
+        }
+    }
+    ranges
+}
+
+fn cfg_expression_has_word(expression: &str, expected: &str) -> bool {
+    expression
+        .split(|character: char| !(character.is_ascii_alphanumeric() || character == '_'))
+        .any(|word| word == expected)
+}
+
+fn source_platform_routes(
+    path: &str,
+    contents: &str,
+    markers: &[(&'static str, &'static str, regex::Regex)],
+) -> BTreeSet<(&'static str, &'static str)> {
+    let mut routes = BTreeSet::new();
+    if [".c", ".cc", ".cpp", ".cxx", ".h", ".hh", ".hpp", ".hxx"]
+        .iter()
+        .any(|extension| path.ends_with(extension))
+    {
+        routes.insert(("native", "macos"));
+        routes.insert(("native", "windows"));
+    }
+    if path.ends_with(".m") || path.ends_with(".mm") {
+        routes.insert(("macos", "macos"));
+    }
+    for (start, end) in rust_cfg_expression_ranges(contents) {
+        let expression = &contents[start..end];
+        if cfg_expression_has_word(expression, "windows") {
+            routes.insert(("windows", "windows"));
+        }
+        if cfg_expression_has_word(expression, "macos") {
+            routes.insert(("macos", "macos"));
+        }
+        if cfg_expression_has_word(expression, "linux") {
+            routes.insert(("linux", "rust"));
+        }
+        if cfg_expression_has_word(expression, "unix") {
+            routes.insert(("unix", "macos"));
+            routes.insert(("unix", "windows"));
+        }
+    }
+    for (platform, filter, path_marker) in [
+        ("windows", "windows", "std::os::windows"),
+        ("macos", "macos", "std::os::macos"),
+        ("linux", "rust", "std::os::linux"),
+        ("unix", "macos", "std::os::unix"),
+        ("unix", "windows", "std::os::unix"),
+    ] {
+        if contents.contains(path_marker) {
+            routes.insert((platform, filter));
+        }
+    }
+    for (platform, filter, marker) in markers {
+        if marker.is_match(contents) {
+            routes.insert((*platform, *filter));
+        }
+    }
+    routes
+}
+
+#[test]
+fn platform_source_markers_cover_native_positive_controls() {
+    let markers = native_platform_markers();
+    let nested_rust_cfg = source_platform_routes(
+        "crates/platform.rs",
+        r#"
+#[cfg(all(not(feature = "portable"), windows))]
+fn windows_only() {}
+#[cfg(all(not(feature = "portable"), macos))]
+fn macos_only() {}
+#[cfg(all(not(feature = "portable"), linux))]
+fn linux_only() {}
+#[cfg(all(not(feature = "portable"), unix))]
+fn unix_only() {}
+"#,
+        &markers,
+    );
+    assert!(nested_rust_cfg.contains(&("windows", "windows")));
+    assert!(nested_rust_cfg.contains(&("macos", "macos")));
+    assert!(nested_rust_cfg.contains(&("linux", "rust")));
+    assert!(nested_rust_cfg.contains(&("unix", "macos")));
+    assert!(nested_rust_cfg.contains(&("unix", "windows")));
+
+    let windows = source_platform_routes("crates/native.c", "#if defined(_WIN32)", &markers);
+    assert!(windows.contains(&("windows", "windows")));
+
+    let shared_native = source_platform_routes(
+        "crates/native.cpp",
+        "void platform_neutral(void);",
+        &markers,
+    );
+    assert!(shared_native.contains(&("native", "macos")));
+    assert!(shared_native.contains(&("native", "windows")));
+
+    let alternate_cpp = source_platform_routes(
+        "crates/native.cxx",
+        "void platform_neutral(void);",
+        &markers,
+    );
+    assert!(alternate_cpp.contains(&("native", "macos")));
+    assert!(alternate_cpp.contains(&("native", "windows")));
+
+    let apple = source_platform_routes("crates/native.h", "#ifdef __APPLE__", &markers);
+    assert!(apple.contains(&("macos", "macos")));
+
+    let linux = source_platform_routes("crates/native.cc", "#ifdef __linux__", &markers);
+    assert!(linux.contains(&("linux", "rust")));
+
+    let unix = source_platform_routes("crates/native.cpp", "#ifdef __unix__", &markers);
+    assert!(unix.contains(&("unix", "macos")));
+    assert!(unix.contains(&("unix", "windows")));
+
+    let objective_c =
+        source_platform_routes("crates/native.m", "void platform_neutral(void);", &markers);
+    assert!(objective_c.contains(&("macos", "macos")));
+}
+
+fn platform_sensitive_paths(root: &Path) -> Vec<(String, &'static str, &'static str)> {
+    let markers = native_platform_markers();
+    let mut paths = BTreeSet::new();
+    let mut native_sources = BTreeSet::new();
+    for pattern in [
+        "*.rs", "*.c", "*.cc", "*.cpp", "*.cxx", "*.h", "*.hh", "*.hpp", "*.hxx", "*.m", "*.mm",
+    ] {
+        native_sources.extend(git_ls_files(root, pattern));
+    }
+    for path in native_sources
+        .into_iter()
+        .filter(|path| path.starts_with("crates/"))
+    {
+        let contents = std::fs::read_to_string(root.join(&path)).unwrap_or_default();
+        for (platform, filter) in source_platform_routes(&path, &contents, &markers) {
+            paths.insert((path.clone(), platform, filter));
+        }
+    }
+
+    for path in git_ls_files(root, "scripts/*") {
+        let lower = path.to_ascii_lowercase();
+        if lower.contains("windows") || lower.ends_with(".ps1") {
+            paths.insert((path.clone(), "windows", "windows"));
+        }
+        if lower.contains("macos") {
+            paths.insert((path.clone(), "macos", "macos"));
+        }
+        if lower.contains("linux") {
+            paths.insert((path, "linux", "rust"));
+        }
+    }
+    for path in git_ls_files(root, "docker/*") {
+        paths.insert((path, "linux", "rust"));
+    }
+
+    paths.into_iter().collect()
+}
+
+fn release_profile_sensitive_paths(root: &Path) -> Vec<String> {
+    let core_lib =
+        std::fs::read_to_string(root.join("crates/wenlan-core/src/lib.rs")).expect("read core lib");
+    assert!(
+        core_lib.contains("#[cfg(test)]\nmod drift_guard;"),
+        "drift_guard.rs exclusion is valid only while the whole module is test-only"
+    );
+    git_ls_files(root, "*.rs")
+        .into_iter()
+        .filter(|path| {
+            path.starts_with("crates/")
+                && path.contains("/src/")
+                // The whole module is imported behind #[cfg(test)] in lib.rs.
+                && path != "crates/wenlan-core/src/drift_guard.rs"
+        })
+        .filter(|path| {
+            std::fs::read_to_string(root.join(path))
+                .is_ok_and(|contents| has_production_release_marker(&contents))
+        })
+        .collect()
+}
+
+fn has_production_release_marker(contents: &str) -> bool {
+    rust_cfg_expression_ranges(contents)
+        .into_iter()
+        .filter(|(start, end)| cfg_expression_has_word(&contents[*start..*end], "debug_assertions"))
+        .any(|(start, end)| {
+            let line_start = contents[..start]
+                .rfind('\n')
+                .map_or(0, |newline| newline + 1);
+            let line_end = contents[end..]
+                .find('\n')
+                .map_or(contents.len(), |newline| end + newline);
+            let adjacent_attributes = contents[..line_start]
+                .lines()
+                .rev()
+                .take_while(|line| line.trim_start().starts_with("#["))
+                .chain(
+                    contents[line_end..]
+                        .lines()
+                        .skip(1)
+                        .take_while(|line| line.trim_start().starts_with("#[")),
+                );
+            !adjacent_attributes.into_iter().any(|line| {
+                let attribute = line.trim();
+                attribute == "#[test]" || attribute.contains("::test")
+            })
+        })
+}
+
+#[test]
+fn release_profile_marker_scan_is_fail_closed_after_test_modules() {
+    let test_only = r#"
+#[test]
+#[cfg(debug_assertions)]
+fn debug_only_assertion() {}
+"#;
+    assert!(!has_production_release_marker(test_only));
+
+    let nonterminal_test_module = r#"
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(debug_assertions)]
+    fn debug_only_assertion() {}
+}
+
+#[cfg(not(debug_assertions))]
+pub fn release_only_runtime() {}
+"#;
+    assert!(has_production_release_marker(nonterminal_test_module));
+
+    let nested_release_predicate = r#"
+#[cfg(all(not(feature = "portable"), debug_assertions))]
+pub fn nested_release_sensitive_runtime() {}
+"#;
+    assert!(has_production_release_marker(nested_release_predicate));
+}
+
+fn filter_routes_path(patterns: &BTreeSet<String>, path: &str) -> bool {
+    patterns.contains(path)
+        || patterns.iter().any(|pattern| {
+            pattern
+                .strip_suffix("/**")
+                .is_some_and(|prefix| path.starts_with(&format!("{prefix}/")))
+        })
+        || patterns.iter().any(|pattern| {
+            pattern
+                .strip_prefix("crates/**/*.")
+                .is_some_and(|extension| {
+                    path.starts_with("crates/") && path.ends_with(&format!(".{extension}"))
+                })
+        })
+}
+
+fn ci_routing_contract_violations(
+    workflow: &str,
+    platform_sensitive_paths: &[(String, &'static str, &'static str)],
+    release_profile_sensitive_paths: &[String],
+) -> Vec<String> {
+    let ci: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse ci.yml");
+    let mut violations = Vec::new();
+
+    for output in ["macos", "windows", "windows-lint", "windows-release"] {
+        if ci["jobs"]["detect-changes"]["outputs"][output]
+            .as_str()
+            .is_none()
+        {
+            violations.push(format!("detect-changes does not expose {output} routing"));
+        }
+    }
+
+    let rust_paths = detect_change_filter_paths(&ci, "rust");
+    if !rust_paths.contains("crates/**/*.rs") {
+        violations.push(
+            "Linux canonical routing is not a fail-closed catch-all for tracked Rust sources"
+                .into(),
+        );
+    }
+    for (path, platform, filter) in platform_sensitive_paths {
+        let routed = detect_change_filter_paths(&ci, filter);
+        if !filter_routes_path(&routed, path) {
+            violations.push(format!(
+                "platform-sensitive {platform} path is not fail-closed through {filter}: {path}"
+            ));
+        }
+        if !filter_routes_path(&rust_paths, path) {
+            violations.push(format!(
+                "platform-sensitive {platform} path cannot bootstrap the CI contract through rust: {path}"
+            ));
+        }
+    }
+
+    let release_sensitive = detect_change_filter_paths(&ci, "windows-release");
+    for path in release_profile_sensitive_paths {
+        if !filter_routes_path(&release_sensitive, path) {
+            violations.push(format!(
+                "release-profile-sensitive source is not routed through windows-release: {path}"
+            ));
+        }
+    }
+    let windows_paths = detect_change_filter_paths(&ci, "windows");
+    let macos_paths = detect_change_filter_paths(&ci, "macos");
+    for extension in ["c", "cc", "cpp", "cxx", "h", "hh", "hpp", "hxx"] {
+        let path = format!("crates/**/*.{extension}");
+        for (filter, paths) in [
+            ("rust", &rust_paths),
+            ("macos", &macos_paths),
+            ("windows", &windows_paths),
+            ("windows-release", &release_sensitive),
+        ] {
+            if !paths.contains(&path) {
+                violations.push(format!(
+                    "{filter} routing omits shared native source glob {path}"
+                ));
+            }
+        }
+    }
+    for path in [
+        "Cargo.toml",
+        "Cargo.lock",
+        "rust-toolchain.toml",
+        "crates/**/Cargo.toml",
+        "crates/**/build.rs",
+        "crates/**/*.c",
+        "crates/**/*.cc",
+        "crates/**/*.cpp",
+        "crates/**/*.cxx",
+        "crates/**/*.h",
+        "crates/**/*.hh",
+        "crates/**/*.hpp",
+        "crates/**/*.hxx",
+        "crates/*/npm/**",
+        "install.sh",
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+        "scripts/stage-onnxruntime-windows.ps1",
+        "scripts/smoke-windows.ps1",
+        "version.txt",
+        ".release-please-manifest.json",
+        "CHANGELOG.md",
+    ] {
+        if !release_sensitive.contains(path) {
+            violations.push(format!(
+                "windows-release routing omits release-sensitive path {path}"
+            ));
+        }
+    }
+    for (platform, paths) in [("macos", &macos_paths), ("windows", &windows_paths)] {
+        if !filter_routes_path(paths, "install.sh") {
+            violations.push(format!(
+                "{platform} routing omits the root installer install.sh"
+            ));
+        }
+        for path in [
+            "crates/wenlan-server/src/**",
+            "crates/wenlan-server/tests/**",
+        ] {
+            if !paths.contains(path) {
+                violations.push(format!(
+                    "{platform} routing omits shared server runtime boundary {path}"
+                ));
+            }
+        }
+        for path in [
+            "version.txt",
+            ".release-please-manifest.json",
+            "CHANGELOG.md",
+        ] {
+            if !paths.contains(path) {
+                violations.push(format!(
+                    "{platform} routing omits pre-release full-platform trigger {path}"
+                ));
+            }
+        }
+    }
+    let windows_lint = detect_change_filter_paths(&ci, "windows-lint");
+    for path in [
+        "crates/wenlan-core/src/lint/**",
+        "scripts/lint-scale-gate.sh",
+    ] {
+        if !windows_lint.contains(path) {
+            violations.push(format!(
+                "windows-lint routing omits lint-sensitive path {path}"
+            ));
+        }
+    }
+    for (child_name, child_paths) in [
+        ("release-sensitive", &release_sensitive),
+        ("lint-sensitive", &windows_lint),
+    ] {
+        for path in child_paths {
+            if !filter_routes_path(&windows_paths, path) {
+                violations.push(format!(
+                    "{child_name} Windows path does not also schedule the Windows job: {path}"
+                ));
+            }
+        }
+    }
+
+    for job in ["lint", "test"] {
+        let actual = job_needs(&ci, job);
+        if actual != ["detect-changes"] {
+            violations.push(format!(
+                "{job} is unnecessarily serialized; needs={actual:?}, expected [\"detect-changes\"]"
+            ));
+        }
+    }
+    for job in ["fmt", "lint", "test", "test-quarantine"] {
+        let condition = ci["jobs"][job]["if"].as_str().unwrap_or_default();
+        for required in [
+            "needs.detect-changes.outputs.rust",
+            "needs.detect-changes.outputs.macos",
+            "needs.detect-changes.outputs.windows",
+            "github.event_name != 'pull_request'",
+        ] {
+            if !condition.contains(required) {
+                violations.push(format!(
+                    "{job} condition omits CI scheduling trigger {required}"
+                ));
+            }
+        }
+        if condition.contains("github.event.head_commit.message") {
+            violations.push(format!(
+                "{job} can skip a non-PR full backstop based on the head commit message"
+            ));
+        }
+    }
+
+    let matrix_run = ci["jobs"]["detect-changes"]["steps"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .find(|step| step["id"].as_str() == Some("matrix"))
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    for required in [
+        "github.event_name",
+        "pull_request",
+        "ubuntu-24.04",
+        "steps.filter.outputs.macos",
+        "steps.filter.outputs.windows",
+    ] {
+        if !matrix_run.contains(required) {
+            violations.push(format!(
+                "dynamic OS matrix is missing differential/backstop routing marker {required:?}"
+            ));
+        }
+    }
+
+    let conclusion_run =
+        workflow_step_run(&ci, "Aggregate expected CI results").unwrap_or_default();
+    if !conclusion_run.contains("expect_job") || conclusion_run.contains("success|skipped") {
+        violations.push(
+            "conclusion has no expected-vs-actual contract and accepts skipped jobs generically"
+                .into(),
+        );
+    }
+    for required in [
+        "needs.detect-changes.outputs.rust",
+        "needs.detect-changes.outputs.macos",
+        "needs.detect-changes.outputs.windows",
+        "github.event_name != 'pull_request'",
+    ] {
+        if !conclusion_run.contains(required) {
+            violations.push(format!(
+                "conclusion expectation omits CI scheduling trigger {required}"
+            ));
+        }
+    }
+    if conclusion_run.contains("github.event.head_commit.message") {
+        violations.push(
+            "conclusion can accept skipped non-PR backstops based on the head commit message"
+                .into(),
+        );
+    }
+    for (job, expected) in [
+        ("fmt", "\"$run_rust\""),
+        ("lint", "\"$run_rust\""),
+        ("test", "\"$run_rust\""),
+        ("docs", "needs.detect-changes.outputs.docs"),
+        ("plugin", "needs.detect-changes.outputs.plugin"),
+        ("npm", "needs.detect-changes.outputs.npm"),
+    ] {
+        let result = format!("needs.{job}.result");
+        if !conclusion_run.lines().any(|line| {
+            line.contains(&format!("expect_job {job}"))
+                && line.contains(expected)
+                && line.contains(&result)
+        }) {
+            violations.push(format!(
+                "conclusion does not compare expected-vs-actual result for {job}"
+            ));
+        }
+    }
+
+    for step_name in [
+        "Build Windows release binaries",
+        "Native ORT smoke (Windows; release profile)",
+    ] {
+        let condition = job_step(&ci, "test", step_name)
+            .and_then(|step| step["if"].as_str())
+            .unwrap_or_default();
+        if !condition.contains("needs.detect-changes.outputs.windows-release == 'true'")
+            || !condition.contains("github.event_name != 'pull_request'")
+        {
+            violations.push(format!(
+                "{step_name} is not gated to release-sensitive PRs plus non-PR backstops"
+            ));
+        }
+    }
+    let windows_release_build = job_step(&ci, "test", "Build Windows release binaries")
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if !windows_release_build.contains("-p wenlan-mcp") {
+        violations.push(
+            "Windows release proof omits the wenlan-mcp artifact built by release.yml".into(),
+        );
+    }
+
+    let windows_lint_condition = job_step(&ci, "test", "Page lint scale gate (Windows functional)")
+        .and_then(|step| step["if"].as_str())
+        .unwrap_or_default();
+    if !windows_lint_condition.contains("needs.detect-changes.outputs.windows-lint == 'true'")
+        || !windows_lint_condition.contains("github.event_name != 'pull_request'")
+    {
+        violations.push(
+            "Windows page-lint proof is not gated to lint-sensitive PRs plus non-PR backstops"
+                .into(),
+        );
+    }
+
+    let debug_build = job_step(&ci, "test", "Build Windows contract binaries");
+    if debug_build
+        .and_then(|step| step["run"].as_str())
+        .is_none_or(|run| {
+            !run.contains("cargo build -p wenlan -p wenlan-server")
+                || !run.contains("target\\debug")
+                || run.contains("--release")
+        })
+    {
+        violations.push(
+            "ordinary Windows contract does not build and stage debug runtime artifacts".into(),
+        );
+    }
+    let schtasks = job_step(
+        &ci,
+        "test",
+        "E2E wenlan background on/off round-trip (Windows; schtasks)",
+    )
+    .and_then(|step| step["run"].as_str())
+    .unwrap_or_default();
+    if !schtasks.contains(r"target\debug\wenlan.exe") {
+        violations.push("ordinary Windows schtasks contract does not use debug binaries".into());
+    }
+
+    let mcp_compile = job_step(&ci, "test", "Compile platform-owned MCP runtime");
+    let mcp_condition = mcp_compile
+        .and_then(|step| step["if"].as_str())
+        .unwrap_or_default();
+    let mcp_run = mcp_compile
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if !mcp_condition.contains("matrix.os == 'macos-14'")
+        || !mcp_condition.contains("matrix.os == 'windows-2022'")
+        || !mcp_run.contains("cargo check -p wenlan-mcp --all-targets")
+    {
+        violations.push("macOS/Windows ownership does not compile every wenlan-mcp target".into());
+    }
+
+    violations
+}
+
+#[test]
+fn ci_routing_is_fail_closed_and_differential() {
+    let root = repo_root();
+    let workflow =
+        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let platform_sensitive_paths = platform_sensitive_paths(&root);
+    let release_profile_sensitive_paths = release_profile_sensitive_paths(&root);
+    let violations = ci_routing_contract_violations(
+        &workflow,
+        &platform_sensitive_paths,
+        &release_profile_sensitive_paths,
+    );
+    assert!(
+        violations.is_empty(),
+        "CI routing contract drift:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn ci_routing_contract_rejects_fail_open_fixture() {
+    let workflow = r#"
+jobs:
+  detect-changes:
+    outputs:
+      windows: ${{ steps.filter.outputs.windows }}
+      windows-release: ${{ steps.filter.outputs.windows-release }}
+    steps:
+      - id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**/*.rs'
+            windows: []
+            windows-release:
+              - 'Cargo.toml'
+      - id: matrix
+        run: echo 'json=["ubuntu-24.04", "macos-14"]'
+  lint:
+    needs: [detect-changes, fmt]
+  test:
+    needs: [detect-changes, fmt, lint]
+    steps:
+      - name: Build Windows release binaries
+        if: matrix.os == 'windows-2022'
+        run: cargo build --release
+      - name: Native ORT smoke (Windows; release profile)
+        if: matrix.os == 'windows-2022'
+        run: smoke
+  conclusion:
+    steps:
+      - name: Aggregate
+        run: |
+          case "$result" in
+            success|skipped) ;;
+          esac
+"#;
+    let platform_sensitive_paths = vec![
+        ("crates/new_windows.rs".to_string(), "windows", "windows"),
+        ("crates/new_macos.rs".to_string(), "macos", "macos"),
+        ("scripts/new-windows.ps1".to_string(), "windows", "windows"),
+    ];
+    let release_profile_sensitive_paths = vec!["crates/release_only.rs".to_string()];
+    let violations = ci_routing_contract_violations(
+        workflow,
+        &platform_sensitive_paths,
+        &release_profile_sensitive_paths,
+    );
+    for expected in [
+        "platform-sensitive windows",
+        "platform-sensitive macos",
+        "bootstrap the CI contract",
+        "expected-vs-actual",
+        "unnecessarily serialized",
+        "condition omits CI scheduling trigger",
+        "release-profile-sensitive",
+        "release-sensitive",
+        "wenlan-mcp artifact",
+        "does not also schedule",
+        "debug runtime artifacts",
+        "compile every wenlan-mcp target",
+        "root installer",
+    ] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
 // ── Teeth #1: repo pointer/path resolver ──
 
 const REPO_TOP_DIRS: &[&str] = &["crates/", "docs/", "app/", "scripts/", ".github/"];

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -265,32 +265,41 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     violations
 }
 
-fn nextest_core_serialization_violations(config: &str) -> Vec<String> {
+fn nextest_whole_core_serialization_violations(config: &str) -> Vec<String> {
     let parsed: toml::Value = toml::from_str(config).expect("parse nextest.toml");
     let mut violations = Vec::new();
-    let max_threads = parsed["test-groups"]["wenlan-core"]["max-threads"].as_integer();
-    if max_threads != Some(1) {
-        violations.push(format!(
-            "wenlan-core nextest group max-threads={max_threads:?}, expected 1"
-        ));
-    }
-
-    let has_override = parsed["profile"]["default"]["overrides"]
-        .as_array()
-        .is_some_and(|overrides| {
-            overrides.iter().any(|override_| {
-                override_["filter"].as_str() == Some("package(wenlan-core)")
-                    && override_["test-group"].as_str() == Some("wenlan-core")
-            })
-        });
-    if !has_override {
-        violations.push(
-            "nextest default profile does not assign package(wenlan-core) to its serialized group"
-                .into(),
-        );
+    let Some(overrides) = parsed["profile"]["default"]["overrides"].as_array() else {
+        return violations;
+    };
+    for override_ in overrides {
+        if override_["filter"].as_str() != Some("package(wenlan-core)") {
+            continue;
+        }
+        let Some(group) = override_["test-group"].as_str() else {
+            continue;
+        };
+        let max_threads = parsed["test-groups"][group]["max-threads"].as_integer();
+        if max_threads == Some(1) {
+            violations.push(format!(
+                "nextest serializes the entire wenlan-core package through group {group:?}"
+            ));
+        }
     }
 
     violations
+}
+
+fn text_embedding_initializer_sites(path: &str, source: &str) -> Vec<String> {
+    source
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.starts_with("//") || !trimmed.contains("TextEmbedding::try_new(") {
+                return None;
+            }
+            Some(format!("{path}:{trimmed}"))
+        })
+        .collect()
 }
 
 #[test]
@@ -382,36 +391,80 @@ jobs:
 }
 
 #[test]
-fn nextest_keeps_core_isolated_while_other_macos_tests_parallelize() {
+fn nextest_does_not_serialize_the_entire_core_package() {
     let config = std::fs::read_to_string(repo_root().join(".config/nextest.toml"))
         .expect("read nextest.toml");
-    let violations = nextest_core_serialization_violations(&config);
+    let violations = nextest_whole_core_serialization_violations(&config);
     assert!(
         violations.is_empty(),
-        "nextest core serialization contract drift:\n{}",
+        "nextest whole-package serialization contract drift:\n{}",
         violations.join("\n")
     );
 }
 
 #[test]
-fn nextest_core_serialization_contract_rejects_missing_group() {
+fn nextest_parallelism_contract_rejects_whole_core_serialization() {
     let config = r#"
 [test-groups]
-wenlan-core = { max-threads = 3 }
+wenlan-core = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'package(other)'
+filter = 'package(wenlan-core)'
 test-group = 'wenlan-core'
 "#;
-    let violations = nextest_core_serialization_violations(config);
-    for expected in ["max-threads", "package(wenlan-core)"] {
-        assert!(
-            violations
-                .iter()
-                .any(|violation| violation.contains(expected)),
-            "fixture must exercise {expected:?}: {violations:?}"
-        );
+    let violations = nextest_whole_core_serialization_violations(config);
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("entire wenlan-core package")),
+        "fixture must exercise whole-package serialization: {violations:?}"
+    );
+}
+
+#[test]
+fn all_text_embedding_initializers_use_the_cross_process_lock() {
+    let root = repo_root();
+    let mut sites = Vec::new();
+    for path in git_ls_files(&root, "*.rs").into_iter().filter(|path| {
+        path.starts_with("crates/wenlan-core/src/")
+            && path != "crates/wenlan-core/src/drift_guard.rs"
+    }) {
+        let source = std::fs::read_to_string(root.join(&path)).expect("read Rust source");
+        sites.extend(text_embedding_initializer_sites(&path, &source));
     }
+    assert_eq!(
+        sites,
+        ["crates/wenlan-core/src/db.rs:TextEmbedding::try_new(options)"],
+        "FastEmbed text initialization bypasses db::init_text_embedding: {sites:?}"
+    );
+}
+
+#[test]
+fn text_embedding_initializer_guard_detects_a_direct_call() {
+    let sites = text_embedding_initializer_sites(
+        "crates/wenlan-core/src/new_model.rs",
+        "let model = fastembed::TextEmbedding::try_new(options)?;",
+    );
+    assert_eq!(sites.len(), 1, "positive control must detect direct init");
+}
+
+#[test]
+fn clippy_syntax_guard_forbids_direct_text_embedding_initializers() {
+    let config =
+        std::fs::read_to_string(repo_root().join("clippy.toml")).expect("read clippy.toml");
+    let parsed: toml::Value = toml::from_str(&config).expect("parse clippy.toml");
+    let guarded = parsed["disallowed-methods"]
+        .as_array()
+        .is_some_and(|methods| {
+            methods.iter().any(|method| {
+                method["path"].as_str() == Some("fastembed::TextEmbedding::try_new")
+                    && method["replacement"].as_str() == Some("crate::db::init_text_embedding")
+            })
+        });
+    assert!(
+        guarded,
+        "clippy.toml must syntax-check every TextEmbedding initializer"
+    );
 }
 
 #[test]
@@ -1292,6 +1345,12 @@ fn ci_routing_contract_violations(
             "coverage workflow cannot bootstrap its FastEmbed cache contract through rust".into(),
         );
     }
+    if !rust_paths.contains("clippy.toml") {
+        violations.push(
+            "clippy configuration cannot bootstrap its syntax-aware FastEmbed guard through rust"
+                .into(),
+        );
+    }
     for (path, platform, filter) in platform_sensitive_paths {
         let routed = detect_change_filter_paths(&ci, filter);
         if !filter_routes_path(&routed, path) {
@@ -1323,7 +1382,7 @@ fn ci_routing_contract_violations(
     ] {
         if !paths.contains(".config/nextest.toml") {
             violations.push(format!(
-                "{filter} routing omits nextest config that guards macOS core-test isolation"
+                "{filter} routing omits nextest config that guards core-test parallelism"
             ));
         }
     }
@@ -1461,6 +1520,24 @@ fn ci_routing_contract_violations(
             ));
         }
     }
+    for job in ["test", "windows-release-proof"] {
+        if ci["jobs"][job]["timeout-minutes"].as_u64() != Some(30) {
+            violations.push(format!("{job} does not enforce the 30-minute CI budget"));
+        }
+    }
+    let windows_release_condition = ci["jobs"]["windows-release-proof"]["if"]
+        .as_str()
+        .unwrap_or_default();
+    if job_needs(&ci, "windows-release-proof") != ["detect-changes"]
+        || !windows_release_condition
+            .contains("needs.detect-changes.outputs.windows-release == 'true'")
+        || !windows_release_condition.contains("github.event_name != 'pull_request'")
+    {
+        violations.push(
+            "Windows release proof is not an independent differential job after detect-changes"
+                .into(),
+        );
+    }
     for profile in ["DEV", "TEST"] {
         let key = format!("CARGO_PROFILE_{profile}_DEBUG");
         let actual = ci["jobs"]["test"]["env"][&key].as_str();
@@ -1559,10 +1636,20 @@ fn ci_routing_contract_violations(
                 .into(),
         );
     }
+    if !job_needs(&ci, "conclusion")
+        .iter()
+        .any(|job| job == "windows-release-proof")
+    {
+        violations.push("conclusion.needs omits the Windows release proof".into());
+    }
     for (job, expected) in [
         ("fmt", "\"$run_rust\""),
         ("lint", "\"$run_rust\""),
         ("test", "\"$run_rust\""),
+        (
+            "windows-release-proof",
+            "needs.detect-changes.outputs.windows-release",
+        ),
         ("docs", "needs.detect-changes.outputs.docs"),
         ("plugin", "needs.detect-changes.outputs.plugin"),
         ("npm", "needs.detect-changes.outputs.npm"),
@@ -1583,24 +1670,76 @@ fn ci_routing_contract_violations(
         "Build Windows release binaries",
         "Native ORT smoke (Windows; release profile)",
     ] {
-        let condition = job_step(&ci, "test", step_name)
-            .and_then(|step| step["if"].as_str())
-            .unwrap_or_default();
-        if !condition.contains("needs.detect-changes.outputs.windows-release == 'true'")
-            || !condition.contains("github.event_name != 'pull_request'")
-        {
+        if job_step(&ci, "test", step_name).is_some() {
             violations.push(format!(
-                "{step_name} is not gated to release-sensitive PRs plus non-PR backstops"
+                "{step_name} still serializes release proof inside the Windows test matrix"
             ));
         }
     }
-    let windows_release_build = job_step(&ci, "test", "Build Windows release binaries")
-        .and_then(|step| step["run"].as_str())
-        .unwrap_or_default();
-    if !windows_release_build.contains("-p wenlan-mcp") {
-        violations.push(
-            "Windows release proof omits the wenlan-mcp artifact built by release.yml".into(),
-        );
+    let windows_release_build = job_step(
+        &ci,
+        "windows-release-proof",
+        "Build Windows release binaries",
+    )
+    .and_then(|step| step["run"].as_str())
+    .unwrap_or_default();
+    if !windows_release_build.contains("--release")
+        || !windows_release_build.contains("-p wenlan")
+        || !windows_release_build.contains("-p wenlan-server")
+        || !windows_release_build.contains("-p wenlan-mcp")
+        || !windows_release_build.contains("--bin model_probe")
+    {
+        violations.push("Windows release proof omits a release artifact or model probe".into());
+    }
+    let windows_release_smoke = job_step(
+        &ci,
+        "windows-release-proof",
+        "Native ORT smoke (Windows; release profile)",
+    )
+    .and_then(|step| step["run"].as_str())
+    .unwrap_or_default();
+    if !windows_release_smoke.contains("scripts/stage-onnxruntime-windows.ps1")
+        || !windows_release_smoke.contains("scripts/smoke-windows.ps1")
+        || !windows_release_smoke.contains(r"target\release")
+    {
+        violations.push("Windows release proof omits the native ORT smoke".into());
+    }
+    let release_cache = job_step(
+        &ci,
+        "windows-release-proof",
+        "Restore Rust cache (read-only)",
+    );
+    if release_cache
+        .and_then(|step| step["uses"].as_str())
+        .is_none_or(|uses| !uses.contains("Swatinem/rust-cache"))
+        || release_cache.and_then(|step| step["with"]["shared-key"].as_str()) != Some("test")
+        || release_cache.and_then(|step| step["with"]["cache-all-crates"].as_str()) != Some("true")
+        || release_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
+    {
+        violations
+            .push("Windows release proof does not restore the shared test cache read-only".into());
+    }
+    for (job, step_name) in [
+        ("test", "Configure rust-lld linker (Windows tests)"),
+        (
+            "windows-release-proof",
+            "Configure rust-lld linker (Windows release)",
+        ),
+    ] {
+        let linker = job_step(&ci, job, step_name);
+        let condition = linker
+            .and_then(|step| step["if"].as_str())
+            .unwrap_or_default();
+        let run = linker
+            .and_then(|step| step["run"].as_str())
+            .unwrap_or_default();
+        if (job == "test" && !condition.contains("matrix.os == 'windows-2022'"))
+            || !run.contains("rust-lld.exe")
+            || !run.contains("RUSTFLAGS=")
+            || !run.contains("$env:GITHUB_ENV")
+        {
+            violations.push(format!("{job} does not configure rust-lld for Windows"));
+        }
     }
 
     let windows_lint_condition = job_step(&ci, "test", "Page lint scale gate (Windows functional)")
@@ -1668,6 +1807,40 @@ fn ci_routing_contract_violations(
     {
         violations.push("macOS nextest workspace proof is unnecessarily single-threaded".into());
     }
+    let shared_integration = job_step(
+        &ci,
+        "test",
+        "Integration tests wenlan-cli + wenlan-server (shared integration only)",
+    );
+    let shared_integration_condition = shared_integration
+        .and_then(|step| step["if"].as_str())
+        .unwrap_or_default();
+    let shared_integration_run = shared_integration
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if !shared_integration_condition.contains("matrix.os != 'windows-2022'")
+        || !shared_integration_run.contains("-E 'kind(test)'")
+    {
+        violations
+            .push("Linux/macOS integration step duplicates wenlan CLI/server lib tests".into());
+    }
+    let windows_integration = job_step(
+        &ci,
+        "test",
+        "Integration tests wenlan-cli + wenlan-server (Windows)",
+    );
+    if windows_integration
+        .and_then(|step| step["if"].as_str())
+        .is_none_or(|condition| !condition.contains("matrix.os == 'windows-2022'"))
+        || windows_integration
+            .and_then(|step| step["run"].as_str())
+            .is_none_or(|run| {
+                !run.contains("cargo nextest run -p wenlan -p wenlan-server")
+                    || run.contains("kind(test)")
+            })
+    {
+        violations.push("Windows does not retain its full CLI/server platform contract".into());
+    }
 
     let Some(test_steps) = ci["jobs"]["test"]["steps"].as_sequence() else {
         violations.push("test job has no steps for fail-fast ordering".into());
@@ -1678,7 +1851,7 @@ fn ci_routing_contract_violations(
             .iter()
             .position(|step| step["name"].as_str() == Some(name))
     };
-    let integration_index = step_index("Integration tests wenlan-cli + wenlan-server");
+    let integration_index = step_index("Integration tests wenlan-cli + wenlan-server (Windows)");
     match (
         step_index("Validate Windows smoke harness"),
         integration_index,
@@ -1689,16 +1862,12 @@ fn ci_routing_contract_violations(
     }
     match (
         integration_index,
-        step_index("Build Windows release binaries"),
         step_index("Compile platform-owned MCP runtime"),
         step_index("Build Windows contract binaries"),
     ) {
-        (Some(integration), Some(release), Some(mcp), Some(debug))
-            if integration < release && release < mcp && release < debug => {}
-        _ => violations.push(
-            "Windows steps do not prioritize integration then release proof before later compilation"
-                .into(),
-        ),
+        (Some(integration), Some(mcp), Some(debug)) if integration < mcp && mcp < debug => {}
+        _ => violations
+            .push("Windows steps do not fail fast from integration into later compilation".into()),
     }
 
     violations
@@ -1788,17 +1957,25 @@ jobs:
         "proven Linux lane",
         "condition omits CI scheduling trigger",
         "coverage workflow",
+        "clippy configuration",
         "nextest config",
         "release-profile-sensitive",
         "release-sensitive",
-        "wenlan-mcp artifact",
+        "30-minute CI budget",
+        "independent differential job",
+        "release artifact or model probe",
+        "native ORT smoke",
+        "shared test cache read-only",
+        "rust-lld",
         "does not also schedule",
         "debug runtime artifacts",
         "differentially compile every wenlan-mcp target",
         "mcp-platform routing",
         "single-threaded",
+        "duplicates wenlan CLI/server lib tests",
+        "full CLI/server platform contract",
         "fail fast before integration",
-        "release proof before later compilation",
+        "fail fast from integration",
         "root installer",
     ] {
         assert!(

--- a/crates/wenlan-core/src/eval/shared.rs
+++ b/crates/wenlan-core/src/eval/shared.rs
@@ -144,12 +144,12 @@ static EVAL_EMBEDDER: LazyLock<Arc<std::sync::Mutex<fastembed::TextEmbedding>>> 
         // otherwise every git worktree starts from an empty cwd cache and re-downloads the
         // model. Mirrors the db.rs production/test embedder via `resolve_fastembed_cache_dir`;
         // the `db_path` here is a sentinel, so only the env + default tiers apply.
-        if let Some(cache) =
-            crate::db::resolve_fastembed_cache_dir(std::path::Path::new(".nonexistent"))
-        {
-            opts = opts.with_cache_dir(cache);
+        let cache_dir =
+            crate::db::resolve_fastembed_cache_dir(std::path::Path::new(".nonexistent"));
+        if let Some(cache) = &cache_dir {
+            opts = opts.with_cache_dir(cache.clone());
         }
-        let embedder = fastembed::TextEmbedding::try_new(opts)
+        let embedder = crate::db::init_text_embedding(opts)
             .expect("failed to load BGE-Base-EN-v1.5-Q ONNX model");
         let arc = Arc::new(std::sync::Mutex::new(embedder));
         // Leak one strong ref so the Arc never reaches zero and the destructor never runs.

--- a/crates/wenlan-core/src/refinery/mod.rs
+++ b/crates/wenlan-core/src/refinery/mod.rs
@@ -1164,7 +1164,7 @@ async fn run_periodic_steep_with_api_scope(
     // the SAME pass but is NEVER gated by `page_map_auto_suggest` — only this
     // background phase is. Bounded to 5 pages per pass. Always Silent (no
     // user-facing nudge; suggestions surface in the map UI, not as a toast).
-    if page_map_auto_suggest && trigger.runs_phase(Phase::PageMaps) {
+    if page_map_auto_suggest && runs_phase(Phase::PageMaps) {
         let phase = run_phase(Phase::PageMaps, || async {
             let improved = crate::page_map_improve::run_proactive_page_maps(db_ref, 5).await?;
             let (nudge, headline) = classify_backfill(improved);
@@ -2608,7 +2608,10 @@ mod tests {
 
     #[tokio::test]
     async fn background_steep_phase_slice_runs_only_the_requested_phase() {
+        let _env_serial = COMPILE_ROUTING_ENV_LOCK.lock().await;
         let (db, _dir) = test_db().await;
+        let data_dir = tempfile::tempdir().unwrap();
+        let data_dir_var = data_dir.path().to_string_lossy().to_string();
         db.upsert_documents(vec![make_memory(
             "phase_slice_smoke",
             "A background turn must return after one refinery phase.",
@@ -2618,22 +2621,32 @@ mod tests {
         .await
         .unwrap();
 
-        let result = run_periodic_steep_phase_with_api(
-            &db,
-            None,
-            None,
-            None,
-            None,
-            &PromptRegistry::default(),
-            &crate::tuning::RefineryConfig::default(),
-            &crate::tuning::ConfidenceConfig::default(),
-            &crate::tuning::DistillationConfig::default(),
-            None,
-            TriggerKind::Backstop,
-            Phase::Decay,
-        )
-        .await
-        .unwrap();
+        let result =
+            temp_env::async_with_vars([("WENLAN_DATA_DIR", Some(data_dir_var.as_str()))], async {
+                let config = crate::config::Config {
+                    page_map_auto_suggest: true,
+                    ..crate::config::Config::default()
+                };
+                crate::config::save_config(&config).unwrap();
+
+                run_periodic_steep_phase_with_api(
+                    &db,
+                    None,
+                    None,
+                    None,
+                    None,
+                    &PromptRegistry::default(),
+                    &crate::tuning::RefineryConfig::default(),
+                    &crate::tuning::ConfidenceConfig::default(),
+                    &crate::tuning::DistillationConfig::default(),
+                    None,
+                    TriggerKind::Backstop,
+                    Phase::Decay,
+                )
+                .await
+            })
+            .await
+            .unwrap();
 
         let phases: Vec<&str> = result
             .result


### PR DESCRIPTION
## What changed

- route PR validation by the paths and platform owners actually affected
- keep Ubuntu as the canonical shared-logic lane and add macOS/Windows only when their contracts are touched
- run Windows page-lint and release-profile proof only for lint- or release-sensitive PR diffs
- keep every non-PR run as a full three-platform backstop
- run `fmt`, `lint`, and `test` in parallel after change detection, with the test matrix retaining `fail-fast: true`
- make the required `conclusion` job compare expected jobs with actual results instead of accepting every skipped job
- add executable drift guards for platform markers, native source extensions, release-sensitive routing, job dependencies, and aggregate semantics

## Why

The previous inclusive Windows allowlist could silently miss platform-sensitive Rust files, while ordinary Windows PR jobs serialized page lint, integration tests, and release builds. A cold cache therefore amplified wall-clock time, and a skipped job could still be treated as success by the aggregate.

This change makes routing fail closed: unknown/shared native platform surfaces schedule their platform owners, and CI contract drift is tested in the same Rust suite that the workflow must bootstrap.

## Impact

Ordinary PRs avoid unrelated platform and release work. Windows-relevant PRs still run debug CLI/server integration and Task Scheduler coverage. Native dependency, Cargo/build, packaging, and release-sensitive changes retain the Windows release build and ORT smoke. Main and other non-PR runs retain the full platform backstop.

Cache warmth affects speed only; correctness does not depend on a cache hit.

## Validation

- `cargo test -p wenlan-core --lib drift_guard:: -- --nocapture` — 23 passed
- `cargo fmt --check --all`
- `cargo clippy -p wenlan-core --lib -- -D warnings`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- independent merit review: no blocker or important finding

This PR is intentionally draft while hosted Linux/macOS/Windows Actions provide live routing, cold-cache, and wall-clock evidence.