### PR TITLE
fix: bound daemon logs and preserve bootstrap errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "file-rotate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
+dependencies = [
+ "chrono",
+ "flate2",
 ]
 
 [[package]]
@@ -5155,6 +5179,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-throttle"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c46c3508c6a909a28ff356171c282cdcc56b71a6f8f95fab791883eff680bc6"
+dependencies = [
+ "ahash",
+ "dashmap",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5730,6 +5767,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 6.0.0",
+ "file-rotate",
  "fs2",
  "futures",
  "libsql",
@@ -5746,6 +5784,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+ "tracing-throttle",
  "uuid",
  "wenlan-core",
  "wenlan-types",

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -178,9 +178,10 @@ fn origin_data_root() -> PathBuf {
 
 /// Builds a launchd plist that mirrors `service-manager`'s default output for
 /// `OnFailure` restart + user-level + autostart, with the extra keys the old
-/// embedded `com.wenlan.server.plist` template carried: `StandardOutPath`,
-/// `StandardErrorPath`, `EnvironmentVariables.RUST_LOG`, and the canonical
-/// `WENLAN_DATA_DIR` ownership marker consumed by the desktop app.
+/// embedded `com.wenlan.server.plist` template carried: stdout/stderr routing,
+/// `EnvironmentVariables.RUST_LOG`, and the canonical `WENLAN_DATA_DIR`
+/// ownership marker consumed by the desktop app. The daemon owns bounded file
+/// logging, so launchd routes its raw streams to `/dev/null`.
 ///
 /// `LaunchdInstallConfig` in service-manager 0.11 only exposes `keep_alive`;
 /// stdout/stderr paths must come through `ServiceInstallCtx.contents` as a
@@ -298,25 +299,18 @@ pub fn install() -> Result<()> {
     // exported in the user environment).
     let environment = Some(vec![("RUST_LOG".to_string(), "info".to_string())]);
 
-    // macOS: hand-roll the plist so we can keep `StandardOutPath` and
-    // `StandardErrorPath` parity with the legacy template. service-manager 0.11
-    // has no struct field for those keys, so the only honest knob is
+    // macOS: hand-roll the plist so launchd does not append an unbounded
+    // duplicate of the daemon-owned rotating log. service-manager 0.11 has no
+    // struct field for these keys, so the only honest knob is
     // `ServiceInstallCtx.contents`.
     let contents = {
         #[cfg(target_os = "macos")]
         {
             let data_root = origin_data_root();
-            let log_dir = data_root.join("logs");
-            // Best-effort: launchd creates parent dirs for log files in many
-            // builds, but creating ahead of time guarantees the daemon never
-            // racing the dir into existence on first start.
-            let _ = std::fs::create_dir_all(&log_dir);
-            let stdout_path = log_dir.join("wenlan-server.stdout.log");
-            let stderr_path = log_dir.join("wenlan-server.stderr.log");
             Some(build_launchd_plist(
                 &program,
-                &stdout_path,
-                &stderr_path,
+                Path::new("/dev/null"),
+                Path::new("/dev/null"),
                 "info",
                 &data_root,
             ))

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -300,6 +300,10 @@ fn print_daemon_log_paths() {
             .join("logs/wenlan-server.bootstrap.log")
             .display()
     );
+    println!(
+        "Daemon fallback log: {}",
+        fallback_root.join("logs/wenlan-server.log").display()
+    );
 }
 
 pub async fn print_runtime_status() -> anyhow::Result<()> {

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -245,6 +245,8 @@ pub async fn run_doctor() -> anyhow::Result<()> {
     println!("Wenlan doctor");
     println!();
     print_daemon_health().await;
+    #[cfg(target_os = "macos")]
+    print_daemon_log_paths();
     print_key_status();
     print_model_status();
     print_reranker_status().await;
@@ -274,6 +276,30 @@ pub async fn run_doctor() -> anyhow::Result<()> {
     print_space_resolution(&cwd);
 
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn print_daemon_log_paths() {
+    let data_root = std::env::var_os("WENLAN_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join("wenlan")
+        });
+    let fallback_root = dirs::home_dir()
+        .map(|home| home.join("Library/Logs/com.wenlan.server-fallback"))
+        .unwrap_or_else(|| std::env::temp_dir().join("wenlan-server-fallback"));
+    println!(
+        "Daemon log: {}",
+        data_root.join("logs/wenlan-server.log").display()
+    );
+    println!(
+        "Bootstrap fallback log: {}",
+        fallback_root
+            .join("logs/wenlan-server.bootstrap.log")
+            .display()
+    );
 }
 
 pub async fn print_runtime_status() -> anyhow::Result<()> {

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -295,6 +295,10 @@ fn print_daemon_log_paths() {
         data_root.join("logs/wenlan-server.log").display()
     );
     println!(
+        "Bootstrap log: {}",
+        data_root.join("logs/wenlan-server.bootstrap.log").display()
+    );
+    println!(
         "Bootstrap fallback log: {}",
         fallback_root
             .join("logs/wenlan-server.bootstrap.log")

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -911,23 +911,23 @@ fn setup_background_status_roundtrip_isolated() {
     assert!(plist.contains("<string>com.wenlan.server</string>"));
     assert!(plist.contains("wenlan-server"));
     assert!(!plist.contains("origin</string>"));
-    // Launchd parity with the legacy embedded plist: stdout/stderr go to the
-    // data-root `logs/` dir and `RUST_LOG=info` survives across reboots.
+    // The daemon owns bounded file logging. launchd must not append an
+    // unbounded second copy of stdout/stderr across every restart.
     assert!(
         plist.contains("<key>StandardOutPath</key>"),
         "missing StandardOutPath in plist: {plist}"
     );
     assert!(
-        plist.contains("wenlan-server.stdout.log"),
-        "stdout log path not threaded into plist: {plist}"
+        plist.contains("<string>/dev/null</string>"),
+        "launchd stdout/stderr must be discarded after daemon-owned logging: {plist}"
     );
     assert!(
         plist.contains("<key>StandardErrorPath</key>"),
         "missing StandardErrorPath in plist: {plist}"
     );
     assert!(
-        plist.contains("wenlan-server.stderr.log"),
-        "stderr log path not threaded into plist: {plist}"
+        !plist.contains("wenlan-server.stdout.log") && !plist.contains("wenlan-server.stderr.log"),
+        "unbounded legacy launchd log paths remain in plist: {plist}"
     );
     assert!(
         plist.contains("<key>EnvironmentVariables</key>"),

--- a/crates/wenlan-server/Cargo.toml
+++ b/crates/wenlan-server/Cargo.toml
@@ -37,6 +37,8 @@ futures = { workspace = true }
 sysinfo = { workspace = true }
 fs2 = { workspace = true }
 sha2 = "0.10"
+file-rotate = "0.8"
+tracing-throttle = "0.4"
 # Pulls openssl-sys with the vendored feature (declared at workspace level).
 # wenlan-server doesn't call openssl_sys directly, but the dep needs to land
 # in at least one workspace-member's tree for cargo feature unification to

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -119,7 +119,9 @@ fn resolve_startup_port(configured_port: u16, startup_repair_claimed: bool) -> a
     Ok(configured_port)
 }
 
+#[cfg(target_os = "macos")]
 const SERVER_LOG_MAX_BYTES: usize = 10 * 1024 * 1024;
+#[cfg(target_os = "macos")]
 const SERVER_LOG_BACKUPS: usize = 5;
 #[cfg(any(target_os = "macos", test))]
 const BOOTSTRAP_LOG_MAX_BYTES: usize = 256 * 1024;
@@ -136,6 +138,7 @@ fn resolve_wenlan_root() -> std::path::PathBuf {
         })
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn new_server_log_writer(
     wenlan_root: &std::path::Path,
     max_bytes: usize,
@@ -166,6 +169,9 @@ fn new_bootstrap_log_writer(
 }
 
 fn report_bootstrap_error(wenlan_root: &std::path::Path, message: &str) {
+    #[cfg(not(target_os = "macos"))]
+    let _ = wenlan_root;
+
     eprintln!("{message}");
     tracing::error!("{message}");
 
@@ -196,6 +202,9 @@ fn new_server_log_rate_limit() -> tracing_throttle::TracingRateLimitLayer {
 
 fn init_logging(wenlan_root: &std::path::Path) -> anyhow::Result<()> {
     use tracing_subscriber::prelude::*;
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = wenlan_root;
 
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| "info,wenlan_core=info,wenlan_server=info".into());

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -123,9 +123,9 @@ fn resolve_startup_port(configured_port: u16, startup_repair_claimed: bool) -> a
 const SERVER_LOG_MAX_BYTES: usize = 10 * 1024 * 1024;
 #[cfg(target_os = "macos")]
 const SERVER_LOG_BACKUPS: usize = 5;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 const BOOTSTRAP_LOG_MAX_BYTES: usize = 256 * 1024;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 const BOOTSTRAP_LOG_BACKUPS: usize = 1;
 
 fn resolve_wenlan_root() -> std::path::PathBuf {

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -123,9 +123,9 @@ fn resolve_startup_port(configured_port: u16, startup_repair_claimed: bool) -> a
 const SERVER_LOG_MAX_BYTES: usize = 10 * 1024 * 1024;
 #[cfg(target_os = "macos")]
 const SERVER_LOG_BACKUPS: usize = 5;
-#[cfg(any(target_os = "macos", test))]
+#[cfg(target_os = "macos")]
 const BOOTSTRAP_LOG_MAX_BYTES: usize = 256 * 1024;
-#[cfg(any(target_os = "macos", test))]
+#[cfg(target_os = "macos")]
 const BOOTSTRAP_LOG_BACKUPS: usize = 1;
 
 fn resolve_wenlan_root() -> std::path::PathBuf {

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -139,18 +139,36 @@ fn resolve_wenlan_root() -> std::path::PathBuf {
 }
 
 #[cfg(any(target_os = "macos", test))]
+fn preflight_rotating_log_path(path: &std::path::Path) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "log path has no parent")
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::other("log path is not a regular file"));
+    }
+    Ok(())
+}
+
+#[cfg(any(target_os = "macos", test))]
 fn new_server_log_writer(
     wenlan_root: &std::path::Path,
     max_bytes: usize,
     backups: usize,
-) -> file_rotate::FileRotate<file_rotate::suffix::AppendCount> {
-    file_rotate::FileRotate::new(
-        wenlan_root.join("logs/wenlan-server.log"),
+) -> std::io::Result<file_rotate::FileRotate<file_rotate::suffix::AppendCount>> {
+    let path = wenlan_root.join("logs/wenlan-server.log");
+    preflight_rotating_log_path(&path)?;
+    Ok(file_rotate::FileRotate::new(
+        path,
         file_rotate::suffix::AppendCount::new(backups),
         file_rotate::ContentLimit::Bytes(max_bytes),
         file_rotate::compression::Compression::None,
         None,
-    )
+    ))
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -158,14 +176,48 @@ fn new_bootstrap_log_writer(
     wenlan_root: &std::path::Path,
     max_bytes: usize,
     backups: usize,
-) -> file_rotate::FileRotate<file_rotate::suffix::AppendCount> {
-    file_rotate::FileRotate::new(
-        wenlan_root.join("logs/wenlan-server.bootstrap.log"),
+) -> std::io::Result<file_rotate::FileRotate<file_rotate::suffix::AppendCount>> {
+    let path = wenlan_root.join("logs/wenlan-server.bootstrap.log");
+    preflight_rotating_log_path(&path)?;
+    Ok(file_rotate::FileRotate::new(
+        path,
         file_rotate::suffix::AppendCount::new(backups),
         file_rotate::ContentLimit::Bytes(max_bytes),
         file_rotate::compression::Compression::None,
         None,
-    )
+    ))
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn write_bootstrap_message(
+    wenlan_root: &std::path::Path,
+    fallback_root: &std::path::Path,
+    message: &str,
+) -> std::io::Result<std::path::PathBuf> {
+    use std::io::Write as _;
+
+    let (mut writer, path) =
+        match new_bootstrap_log_writer(wenlan_root, BOOTSTRAP_LOG_MAX_BYTES, BOOTSTRAP_LOG_BACKUPS)
+        {
+            Ok(writer) => (writer, wenlan_root.join("logs/wenlan-server.bootstrap.log")),
+            Err(primary_error) => {
+                eprintln!(
+                    "Primary bootstrap log unavailable at {}: {primary_error}",
+                    wenlan_root.display()
+                );
+                (
+                    new_bootstrap_log_writer(
+                        fallback_root,
+                        BOOTSTRAP_LOG_MAX_BYTES,
+                        BOOTSTRAP_LOG_BACKUPS,
+                    )?,
+                    fallback_root.join("logs/wenlan-server.bootstrap.log"),
+                )
+            }
+        };
+    writeln!(writer, "{message}")?;
+    writer.flush()?;
+    Ok(path)
 }
 
 fn report_bootstrap_error(wenlan_root: &std::path::Path, message: &str) {
@@ -177,11 +229,15 @@ fn report_bootstrap_error(wenlan_root: &std::path::Path, message: &str) {
 
     #[cfg(target_os = "macos")]
     if std::env::var_os("XPC_SERVICE_NAME").is_some() {
-        use std::io::Write as _;
-
-        let mut writer =
-            new_bootstrap_log_writer(wenlan_root, BOOTSTRAP_LOG_MAX_BYTES, BOOTSTRAP_LOG_BACKUPS);
-        if let Err(error) = writeln!(writer, "{message}") {
+        let fallback_root = fallback_log_root();
+        let write_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            write_bootstrap_message(wenlan_root, &fallback_root, message)
+        }));
+        if let Err(error) = write_result.unwrap_or_else(|_| {
+            Err(std::io::Error::other(
+                "bootstrap log writer panicked while reporting an error",
+            ))
+        }) {
             eprintln!("Failed to write bootstrap log: {error}");
         }
     }
@@ -200,6 +256,13 @@ fn new_server_log_rate_limit() -> tracing_throttle::TracingRateLimitLayer {
     tracing_throttle::TracingRateLimitLayer::new()
 }
 
+#[cfg(target_os = "macos")]
+fn fallback_log_root() -> std::path::PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join("Library/Logs/com.wenlan.server-fallback"))
+        .unwrap_or_else(|| std::env::temp_dir().join("wenlan-server-fallback"))
+}
+
 fn init_logging(wenlan_root: &std::path::Path) -> anyhow::Result<()> {
     use tracing_subscriber::prelude::*;
 
@@ -210,28 +273,52 @@ fn init_logging(wenlan_root: &std::path::Path) -> anyhow::Result<()> {
         .unwrap_or_else(|_| "info,wenlan_core=info,wenlan_server=info".into());
 
     #[cfg(target_os = "macos")]
-    if std::env::var_os("XPC_SERVICE_NAME").is_some() {
-        let writer = std::sync::Mutex::new(new_server_log_writer(
+    {
+        let writer = match new_server_log_writer(
             wenlan_root,
             SERVER_LOG_MAX_BYTES,
             SERVER_LOG_BACKUPS,
-        ));
+        ) {
+            Ok(writer) => writer,
+            Err(primary_error) => {
+                let fallback_root = fallback_log_root();
+                eprintln!(
+                    "Primary daemon log unavailable at {}: {primary_error}; using {}",
+                    wenlan_root.display(),
+                    fallback_root.display()
+                );
+                new_server_log_writer(
+                    &fallback_root,
+                    SERVER_LOG_MAX_BYTES,
+                    SERVER_LOG_BACKUPS,
+                )
+                .map_err(|fallback_error| {
+                    anyhow::anyhow!(
+                        "initialize rotating file logging: primary={primary_error}; fallback={fallback_error}"
+                    )
+                })?
+            }
+        };
+        let writer = std::sync::Mutex::new(writer);
         let fmt = tracing_subscriber::fmt::layer()
             .with_writer(writer)
             .with_filter(new_server_log_rate_limit());
-        return tracing_subscriber::registry()
+        tracing_subscriber::registry()
             .with(filter)
             .with(fmt)
             .try_init()
-            .map_err(|error| anyhow::anyhow!("initialize rotating file logging: {error}"));
+            .map_err(|error| anyhow::anyhow!("initialize rotating file logging: {error}"))
     }
 
-    let fmt = tracing_subscriber::fmt::layer().with_filter(new_server_log_rate_limit());
-    tracing_subscriber::registry()
-        .with(filter)
-        .with(fmt)
-        .try_init()
-        .map_err(|error| anyhow::anyhow!("initialize console logging: {error}"))
+    #[cfg(not(target_os = "macos"))]
+    {
+        let fmt = tracing_subscriber::fmt::layer().with_filter(new_server_log_rate_limit());
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt)
+            .try_init()
+            .map_err(|error| anyhow::anyhow!("initialize console logging: {error}"))
+    }
 }
 
 fn startup_projection_writes_allowed(repair_recovery_pending: bool) -> bool {
@@ -415,7 +502,7 @@ mod bind_addr_tests {
         use std::io::Write as _;
 
         let root = tempfile::tempdir().unwrap();
-        let mut writer = new_server_log_writer(root.path(), 64, 2);
+        let mut writer = new_server_log_writer(root.path(), 64, 2).unwrap();
         for index in 0..20 {
             writeln!(writer, "bounded log line {index:02}").unwrap();
         }
@@ -449,7 +536,7 @@ mod bind_addr_tests {
         use std::io::Write as _;
 
         let root = tempfile::tempdir().unwrap();
-        let mut writer = new_bootstrap_log_writer(root.path(), 64, 1);
+        let mut writer = new_bootstrap_log_writer(root.path(), 64, 1).unwrap();
         for index in 0..20 {
             writeln!(writer, "bootstrap failure line {index:02}").unwrap();
         }
@@ -497,6 +584,35 @@ mod bind_addr_tests {
             metrics.events_suppressed() > 0,
             "an identical 100-event burst must be throttled"
         );
+    }
+
+    #[test]
+    fn rotating_log_construction_reports_an_unusable_directory_without_panicking() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("logs"), "not a directory").unwrap();
+
+        let result = std::panic::catch_unwind(|| new_server_log_writer(root.path(), 64, 1));
+
+        assert!(result.is_ok(), "logger construction must not panic");
+        assert!(
+            result.unwrap().is_err(),
+            "unusable log paths must fail loud"
+        );
+    }
+
+    #[test]
+    fn bootstrap_logging_falls_back_when_the_data_root_is_unwritable() {
+        let primary = tempfile::tempdir().unwrap();
+        let fallback = tempfile::tempdir().unwrap();
+        std::fs::write(primary.path().join("logs"), "not a directory").unwrap();
+
+        let path =
+            write_bootstrap_message(primary.path(), fallback.path(), "bootstrap sentinel").unwrap();
+
+        assert!(path.starts_with(fallback.path()));
+        assert!(std::fs::read_to_string(path)
+            .unwrap()
+            .contains("bootstrap sentinel"));
     }
 
     #[test]
@@ -972,8 +1088,11 @@ async fn run_daemon(startup_repair_claim: Option<StartupRepairClaim>) -> anyhow:
                     // = false treats exit-0 as success). For sidecar invocation
                     // by the app, exit 0 is the right answer.
                     if std::env::var_os("XPC_SERVICE_NAME").is_some() {
-                        eprintln!(
-                            "Existing healthy daemon on port {port} — exiting 75 (launchd retry)"
+                        report_bootstrap_error(
+                            &wenlan_root,
+                            &format!(
+                                "Existing healthy daemon on port {port} — exiting 75 (launchd retry)"
+                            ),
                         );
                         std::process::exit(75);
                     }

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -119,6 +119,112 @@ fn resolve_startup_port(configured_port: u16, startup_repair_claimed: bool) -> a
     Ok(configured_port)
 }
 
+const SERVER_LOG_MAX_BYTES: usize = 10 * 1024 * 1024;
+const SERVER_LOG_BACKUPS: usize = 5;
+#[cfg(any(target_os = "macos", test))]
+const BOOTSTRAP_LOG_MAX_BYTES: usize = 256 * 1024;
+#[cfg(any(target_os = "macos", test))]
+const BOOTSTRAP_LOG_BACKUPS: usize = 1;
+
+fn resolve_wenlan_root() -> std::path::PathBuf {
+    wenlan_core::env_compat::var_compat("WENLAN_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join("wenlan")
+        })
+}
+
+fn new_server_log_writer(
+    wenlan_root: &std::path::Path,
+    max_bytes: usize,
+    backups: usize,
+) -> file_rotate::FileRotate<file_rotate::suffix::AppendCount> {
+    file_rotate::FileRotate::new(
+        wenlan_root.join("logs/wenlan-server.log"),
+        file_rotate::suffix::AppendCount::new(backups),
+        file_rotate::ContentLimit::Bytes(max_bytes),
+        file_rotate::compression::Compression::None,
+        None,
+    )
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn new_bootstrap_log_writer(
+    wenlan_root: &std::path::Path,
+    max_bytes: usize,
+    backups: usize,
+) -> file_rotate::FileRotate<file_rotate::suffix::AppendCount> {
+    file_rotate::FileRotate::new(
+        wenlan_root.join("logs/wenlan-server.bootstrap.log"),
+        file_rotate::suffix::AppendCount::new(backups),
+        file_rotate::ContentLimit::Bytes(max_bytes),
+        file_rotate::compression::Compression::None,
+        None,
+    )
+}
+
+fn report_bootstrap_error(wenlan_root: &std::path::Path, message: &str) {
+    eprintln!("{message}");
+    tracing::error!("{message}");
+
+    #[cfg(target_os = "macos")]
+    if std::env::var_os("XPC_SERVICE_NAME").is_some() {
+        use std::io::Write as _;
+
+        let mut writer =
+            new_bootstrap_log_writer(wenlan_root, BOOTSTRAP_LOG_MAX_BYTES, BOOTSTRAP_LOG_BACKUPS);
+        if let Err(error) = writeln!(writer, "{message}") {
+            eprintln!("Failed to write bootstrap log: {error}");
+        }
+    }
+}
+
+fn install_bootstrap_panic_hook(wenlan_root: std::path::PathBuf) {
+    std::panic::set_hook(Box::new(move |panic| {
+        report_bootstrap_error(
+            &wenlan_root,
+            &format!("panic during daemon bootstrap: {panic}"),
+        );
+    }));
+}
+
+fn new_server_log_rate_limit() -> tracing_throttle::TracingRateLimitLayer {
+    tracing_throttle::TracingRateLimitLayer::new()
+}
+
+fn init_logging(wenlan_root: &std::path::Path) -> anyhow::Result<()> {
+    use tracing_subscriber::prelude::*;
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "info,wenlan_core=info,wenlan_server=info".into());
+
+    #[cfg(target_os = "macos")]
+    if std::env::var_os("XPC_SERVICE_NAME").is_some() {
+        let writer = std::sync::Mutex::new(new_server_log_writer(
+            wenlan_root,
+            SERVER_LOG_MAX_BYTES,
+            SERVER_LOG_BACKUPS,
+        ));
+        let fmt = tracing_subscriber::fmt::layer()
+            .with_writer(writer)
+            .with_filter(new_server_log_rate_limit());
+        return tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt)
+            .try_init()
+            .map_err(|error| anyhow::anyhow!("initialize rotating file logging: {error}"));
+    }
+
+    let fmt = tracing_subscriber::fmt::layer().with_filter(new_server_log_rate_limit());
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt)
+        .try_init()
+        .map_err(|error| anyhow::anyhow!("initialize console logging: {error}"))
+}
+
 fn startup_projection_writes_allowed(repair_recovery_pending: bool) -> bool {
     !repair_recovery_pending
 }
@@ -293,6 +399,95 @@ mod bind_addr_tests {
         let _guard = env_lock().lock().unwrap();
         std::env::remove_var("WENLAN_BIND_ADDR");
         assert_eq!(resolve_bind_addr(7878), "127.0.0.1:7878");
+    }
+
+    #[test]
+    fn server_log_writer_rotates_at_byte_cap_and_bounds_retention() {
+        use std::io::Write as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let mut writer = new_server_log_writer(root.path(), 64, 2);
+        for index in 0..20 {
+            writeln!(writer, "bounded log line {index:02}").unwrap();
+        }
+        drop(writer);
+
+        let log_dir = root.path().join("logs");
+        let mut logs = std::fs::read_dir(&log_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("wenlan-server.log"))
+            })
+            .collect::<Vec<_>>();
+        logs.sort();
+
+        assert_eq!(
+            logs.len(),
+            3,
+            "current log plus exactly two retained rotations: {logs:?}"
+        );
+        assert!(
+            logs.iter().all(|path| path.metadata().unwrap().len() <= 64),
+            "a rotated log exceeded the byte cap: {logs:?}"
+        );
+    }
+
+    #[test]
+    fn bootstrap_log_writer_rotates_at_byte_cap_and_bounds_retention() {
+        use std::io::Write as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let mut writer = new_bootstrap_log_writer(root.path(), 64, 1);
+        for index in 0..20 {
+            writeln!(writer, "bootstrap failure line {index:02}").unwrap();
+        }
+        drop(writer);
+
+        let log_dir = root.path().join("logs");
+        let mut logs = std::fs::read_dir(&log_dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("wenlan-server.bootstrap.log"))
+            })
+            .collect::<Vec<_>>();
+        logs.sort();
+
+        assert_eq!(logs.len(), 2, "current log plus one rotation: {logs:?}");
+        assert!(
+            logs.iter().all(|path| path.metadata().unwrap().len() <= 64),
+            "a bootstrap log exceeded the byte cap: {logs:?}"
+        );
+    }
+
+    #[test]
+    fn server_log_rate_limit_suppresses_duplicate_bursts() {
+        use tracing_subscriber::prelude::*;
+
+        let rate_limit = new_server_log_rate_limit();
+        let metrics_layer = rate_limit.clone();
+        let metrics = metrics_layer.metrics();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::sync::Mutex::new(Vec::<u8>::new()))
+                .with_filter(rate_limit),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            for _ in 0..100 {
+                tracing::warn!("identical repeatable failure");
+            }
+        });
+
+        assert!(
+            metrics.events_suppressed() > 0,
+            "an identical 100-event burst must be throttled"
+        );
     }
 
     #[test]
@@ -722,15 +917,7 @@ async fn run_daemon(startup_repair_claim: Option<StartupRepairClaim>) -> anyhow:
     // instead of taking the process down through the platform default path.
     let termination_signals = install_termination_signals()
         .map_err(|error| anyhow::anyhow!("install termination signal handlers: {error}"))?;
-    // Logging
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "info,wenlan_core=info,wenlan_server=info".into()),
-        )
-        .init();
-
-    tracing::info!("wenlan-server v{}", wenlan_core::version());
+    let wenlan_root = resolve_wenlan_root();
 
     // Port (clap `--port`/`WENLAN_PORT` → env var set by main(); read here)
     let configured_port: u16 = wenlan_core::env_compat::var_compat("WENLAN_PORT")
@@ -756,7 +943,7 @@ async fn run_daemon(startup_repair_claim: Option<StartupRepairClaim>) -> anyhow:
                 ));
             }
             // Check if existing daemon is healthy
-            tracing::warn!("Failed to bind {}: {}", addr, e);
+            eprintln!("Failed to bind {addr}: {e}");
             let url = format!("http://127.0.0.1:{}/api/health", port);
             // Bounded probe: a mute port-holder (accepts, never responds)
             // must not hang this process forever — under launchd KeepAlive
@@ -776,13 +963,12 @@ async fn run_daemon(startup_repair_claim: Option<StartupRepairClaim>) -> anyhow:
                     // = false treats exit-0 as success). For sidecar invocation
                     // by the app, exit 0 is the right answer.
                     if std::env::var_os("XPC_SERVICE_NAME").is_some() {
-                        tracing::info!(
-                            "Existing healthy daemon on port {} — exiting 75 (launchd retry)",
-                            port
+                        eprintln!(
+                            "Existing healthy daemon on port {port} — exiting 75 (launchd retry)"
                         );
                         std::process::exit(75);
                     }
-                    tracing::info!("Existing healthy daemon on port {} — exiting cleanly", port);
+                    eprintln!("Existing healthy daemon on port {port} — exiting cleanly");
                     return Ok(());
                 }
                 _ => {
@@ -795,17 +981,16 @@ async fn run_daemon(startup_repair_claim: Option<StartupRepairClaim>) -> anyhow:
         }
     };
 
+    init_logging(&wenlan_root)?;
+    std::panic::set_hook(Box::new(|panic| {
+        tracing::error!("panic: {panic}");
+    }));
+    tracing::info!("wenlan-server v{}", wenlan_core::version());
+
     #[cfg(debug_assertions)]
     wait_at_startup_signal_test_barrier().await?;
     // Data directory. `WENLAN_DATA_DIR` (set by `--data-dir` flag) overrides the
     // default, enabling isolated dev/demo runs (e.g. `--data-dir /tmp/wenlan-demo`).
-    let wenlan_root = wenlan_core::env_compat::var_compat("WENLAN_DATA_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
-            dirs::data_local_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join("wenlan")
-        });
     let data_dir = wenlan_root.join("memorydb");
     tracing::info!("Wenlan data root: {}", wenlan_root.display());
     let _data_root_lock = DaemonDataLock::acquire(&wenlan_root, startup_repair_claimed)?;
@@ -1830,14 +2015,6 @@ async fn ingest_batch_process(
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
-    let startup_repair_claim = StartupRepairClaim::try_new(
-        cli.repair_manifest_id.clone(),
-        cli.repair_manifest_digest.clone(),
-    )?;
-
-    if cli.command.is_some() && startup_repair_claim.is_some() {
-        anyhow::bail!("startup repair claim is only valid when running the daemon");
-    }
 
     // Propagate flags through env vars so both wenlan-server's own path logic
     // and wenlan-core's config loader (`wenlan_core::config::config_path`) see
@@ -1849,8 +2026,34 @@ async fn main() -> anyhow::Result<()> {
         std::env::set_var("WENLAN_PORT", port.to_string());
     }
 
-    match cli.command {
-        Some(Command::BackfillStalePages { dry_run }) => cmd_backfill::run(dry_run).await,
-        None => run_daemon(startup_repair_claim).await,
+    // Resolving the path is read-only. Before rotating tracing is available,
+    // a bounded bootstrap file keeps launchd failures and panics observable
+    // even though the plist intentionally redirects stdout/stderr to /dev/null.
+    let wenlan_root = resolve_wenlan_root();
+    install_bootstrap_panic_hook(wenlan_root.clone());
+
+    let result = async {
+        let startup_repair_claim = StartupRepairClaim::try_new(
+            cli.repair_manifest_id.clone(),
+            cli.repair_manifest_digest.clone(),
+        )?;
+
+        if cli.command.is_some() && startup_repair_claim.is_some() {
+            anyhow::bail!("startup repair claim is only valid when running the daemon");
+        }
+
+        match cli.command {
+            Some(Command::BackfillStalePages { dry_run }) => cmd_backfill::run(dry_run).await,
+            None => run_daemon(startup_repair_claim).await,
+        }
     }
+    .await;
+
+    if let Err(error) = &result {
+        report_bootstrap_error(
+            &wenlan_root,
+            &format!("wenlan-server terminated with an error: {error:#}"),
+        );
+    }
+    result
 }


### PR DESCRIPTION
## What changed

- Move macOS daemon logging into bounded 10 MiB files with 5 retained backups for launchd, app-sidecar, and direct/dev launches.
- Rate-limit duplicate tracing bursts before they reach disk.
- Preserve failures and panics after Rust `main` begins in a separate bounded 256 KiB bootstrap log with 1 backup.
- Preflight log destinations so `file-rotate` cannot silently discard writes or panic the panic hook; fall back to `~/Library/Logs/com.wenlan.server-fallback/` when the data-root log is unusable.
- Surface primary, bootstrap-fallback, and runtime-fallback paths in `wenlan doctor`.
- Keep bind-before-initialization ordering so an occupied port fails before database/model side effects, and record launchd's healthy-port exit before status 75.
- Route launchd stdout and stderr to `/dev/null` once daemon-owned logging is active.

## Why

The production launchd service appended raw stdout/stderr without rotation. One historical stdout log reached about 25 GB, and repeated schema/ownership errors could create an unbounded error storm. The prior `file-rotate` construction path could also panic or accept an unusable file and silently drop writes.

## Impact

macOS daemon logs are bounded across launch modes, repeated errors are throttled, and failures after Rust `main` begins retain a discoverable fallback even if the selected data-root log cannot be opened.

This does not claim to capture loader, code-signing, `exec`, or other failures before Rust `main`; those remain in macOS/launchd diagnostics. It also does not claim to identify the exact historical reason a Codex-managed MCP stdio child first exited, because that exit reason was not recorded.

## Validation

- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p wenlan-server --bin wenlan-server` — 26/26 plus the child-process harness
- `cargo test -p wenlan --lib` — 24/24
- focused rotation, fallback, rate-limit, occupied-port, service-lifecycle, and MCP round-trip checks
- live dual-runtime run from the companion app: production stayed healthy on PID 19070/port 7878 while the PR daemon was healthy on PID 56029/port 17734; dev teardown removed only the dev listener
