### PR TITLE
ci: run fail-closed impacted tests and release preflights

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       windows-lint: ${{ steps.filter.outputs.windows-lint }}
       windows-release: ${{ steps.filter.outputs.windows-release }}
       mcp-platform: ${{ steps.filter.outputs.mcp-platform }}
+      test-plan: ${{ steps.test-plan.outputs.test-plan }}
       # Test matrix OSes as a JSON array. On PRs, Windows is included only when
       # Windows-affecting files changed. Non-PR runs keep the full backstop.
       test-oses: ${{ steps.matrix.outputs.json }}
@@ -47,7 +48,13 @@ jobs:
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
+          list-files: json
           filters: |
+            # Complete changed-file inventory for fail-closed test planning.
+            # Specific filters below decide whether jobs run; this catch-all
+            # decides which tests those already-scheduled jobs execute.
+            impact:
+              - '**'
             rust:
               # Positive-only globs. With dorny/paths-filter's default
               # `some` quantifier, a negative glob like `!crates/*/npm/**`
@@ -291,6 +298,27 @@ jobs:
           else
             echo 'json=["ubuntu-24.04"]' >> "$GITHUB_OUTPUT"
           fi
+      - name: Set up Rust for affected-test planning
+        if: "steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || github.event_name != 'pull_request'"
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - name: Test CI impact planner
+        if: "steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || github.event_name != 'pull_request'"
+        run: python3 scripts/ci_test_plan.test.py
+      - name: Plan affected Rust tests
+        id: test-plan
+        if: "steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || github.event_name != 'pull_request'"
+        env:
+          CHANGED_FILES_JSON: ${{ steps.filter.outputs.impact_files }}
+          CI_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          cargo metadata --format-version 1 --locked --no-deps > "$RUNNER_TEMP/cargo-metadata.json"
+          python3 scripts/ci_test_plan.py plan \
+            --changed-files-json "$CHANGED_FILES_JSON" \
+            --metadata-file "$RUNNER_TEMP/cargo-metadata.json" \
+            --event-name "$CI_EVENT_NAME" \
+            --github-output "$GITHUB_OUTPUT"
       - name: Test FastEmbed cache preparation
         run: python3 scripts/prepare-fastembed-cache.test.py
       - name: Restore portable FastEmbed model
@@ -498,13 +526,17 @@ jobs:
       # round-trip E2E further down.
       - name: Workspace lib tests (Linux)
         if: matrix.os == 'ubuntu-24.04'
-        run: cargo nextest run --workspace --lib
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
+        run: python3 scripts/ci_test_plan.py run --suite workspace-lib --plan-json "$CI_TEST_PLAN"
       - name: Workspace lib tests (macOS)
         if: matrix.os == 'macos-14'
         # nextest spawns one process per test by default — sidesteps the
         # ONNX atexit FFI race that required --test-threads=1 with cargo test.
         # FastEmbed initialization has its own cross-process file lock.
-        run: cargo nextest run --workspace --lib
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
+        run: python3 scripts/ci_test_plan.py run --suite workspace-lib --plan-json "$CI_TEST_PLAN"
       - name: Page lint scale gate (Windows functional)
         if: matrix.os == 'windows-2022' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-lint == 'true')
         shell: pwsh
@@ -733,12 +765,16 @@ jobs:
           retention-days: 30
           if-no-files-found: error
       - name: Integration tests wenlan-cli + wenlan-server (Linux)
-        run: cargo nextest run -p wenlan -p wenlan-server -E 'kind(test)'
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
+        run: python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json "$CI_TEST_PLAN"
       - name: Run integration tests (core) (Linux)
         # --features eval-harness: selected eval_* targets compile to zero
         # tests without it. eval_harness.rs itself remains manual-only because
         # it requires external data or API credentials.
-        run: cargo nextest run -p wenlan-core --features eval-harness --test build_env --test chat_import_e2e --test distill_redesign_e2e --test distillation_quality --test doc_reconcile_e2e --test eval_cost_caps --test eval_report_paths --test eval_report_roundtrip --test eval_save_guards --test folder_ingest_e2e --test lint_maintenance_probe_e2e --test page_citations_e2e --test pdf_ordered_text --test provenance_p2 --test provenance_p3 --test read_scope --test space_scoping_e2e
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
+        run: python3 scripts/ci_test_plan.py run --suite core-integration --plan-json "$CI_TEST_PLAN"
       - name: E2E wenlan background on/off (Linux user-systemd)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,33 @@ jobs:
       macos:   ${{ steps.filter.outputs.macos }}
       windows: ${{ steps.filter.outputs.windows }}
       windows-lint: ${{ steps.filter.outputs.windows-lint }}
-      windows-release: ${{ steps.filter.outputs.windows-release }}
+      release-preflight: ${{ steps.filter.outputs.release-preflight }}
       mcp-platform: ${{ steps.filter.outputs.mcp-platform }}
       test-plan: ${{ steps.test-plan.outputs.test-plan }}
+      release-targets: ${{ steps.release-targets.outputs.release-targets }}
       # Test matrix OSes as a JSON array. On PRs, Windows is included only when
       # Windows-affecting files changed. Non-PR runs keep the full backstop.
       test-oses: ${{ steps.matrix.outputs.json }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      # dorny/paths-filter reads pull-request files through the REST API, whose
+      # response is capped at 3,000 files. Reject a larger PR before routing a
+      # silently truncated inventory.
+      - name: Reject truncated PR file inventory
+        if: github.event_name == 'pull_request'
+        env:
+          CHANGED_FILE_COUNT: ${{ github.event.pull_request.changed_files }}
+        run: |
+          case "$CHANGED_FILE_COUNT" in
+            ''|*[!0-9]*)
+              echo "invalid pull-request changed_files count: $CHANGED_FILE_COUNT"
+              exit 1
+              ;;
+          esac
+          if [ "$CHANGED_FILE_COUNT" -gt 3000 ]; then
+            echo "$CHANGED_FILE_COUNT changed files exceed the REST API limit; cannot route fail-closed"
+            exit 1
+          fi
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
@@ -162,6 +181,10 @@ jobs:
               - 'crates/wenlan-server/tests/**'
               - 'scripts/install-macos-app.sh'
               - 'scripts/test-install-macos-app.sh'
+              - 'scripts/release_targets.py'
+              - 'scripts/release_targets.test.py'
+              - 'scripts/build-release-binaries.sh'
+              - 'scripts/build-release-binaries.test.sh'
               - 'install.sh'
               - '.config/nextest.toml'
               - 'crates/**/Cargo.toml'
@@ -210,6 +233,10 @@ jobs:
               - 'scripts/smoke-windows-llm.test.ps1'
               - 'scripts/stabilize-rust-cache-toolchains.sh'
               - 'scripts/stabilize-rust-cache-toolchains.test.sh'
+              - 'scripts/release_targets.py'
+              - 'scripts/release_targets.test.py'
+              - 'scripts/build-release-binaries.sh'
+              - 'scripts/build-release-binaries.test.sh'
               - 'scripts/lint-scale-gate.sh'
               - 'crates/wenlan-core/src/lint/**'
               - '.config/nextest.toml'
@@ -236,10 +263,10 @@ jobs:
               # its implementation or harness changes.
               - 'crates/wenlan-core/src/lint/**'
               - 'scripts/lint-scale-gate.sh'
-            windows-release:
-              # Expensive release-profile proof is required only when a PR can
+            release-preflight:
+              # The four shipped release targets build only when a PR can
               # change native linkage, Cargo/build inputs, or packaged output.
-              # Non-PR backstops run it regardless of this filter.
+              # Non-PR backstops run the full matrix regardless of this filter.
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -264,6 +291,10 @@ jobs:
               - 'scripts/smoke-windows.ps1'
               - 'scripts/smoke-windows-llm.ps1'
               - 'scripts/smoke-windows-llm.test.ps1'
+              - 'scripts/release_targets.py'
+              - 'scripts/release_targets.test.py'
+              - 'scripts/build-release-binaries.sh'
+              - 'scripts/build-release-binaries.test.sh'
               - 'version.txt'
               - '.release-please-manifest.json'
               - 'CHANGELOG.md'
@@ -319,6 +350,13 @@ jobs:
             --metadata-file "$RUNNER_TEMP/cargo-metadata.json" \
             --event-name "$CI_EVENT_NAME" \
             --github-output "$GITHUB_OUTPUT"
+      - name: Test release target inventory
+        run: |
+          python3 scripts/release_targets.test.py
+          bash scripts/build-release-binaries.test.sh
+      - name: Emit release target matrix
+        id: release-targets
+        run: python3 scripts/release_targets.py matrix --github-output "$GITHUB_OUTPUT"
       - name: Test FastEmbed cache preparation
         run: python3 scripts/prepare-fastembed-cache.test.py
       - name: Restore portable FastEmbed model
@@ -817,26 +855,34 @@ jobs:
       - name: E2E folder ingest over HTTP (Linux)
         run: bash scripts/smoke-folder-ingest.sh
 
-  # Release-profile proof runs beside the ordinary Windows contract instead of
-  # adding ~25-30 minutes to its critical path. It is required for native,
-  # Cargo/build, packaging, and release workflow diffs, plus every non-PR
-  # backstop. PRs restore the cache produced by the latest non-PR backstop;
-  # correctness never depends on a warm restore.
-  windows-release-proof:
-    name: windows-release-proof
+  # Build-only preflight for every shipped release target. Ordinary PRs never
+  # pay this release-profile cost; native, Cargo/build, packaging, and release
+  # diffs do, as does every non-PR backstop. The tag-triggered release workflow
+  # remains authoritative for packaging and publishing.
+  release-preflight:
+    name: release-preflight (${{ matrix.target }})
     needs: [detect-changes]
-    if: "github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true'"
-    runs-on: windows-2022
-    timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 60 }}
+    if: "github.event_name != 'pull_request' || needs.detect-changes.outputs.release-preflight == 'true'"
+    runs-on: ${{ matrix.os }}
+    # 30 minutes is the performance target, not a correctness timeout. The
+    # larger PR ceiling keeps a cold Windows cache miss from becoming an
+    # infrastructure failure while live hosted-run data is collected.
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 45 || 60 }}
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.detect-changes.outputs.release-targets) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
         with:
           toolchain: 1.95.0
+          targets: ${{ matrix.target }}
       - name: Stabilize Windows Rust cache toolchain inputs
+        if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: bash
         run: bash scripts/stabilize-rust-cache-toolchains.sh
-      - name: Configure rust-lld linker (Windows release)
+      - name: Configure rust-lld linker (Windows release preflight)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
         run: |
           $sysroot = (rustc --print sysroot).Trim()
@@ -846,28 +892,34 @@ jobs:
           }
           "RUSTFLAGS=-C linker=$lld -C linker-flavor=lld-link" |
             Out-File -FilePath $env:GITHUB_ENV -Append
-      - name: Cache Windows release artifacts (main-owned)
+      - name: Cache release artifacts (main-owned)
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          shared-key: windows-release
+          shared-key: release-${{ matrix.target }}
           cache-all-crates: "true"
+          # The repository cache is already at its 10 GB ceiling. Preserve the
+          # expensive Windows release target only; other legs cache dependency
+          # inputs without adding three more large target archives.
+          cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install sqlite3 (Windows only)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
         run: |
           vcpkg install sqlite3:x64-windows-static-md
           "LIB=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static-md\lib;$env:LIB" |
             Out-File -FilePath $env:GITHUB_ENV -Append
-      - name: Build Windows release binaries
-        shell: pwsh
-        run: cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp -p wenlan-core --bin wenlan --bin wenlan-server --bin wenlan-mcp --bin model_probe
-      - name: Native ORT smoke (Windows; release profile)
+      - name: Build and smoke shipped release binaries
+        shell: bash
+        run: bash scripts/build-release-binaries.sh "${{ matrix.target }}"
+      - name: Native ORT smoke (Windows release preflight)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
         run: |
           & scripts/stage-onnxruntime-windows.ps1 `
-            -DestinationDirectory "target\release"
+            -DestinationDirectory "target\${{ matrix.target }}\release"
           & scripts/smoke-windows.ps1 `
-            -ExePath "target\release\wenlan-server.exe"
+            -ExePath "target\${{ matrix.target }}\release\wenlan-server.exe"
 
   # Quarantine lane: exercises test files present in the tree but not wired
   # into the required `test` job (dormant wenlan-mcp / wenlan-types
@@ -942,7 +994,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, fmt, lint, test, canonical-acceptance, windows-release-proof, docs, plugin, npm]
+    needs: [detect-changes, fmt, lint, test, canonical-acceptance, release-preflight, docs, plugin, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -974,7 +1026,7 @@ jobs:
           expect_job lint "$run_rust" '${{ needs.lint.result }}'
           expect_job test "$run_rust" '${{ needs.test.result }}'
           expect_job canonical-acceptance "$run_rust" '${{ needs.canonical-acceptance.result }}'
-          expect_job windows-release-proof '${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true' }}' '${{ needs.windows-release-proof.result }}'
+          expect_job release-preflight '${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.release-preflight == 'true' }}' '${{ needs.release-preflight.result }}'
           expect_job docs '${{ needs.detect-changes.outputs.docs == 'true' }}' '${{ needs.docs.result }}'
           expect_job plugin '${{ needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'
           expect_job npm '${{ needs.detect-changes.outputs.npm == 'true' }}' '${{ needs.npm.result }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,12 +678,12 @@ jobs:
             $global:LASTEXITCODE = 0
           }
 
-  # Linux acceptance runs beside the long workspace-lib lane. On PR #384,
+  # Canonical acceptance runs beside the long workspace-lib lane. On PR #384,
   # these steps occupied ~9 minutes after workspace lib tests had already
   # finished; keeping them independent removes that serialization without
   # transferring a target directory or making correctness depend on cache hits.
-  linux-acceptance:
-    name: linux-acceptance
+  canonical-acceptance:
+    name: canonical-acceptance (ubuntu)
     needs: [detect-changes]
     if: "needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || github.event_name != 'pull_request'"
     runs-on: ubuntu-24.04
@@ -906,7 +906,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, fmt, lint, test, linux-acceptance, windows-release-proof, docs, plugin, npm]
+    needs: [detect-changes, fmt, lint, test, canonical-acceptance, windows-release-proof, docs, plugin, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -937,7 +937,7 @@ jobs:
           expect_job fmt "$run_rust" '${{ needs.fmt.result }}'
           expect_job lint "$run_rust" '${{ needs.lint.result }}'
           expect_job test "$run_rust" '${{ needs.test.result }}'
-          expect_job linux-acceptance "$run_rust" '${{ needs.linux-acceptance.result }}'
+          expect_job canonical-acceptance "$run_rust" '${{ needs.canonical-acceptance.result }}'
           expect_job windows-release-proof '${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.windows-release == 'true' }}' '${{ needs.windows-release-proof.result }}'
           expect_job docs '${{ needs.detect-changes.outputs.docs == 'true' }}' '${{ needs.docs.result }}'
           expect_job plugin '${{ needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,6 +892,27 @@ jobs:
           }
           "RUSTFLAGS=-C linker=$lld -C linker-flavor=lld-link" |
             Out-File -FilePath $env:GITHUB_ENV -Append
+      - name: Select native Perl for vendored OpenSSL
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $nativePerl = $null
+          foreach ($candidate in Get-Command perl.exe -CommandType Application -All) {
+            if ($candidate.Source -match '[\\/]Git[\\/]') {
+              continue
+            }
+            & $candidate.Source "-MLocale::Maketext::Simple" "-e" "1"
+            if ($LASTEXITCODE -eq 0) {
+              $nativePerl = $candidate.Source
+              break
+            }
+          }
+          if (-not $nativePerl) {
+            throw "No native Perl can load Locale::Maketext::Simple"
+          }
+          "OPENSSL_SRC_PERL=$nativePerl" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "OPENSSL_SRC_PERL=$nativePerl"
       - name: Cache release artifacts (main-owned)
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,28 @@ jobs:
           "RUSTFLAGS=$rustflags" | Out-File -FilePath $env:GITHUB_ENV -Append
           Write-Host "RUSTFLAGS=$rustflags"
 
+      - name: Select native Perl for vendored OpenSSL
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $nativePerl = $null
+          foreach ($candidate in Get-Command perl.exe -CommandType Application -All) {
+            if ($candidate.Source -match '[\\/]Git[\\/]') {
+              continue
+            }
+            & $candidate.Source "-MLocale::Maketext::Simple" "-e" "1"
+            if ($LASTEXITCODE -eq 0) {
+              $nativePerl = $candidate.Source
+              break
+            }
+          }
+          if (-not $nativePerl) {
+            throw "No native Perl can load Locale::Maketext::Simple"
+          }
+          "OPENSSL_SRC_PERL=$nativePerl" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "OPENSSL_SRC_PERL=$nativePerl"
+
       # CI release-preflight and the authoritative tag build share this exact
       # shipped-binary build/smoke contract. Packaging and publishing remain
       # release-only below.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
   prepare-release:
     name: Create GitHub Release
     runs-on: ubuntu-24.04
+    outputs:
+      release-targets: ${{ steps.release-targets.outputs.release-targets }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,6 +33,30 @@ jobs:
           ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0
           fetch-tags: true
+
+      # Manual release reruns may target a tag created before these scripts
+      # existed. Pin orchestration to the commit that supplied this workflow,
+      # while the release source itself remains the exact tag checkout above.
+      - name: Checkout release tooling
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tools
+          sparse-checkout: |
+            scripts/release_targets.py
+            scripts/release_targets.test.py
+            scripts/build-release-binaries.sh
+            scripts/build-release-binaries.test.sh
+          sparse-checkout-cone-mode: false
+
+      - name: Test release target inventory
+        run: |
+          python3 .release-tools/scripts/release_targets.test.py
+          bash .release-tools/scripts/build-release-binaries.test.sh
+
+      - name: Emit release target matrix
+        id: release-targets
+        run: python3 .release-tools/scripts/release_targets.py matrix --github-output "$GITHUB_OUTPUT"
 
       - name: Verify release checkout
         shell: bash
@@ -132,32 +158,7 @@ jobs:
     needs: prepare-release
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - target: aarch64-apple-darwin
-            os: macos-14
-            archive: tar.gz
-            artifact_name: wenlan-darwin-arm64
-          # x86_64-apple-darwin dropped from v0.7.0: `ort` 2.x does not
-          # publish prebuilt ONNX Runtime binaries for Intel Mac. Adding it
-          # back requires compiling ONNX from source (~15min build) or
-          # switching to the `ort-tract` backend. Tracked as follow-up.
-          # Native ARM Linux runner is free for public repos
-          # (ubuntu-24.04-arm, 4 vCPU Cortex / 16GB). Drops cross entirely
-          # for aarch64: no Docker container, no Cross.toml, no OpenSSL
-          # version chasing. Same setup as x86 below.
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-            archive: tar.gz
-            artifact_name: wenlan-linux-arm64
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-24.04
-            archive: tar.gz
-            artifact_name: wenlan-linux-x64
-          - target: x86_64-pc-windows-msvc
-            os: windows-2022
-            archive: zip
-            artifact_name: wenlan-windows-x64
+      matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -166,6 +167,16 @@ jobs:
           ref: refs/tags/${{ env.RELEASE_TAG }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Checkout release tooling
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tools
+          sparse-checkout: |
+            scripts/release_targets.py
+            scripts/build-release-binaries.sh
+          sparse-checkout-cone-mode: false
 
       - name: Verify release checkout
         shell: bash
@@ -210,6 +221,9 @@ jobs:
         with:
           shared-key: release-${{ matrix.target }}
           cache-all-crates: "true"
+          # Keep the rare tag build from evicting ordinary CI caches. Every
+          # target still builds; only the costly Windows target is persisted.
+          cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
 
       # rust-lld shipped with the Rust toolchain (~3-5min faster link
       # than MSVC link.exe on our binary sizes). rustup does NOT proxy
@@ -231,19 +245,14 @@ jobs:
           "RUSTFLAGS=$rustflags" | Out-File -FilePath $env:GITHUB_ENV -Append
           Write-Host "RUSTFLAGS=$rustflags"
 
-      # All targets build natively now. aarch64-unknown-linux-gnu uses the
-      # free ubuntu-24.04-arm runner, x86_64-unknown-linux-gnu uses
-      # ubuntu-24.04. No cross / zigbuild / QEMU needed. Eliminates an
-      # entire class of openssl-sys/system-OpenSSL/container-version traps
-      # that consumed several PRs for v0.7.0.
-      - name: Build
-        run: cargo build --release -p wenlan -p wenlan-server -p wenlan-mcp --target ${{ matrix.target }}
-
-      - name: Smoke
+      # CI release-preflight and the authoritative tag build share this exact
+      # shipped-binary build/smoke contract. Packaging and publishing remain
+      # release-only below.
+      - name: Build and smoke shipped release binaries
         shell: bash
-        run: |
-          ./target/${{ matrix.target }}/release/wenlan${{ runner.os == 'Windows' && '.exe' || '' }} --help
-          ./target/${{ matrix.target }}/release/wenlan-server${{ runner.os == 'Windows' && '.exe' || '' }} --help
+        env:
+          WENLAN_REPO_ROOT: ${{ github.workspace }}
+        run: bash .release-tools/scripts/build-release-binaries.sh "${{ matrix.target }}"
 
       - name: List Windows build artifacts
         if: matrix.target == 'x86_64-pc-windows-msvc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,16 @@ jobs:
     outputs:
       release-targets: ${{ steps.release-targets.outputs.release-targets }}
     steps:
+      - name: Require main workflow for manual release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          if [[ "$WORKFLOW_REF" != "refs/heads/main" ]]; then
+            echo "Manual releases must run the current workflow from main; choose the release tag through the tag input."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/crates/wenlan-cli/tests/distribution.rs
+++ b/crates/wenlan-cli/tests/distribution.rs
@@ -94,7 +94,7 @@ fn npm_package_allowlists_match_release_generated_files() {
     );
 
     // wenlan-mcp ships prebuilt binaries for every release-matrix target
-    // (darwin x2, linux x2, windows x1) via its npm postinstall. The
+    // (darwin arm64, linux arm64/x64, windows x64) via its npm postinstall. The
     // allowlist must include each platform the matrix uploads or `npm
     // install` rejects the package on those hosts.
     let mcp_pkg = read_json("crates/wenlan-mcp/npm/package.json");
@@ -114,27 +114,17 @@ fn npm_package_allowlists_match_release_generated_files() {
 }
 
 #[test]
-fn release_workflow_publishes_cli_and_mcp_npm_packages() {
+fn release_workflow_consumes_target_inventory_and_publishes_npm_packages() {
     let workflow = fs::read_to_string(repo_root().join(".github/workflows/release.yml"))
         .expect("read release workflow");
-    // The release workflow uses a target matrix; the strings below are the
-    // matrix step names + artifact names every release must continue to
-    // produce. Adding a target should ALSO add its artifact name here so a
-    // dropped target shows up as a test failure rather than a silent gap in
-    // the release.
     for needle in [
         "Build & Publish ${{ matrix.target }}",
+        "matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}",
+        "python3 .release-tools/scripts/release_targets.py matrix",
         "Publish wenlan-mcp",
         "Publish wenlan",
         "cp README.md crates/wenlan-mcp/npm/README.md",
         "cp README.md crates/wenlan-cli/npm/README.md",
-        "wenlan-darwin-arm64",
-        // wenlan-darwin-x64 dropped in v0.7.0 (PR #168) — ort has no
-        // prebuilt for x86_64-apple-darwin. Re-add when ONNX builds from
-        // source or ort-tract becomes viable.
-        "wenlan-linux-arm64",
-        "wenlan-linux-x64",
-        "wenlan-windows-x64",
         "wenlan-mcp-darwin-arm64.tar.gz",
     ] {
         assert!(
@@ -142,6 +132,35 @@ fn release_workflow_publishes_cli_and_mcp_npm_packages() {
             "release workflow missing `{needle}`"
         );
     }
+
+    let inventory = Command::new("python3")
+        .arg(repo_root().join("scripts/release_targets.py"))
+        .arg("matrix")
+        .output()
+        .expect("run canonical release-target inventory");
+    assert!(
+        inventory.status.success(),
+        "release-target inventory failed:\n{}",
+        String::from_utf8_lossy(&inventory.stderr)
+    );
+    let matrix: Value =
+        serde_json::from_slice(&inventory.stdout).expect("parse canonical release-target matrix");
+    let artifact_names = matrix["include"]
+        .as_array()
+        .expect("release matrix include array")
+        .iter()
+        .map(|entry| json_string(entry, "artifact_name"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        artifact_names,
+        [
+            "wenlan-darwin-arm64",
+            "wenlan-linux-arm64",
+            "wenlan-linux-x64",
+            "wenlan-windows-x64",
+        ],
+        "canonical release artifact inventory drift"
+    );
 }
 
 #[test]

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -114,7 +114,7 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
             ],
         ),
         (
-            "linux-acceptance",
+            "canonical-acceptance",
             &["Integration tests wenlan-cli + wenlan-server (Linux)"],
         ),
         (
@@ -661,7 +661,7 @@ jobs:
         with:
           path: ~/.local/share/wenlan/memorydb/fastembed_cache
           key: stale
-  linux-acceptance:
+  canonical-acceptance:
     env:
       FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
     steps:
@@ -2094,7 +2094,7 @@ fn ci_routing_contract_violations(
     }
     let linux_integration = job_step(
         &ci,
-        "linux-acceptance",
+        "canonical-acceptance",
         "Integration tests wenlan-cli + wenlan-server (Linux)",
     );
     let macos_integration = job_step(
@@ -2282,25 +2282,26 @@ jobs:
     }
 }
 
-// ── Teeth #9: Linux acceptance runs beside the long workspace-lib lane ──
+// ── Teeth #9: canonical acceptance runs beside the long workspace-lib lane ──
 
-fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
+fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
     let mut violations = Vec::new();
-    let job = &ci["jobs"]["linux-acceptance"];
+    let job = &ci["jobs"]["canonical-acceptance"];
 
-    if job_needs(&ci, "linux-acceptance") != ["detect-changes"] {
-        violations.push("Linux acceptance is serialized behind another required job".into());
+    if job_needs(&ci, "canonical-acceptance") != ["detect-changes"] {
+        violations.push("Canonical acceptance is serialized behind another required job".into());
     }
     if job["if"].as_str() != ci["jobs"]["test"]["if"].as_str() {
-        violations
-            .push("Linux acceptance does not share the fail-closed Rust routing condition".into());
+        violations.push(
+            "Canonical acceptance does not share the fail-closed Rust routing condition".into(),
+        );
     }
     if job["runs-on"].as_str() != Some("ubuntu-24.04")
         || job["timeout-minutes"].as_str()
             != Some("${{ github.event_name == 'pull_request' && 30 || 60 }}")
     {
-        violations.push("Linux acceptance is not bounded on the canonical Linux runner".into());
+        violations.push("Canonical acceptance is not bounded on the canonical Linux runner".into());
     }
     for (name, expected) in [
         ("CARGO_PROFILE_DEV_DEBUG", "0"),
@@ -2316,7 +2317,7 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     ] {
         if job["env"][name].as_str() != Some(expected) {
             violations.push(format!(
-                "Linux acceptance env {name} is not pinned to {expected}"
+                "Canonical acceptance env {name} is not pinned to {expected}"
             ));
         }
     }
@@ -2329,9 +2330,9 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         "E2E wenlan background on/off (Linux user-systemd)",
         "E2E folder ingest over HTTP (Linux)",
     ] {
-        if job_step(&ci, "linux-acceptance", step_name).is_none() {
+        if job_step(&ci, "canonical-acceptance", step_name).is_none() {
             violations.push(format!(
-                "Linux acceptance does not own required step {step_name}"
+                "Canonical acceptance does not own required step {step_name}"
             ));
         }
         if job_step(&ci, "test", step_name).is_some() {
@@ -2344,20 +2345,20 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         (
             "Page lint scale gate (Linux time + RSS)",
             r#"bash scripts/lint-scale-gate.sh "$RUNNER_TEMP/task-19-memory-lint-debugger-linux.txt""#,
-            "Linux acceptance page lint command is not executable",
+            "Canonical acceptance page lint command is not executable",
         ),
         (
             "Integration tests wenlan-cli + wenlan-server (Linux)",
             "cargo nextest run -p wenlan -p wenlan-server -E 'kind(test)'",
-            "Linux acceptance CLI/server integration command is not executable",
+            "Canonical acceptance CLI/server integration command is not executable",
         ),
         (
             "E2E folder ingest over HTTP (Linux)",
             "bash scripts/smoke-folder-ingest.sh",
-            "Linux acceptance folder ingest smoke is not unconditional",
+            "Canonical acceptance folder ingest smoke is not unconditional",
         ),
     ] {
-        let step = job_step(&ci, "linux-acceptance", step_name);
+        let step = job_step(&ci, "canonical-acceptance", step_name);
         if step.and_then(|step| step["run"].as_str()) != Some(expected_run)
             || step.is_some_and(|step| step.get("if").is_some())
         {
@@ -2366,7 +2367,7 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     }
     let core_integration = job_step(
         &ci,
-        "linux-acceptance",
+        "canonical-acceptance",
         "Run integration tests (core) (Linux)",
     );
     if core_integration.is_some_and(|step| step.get("if").is_some()) {
@@ -2374,7 +2375,7 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     }
     let systemd = job_step(
         &ci,
-        "linux-acceptance",
+        "canonical-acceptance",
         "E2E wenlan background on/off (Linux user-systemd)",
     );
     let systemd_run = systemd
@@ -2402,7 +2403,7 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     }
     let lint_upload = job_step(
         &ci,
-        "linux-acceptance",
+        "canonical-acceptance",
         "Upload Page lint scale receipt (Linux)",
     );
     if lint_upload.and_then(|step| step["if"].as_str()) != Some("always()")
@@ -2441,7 +2442,8 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         || rust_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some("false")
         || rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
     {
-        violations.push("Linux acceptance needs exactly one restore-only rust-cache action".into());
+        violations
+            .push("Canonical acceptance needs exactly one restore-only rust-cache action".into());
     }
     let sccache_actions = acceptance_steps
         .iter()
@@ -2452,7 +2454,7 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         })
         .count();
     if sccache_actions != 1 {
-        violations.push("Linux acceptance needs exactly one read-only sccache action".into());
+        violations.push("Canonical acceptance needs exactly one read-only sccache action".into());
     }
     let fastembed_restores = acceptance_steps
         .iter()
@@ -2470,48 +2472,48 @@ fn linux_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         || fastembed.and_then(|step| step["with"]["enableCrossOsArchive"].as_str()) != Some("true")
         || fastembed.and_then(|step| step["with"]["fail-on-cache-miss"].as_str()) != Some("true")
     {
-        violations.push("Linux acceptance FastEmbed cache is not restore-only".into());
+        violations.push("Canonical acceptance FastEmbed cache is not restore-only".into());
     }
     if acceptance_steps
         .iter()
         .filter_map(|step| step["uses"].as_str())
         .any(|uses| uses.starts_with("actions/cache@") || uses.contains("actions/cache/save@"))
     {
-        violations.push("Linux acceptance contains a FastEmbed cache writer".into());
+        violations.push("Canonical acceptance contains a FastEmbed cache writer".into());
     }
 
     if !job_needs(&ci, "conclusion")
         .iter()
-        .any(|need| need == "linux-acceptance")
+        .any(|need| need == "canonical-acceptance")
     {
-        violations.push("conclusion.needs omits Linux acceptance".into());
+        violations.push("conclusion.needs omits canonical acceptance".into());
     }
     let conclusion = workflow_step_run(&ci, "Aggregate expected CI results").unwrap_or_default();
     if !conclusion.lines().map(str::trim).any(|line| {
-        line.starts_with("expect_job linux-acceptance ")
+        line.starts_with("expect_job canonical-acceptance ")
             && line.contains("\"$run_rust\"")
-            && line.contains("needs.linux-acceptance.result")
+            && line.contains("needs.canonical-acceptance.result")
     }) {
-        violations.push("conclusion does not fail closed on Linux acceptance".into());
+        violations.push("conclusion does not fail closed on canonical acceptance".into());
     }
 
     violations
 }
 
 #[test]
-fn linux_acceptance_is_parallel_required_and_restore_only() {
+fn canonical_acceptance_is_parallel_required_and_restore_only() {
     let root = repo_root();
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
-    let violations = linux_acceptance_contract_violations(&ci);
+    let violations = canonical_acceptance_contract_violations(&ci);
     assert!(
         violations.is_empty(),
-        "Linux acceptance critical-path contract drift:\n{}",
+        "Canonical acceptance critical-path contract drift:\n{}",
         violations.join("\n")
     );
 }
 
 #[test]
-fn linux_acceptance_contract_rejects_serialized_or_optional_fixture() {
+fn canonical_acceptance_contract_rejects_serialized_or_optional_fixture() {
     let ci = r#"
 jobs:
   test:
@@ -2519,7 +2521,7 @@ jobs:
     steps:
       - name: E2E folder ingest over HTTP (Linux)
         run: old
-  linux-acceptance:
+  canonical-acceptance:
     needs: [test]
     if: other
     runs-on: windows-2022
@@ -2537,7 +2539,7 @@ jobs:
       - name: Aggregate expected CI results
         run: echo success
 "#;
-    let violations = linux_acceptance_contract_violations(ci);
+    let violations = canonical_acceptance_contract_violations(ci);
     for expected in [
         "serialized",
         "fail-closed Rust routing",
@@ -2562,7 +2564,7 @@ jobs:
 }
 
 #[test]
-fn linux_acceptance_contract_rejects_semantic_noops_and_secondary_writers() {
+fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() {
     let root = repo_root();
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
     let ci = ci
@@ -2587,10 +2589,10 @@ fn linux_acceptance_contract_rejects_semantic_noops_and_secondary_writers() {
             "      - uses: Swatinem/rust-cache@v2\n        with:\n          save-if: \"true\"\n      - name: Install cargo-nextest",
         )
         .replace(
-            "          expect_job linux-acceptance \"$run_rust\" '${{ needs.linux-acceptance.result }}'",
-            "          # expect_job linux-acceptance \"$run_rust\" '${{ needs.linux-acceptance.result }}'",
+            "          expect_job canonical-acceptance \"$run_rust\" '${{ needs.canonical-acceptance.result }}'",
+            "          # expect_job canonical-acceptance \"$run_rust\" '${{ needs.canonical-acceptance.result }}'",
         );
-    let violations = linux_acceptance_contract_violations(&ci);
+    let violations = canonical_acceptance_contract_violations(&ci);
     for expected in [
         "SCCACHE_GHA_RW_MODE",
         "CLI/server integration command",
@@ -2628,7 +2630,7 @@ fn core_integration_contract_violations(
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
     let Some(run) = job_step(
         &ci,
-        "linux-acceptance",
+        "canonical-acceptance",
         "Run integration tests (core) (Linux)",
     )
     .and_then(|step| step["run"].as_str()) else {
@@ -2734,7 +2736,7 @@ fn every_core_integration_target_has_a_required_or_manual_owner() {
 fn core_integration_inventory_fails_closed_for_an_unknown_target() {
     let ci = r#"
 jobs:
-  linux-acceptance:
+  canonical-acceptance:
     steps:
       - name: Run integration tests (core) (Linux)
         run: cargo nextest run -p wenlan-core --features eval-harness --test known
@@ -2756,7 +2758,7 @@ jobs:
 fn core_integration_inventory_rejects_dead_text_coverage() {
     let ci = r#"
 jobs:
-  linux-acceptance:
+  canonical-acceptance:
     steps:
       - name: Run integration tests (core) (Linux)
         run: |
@@ -2787,7 +2789,7 @@ fn core_integration_inventory_rejects_shell_operator_dead_text() {
         let ci = format!(
             r#"
 jobs:
-  linux-acceptance:
+  canonical-acceptance:
     steps:
       - name: Run integration tests (core) (Linux)
         run: cargo nextest run -p wenlan-core --features eval-harness --test actually_run {operator} echo --test {dead_target}

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -1556,6 +1556,7 @@ fn ci_routing_contract_violations(
         "windows-lint",
         "windows-release",
         "mcp-platform",
+        "test-plan",
     ] {
         if ci["jobs"]["detect-changes"]["outputs"][output]
             .as_str()
@@ -1563,6 +1564,49 @@ fn ci_routing_contract_violations(
         {
             violations.push(format!("detect-changes does not expose {output} routing"));
         }
+    }
+
+    let filter_step = ci["jobs"]["detect-changes"]["steps"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .find(|step| step["id"].as_str() == Some("filter"));
+    if filter_step.and_then(|step| step["with"]["list-files"].as_str()) != Some("json") {
+        violations.push("detect-changes does not expose the changed-file inventory as JSON".into());
+    }
+    let impact_paths = detect_change_filter_paths(&ci, "impact");
+    if !impact_paths.contains("**") {
+        violations.push("impact routing is not a fail-closed repository catch-all".into());
+    }
+    let planner_test = job_step(&ci, "detect-changes", "Test CI impact planner")
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if planner_test != "python3 scripts/ci_test_plan.test.py" {
+        violations.push("detect-changes does not test the impact planner before use".into());
+    }
+    let planner = job_step(&ci, "detect-changes", "Plan affected Rust tests");
+    let planner_run = planner
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    let changed_files = planner
+        .and_then(|step| step["env"]["CHANGED_FILES_JSON"].as_str())
+        .unwrap_or_default();
+    let event_name = planner
+        .and_then(|step| step["env"]["CI_EVENT_NAME"].as_str())
+        .unwrap_or_default();
+    if planner.and_then(|step| step["id"].as_str()) != Some("test-plan")
+        || !planner_run.contains("cargo metadata --format-version 1 --locked --no-deps")
+        || !planner_run.contains("python3 scripts/ci_test_plan.py plan")
+        || !planner_run.contains("--changed-files-json \"$CHANGED_FILES_JSON\"")
+        || !planner_run.contains("--event-name \"$CI_EVENT_NAME\"")
+        || !planner_run.contains("--github-output \"$GITHUB_OUTPUT\"")
+        || changed_files != "${{ steps.filter.outputs.impact_files }}"
+        || event_name != "${{ github.event_name }}"
+    {
+        violations.push(
+            "detect-changes does not derive its test plan from Cargo metadata and the complete changed-file inventory"
+                .into(),
+        );
     }
 
     let rust_paths = detect_change_filter_paths(&ci, "rust");
@@ -2083,14 +2127,36 @@ fn ci_routing_contract_violations(
         );
     }
 
-    let macos_lib = job_step(&ci, "test", "Workspace lib tests (macOS)");
-    let macos_lib_run = macos_lib
-        .and_then(|step| step["run"].as_str())
-        .unwrap_or_default();
-    if !macos_lib_run.contains("cargo nextest run --workspace --lib")
-        || macos_lib_run.contains("--test-threads=1")
-    {
-        violations.push("macOS nextest workspace proof is unnecessarily single-threaded".into());
+    for (job, step_name, suite) in [
+        ("test", "Workspace lib tests (Linux)", "workspace-lib"),
+        ("test", "Workspace lib tests (macOS)", "workspace-lib"),
+        (
+            "canonical-acceptance",
+            "Integration tests wenlan-cli + wenlan-server (Linux)",
+            "cli-server-integration",
+        ),
+        (
+            "canonical-acceptance",
+            "Run integration tests (core) (Linux)",
+            "core-integration",
+        ),
+    ] {
+        let step = job_step(&ci, job, step_name);
+        let run = step
+            .and_then(|candidate| candidate["run"].as_str())
+            .unwrap_or_default();
+        let plan = step
+            .and_then(|candidate| candidate["env"]["CI_TEST_PLAN"].as_str())
+            .unwrap_or_default();
+        if !run.contains("python3 scripts/ci_test_plan.py run")
+            || !run.contains(&format!("--suite {suite}"))
+            || !run.contains("--plan-json \"$CI_TEST_PLAN\"")
+            || plan != "${{ needs.detect-changes.outputs.test-plan }}"
+        {
+            violations.push(format!(
+                "{job} {step_name} does not execute the validated impacted-test plan"
+            ));
+        }
     }
     let linux_integration = job_step(
         &ci,
@@ -2102,9 +2168,7 @@ fn ci_routing_contract_violations(
         "test",
         "Integration tests wenlan-cli + wenlan-server (macOS)",
     );
-    if linux_integration
-        .and_then(|step| step["run"].as_str())
-        .is_none_or(|run| !run.contains("-E 'kind(test)'"))
+    if linux_integration.is_none()
         || macos_integration.and_then(|step| step["if"].as_str()) != Some("matrix.os == 'macos-14'")
         || macos_integration
             .and_then(|step| step["run"].as_str())
@@ -2266,12 +2330,16 @@ jobs:
         "debug runtime artifacts",
         "differentially compile every wenlan-mcp target",
         "mcp-platform routing",
-        "single-threaded",
         "duplicates wenlan CLI/server lib tests",
         "full CLI/server platform contract",
         "fail fast before integration",
         "fail fast from integration",
         "root installer",
+        "changed-file inventory as JSON",
+        "repository catch-all",
+        "test the impact planner",
+        "derive its test plan",
+        "validated impacted-test plan",
     ] {
         assert!(
             violations
@@ -2349,7 +2417,7 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         ),
         (
             "Integration tests wenlan-cli + wenlan-server (Linux)",
-            "cargo nextest run -p wenlan -p wenlan-server -E 'kind(test)'",
+            "python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json \"$CI_TEST_PLAN\"",
             "Canonical acceptance CLI/server integration command is not executable",
         ),
         (
@@ -2370,6 +2438,19 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         "canonical-acceptance",
         "Run integration tests (core) (Linux)",
     );
+    for step_name in [
+        "Integration tests wenlan-cli + wenlan-server (Linux)",
+        "Run integration tests (core) (Linux)",
+    ] {
+        if job_step(&ci, "canonical-acceptance", step_name)
+            .and_then(|step| step["env"]["CI_TEST_PLAN"].as_str())
+            != Some("${{ needs.detect-changes.outputs.test-plan }}")
+        {
+            violations.push(format!(
+                "Canonical acceptance {step_name} does not consume the validated test plan"
+            ));
+        }
+    }
     if core_integration.is_some_and(|step| step.get("if").is_some()) {
         violations.push("Linux core integration coverage is conditionally disabled".into());
     }
@@ -2573,7 +2654,7 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
             "      SCCACHE_GHA_RW_MODE: READ_ONLY",
         )
         .replace(
-            "        run: cargo nextest run -p wenlan -p wenlan-server -E 'kind(test)'",
+            "        run: python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json \"$CI_TEST_PLAN\"",
             "        run: \"true\"",
         )
         .replace(
@@ -2612,128 +2693,46 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
 
 // ── Teeth #10: every normal core integration target has a required owner ──
 
-fn core_integration_contract_violations(
-    ci_workflow: &str,
-    integration_targets: &[String],
-) -> Vec<String> {
-    const MANUAL_ONLY: &[(&str, &str)] = &[
-        (
-            "cached_scenario_db_check",
-            "requires the external cached eval scenario databases",
-        ),
-        (
-            "eval_harness",
-            "contains manual eval cases that require external data or API credentials",
-        ),
-    ];
-
+fn core_integration_contract_violations(ci_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
-    let Some(run) = job_step(
+    let Some(step) = job_step(
         &ci,
         "canonical-acceptance",
         "Run integration tests (core) (Linux)",
-    )
-    .and_then(|step| step["run"].as_str()) else {
+    ) else {
         return vec!["required Linux core integration step is missing".into()];
     };
 
-    let nextest_commands = run
-        .lines()
-        .map(str::trim)
-        .filter(|line| line.starts_with("cargo nextest run "))
-        .collect::<Vec<_>>();
+    let expected =
+        "python3 scripts/ci_test_plan.py run --suite core-integration --plan-json \"$CI_TEST_PLAN\"";
     let mut violations = Vec::new();
-    if nextest_commands.len() != 1 {
-        violations.push(format!(
-            "required Linux core integration step has {} canonical cargo nextest invocations, expected exactly one",
-            nextest_commands.len()
-        ));
-    }
-    let words = nextest_commands
-        .first()
-        .map(|command| command.split_whitespace().collect::<Vec<_>>())
-        .unwrap_or_default();
-    let prefix = [
-        "cargo",
-        "nextest",
-        "run",
-        "-p",
-        "wenlan-core",
-        "--features",
-        "eval-harness",
-    ];
-    let test_arguments = words.get(prefix.len()..).unwrap_or_default();
-    let valid_test_arguments = words.starts_with(&prefix)
-        && test_arguments.len() % 2 == 0
-        && test_arguments.chunks_exact(2).all(|pair| {
-            pair[0] == "--test"
-                && !pair[1].is_empty()
-                && pair[1]
-                    .chars()
-                    .all(|character| character.is_ascii_alphanumeric() || "_-".contains(character))
-        });
-    if !valid_test_arguments {
+    if step["run"].as_str() != Some(expected)
+        || step["env"]["CI_TEST_PLAN"].as_str()
+            != Some("${{ needs.detect-changes.outputs.test-plan }}")
+        || step.get("if").is_some()
+    {
         violations.push(
-            "required Linux core integration command is not the exact canonical argv contract"
+            "required Linux core integration step does not execute the validated fail-closed planner"
                 .into(),
         );
     }
-    let selected = if valid_test_arguments {
-        test_arguments
-            .chunks_exact(2)
-            .map(|pair| pair[1])
-            .collect::<BTreeSet<_>>()
-    } else {
-        BTreeSet::new()
-    };
-    let manual_only = MANUAL_ONLY
-        .iter()
-        .map(|(target, _reason)| *target)
-        .collect::<BTreeSet<_>>();
-
-    violations.extend(
-        integration_targets
-            .iter()
-            .filter(|target| !manual_only.contains(target.as_str()))
-            .filter(|target| !selected.contains(target.as_str()))
-            .map(|target| {
-            format!(
-                "core integration target {target:?} has no required canonical Linux proof and is not manual-only"
-            )
-            }),
-    );
     violations
-}
-
-fn core_integration_targets(root: &Path) -> Vec<String> {
-    let mut targets = std::fs::read_dir(root.join("crates/wenlan-core/tests"))
-        .expect("read wenlan-core integration tests")
-        .filter_map(Result::ok)
-        .filter_map(|entry| {
-            let path = entry.path();
-            (path.extension().and_then(|ext| ext.to_str()) == Some("rs"))
-                .then(|| path.file_stem()?.to_str().map(str::to_owned))
-                .flatten()
-        })
-        .collect::<Vec<_>>();
-    targets.sort();
-    targets
 }
 
 #[test]
 fn every_core_integration_target_has_a_required_or_manual_owner() {
     let root = repo_root();
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
-    let violations = core_integration_contract_violations(&ci, &core_integration_targets(&root));
+    let violations = core_integration_contract_violations(&ci);
     assert!(
         violations.is_empty(),
-        "core integration inventory drift:\n{}",
+        "core integration planner wiring drift:\n{}",
         violations.join("\n")
     );
 }
 
 #[test]
-fn core_integration_inventory_fails_closed_for_an_unknown_target() {
+fn core_integration_inventory_rejects_direct_command_bypass() {
     let ci = r#"
 jobs:
   canonical-acceptance:
@@ -2741,16 +2740,12 @@ jobs:
       - name: Run integration tests (core) (Linux)
         run: cargo nextest run -p wenlan-core --features eval-harness --test known
 "#;
-    let targets = vec![
-        "known".to_string(),
-        "new_platform_sensitive_test".to_string(),
-    ];
-    let violations = core_integration_contract_violations(ci, &targets);
+    let violations = core_integration_contract_violations(ci);
     assert!(
         violations
             .iter()
-            .any(|violation| violation.contains("new_platform_sensitive_test")),
-        "an unknown integration target must default into required Linux proof: {violations:?}"
+            .any(|violation| violation.contains("fail-closed planner")),
+        "a hand-maintained target list must not bypass the fail-closed planner: {violations:?}"
     );
 }
 
@@ -2766,42 +2761,35 @@ jobs:
           echo --test echoed_only
           cargo nextest run -p wenlan-core --features eval-harness --test actually_run # --test inline_commented
 "#;
-    let targets = vec![
-        "actually_run".to_string(),
-        "commented_out".to_string(),
-        "echoed_only".to_string(),
-        "inline_commented".to_string(),
-    ];
-    let violations = core_integration_contract_violations(ci, &targets);
-    for missing in ["commented_out", "echoed_only", "inline_commented"] {
-        assert!(
-            violations
-                .iter()
-                .any(|violation| violation.contains(missing)),
-            "dead text must not satisfy required integration ownership for {missing}: {violations:?}"
-        );
-    }
+    let violations = core_integration_contract_violations(ci);
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("fail-closed planner")),
+        "dead command text must not satisfy required integration ownership: {violations:?}"
+    );
 }
 
 #[test]
 fn core_integration_inventory_rejects_shell_operator_dead_text() {
-    for (operator, dead_target) in [("|", "piped_only"), ("&", "background_only")] {
+    for operator in ["|", "&"] {
         let ci = format!(
             r#"
 jobs:
   canonical-acceptance:
     steps:
       - name: Run integration tests (core) (Linux)
-        run: cargo nextest run -p wenlan-core --features eval-harness --test actually_run {operator} echo --test {dead_target}
+        env:
+          CI_TEST_PLAN: ${{{{ needs.detect-changes.outputs.test-plan }}}}
+        run: python3 scripts/ci_test_plan.py run --suite core-integration --plan-json "$CI_TEST_PLAN" {operator} true
 "#
         );
-        let targets = vec!["actually_run".to_string(), dead_target.to_string()];
-        let violations = core_integration_contract_violations(&ci, &targets);
+        let violations = core_integration_contract_violations(&ci);
         assert!(
             violations
                 .iter()
-                .any(|violation| violation.contains(dead_target)),
-            "shell operator {operator:?} must not make {dead_target} look executed: {violations:?}"
+                .any(|violation| violation.contains("fail-closed planner")),
+            "shell operator {operator:?} must not weaken the exact planner invocation: {violations:?}"
         );
     }
 }

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -2485,6 +2485,49 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     {
         violations.push("release-preflight does not link the Windows sqlite dependency".into());
     }
+    for (workflow, job_name) in [(&ci, "release-preflight"), (&release, "release")] {
+        let native_perl = job_step(
+            workflow,
+            job_name,
+            "Select native Perl for vendored OpenSSL",
+        );
+        let native_perl_run = native_perl
+            .and_then(|step| step["run"].as_str())
+            .unwrap_or_default();
+        if native_perl.and_then(|step| step["if"].as_str()) != Some(windows_condition)
+            || native_perl.and_then(|step| step["shell"].as_str()) != Some("pwsh")
+            || !native_perl_run.contains("Get-Command perl.exe")
+            || !native_perl_run.contains("-All")
+            || !native_perl_run.contains("candidate.Source -match")
+            || !native_perl_run.contains("[\\\\/]Git[\\\\/]")
+            || !native_perl_run.contains("Locale::Maketext::Simple")
+            || !native_perl_run.contains("OPENSSL_SRC_PERL=")
+            || !native_perl_run.contains("$env:GITHUB_ENV")
+        {
+            violations.push(format!(
+                "{job_name} does not select and validate native Windows Perl before vendored OpenSSL"
+            ));
+        }
+        let steps = workflow["jobs"][job_name]["steps"].as_sequence();
+        let native_perl_index = steps.and_then(|items| {
+            items.iter().position(|step| {
+                step["name"].as_str() == Some("Select native Perl for vendored OpenSSL")
+            })
+        });
+        let build_index = steps.and_then(|items| {
+            items.iter().position(|step| {
+                step["name"].as_str() == Some("Build and smoke shipped release binaries")
+            })
+        });
+        if !matches!(
+            (native_perl_index, build_index),
+            (Some(native_perl_index), Some(build_index)) if native_perl_index < build_index
+        ) {
+            violations.push(format!(
+                "{job_name} selects native Windows Perl after the release build"
+            ));
+        }
+    }
     let cache = job_step_using(&ci, "release-preflight", "Swatinem/rust-cache");
     if cache.and_then(|step| step["with"]["shared-key"].as_str())
         != Some("release-${{ matrix.target }}")
@@ -2599,6 +2642,10 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
         .replace(
             "      - name: Native ORT smoke (Windows release preflight)",
             "      - name: Native ORT smoke removed",
+        )
+        .replace(
+            "      - name: Select native Perl for vendored OpenSSL",
+            "      - name: Native Perl removed",
         );
     let release = release.replace(
         "      matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}",
@@ -2612,6 +2659,7 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
         "shared shipped-binary",
         "target-scoped, capacity-bounded, and main-owned",
         "truncated PR file inventory",
+        "native Windows Perl",
         "native ORT smoke",
         "publishing or packaging side effect",
         "conclusion does not fail closed",

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -2304,6 +2304,25 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
             "detect-changes does not reject the REST API's truncated PR file inventory".into(),
         );
     }
+    let dispatch_guard = job_step(
+        &release,
+        "prepare-release",
+        "Require main workflow for manual release",
+    );
+    let dispatch_guard_run = dispatch_guard
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if dispatch_guard.and_then(|step| step["if"].as_str())
+        != Some("github.event_name == 'workflow_dispatch'")
+        || dispatch_guard.and_then(|step| step["env"]["WORKFLOW_REF"].as_str())
+            != Some("${{ github.ref }}")
+        || !dispatch_guard_run.contains("$WORKFLOW_REF")
+        || !dispatch_guard_run.contains("refs/heads/main")
+        || !dispatch_guard_run.contains("exit 1")
+    {
+        violations
+            .push("manual release dispatch does not require the current main workflow ref".into());
+    }
 
     if ci["jobs"]["detect-changes"]["outputs"]["release-targets"]
         .as_str()
@@ -2647,16 +2666,22 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
             "      - name: Select native Perl for vendored OpenSSL",
             "      - name: Native Perl removed",
         );
-    let release = release.replace(
-        "      matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}",
-        "      matrix: {}",
-    );
+    let release = release
+        .replace(
+            "      matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}",
+            "      matrix: {}",
+        )
+        .replace(
+            "      - name: Require main workflow for manual release",
+            "      - name: Manual release ref guard removed",
+        );
     let violations = release_preflight_contract_violations(&ci, &release);
     for expected in [
         "independent fail-closed",
         "fail-fast four-target",
         "canonical release matrix",
         "shared shipped-binary",
+        "current main workflow ref",
         "target-scoped, capacity-bounded, and main-owned",
         "truncated PR file inventory",
         "native Windows Perl",

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -393,19 +393,25 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     }
     let build = steps
         .iter()
-        .find(|step| step["name"].as_str() == Some("Build"));
+        .find(|step| step["name"].as_str() == Some("Build and smoke shipped release binaries"));
     if build.is_none_or(|step| {
         step["env"]["RUSTC_WRAPPER"].as_str() == Some("sccache")
             || step["env"]["SCCACHE_GHA_ENABLED"].as_str() == Some("true")
     }) {
-        violations.push("release Build still depends on sccache GHA state".into());
+        violations.push("release shipped-binary build still depends on sccache GHA state".into());
     }
-    if !steps.iter().any(|step| {
+    let rust_cache = steps.iter().find(|step| {
         step["uses"]
             .as_str()
             .is_some_and(|uses| uses.contains("Swatinem/rust-cache"))
-    }) {
+    });
+    if rust_cache.is_none() {
         violations.push("release job removed its target-level rust-cache fallback".into());
+    }
+    if rust_cache.and_then(|step| step["with"]["cache-targets"].as_str())
+        != Some("${{ matrix.target == 'x86_64-pc-windows-msvc' }}")
+    {
+        violations.push("release target cache is not capacity-bounded to Windows".into());
     }
 
     violations
@@ -549,7 +555,7 @@ jobs:
     steps:
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@sha
-      - name: Build
+      - name: Build and smoke shipped release binaries
         env:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
@@ -560,6 +566,7 @@ jobs:
         "install sccache",
         "depends on sccache",
         "rust-cache fallback",
+        "capacity-bounded",
     ] {
         assert!(
             violations
@@ -935,9 +942,10 @@ fn windows_ort_distribution_violations(
         violations.push("release workflow does not smoke the extracted Windows archive".into());
     }
 
-    let pr_build = workflow_step_run(&ci, "Build Windows release binaries").unwrap_or_default();
+    let pr_build =
+        workflow_step_run(&ci, "Build and smoke shipped release binaries").unwrap_or_default();
     let pr_smoke =
-        workflow_step_run(&ci, "Native ORT smoke (Windows; release profile)").unwrap_or_default();
+        workflow_step_run(&ci, "Native ORT smoke (Windows release preflight)").unwrap_or_default();
     let windows_test_bootstrap =
         workflow_step_run(&ci, "Stage ONNX Runtime for Windows tests").unwrap_or_default();
     if !windows_test_bootstrap.contains("scripts/stage-onnxruntime-windows.ps1")
@@ -986,7 +994,7 @@ fn windows_ort_distribution_violations(
         violations
             .push("Windows ORT test bootstrap must run before inference-capable tests".into());
     }
-    if !pr_build.contains("cargo build --release")
+    if !pr_build.contains("scripts/build-release-binaries.sh")
         || !pr_smoke.contains("scripts/stage-onnxruntime-windows.ps1")
         || !pr_smoke.contains("scripts/smoke-windows.ps1")
     {
@@ -1554,7 +1562,7 @@ fn ci_routing_contract_violations(
         "macos",
         "windows",
         "windows-lint",
-        "windows-release",
+        "release-preflight",
         "mcp-platform",
         "test-plan",
     ] {
@@ -1646,11 +1654,11 @@ fn ci_routing_contract_violations(
         }
     }
 
-    let release_sensitive = detect_change_filter_paths(&ci, "windows-release");
+    let release_sensitive = detect_change_filter_paths(&ci, "release-preflight");
     for path in release_profile_sensitive_paths {
         if !filter_routes_path(&release_sensitive, path) {
             violations.push(format!(
-                "release-profile-sensitive source is not routed through windows-release: {path}"
+                "release-profile-sensitive source is not routed through release-preflight: {path}"
             ));
         }
     }
@@ -1673,7 +1681,7 @@ fn ci_routing_contract_violations(
             ("rust", &rust_paths),
             ("macos", &macos_paths),
             ("windows", &windows_paths),
-            ("windows-release", &release_sensitive),
+            ("release-preflight", &release_sensitive),
         ] {
             if !paths.contains(&path) {
                 violations.push(format!(
@@ -1708,7 +1716,7 @@ fn ci_routing_contract_violations(
     ] {
         if !release_sensitive.contains(path) {
             violations.push(format!(
-                "windows-release routing omits release-sensitive path {path}"
+                "release-preflight routing omits release-sensitive path {path}"
             ));
         }
     }
@@ -1802,24 +1810,22 @@ fn ci_routing_contract_violations(
         }
     }
     let differential_timeout = "${{ github.event_name == 'pull_request' && 30 || 60 }}";
-    for job in ["test", "windows-release-proof"] {
-        if ci["jobs"][job]["timeout-minutes"].as_str() != Some(differential_timeout) {
-            violations.push(format!(
-                "{job} does not enforce the 30-minute PR budget while allowing a 60-minute non-PR backstop"
-            ));
-        }
+    if ci["jobs"]["test"]["timeout-minutes"].as_str() != Some(differential_timeout) {
+        violations.push(
+            "test does not enforce the 30-minute PR budget while allowing a 60-minute non-PR backstop"
+                .into(),
+        );
     }
-    let windows_release_condition = ci["jobs"]["windows-release-proof"]["if"]
+    let release_preflight_condition = ci["jobs"]["release-preflight"]["if"]
         .as_str()
         .unwrap_or_default();
-    if job_needs(&ci, "windows-release-proof") != ["detect-changes"]
-        || !windows_release_condition
-            .contains("needs.detect-changes.outputs.windows-release == 'true'")
-        || !windows_release_condition.contains("github.event_name != 'pull_request'")
+    if job_needs(&ci, "release-preflight") != ["detect-changes"]
+        || !release_preflight_condition
+            .contains("needs.detect-changes.outputs.release-preflight == 'true'")
+        || !release_preflight_condition.contains("github.event_name != 'pull_request'")
     {
         violations.push(
-            "Windows release proof is not an independent differential job after detect-changes"
-                .into(),
+            "release-preflight is not an independent differential job after detect-changes".into(),
         );
     }
     for profile in ["DEV", "TEST"] {
@@ -1853,7 +1859,7 @@ fn ci_routing_contract_violations(
         );
     }
     let main_owned_cache = "${{ github.ref == 'refs/heads/main' }}";
-    for job in ["lint", "test", "test-quarantine", "windows-release-proof"] {
+    for job in ["lint", "test", "test-quarantine", "release-preflight"] {
         let rust_cache = job_step_using(&ci, job, "Swatinem/rust-cache");
         if rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some(main_owned_cache) {
             violations.push(format!("{job} cache writes are not restricted to main"));
@@ -1947,17 +1953,17 @@ fn ci_routing_contract_violations(
     }
     if !job_needs(&ci, "conclusion")
         .iter()
-        .any(|job| job == "windows-release-proof")
+        .any(|job| job == "release-preflight")
     {
-        violations.push("conclusion.needs omits the Windows release proof".into());
+        violations.push("conclusion.needs omits release-preflight".into());
     }
     for (job, expected) in [
         ("fmt", "\"$run_rust\""),
         ("lint", "\"$run_rust\""),
         ("test", "\"$run_rust\""),
         (
-            "windows-release-proof",
-            "needs.detect-changes.outputs.windows-release",
+            "release-preflight",
+            "needs.detect-changes.outputs.release-preflight",
         ),
         ("docs", "needs.detect-changes.outputs.docs"),
         ("plugin", "needs.detect-changes.outputs.plugin"),
@@ -1976,8 +1982,8 @@ fn ci_routing_contract_violations(
     }
 
     for step_name in [
-        "Build Windows release binaries",
-        "Native ORT smoke (Windows; release profile)",
+        "Build and smoke shipped release binaries",
+        "Native ORT smoke (Windows release preflight)",
     ] {
         if job_step(&ci, "test", step_name).is_some() {
             violations.push(format!(
@@ -1985,90 +1991,19 @@ fn ci_routing_contract_violations(
             ));
         }
     }
-    let windows_release_build = job_step(
-        &ci,
-        "windows-release-proof",
-        "Build Windows release binaries",
-    )
-    .and_then(|step| step["run"].as_str())
-    .unwrap_or_default();
-    let release_build_commands = windows_release_build
-        .lines()
-        .map(str::trim)
-        .filter(|line| line.starts_with("cargo build --release"))
-        .collect::<Vec<_>>();
-    if release_build_commands.len() != 1 {
-        violations.push(format!(
-            "Windows release proof uses {} Cargo release build invocations, expected a single Cargo invocation",
-            release_build_commands.len()
-        ));
-    }
-    let release_build_args = release_build_commands
-        .first()
-        .map(|command| command.split_whitespace().collect::<Vec<_>>())
+    let windows_linker = job_step(&ci, "test", "Configure rust-lld linker (Windows tests)");
+    let windows_linker_condition = windows_linker
+        .and_then(|step| step["if"].as_str())
         .unwrap_or_default();
-    let has_arg_pair = |flag: &str, value: &str| {
-        release_build_args
-            .windows(2)
-            .any(|args| args == [flag, value])
-    };
-    if !has_arg_pair("-p", "wenlan")
-        || !has_arg_pair("-p", "wenlan-server")
-        || !has_arg_pair("-p", "wenlan-mcp")
-        || !has_arg_pair("-p", "wenlan-core")
-        || !has_arg_pair("--bin", "wenlan")
-        || !has_arg_pair("--bin", "wenlan-server")
-        || !has_arg_pair("--bin", "wenlan-mcp")
-        || !has_arg_pair("--bin", "model_probe")
+    let windows_linker_run = windows_linker
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if !windows_linker_condition.contains("matrix.os == 'windows-2022'")
+        || !windows_linker_run.contains("rust-lld.exe")
+        || !windows_linker_run.contains("RUSTFLAGS=")
+        || !windows_linker_run.contains("$env:GITHUB_ENV")
     {
-        violations.push("Windows release proof omits a release artifact or model probe".into());
-    }
-    let windows_release_smoke = job_step(
-        &ci,
-        "windows-release-proof",
-        "Native ORT smoke (Windows; release profile)",
-    )
-    .and_then(|step| step["run"].as_str())
-    .unwrap_or_default();
-    if !windows_release_smoke.contains("scripts/stage-onnxruntime-windows.ps1")
-        || !windows_release_smoke.contains("scripts/smoke-windows.ps1")
-        || !windows_release_smoke.contains(r"target\release")
-    {
-        violations.push("Windows release proof omits the native ORT smoke".into());
-    }
-    let release_cache = job_step_using(&ci, "windows-release-proof", "Swatinem/rust-cache");
-    if release_cache
-        .and_then(|step| step["uses"].as_str())
-        .is_none_or(|uses| !uses.contains("Swatinem/rust-cache"))
-        || release_cache.and_then(|step| step["with"]["shared-key"].as_str())
-            != Some("windows-release")
-        || release_cache.and_then(|step| step["with"]["cache-all-crates"].as_str()) != Some("true")
-        || release_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some(main_owned_cache)
-    {
-        violations
-            .push("Windows release cache is not main-owned under a dedicated release key".into());
-    }
-    for (job, step_name) in [
-        ("test", "Configure rust-lld linker (Windows tests)"),
-        (
-            "windows-release-proof",
-            "Configure rust-lld linker (Windows release)",
-        ),
-    ] {
-        let linker = job_step(&ci, job, step_name);
-        let condition = linker
-            .and_then(|step| step["if"].as_str())
-            .unwrap_or_default();
-        let run = linker
-            .and_then(|step| step["run"].as_str())
-            .unwrap_or_default();
-        if (job == "test" && !condition.contains("matrix.os == 'windows-2022'"))
-            || !run.contains("rust-lld.exe")
-            || !run.contains("RUSTFLAGS=")
-            || !run.contains("$env:GITHUB_ENV")
-        {
-            violations.push(format!("{job} does not configure rust-lld for Windows"));
-        }
+        violations.push("test does not configure rust-lld for Windows".into());
     }
 
     let windows_lint_condition = job_step(&ci, "test", "Page lint scale gate (Windows functional)")
@@ -2252,7 +2187,7 @@ jobs:
   detect-changes:
     outputs:
       windows: ${{ steps.filter.outputs.windows }}
-      windows-release: ${{ steps.filter.outputs.windows-release }}
+      release-preflight: ${{ steps.filter.outputs.release-preflight }}
     steps:
       - id: filter
         with:
@@ -2260,7 +2195,7 @@ jobs:
             rust:
               - 'crates/**/*.rs'
             windows: []
-            windows-release:
+            release-preflight:
               - 'Cargo.toml'
       - id: matrix
         run: echo 'json=["ubuntu-24.04", "macos-14"]'
@@ -2321,10 +2256,6 @@ jobs:
         "release-sensitive",
         "30-minute PR budget",
         "independent differential job",
-        "single Cargo invocation",
-        "release artifact or model probe",
-        "native ORT smoke",
-        "release cache is not main-owned",
         "rust-lld",
         "does not also schedule",
         "debug runtime artifacts",
@@ -2350,7 +2281,351 @@ jobs:
     }
 }
 
-// ── Teeth #9: canonical acceptance runs beside the long workspace-lib lane ──
+// ── Teeth #9: release preflight mirrors every shipped target without publishing ──
+
+fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &str) -> Vec<String> {
+    let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
+    let release: serde_yaml::Value =
+        serde_yaml::from_str(release_workflow).expect("parse release.yml");
+    let mut violations = Vec::new();
+
+    let inventory_guard = job_step(&ci, "detect-changes", "Reject truncated PR file inventory");
+    let inventory_guard_run = inventory_guard
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if inventory_guard.and_then(|step| step["if"].as_str())
+        != Some("github.event_name == 'pull_request'")
+        || inventory_guard.and_then(|step| step["env"]["CHANGED_FILE_COUNT"].as_str())
+            != Some("${{ github.event.pull_request.changed_files }}")
+        || !inventory_guard_run.contains("-gt 3000")
+        || !inventory_guard_run.contains("cannot route fail-closed")
+    {
+        violations.push(
+            "detect-changes does not reject the REST API's truncated PR file inventory".into(),
+        );
+    }
+
+    if ci["jobs"]["detect-changes"]["outputs"]["release-targets"]
+        .as_str()
+        .is_none()
+    {
+        violations.push("detect-changes does not expose the canonical release matrix".into());
+    }
+    for (job, test_name) in [
+        ("detect-changes", "Test release target inventory"),
+        ("prepare-release", "Test release target inventory"),
+    ] {
+        let workflow = if job == "detect-changes" {
+            &ci
+        } else {
+            &release
+        };
+        let run = job_step(workflow, job, test_name)
+            .and_then(|step| step["run"].as_str())
+            .unwrap_or_default();
+        let prefix = if job == "detect-changes" {
+            "scripts"
+        } else {
+            ".release-tools/scripts"
+        };
+        if !run.contains(&format!("python3 {prefix}/release_targets.test.py"))
+            || !run.contains(&format!("bash {prefix}/build-release-binaries.test.sh"))
+        {
+            violations.push(format!("{job} does not test the shared release inventory"));
+        }
+    }
+    for (workflow, job, expected_output) in [
+        (
+            &ci,
+            "detect-changes",
+            "${{ steps.release-targets.outputs.release-targets }}",
+        ),
+        (
+            &release,
+            "prepare-release",
+            "${{ steps.release-targets.outputs.release-targets }}",
+        ),
+    ] {
+        if workflow["jobs"][job]["outputs"]["release-targets"].as_str() != Some(expected_output) {
+            violations.push(format!("{job} does not expose the shared release matrix"));
+        }
+        let step = job_step(workflow, job, "Emit release target matrix");
+        let command = if job == "detect-changes" {
+            "python3 scripts/release_targets.py matrix --github-output \"$GITHUB_OUTPUT\""
+        } else {
+            "python3 .release-tools/scripts/release_targets.py matrix --github-output \"$GITHUB_OUTPUT\""
+        };
+        if step.and_then(|candidate| candidate["id"].as_str()) != Some("release-targets")
+            || step.and_then(|candidate| candidate["run"].as_str()) != Some(command)
+        {
+            violations.push(format!("{job} does not emit the shared release matrix"));
+        }
+    }
+    for job in ["prepare-release", "release"] {
+        let tooling = job_step(&release, job, "Checkout release tooling");
+        if tooling
+            .and_then(|step| step["uses"].as_str())
+            .is_none_or(|uses| !uses.starts_with("actions/checkout@"))
+            || tooling.and_then(|step| step["with"]["ref"].as_str())
+                != Some("${{ github.workflow_sha }}")
+            || tooling.and_then(|step| step["with"]["path"].as_str()) != Some(".release-tools")
+        {
+            violations.push(format!(
+                "{job} cannot rerun historical tags with workflow-pinned release tooling"
+            ));
+        }
+    }
+
+    let job = &ci["jobs"]["release-preflight"];
+    if job_needs(&ci, "release-preflight") != ["detect-changes"]
+        || job["if"].as_str().is_none_or(|condition| {
+            !condition.contains("needs.detect-changes.outputs.release-preflight == 'true'")
+                || !condition.contains("github.event_name != 'pull_request'")
+        })
+    {
+        violations
+            .push("release-preflight is not an independent fail-closed differential job".into());
+    }
+    if job["runs-on"].as_str() != Some("${{ matrix.os }}")
+        || job["timeout-minutes"].as_str()
+            != Some("${{ github.event_name == 'pull_request' && 45 || 60 }}")
+        || job["strategy"]["fail-fast"].as_bool() != Some(true)
+        || job["strategy"]["matrix"].as_str()
+            != Some("${{ fromJSON(needs.detect-changes.outputs.release-targets) }}")
+    {
+        violations.push(
+            "release-preflight is not a fail-fast four-target matrix with a cold-cache safety ceiling"
+                .into(),
+        );
+    }
+    if release["jobs"]["release"]["strategy"]["matrix"].as_str()
+        != Some("${{ fromJSON(needs.prepare-release.outputs.release-targets) }}")
+    {
+        violations.push("tag release does not consume the canonical release matrix".into());
+    }
+
+    for (workflow, job_name, expected) in [
+        (
+            &ci,
+            "release-preflight",
+            "bash scripts/build-release-binaries.sh \"${{ matrix.target }}\"",
+        ),
+        (
+            &release,
+            "release",
+            "bash .release-tools/scripts/build-release-binaries.sh \"${{ matrix.target }}\"",
+        ),
+    ] {
+        let build = job_step(
+            workflow,
+            job_name,
+            "Build and smoke shipped release binaries",
+        )
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+        if build != expected {
+            violations.push(format!(
+                "{job_name} does not use the shared shipped-binary build contract"
+            ));
+        }
+    }
+    if job_step(
+        &release,
+        "release",
+        "Build and smoke shipped release binaries",
+    )
+    .and_then(|step| step["env"]["WENLAN_REPO_ROOT"].as_str())
+        != Some("${{ github.workspace }}")
+    {
+        violations.push(
+            "tag release does not run workflow-pinned tooling against the tag checkout".into(),
+        );
+    }
+
+    let toolchain = job_step_using(&ci, "release-preflight", "dtolnay/rust-toolchain");
+    if toolchain.and_then(|step| step["with"]["toolchain"].as_str()) != Some("1.95.0")
+        || toolchain.and_then(|step| step["with"]["targets"].as_str())
+            != Some("${{ matrix.target }}")
+    {
+        violations.push("release-preflight does not install the matrix target".into());
+    }
+    let windows_condition = "matrix.target == 'x86_64-pc-windows-msvc'";
+    for step_name in [
+        "Stabilize Windows Rust cache toolchain inputs",
+        "Configure rust-lld linker (Windows release preflight)",
+        "Install sqlite3 (Windows only)",
+        "Native ORT smoke (Windows release preflight)",
+    ] {
+        if job_step(&ci, "release-preflight", step_name).and_then(|step| step["if"].as_str())
+            != Some(windows_condition)
+        {
+            violations.push(format!(
+                "{step_name} is not restricted to the shipped Windows target"
+            ));
+        }
+    }
+    let linker = job_step(
+        &ci,
+        "release-preflight",
+        "Configure rust-lld linker (Windows release preflight)",
+    )
+    .and_then(|step| step["run"].as_str())
+    .unwrap_or_default();
+    if !linker.contains("rust-lld.exe")
+        || !linker.contains("RUSTFLAGS=")
+        || !linker.contains("$env:GITHUB_ENV")
+    {
+        violations.push("release-preflight does not configure rust-lld on Windows".into());
+    }
+    let sqlite = job_step(&ci, "release-preflight", "Install sqlite3 (Windows only)")
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if !sqlite.contains("vcpkg install sqlite3:x64-windows-static-md")
+        || !sqlite.contains("$env:GITHUB_ENV")
+    {
+        violations.push("release-preflight does not link the Windows sqlite dependency".into());
+    }
+    let cache = job_step_using(&ci, "release-preflight", "Swatinem/rust-cache");
+    if cache.and_then(|step| step["with"]["shared-key"].as_str())
+        != Some("release-${{ matrix.target }}")
+        || cache.and_then(|step| step["with"]["cache-all-crates"].as_str()) != Some("true")
+        || cache.and_then(|step| step["with"]["cache-targets"].as_str())
+            != Some("${{ matrix.target == 'x86_64-pc-windows-msvc' }}")
+        || cache.and_then(|step| step["with"]["save-if"].as_str())
+            != Some("${{ github.ref == 'refs/heads/main' }}")
+    {
+        violations.push(
+            "release-preflight cache is not target-scoped, capacity-bounded, and main-owned".into(),
+        );
+    }
+    let windows_smoke = job_step(
+        &ci,
+        "release-preflight",
+        "Native ORT smoke (Windows release preflight)",
+    )
+    .and_then(|step| step["run"].as_str())
+    .unwrap_or_default();
+    if !windows_smoke.contains("scripts/stage-onnxruntime-windows.ps1")
+        || !windows_smoke.contains("scripts/smoke-windows.ps1")
+        || !windows_smoke.contains(r"target\${{ matrix.target }}\release")
+    {
+        violations.push("Windows release preflight omits the native ORT smoke".into());
+    }
+
+    for step in job["steps"].as_sequence().into_iter().flatten() {
+        let name = step["name"]
+            .as_str()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let run = step["run"]
+            .as_str()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let uses = step["uses"]
+            .as_str()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if name.contains("package")
+            || name.contains("publish")
+            || run.contains("gh release")
+            || run.contains("npm publish")
+            || uses.contains("upload-artifact")
+        {
+            violations
+                .push("release-preflight contains a publishing or packaging side effect".into());
+        }
+    }
+
+    if !job_needs(&ci, "conclusion")
+        .iter()
+        .any(|need| need == "release-preflight")
+    {
+        violations.push("conclusion.needs omits release-preflight".into());
+    }
+    let conclusion = workflow_step_run(&ci, "Aggregate expected CI results").unwrap_or_default();
+    if !conclusion.lines().map(str::trim).any(|line| {
+        line.starts_with("expect_job release-preflight ")
+            && line.contains("needs.detect-changes.outputs.release-preflight")
+            && line.contains("needs.release-preflight.result")
+    }) {
+        violations.push("conclusion does not fail closed on release-preflight".into());
+    }
+
+    violations
+}
+
+#[test]
+fn release_preflight_is_shared_differential_and_read_only() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let release =
+        std::fs::read_to_string(root.join(".github/workflows/release.yml")).expect("read release");
+    let violations = release_preflight_contract_violations(&ci, &release);
+    assert!(
+        violations.is_empty(),
+        "release-preflight contract drift:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn release_preflight_contract_rejects_drift_and_side_effects() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let release =
+        std::fs::read_to_string(root.join(".github/workflows/release.yml")).expect("read release");
+    let ci = ci
+        .replace(
+            "      - name: Reject truncated PR file inventory",
+            "      - name: Accept truncated PR file inventory",
+        )
+        .replace(
+            "needs.detect-changes.outputs.release-preflight == 'true'",
+            "false",
+        )
+        .replace("      fail-fast: true", "      fail-fast: false")
+        .replace(
+            "          save-if: ${{ github.ref == 'refs/heads/main' }}",
+            "          save-if: \"true\"",
+        )
+        .replace(
+            "        run: bash scripts/build-release-binaries.sh \"${{ matrix.target }}\"",
+            "        run: gh release create unsafe",
+        )
+        .replace(
+            "          expect_job release-preflight '${{ github.event_name != 'pull_request' || needs.detect-changes.outputs.release-preflight == 'true' }}' '${{ needs.release-preflight.result }}'",
+            "          echo release-preflight skipped",
+        )
+        .replace(
+            "      - name: Native ORT smoke (Windows release preflight)",
+            "      - name: Native ORT smoke removed",
+        );
+    let release = release.replace(
+        "      matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}",
+        "      matrix: {}",
+    );
+    let violations = release_preflight_contract_violations(&ci, &release);
+    for expected in [
+        "independent fail-closed",
+        "fail-fast four-target",
+        "canonical release matrix",
+        "shared shipped-binary",
+        "target-scoped, capacity-bounded, and main-owned",
+        "truncated PR file inventory",
+        "native ORT smoke",
+        "publishing or packaging side effect",
+        "conclusion does not fail closed",
+    ] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "mutation must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
+// ── Teeth #10: canonical acceptance runs beside the long workspace-lib lane ──
 
 fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
@@ -2691,7 +2966,7 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
     }
 }
 
-// ── Teeth #10: every normal core integration target has a required owner ──
+// ── Teeth #11: every normal core integration target has a required owner ──
 
 fn core_integration_contract_violations(ci_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
@@ -2794,7 +3069,7 @@ jobs:
     }
 }
 
-// ── Teeth #11: the main eval canary stays off the required CI path ──
+// ── Teeth #12: the main eval canary stays off the required CI path ──
 
 fn main_canary_contract_violations(ci_workflow: &str, canary_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
@@ -3128,7 +3403,7 @@ fn main_canary_contract_rejects_eval_inside_conclusion_itself() {
     );
 }
 
-// ── Teeth #12: CI measurements stay read-only and off the required path ──
+// ── Teeth #13: CI measurements stay read-only and off the required path ──
 
 fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
@@ -3454,7 +3729,7 @@ fn ci_observer_contract_rejects_non_blocking_measurement_tests() {
     );
 }
 
-// ── Teeth #13: hosted optimization experiments stay manual and restore-only ──
+// ── Teeth #14: hosted optimization experiments stay manual and restore-only ──
 
 fn ci_benchmark_contract_violations(ci_workflow: &str, benchmark_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");

--- a/scripts/build-release-binaries.sh
+++ b/scripts/build-release-binaries.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tools_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${WENLAN_REPO_ROOT:-$(cd "$tools_root/.." && pwd)}"
+target="${1:?usage: build-release-binaries.sh <target>}"
+
+if command -v python3 >/dev/null 2>&1; then
+  python_bin=python3
+else
+  python_bin=python
+fi
+"$python_bin" "$tools_root/release_targets.py" check --target "$target" >/dev/null
+
+cd "$repo_root"
+cargo build --release \
+  -p wenlan \
+  -p wenlan-server \
+  -p wenlan-mcp \
+  --target "$target"
+
+suffix=""
+if [[ "$target" == "x86_64-pc-windows-msvc" ]]; then
+  suffix=".exe"
+fi
+target_root="${CARGO_TARGET_DIR:-target}"
+binary_dir="$target_root/$target/release"
+"$binary_dir/wenlan$suffix" --help
+"$binary_dir/wenlan-server$suffix" --help
+"$binary_dir/wenlan-mcp$suffix" --help

--- a/scripts/build-release-binaries.test.sh
+++ b/scripts/build-release-binaries.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "$CARGO_LOG"
+target=""
+while (($#)); do
+  if [[ "$1" == "--target" ]]; then
+    target="$2"
+    break
+  fi
+  shift
+done
+[[ -n "$target" ]]
+suffix=""
+[[ "$target" == "x86_64-pc-windows-msvc" ]] && suffix=".exe"
+mkdir -p "$CARGO_TARGET_DIR/$target/release"
+for binary in wenlan wenlan-server wenlan-mcp; do
+  if [[ "${OMIT_MCP:-0}" == "1" && "$binary" == "wenlan-mcp" ]]; then
+    continue
+  fi
+  cat > "$CARGO_TARGET_DIR/$target/release/$binary$suffix" <<'BIN'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--help" ]]
+BIN
+  chmod +x "$CARGO_TARGET_DIR/$target/release/$binary$suffix"
+done
+EOF
+chmod +x "$tmp/bin/cargo"
+
+export PATH="$tmp/bin:$PATH"
+export CARGO_LOG="$tmp/cargo.log"
+export CARGO_TARGET_DIR="$tmp/target"
+
+bash "$repo_root/scripts/build-release-binaries.sh" x86_64-unknown-linux-gnu
+expected="build --release -p wenlan -p wenlan-server -p wenlan-mcp --target x86_64-unknown-linux-gnu"
+[[ "$(cat "$CARGO_LOG")" == "$expected" ]]
+
+mkdir -p "$tmp/release-tools/scripts"
+cp "$repo_root/scripts/build-release-binaries.sh" \
+  "$repo_root/scripts/release_targets.py" \
+  "$tmp/release-tools/scripts/"
+WENLAN_REPO_ROOT="$repo_root" \
+  bash "$tmp/release-tools/scripts/build-release-binaries.sh" aarch64-apple-darwin
+expected="build --release -p wenlan -p wenlan-server -p wenlan-mcp --target aarch64-apple-darwin"
+[[ "$(cat "$CARGO_LOG")" == "$expected" ]]
+
+rm -rf "$CARGO_TARGET_DIR/x86_64-unknown-linux-gnu"
+if OMIT_MCP=1 \
+  bash "$repo_root/scripts/build-release-binaries.sh" x86_64-unknown-linux-gnu; then
+  echo "release smoke unexpectedly accepted a missing wenlan-mcp binary" >&2
+  exit 1
+fi
+
+rm "$CARGO_LOG"
+if bash "$repo_root/scripts/build-release-binaries.sh" x86_64-apple-darwin; then
+  echo "unsupported release target unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ ! -e "$CARGO_LOG" ]]

--- a/scripts/ci_test_plan.py
+++ b/scripts/ci_test_plan.py
@@ -19,7 +19,7 @@ class PlanError(ValueError):
 ISOLATED_UNIT_MODULES = {
     "crates/wenlan-core/src/lint/pages/security_test.rs": (
         "wenlan-core",
-        "lint::pages::security_test",
+        "lint::pages::fs::tests::security_cases",
     ),
 }
 
@@ -194,7 +194,11 @@ def _workspace_lib_plan(
     if not expressions:
         return {"mode": "skip"}
     if isolated_filters:
-        return {"mode": "filterset", "filterset": " | ".join(expressions)}
+        return {
+            "mode": "filterset",
+            "packages": sorted(broad_packages | set(isolated_filters)),
+            "filterset": " | ".join(expressions),
+        }
     return {"mode": "packages", "packages": sorted(broad_packages)}
 
 
@@ -210,15 +214,14 @@ def build_plan(
     packages, directories = _workspace(cargo_metadata)
     reverse = _reverse_dependencies(packages)
     paths = [_normalize_path(path) for path in changed_paths]
+    if event_name != "pull_request":
+        return _full_plan(f"{event_name} keeps the full backstop")
     if not paths:
         raise PlanError("changed path inventory is empty")
     if existing_paths is None:
         existing = {path for path in paths if Path(path).exists()}
     else:
         existing = {_normalize_path(path) for path in existing_paths}
-
-    if event_name != "pull_request":
-        return _full_plan(f"{event_name} keeps the full backstop")
 
     broad_packages: set[str] = set()
     isolated_filters: dict[str, set[str]] = defaultdict(set)
@@ -394,7 +397,8 @@ def command_groups_for(
             filterset = suite.get("filterset")
             if not isinstance(filterset, str) or not filterset:
                 raise PlanError("workspace filterset is empty")
-            return [[*cargo, "--workspace", "--lib", "-E", filterset]]
+            names = _validated_package_names(suite.get("packages"), packages)
+            return [[*cargo, *_package_args(names), "--lib", "-E", filterset]]
         raise PlanError(f"unknown workspace-lib mode: {mode!r}")
 
     if suite_name == "cli-server-integration":

--- a/scripts/ci_test_plan.py
+++ b/scripts/ci_test_plan.py
@@ -1,0 +1,593 @@
+#!/usr/bin/env python3
+"""Build fail-closed Rust test plans from a Git diff and Cargo metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict, deque
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+class PlanError(ValueError):
+    """Planner input is malformed and CI must stop."""
+
+
+ISOLATED_UNIT_MODULES = {
+    "crates/wenlan-core/src/lint/pages/security_test.rs": (
+        "wenlan-core",
+        "lint::pages::security_test",
+    ),
+}
+
+SHARED_TEST_HELPERS = {
+    "crates/wenlan-core/src/lint/test_support.rs",
+    "crates/wenlan-core/src/lint/test_support_db.rs",
+    "crates/wenlan-core/src/lint/test_support_fs.rs",
+    "crates/wenlan-core/src/lint/test_support_privacy.rs",
+}
+
+FULL_INPUTS = {
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    ".config/nextest.toml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/release.yml",
+    "scripts/ci_test_plan.py",
+    "scripts/ci_test_plan.test.py",
+}
+
+NATIVE_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".cxx",
+    ".h",
+    ".hh",
+    ".hpp",
+    ".hxx",
+    ".m",
+    ".mm",
+}
+
+CLI_SERVER_PACKAGES = {"wenlan", "wenlan-server"}
+MANUAL_CORE_INTEGRATION = {"cached_scenario_db_check", "eval_harness"}
+
+
+def _full_plan(reason: str) -> dict:
+    return {
+        "version": 1,
+        "mode": "full",
+        "reasons": [reason],
+        "workspace_lib": {"mode": "full"},
+        "cli_server_integration": {"mode": "full"},
+        "core_integration": {"mode": "full"},
+    }
+
+
+def _normalize_path(raw_path: object) -> str:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise PlanError("changed paths must be non-empty strings")
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or ".." in path.parts:
+        raise PlanError(f"changed path is not repository-relative: {raw_path!r}")
+    return path.as_posix()
+
+
+def _workspace(metadata: object) -> tuple[dict[str, dict], dict[str, str]]:
+    if not isinstance(metadata, dict):
+        raise PlanError("Cargo metadata must be a JSON object")
+    workspace_root = metadata.get("workspace_root")
+    packages = metadata.get("packages")
+    if not isinstance(workspace_root, str) or not workspace_root:
+        raise PlanError("Cargo metadata is missing workspace_root")
+    if not isinstance(packages, list) or not packages:
+        raise PlanError("Cargo metadata has no workspace packages")
+
+    root = Path(workspace_root)
+    by_name: dict[str, dict] = {}
+    directories: dict[str, str] = {}
+    for package in packages:
+        if not isinstance(package, dict):
+            raise PlanError("Cargo metadata package is not an object")
+        name = package.get("name")
+        manifest_path = package.get("manifest_path")
+        dependencies = package.get("dependencies")
+        targets = package.get("targets")
+        if (
+            not isinstance(name, str)
+            or not name
+            or name in by_name
+            or not isinstance(manifest_path, str)
+            or not isinstance(dependencies, list)
+            or not isinstance(targets, list)
+        ):
+            raise PlanError(f"malformed Cargo package metadata: {package!r}")
+        try:
+            directory = Path(manifest_path).parent.relative_to(root).as_posix()
+        except ValueError as error:
+            raise PlanError(
+                f"workspace manifest is outside workspace_root: {manifest_path}"
+            ) from error
+        by_name[name] = package
+        directories[directory] = name
+
+    return by_name, directories
+
+
+def _reverse_dependencies(packages: dict[str, dict]) -> dict[str, set[str]]:
+    reverse: dict[str, set[str]] = defaultdict(set)
+    for package_name, package in packages.items():
+        for dependency in package["dependencies"]:
+            if not isinstance(dependency, dict):
+                raise PlanError(
+                    f"malformed dependency metadata in package {package_name}"
+                )
+            dependency_name = dependency.get("name")
+            dependency_path = dependency.get("path")
+            if dependency_path is None:
+                continue
+            if not isinstance(dependency_name, str):
+                raise PlanError(
+                    f"path dependency without a name in package {package_name}"
+                )
+            if dependency_name not in packages:
+                raise PlanError(
+                    f"workspace path dependency {dependency_name!r} is absent"
+                )
+            reverse[dependency_name].add(package_name)
+    return reverse
+
+
+def _closure(seed: str, reverse: dict[str, set[str]]) -> set[str]:
+    selected: set[str] = set()
+    pending = deque([seed])
+    while pending:
+        package = pending.popleft()
+        if package in selected:
+            continue
+        selected.add(package)
+        pending.extend(sorted(reverse.get(package, ())))
+    return selected
+
+
+def _owner(path: str, directories: dict[str, str]) -> tuple[str, str] | None:
+    matches = [
+        (directory, package)
+        for directory, package in directories.items()
+        if path == directory or path.startswith(f"{directory}/")
+    ]
+    if not matches:
+        return None
+    directory, package = max(matches, key=lambda item: len(item[0]))
+    return package, path[len(directory) + 1 :]
+
+
+def _integration_targets(package: dict) -> set[str]:
+    targets = set()
+    for target in package["targets"]:
+        if not isinstance(target, dict):
+            raise PlanError("Cargo target metadata is not an object")
+        name = target.get("name")
+        kinds = target.get("kind")
+        if not isinstance(name, str) or not isinstance(kinds, list):
+            raise PlanError(f"malformed Cargo target metadata: {target!r}")
+        if "test" in kinds:
+            targets.add(name)
+    return targets
+
+
+def _workspace_lib_plan(
+    broad_packages: set[str],
+    isolated_filters: dict[str, set[str]],
+) -> dict:
+    for package in broad_packages:
+        isolated_filters.pop(package, None)
+    expressions = [f"package({package})" for package in sorted(broad_packages)]
+    for package in sorted(isolated_filters):
+        for prefix in sorted(isolated_filters[package]):
+            expressions.append(f"package({package}) & test(/^{prefix}::/)")
+    if not expressions:
+        return {"mode": "skip"}
+    if isolated_filters:
+        return {"mode": "filterset", "filterset": " | ".join(expressions)}
+    return {"mode": "packages", "packages": sorted(broad_packages)}
+
+
+def build_plan(
+    changed_paths: Iterable[object],
+    cargo_metadata: object,
+    *,
+    event_name: str,
+    existing_paths: set[str] | None = None,
+) -> dict:
+    """Return a deterministic test plan or raise PlanError for malformed input."""
+
+    packages, directories = _workspace(cargo_metadata)
+    reverse = _reverse_dependencies(packages)
+    paths = [_normalize_path(path) for path in changed_paths]
+    if not paths:
+        raise PlanError("changed path inventory is empty")
+    if existing_paths is None:
+        existing = {path for path in paths if Path(path).exists()}
+    else:
+        existing = {_normalize_path(path) for path in existing_paths}
+
+    if event_name != "pull_request":
+        return _full_plan(f"{event_name} keeps the full backstop")
+
+    broad_packages: set[str] = set()
+    isolated_filters: dict[str, set[str]] = defaultdict(set)
+    cli_server_packages: set[str] = set()
+    cli_server_targets: dict[str, set[str]] = defaultdict(set)
+    core_full = False
+    core_targets: set[str] = set()
+    reasons: list[str] = []
+
+    for path in paths:
+        if (
+            path in FULL_INPUTS
+            or path.endswith("/Cargo.toml")
+            or path.endswith("/build.rs")
+            or PurePosixPath(path).suffix.lower() in NATIVE_SUFFIXES
+        ):
+            return _full_plan(f"shared build or native input changed: {path}")
+        if path in SHARED_TEST_HELPERS:
+            return _full_plan(f"shared test helper changed: {path}")
+
+        isolated = ISOLATED_UNIT_MODULES.get(path)
+        if isolated is not None:
+            if path not in existing:
+                return _full_plan(f"isolated test module was removed or renamed: {path}")
+            package, prefix = isolated
+            if package not in packages:
+                raise PlanError(
+                    f"isolated test module maps to unknown package {package!r}"
+                )
+            isolated_filters[package].add(prefix)
+            reasons.append(f"isolated unit module changed: {path}")
+            continue
+
+        owner = _owner(path, directories)
+        if owner is None:
+            return _full_plan(f"unowned changed path: {path}")
+        package_name, package_path = owner
+        package = packages[package_name]
+
+        parts = PurePosixPath(package_path).parts
+        if len(parts) == 2 and parts[0] == "tests" and path.endswith(".rs"):
+            target = PurePosixPath(package_path).stem
+            known_targets = _integration_targets(package)
+            if path not in existing or target not in known_targets:
+                if package_name in CLI_SERVER_PACKAGES:
+                    cli_server_packages.add(package_name)
+                    reasons.append(
+                        f"removed or unknown integration target uses package suite: {path}"
+                    )
+                    continue
+                if package_name == "wenlan-core":
+                    core_full = True
+                    reasons.append(
+                        f"removed or unknown core target uses full core suite: {path}"
+                    )
+                    continue
+                return _full_plan(
+                    f"unowned integration target changed in {package_name}: {path}"
+                )
+            if package_name in CLI_SERVER_PACKAGES:
+                cli_server_targets[package_name].add(target)
+                reasons.append(f"owned integration target changed: {path}")
+                continue
+            if package_name == "wenlan-core":
+                if target not in MANUAL_CORE_INTEGRATION:
+                    core_targets.add(target)
+                reasons.append(f"owned core integration target changed: {path}")
+                continue
+            return _full_plan(
+                f"integration target has no required-suite planner: {path}"
+            )
+
+        if parts and parts[0] == "src" and path.endswith(".rs"):
+            closure = _closure(package_name, reverse)
+            broad_packages.update(closure)
+            cli_server_packages.update(closure & CLI_SERVER_PACKAGES)
+            core_full = core_full or "wenlan-core" in closure
+            reasons.append(f"source change selects reverse dependency closure: {path}")
+            continue
+
+        return _full_plan(f"unclassified crate input changed: {path}")
+
+    for package_name in cli_server_packages:
+        cli_server_targets.pop(package_name, None)
+
+    if cli_server_packages:
+        cli_server_plan = {
+            "mode": "packages",
+            "packages": sorted(cli_server_packages),
+        }
+    elif cli_server_targets:
+        cli_server_plan = {
+            "mode": "targets",
+            "targets": {
+                package: sorted(targets)
+                for package, targets in sorted(cli_server_targets.items())
+            },
+        }
+    else:
+        cli_server_plan = {"mode": "skip"}
+
+    if core_full:
+        core_plan = {"mode": "full"}
+    elif core_targets:
+        core_plan = {"mode": "targets", "targets": sorted(core_targets)}
+    else:
+        core_plan = {"mode": "skip"}
+
+    return {
+        "version": 1,
+        "mode": "differential",
+        "reasons": sorted(set(reasons)),
+        "workspace_lib": _workspace_lib_plan(broad_packages, isolated_filters),
+        "cli_server_integration": cli_server_plan,
+        "core_integration": core_plan,
+    }
+
+
+def _validated_package_names(
+    raw_names: object,
+    packages: dict[str, dict],
+    *,
+    allowed: set[str] | None = None,
+) -> list[str]:
+    if (
+        not isinstance(raw_names, list)
+        or not raw_names
+        or not all(isinstance(name, str) and name for name in raw_names)
+    ):
+        raise PlanError("suite package inventory must be a non-empty string list")
+    names = sorted(set(raw_names))
+    unknown = set(names) - set(packages)
+    if unknown:
+        raise PlanError(f"suite plan contains unknown packages: {sorted(unknown)}")
+    if allowed is not None and not set(names) <= allowed:
+        raise PlanError(f"suite plan contains packages outside its owner set: {names}")
+    return names
+
+
+def _package_args(package_names: Iterable[str]) -> list[str]:
+    arguments: list[str] = []
+    for package in package_names:
+        arguments.extend(["-p", package])
+    return arguments
+
+
+def command_groups_for(
+    suite_name: str,
+    plan: object,
+    cargo_metadata: object,
+) -> list[list[str]]:
+    """Translate a plan suite into validated argv vectors."""
+
+    if not isinstance(plan, dict) or plan.get("version") != 1:
+        raise PlanError("unsupported or malformed test plan")
+    packages, _directories = _workspace(cargo_metadata)
+    plan_key = suite_name.replace("-", "_")
+    suite = plan.get(plan_key)
+    if not isinstance(suite, dict):
+        raise PlanError(f"test plan has no suite {suite_name!r}")
+    mode = suite.get("mode")
+    if mode == "skip":
+        return []
+
+    cargo = ["cargo", "nextest", "run"]
+    if suite_name == "workspace-lib":
+        if mode == "full":
+            return [[*cargo, "--workspace", "--lib"]]
+        if mode == "packages":
+            names = _validated_package_names(suite.get("packages"), packages)
+            return [[*cargo, *_package_args(names), "--lib"]]
+        if mode == "filterset":
+            filterset = suite.get("filterset")
+            if not isinstance(filterset, str) or not filterset:
+                raise PlanError("workspace filterset is empty")
+            return [[*cargo, "--workspace", "--lib", "-E", filterset]]
+        raise PlanError(f"unknown workspace-lib mode: {mode!r}")
+
+    if suite_name == "cli-server-integration":
+        if mode == "full":
+            names = sorted(CLI_SERVER_PACKAGES)
+            return [[*cargo, *_package_args(names), "-E", "kind(test)"]]
+        if mode == "packages":
+            names = _validated_package_names(
+                suite.get("packages"),
+                packages,
+                allowed=CLI_SERVER_PACKAGES,
+            )
+            return [[*cargo, *_package_args(names), "-E", "kind(test)"]]
+        if mode == "targets":
+            raw_targets = suite.get("targets")
+            if not isinstance(raw_targets, dict) or not raw_targets:
+                raise PlanError("CLI/server target plan is empty")
+            commands = []
+            for package_name in sorted(raw_targets):
+                if package_name not in CLI_SERVER_PACKAGES:
+                    raise PlanError(
+                        f"integration target package has no owner: {package_name}"
+                    )
+                names = raw_targets[package_name]
+                if (
+                    not isinstance(names, list)
+                    or not names
+                    or not all(isinstance(name, str) and name for name in names)
+                ):
+                    raise PlanError(
+                        f"integration targets for {package_name} are malformed"
+                    )
+                known = _integration_targets(packages[package_name])
+                unknown = set(names) - known
+                if unknown:
+                    raise PlanError(
+                        f"unknown integration targets for {package_name}: "
+                        f"{sorted(unknown)}"
+                    )
+                target_args = [
+                    argument
+                    for target in sorted(set(names))
+                    for argument in ("--test", target)
+                ]
+                commands.append(
+                    [*cargo, "-p", package_name, *target_args]
+                )
+            return commands
+        raise PlanError(f"unknown cli-server-integration mode: {mode!r}")
+
+    if suite_name == "core-integration":
+        if "wenlan-core" not in packages:
+            raise PlanError("Cargo metadata has no wenlan-core package")
+        known = _integration_targets(packages["wenlan-core"])
+        if mode == "full":
+            targets = sorted(known - MANUAL_CORE_INTEGRATION)
+        elif mode == "targets":
+            raw_targets = suite.get("targets")
+            if (
+                not isinstance(raw_targets, list)
+                or not raw_targets
+                or not all(
+                    isinstance(target, str) and target for target in raw_targets
+                )
+            ):
+                raise PlanError("core integration target plan is empty")
+            targets = sorted(set(raw_targets))
+            unknown = set(targets) - known
+            if unknown:
+                raise PlanError(
+                    f"unknown core integration targets: {sorted(unknown)}"
+                )
+            forbidden = set(targets) & MANUAL_CORE_INTEGRATION
+            if forbidden:
+                raise PlanError(
+                    f"manual-only core targets entered required CI: "
+                    f"{sorted(forbidden)}"
+                )
+        else:
+            raise PlanError(f"unknown core-integration mode: {mode!r}")
+        if not targets:
+            raise PlanError("required core integration inventory is empty")
+        target_args = [
+            argument
+            for target in targets
+            for argument in ("--test", target)
+        ]
+        return [
+            [
+                *cargo,
+                "-p",
+                "wenlan-core",
+                "--features",
+                "eval-harness",
+                *target_args,
+            ]
+        ]
+
+    raise PlanError(f"unknown suite name: {suite_name!r}")
+
+
+def _load_json_file(path: str) -> object:
+    try:
+        return json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as error:
+        raise PlanError(f"cannot read JSON from {path}: {error}") from error
+
+
+def _cargo_metadata() -> object:
+    result = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--format-version",
+            "1",
+            "--locked",
+            "--no-deps",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise PlanError("cargo metadata emitted invalid JSON") from error
+
+
+def _write_github_output(path: str, plan_json: str) -> None:
+    if "\n" in plan_json or "\r" in plan_json:
+        raise PlanError("compact plan JSON unexpectedly contains a newline")
+    with Path(path).open("a", encoding="utf-8") as output:
+        output.write(f"test-plan={plan_json}\n")
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan_parser = subparsers.add_parser("plan")
+    plan_parser.add_argument("--changed-files-json", required=True)
+    plan_parser.add_argument("--metadata-file", required=True)
+    plan_parser.add_argument("--event-name", required=True)
+    plan_parser.add_argument("--github-output")
+
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument(
+        "--suite",
+        required=True,
+        choices=(
+            "workspace-lib",
+            "cli-server-integration",
+            "core-integration",
+        ),
+    )
+    run_parser.add_argument("--plan-json", required=True)
+
+    arguments = parser.parse_args(argv)
+    if arguments.command == "plan":
+        try:
+            changed_paths = json.loads(arguments.changed_files_json)
+        except json.JSONDecodeError as error:
+            raise PlanError("changed-files-json is invalid") from error
+        if not isinstance(changed_paths, list):
+            raise PlanError("changed-files-json must be an array")
+        plan = build_plan(
+            changed_paths,
+            _load_json_file(arguments.metadata_file),
+            event_name=arguments.event_name,
+        )
+        plan_json = json.dumps(plan, separators=(",", ":"), sort_keys=True)
+        print(plan_json)
+        if arguments.github_output:
+            _write_github_output(arguments.github_output, plan_json)
+        return 0
+
+    try:
+        plan = json.loads(arguments.plan_json)
+    except json.JSONDecodeError as error:
+        raise PlanError("plan-json is invalid") from error
+    commands = command_groups_for(arguments.suite, plan, _cargo_metadata())
+    if not commands:
+        print(f"{arguments.suite}: no affected tests")
+        return 0
+    for command in commands:
+        print("+", " ".join(command), flush=True)
+        subprocess.run(command, check=True)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(_main(sys.argv[1:]))
+    except (PlanError, subprocess.CalledProcessError) as error:
+        print(f"ci_test_plan: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/ci_test_plan.py
+++ b/scripts/ci_test_plan.py
@@ -527,6 +527,50 @@ def _cargo_metadata() -> object:
         raise PlanError("cargo metadata emitted invalid JSON") from error
 
 
+def _require_filterset_match(command: list[str]) -> None:
+    if command[:3] != ["cargo", "nextest", "run"]:
+        raise PlanError(f"cannot validate non-nextest command: {command!r}")
+    list_command = [
+        "cargo",
+        "nextest",
+        "list",
+        *command[3:],
+        "--message-format",
+        "json",
+    ]
+    print("+", " ".join(list_command), flush=True)
+    result = subprocess.run(
+        list_command,
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        listing = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise PlanError("cargo nextest list emitted invalid JSON") from error
+    suites = listing.get("rust-suites") if isinstance(listing, dict) else None
+    matched = 0
+    if isinstance(suites, dict):
+        for suite in suites.values():
+            testcases = suite.get("testcases") if isinstance(suite, dict) else None
+            if not isinstance(testcases, dict):
+                continue
+            matched += sum(
+                isinstance(testcase, dict)
+                and testcase.get("ignored") is False
+                and isinstance(testcase.get("filter-match"), dict)
+                and testcase["filter-match"].get("status") == "matches"
+                for testcase in testcases.values()
+            )
+    if matched == 0:
+        raise PlanError(
+            "workspace-lib filterset selected zero tests; "
+            "isolated module ownership has drifted"
+        )
+    print(f"workspace-lib filterset matched {matched} tests")
+
+
 def _write_github_output(path: str, plan_json: str) -> None:
     if "\n" in plan_json or "\r" in plan_json:
         raise PlanError("compact plan JSON unexpectedly contains a newline")
@@ -584,6 +628,14 @@ def _main(argv: list[str]) -> int:
         print(f"{arguments.suite}: no affected tests")
         return 0
     for command in commands:
+        suite_key = arguments.suite.replace("-", "_")
+        suite = plan.get(suite_key) if isinstance(plan, dict) else None
+        if (
+            arguments.suite == "workspace-lib"
+            and isinstance(suite, dict)
+            and suite.get("mode") == "filterset"
+        ):
+            _require_filterset_match(command)
         print("+", " ".join(command), flush=True)
         subprocess.run(command, check=True)
     return 0

--- a/scripts/ci_test_plan.test.py
+++ b/scripts/ci_test_plan.test.py
@@ -3,7 +3,13 @@
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+import tempfile
 import unittest
+from pathlib import Path
 
 from ci_test_plan import PlanError, build_plan, command_groups_for
 
@@ -93,6 +99,119 @@ def plan_for(*paths: str, existing_paths: set[str] | None = None) -> dict:
         event_name="pull_request",
         existing_paths=set(paths) if existing_paths is None else existing_paths,
     )
+
+
+class FiltersetExecutionTests(unittest.TestCase):
+    def run_filterset_with_listing(
+        self,
+        listing: dict,
+    ) -> tuple[subprocess.CompletedProcess[str], bool]:
+        plan = plan_for(
+            "crates/wenlan-core/src/lint/pages/security_test.rs"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            fake_cargo = Path(directory) / "cargo"
+            run_marker = Path(directory) / "nextest-ran"
+            fake_cargo.write_text(
+                """#!/usr/bin/env python3
+import os
+from pathlib import Path
+import sys
+
+if sys.argv[1] == "metadata":
+    print(os.environ["FAKE_CARGO_METADATA"])
+elif sys.argv[1:3] == ["nextest", "list"]:
+    print(os.environ["FAKE_NEXTEST_LISTING"])
+elif sys.argv[1:3] == ["nextest", "run"]:
+    Path(os.environ["NEXTEST_RUN_MARKER"]).write_text("ran")
+else:
+    raise SystemExit(f"unexpected cargo arguments: {sys.argv[1:]}")
+""",
+                encoding="utf-8",
+            )
+            fake_cargo.chmod(0o755)
+            environment = os.environ.copy()
+            environment["PATH"] = f"{directory}{os.pathsep}{environment['PATH']}"
+            environment["FAKE_CARGO_METADATA"] = json.dumps(cargo_metadata())
+            environment["FAKE_NEXTEST_LISTING"] = json.dumps(listing)
+            environment["NEXTEST_RUN_MARKER"] = str(run_marker)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("ci_test_plan.py")),
+                    "run",
+                    "--suite",
+                    "workspace-lib",
+                    "--plan-json",
+                    json.dumps(plan),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            did_run = run_marker.exists()
+        return result, did_run
+
+    def test_zero_match_filterset_fails_before_running_tests(self) -> None:
+        result, did_run = self.run_filterset_with_listing(
+            {
+                "rust-suites": {
+                    "wenlan-core": {
+                        "testcases": {
+                            "wrong::test": {
+                                "ignored": False,
+                                "filter-match": {"status": "mismatch"},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("selected zero tests", result.stderr)
+        self.assertFalse(did_run)
+
+    def test_ignored_only_match_fails_before_running_tests(self) -> None:
+        result, did_run = self.run_filterset_with_listing(
+            {
+                "rust-suites": {
+                    "wenlan-core": {
+                        "testcases": {
+                            "owned::ignored": {
+                                "ignored": True,
+                                "filter-match": {"status": "matches"},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("selected zero tests", result.stderr)
+        self.assertFalse(did_run)
+
+    def test_runnable_match_executes_nextest(self) -> None:
+        result, did_run = self.run_filterset_with_listing(
+            {
+                "rust-suites": {
+                    "wenlan-core": {
+                        "testcases": {
+                            "owned::active": {
+                                "ignored": False,
+                                "filter-match": {"status": "matches"},
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(did_run)
 
 
 class PackageClosureTests(unittest.TestCase):

--- a/scripts/ci_test_plan.test.py
+++ b/scripts/ci_test_plan.test.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Contract tests for fail-closed differential Rust test planning."""
+
+from __future__ import annotations
+
+import unittest
+
+from ci_test_plan import PlanError, build_plan, command_groups_for
+
+
+WORKSPACE_ROOT = "/repo"
+
+
+def package(
+    name: str,
+    directory: str,
+    dependencies: tuple[str, ...],
+    integration_targets: tuple[str, ...] = (),
+) -> dict:
+    targets = [
+        {
+            "name": name.replace("-", "_"),
+            "kind": ["lib"],
+            "src_path": f"{WORKSPACE_ROOT}/{directory}/src/lib.rs",
+        }
+    ]
+    targets.extend(
+        {
+            "name": target,
+            "kind": ["test"],
+            "src_path": f"{WORKSPACE_ROOT}/{directory}/tests/{target}.rs",
+        }
+        for target in integration_targets
+    )
+    return {
+        "name": name,
+        "manifest_path": f"{WORKSPACE_ROOT}/{directory}/Cargo.toml",
+        "dependencies": [
+            {
+                "name": dependency,
+                "path": f"{WORKSPACE_ROOT}/crates/{dependency}",
+            }
+            for dependency in dependencies
+        ],
+        "targets": targets,
+    }
+
+
+def cargo_metadata() -> dict:
+    return {
+        "workspace_root": WORKSPACE_ROOT,
+        "workspace_members": [
+            "wenlan",
+            "wenlan-core",
+            "wenlan-types",
+            "wenlan-server",
+            "wenlan-mcp",
+        ],
+        "packages": [
+            package(
+                "wenlan",
+                "crates/wenlan-cli",
+                ("wenlan-core", "wenlan-types"),
+                ("cli_integration", "distribution"),
+            ),
+            package(
+                "wenlan-core",
+                "crates/wenlan-core",
+                ("wenlan-types",),
+                ("eval_harness", "folder_ingest_e2e", "read_scope"),
+            ),
+            package("wenlan-types", "crates/wenlan-types", ()),
+            package(
+                "wenlan-server",
+                "crates/wenlan-server",
+                ("wenlan-core", "wenlan-types"),
+                ("graceful_shutdown", "space_scoping_e2e"),
+            ),
+            package(
+                "wenlan-mcp",
+                "crates/wenlan-mcp",
+                ("wenlan-core", "wenlan-server", "wenlan-types"),
+                ("real_router",),
+            ),
+        ],
+    }
+
+
+def plan_for(*paths: str, existing_paths: set[str] | None = None) -> dict:
+    return build_plan(
+        list(paths),
+        cargo_metadata(),
+        event_name="pull_request",
+        existing_paths=set(paths) if existing_paths is None else existing_paths,
+    )
+
+
+class PackageClosureTests(unittest.TestCase):
+    def test_server_source_runs_server_and_reverse_dependent_mcp_libs(self) -> None:
+        plan = plan_for("crates/wenlan-server/src/routes.rs")
+
+        self.assertEqual(plan["workspace_lib"]["mode"], "packages")
+        self.assertEqual(
+            plan["workspace_lib"]["packages"],
+            ["wenlan-mcp", "wenlan-server"],
+        )
+        self.assertEqual(
+            plan["cli_server_integration"],
+            {"mode": "packages", "packages": ["wenlan-server"]},
+        )
+        self.assertEqual(plan["core_integration"], {"mode": "skip"})
+
+    def test_types_source_runs_every_reverse_dependent_package_and_integration(self) -> None:
+        plan = plan_for("crates/wenlan-types/src/responses.rs")
+
+        self.assertEqual(plan["workspace_lib"]["mode"], "packages")
+        self.assertEqual(
+            plan["workspace_lib"]["packages"],
+            [
+                "wenlan",
+                "wenlan-core",
+                "wenlan-mcp",
+                "wenlan-server",
+                "wenlan-types",
+            ],
+        )
+        self.assertEqual(
+            plan["cli_server_integration"],
+            {"mode": "packages", "packages": ["wenlan", "wenlan-server"]},
+        )
+        self.assertEqual(plan["core_integration"], {"mode": "full"})
+
+    def test_unknown_source_inside_known_crate_uses_package_closure_not_module_guess(
+        self,
+    ) -> None:
+        plan = plan_for("crates/wenlan-core/src/new_algorithm.rs")
+
+        self.assertEqual(plan["workspace_lib"]["mode"], "packages")
+        self.assertEqual(
+            plan["workspace_lib"]["packages"],
+            ["wenlan", "wenlan-core", "wenlan-mcp", "wenlan-server"],
+        )
+        self.assertNotIn("filterset", plan["workspace_lib"])
+
+
+class NarrowOwnerTests(unittest.TestCase):
+    def test_extant_core_integration_file_selects_only_its_test_target(self) -> None:
+        path = "crates/wenlan-core/tests/folder_ingest_e2e.rs"
+        plan = plan_for(path)
+
+        self.assertEqual(plan["workspace_lib"], {"mode": "skip"})
+        self.assertEqual(plan["cli_server_integration"], {"mode": "skip"})
+        self.assertEqual(
+            plan["core_integration"],
+            {"mode": "targets", "targets": ["folder_ingest_e2e"]},
+        )
+
+    def test_extant_cli_integration_file_selects_only_its_test_target(self) -> None:
+        path = "crates/wenlan-cli/tests/distribution.rs"
+        plan = plan_for(path)
+
+        self.assertEqual(plan["workspace_lib"], {"mode": "skip"})
+        self.assertEqual(
+            plan["cli_server_integration"],
+            {
+                "mode": "targets",
+                "targets": {"wenlan": ["distribution"]},
+            },
+        )
+        self.assertEqual(plan["core_integration"], {"mode": "skip"})
+
+    def test_explicit_isolated_test_module_selects_its_real_prefix(self) -> None:
+        path = "crates/wenlan-core/src/lint/pages/security_test.rs"
+        plan = plan_for(path)
+
+        self.assertEqual(
+            plan["workspace_lib"],
+            {
+                "mode": "filterset",
+                "filterset": (
+                    "package(wenlan-core) "
+                    "& test(/^lint::pages::security_test::/)"
+                ),
+            },
+        )
+        self.assertEqual(plan["cli_server_integration"], {"mode": "skip"})
+        self.assertEqual(plan["core_integration"], {"mode": "skip"})
+
+
+class FailClosedTests(unittest.TestCase):
+    def test_deleted_integration_target_falls_back_to_owning_package_suite(self) -> None:
+        path = "crates/wenlan-server/tests/graceful_shutdown.rs"
+        plan = plan_for(path, existing_paths=set())
+
+        self.assertEqual(
+            plan["cli_server_integration"],
+            {"mode": "packages", "packages": ["wenlan-server"]},
+        )
+
+    def test_shared_test_helper_falls_back_to_all_suites(self) -> None:
+        plan = plan_for("crates/wenlan-core/src/lint/test_support.rs")
+
+        self.assertEqual(plan["mode"], "full")
+        self.assertEqual(plan["workspace_lib"], {"mode": "full"})
+        self.assertEqual(plan["cli_server_integration"], {"mode": "full"})
+        self.assertEqual(plan["core_integration"], {"mode": "full"})
+
+    def test_unknown_workspace_rust_path_falls_back_to_all_suites(self) -> None:
+        plan = plan_for("crates/new-crate/src/lib.rs")
+
+        self.assertEqual(plan["mode"], "full")
+
+    def test_cargo_build_native_and_ci_inputs_fall_back_to_all_suites(self) -> None:
+        for path in [
+            "Cargo.lock",
+            "crates/wenlan-core/Cargo.toml",
+            "crates/wenlan-core/build.rs",
+            "crates/wenlan-core/native/bridge.cpp",
+            ".config/nextest.toml",
+            ".github/workflows/ci.yml",
+            "scripts/ci_test_plan.py",
+        ]:
+            with self.subTest(path=path):
+                self.assertEqual(plan_for(path)["mode"], "full")
+
+    def test_non_pr_event_always_runs_full_backstop(self) -> None:
+        plan = build_plan(
+            ["crates/wenlan-server/src/routes.rs"],
+            cargo_metadata(),
+            event_name="push",
+            existing_paths={"crates/wenlan-server/src/routes.rs"},
+        )
+
+        self.assertEqual(plan["mode"], "full")
+
+    def test_malformed_metadata_fails_instead_of_emitting_empty_plan(self) -> None:
+        with self.assertRaises(PlanError):
+            build_plan(
+                ["crates/wenlan-server/src/routes.rs"],
+                {"packages": []},
+                event_name="pull_request",
+                existing_paths={"crates/wenlan-server/src/routes.rs"},
+            )
+
+
+class CommandGenerationTests(unittest.TestCase):
+    def test_workspace_package_plan_is_an_argv_vector_without_shell_text(self) -> None:
+        plan = plan_for("crates/wenlan-server/src/routes.rs")
+
+        self.assertEqual(
+            command_groups_for("workspace-lib", plan, cargo_metadata()),
+            [
+                [
+                    "cargo",
+                    "nextest",
+                    "run",
+                    "-p",
+                    "wenlan-mcp",
+                    "-p",
+                    "wenlan-server",
+                    "--lib",
+                ]
+            ],
+        )
+
+    def test_isolated_module_uses_literal_nextest_filterset_argument(self) -> None:
+        plan = plan_for(
+            "crates/wenlan-core/src/lint/pages/security_test.rs"
+        )
+
+        self.assertEqual(
+            command_groups_for("workspace-lib", plan, cargo_metadata()),
+            [
+                [
+                    "cargo",
+                    "nextest",
+                    "run",
+                    "--workspace",
+                    "--lib",
+                    "-E",
+                    (
+                        "package(wenlan-core) "
+                        "& test(/^lint::pages::security_test::/)"
+                    ),
+                ]
+            ],
+        )
+
+    def test_owned_cli_target_is_executed_without_other_integration_targets(
+        self,
+    ) -> None:
+        plan = plan_for("crates/wenlan-cli/tests/distribution.rs")
+
+        self.assertEqual(
+            command_groups_for(
+                "cli-server-integration", plan, cargo_metadata()
+            ),
+            [
+                [
+                    "cargo",
+                    "nextest",
+                    "run",
+                    "-p",
+                    "wenlan",
+                    "--test",
+                    "distribution",
+                ]
+            ],
+        )
+
+    def test_full_core_command_excludes_only_explicit_manual_targets(self) -> None:
+        plan = plan_for("Cargo.lock")
+
+        self.assertEqual(
+            command_groups_for("core-integration", plan, cargo_metadata()),
+            [
+                [
+                    "cargo",
+                    "nextest",
+                    "run",
+                    "-p",
+                    "wenlan-core",
+                    "--features",
+                    "eval-harness",
+                    "--test",
+                    "folder_ingest_e2e",
+                    "--test",
+                    "read_scope",
+                ]
+            ],
+        )
+
+    def test_skipped_suite_executes_no_command(self) -> None:
+        plan = plan_for("crates/wenlan-core/tests/folder_ingest_e2e.rs")
+
+        self.assertEqual(
+            command_groups_for(
+                "cli-server-integration", plan, cargo_metadata()
+            ),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci_test_plan.test.py
+++ b/scripts/ci_test_plan.test.py
@@ -177,9 +177,10 @@ class NarrowOwnerTests(unittest.TestCase):
             plan["workspace_lib"],
             {
                 "mode": "filterset",
+                "packages": ["wenlan-core"],
                 "filterset": (
                     "package(wenlan-core) "
-                    "& test(/^lint::pages::security_test::/)"
+                    "& test(/^lint::pages::fs::tests::security_cases::/)"
                 ),
             },
         )
@@ -233,6 +234,25 @@ class FailClosedTests(unittest.TestCase):
 
         self.assertEqual(plan["mode"], "full")
 
+    def test_non_pr_event_without_diff_inventory_runs_full_backstop(self) -> None:
+        plan = build_plan(
+            [],
+            cargo_metadata(),
+            event_name="workflow_dispatch",
+            existing_paths=set(),
+        )
+
+        self.assertEqual(plan["mode"], "full")
+
+    def test_pr_without_diff_inventory_fails_closed(self) -> None:
+        with self.assertRaisesRegex(PlanError, "changed path inventory is empty"):
+            build_plan(
+                [],
+                cargo_metadata(),
+                event_name="pull_request",
+                existing_paths=set(),
+            )
+
     def test_malformed_metadata_fails_instead_of_emitting_empty_plan(self) -> None:
         with self.assertRaises(PlanError):
             build_plan(
@@ -275,12 +295,13 @@ class CommandGenerationTests(unittest.TestCase):
                     "cargo",
                     "nextest",
                     "run",
-                    "--workspace",
+                    "-p",
+                    "wenlan-core",
                     "--lib",
                     "-E",
                     (
                         "package(wenlan-core) "
-                        "& test(/^lint::pages::security_test::/)"
+                        "& test(/^lint::pages::fs::tests::security_cases::/)"
                     ),
                 ]
             ],
@@ -329,6 +350,34 @@ class CommandGenerationTests(unittest.TestCase):
                 ]
             ],
         )
+
+    def test_new_core_target_is_automatically_owned_by_full_plan(self) -> None:
+        metadata = cargo_metadata()
+        core = next(
+            package
+            for package in metadata["packages"]
+            if package["name"] == "wenlan-core"
+        )
+        core["targets"].append(
+            {
+                "name": "new_required_target",
+                "kind": ["test"],
+                "src_path": (
+                    f"{WORKSPACE_ROOT}/crates/wenlan-core/tests/"
+                    "new_required_target.rs"
+                ),
+            }
+        )
+        plan = build_plan(
+            ["Cargo.lock"],
+            metadata,
+            event_name="pull_request",
+            existing_paths={"Cargo.lock"},
+        )
+
+        commands = command_groups_for("core-integration", plan, metadata)
+
+        self.assertIn("new_required_target", commands[0])
 
     def test_skipped_suite_executes_no_command(self) -> None:
         plan = plan_for("crates/wenlan-core/tests/folder_ingest_e2e.rs")

--- a/scripts/release_targets.py
+++ b/scripts/release_targets.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Expose Wenlan's canonical shipped release-target matrix."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+
+class TargetError(ValueError):
+    """A requested target is not part of the shipped release surface."""
+
+
+_TARGETS = (
+    {
+        "target": "aarch64-apple-darwin",
+        "os": "macos-14",
+        "archive": "tar.gz",
+        "artifact_name": "wenlan-darwin-arm64",
+    },
+    # Intel macOS is intentionally absent: ort 2.x has no matching prebuilt
+    # runtime, so restoring it requires a separate source-build decision.
+    {
+        "target": "aarch64-unknown-linux-gnu",
+        "os": "ubuntu-24.04-arm",
+        "archive": "tar.gz",
+        "artifact_name": "wenlan-linux-arm64",
+    },
+    {
+        "target": "x86_64-unknown-linux-gnu",
+        "os": "ubuntu-24.04",
+        "archive": "tar.gz",
+        "artifact_name": "wenlan-linux-x64",
+    },
+    {
+        "target": "x86_64-pc-windows-msvc",
+        "os": "windows-2022",
+        "archive": "zip",
+        "artifact_name": "wenlan-windows-x64",
+    },
+)
+
+
+def release_matrix() -> dict:
+    """Return a caller-owned copy of the canonical GitHub Actions matrix."""
+
+    return {"include": copy.deepcopy(list(_TARGETS))}
+
+
+def require_target(target: str) -> dict:
+    """Return a caller-owned target entry or fail closed."""
+
+    for entry in _TARGETS:
+        if entry["target"] == target:
+            return copy.deepcopy(entry)
+    raise TargetError(f"{target!r} is not a shipped release target")
+
+
+def _write_github_output(path: str, matrix_json: str) -> None:
+    if "\n" in matrix_json or "\r" in matrix_json:
+        raise TargetError("compact release matrix unexpectedly contains a newline")
+    with Path(path).open("a", encoding="utf-8") as output:
+        output.write(f"release-targets={matrix_json}\n")
+
+
+def _main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    matrix_parser = subparsers.add_parser("matrix")
+    matrix_parser.add_argument("--github-output")
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("--target", required=True)
+
+    arguments = parser.parse_args(argv)
+    if arguments.command == "check":
+        entry = require_target(arguments.target)
+        print(json.dumps(entry, separators=(",", ":"), sort_keys=True))
+        return 0
+
+    matrix_json = json.dumps(
+        release_matrix(),
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    print(matrix_json)
+    if arguments.github_output:
+        _write_github_output(arguments.github_output, matrix_json)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(_main(sys.argv[1:]))
+    except TargetError as error:
+        print(f"release_targets: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/release_targets.test.py
+++ b/scripts/release_targets.test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Contract tests for the shared shipped release-target inventory."""
+
+from __future__ import annotations
+
+import unittest
+
+from release_targets import TargetError, release_matrix, require_target
+
+
+EXPECTED = [
+    {
+        "target": "aarch64-apple-darwin",
+        "os": "macos-14",
+        "archive": "tar.gz",
+        "artifact_name": "wenlan-darwin-arm64",
+    },
+    {
+        "target": "aarch64-unknown-linux-gnu",
+        "os": "ubuntu-24.04-arm",
+        "archive": "tar.gz",
+        "artifact_name": "wenlan-linux-arm64",
+    },
+    {
+        "target": "x86_64-unknown-linux-gnu",
+        "os": "ubuntu-24.04",
+        "archive": "tar.gz",
+        "artifact_name": "wenlan-linux-x64",
+    },
+    {
+        "target": "x86_64-pc-windows-msvc",
+        "os": "windows-2022",
+        "archive": "zip",
+        "artifact_name": "wenlan-windows-x64",
+    },
+]
+
+
+class ReleaseTargetTests(unittest.TestCase):
+    def test_matrix_is_exactly_the_four_shipped_targets(self) -> None:
+        self.assertEqual(release_matrix(), {"include": EXPECTED})
+
+    def test_every_shipped_target_is_accepted(self) -> None:
+        for entry in EXPECTED:
+            with self.subTest(target=entry["target"]):
+                self.assertEqual(require_target(entry["target"]), entry)
+
+    def test_unknown_target_fails_closed(self) -> None:
+        with self.assertRaisesRegex(TargetError, "not a shipped release target"):
+            require_target("x86_64-apple-darwin")
+
+    def test_callers_cannot_mutate_the_canonical_inventory(self) -> None:
+        first = release_matrix()
+        first["include"].clear()
+
+        self.assertEqual(release_matrix(), {"include": EXPECTED})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What changed

- rename the Ubuntu shared-runtime owner to `canonical-acceptance`
- derive a fail-closed Rust test plan from Cargo metadata, reverse dependencies, integration-test ownership, and one explicitly isolated module
- run exact impacted test targets where ownership is known; fall back to the affected crate/workspace/platform suite for unknown Rust, shared helpers, Cargo/build/native, workflow, or mapping drift
- replace the historical Windows-only release proof with a parallel build-only `release-preflight` matrix for every shipped target
- share the shipped release target inventory and binary build/smoke script with the authoritative tag workflow
- keep ordinary PRs off release-profile builds while preserving native macOS, Linux, and Windows ownership
- reject PR file inventories above GitHub's 3,000-file REST limit instead of routing a truncated diff
- bound cache growth: only Windows persists release target artifacts; the other release legs cache dependency inputs

## Why

The previous workflow had two opposing failure modes: broad PRs paid for work unrelated to their diff, while path filters and skipped-job aggregation could miss platform-sensitive coverage. Windows cold-cache runs were especially expensive because release-profile work shared the ordinary Windows job's critical path.

This change makes the default path differential without making correctness depend on a warm cache or a complete hand-maintained allowlist. Unknown ownership fails closed, expected jobs must actually run, and full main/tag backstops remain.

## Developer impact

A normal shared-core PR runs Ubuntu canonical acceptance plus the impacted Cargo/test closure. macOS or Windows jobs are added only for their platform-sensitive paths and shared CLI/server/MCP/native boundaries. Release-sensitive PRs run four shipped release targets in parallel, build/smoke only; packaging and publishing remain tag-release-only.

The 30-minute ordinary PR limit remains. Release preflight has a 45-minute cold-cache safety ceiling while hosted timings are measured; 30 minutes remains the performance target.

## Validation

- impact planner: 20/20 tests
- release target inventory: 4/4 tests
- CI drift guards: 58/58 tests
- `actionlint` on CI and release workflows
- Rust fmt and Wenlan-core lib/all-features Clippy
- pre-commit changed-crate Clippy
- shared shell-script positive and negative controls, including missing `wenlan-mcp`
- local ARM64 macOS release build and `--help` smoke for `wenlan`, `wenlan-server`, and `wenlan-mcp`

Hosted warm/cold timings are intentionally left as PR evidence rather than claimed from local runs.