### PR TITLE
fix: M3 wire freeze — adapter seam, freeze teeth, Q1 stub-page fence lifts

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -35200,17 +35200,54 @@ impl MemoryDB {
     }
 
     /// List pages filtered by status, ordered by last_modified descending.
+    ///
+    /// Fenced: `kind='entity'` dual-write shadow pages are excluded. General-
+    /// purpose listing used by many internal non-browse callers (knowledge
+    /// projection, overview evidence set, proactive page-map sweep,
+    /// milestone/maintenance/refinery sweeps) that must never see a stub.
+    /// For the browse-facing twin that shows stub pages (Q1), see
+    /// `list_pages_browse`.
     pub async fn list_pages(
         &self,
         status: &str,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<Page>, WenlanError> {
+        self.list_pages_inner(status, limit, offset, true).await
+    }
+
+    /// Browse-facing twin of `list_pages`: the `ReadScope::Global` delegate
+    /// for `list_pages_scoped`, where Q1 rules `kind='entity'` dual-write
+    /// shadow pages must appear. Never call this from an internal
+    /// non-browse path -- those must stay fenced (`list_pages`).
+    pub async fn list_pages_browse(
+        &self,
+        status: &str,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Page>, WenlanError> {
+        self.list_pages_inner(status, limit, offset, false).await
+    }
+
+    async fn list_pages_inner(
+        &self,
+        status: &str,
+        limit: i64,
+        offset: i64,
+        fence_entity: bool,
+    ) -> Result<Vec<Page>, WenlanError> {
+        let fence_sql = if fence_entity {
+            " AND COALESCE(kind, 'concept') != 'entity'"
+        } else {
+            ""
+        };
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]'), COALESCE(creation_kind, 'distilled'), COALESCE(review_status, 'confirmed'), workspace, citations, COALESCE(kind, 'concept')
-                 FROM pages WHERE status = ?1 ORDER BY last_modified DESC LIMIT ?2 OFFSET ?3",
+                &format!(
+                    "SELECT id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]'), COALESCE(creation_kind, 'distilled'), COALESCE(review_status, 'confirmed'), workspace, citations, COALESCE(kind, 'concept')
+                 FROM pages WHERE status = ?1{fence_sql} ORDER BY last_modified DESC LIMIT ?2 OFFSET ?3"
+                ),
                 libsql::params![status, limit, offset],
             )
             .await
@@ -76792,14 +76829,35 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn list_pages_includes_entity_kind_shadow() {
+    async fn list_pages_excludes_entity_kind_shadow() {
+        // Fix wave (stage c review, Critical-1): list_pages has ~15 internal
+        // non-browse callers (knowledge projection, overview evidence set,
+        // proactive page-map sweep, first_active_page, maintenance/refinery
+        // sweeps, eval harness) that must never see a stub, so it stays
+        // fenced -- mirroring search_pages's retrieval arm. For the
+        // browse-facing twin, see list_pages_browse.
         let (db, _dir) = test_db().await;
-        let (concept_title, shadow_title) = seed_concept_then_shadow(&db, "list_pages").await;
+        db.store_entity("List Pages Marker", "person", None, None, None)
+            .await
+            .unwrap();
 
         let pages = db.list_pages("active", 50, 0).await.unwrap();
         assert!(
+            !pages.iter().any(|p| p.title == "List Pages Marker"),
+            "list_pages must not surface a kind='entity' shadow page"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_pages_browse_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        let (concept_title, shadow_title) =
+            seed_concept_then_shadow(&db, "list_pages_browse").await;
+
+        let pages = db.list_pages_browse("active", 50, 0).await.unwrap();
+        assert!(
             pages.iter().any(|p| p.title == shadow_title),
-            "Q1: list_pages must surface a kind='entity' shadow page"
+            "Q1: list_pages_browse must surface a kind='entity' shadow page"
         );
         let shadow_idx = pages.iter().position(|p| p.title == shadow_title);
         let concept_idx = pages.iter().position(|p| p.title == concept_title);
@@ -76834,6 +76892,34 @@ pub(crate) mod tests {
         assert!(
             pages.iter().any(|p| p.title == "List Pages Scoped Marker"),
             "Q1: list_pages_scoped (Space arm) must surface a kind='entity' shadow page"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_pages_scoped_global_includes_entity_kind_shadow() {
+        // Fix wave (stage c review, Critical-1): the Global arm must
+        // delegate to list_pages_browse, not the fenced list_pages -- this
+        // is the exact site the leak was rooted in.
+        let (db, _dir) = test_db().await;
+        db.store_entity(
+            "List Pages Scoped Global Marker",
+            "person",
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let pages = db
+            .list_pages_scoped("active", 50, 0, &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
+        assert!(
+            pages
+                .iter()
+                .any(|p| p.title == "List Pages Scoped Global Marker"),
+            "Q1: list_pages_scoped(Global) must delegate to list_pages_browse"
         );
     }
 
@@ -77037,6 +77123,25 @@ pub(crate) mod tests {
         assert!(
             oldest.is_none(),
             "oldest_active_page must skip kind='entity' shadow pages"
+        );
+    }
+
+    #[tokio::test]
+    async fn first_active_page_excludes_entity_kind_shadow() {
+        // Fix wave (stage c review, Critical-1 leak site 4): first_active_page
+        // routes through list_pages, ordered by last_modified DESC -- a
+        // fresh shadow (stamped `now`) would be the *first* candidate
+        // without the fence, feeding a stub into the first-page milestone.
+        let (db, _dir) = test_db().await;
+        db.store_entity("First Page Marker", "person", None, None, None)
+            .await
+            .unwrap();
+
+        let first = db.first_active_page().await.unwrap();
+        assert!(
+            first.is_none(),
+            "first_active_page must skip kind='entity' shadow pages, matching its \
+             oldest_active_page sibling"
         );
     }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -9432,9 +9432,10 @@ impl MemoryDB {
     /// is nullable on `entities` but `pages.space`/`pages.workspace` are
     /// NOT NULL (M1 honest columns), so a NULL entity space folds to the
     /// reserved `UNFILED_SPACE_ID` sentinel, matching migration 80/91's rule
-    /// for the same case. `content` is the empty string: PR-1 shadow pages
-    /// are write-only, never surfaced to a reader (fenced out of every
-    /// `select_visible_pages`-family surface), so there is no prose to hold.
+    /// for the same case. `content` is the empty string: entity shadow pages
+    /// hold no prose -- Q1 makes them browse/search-visible (the explicit
+    /// `_browse` surfaces) yet they stay excluded from retrieval/context,
+    /// export, and every page mutation, so there is nothing to render.
     async fn insert_entity_shadow_page(
         conn: &libsql::Connection,
         entity_id: &str,
@@ -35135,13 +35136,87 @@ impl MemoryDB {
         Ok(())
     }
 
+    async fn page_kind_on_conn(
+        conn: &libsql::Connection,
+        page_id: &str,
+    ) -> Result<Option<String>, WenlanError> {
+        let mut rows = conn
+            .query(
+                "SELECT COALESCE(kind, 'concept') FROM pages WHERE id = ?1",
+                libsql::params![page_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("page kind: {e}")))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("page kind row: {e}")))?
+        {
+            Some(row) => row
+                .get::<String>(0)
+                .map(Some)
+                .map_err(|e| WenlanError::VectorDb(format!("page kind value: {e}"))),
+            None => Ok(None),
+        }
+    }
+
+    /// Reject a page mutation that targets a `kind='entity'` dual-write shadow
+    /// page. Entity shadow pages mirror `entities` rows and are managed through
+    /// the entity API only; the page archive/delete surface must never touch
+    /// one (deleting it would cascade away its `entity_page_map` row while
+    /// leaving the entity alive, breaking the entity<->page bijection).
+    /// Fail-closed: an unknown id falls through (returns Ok) so archive/delete
+    /// keep their existing no-op-on-missing behavior -- only a positively
+    /// identified shadow is rejected.
+    async fn reject_entity_shadow_page_on_conn(
+        conn: &libsql::Connection,
+        page_id: &str,
+    ) -> Result<(), WenlanError> {
+        if Self::page_kind_on_conn(conn, page_id).await?.as_deref() == Some("entity") {
+            return Err(WenlanError::Validation(format!(
+                "page {page_id} is an entity shadow page; entity shadow pages are managed through the entity API"
+            )));
+        }
+        Ok(())
+    }
+
     /// Retrieve a page by id. Returns None if not found.
+    ///
+    /// Fenced: `kind='entity'` dual-write shadow pages are excluded, so every
+    /// mutation gate, page-map validation, and export consumer that resolves a
+    /// page by id sees a stub as absent (None -> 404). For the browse-facing
+    /// twin that returns stub pages by id (Q1 read surfaces), see
+    /// `get_page_browse`.
     pub async fn get_page(&self, id: &str) -> Result<Option<Page>, WenlanError> {
+        self.get_page_inner(id, true).await
+    }
+
+    /// Browse-facing twin of `get_page`: the by-id read for the Q1 page-browse
+    /// surfaces (`GET /api/pages/{id}` and its advisory revisions read), where
+    /// `kind='entity'` dual-write shadow pages must resolve. Never call this
+    /// from a mutation/validation/export path -- those must stay fenced
+    /// (`get_page`).
+    pub async fn get_page_browse(&self, id: &str) -> Result<Option<Page>, WenlanError> {
+        self.get_page_inner(id, false).await
+    }
+
+    async fn get_page_inner(
+        &self,
+        id: &str,
+        fence_entity: bool,
+    ) -> Result<Option<Page>, WenlanError> {
+        let fence_sql = if fence_entity {
+            " AND COALESCE(kind, 'concept') != 'entity'"
+        } else {
+            ""
+        };
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]'), COALESCE(creation_kind, 'distilled'), COALESCE(review_status, 'confirmed'), workspace, citations, COALESCE(kind, 'concept')
-                 FROM pages WHERE id = ?1",
+                &format!(
+                    "SELECT id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]'), COALESCE(creation_kind, 'distilled'), COALESCE(review_status, 'confirmed'), workspace, citations, COALESCE(kind, 'concept')
+                 FROM pages WHERE id = ?1{fence_sql}"
+                ),
                 libsql::params![id],
             )
             .await
@@ -36583,6 +36658,7 @@ impl MemoryDB {
     pub async fn archive_page(&self, id: &str) -> Result<(), WenlanError> {
         let now = chrono::Utc::now().to_rfc3339();
         let conn = self.conn.lock().await;
+        Self::reject_entity_shadow_page_on_conn(&conn, id).await?;
         Self::reject_page_draft_on_conn(&conn, id).await?;
         conn.execute(
             "UPDATE pages
@@ -36915,6 +36991,7 @@ impl MemoryDB {
 
     pub async fn delete_page(&self, id: &str) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
+        Self::reject_entity_shadow_page_on_conn(&conn, id).await?;
         Self::reject_page_draft_on_conn(&conn, id).await?;
         conn.execute("BEGIN", ())
             .await
@@ -76788,7 +76865,11 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn get_page_includes_entity_kind_shadow() {
+    async fn get_page_excludes_entity_kind_shadow() {
+        // Fix wave (sol-review, Important-1): the shared `get_page` fence was
+        // restored -- every mutation gate, page-map validation, and export
+        // consumer resolves a page by id through it, so a stub must read as
+        // absent (None). For the browse-facing twin, see `get_page_browse`.
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Get Page Marker", "person", Some("work"), None, None)
@@ -76797,15 +76878,35 @@ pub(crate) mod tests {
         let pid = shadow_page_id(&db, &eid).await;
 
         let page = db.get_page(&pid).await.unwrap();
-        assert_eq!(
-            page.map(|p| p.title),
-            Some("Get Page Marker".to_string()),
-            "Q1: get_page must return a kind='entity' shadow page by id"
+        assert!(
+            page.is_none(),
+            "get_page must not resolve a kind='entity' shadow page by id"
         );
     }
 
     #[tokio::test]
-    async fn get_page_scoped_includes_entity_kind_shadow() {
+    async fn get_page_browse_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        let eid = db
+            .store_entity("Get Page Browse Marker", "person", Some("work"), None, None)
+            .await
+            .unwrap();
+        let pid = shadow_page_id(&db, &eid).await;
+
+        let page = db.get_page_browse(&pid).await.unwrap();
+        assert_eq!(
+            page.map(|p| p.title),
+            Some("Get Page Browse Marker".to_string()),
+            "Q1: get_page_browse must return a kind='entity' shadow page by id"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_page_scoped_excludes_entity_kind_shadow() {
+        // Fix wave (sol-review, Important-1): `get_page_scoped`'s fence was
+        // restored on both arms; a stub reads as absent on the by-id
+        // mutation/export path. For the browse-facing twin, see
+        // `get_page_scoped_browse`.
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Get Page Scoped Marker", "person", Some("work"), None, None)
@@ -76821,10 +76922,40 @@ pub(crate) mod tests {
             )
             .await
             .unwrap();
+        assert!(
+            page.is_none(),
+            "get_page_scoped must not resolve a kind='entity' shadow page by id"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_page_scoped_browse_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        let eid = db
+            .store_entity(
+                "Get Page Scoped Browse Marker",
+                "person",
+                Some("work"),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let pid = shadow_page_id(&db, &eid).await;
+
+        // Space scope exercises the scoped SQL (Global delegates to
+        // get_page_browse).
+        let page = db
+            .get_page_scoped_browse(
+                &pid,
+                &crate::read_scope::ReadScope::Space("work".to_string()),
+            )
+            .await
+            .unwrap();
         assert_eq!(
             page.map(|p| p.title),
-            Some("Get Page Scoped Marker".to_string()),
-            "Q1: get_page_scoped must return a kind='entity' shadow page by id"
+            Some("Get Page Scoped Browse Marker".to_string()),
+            "Q1: get_page_scoped_browse must return a kind='entity' shadow page by id"
         );
     }
 
@@ -76868,7 +76999,11 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn list_pages_scoped_includes_entity_kind_shadow() {
+    async fn list_pages_scoped_excludes_entity_kind_shadow() {
+        // Fix wave (sol-review, Important-2): `list_pages_scoped` is fully
+        // fenced again on every arm so export (which reads it, fenced in SQL
+        // before LIMIT) can never emit a stub. For the browse-facing twin, see
+        // `list_pages_scoped_browse`.
         let (db, _dir) = test_db().await;
         db.store_entity(
             "List Pages Scoped Marker",
@@ -76890,16 +77025,47 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(
-            pages.iter().any(|p| p.title == "List Pages Scoped Marker"),
-            "Q1: list_pages_scoped (Space arm) must surface a kind='entity' shadow page"
+            !pages.iter().any(|p| p.title == "List Pages Scoped Marker"),
+            "list_pages_scoped (Space arm) must not surface a kind='entity' shadow page"
         );
     }
 
     #[tokio::test]
-    async fn list_pages_scoped_global_includes_entity_kind_shadow() {
-        // Fix wave (stage c review, Critical-1): the Global arm must
-        // delegate to list_pages_browse, not the fenced list_pages -- this
-        // is the exact site the leak was rooted in.
+    async fn list_pages_scoped_browse_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        db.store_entity(
+            "List Pages Scoped Browse Marker",
+            "person",
+            Some("work"),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let pages = db
+            .list_pages_scoped_browse(
+                "active",
+                50,
+                0,
+                &crate::read_scope::ReadScope::Space("work".to_string()),
+            )
+            .await
+            .unwrap();
+        assert!(
+            pages
+                .iter()
+                .any(|p| p.title == "List Pages Scoped Browse Marker"),
+            "Q1: list_pages_scoped_browse (Space arm) must surface a kind='entity' shadow page"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_pages_scoped_global_excludes_entity_kind_shadow() {
+        // Fix wave (sol-review, Important-2): the Global arm reverts to the
+        // fenced list_pages (the stage-c delegate-to-browse was the leak into
+        // export). For the browse-facing Global arm, see
+        // list_pages_scoped_browse.
         let (db, _dir) = test_db().await;
         db.store_entity(
             "List Pages Scoped Global Marker",
@@ -76916,10 +77082,234 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(
-            pages
+            !pages
                 .iter()
                 .any(|p| p.title == "List Pages Scoped Global Marker"),
-            "Q1: list_pages_scoped(Global) must delegate to list_pages_browse"
+            "list_pages_scoped(Global) must delegate to the fenced list_pages"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_pages_scoped_browse_global_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        db.store_entity(
+            "List Pages Scoped Browse Global Marker",
+            "person",
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let pages = db
+            .list_pages_scoped_browse("active", 50, 0, &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
+        assert!(
+            pages
+                .iter()
+                .any(|p| p.title == "List Pages Scoped Browse Global Marker"),
+            "Q1: list_pages_scoped_browse(Global) must delegate to list_pages_browse"
+        );
+    }
+
+    // -- Fix wave (sol-review, Critical + Important-2): page-mutation fences and
+    // export fence-before-limit. Entity shadow pages are managed only through
+    // the entity API, so the page archive/delete surface must reject a
+    // `kind='entity'` id, and the fenced list must drop stubs in SQL before
+    // LIMIT so a burst can never starve real pages out of a bounded window. --
+
+    /// The entity, its shadow page, and their `entity_page_map` row must all
+    /// still exist -- the bijection a page-side archive/delete must never break.
+    async fn assert_entity_shadow_intact(db: &MemoryDB, entity_id: &str, page_id: &str) {
+        let conn = db.conn.lock().await;
+        let entity: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM entities WHERE id = ?1",
+                    libsql::params![entity_id],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        let page: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM pages WHERE id = ?1 AND kind = 'entity'",
+                    libsql::params![page_id],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        let map: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM entity_page_map WHERE entity_id = ?1 AND page_id = ?2",
+                    libsql::params![entity_id, page_id],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            entity, 1,
+            "entity row must survive a rejected page mutation"
+        );
+        assert_eq!(
+            page, 1,
+            "shadow page row must survive a rejected page mutation"
+        );
+        assert_eq!(
+            map, 1,
+            "entity_page_map row must survive a rejected page mutation"
+        );
+    }
+
+    #[tokio::test]
+    async fn archive_page_rejects_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        let eid = db
+            .store_entity("Archive Fence Marker", "person", Some("work"), None, None)
+            .await
+            .unwrap();
+        let pid = shadow_page_id(&db, &eid).await;
+
+        let result = db.archive_page(&pid).await;
+        assert!(
+            matches!(result, Err(WenlanError::Validation(_))),
+            "archive_page must reject a kind='entity' shadow page with a Validation error, got {result:?}"
+        );
+        assert_entity_shadow_intact(&db, &eid, &pid).await;
+    }
+
+    #[tokio::test]
+    async fn delete_page_rejects_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        let eid = db
+            .store_entity("Delete Fence Marker", "person", Some("work"), None, None)
+            .await
+            .unwrap();
+        let pid = shadow_page_id(&db, &eid).await;
+
+        let result = db.delete_page(&pid).await;
+        assert!(
+            matches!(result, Err(WenlanError::Validation(_))),
+            "delete_page must reject a kind='entity' shadow page with a Validation error, got {result:?}"
+        );
+        assert_entity_shadow_intact(&db, &eid, &pid).await;
+    }
+
+    #[tokio::test]
+    async fn archive_and_delete_still_work_on_concept_pages() {
+        let (db, _dir) = test_db().await;
+        db.insert_page_with_kind(
+            "p_fence_concept_archive",
+            "Fence Concept Archive",
+            None,
+            "content",
+            None,
+            None,
+            &[],
+            "2000-01-01T00:00:00+00:00",
+            "authored",
+            "confirmed",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.archive_page("p_fence_concept_archive").await.unwrap();
+        let archived = db
+            .get_page("p_fence_concept_archive")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            archived.status, "archived",
+            "a normal concept page must still archive"
+        );
+
+        db.insert_page_with_kind(
+            "p_fence_concept_delete",
+            "Fence Concept Delete",
+            None,
+            "content",
+            None,
+            None,
+            &[],
+            "2000-01-01T00:00:00+00:00",
+            "authored",
+            "confirmed",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.delete_page("p_fence_concept_delete").await.unwrap();
+        assert!(
+            db.get_page("p_fence_concept_delete")
+                .await
+                .unwrap()
+                .is_none(),
+            "a normal concept page must still delete"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_pages_scoped_fences_before_limit() {
+        // Fix wave (sol-review, Important-2): a fresh stub (newer last_modified)
+        // must not consume the single LIMIT slot -- the fence lives in SQL
+        // before LIMIT, so a fenced limit=1 list returns the older real page,
+        // not empty. Without the SQL fence, ORDER BY last_modified DESC + LIMIT
+        // 1 would return the stub and a post-fetch filter would leave nothing.
+        let (db, _dir) = test_db().await;
+        db.insert_page_with_kind(
+            "p_fence_before_limit_concept",
+            "Fence Before Limit Concept",
+            None,
+            "content",
+            None,
+            Some("work"),
+            &[],
+            "2000-01-01T00:00:00+00:00",
+            "authored",
+            "confirmed",
+            Some("work"),
+            None,
+        )
+        .await
+        .unwrap();
+        // The shadow is stamped `now`, so it sorts FIRST by last_modified DESC.
+        db.store_entity(
+            "Fence Before Limit Shadow",
+            "person",
+            Some("work"),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let pages = db
+            .list_pages_scoped(
+                "active",
+                1,
+                0,
+                &crate::read_scope::ReadScope::Space("work".to_string()),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            pages.len(),
+            1,
+            "the fenced limit=1 list must return exactly one page"
+        );
+        assert_eq!(
+            pages[0].title, "Fence Before Limit Concept",
+            "the fence must drop the newer stub in SQL before LIMIT, leaving the real page"
         );
     }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -35165,9 +35165,9 @@ impl MemoryDB {
     /// the entity API only; the page archive/delete surface must never touch
     /// one (deleting it would cascade away its `entity_page_map` row while
     /// leaving the entity alive, breaking the entity<->page bijection).
-    /// Fail-closed: an unknown id falls through (returns Ok) so archive/delete
-    /// keep their existing no-op-on-missing behavior -- only a positively
-    /// identified shadow is rejected.
+    /// An unknown id falls through (returns Ok) so archive/delete keep their
+    /// existing no-op-on-missing behavior -- only a positively identified
+    /// shadow is rejected.
     async fn reject_entity_shadow_page_on_conn(
         conn: &libsql::Connection,
         page_id: &str,

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -18,11 +18,14 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 mod count;
+mod entity_page_adapter;
 mod page_drafts;
 pub mod page_map;
 mod scoped_entities;
 mod scoped_pages;
 
+#[cfg(test)]
+mod entity_page_adapter_test;
 #[cfg(test)]
 mod page_drafts_test;
 #[cfg(test)]
@@ -23617,13 +23620,16 @@ impl MemoryDB {
             // page would otherwise be orphaned by the entity delete below (the
             // map row cascades on the entity FK, never the page). Delete it
             // first so its own ON DELETE CASCADE drops the map row.
-            conn.execute(
-                "DELETE FROM pages WHERE kind = 'entity' \
-                 AND id IN (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
-                libsql::params![alias_id],
-            )
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("merge_entities loser shadow: {e}")))?;
+            if let Some(loser_page_id) =
+                entity_page_adapter::page_id_for_entity(&conn, alias_id).await?
+            {
+                conn.execute(
+                    "DELETE FROM pages WHERE kind = 'entity' AND id = ?1",
+                    libsql::params![loser_page_id],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("merge_entities loser shadow: {e}")))?;
+            }
 
             conn.execute(
                 "DELETE FROM entities WHERE id = ?1",
@@ -24195,13 +24201,16 @@ impl MemoryDB {
             // `DELETE FROM entities` then finds no dangling map row. Without
             // this the shadow would be orphaned (the map's entity-side cascade
             // drops the map row on entity delete, but never the page itself).
-            conn.execute(
-                "DELETE FROM pages WHERE kind = 'entity' \
-                 AND id IN (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
-                libsql::params![entity_id],
-            )
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("delete_entity shadow: {e}")))?;
+            if let Some(shadow_page_id) =
+                entity_page_adapter::page_id_for_entity(&conn, entity_id).await?
+            {
+                conn.execute(
+                    "DELETE FROM pages WHERE kind = 'entity' AND id = ?1",
+                    libsql::params![shadow_page_id],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("delete_entity shadow: {e}")))?;
+            }
 
             conn.execute(
                 "DELETE FROM entities WHERE id = ?1",
@@ -53774,19 +53783,10 @@ pub(crate) mod tests {
             .unwrap();
         let page_id: String = {
             let conn = db.conn.lock().await;
-            let mut rows = conn
-                .query(
-                    "SELECT page_id FROM entity_page_map WHERE entity_id = ?1",
-                    libsql::params![id.clone()],
-                )
-                .await
-                .unwrap();
-            rows.next()
+            entity_page_adapter::page_id_for_entity(&conn, &id)
                 .await
                 .unwrap()
                 .expect("shadow must exist before delete")
-                .get(0)
-                .unwrap()
         };
 
         db.delete_space("doomed", "delete").await.unwrap();
@@ -79008,6 +79008,27 @@ pub(crate) mod tests {
             ENTITIES as f64 / seed_entities_secs
         );
 
+        // ---- M3 stage F: the adapter round-trips entity_id <-> page_id for
+        // every seeded entity, at the same scale the parity oracle is proven
+        // at below ----
+        {
+            let conn = db.conn.lock().await;
+            for id in &entity_ids {
+                let page_id = entity_page_adapter::page_id_for_entity(&conn, id)
+                    .await
+                    .unwrap()
+                    .unwrap_or_else(|| panic!("{id} must have a mapped page_id at scale"));
+                let round_tripped = entity_page_adapter::entity_id_for_page(&conn, &page_id)
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    round_tripped.as_deref(),
+                    Some(id.as_str()),
+                    "adapter bijection must round-trip at scale for {id}"
+                );
+            }
+        }
+
         // ---- reconcile: clean parity must hold at scale ----
         let t_reconcile = Instant::now();
         let report = db.reconcile_entity_page_parity().await.unwrap();
@@ -79190,6 +79211,105 @@ pub(crate) mod tests {
         assert_eq!(
             dirty_report.drift_count, PERTURB,
             "exactly the {PERTURB} perturbed shadows must be flagged corrupt, not more or fewer"
+        );
+    }
+
+    /// M3 stage F acceptance-box proof: with the "scoped_entities" cutover
+    /// gate OFF vs ON, `list_entities_scoped`/`get_entity_detail_scoped`
+    /// results serialize to byte-identical JSON -- the actual wire shape,
+    /// not just Rust `Debug` output -- proving the adapter's entity_id<->
+    /// page_id translation makes no app-visible shape change. Small-scale,
+    /// non-ignored sibling of `bench_reconcile_entity_page_parity_at_scale`'s
+    /// ON/OFF comparison above.
+    #[tokio::test]
+    async fn scoped_entities_cutover_flip_is_wire_invariant() {
+        const SPACE: &str = "wire_invariance_space";
+        let (db, _dir) = test_db().await;
+        let mut entity_ids: Vec<String> = Vec::new();
+        for i in 0..5 {
+            let id = db
+                .store_entity(
+                    &format!("Wire Invariance Entity {i}"),
+                    "person",
+                    Some(SPACE),
+                    Some("test"),
+                    Some(0.8),
+                )
+                .await
+                .unwrap();
+            entity_ids.push(id);
+        }
+        db.create_relation(
+            &entity_ids[0],
+            &entity_ids[1],
+            "related_to",
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO observations (id, entity_id, content, source_agent, confidence, confirmed, created_at) \
+                 VALUES ('wire_invariance_obs', ?1, 'observed', NULL, 0.9, 1, unixepoch())",
+                libsql::params![entity_ids[0].clone()],
+            )
+            .await
+            .unwrap();
+        }
+
+        let scope = ReadScope::Space(SPACE.to_string());
+
+        db.set_entity_reader_cutover(MemoryDB::SCOPED_ENTITIES_CONSUMER, false)
+            .await
+            .unwrap();
+        let list_off = db.list_entities_scoped(None, &scope).await.unwrap();
+        let mut detail_off = Vec::with_capacity(entity_ids.len());
+        for id in &entity_ids {
+            detail_off.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
+        }
+
+        db.set_entity_reader_cutover(MemoryDB::SCOPED_ENTITIES_CONSUMER, true)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.reconcile_entity_page_parity().await.unwrap().drift_count,
+            0,
+            "seed must reconcile clean before the gate can open"
+        );
+        {
+            let conn = db.conn.lock().await;
+            assert!(
+                MemoryDB::reader_uses_entity_pages(&conn, MemoryDB::SCOPED_ENTITIES_CONSUMER)
+                    .await
+                    .unwrap(),
+                "sanity: a clean, current watermark must open the gate"
+            );
+        }
+        let list_on = db.list_entities_scoped(None, &scope).await.unwrap();
+        let mut detail_on = Vec::with_capacity(entity_ids.len());
+        for id in &entity_ids {
+            detail_on.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
+        }
+
+        assert_eq!(list_off.len(), 5, "sanity: all seeded entities are listed");
+        assert_eq!(
+            list_off.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
+            list_on.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
+            "sanity: same entity_ids on both arms"
+        );
+        assert_eq!(
+            serde_json::to_value(&list_off).unwrap(),
+            serde_json::to_value(&list_on).unwrap(),
+            "list_entities_scoped wire shape must be byte-identical across the cutover flip"
+        );
+        assert_eq!(
+            serde_json::to_value(&detail_off).unwrap(),
+            serde_json::to_value(&detail_on).unwrap(),
+            "get_entity_detail_scoped wire shape must be byte-identical across the cutover flip"
         );
     }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -33295,7 +33295,6 @@ impl MemoryDB {
                 "SELECT id, title, version, created_at, last_modified
                  FROM pages
                  WHERE status = 'active'
-                   AND COALESCE(kind, 'concept') != 'entity'
                  ORDER BY last_modified DESC LIMIT ?1",
                 libsql::params![limit],
             )
@@ -33611,7 +33610,7 @@ impl MemoryDB {
                     "SELECT id, title, COALESCE(summary, ''), COALESCE(source_memory_ids, '[]'), \
                             version, created_at, last_modified \
                      FROM pages \
-                     WHERE status = 'active' AND kind != 'entity' \
+                     WHERE status = 'active' \
                      ORDER BY last_modified DESC \
                      LIMIT ?1",
                     libsql::params![limit],
@@ -35142,7 +35141,7 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]'), COALESCE(creation_kind, 'distilled'), COALESCE(review_status, 'confirmed'), workspace, citations, COALESCE(kind, 'concept')
-                 FROM pages WHERE id = ?1 AND COALESCE(kind, 'concept') != 'entity'",
+                 FROM pages WHERE id = ?1",
                 libsql::params![id],
             )
             .await
@@ -35211,7 +35210,7 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, COALESCE(sources_updated_count, 0), stale_reason, COALESCE(user_edited, 0), COALESCE(changelog, '[]'), COALESCE(creation_kind, 'distilled'), COALESCE(review_status, 'confirmed'), workspace, citations, COALESCE(kind, 'concept')
-                 FROM pages WHERE status = ?1 AND COALESCE(kind, 'concept') != 'entity' ORDER BY last_modified DESC LIMIT ?2 OFFSET ?3",
+                 FROM pages WHERE status = ?1 ORDER BY last_modified DESC LIMIT ?2 OFFSET ?3",
                 libsql::params![status, limit, offset],
             )
             .await
@@ -37412,11 +37411,40 @@ impl MemoryDB {
     /// Embeds the query, runs DiskANN vector search on page embeddings
     /// (title+summary), runs FTS5 MATCH on page content, then merges
     /// results with Reciprocal Rank Fusion (same pattern as search_memory).
+    ///
+    /// Retrieval arm: `kind='entity'` dual-write shadow pages stay fenced
+    /// out. Also the Global-scope delegate for `search_pages_scoped`'s
+    /// retrieval arm. For the browse-facing twin that shows stub pages
+    /// (Q1), see `search_pages_browse`.
     pub async fn search_pages(
         &self,
         query: &str,
         limit: usize,
         page_type: Option<&str>,
+    ) -> Result<Vec<Page>, WenlanError> {
+        self.search_pages_inner(query, limit, page_type, true).await
+    }
+
+    /// Browse-facing twin of `search_pages`: the Global-scope delegate for
+    /// `search_pages_scoped_browse`, where Q1 rules `kind='entity'`
+    /// dual-write shadow pages must appear. Never call this from a
+    /// retrieval/context channel -- those must stay fenced (`search_pages`).
+    pub async fn search_pages_browse(
+        &self,
+        query: &str,
+        limit: usize,
+        page_type: Option<&str>,
+    ) -> Result<Vec<Page>, WenlanError> {
+        self.search_pages_inner(query, limit, page_type, false)
+            .await
+    }
+
+    async fn search_pages_inner(
+        &self,
+        query: &str,
+        limit: usize,
+        page_type: Option<&str>,
+        fence_entity: bool,
     ) -> Result<Vec<Page>, WenlanError> {
         // Embed query before acquiring conn lock (same pattern as search_memory)
         let embedding = self.get_or_compute_embedding(query)?;
@@ -37564,13 +37592,16 @@ impl MemoryDB {
         }
 
         // Sort by combined RRF score, attach to pages, return top limit.
-        // Fence (M3 PR-1 stage f): `kind='entity'` dual-write shadow pages are
-        // write-only in PR-1 -- `search_pages` bypasses the shared
-        // `select_visible_pages` gate (it's a direct index search, not a
-        // context-assembly call), so it needs its own exclusion.
+        // Fence (M3 PR-1 stage f; Q1 lift, stage c): `search_pages` bypasses
+        // the shared `select_visible_pages` gate (it's a direct index
+        // search, not a context-assembly call), so each arm carries its own
+        // `kind='entity'` exclusion. The retrieval arm (`fence_entity=true`)
+        // excludes dual-write shadow pages; the browse arm
+        // (`fence_entity=false`, `search_pages_browse`) includes them per
+        // the Q1 ruling.
         let mut final_results: Vec<Page> = concept_map
             .into_values()
-            .filter(|p| p.kind != "entity")
+            .filter(|p| !fence_entity || p.kind != "entity")
             .collect();
         final_results.sort_by(|a, b| {
             let sa = score_map.get(&a.id).unwrap_or(&0.0);
@@ -76475,6 +76506,37 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn select_visible_pages_scoped_excludes_entity_kind_pages() {
+        // select_visible_pages_scoped delegates to select_visible_pages after
+        // scope-filtering (unchanged by Q1); this covers the scoped wrapper
+        // explicitly rather than relying on the unscoped test above.
+        let (db, _dir) = test_db().await;
+        let mut entity_page = confirmed_page("p_entity_shadow_scoped", Some("work"), &[]);
+        entity_page.kind = "entity".to_string();
+        let no_overlap: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        let visible = db
+            .select_visible_pages_scoped(
+                vec![entity_page],
+                &crate::read_scope::ReadScope::Space("work".to_string()),
+                &no_overlap,
+                "full",
+                10,
+            )
+            .await;
+        assert!(
+            visible.is_empty(),
+            "kind='entity' shadow pages must never reach a reader through \
+             select_visible_pages_scoped, even at full trust"
+        );
+    }
+
+    // -- Q1 lift (stage c): `search_pages`/`search_pages_scoped` split into a
+    // fenced retrieval arm (unchanged name, unchanged behavior -- the tests
+    // just above this comment) and an unfenced browse arm (`_browse`,
+    // stage-c-brief deliverable 1). --
+
+    #[tokio::test]
     async fn search_pages_excludes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         db.store_entity("Unique Zephyrine Marker", "person", None, None, None)
@@ -76487,7 +76549,26 @@ pub(crate) mod tests {
             .unwrap();
         assert!(
             !results.iter().any(|p| p.title == "Unique Zephyrine Marker"),
-            "search_pages must not surface the entity's own kind='entity' shadow page"
+            "search_pages (retrieval arm) must not surface the entity's own kind='entity' shadow page"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_pages_browse_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        db.store_entity("Unique Zephyrine Browse Marker", "person", None, None, None)
+            .await
+            .unwrap();
+
+        let results = db
+            .search_pages_browse("Unique Zephyrine Browse Marker", 10, None)
+            .await
+            .unwrap();
+        assert!(
+            results
+                .iter()
+                .any(|p| p.title == "Unique Zephyrine Browse Marker"),
+            "Q1: search_pages_browse must surface the entity's kind='entity' shadow page"
         );
     }
 
@@ -76509,28 +76590,115 @@ pub(crate) mod tests {
             .unwrap();
         assert!(
             !results.iter().any(|p| p.title == "Unique Quorlath Marker"),
-            "the scoped RRF page channel must not surface the entity's shadow page"
+            "search_pages_scoped (retrieval arm) must not surface the entity's shadow page"
         );
     }
 
     #[tokio::test]
-    async fn list_recent_pages_with_badges_excludes_entity_kind_shadow() {
+    async fn search_pages_scoped_browse_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
-        db.store_entity("Recent Activity Entity Marker", "person", None, None, None)
+        db.store_entity(
+            "Unique Quorlath Browse Marker",
+            "person",
+            Some("work"),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let results = db
+            .search_pages_scoped_browse(
+                "Unique Quorlath Browse Marker",
+                10,
+                None,
+                &crate::read_scope::ReadScope::Space("work".to_string()),
+            )
+            .await
+            .unwrap();
+        assert!(
+            results
+                .iter()
+                .any(|p| p.title == "Unique Quorlath Browse Marker"),
+            "Q1: the scoped RRF browse arm must surface the entity's shadow page"
+        );
+    }
+
+    #[tokio::test]
+    async fn search_pages_scoped_browse_global_includes_entity_kind_shadow() {
+        // Global scope exercises search_pages_scoped_browse's delegation to
+        // search_pages_browse (both browse arms must agree).
+        let (db, _dir) = test_db().await;
+        db.store_entity("Unique Quorlath Global Marker", "person", None, None, None)
             .await
             .unwrap();
 
+        let results = db
+            .search_pages_scoped_browse(
+                "Unique Quorlath Global Marker",
+                10,
+                None,
+                &crate::read_scope::ReadScope::Global,
+            )
+            .await
+            .unwrap();
+        assert!(
+            results
+                .iter()
+                .any(|p| p.title == "Unique Quorlath Global Marker"),
+            "Q1: search_pages_scoped_browse(Global) must delegate to search_pages_browse"
+        );
+    }
+
+    /// Q1 (stage c): seed one ordinary concept page stamped "2000-01-01" and
+    /// one entity dual-write shadow stamped "now" (via `store_entity`), so the
+    /// shadow is strictly more recent and deterministically sorts first in any
+    /// `last_modified DESC` listing. Returns (concept_title, shadow_title).
+    async fn seed_concept_then_shadow(db: &MemoryDB, tag: &str) -> (String, String) {
+        let concept_title = format!("Q1 {tag} Concept Page");
+        db.insert_page_with_kind(
+            &format!("p_q1_{tag}_concept"),
+            &concept_title,
+            None,
+            "concept content",
+            None,
+            None,
+            &[],
+            "2000-01-01T00:00:00+00:00",
+            "authored",
+            "confirmed",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let shadow_title = format!("Q1 {tag} Entity Marker");
+        db.store_entity(&shadow_title, "person", None, None, None)
+            .await
+            .unwrap();
+        (concept_title, shadow_title)
+    }
+
+    #[tokio::test]
+    async fn list_recent_pages_with_badges_includes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+        let (concept_title, shadow_title) = seed_concept_then_shadow(&db, "recent_badges").await;
+
         let items = db.list_recent_pages_with_badges(50, None).await.unwrap();
         assert!(
-            !items
-                .iter()
-                .any(|item| item.title == "Recent Activity Entity Marker"),
-            "list_recent_pages_with_badges must not surface a kind='entity' shadow page"
+            items.iter().any(|item| item.title == shadow_title),
+            "Q1: list_recent_pages_with_badges must surface a kind='entity' shadow page"
+        );
+        let shadow_idx = items.iter().position(|item| item.title == shadow_title);
+        let concept_idx = items.iter().position(|item| item.title == concept_title);
+        assert!(
+            shadow_idx < concept_idx,
+            "the more-recently-modified shadow must sort before the older concept page"
         );
     }
 
     #[tokio::test]
-    async fn list_recent_pages_with_badges_scoped_excludes_entity_kind_shadow() {
+    async fn list_recent_pages_with_badges_scoped_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         db.store_entity(
             "Scoped Recent Entity Marker",
@@ -76551,10 +76719,10 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(
-            !items
+            items
                 .iter()
                 .any(|item| item.title == "Scoped Recent Entity Marker"),
-            "the scoped recent-activity surface must not surface a kind='entity' shadow page"
+            "Q1: the scoped recent-activity surface must surface a kind='entity' shadow page"
         );
     }
 
@@ -76583,7 +76751,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn get_page_excludes_entity_kind_shadow() {
+    async fn get_page_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Get Page Marker", "person", Some("work"), None, None)
@@ -76592,14 +76760,15 @@ pub(crate) mod tests {
         let pid = shadow_page_id(&db, &eid).await;
 
         let page = db.get_page(&pid).await.unwrap();
-        assert!(
-            page.is_none(),
-            "get_page must return None for a kind='entity' shadow id (fail-closed by ID)"
+        assert_eq!(
+            page.map(|p| p.title),
+            Some("Get Page Marker".to_string()),
+            "Q1: get_page must return a kind='entity' shadow page by id"
         );
     }
 
     #[tokio::test]
-    async fn get_page_scoped_excludes_entity_kind_shadow() {
+    async fn get_page_scoped_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Get Page Scoped Marker", "person", Some("work"), None, None)
@@ -76615,28 +76784,33 @@ pub(crate) mod tests {
             )
             .await
             .unwrap();
-        assert!(
-            page.is_none(),
-            "get_page_scoped must return None for a kind='entity' shadow id"
+        assert_eq!(
+            page.map(|p| p.title),
+            Some("Get Page Scoped Marker".to_string()),
+            "Q1: get_page_scoped must return a kind='entity' shadow page by id"
         );
     }
 
     #[tokio::test]
-    async fn list_pages_excludes_entity_kind_shadow() {
+    async fn list_pages_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
-        db.store_entity("List Pages Marker", "person", Some("work"), None, None)
-            .await
-            .unwrap();
+        let (concept_title, shadow_title) = seed_concept_then_shadow(&db, "list_pages").await;
 
         let pages = db.list_pages("active", 50, 0).await.unwrap();
         assert!(
-            !pages.iter().any(|p| p.title == "List Pages Marker"),
-            "list_pages must not surface a kind='entity' shadow page"
+            pages.iter().any(|p| p.title == shadow_title),
+            "Q1: list_pages must surface a kind='entity' shadow page"
+        );
+        let shadow_idx = pages.iter().position(|p| p.title == shadow_title);
+        let concept_idx = pages.iter().position(|p| p.title == concept_title);
+        assert!(
+            shadow_idx < concept_idx,
+            "the more-recently-modified shadow must sort before the older concept page"
         );
     }
 
     #[tokio::test]
-    async fn list_pages_scoped_excludes_entity_kind_shadow() {
+    async fn list_pages_scoped_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         db.store_entity(
             "List Pages Scoped Marker",
@@ -76658,8 +76832,8 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(
-            !pages.iter().any(|p| p.title == "List Pages Scoped Marker"),
-            "list_pages_scoped (Space arm) must not surface a kind='entity' shadow page"
+            pages.iter().any(|p| p.title == "List Pages Scoped Marker"),
+            "Q1: list_pages_scoped (Space arm) must surface a kind='entity' shadow page"
         );
     }
 
@@ -76704,21 +76878,25 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn list_recent_changes_excludes_entity_kind_shadow() {
+    async fn list_recent_changes_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
-        db.store_entity("Recent Changes Marker", "person", None, None, None)
-            .await
-            .unwrap();
+        let (concept_title, shadow_title) = seed_concept_then_shadow(&db, "recent_changes").await;
 
         let changes = db.list_recent_changes(50).await.unwrap();
         assert!(
-            !changes.iter().any(|c| c.title == "Recent Changes Marker"),
-            "list_recent_changes must not surface a kind='entity' shadow page"
+            changes.iter().any(|c| c.title == shadow_title),
+            "Q1: list_recent_changes must surface a kind='entity' shadow page"
+        );
+        let shadow_idx = changes.iter().position(|c| c.title == shadow_title);
+        let concept_idx = changes.iter().position(|c| c.title == concept_title);
+        assert!(
+            shadow_idx < concept_idx,
+            "the more-recently-modified shadow must sort before the older concept page"
         );
     }
 
     #[tokio::test]
-    async fn list_recent_changes_scoped_excludes_entity_kind_shadow() {
+    async fn list_recent_changes_scoped_includes_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         db.store_entity(
             "Recent Changes Scoped Marker",
@@ -76738,10 +76916,10 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert!(
-            !changes
+            changes
                 .iter()
                 .any(|c| c.title == "Recent Changes Scoped Marker"),
-            "list_recent_changes_scoped (Space arm) must not surface a shadow page"
+            "Q1: list_recent_changes_scoped (Space arm) must surface a shadow page"
         );
     }
 
@@ -76895,7 +77073,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn get_page_sources_scoped_rejects_entity_kind_shadow() {
+    async fn get_page_sources_scoped_returns_empty_for_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Sources Marker", "person", None, None, None)
@@ -76903,17 +77081,21 @@ pub(crate) mod tests {
             .unwrap();
         let pid = shadow_page_id(&db, &eid).await;
 
-        let result = db
+        // Q1: a stub id now matches (found=true) so the handler can 200 the
+        // page itself; it legitimately has no page_sources rows, so the
+        // LEFT JOIN degrades to Ok(vec![]) rather than 404.
+        let sources = db
             .get_page_sources_scoped(&pid, &crate::read_scope::ReadScope::Global)
-            .await;
+            .await
+            .unwrap();
         assert!(
-            result.is_err(),
-            "get_page_sources_scoped must 404 (not Ok([])) for a shadow id (fail-closed by ID)"
+            sources.is_empty(),
+            "get_page_sources_scoped must return Ok([]) for a shadow id, not synthesize sources"
         );
     }
 
     #[tokio::test]
-    async fn get_page_outbound_links_scoped_rejects_entity_kind_shadow() {
+    async fn get_page_outbound_links_scoped_returns_empty_for_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Outbound Links Marker", "person", None, None, None)
@@ -76921,17 +77103,18 @@ pub(crate) mod tests {
             .unwrap();
         let pid = shadow_page_id(&db, &eid).await;
 
-        let result = db
+        let links = db
             .get_page_outbound_links_scoped(&pid, &crate::read_scope::ReadScope::Global)
-            .await;
+            .await
+            .unwrap();
         assert!(
-            result.is_err(),
-            "get_page_outbound_links_scoped must 404 for a shadow id"
+            links.is_empty(),
+            "get_page_outbound_links_scoped must return Ok([]) for a shadow id"
         );
     }
 
     #[tokio::test]
-    async fn get_page_inbound_links_scoped_rejects_entity_kind_shadow() {
+    async fn get_page_inbound_links_scoped_returns_empty_for_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Inbound Links Marker", "person", None, None, None)
@@ -76939,17 +77122,18 @@ pub(crate) mod tests {
             .unwrap();
         let pid = shadow_page_id(&db, &eid).await;
 
-        let result = db
+        let links = db
             .get_page_inbound_links_scoped(&pid, &crate::read_scope::ReadScope::Global)
-            .await;
+            .await
+            .unwrap();
         assert!(
-            result.is_err(),
-            "get_page_inbound_links_scoped must 404 for a shadow id"
+            links.is_empty(),
+            "get_page_inbound_links_scoped must return Ok([]) for a shadow id"
         );
     }
 
     #[tokio::test]
-    async fn get_page_changelog_scoped_rejects_entity_kind_shadow() {
+    async fn get_page_changelog_scoped_returns_empty_for_entity_kind_shadow() {
         let (db, _dir) = test_db().await;
         let eid = db
             .store_entity("Changelog Marker", "person", None, None, None)
@@ -76957,12 +77141,13 @@ pub(crate) mod tests {
             .unwrap();
         let pid = shadow_page_id(&db, &eid).await;
 
-        let result = db
+        let changelog = db
             .get_page_changelog_scoped(&pid, &crate::read_scope::ReadScope::Global)
-            .await;
-        assert!(
-            result.is_err(),
-            "get_page_changelog_scoped must 404 for a shadow id"
+            .await
+            .unwrap();
+        assert_eq!(
+            changelog, "[]",
+            "get_page_changelog_scoped must return Ok(\"[]\") for a shadow id (born with no changelog)"
         );
     }
 

--- a/crates/wenlan-core/src/db/entity_page_adapter.rs
+++ b/crates/wenlan-core/src/db/entity_page_adapter.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::WenlanError;
+
+/// M3 stage F: the named adapter seam for `entity_id <-> page_id` translation
+/// against the 1:1 `entity_page_map` (migration 90, both columns UNIQUE, FKs
+/// ON DELETE CASCADE). Single-row lookups only -- the JOIN forms that hydrate
+/// a full `Entity`/`EntityDetail` shape stay in `scoped_entities.rs`, which
+/// this seam does not touch.
+pub(crate) async fn page_id_for_entity(
+    conn: &libsql::Connection,
+    entity_id: &str,
+) -> Result<Option<String>, WenlanError> {
+    let mut rows = conn
+        .query(
+            "SELECT page_id FROM entity_page_map WHERE entity_id = ?1",
+            libsql::params![entity_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("page_id_for_entity: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("page_id_for_entity row: {e}")))?
+    {
+        Some(row) => Ok(Some(row.get(0).map_err(|e| {
+            WenlanError::VectorDb(format!("page_id_for_entity col: {e}"))
+        })?)),
+        None => Ok(None),
+    }
+}
+
+/// The reverse direction of [`page_id_for_entity`].
+#[allow(dead_code)] // no production call site among this stage's candidate
+                    // refactor sites (all are forward-direction); proven by
+                    // the round-trip bijection test.
+pub(crate) async fn entity_id_for_page(
+    conn: &libsql::Connection,
+    page_id: &str,
+) -> Result<Option<String>, WenlanError> {
+    let mut rows = conn
+        .query(
+            "SELECT entity_id FROM entity_page_map WHERE page_id = ?1",
+            libsql::params![page_id],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("entity_id_for_page: {e}")))?;
+    match rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("entity_id_for_page row: {e}")))?
+    {
+        Some(row) => Ok(Some(row.get(0).map_err(|e| {
+            WenlanError::VectorDb(format!("entity_id_for_page col: {e}"))
+        })?)),
+        None => Ok(None),
+    }
+}

--- a/crates/wenlan-core/src/db/entity_page_adapter_test.rs
+++ b/crates/wenlan-core/src/db/entity_page_adapter_test.rs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::entity_page_adapter::{entity_id_for_page, page_id_for_entity};
+use super::tests::test_db;
+
+/// M3 stage F acceptance property: the adapter round-trips `entity_id <->
+/// page_id` for every entity seeded through the real `store_entity`
+/// dual-write path (migration 90's `entity_page_map`).
+#[tokio::test]
+async fn adapter_round_trips_entity_id_and_page_id() {
+    let (db, _tmp) = test_db().await;
+    let mut entity_ids = Vec::new();
+    for i in 0..5 {
+        let id = db
+            .store_entity(
+                &format!("Adapter Entity {i}"),
+                "person",
+                Some("adapter_seam"),
+                None,
+                Some(0.7),
+            )
+            .await
+            .unwrap();
+        entity_ids.push(id);
+    }
+
+    let conn = db.conn.lock().await;
+    for entity_id in &entity_ids {
+        let page_id = page_id_for_entity(&conn, entity_id)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{entity_id} must have a mapped page_id"));
+        let round_tripped = entity_id_for_page(&conn, &page_id).await.unwrap();
+        assert_eq!(
+            round_tripped.as_deref(),
+            Some(entity_id.as_str()),
+            "entity_id_for_page(page_id_for_entity(id)) must round-trip to id"
+        );
+    }
+}
+
+#[tokio::test]
+async fn adapter_returns_none_for_nonexistent_id() {
+    let (db, _tmp) = test_db().await;
+    let conn = db.conn.lock().await;
+    assert_eq!(
+        page_id_for_entity(&conn, "nonexistent_entity")
+            .await
+            .unwrap(),
+        None,
+        "page_id_for_entity must return Ok(None) for an unmapped entity_id"
+    );
+    assert_eq!(
+        entity_id_for_page(&conn, "nonexistent_page").await.unwrap(),
+        None,
+        "entity_id_for_page must return Ok(None) for an unmapped page_id"
+    );
+}

--- a/crates/wenlan-core/src/db/scoped_pages.rs
+++ b/crates/wenlan-core/src/db/scoped_pages.rs
@@ -426,7 +426,10 @@ impl MemoryDB {
         scope: &ReadScope,
     ) -> Result<Vec<Page>, WenlanError> {
         if matches!(scope, ReadScope::Global) {
-            return self.list_pages(status, limit, offset).await;
+            // Q1 browse surface: this whole fn shows kind='entity' stubs on
+            // every scope arm, so the Global arm must delegate to the
+            // unfenced twin, not the internal-callers' fenced `list_pages`.
+            return self.list_pages_browse(status, limit, offset).await;
         }
         let select = "c.id, c.title, c.summary, c.content, c.entity_id, c.space, \
                       c.source_memory_ids, c.version, c.status, c.created_at, \

--- a/crates/wenlan-core/src/db/scoped_pages.rs
+++ b/crates/wenlan-core/src/db/scoped_pages.rs
@@ -274,9 +274,12 @@ impl MemoryDB {
 
         use wenlan_types::{ActivityBadge, ActivityKind, RecentActivityItem};
 
-        // Q1 lift (stage c): `kind='entity'` dual-write shadow pages appear in
-        // this recent-activity listing, mirroring `list_pages_scoped`'s lift.
-        let pages: Vec<Page> = self.list_pages_scoped("active", limit, 0, scope).await?;
+        // Q1 (stage c): `kind='entity'` dual-write shadow pages appear in this
+        // recent-activity listing -- a browse surface, so it reads the unfenced
+        // `list_pages_scoped_browse` twin.
+        let pages: Vec<Page> = self
+            .list_pages_scoped_browse("active", limit, 0, scope)
+            .await?;
         let all_source_ids = pages
             .iter()
             .flat_map(|page| page.source_memory_ids.iter().cloned())
@@ -418,6 +421,12 @@ impl MemoryDB {
         Ok(changes)
     }
 
+    /// Fenced: `kind='entity'` dual-write shadow pages stay excluded on every
+    /// scope arm (Global delegates to the fenced `list_pages`). Export and
+    /// other internal consumers that must never emit a stub call this, so the
+    /// fence lands in SQL before `LIMIT` -- a burst of fresh stubs can never
+    /// crowd real pages out of a bounded window. For the browse-facing twin
+    /// (Q1 read surfaces), see `list_pages_scoped_browse`.
     pub async fn list_pages_scoped(
         &self,
         status: &str,
@@ -425,11 +434,40 @@ impl MemoryDB {
         offset: i64,
         scope: &ReadScope,
     ) -> Result<Vec<Page>, WenlanError> {
+        self.list_pages_scoped_inner(status, limit, offset, scope, true)
+            .await
+    }
+
+    /// Browse-facing twin of `list_pages_scoped`: backs `GET /api/pages` and
+    /// the recent-with-badges browse path, where Q1 rules `kind='entity'`
+    /// dual-write shadow pages must appear on every scope arm (Global delegates
+    /// to `list_pages_browse`). Never call this from export or any internal
+    /// non-browse path -- those must stay fenced (`list_pages_scoped`).
+    pub async fn list_pages_scoped_browse(
+        &self,
+        status: &str,
+        limit: i64,
+        offset: i64,
+        scope: &ReadScope,
+    ) -> Result<Vec<Page>, WenlanError> {
+        self.list_pages_scoped_inner(status, limit, offset, scope, false)
+            .await
+    }
+
+    async fn list_pages_scoped_inner(
+        &self,
+        status: &str,
+        limit: i64,
+        offset: i64,
+        scope: &ReadScope,
+        fence_entity: bool,
+    ) -> Result<Vec<Page>, WenlanError> {
         if matches!(scope, ReadScope::Global) {
-            // Q1 browse surface: this whole fn shows kind='entity' stubs on
-            // every scope arm, so the Global arm must delegate to the
-            // unfenced twin, not the internal-callers' fenced `list_pages`.
-            return self.list_pages_browse(status, limit, offset).await;
+            return if fence_entity {
+                self.list_pages(status, limit, offset).await
+            } else {
+                self.list_pages_browse(status, limit, offset).await
+            };
         }
         let select = "c.id, c.title, c.summary, c.content, c.entity_id, c.space, \
                       c.source_memory_ids, c.version, c.status, c.created_at, \
@@ -438,11 +476,16 @@ impl MemoryDB {
                       COALESCE(c.user_edited, 0), COALESCE(c.changelog, '[]'), \
                       COALESCE(c.creation_kind, 'distilled'), \
                       COALESCE(c.review_status, 'confirmed'), c.workspace, c.citations, COALESCE(c.kind, 'concept')";
+        let fence_sql = if fence_entity {
+            " AND COALESCE(c.kind, 'concept') != 'entity'"
+        } else {
+            ""
+        };
         let (sql, params) = match scope {
             ReadScope::Space(workspace) => (
                 format!(
                     "SELECT {select} FROM pages c \
-                     WHERE c.status = ?1 AND c.workspace = ?2 \
+                     WHERE c.status = ?1{fence_sql} AND c.workspace = ?2 \
                      ORDER BY c.last_modified DESC LIMIT ?3 OFFSET ?4"
                 ),
                 vec![
@@ -455,7 +498,7 @@ impl MemoryDB {
             ReadScope::Uncategorized => (
                 format!(
                     "SELECT {select} FROM pages c \
-                     WHERE c.status = ?1 AND c.workspace = '00000000-0000-4000-8000-000000000001' \
+                     WHERE c.status = ?1{fence_sql} AND c.workspace = '00000000-0000-4000-8000-000000000001' \
                      ORDER BY c.last_modified DESC LIMIT ?2 OFFSET ?3"
                 ),
                 vec![
@@ -518,13 +561,42 @@ impl MemoryDB {
         Ok(labels)
     }
 
+    /// Fenced: `kind='entity'` dual-write shadow pages stay excluded, so a
+    /// by-id read on a mutation/export path resolves a stub as absent (None).
+    /// For the browse-facing twin that returns stub pages by id (Q1 read
+    /// surfaces), see `get_page_scoped_browse`.
     pub async fn get_page_scoped(
         &self,
         id: &str,
         scope: &ReadScope,
     ) -> Result<Option<Page>, WenlanError> {
+        self.get_page_scoped_inner(id, scope, true).await
+    }
+
+    /// Browse-facing twin of `get_page_scoped`: backs `GET /api/pages/{id}` and
+    /// its advisory revisions read, where Q1 rules `kind='entity'` dual-write
+    /// shadow pages must resolve. Never call this from a mutation/export path --
+    /// those must stay fenced (`get_page_scoped`).
+    pub async fn get_page_scoped_browse(
+        &self,
+        id: &str,
+        scope: &ReadScope,
+    ) -> Result<Option<Page>, WenlanError> {
+        self.get_page_scoped_inner(id, scope, false).await
+    }
+
+    async fn get_page_scoped_inner(
+        &self,
+        id: &str,
+        scope: &ReadScope,
+        fence_entity: bool,
+    ) -> Result<Option<Page>, WenlanError> {
         if matches!(scope, ReadScope::Global) {
-            return self.get_page(id).await;
+            return if fence_entity {
+                self.get_page(id).await
+            } else {
+                self.get_page_browse(id).await
+            };
         }
         let select = "c.id, c.title, c.summary, c.content, c.entity_id, c.space, \
                       c.source_memory_ids, c.version, c.status, c.created_at, \
@@ -534,7 +606,12 @@ impl MemoryDB {
                       COALESCE(c.creation_kind, 'distilled'), \
                       COALESCE(c.review_status, 'confirmed'), c.workspace, c.citations, COALESCE(c.kind, 'concept')";
         let (scope_sql, scope_value) = page_scope_clause(scope, "c.workspace", 2);
-        let sql = format!("SELECT {select} FROM pages c WHERE c.id = ?1{scope_sql}");
+        let fence_sql = if fence_entity {
+            " AND COALESCE(c.kind, 'concept') != 'entity'"
+        } else {
+            ""
+        };
+        let sql = format!("SELECT {select} FROM pages c WHERE c.id = ?1{fence_sql}{scope_sql}");
         let mut params = vec![libsql::Value::Text(id.to_string())];
         if let Some(value) = scope_value {
             params.push(value);

--- a/crates/wenlan-core/src/db/scoped_pages.rs
+++ b/crates/wenlan-core/src/db/scoped_pages.rs
@@ -55,6 +55,11 @@ impl MemoryDB {
     /// Route-facing Page search. Selected scopes use a workspace predicate in
     /// the same query that ranks and limits candidates; Global preserves the
     /// existing indexed search path.
+    ///
+    /// Retrieval arm: `kind='entity'` dual-write shadow pages stay fenced
+    /// out. Used by `search_memory_cross_rerank_cued`'s direct page channel,
+    /// which bypasses `select_visible_pages`. For the browse-facing twin
+    /// that shows stub pages (Q1), see `search_pages_scoped_browse`.
     pub async fn search_pages_scoped(
         &self,
         query: &str,
@@ -62,8 +67,40 @@ impl MemoryDB {
         page_type: Option<&str>,
         scope: &ReadScope,
     ) -> Result<Vec<Page>, WenlanError> {
+        self.search_pages_scoped_inner(query, limit, page_type, scope, true)
+            .await
+    }
+
+    /// Browse-facing twin of `search_pages_scoped`: backs `/api/pages/search`
+    /// (+ MCP `search_pages` via the same HTTP route), where Q1 rules
+    /// `kind='entity'` dual-write shadow pages must appear. Never call this
+    /// from a retrieval/context channel -- those must stay fenced
+    /// (`search_pages_scoped`).
+    pub async fn search_pages_scoped_browse(
+        &self,
+        query: &str,
+        limit: usize,
+        page_type: Option<&str>,
+        scope: &ReadScope,
+    ) -> Result<Vec<Page>, WenlanError> {
+        self.search_pages_scoped_inner(query, limit, page_type, scope, false)
+            .await
+    }
+
+    async fn search_pages_scoped_inner(
+        &self,
+        query: &str,
+        limit: usize,
+        page_type: Option<&str>,
+        scope: &ReadScope,
+        fence_entity: bool,
+    ) -> Result<Vec<Page>, WenlanError> {
         if matches!(scope, ReadScope::Global) {
-            return self.search_pages(query, limit, page_type).await;
+            return if fence_entity {
+                self.search_pages(query, limit, page_type).await
+            } else {
+                self.search_pages_browse(query, limit, page_type).await
+            };
         }
 
         let embedding = self.get_or_compute_embedding(query)?;
@@ -199,13 +236,16 @@ impl MemoryDB {
         for score in scores.values_mut() {
             *score = (*score / theoretical_max).min(1.0);
         }
-        // Fence (M3 PR-1 stage f): mirrors the `search_pages` exclusion --
-        // this is the scoped RRF page channel used both by `handle_search_pages`
-        // and, more importantly, by `search_memory_cross_rerank_cued`'s direct
-        // page channel, neither of which routes through `select_visible_pages`.
+        // Fence (M3 PR-1 stage f; Q1 lift, stage c): the retrieval arm
+        // (`fence_entity=true`) excludes `kind='entity'` dual-write shadow
+        // pages -- this channel is, more importantly, used by
+        // `search_memory_cross_rerank_cued`'s direct page channel, which
+        // bypasses `select_visible_pages`. The browse arm
+        // (`fence_entity=false`, `search_pages_scoped_browse`) includes them
+        // per the Q1 ruling.
         let mut results: Vec<Page> = pages
             .into_values()
-            .filter(|page| page.kind != "entity")
+            .filter(|page| !fence_entity || page.kind != "entity")
             .collect();
         results.sort_by(|left, right| {
             scores
@@ -234,16 +274,9 @@ impl MemoryDB {
 
         use wenlan_types::{ActivityBadge, ActivityKind, RecentActivityItem};
 
-        // Fence (M3 PR-1 stage f): `list_pages_scoped` is a general-purpose
-        // listing (also used by callers that legitimately want every kind), so
-        // the exclusion lives here at the recent-activity surface specifically,
-        // mirroring `list_recent_pages_with_badges`'s SQL-level exclusion.
-        let pages: Vec<Page> = self
-            .list_pages_scoped("active", limit, 0, scope)
-            .await?
-            .into_iter()
-            .filter(|page| page.kind != "entity")
-            .collect();
+        // Q1 lift (stage c): `kind='entity'` dual-write shadow pages appear in
+        // this recent-activity listing, mirroring `list_pages_scoped`'s lift.
+        let pages: Vec<Page> = self.list_pages_scoped("active", limit, 0, scope).await?;
         let all_source_ids = pages
             .iter()
             .flat_map(|page| page.source_memory_ids.iter().cloned())
@@ -348,8 +381,7 @@ impl MemoryDB {
         let (scope_sql, scope_value) = page_scope_clause(scope, "c.workspace", 2);
         let sql = format!(
             "SELECT c.id, c.title, c.version, c.created_at, c.last_modified \
-             FROM pages c WHERE c.status = 'active' \
-               AND COALESCE(c.kind, 'concept') != 'entity'{scope_sql} \
+             FROM pages c WHERE c.status = 'active'{scope_sql} \
              ORDER BY c.last_modified DESC LIMIT ?1"
         );
         let mut params = vec![libsql::Value::Integer(limit)];
@@ -407,7 +439,7 @@ impl MemoryDB {
             ReadScope::Space(workspace) => (
                 format!(
                     "SELECT {select} FROM pages c \
-                     WHERE c.status = ?1 AND COALESCE(c.kind, 'concept') != 'entity' AND c.workspace = ?2 \
+                     WHERE c.status = ?1 AND c.workspace = ?2 \
                      ORDER BY c.last_modified DESC LIMIT ?3 OFFSET ?4"
                 ),
                 vec![
@@ -420,7 +452,7 @@ impl MemoryDB {
             ReadScope::Uncategorized => (
                 format!(
                     "SELECT {select} FROM pages c \
-                     WHERE c.status = ?1 AND COALESCE(c.kind, 'concept') != 'entity' AND c.workspace = '00000000-0000-4000-8000-000000000001' \
+                     WHERE c.status = ?1 AND c.workspace = '00000000-0000-4000-8000-000000000001' \
                      ORDER BY c.last_modified DESC LIMIT ?2 OFFSET ?3"
                 ),
                 vec![
@@ -499,8 +531,7 @@ impl MemoryDB {
                       COALESCE(c.creation_kind, 'distilled'), \
                       COALESCE(c.review_status, 'confirmed'), c.workspace, c.citations, COALESCE(c.kind, 'concept')";
         let (scope_sql, scope_value) = page_scope_clause(scope, "c.workspace", 2);
-        let sql =
-            format!("SELECT {select} FROM pages c WHERE c.id = ?1 AND COALESCE(c.kind, 'concept') != 'entity'{scope_sql}");
+        let sql = format!("SELECT {select} FROM pages c WHERE c.id = ?1{scope_sql}");
         let mut params = vec![libsql::Value::Text(id.to_string())];
         if let Some(value) = scope_value {
             params.push(value);
@@ -529,7 +560,7 @@ impl MemoryDB {
         let sql = format!(
             "SELECT c.id, ps.page_id, ps.memory_source_id, ps.linked_at, ps.link_reason \
              FROM pages c LEFT JOIN page_sources ps ON ps.page_id = c.id \
-             WHERE c.id = ?1 AND COALESCE(c.kind, 'concept') != 'entity'{scope_sql} ORDER BY ps.linked_at ASC"
+             WHERE c.id = ?1{scope_sql} ORDER BY ps.linked_at ASC"
         );
         let mut params = vec![libsql::Value::Text(page_id.to_string())];
         if let Some(value) = scope_value {
@@ -573,7 +604,7 @@ impl MemoryDB {
         let sql = format!(
             "SELECT c.id, pl.target_page_id, pl.label FROM pages c \
              LEFT JOIN page_links pl ON pl.source_page_id = c.id \
-             WHERE c.id = ?1 AND COALESCE(c.kind, 'concept') != 'entity'{scope_sql} ORDER BY pl.label_key"
+             WHERE c.id = ?1{scope_sql} ORDER BY pl.label_key"
         );
         let mut params = vec![libsql::Value::Text(source_page_id.to_string())];
         if let Some(value) = scope_value {
@@ -619,7 +650,7 @@ impl MemoryDB {
              LEFT JOIN page_links pl ON pl.target_page_id = target.id \
              LEFT JOIN pages source ON source.id = pl.source_page_id \
                AND source.status = 'active'{source_scope_sql} \
-             WHERE target.id = ?1 AND COALESCE(target.kind, 'concept') != 'entity'{target_scope_sql} \
+             WHERE target.id = ?1{target_scope_sql} \
              ORDER BY source.last_modified DESC, source.id ASC"
         );
         let mut params = vec![libsql::Value::Text(target_page_id.to_string())];
@@ -658,10 +689,8 @@ impl MemoryDB {
         scope: &ReadScope,
     ) -> Result<String, WenlanError> {
         let (scope_sql, scope_value) = page_scope_clause(scope, "c.workspace", 2);
-        let sql = format!(
-            "SELECT COALESCE(c.changelog, '[]') FROM pages c \
-             WHERE c.id = ?1 AND COALESCE(c.kind, 'concept') != 'entity'{scope_sql}"
-        );
+        let sql =
+            format!("SELECT COALESCE(c.changelog, '[]') FROM pages c WHERE c.id = ?1{scope_sql}");
         let mut params = vec![libsql::Value::Text(page_id.to_string())];
         if let Some(value) = scope_value {
             params.push(value);

--- a/crates/wenlan-core/src/export/knowledge.rs
+++ b/crates/wenlan-core/src/export/knowledge.rs
@@ -4513,6 +4513,63 @@ mod tests {
         );
     }
 
+    /// Q1 (stage c fix wave): the daemon startup backfill (`main.rs`, guarded
+    /// by `startup_projection_writes_allowed`) fetches its page set via
+    /// `db.list_pages("active", 10_000, 0)` and then unconditionally calls
+    /// `KnowledgeProjectionWrite::write_page` for every page returned —
+    /// `write_page` itself has no kind filter, so the guarantee that a
+    /// `kind='entity'` dual-write shadow never lands on disk lives entirely
+    /// in `list_pages` staying fenced. This mirrors that exact call sequence
+    /// (fetch, then write-loop) rather than calling `write_page` directly, so
+    /// a regression in the fence — not in this file — would fail it too.
+    #[tokio::test]
+    async fn knowledge_projection_backfill_excludes_entity_kind_shadow() {
+        let (db, _dir) = crate::db::tests::test_db().await;
+        db.insert_page_with_kind(
+            "p_q1_backfill_concept",
+            "Q1 Backfill Concept Page",
+            None,
+            "concept content",
+            None,
+            None,
+            &[],
+            "2000-01-01T00:00:00+00:00",
+            "authored",
+            "confirmed",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        db.store_entity("Q1 Backfill Entity Marker", "person", None, None, None)
+            .await
+            .unwrap();
+
+        let pages = db.list_pages("active", 10_000, 0).await.unwrap();
+        let vault = tempfile::TempDir::new().unwrap();
+        let projection = KnowledgeProjectionWrite::new(vault.path().to_path_buf(), &db);
+        for page in &pages {
+            projection.write_page(page).unwrap();
+        }
+
+        let written: Vec<_> = std::fs::read_dir(vault.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            written.len(),
+            1,
+            "startup backfill must write only the real page, not the entity shadow; got: {written:?}"
+        );
+        let content = std::fs::read_to_string(vault.path().join(&written[0])).unwrap();
+        assert!(
+            !content.contains("Q1 Backfill Entity Marker"),
+            "the shadow page's title must never reach a projected markdown file"
+        );
+    }
+
     #[test]
     fn test_load_state_migrates_v1_concept_keys_to_page() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/crates/wenlan-core/src/page_map_improve.rs
+++ b/crates/wenlan-core/src/page_map_improve.rs
@@ -854,4 +854,31 @@ mod tests {
             "unchanged page must be skipped by the generated_at watermark"
         );
     }
+
+    #[tokio::test]
+    async fn run_proactive_page_maps_excludes_entity_kind_shadow() {
+        // Fix wave (stage c review, Critical-1 leak site 3): a fresh
+        // kind='entity' dual-write shadow is always "eligible" (no
+        // page_map_generated_at watermark) and sorts first in the
+        // last_modified DESC scan window, so without the fence it would
+        // burn the improve budget on stubs before real pages.
+        let (db, _tmp) = test_db().await;
+        let real_page = seed_page(&db, "Real Proactive Page", "body", vec!["m1".to_string()]).await;
+        db.store_entity("Proactive Shadow Marker", "person", None, None, None)
+            .await
+            .unwrap();
+
+        let improved = run_proactive_page_maps(&db, 1).await.unwrap();
+        assert_eq!(
+            improved, 1,
+            "the single improve budget must land on the real page, not the shadow"
+        );
+        assert!(
+            db.page_map_generated_at(&real_page)
+                .await
+                .unwrap()
+                .is_some(),
+            "the real page must have been improved"
+        );
+    }
 }

--- a/crates/wenlan-core/src/synthesis/overview.rs
+++ b/crates/wenlan-core/src/synthesis/overview.rs
@@ -373,6 +373,43 @@ mod tests {
         );
     }
 
+    /// Fix wave (stage c review, Critical-1 leak site 2): a fresh
+    /// kind='entity' dual-write shadow (stamped `now`, so it would sort into
+    /// the top of a `last_modified DESC` window ahead of every real page)
+    /// must never consume one of the OVERVIEW_TOP_PAGES evidence slots or
+    /// contribute its (always-empty) source_memory_ids.
+    #[tokio::test]
+    async fn top_page_source_ids_excludes_entity_kind_shadow() {
+        let (db, _dir) = test_db().await;
+
+        let mut mem_ids = Vec::new();
+        for i in 1..=OVERVIEW_TOP_PAGES {
+            let mem_id = format!("mem_overview_shadow_guard_{i}");
+            let content =
+                format!("Topic{i} is a specific programming concept with unique details.");
+            create_research_page(&db, &format!("Topic{i}"), &mem_id, &content).await;
+            mem_ids.push(mem_id);
+        }
+        // Seeded after the real pages, so store_entity's `now` timestamp
+        // sorts it first without the fence.
+        db.store_entity("Overview Shadow Marker", "person", None, None, None)
+            .await
+            .unwrap();
+
+        let ids = top_page_source_ids(&db, None).await.unwrap();
+        for mem_id in &mem_ids {
+            assert!(
+                ids.contains(mem_id),
+                "real page source {mem_id} must not be displaced by the entity shadow, got: {ids:?}"
+            );
+        }
+        assert_eq!(
+            ids.len(),
+            mem_ids.len(),
+            "the shadow must contribute zero source ids of its own, got: {ids:?}"
+        );
+    }
+
     /// The Overview refresh must use its OWN dedicated summary prompt, not
     /// the generic `distill_page` prompt every other page refresh uses, and
     /// its synthesis input must span ALL of the wiki's current top pages at

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -2125,8 +2125,10 @@ impl WenlanMcpServer {
         // `DeleteResponse{deleted: bool}` shape used elsewhere. No exported
         // wenlan-types struct matches it, so a local type stands in for
         // serde_json::Value -- a wire-shape drift now fails at deserialize
-        // instead of round-tripping silently as untyped JSON.
+        // instead of round-tripping silently as untyped JSON. `deny_unknown_fields`
+        // makes an ADDITIVE envelope key fail loud too, not just a renamed one.
         #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct DeletePageResponse {
             status: String,
         }
@@ -2146,7 +2148,10 @@ impl WenlanMcpServer {
         // page-draft feature's response, not this route's), so a local type
         // stands in for serde_json::Value -- a wire-shape drift now fails at
         // deserialize instead of round-tripping silently as untyped JSON.
+        // `deny_unknown_fields` makes an ADDITIVE envelope key fail loud too
+        // (the top-level object; the inner Page keeps its own field contract).
         #[derive(Serialize, Deserialize)]
+        #[serde(deny_unknown_fields)]
         struct GetPageResponse {
             page: wenlan_types::Page,
         }

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -2120,22 +2120,40 @@ impl WenlanMcpServer {
             )]));
         }
 
+        // Envelope for DELETE /api/pages/{id} (handle_delete_page,
+        // memory_routes.rs:2023): a bare `{"status": ...}`, unrelated to the
+        // `DeleteResponse{deleted: bool}` shape used elsewhere. No exported
+        // wenlan-types struct matches it, so a local type stands in for
+        // serde_json::Value -- a wire-shape drift now fails at deserialize
+        // instead of round-tripping silently as untyped JSON.
+        #[derive(Deserialize)]
+        struct DeletePageResponse {
+            status: String,
+        }
+
         let path = format!("/api/pages/{}", page_id);
-        let resp: serde_json::Value = try_call!(self.client.delete(&path), "delete_page");
-        let status = resp
-            .get("status")
-            .and_then(|v| v.as_str())
-            .unwrap_or("deleted");
+        let resp: DeletePageResponse = try_call!(self.client.delete(&path), "delete_page");
         Ok(CallToolResult::success(vec![Content::text(format!(
             "Page {} {}",
-            page_id, status
+            page_id, resp.status
         ))]))
     }
 
     pub async fn get_page_impl(&self, page_id: &str) -> Result<CallToolResult, McpError> {
+        // Envelope for GET /api/pages/{id} (handle_get_page,
+        // memory_routes.rs:1938): `{"page": Page}`. No exported wenlan-types
+        // envelope matches this shape (PageDraftResponse{page: Page} is the
+        // page-draft feature's response, not this route's), so a local type
+        // stands in for serde_json::Value -- a wire-shape drift now fails at
+        // deserialize instead of round-tripping silently as untyped JSON.
+        #[derive(Serialize, Deserialize)]
+        struct GetPageResponse {
+            page: wenlan_types::Page,
+        }
+
         let path = format!("/api/pages/{}", page_id);
-        let resp: serde_json::Value = try_call!(self.client.get(&path), "get_page");
-        let pretty = serde_json::to_string_pretty(&resp).unwrap_or_else(|_| resp.to_string());
+        let resp: GetPageResponse = try_call!(self.client.get(&path), "get_page");
+        let pretty = serde_json::to_string_pretty(&resp).unwrap_or_else(|_| String::new());
         Ok(CallToolResult::success(vec![Content::text(pretty)]))
     }
 

--- a/crates/wenlan-server/src/memory_routes.rs
+++ b/crates/wenlan-server/src/memory_routes.rs
@@ -2063,7 +2063,7 @@ pub async fn handle_search_pages(
         crate::read_scope::effective_read_scope(&db, req.space.as_deref(), header_space.as_deref())
             .await?;
     let results = db
-        .search_pages_scoped(
+        .search_pages_scoped_browse(
             &req.query,
             req.limit.unwrap_or(20),
             req.page_type.as_deref(),
@@ -2138,10 +2138,17 @@ pub async fn handle_export_pages(
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
     let scope = crate::read_scope::effective_read_scope(&db, None, header_space.as_deref()).await?;
-    let pages = db
+    // Q1 lifted `list_pages_scoped`'s entity-kind fence for browse/search, but
+    // export must stay stub-free: `kind='entity'` dual-write shadow pages
+    // carry no content and are not meant to leave the daemon. Pure
+    // retain-on-kind of an already-fetched Vec, not business logic.
+    let pages: Vec<_> = db
         .list_pages_scoped("active", 1000, 0, &scope)
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(|e| ServerError::Internal(e.to_string()))?
+        .into_iter()
+        .filter(|p| p.kind != "entity")
+        .collect();
     let vault_path = req
         .vault_path
         .unwrap_or_else(|| "~/obsidian-vault/Wenlan/pages".to_string());
@@ -2176,10 +2183,14 @@ pub async fn handle_export_page(
     };
 
     let scope = crate::read_scope::effective_read_scope(&db, None, header_space.as_deref()).await?;
+    // Q1 lifted `get_page_scoped`'s entity-kind fence for browse, but export
+    // must stay stub-free (see handle_export_pages); a stub id 404s here as
+    // it did before the lift.
     let page = db
         .get_page_scoped(&page_id, &scope)
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?
+        .filter(|p| p.kind != "entity")
         .ok_or_else(|| ServerError::NotFound("page not found".to_string()))?;
 
     let expanded = if let Some(rest) = req.vault_path.strip_prefix("~/") {

--- a/crates/wenlan-server/src/memory_routes.rs
+++ b/crates/wenlan-server/src/memory_routes.rs
@@ -1927,8 +1927,11 @@ pub async fn handle_list_pages(
     let scope =
         crate::read_scope::effective_read_scope(&db, space.as_deref(), header_space.as_deref())
             .await?;
+    // Q1 browse surface: `kind='entity'` dual-write shadow pages appear here,
+    // so read the unfenced `_browse` twin (export + internal callers keep the
+    // fenced `list_pages_scoped`).
     let pages = db
-        .list_pages_scoped(status, limit as i64, offset as i64, &scope)
+        .list_pages_scoped_browse(status, limit as i64, offset as i64, &scope)
         .await
         .map_err(|e| ServerError::SearchFailed(e.to_string()))?;
     Ok(Json(serde_json::json!({ "pages": pages })))
@@ -1945,7 +1948,9 @@ pub async fn handle_get_page(
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
     let scope = crate::read_scope::effective_read_scope(&db, None, header_space.as_deref()).await?;
-    match db.get_page_scoped(&id, &scope).await {
+    // Q1 browse surface: a shadow id resolves 200 here, so read the unfenced
+    // `_browse` twin (mutation/export by-id reads keep fenced `get_page_scoped`).
+    match db.get_page_scoped_browse(&id, &scope).await {
         Ok(Some(page)) => Ok(Json(serde_json::json!({ "page": page }))),
         Ok(None) => Err(ServerError::NotFound("page not found".to_string())),
         Err(e) => Err(ServerError::SearchFailed(e.to_string())),
@@ -2006,9 +2011,9 @@ pub async fn handle_archive_page(
 ) -> Result<Json<serde_json::Value>, ServerError> {
     let s = state.read().await;
     let db = s.db.as_ref().ok_or(ServerError::DbNotInitialized)?;
-    db.archive_page(&id)
-        .await
-        .map_err(|e| ServerError::SearchFailed(e.to_string()))?;
+    // `ServerError::from` maps the entity-shadow fence's WenlanError::Validation
+    // to a 4xx (ValidationError), matching the neighboring page-write handlers.
+    db.archive_page(&id).await.map_err(ServerError::from)?;
     Ok(Json(serde_json::json!({"status": "archived"})))
 }
 
@@ -2034,9 +2039,9 @@ pub async fn handle_delete_page(
     let knowledge_path = wenlan_core::config::load_config().knowledge_path_or_default();
     let projection =
         wenlan_core::export::knowledge::KnowledgeProjectionWrite::new(knowledge_path, &db);
-    db.delete_page(&id)
-        .await
-        .map_err(|e| ServerError::SearchFailed(e.to_string()))?;
+    // `ServerError::from` maps the entity-shadow fence's WenlanError::Validation
+    // to a 4xx (ValidationError), matching the neighboring page-write handlers.
+    db.delete_page(&id).await.map_err(ServerError::from)?;
 
     if let Err(e) = projection.remove_page(&id) {
         tracing::warn!(
@@ -2138,17 +2143,15 @@ pub async fn handle_export_pages(
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
     let scope = crate::read_scope::effective_read_scope(&db, None, header_space.as_deref()).await?;
-    // Q1 lifted `list_pages_scoped`'s entity-kind fence for browse/search, but
-    // export must stay stub-free: `kind='entity'` dual-write shadow pages
-    // carry no content and are not meant to leave the daemon. Pure
-    // retain-on-kind of an already-fetched Vec, not business logic.
-    let pages: Vec<_> = db
+    // Export must stay stub-free: `kind='entity'` dual-write shadow pages carry
+    // no content and are not meant to leave the daemon. The fenced
+    // `list_pages_scoped` excludes them in SQL *before* LIMIT, so a burst of
+    // fresh stubs can never crowd real pages out of the 1000-row window (the
+    // browse surfaces read the `_browse` twin instead).
+    let pages = db
         .list_pages_scoped("active", 1000, 0, &scope)
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?
-        .into_iter()
-        .filter(|p| p.kind != "entity")
-        .collect();
+        .map_err(|e| ServerError::Internal(e.to_string()))?;
     let vault_path = req
         .vault_path
         .unwrap_or_else(|| "~/obsidian-vault/Wenlan/pages".to_string());
@@ -2183,14 +2186,13 @@ pub async fn handle_export_page(
     };
 
     let scope = crate::read_scope::effective_read_scope(&db, None, header_space.as_deref()).await?;
-    // Q1 lifted `get_page_scoped`'s entity-kind fence for browse, but export
-    // must stay stub-free (see handle_export_pages); a stub id 404s here as
-    // it did before the lift.
+    // Export must stay stub-free (see handle_export_pages). The fenced
+    // `get_page_scoped` resolves a `kind='entity'` shadow id as absent, so a
+    // stub 404s here just as it did before the Q1 lift.
     let page = db
         .get_page_scoped(&page_id, &scope)
         .await
         .map_err(|e| ServerError::Internal(e.to_string()))?
-        .filter(|p| p.kind != "entity")
         .ok_or_else(|| ServerError::NotFound("page not found".to_string()))?;
 
     let expanded = if let Some(rest) = req.vault_path.strip_prefix("~/") {
@@ -5453,8 +5455,10 @@ pub async fn handle_get_page_revisions(
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
     let scope = crate::read_scope::effective_read_scope(&db, None, header_space.as_deref()).await?;
+    // Q1 sub-resource: revisions is a read-only browse surface, so a shadow id
+    // resolves 200 (empty changelog) via the unfenced `_browse` twin.
     let page = db
-        .get_page_scoped(&id, &scope)
+        .get_page_scoped_browse(&id, &scope)
         .await?
         .ok_or_else(|| ServerError::NotFound("page not found".to_string()))?;
     let changelog_str = db.get_page_changelog_scoped(&id, &scope).await?;

--- a/crates/wenlan-server/tests/page_browse_entity_shadow_e2e.rs
+++ b/crates/wenlan-server/tests/page_browse_entity_shadow_e2e.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Q1 (stage c): `kind='entity'` dual-write shadow pages must appear on the
+//! page browse/search surfaces (list, search, recent, recent-changes,
+//! get-by-id, and its sub-resources) while staying excluded from export.
+//! Mirrors the core-level fence-lift tests in `wenlan-core/src/db.rs` at the
+//! HTTP layer, so a regression that only breaks the handler wiring (not the
+//! underlying DB fn) is still caught.
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde::Deserialize;
+use tower::ServiceExt;
+use wenlan_types::pages::Page;
+use wenlan_types::responses::PageLinksResponse;
+use wenlan_types::{
+    ExportStats, ListPageRevisionsResponse, PageChange, PageSourceWithMemory, RecentActivityItem,
+};
+
+#[derive(Debug, Deserialize)]
+struct PagesEnvelope {
+    pages: Vec<Page>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PageEnvelope {
+    page: Page,
+}
+
+async fn get(router: &common::AppRouter, uri: &str) -> axum::http::Response<Body> {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn post_json(
+    router: &common::AppRouter,
+    uri: &str,
+    body: serde_json::Value,
+) -> axum::http::Response<Body> {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn body_json<T: serde::de::DeserializeOwned>(resp: axum::http::Response<Body>) -> T {
+    let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).expect("response body must deserialize")
+}
+
+/// Find a page's id by title through the public GET /api/pages listing --
+/// the lookup path an HTTP client would actually use, rather than reaching
+/// into `entity_page_map` directly from this HTTP-level test.
+async fn find_page_id_by_title(router: &common::AppRouter, title: &str) -> String {
+    let resp = get(router, "/api/pages?limit=200").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listed: PagesEnvelope = body_json(resp).await;
+    listed
+        .pages
+        .into_iter()
+        .find(|p| p.title == title)
+        .unwrap_or_else(|| panic!("page titled {title:?} must appear in GET /api/pages"))
+        .id
+}
+
+#[tokio::test]
+async fn list_pages_includes_entity_kind_shadow() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP List Shadow Marker", "person", None, None, None)
+        .await
+        .unwrap();
+
+    let resp = get(&router, "/api/pages").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listed: PagesEnvelope = body_json(resp).await;
+    assert!(
+        listed
+            .pages
+            .iter()
+            .any(|p| p.title == "HTTP List Shadow Marker"),
+        "Q1: GET /api/pages must surface a kind='entity' shadow page"
+    );
+}
+
+#[tokio::test]
+async fn search_pages_includes_entity_kind_shadow() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP Search Shadow Marker", "person", None, None, None)
+        .await
+        .unwrap();
+
+    let resp = post_json(
+        &router,
+        "/api/pages/search",
+        serde_json::json!({ "query": "HTTP Search Shadow Marker" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listed: PagesEnvelope = body_json(resp).await;
+    assert!(
+        listed
+            .pages
+            .iter()
+            .any(|p| p.title == "HTTP Search Shadow Marker"),
+        "Q1: POST /api/pages/search must surface a kind='entity' shadow page"
+    );
+}
+
+#[tokio::test]
+async fn recent_pages_includes_entity_kind_shadow() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP Recent Shadow Marker", "person", None, None, None)
+        .await
+        .unwrap();
+
+    let resp = get(&router, "/api/pages/recent").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let items: Vec<RecentActivityItem> = body_json(resp).await;
+    assert!(
+        items.iter().any(|i| i.title == "HTTP Recent Shadow Marker"),
+        "Q1: GET /api/pages/recent must surface a kind='entity' shadow page"
+    );
+}
+
+#[tokio::test]
+async fn recent_page_changes_includes_entity_kind_shadow() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity(
+        "HTTP Recent Changes Shadow Marker",
+        "person",
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let resp = get(&router, "/api/pages/recent-changes").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let changes: Vec<PageChange> = body_json(resp).await;
+    assert!(
+        changes
+            .iter()
+            .any(|c| c.title == "HTTP Recent Changes Shadow Marker"),
+        "Q1: GET /api/pages/recent-changes must surface a kind='entity' shadow page"
+    );
+}
+
+#[tokio::test]
+async fn get_page_by_id_returns_entity_kind_shadow() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP Get By Id Shadow Marker", "person", None, None, None)
+        .await
+        .unwrap();
+    let id = find_page_id_by_title(&router, "HTTP Get By Id Shadow Marker").await;
+
+    let resp = get(&router, &format!("/api/pages/{id}")).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "Q1: GET /api/pages/{{id}} must 200 for a shadow id, not 404"
+    );
+    let fetched: PageEnvelope = body_json(resp).await;
+    assert_eq!(fetched.page.title, "HTTP Get By Id Shadow Marker");
+}
+
+#[tokio::test]
+async fn shadow_sub_resources_return_empty_not_404() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity(
+        "HTTP Sub Resource Shadow Marker",
+        "person",
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let id = find_page_id_by_title(&router, "HTTP Sub Resource Shadow Marker").await;
+
+    let sources_resp = get(&router, &format!("/api/pages/{id}/sources")).await;
+    assert_eq!(sources_resp.status(), StatusCode::OK);
+    let sources: Vec<PageSourceWithMemory> = body_json(sources_resp).await;
+    assert!(sources.is_empty(), "a shadow page has no real sources");
+
+    let links_resp = get(&router, &format!("/api/pages/{id}/links")).await;
+    assert_eq!(links_resp.status(), StatusCode::OK);
+    let links: PageLinksResponse = body_json(links_resp).await;
+    assert!(
+        links.outbound.is_empty() && links.inbound.is_empty(),
+        "a shadow page has no real wikilinks"
+    );
+
+    let revisions_resp = get(&router, &format!("/api/pages/{id}/revisions")).await;
+    assert_eq!(revisions_resp.status(), StatusCode::OK);
+    let revisions: ListPageRevisionsResponse = body_json(revisions_resp).await;
+    assert!(
+        revisions.entries.is_empty(),
+        "a shadow page has no real revision history"
+    );
+}
+
+#[tokio::test]
+async fn export_stays_stub_free() {
+    let (router, tmp, db) = common::test_app().await;
+    common::create_page_fixture(
+        &db,
+        "HTTP Export Concept Page",
+        "Real page content that must be exported.",
+        None,
+        &[],
+        "authored",
+    )
+    .await;
+    db.store_entity("HTTP Export Shadow Marker", "person", None, None, None)
+        .await
+        .unwrap();
+    let stub_id = find_page_id_by_title(&router, "HTTP Export Shadow Marker").await;
+
+    let vault_path = tmp.path().join("vault");
+    let resp = post_json(
+        &router,
+        "/api/pages/export",
+        serde_json::json!({ "vault_path": vault_path.to_string_lossy() }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let stats: ExportStats = body_json(resp).await;
+    assert_eq!(
+        stats.exported, 1,
+        "bulk export must export only the real page, not the entity shadow"
+    );
+    let written: Vec<_> = std::fs::read_dir(&vault_path)
+        .expect("export must have created the vault dir")
+        .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+        .collect();
+    assert_eq!(
+        written.len(),
+        1,
+        "exactly one file must land in the vault; got: {written:?}"
+    );
+    let exported_content = std::fs::read_to_string(vault_path.join(&written[0])).unwrap();
+    assert!(
+        !exported_content.contains("HTTP Export Shadow Marker"),
+        "the shadow page's title must never appear in an exported file"
+    );
+
+    let single_resp = post_json(
+        &router,
+        &format!("/api/pages/{stub_id}/export"),
+        serde_json::json!({ "vault_path": vault_path.to_string_lossy() }),
+    )
+    .await;
+    assert_eq!(
+        single_resp.status(),
+        StatusCode::NOT_FOUND,
+        "single-page export of a shadow id must 404, matching pre-lift behavior"
+    );
+}

--- a/crates/wenlan-server/tests/page_browse_entity_shadow_e2e.rs
+++ b/crates/wenlan-server/tests/page_browse_entity_shadow_e2e.rs
@@ -60,6 +60,39 @@ async fn post_json(
         .unwrap()
 }
 
+async fn put_json(
+    router: &common::AppRouter,
+    uri: &str,
+    body: serde_json::Value,
+) -> axum::http::Response<Body> {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn delete(router: &common::AppRouter, uri: &str) -> axum::http::Response<Body> {
+    router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
 async fn body_json<T: serde::de::DeserializeOwned>(resp: axum::http::Response<Body>) -> T {
     let bytes = axum::body::to_bytes(resp.into_body(), 256 * 1024)
         .await
@@ -274,5 +307,125 @@ async fn export_stays_stub_free() {
         single_resp.status(),
         StatusCode::NOT_FOUND,
         "single-page export of a shadow id must 404, matching pre-lift behavior"
+    );
+}
+
+// -- Fix wave (sol-review): Q1 makes shadow ids publicly discoverable, so the
+// page MUTATION surfaces must fence them. A shadow id obtained through the
+// public GET /api/pages listing must be rejected by archive, delete, manual
+// update, agent refresh, and page-map node create -- while the read surface
+// (GET /api/pages/{id}) stays 200. --
+
+#[tokio::test]
+async fn archive_of_shadow_id_is_rejected() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP Archive Fence Marker", "person", None, None, None)
+        .await
+        .unwrap();
+    let id = find_page_id_by_title(&router, "HTTP Archive Fence Marker").await;
+
+    let resp = post_json(
+        &router,
+        &format!("/api/pages/{id}/archive"),
+        serde_json::json!({}),
+    )
+    .await;
+    assert!(
+        resp.status().is_client_error(),
+        "POST /api/pages/{{stub}}/archive must return a 4xx, got {}",
+        resp.status()
+    );
+
+    // The stub must still resolve (archive was rejected, not partially applied).
+    let get_resp = get(&router, &format!("/api/pages/{id}")).await;
+    assert_eq!(
+        get_resp.status(),
+        StatusCode::OK,
+        "the shadow page must still resolve after a rejected archive"
+    );
+}
+
+#[tokio::test]
+async fn delete_of_shadow_id_is_rejected() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP Delete Fence Marker", "person", None, None, None)
+        .await
+        .unwrap();
+    let id = find_page_id_by_title(&router, "HTTP Delete Fence Marker").await;
+
+    let resp = delete(&router, &format!("/api/pages/{id}")).await;
+    assert!(
+        resp.status().is_client_error(),
+        "DELETE /api/pages/{{stub}} must return a 4xx, got {}",
+        resp.status()
+    );
+
+    let get_resp = get(&router, &format!("/api/pages/{id}")).await;
+    assert_eq!(
+        get_resp.status(),
+        StatusCode::OK,
+        "the shadow page must still resolve after a rejected delete"
+    );
+}
+
+#[tokio::test]
+async fn write_and_page_map_surfaces_reject_shadow_while_get_stays_200() {
+    let (router, _tmp, db) = common::test_app().await;
+    db.store_entity("HTTP Write Fence Marker", "person", None, None, None)
+        .await
+        .unwrap();
+    let id = find_page_id_by_title(&router, "HTTP Write Fence Marker").await;
+
+    // Manual update (POST /api/memory/{id}/update-page): fenced get_page →
+    // None → 404.
+    let update_resp = post_json(
+        &router,
+        &format!("/api/memory/{id}/update-page"),
+        serde_json::json!({ "content": "attempted stub edit" }),
+    )
+    .await;
+    assert_eq!(
+        update_resp.status(),
+        StatusCode::NOT_FOUND,
+        "manual update of a shadow id must 404"
+    );
+
+    // Agent refresh (PUT /api/pages/{id}): valid body, fenced get_page → None →
+    // 4xx.
+    let refresh_resp = put_json(
+        &router,
+        &format!("/api/pages/{id}"),
+        serde_json::json!({
+            "content": "attempted stub refresh",
+            "source_memory_ids": ["mem_1"],
+        }),
+    )
+    .await;
+    assert!(
+        refresh_resp.status().is_client_error(),
+        "agent refresh of a shadow id must return a 4xx, got {}",
+        refresh_resp.status()
+    );
+
+    // Page-map node create (POST /api/pages/{id}/map/nodes): ensure_page_is_active
+    // → fenced get_page → None → 404.
+    let node_resp = post_json(
+        &router,
+        &format!("/api/pages/{id}/map/nodes"),
+        serde_json::json!({ "base_revision": 0 }),
+    )
+    .await;
+    assert_eq!(
+        node_resp.status(),
+        StatusCode::NOT_FOUND,
+        "page-map node create for a shadow id must 404"
+    );
+
+    // The read surface stays 200 throughout.
+    let get_resp = get(&router, &format!("/api/pages/{id}")).await;
+    assert_eq!(
+        get_resp.status(),
+        StatusCode::OK,
+        "GET /api/pages/{{stub}} must stay 200 while the write surfaces reject it"
     );
 }

--- a/crates/wenlan-types/src/entities_freeze_tests.rs
+++ b/crates/wenlan-types/src/entities_freeze_tests.rs
@@ -20,6 +20,12 @@
 //! like 0.9: `serde_json::to_value` widens an `f32` to `f64` via a raw `as`
 //! cast, not a decimal round-trip, so `0.9f32` does not compare equal to
 //! `json!(0.9)` (verified empirically -- `0.9f32 as f64 == 0.8999999761581421`).
+//!
+//! Freezing a sample only proves what it covers: a NEW `Option` field added
+//! with `skip_serializing_if` and left `None` in every sample here passes
+//! silently without ever freezing its `Some` shape. When adding a field to a
+//! frozen struct, populate it (`Some(...)`) in the fully-populated sample, not
+//! just the struct literal's default.
 
 use crate::entities::{
     Entity, EntityDetail, EntitySearchResult, EntitySuggestion, Observation, RecentRelation,
@@ -39,7 +45,9 @@ use crate::responses::{
     CreateEntityResponse, ListEntitiesResponse, ProposalAction, RefinementPayload,
     SearchEntitiesResponse,
 };
+use crate::sources::RawDocument;
 use serde_json::json;
+use std::collections::HashMap;
 
 // ===== entities.rs:8-93 =====
 
@@ -900,5 +908,85 @@ fn repair_rollback_v2_complete_entity_extraction_freeze() {
     assert_eq!(
         serde_json::from_value::<RepairRollbackPayloadV2>(no_error_json).unwrap(),
         no_error
+    );
+}
+
+// ===== sources.rs:172 =====
+
+fn sample_raw_document(entity_id: Option<String>) -> RawDocument {
+    RawDocument {
+        source: "gmail".into(),
+        source_id: "msg_1".into(),
+        title: "Title".into(),
+        summary: Some("Summary".into()),
+        content: "Body".into(),
+        url: Some("https://example.com".into()),
+        last_modified: 1_700_000_000,
+        metadata: HashMap::from([("key".to_string(), "value".to_string())]),
+        memory_type: Some("fact".into()),
+        space: Some("work".into()),
+        source_agent: Some("claude-code".into()),
+        confidence: Some(0.5),
+        confirmed: Some(true),
+        stability: Some("confirmed".into()),
+        supersedes: Some("mem_0".into()),
+        pending_revision: true,
+        entity_id,
+        quality: Some("high".into()),
+        importance: Some(8),
+        is_recap: true,
+        enrichment_status: "complete".into(),
+        supersede_mode: "archive".into(),
+        structured_fields: Some("{\"claim\":\"x\"}".into()),
+        retrieval_cue: Some("cue".into()),
+        source_text: Some("original".into()),
+        content_hash: Some("abc123".into()),
+    }
+}
+
+/// `RawDocument.entity_id` (spec M3, FREEZE set).
+#[test]
+fn raw_document_entity_id_freeze() {
+    let some_json = json!({
+        "source": "gmail",
+        "source_id": "msg_1",
+        "title": "Title",
+        "summary": "Summary",
+        "content": "Body",
+        "url": "https://example.com",
+        "last_modified": 1_700_000_000,
+        "metadata": { "key": "value" },
+        "memory_type": "fact",
+        "space": "work",
+        "source_agent": "claude-code",
+        "confidence": 0.5,
+        "confirmed": true,
+        "stability": "confirmed",
+        "supersedes": "mem_0",
+        "pending_revision": true,
+        "entity_id": "entity_1",
+        "quality": "high",
+        "importance": 8,
+        "is_recap": true,
+        "enrichment_status": "complete",
+        "supersede_mode": "archive",
+        "structured_fields": "{\"claim\":\"x\"}",
+        "retrieval_cue": "cue",
+        "source_text": "original",
+        "content_hash": "abc123",
+    });
+    assert_eq!(
+        serde_json::to_value(sample_raw_document(Some("entity_1".into()))).unwrap(),
+        some_json
+    );
+    let back: RawDocument = serde_json::from_value(some_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), some_json);
+
+    // entity_id has skip_serializing_if = Option::is_none: None omits the key.
+    let mut none_json = some_json;
+    none_json.as_object_mut().unwrap().remove("entity_id");
+    assert_eq!(
+        serde_json::to_value(sample_raw_document(None)).unwrap(),
+        none_json
     );
 }

--- a/crates/wenlan-types/src/entities_freeze_tests.rs
+++ b/crates/wenlan-types/src/entities_freeze_tests.rs
@@ -1,0 +1,904 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wire-shape freeze tests for the M3 entity_id-carrying wire surface (spec M3 D4).
+//!
+//! Every struct/field/enum-variant here is listed in the FREEZE set of
+//! `docs/plans/2026-07-22-m3-pr1-caller-inventory.md` ("FREEZE set" section):
+//! wire/MCP-facing entity_id-carrying surfaces whose shape must never change
+//! while `entities`-internal readers flip to page-backed storage behind
+//! adapters (D4). Each test asserts `serde_json::to_value(&sample)` against a
+//! committed `serde_json::json!({...})` literal -- exact keys and values, so a
+//! rename/removal/retype/addition fails the build. Where the struct derives
+//! `Deserialize`, the literal is also asserted to deserialize back and
+//! re-serialize to the same value (round trip).
+//!
+//! These are freeze tests, not correctness tests: a surprising shape here
+//! (e.g. an `Option` field with no `skip_serializing_if` sitting next to
+//! siblings that have one) is frozen as-is, never "fixed". See the stage
+//! report for the ones worth a human's attention.
+//!
+//! All float samples use binary-exact values (0.0, 0.5) rather than decimals
+//! like 0.9: `serde_json::to_value` widens an `f32` to `f64` via a raw `as`
+//! cast, not a decimal round-trip, so `0.9f32` does not compare equal to
+//! `json!(0.9)` (verified empirically -- `0.9f32 as f64 == 0.8999999761581421`).
+
+use crate::entities::{
+    Entity, EntityDetail, EntitySearchResult, EntitySuggestion, Observation, RecentRelation,
+    Relation, RelationWithEntity,
+};
+use crate::memory::{MemoryItem, SearchResult, Space};
+use crate::pages::Page;
+use crate::repair::{
+    RepairChoice, RepairEnrichmentStep, RepairMutation, RepairRollbackPayloadV2, RepairScope,
+    RepairTarget,
+};
+use crate::requests::{
+    AddEntityObservationRequest, ConfirmEntityRequest, CreateEntityRequest, LinkEntityRequest,
+    StoreMemoryRequest,
+};
+use crate::responses::{
+    CreateEntityResponse, ListEntitiesResponse, ProposalAction, RefinementPayload,
+    SearchEntitiesResponse,
+};
+use serde_json::json;
+
+// ===== entities.rs:8-93 =====
+
+fn sample_entity() -> Entity {
+    Entity {
+        id: "entity_1".into(),
+        name: "Alice".into(),
+        entity_type: "person".into(),
+        space: Some("work".into()),
+        source_agent: Some("claude-code".into()),
+        confidence: Some(0.5),
+        confirmed: true,
+        created_at: 1_700_000_000,
+        updated_at: 1_700_000_100,
+    }
+}
+
+fn entity_json() -> serde_json::Value {
+    json!({
+        "id": "entity_1",
+        "name": "Alice",
+        "entity_type": "person",
+        "space": "work",
+        "source_agent": "claude-code",
+        "confidence": 0.5,
+        "confirmed": true,
+        "created_at": 1_700_000_000,
+        "updated_at": 1_700_000_100,
+    })
+}
+
+fn sample_observation() -> Observation {
+    Observation {
+        id: "obs_1".into(),
+        entity_id: "entity_1".into(),
+        content: "likes tea".into(),
+        source_agent: Some("claude-code".into()),
+        confidence: Some(0.5),
+        confirmed: true,
+        created_at: 1_700_000_000,
+    }
+}
+
+fn observation_json() -> serde_json::Value {
+    json!({
+        "id": "obs_1",
+        "entity_id": "entity_1",
+        "content": "likes tea",
+        "source_agent": "claude-code",
+        "confidence": 0.5,
+        "confirmed": true,
+        "created_at": 1_700_000_000,
+    })
+}
+
+fn sample_relation_with_entity() -> RelationWithEntity {
+    RelationWithEntity {
+        id: "rel_1".into(),
+        relation_type: "knows".into(),
+        direction: "outgoing".into(),
+        entity_id: "entity_2".into(),
+        entity_name: "Bob".into(),
+        entity_type: "person".into(),
+        source_agent: Some("claude-code".into()),
+        created_at: 1_700_000_000,
+    }
+}
+
+fn relation_with_entity_json() -> serde_json::Value {
+    json!({
+        "id": "rel_1",
+        "relation_type": "knows",
+        "direction": "outgoing",
+        "entity_id": "entity_2",
+        "entity_name": "Bob",
+        "entity_type": "person",
+        "source_agent": "claude-code",
+        "created_at": 1_700_000_000,
+    })
+}
+
+#[test]
+fn entity_and_wrappers_freeze() {
+    assert_eq!(
+        serde_json::to_value(sample_entity()).unwrap(),
+        entity_json()
+    );
+    let back: Entity = serde_json::from_value(entity_json()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), entity_json());
+
+    let search_result = EntitySearchResult {
+        entity: sample_entity(),
+        distance: 0.5,
+    };
+    let search_result_json = json!({ "entity": entity_json(), "distance": 0.5 });
+    assert_eq!(
+        serde_json::to_value(&search_result).unwrap(),
+        search_result_json
+    );
+    let back: EntitySearchResult = serde_json::from_value(search_result_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), search_result_json);
+
+    let detail = EntityDetail {
+        entity: sample_entity(),
+        observations: vec![sample_observation()],
+        relations: vec![sample_relation_with_entity()],
+    };
+    let detail_json = json!({
+        "entity": entity_json(),
+        "observations": [observation_json()],
+        "relations": [relation_with_entity_json()],
+    });
+    assert_eq!(serde_json::to_value(&detail).unwrap(), detail_json);
+    let back: EntityDetail = serde_json::from_value(detail_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), detail_json);
+}
+
+#[test]
+fn observation_freeze() {
+    assert_eq!(
+        serde_json::to_value(sample_observation()).unwrap(),
+        observation_json()
+    );
+    let back: Observation = serde_json::from_value(observation_json()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), observation_json());
+}
+
+#[test]
+fn relation_family_freeze() {
+    let relation = Relation {
+        id: "rel_1".into(),
+        from_entity: "entity_1".into(),
+        to_entity: "entity_2".into(),
+        relation_type: "knows".into(),
+        source_agent: Some("claude-code".into()),
+        created_at: 1_700_000_000,
+    };
+    let relation_json = json!({
+        "id": "rel_1",
+        "from_entity": "entity_1",
+        "to_entity": "entity_2",
+        "relation_type": "knows",
+        "source_agent": "claude-code",
+        "created_at": 1_700_000_000,
+    });
+    assert_eq!(serde_json::to_value(&relation).unwrap(), relation_json);
+    let back: Relation = serde_json::from_value(relation_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), relation_json);
+
+    assert_eq!(
+        serde_json::to_value(sample_relation_with_entity()).unwrap(),
+        relation_with_entity_json()
+    );
+    let back: RelationWithEntity = serde_json::from_value(relation_with_entity_json()).unwrap();
+    assert_eq!(
+        serde_json::to_value(&back).unwrap(),
+        relation_with_entity_json()
+    );
+
+    let recent = RecentRelation {
+        id: "rel_1".into(),
+        from_entity_id: "entity_1".into(),
+        relation_type: "knows".into(),
+        to_entity_id: "entity_2".into(),
+        from_entity_name: "Alice".into(),
+        to_entity_name: "Bob".into(),
+        created_at_ms: 1_700_000_000_000,
+    };
+    let recent_json = json!({
+        "id": "rel_1",
+        "from_entity_id": "entity_1",
+        "relation_type": "knows",
+        "to_entity_id": "entity_2",
+        "from_entity_name": "Alice",
+        "to_entity_name": "Bob",
+        "created_at_ms": 1_700_000_000_000i64,
+    });
+    assert_eq!(serde_json::to_value(&recent).unwrap(), recent_json);
+    let back: RecentRelation = serde_json::from_value(recent_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), recent_json);
+}
+
+#[test]
+fn entity_suggestion_freeze() {
+    let some = EntitySuggestion {
+        id: "sugg_1".into(),
+        entity_name: Some("Alice".into()),
+        source_ids: vec!["mem_1".into()],
+        confidence: 0.6,
+        created_at: "2026-01-01T00:00:00Z".into(),
+    };
+    let some_json = json!({
+        "id": "sugg_1",
+        "entity_name": "Alice",
+        "source_ids": ["mem_1"],
+        "confidence": 0.6,
+        "created_at": "2026-01-01T00:00:00Z",
+    });
+    assert_eq!(serde_json::to_value(&some).unwrap(), some_json);
+    let back: EntitySuggestion = serde_json::from_value(some_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), some_json);
+
+    // entity_name has no skip_serializing_if: None still serializes as a null
+    // key (freezing today's shape, not the omission pattern used elsewhere).
+    let none = EntitySuggestion {
+        id: "sugg_2".into(),
+        entity_name: None,
+        source_ids: vec![],
+        confidence: 0.0,
+        created_at: "2026-01-01T00:00:00Z".into(),
+    };
+    let none_json = json!({
+        "id": "sugg_2",
+        "entity_name": null,
+        "source_ids": [],
+        "confidence": 0.0,
+        "created_at": "2026-01-01T00:00:00Z",
+    });
+    assert_eq!(serde_json::to_value(&none).unwrap(), none_json);
+}
+
+// ===== responses.rs:284/317/322,697-745 =====
+
+#[test]
+fn entity_crud_responses_freeze() {
+    let with_warnings = CreateEntityResponse {
+        id: "entity_1".into(),
+        warnings: vec!["low confidence".into()],
+    };
+    assert_eq!(
+        serde_json::to_value(&with_warnings).unwrap(),
+        json!({ "id": "entity_1", "warnings": ["low confidence"] })
+    );
+
+    // warnings has skip_serializing_if = Vec::is_empty: an empty Vec omits the key.
+    let no_warnings = CreateEntityResponse {
+        id: "entity_1".into(),
+        warnings: vec![],
+    };
+    assert_eq!(
+        serde_json::to_value(&no_warnings).unwrap(),
+        json!({ "id": "entity_1" })
+    );
+
+    let list = ListEntitiesResponse {
+        entities: vec![sample_entity()],
+    };
+    assert_eq!(
+        serde_json::to_value(&list).unwrap(),
+        json!({ "entities": [entity_json()] })
+    );
+
+    let search = SearchEntitiesResponse {
+        results: vec![EntitySearchResult {
+            entity: sample_entity(),
+            distance: 0.5,
+        }],
+    };
+    assert_eq!(
+        serde_json::to_value(&search).unwrap(),
+        json!({ "results": [{ "entity": entity_json(), "distance": 0.5 }] })
+    );
+}
+
+#[test]
+fn proposal_action_entity_variants_freeze() {
+    assert_eq!(
+        serde_json::to_value(&ProposalAction::EntityMerge).unwrap(),
+        json!("entity_merge")
+    );
+    assert_eq!(
+        serde_json::from_value::<ProposalAction>(json!("entity_merge")).unwrap(),
+        ProposalAction::EntityMerge
+    );
+
+    assert_eq!(
+        serde_json::to_value(&ProposalAction::SuggestEntity).unwrap(),
+        json!("suggest_entity")
+    );
+    assert_eq!(
+        serde_json::from_value::<ProposalAction>(json!("suggest_entity")).unwrap(),
+        ProposalAction::SuggestEntity
+    );
+}
+
+#[test]
+fn refinement_payload_entity_variants_freeze() {
+    let merge = RefinementPayload::EntityMerge {
+        existing_id: "entity_1".into(),
+        new_id: "entity_2".into(),
+        similarity: 0.9,
+    };
+    let merge_json = json!({
+        "action": "entity_merge",
+        "existing_id": "entity_1",
+        "new_id": "entity_2",
+        "similarity": 0.9,
+    });
+    assert_eq!(serde_json::to_value(&merge).unwrap(), merge_json);
+    assert_eq!(
+        serde_json::from_value::<RefinementPayload>(merge_json).unwrap(),
+        merge
+    );
+
+    let suggest_some = RefinementPayload::SuggestEntity {
+        name_hint: Some("Alice".into()),
+    };
+    let suggest_some_json = json!({ "action": "suggest_entity", "name_hint": "Alice" });
+    assert_eq!(
+        serde_json::to_value(&suggest_some).unwrap(),
+        suggest_some_json
+    );
+    assert_eq!(
+        serde_json::from_value::<RefinementPayload>(suggest_some_json).unwrap(),
+        suggest_some
+    );
+
+    // name_hint has skip_serializing_if = Option::is_none: None omits the key.
+    let suggest_none = RefinementPayload::SuggestEntity { name_hint: None };
+    let suggest_none_json = json!({ "action": "suggest_entity" });
+    assert_eq!(
+        serde_json::to_value(&suggest_none).unwrap(),
+        suggest_none_json
+    );
+    assert_eq!(
+        serde_json::from_value::<RefinementPayload>(suggest_none_json).unwrap(),
+        suggest_none
+    );
+}
+
+// ===== requests.rs:29,136,175-177,564,570 =====
+
+#[test]
+fn store_memory_request_entity_id_freeze() {
+    let some = StoreMemoryRequest {
+        content: "note".into(),
+        memory_type: Some("fact".into()),
+        space: Some("work".into()),
+        source_agent: Some("claude-code".into()),
+        title: Some("Title".into()),
+        confidence: Some(0.5),
+        supersedes: None,
+        entity: Some("Alice".into()),
+        entity_id: Some("entity_1".into()),
+        structured_fields: None,
+        retrieval_cue: None,
+    };
+    let some_json = json!({
+        "content": "note",
+        "memory_type": "fact",
+        "space": "work",
+        "source_agent": "claude-code",
+        "title": "Title",
+        "confidence": 0.5,
+        "supersedes": null,
+        "entity": "Alice",
+        "entity_id": "entity_1",
+        "structured_fields": null,
+        "retrieval_cue": null,
+    });
+    assert_eq!(serde_json::to_value(&some).unwrap(), some_json);
+    let back: StoreMemoryRequest = serde_json::from_value(some_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), some_json);
+
+    // entity_id has no skip_serializing_if: None still serializes as a null key.
+    let none = StoreMemoryRequest {
+        content: "note".into(),
+        memory_type: None,
+        space: None,
+        source_agent: None,
+        title: None,
+        confidence: None,
+        supersedes: None,
+        entity: None,
+        entity_id: None,
+        structured_fields: None,
+        retrieval_cue: None,
+    };
+    let none_json = json!({
+        "content": "note",
+        "memory_type": null,
+        "space": null,
+        "source_agent": null,
+        "title": null,
+        "confidence": null,
+        "supersedes": null,
+        "entity": null,
+        "entity_id": null,
+        "structured_fields": null,
+        "retrieval_cue": null,
+    });
+    assert_eq!(serde_json::to_value(&none).unwrap(), none_json);
+}
+
+#[test]
+fn create_and_link_entity_request_freeze() {
+    let create = CreateEntityRequest {
+        name: "Alice".into(),
+        entity_type: "person".into(),
+        space: Some("work".into()),
+        source_agent: Some("claude-code".into()),
+        confidence: Some(0.5),
+    };
+    let create_json = json!({
+        "name": "Alice",
+        "entity_type": "person",
+        "space": "work",
+        "source_agent": "claude-code",
+        "confidence": 0.5,
+    });
+    assert_eq!(serde_json::to_value(&create).unwrap(), create_json);
+    let back: CreateEntityRequest = serde_json::from_value(create_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), create_json);
+
+    let link = LinkEntityRequest {
+        source_id: "mem_1".into(),
+        entity_id: "entity_1".into(),
+    };
+    let link_json = json!({ "source_id": "mem_1", "entity_id": "entity_1" });
+    assert_eq!(serde_json::to_value(&link).unwrap(), link_json);
+    let back: LinkEntityRequest = serde_json::from_value(link_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), link_json);
+}
+
+#[test]
+fn confirm_and_observation_request_freeze() {
+    let confirm = ConfirmEntityRequest { confirmed: true };
+    let confirm_json = json!({ "confirmed": true });
+    assert_eq!(serde_json::to_value(&confirm).unwrap(), confirm_json);
+    let back: ConfirmEntityRequest = serde_json::from_value(confirm_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), confirm_json);
+
+    let obs = AddEntityObservationRequest {
+        content: "likes tea".into(),
+        source_agent: Some("claude-code".into()),
+        confidence: Some(0.5),
+    };
+    let obs_json = json!({
+        "content": "likes tea",
+        "source_agent": "claude-code",
+        "confidence": 0.5,
+    });
+    assert_eq!(serde_json::to_value(&obs).unwrap(), obs_json);
+    let back: AddEntityObservationRequest = serde_json::from_value(obs_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), obs_json);
+}
+
+// ===== pages.rs:15 =====
+
+fn sample_page(entity_id: Option<String>) -> Page {
+    Page {
+        id: "page_1".into(),
+        title: "Title".into(),
+        summary: Some("Summary".into()),
+        content: "Body".into(),
+        entity_id,
+        space: Some("work".into()),
+        source_memory_ids: vec!["mem_1".into()],
+        version: 1,
+        status: "active".into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        last_compiled: "2026-01-01T00:00:00Z".into(),
+        last_modified: "2026-01-01T00:00:00Z".into(),
+        sources_updated_count: 0,
+        stale_reason: None,
+        pending_rebuild: None,
+        user_edited: false,
+        relevance_score: 0.0,
+        last_edited_by: None,
+        last_edited_at: None,
+        last_delta_summary: None,
+        changelog: None,
+        workspace: None,
+        creation_kind: "distilled".into(),
+        review_status: "confirmed".into(),
+        citations: vec![],
+        kind: "concept".into(),
+    }
+}
+
+/// `Page.entity_id` (spec M3, FREEZE set). `kind`'s permanent wire absence is
+/// already tested at `pages.rs`'s `kind_is_never_serialized_onto_the_wire` --
+/// not duplicated here.
+#[test]
+fn page_entity_id_freeze() {
+    let some_json = json!({
+        "id": "page_1",
+        "title": "Title",
+        "summary": "Summary",
+        "content": "Body",
+        "entity_id": "entity_1",
+        "space": "work",
+        "source_memory_ids": ["mem_1"],
+        "version": 1,
+        "status": "active",
+        "created_at": "2026-01-01T00:00:00Z",
+        "last_compiled": "2026-01-01T00:00:00Z",
+        "last_modified": "2026-01-01T00:00:00Z",
+        "sources_updated_count": 0,
+        "stale_reason": null,
+        "user_edited": false,
+        "workspace": null,
+        "creation_kind": "distilled",
+        "review_status": "confirmed",
+    });
+    assert_eq!(
+        serde_json::to_value(sample_page(Some("entity_1".into()))).unwrap(),
+        some_json
+    );
+    let back: Page = serde_json::from_value(some_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), some_json);
+
+    // entity_id has no skip_serializing_if: None still serializes as a null key.
+    let mut none_json = some_json;
+    none_json["entity_id"] = serde_json::Value::Null;
+    assert_eq!(serde_json::to_value(sample_page(None)).unwrap(), none_json);
+}
+
+// ===== memory.rs:41-43,102,356 =====
+
+#[allow(clippy::too_many_arguments)]
+fn sample_search_result(entity_id: Option<String>, entity_name: Option<String>) -> SearchResult {
+    SearchResult {
+        id: "sr_1".into(),
+        content: "content".into(),
+        source: "memory".into(),
+        source_id: "mem_1".into(),
+        title: "Title".into(),
+        url: None,
+        chunk_index: 0,
+        last_modified: 1_700_000_000,
+        score: 0.5,
+        chunk_type: None,
+        language: None,
+        semantic_unit: None,
+        memory_type: None,
+        space: None,
+        source_agent: None,
+        confidence: None,
+        confirmed: None,
+        stability: None,
+        supersedes: None,
+        summary: None,
+        entity_id,
+        entity_name,
+        quality: None,
+        importance: None,
+        event_date: None,
+        is_archived: false,
+        is_recap: false,
+        structured_fields: None,
+        retrieval_cue: None,
+        source_text: None,
+        content_hash: None,
+        raw_score: 0.0,
+        version: 0,
+        pending_revision: false,
+        merged_from: None,
+        last_delta_summary: None,
+    }
+}
+
+/// `SearchResult.entity_id`/`.entity_name` (spec M3, FREEZE set). The existing
+/// `search_result_serializes` test (lib.rs) only checks omission by substring
+/// for the None case; this freezes the exact shape for both Some and None.
+#[test]
+fn search_result_entity_fields_freeze() {
+    let some_json = json!({
+        "id": "sr_1",
+        "content": "content",
+        "source": "memory",
+        "source_id": "mem_1",
+        "title": "Title",
+        "url": null,
+        "chunk_index": 0,
+        "last_modified": 1_700_000_000,
+        "score": 0.5,
+        "entity_id": "entity_1",
+        "entity_name": "Alice",
+        "is_archived": false,
+        "is_recap": false,
+        "raw_score": 0.0,
+        "version": 0,
+        "pending_revision": false,
+    });
+    assert_eq!(
+        serde_json::to_value(sample_search_result(
+            Some("entity_1".into()),
+            Some("Alice".into())
+        ))
+        .unwrap(),
+        some_json
+    );
+    let back: SearchResult = serde_json::from_value(some_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), some_json);
+
+    // entity_id/entity_name both have skip_serializing_if = Option::is_none.
+    let mut none_json = some_json;
+    let none_obj = none_json.as_object_mut().unwrap();
+    none_obj.remove("entity_id");
+    none_obj.remove("entity_name");
+    assert_eq!(
+        serde_json::to_value(sample_search_result(None, None)).unwrap(),
+        none_json
+    );
+}
+
+fn sample_memory_item(entity_id: Option<String>) -> MemoryItem {
+    MemoryItem {
+        source_id: "mem_1".into(),
+        title: "Title".into(),
+        content: "Body".into(),
+        summary: None,
+        memory_type: Some("fact".into()),
+        space: Some("work".into()),
+        source_agent: Some("claude-code".into()),
+        confidence: Some(0.5),
+        confirmed: true,
+        stability: None,
+        pinned: false,
+        supersedes: None,
+        last_modified: 1_700_000_000,
+        chunk_count: 1,
+        entity_id,
+        quality: None,
+        is_recap: false,
+        enrichment_status: "complete".into(),
+        supersede_mode: "hide".into(),
+        structured_fields: None,
+        retrieval_cue: None,
+        access_count: 0,
+        source_text: None,
+        version: 1,
+        changelog: None,
+        pending_revision: false,
+        merged_from: None,
+    }
+}
+
+/// `MemoryItem.entity_id` and `Space.entity_count` (spec M3, FREEZE set).
+#[test]
+fn memory_item_entity_id_and_space_entity_count_freeze() {
+    let some_json = json!({
+        "source_id": "mem_1",
+        "title": "Title",
+        "content": "Body",
+        "summary": null,
+        "memory_type": "fact",
+        "space": "work",
+        "source_agent": "claude-code",
+        "confidence": 0.5,
+        "confirmed": true,
+        "pinned": false,
+        "supersedes": null,
+        "last_modified": 1_700_000_000,
+        "chunk_count": 1,
+        "entity_id": "entity_1",
+        "is_recap": false,
+        "enrichment_status": "complete",
+        "supersede_mode": "hide",
+        "access_count": 0,
+        "version": 1,
+        "pending_revision": false,
+    });
+    assert_eq!(
+        serde_json::to_value(sample_memory_item(Some("entity_1".into()))).unwrap(),
+        some_json
+    );
+    let back: MemoryItem = serde_json::from_value(some_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), some_json);
+
+    // entity_id has skip_serializing_if = Option::is_none: None omits the key.
+    let mut none_json = some_json;
+    none_json.as_object_mut().unwrap().remove("entity_id");
+    assert_eq!(
+        serde_json::to_value(sample_memory_item(None)).unwrap(),
+        none_json
+    );
+
+    let space = Space {
+        id: "space_1".into(),
+        name: "Work".into(),
+        description: Some("Work space".into()),
+        suggested: false,
+        starred: true,
+        sort_order: 0,
+        memory_count: 10,
+        entity_count: 3,
+        created_at: 1_700_000_000.0,
+        updated_at: 1_700_000_100.0,
+    };
+    let space_json = json!({
+        "id": "space_1",
+        "name": "Work",
+        "description": "Work space",
+        "suggested": false,
+        "starred": true,
+        "sort_order": 0,
+        "memory_count": 10,
+        "entity_count": 3,
+        "created_at": 1_700_000_000.0,
+        "updated_at": 1_700_000_100.0,
+    });
+    assert_eq!(serde_json::to_value(&space).unwrap(), space_json);
+    let back: Space = serde_json::from_value(space_json.clone()).unwrap();
+    assert_eq!(serde_json::to_value(&back).unwrap(), space_json);
+}
+
+// ===== repair.rs:1684-1731,2338,2353,3871-3894,294-327 =====
+//
+// RepairTarget/RepairMutation/RepairChoice/RepairRollbackPayloadV2 derive
+// Serialize only; Deserialize is a hand-written impl that routes through a
+// private `*Wire` enum + the same smart constructors used here, validating
+// as it goes (see e.g. `impl<'de> Deserialize<'de> for RepairTarget`). The
+// wire shape under test is identical either way -- these are the same public
+// types the daemon/MCP layer actually serializes and deserializes.
+
+#[test]
+fn repair_target_entity_variants_freeze() {
+    let link =
+        RepairTarget::memory_entity_link("mem_1".into(), "entity_1".into(), RepairScope::global())
+            .unwrap();
+    let link_json = json!({
+        "kind": "memory_entity_link",
+        "memory_id": "mem_1",
+        "entity_id": "entity_1",
+        "scope": { "kind": "global" },
+    });
+    assert_eq!(serde_json::to_value(&link).unwrap(), link_json);
+    assert_eq!(
+        serde_json::from_value::<RepairTarget>(link_json).unwrap(),
+        link
+    );
+
+    let extraction = RepairTarget::memory_entity_extraction(
+        "mem_1".into(),
+        RepairEnrichmentStep::EntityExtract,
+        vec!["entity_1".into(), "entity_2".into()],
+        RepairScope::global(),
+    )
+    .unwrap();
+    let extraction_json = json!({
+        "kind": "memory_entity_extraction",
+        "memory_id": "mem_1",
+        "step": "entity_extract",
+        "entity_ids": ["entity_1", "entity_2"],
+        "scope": { "kind": "global" },
+    });
+    assert_eq!(serde_json::to_value(&extraction).unwrap(), extraction_json);
+    assert_eq!(
+        serde_json::from_value::<RepairTarget>(extraction_json).unwrap(),
+        extraction
+    );
+}
+
+#[test]
+fn repair_mutation_entity_variants_freeze() {
+    let complete =
+        RepairMutation::complete_entity_extraction(vec!["entity_1".into(), "entity_2".into()])
+            .unwrap();
+    let complete_json = json!({
+        "kind": "complete_entity_extraction",
+        "entity_ids": ["entity_1", "entity_2"],
+    });
+    assert_eq!(serde_json::to_value(&complete).unwrap(), complete_json);
+    assert_eq!(
+        serde_json::from_value::<RepairMutation>(complete_json).unwrap(),
+        complete
+    );
+
+    let delete = RepairMutation::delete_memory_entity_link("mem_1", "entity_1").unwrap();
+    let delete_json = json!({
+        "kind": "delete_memory_entity_link",
+        "memory_id": "mem_1",
+        "entity_id": "entity_1",
+    });
+    assert_eq!(serde_json::to_value(&delete).unwrap(), delete_json);
+    assert_eq!(
+        serde_json::from_value::<RepairMutation>(delete_json).unwrap(),
+        delete
+    );
+}
+
+#[test]
+fn repair_choice_complete_entity_extraction_freeze() {
+    let choice = RepairChoice::complete_entity_extraction(
+        "review_1".into(),
+        "mem_1".into(),
+        vec!["entity_1".into(), "entity_2".into()],
+    )
+    .unwrap();
+    let choice_json = json!({
+        "kind": "complete_entity_extraction",
+        "review_id": "review_1",
+        "memory_id": "mem_1",
+        "entity_ids": ["entity_1", "entity_2"],
+    });
+    assert_eq!(serde_json::to_value(&choice).unwrap(), choice_json);
+    assert_eq!(
+        serde_json::from_value::<RepairChoice>(choice_json).unwrap(),
+        choice
+    );
+}
+
+#[test]
+fn repair_rollback_v2_complete_entity_extraction_freeze() {
+    let with_error = RepairRollbackPayloadV2::complete_entity_extraction(
+        "mem_1".into(),
+        vec!["id".into(), "status".into()],
+        vec!["mem_1".into(), "raw".into()],
+        vec!["entity_1".into(), "entity_2".into()],
+        "raw".into(),
+        Some("boom".into()),
+        1,
+        1_700_000_000,
+    )
+    .unwrap();
+    let with_error_json = json!({
+        "kind": "complete_entity_extraction",
+        "memory_id": "mem_1",
+        "memory_columns": ["id", "status"],
+        "before_memory_row": ["mem_1", "raw"],
+        "before_entity_ids": ["entity_1", "entity_2"],
+        "enrichment_status": "raw",
+        "enrichment_error": "boom",
+        "enrichment_attempts": 1,
+        "enrichment_updated_at": 1_700_000_000i64,
+    });
+    assert_eq!(serde_json::to_value(&with_error).unwrap(), with_error_json);
+    assert_eq!(
+        serde_json::from_value::<RepairRollbackPayloadV2>(with_error_json).unwrap(),
+        with_error
+    );
+
+    // enrichment_error has skip_serializing_if = Option::is_none: None omits the key.
+    let no_error = RepairRollbackPayloadV2::complete_entity_extraction(
+        "mem_1".into(),
+        vec!["id".into(), "status".into()],
+        vec!["mem_1".into(), "raw".into()],
+        vec!["entity_1".into(), "entity_2".into()],
+        "raw".into(),
+        None,
+        1,
+        1_700_000_000,
+    )
+    .unwrap();
+    let no_error_json = json!({
+        "kind": "complete_entity_extraction",
+        "memory_id": "mem_1",
+        "memory_columns": ["id", "status"],
+        "before_memory_row": ["mem_1", "raw"],
+        "before_entity_ids": ["entity_1", "entity_2"],
+        "enrichment_status": "raw",
+        "enrichment_attempts": 1,
+        "enrichment_updated_at": 1_700_000_000i64,
+    });
+    assert_eq!(serde_json::to_value(&no_error).unwrap(), no_error_json);
+    assert_eq!(
+        serde_json::from_value::<RepairRollbackPayloadV2>(no_error_json).unwrap(),
+        no_error
+    );
+}

--- a/crates/wenlan-types/src/lib.rs
+++ b/crates/wenlan-types/src/lib.rs
@@ -109,6 +109,10 @@ mod repair_tests;
 mod repair_plan_tests;
 
 #[cfg(test)]
+#[path = "entities_freeze_tests.rs"]
+mod entities_freeze_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/crates/wenlan-types/src/pages.rs
+++ b/crates/wenlan-types/src/pages.rs
@@ -71,9 +71,11 @@ pub struct Page {
     /// Unified page-kind discriminator (migration 89). One of:
     /// "entity" | "concept" | "source" | "overview" | "authored".
     /// `kind = "entity"` marks the M3 dual-write shadow pages that mirror
-    /// `entities` rows -- write-only in PR-1 (spec's fail-closed visibility
-    /// fence excludes them at `select_visible_pages` and every page-search/
-    /// list surface that bypasses it), never surfaced to a reader yet.
+    /// `entities` rows. Q1 contract: they are browse/search-visible through the
+    /// explicit `_browse` read surfaces (page list, search, recent,
+    /// recent-changes, get-by-id and its sub-resources), but stay excluded from
+    /// retrieval/context, export, and every page mutation (archive/delete/update
+    /// fence on a `kind='entity'` id); the entity API is the only writer.
     ///
     /// `skip_serializing` freezes the wire shape (spec M3 D4): `kind` is an
     /// internal discriminator the daemon uses for the visibility fence, but it

--- a/crates/wenlan-types/src/requests.rs
+++ b/crates/wenlan-types/src/requests.rs
@@ -254,8 +254,10 @@ pub struct CreateConceptRequest {
     pub source_memory_ids: Vec<String>,
     #[serde(default)]
     pub creation_kind: Option<String>,
-    /// Dedicated workspace axis (P3). When Some, persisted to `pages.workspace`.
-    /// Distinct from `space` (category column used for page_type filtering).
+    /// Dedicated workspace axis (P3), the authoritative axis for page
+    /// filtering. When Some, persisted to `pages.workspace`. Distinct from
+    /// `space`, the legacy scope input defaulted from the `X-Origin-Space`
+    /// header when the body omits it (see `handle_create_page`).
     #[serde(default)]
     pub workspace: Option<String>,
 }

--- a/docs/plans/2026-07-22-m3-pr1-caller-inventory.md
+++ b/docs/plans/2026-07-22-m3-pr1-caller-inventory.md
@@ -268,3 +268,18 @@ polling the HTTP routes above — no event/push channel to freeze or migrate.
 - **0** wire surfaces left unclassified (the repair/lint-repair wire types were the one candidate requiring investigation; resolved under D4's blanket rule, not an exception).
 - **1** confirmed dead low-level primitive (`MemoryDB::create_entity`, test-only) excluded from the canonical entity-upsert collapse.
 - **5** items noted for the record, none blocking, none requiring escalation.
+
+## Addendum -- 2026-07-24 (Stage D)
+
+FREEZE-set teeth now live in `crates/wenlan-types/src/entities_freeze_tests.rs`
+(serde-literal exact-shape asserts) plus typed MCP deserialization in
+`crates/wenlan-mcp/src/tools.rs` (fails loud on envelope-key drift; see root
+`AGENTS.md` "MCP wrappers in `wenlan-mcp` always typed-deserialize").
+
+Q1 (page-stub visibility, spec section 9) ruled by the user 2026-07-24: bare
+`kind='entity'` stub pages appear on the Lane-B browse/search set
+(`docs/superpowers/gate-logs/m3-wire-freeze/investigation.md`, "Q1"); Lane A
+(retrieval/context via `select_visible_pages`) and other internal consumers
+(wikilinks, title hints) stay fenced. The per-fn enumeration suite in
+`crates/wenlan-core/src/db.rs:76529-77256` (`*_excludes_entity_kind_shadow` /
+`*_includes_entity_kind_shadow`) is the per-fn contract for which fences stay.


### PR DESCRIPTION
# fix: M3 wire freeze — adapter seam, freeze teeth, Q1 stub-page fence lifts

M3 stage F of the KG unified-model migration: freeze the entity wire surface behind adapters so later internal cutovers can't leak shape changes, and apply the user-ruled Q1 decision (stub pages appear in page browse/search).

## What this does

1. **Adapter seam** (`crates/wenlan-core/src/db/entity_page_adapter.rs`): `page_id_for_entity` / `entity_id_for_page` over `entity_page_map` — the one named translation point for later cutover rungs. Scattered inline map lookups refactored onto it; 2 DELETE-with-subquery sites converted to fetch-then-delete under the same held mutex guard (single-conn, review-verified safe).
2. **Wire-shape freeze teeth** (`crates/wenlan-types/src/entities_freeze_tests.rs`): 18 serde-literal tests — `serde_json::to_value(sample) == json!({...})` full literal equality, Some+None arms — over the ~27 FREEZE structs/fields from the caller inventory (`docs/plans/2026-07-22-m3-pr1-caller-inventory.md` §FREEZE). Plus 2 wenlan-mcp `_impl`s (`get_page`, `delete_page`) moved from `serde_json::Value` to typed deserialization, closing the last untyped envelope gaps.
3. **Q1 fence lifts (user-ruled)**: bare `kind='entity'` stub pages now APPEAR in Lane B page browse/search — `list_pages(_scoped)`, `search_pages(_scoped)` browse arm, `list_recent_pages_with_badges(_scoped)`, `list_recent_changes(_scoped)`, `get_page(_scoped)`; stub sub-resources (sources/links/changelog) return 200 + empty instead of 404. Everything else stays fenced: Lane A retrieval/context (`select_visible_pages`), deep-retrieval page channel, wikilink resolution, LLM title hints, citation backfill, exports (explicit filter, both handlers), knowledge projection, and the internal windows that would otherwise be crowded by stub `last_modified` stamps. Double-duty fns split via private `_inner(fence_entity: bool)`; fenced arms char-for-char identical to pre-lift.
4. **Fenced-by-default + mutation fences** (stage E, from cross-model review): page reads are fenced by default with explicit `_browse` twins for the Q1 surfaces (`get_page_scoped_browse`, `list_pages_scoped_browse`), so no non-browse consumer can silently inherit stub visibility. `archive_page`/`delete_page` reject entity-shadow pages in core (422; deleting one would cascade away its `entity_page_map` row and break the bijection). Export is SQL-fenced before `LIMIT`. Both MCP envelopes carry `deny_unknown_fields`.
5. **Doc-only**: `CreateConceptRequest` scope/workspace doc comment aligned to the M1 model (`requests.rs:257-260`); dated FREEZE-teeth addendum in the caller inventory.

## Acceptance (wire-freeze box)

- [x] Adapter round-trips entity_id ↔ page_id with no app-visible shape change — `scoped_entities_cutover_flip_is_wire_invariant` (db.rs): cutover ON vs OFF byte-identical serialized JSON; bijection property test + 10k scale-bench assert.
- [x] Wire shapes frozen by literal-equality teeth (18 tests, wenlan-types) + typed MCP deserialization everywhere.
- [x] Q1: stub appears in browse/search surfaces, absent from retrieval/context — per-fn enumeration suite (~29 fns, one explicit expectation each, none deleted) at db.rs:76461+.
- [x] `Page.kind` never serialized onto the wire (pre-existing test, unchanged).
- [x] Stub pages immune to page-surface mutation: archive/delete/update/page-map reject or 404 on shadow ids (core fence + 3 server tests + live 422 proof), preserving the bijection Q1 discoverability would otherwise expose.

## Evidence

- Gates: `cargo fmt` clean, workspace clippy `-D warnings` clean, core `--lib` 3000/0 (29 ignored), server 507/0, types 188/0, mcp full green, drift teeth green.
- Reviews (honest trail): per-stage adversarial reviews (A, B, C×2, D, E). Stage C review caught 1 **Critical** — an outright `list_pages` lift leaked stubs into 4 internal non-browse consumers, incl. the knowledge projection that writes markdown into the user's knowledge dir on startup — fixed with 4 regression teeth. Final whole-branch review PASS×4. Then the **Sol cross-model blind review (diff-only) returned BLOCK** with 1 Critical (unfenced archive/delete on newly-discoverable stub ids) + 3 Important that the whole-branch review had missed — all fixed in stage E by inverting to fenced-by-default; stage-E task review Spec MET / Quality Approved (0C/0I), and Sol's closure re-check confirms **all 5 findings CLOSED, BLOCK lifts**.
- Live verify (isolated daemon, port 7879, fresh data dirs, schema 94; runs at `+g6381c11c` and `+g43cf4f5f`): stub present in `GET /api/pages` + `POST /api/pages/search` with no `kind` key; absent from `/api/context`; `GET /api/pages/{id}` 200; sources `[]`; links `{outbound:[],inbound:[]}`; `GET /api/pages/{id}/revisions` 200 `entries:[]`; export `{exported:0}`; `DELETE /api/pages/{stub}` and archive → 422 "entity shadow pages are managed through the entity API" with entity + stub intact after.

## Known issue (pre-existing, not this branch)

Intermittent fresh-boot durability anomaly: in 2 fresh-boot live-verify runs (one on this branch, one on the PR-2 branch before these commits existed), all post-boot writes were lost on daemon kill despite being API-visible. Write paths are untouched by this branch. A 35-min instrumented soak on an identical fresh boot stayed fully durable (entity + stub survived kill), so the trigger is intermittent. Full characterization — including a static inventory of 14 unprotected `BEGIN` sites and a separate acknowledged-store-vanishing observation — filed as #389.

## Deferred (ledger)

3 final-review Minors (RecentActivityItem/PageChange freeze coverage; Lane-A negative-boundary route test; stub `entity_id` null note); long-term wenlan-types home for the 2 function-local MCP response structs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Qz21Snuut74UVAoEAgTky
