### PR TITLE
ci: record required gate timing target

### DIFF
--- a/scripts/ci-observer.py
+++ b/scripts/ci-observer.py
@@ -12,6 +12,7 @@ from pathlib import Path
 MAX_INPUT_BYTES = 16 * 1024 * 1024
 MAX_GITHUB_CLOCK_SKEW_MS = 5_000
 CACHE_ALERT_RATIO_PPM = 1_150_000
+REQUIRED_GATE_TARGET_MS = 20 * 60 * 1000
 FULL_SHA = re.compile(r"[0-9a-f]{40}")
 
 
@@ -164,6 +165,9 @@ def build_receipt(event_payload, pages, usage, limit):
     over_by = max(0, usage_bytes - budget_bytes)
     ratio_ppm = usage_bytes * 1_000_000 // budget_bytes
     alert = usage_bytes * 1_000_000 > budget_bytes * CACHE_ALERT_RATIO_PPM
+    required_gate_elapsed_ms = duration_ms(
+        run.get("run_started_at"), gates[0]["completed_at"]
+    )
 
     return {
         "schema_version": 1,
@@ -177,9 +181,10 @@ def build_receipt(event_payload, pages, usage, limit):
             "run_started_at": run.get("run_started_at"),
             "updated_at": run.get("updated_at"),
         },
-        "required_gate_elapsed_ms": duration_ms(
-            run.get("run_started_at"), gates[0]["completed_at"]
-        ),
+        "required_gate_elapsed_ms": required_gate_elapsed_ms,
+        "required_gate_target_ms": REQUIRED_GATE_TARGET_MS,
+        "required_gate_target_met": required_gate_elapsed_ms is not None
+        and required_gate_elapsed_ms < REQUIRED_GATE_TARGET_MS,
         "jobs": jobs,
         "cache": {
             "usage_bytes": usage_bytes,

--- a/scripts/ci-observer.test.py
+++ b/scripts/ci-observer.test.py
@@ -121,6 +121,30 @@ class CiObserverTests(unittest.TestCase):
         self.assertEqual(receipt["required_gate_elapsed_ms"], 1_230_000)
         self.assertEqual(receipt["cache"]["status"], "under_budget")
 
+    def test_required_gate_target_is_strictly_under_twenty_minutes(self):
+        conclusion = job(102, "conclusion")
+        conclusion["completed_at"] = "2026-07-24T01:19:59Z"
+        result, receipt = self.run_observer(
+            event(),
+            [{"total_count": 1, "jobs": [conclusion]}],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+            {"max_cache_size_gb": 10},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(receipt["required_gate_target_ms"], 1_200_000)
+        self.assertTrue(receipt["required_gate_target_met"])
+
+        conclusion["completed_at"] = "2026-07-24T01:20:00Z"
+        result, receipt = self.run_observer(
+            event(),
+            [{"total_count": 1, "jobs": [conclusion]}],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+            {"max_cache_size_gb": 10},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(receipt["required_gate_target_ms"], 1_200_000)
+        self.assertFalse(receipt["required_gate_target_met"])
+
     def test_normal_eviction_pressure_is_recorded_without_failing(self):
         result, receipt = self.run_observer(
             event(),


### PR DESCRIPTION
## Summary

- record the 20-minute required `conclusion` target in each CI observer receipt
- report whether the observed gate is strictly below the target
- cover both 19:59 (pass) and exactly 20:00 (not met)

## Why this is the ordinary-PR timing proof

Only `scripts/ci-observer.py` and its test change. The Rust path filter includes `scripts/**`, while this diff does not match platform or release-preflight filters. The affected-test planner therefore kept the full Linux required plan, making this a representative ordinary PR rather than another workflow-changing or release-sensitive run.

## Verification

- `python3 scripts/ci-observer.test.py` — 8 passed
- `git diff --check`
- independent review: APPROVE
- hosted run: https://github.com/7xuanlu/wenlan/actions/runs/30211699450
- required `conclusion`: success at 17:14:28Z, 13m08s after run start (6m52s below target)
- critical jobs: shard 1/2 12m38s; shard 2/2 12m19s; canonical 11m49s; quarantine 5m08s
- platform compile and release-preflight: skipped as intended