### PR TITLE
test: per-surface smoke loops (CLI, MCP) + behavior-trace checker

### DIFF
--- a/.claude/skills/prove/SKILL.md
+++ b/.claude/skills/prove/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: prove
+description: Per-surface verification loops for wenlan — daemon, cli, mcp, plugin, suite strength (mutation), behavior trace, weekly sweep. Routes to scripts; every check records evidence via attest. Deeper than the built-in verify skill — use prove for mutation audits, behavior tracing, and the weekly sweep; built-in /verify handles generic runtime observation.
+---
+
+# /prove [surface] — wenlan verification loops
+
+Run every check through the evidence wrapper (records to `.claude/attest.jsonl`,
+which the weekly sweep audits): `~/.claude/bin/attest.sh <command>`.
+Sandboxed local runs need `TMPDIR=/tmp/claude` prefixed (macOS mktemp gotcha).
+
+| Surface | Command | Proves |
+|---|---|---|
+| `daemon` | read `references/daemon.md` | HTTP behavior on an isolated daemon |
+| `cli` | `attest.sh bash scripts/smoke-cli.sh` | shipped CLI black-box round-trip |
+| `mcp` | `attest.sh bash scripts/smoke-mcp.sh` | stdio JSON-RPC round-trip |
+| `plugin` | `/wenlan:setup` verify path | plugin → MCP → daemon wiring |
+| `suite` | breadth: `cargo mutants -f <file>` (auto-generated mutants, lib-test oracle); depth: read `references/mutprove.md` | tests can actually go red (mutation audit) |
+| `behaviors` | `attest.sh python3 scripts/check-behavior-trace.py <plan.md> <tests...>` | tests trace to intent, both directions |
+| `sweep` | read `references/sweep.md` | weekly verify-the-verifier |
+
+No argument → pick the surfaces the current diff touches (server/core → daemon;
+cli crate → cli; mcp crate → mcp; new/changed tests → behaviors + suite).
+App/UI surface (wenlan-app repo, or anything rendered): rendered evidence
+required — drive the running app and look at the screen; unit/build green is
+not proof of visible correctness.
+
+Live-smoke legs that need the real GPU model (L7) stay manual:
+`scripts/live-smoke-*.sh` — run before merging features whose e2e stubs the LLM.

--- a/.claude/skills/prove/references/behaviors.md
+++ b/.claude/skills/prove/references/behaviors.md
@@ -1,0 +1,35 @@
+# Behavior trace — "is this the right test?"
+
+The intent anchor is the plan/spec itself (no separate contract artifact):
+the plan carries a `## Behaviors` section written BEFORE implementation and
+glanced/vetoed by the human at dispatch.
+
+```markdown
+## Behaviors
+- B1: given a stored memory, `wenlan memories` lists it
+- B2: given a dirty file, mutprove refuses to mutate it
+```
+
+Rules:
+- ≤10 behaviors, each one observable outcome (given/when/then in one line).
+- Tests cite what they protect: `// covers: B2` (any comment syntax;
+  `covers: B1, B2` for multi-id).
+- The checker enforces the mapping both ways — every behavior covered, every
+  tag defined: `python3 scripts/check-behavior-trace.py <plan.md> <tests...>`
+  Uncovered behavior = untested intent. Dangling tag = test mirroring nothing.
+
+## Blind audit (catches tautological tests the checker can't)
+
+A test can cite B3 and still just assert whatever the implementation does.
+Periodically (per risky feature, and in the weekly sweep) spawn a subagent
+that gets ONLY the `## Behaviors` section and the test file — never the
+implementation — and answers per test:
+
+1. Restated in plain English, what does this test require?
+2. Does that match the cited behavior, or does it smell like a mirror of
+   implementation internals (asserting exact strings/structures no behavior
+   line mentions)?
+3. Which behavior would a malicious-but-green implementation break?
+
+Findings are advisory (taste, not teeth) — route real mismatches into fixes,
+and recurring ones into the plan template.

--- a/.claude/skills/prove/references/daemon.md
+++ b/.claude/skills/prove/references/daemon.md
@@ -1,0 +1,34 @@
+# Verifying wenlan-server changes at the HTTP surface
+
+Build, then boot an isolated daemon (never port 7878 — a launchd daemon or a
+stale app may own it):
+
+```bash
+cargo build -p wenlan-server
+WENLAN_PORT=7879 WENLAN_DATA_DIR=/tmp/<unique> RUST_LOG=warn,wenlan_server=info \
+  ./target/debug/wenlan-server   # run in background; poll /api/health until 200
+```
+
+- Health: `curl http://127.0.0.1:7879/api/health` → `{"status":"ok","db_initialized":true,"version":"0.x.y+g<sha>"}`.
+  The `+g<sha>` suffix confirms which build is running.
+- Fresh `WENLAN_DATA_DIR` exercises the full migration chain on boot; check
+  with `sqlite3 <dir>/memorydb/origin_memory.db "PRAGMA user_version"`.
+- Boot needs no GPU/LLM: FastEmbed loads from cache, LLM degrades gracefully.
+
+## Seeding fixtures
+
+Seed through the API, not sqlite3 — the `pages` table has a libsql-only
+vector index (`libsql_vector_idx`), so system sqlite3 cannot INSERT into it
+(reads are fine).
+
+- Memories: `POST /api/memory/store {"content": "..."}` → `source_id`.
+- Pages: `POST /api/pages {"title", "content", "source_memory_ids": [...], "creation_kind": "authored"}`
+  — `source_memory_ids` are validated against real memories, so store those first.
+
+## Gotchas
+
+- A sandboxed `kill` does not reach the daemon; kill unsandboxed and confirm
+  with `lsof -ti :<port>` (probe the port, not the PID).
+- Curl payloads needing control characters (e.g. the page-map U+001F
+  fingerprint separator) must be written to a file via python and sent with
+  `-d @file` — literal control chars in a Bash command are rejected.

--- a/.claude/skills/prove/references/mutprove.md
+++ b/.claude/skills/prove/references/mutprove.md
@@ -1,0 +1,38 @@
+# Mutation audit — prove the suite can go red
+
+Two tools, split by question:
+
+- **Breadth — "where is my suite blind?"**: `cargo mutants -f <file>` (install:
+  `cargo install cargo-mutants`). Auto-enumerates mutants, no hand-writing,
+  oracle is cargo test/nextest. Use for the weekly sweep's mutation sample.
+- **Depth — "does THIS gate reject THIS breakage?"**: `~/.claude/bin/mutprove.py`
+  below. Hand-picked mutations against an ARBITRARY oracle (smoke script, e2e
+  binary) — the class cargo-mutants can't drive. Generalizes the pattern of
+  `scripts/m3g-gate1-mutation-proof.sh` (same mechanics: unique-anchor assert,
+  expect-red, restore); future gate proofs write a mutations.json instead of a
+  bespoke script.
+
+Scripted, never conversational (the model round-trip is the cost; measured
+19s machine vs ~90s model per cycle).
+
+```bash
+# mutations.json: [{"id","desc","file","old","new"}, ...]
+TMPDIR=/tmp/claude ~/.claude/bin/attest.sh \
+  python3 ~/.claude/bin/mutprove.py mutations.json -- \
+  cargo test -p wenlan-core --lib <module>::tests
+```
+
+Writing mutations:
+- Mutate BEHAVIOR the tests should protect: flip a comparison, drop a filter
+  arm, wrong endpoint path, off-by-one a limit. Not syntax the compiler catches.
+- `old` must appear exactly once in the file — the runner errors otherwise
+  (a no-op edit must never report as a survivor; substring anchors have
+  matched wrong indentation before).
+- Files must be committed-clean; the runner restores via `git checkout --`.
+- Don't pre-declare which test should kill a mutation — the report records
+  which tests actually died, which reveals coverage gaps for free.
+- The test command can be a smoke script too: mutating `crates/wenlan-cli`
+  with `-- bash scripts/smoke-cli.sh` red-proves the smoke itself.
+
+Exit 0 = all killed. Exit 1 = survivors → either add the missing test or
+consciously accept and note why. Exit 2 = harness error, fix before trusting.

--- a/.claude/skills/prove/references/sweep.md
+++ b/.claude/skills/prove/references/sweep.md
@@ -1,0 +1,20 @@
+# Weekly verification sweep — verify-the-verifier on a schedule
+
+Recurring: `/loop 7d "/prove sweep"` (or run manually alongside
+`bash scripts/drift-audit.sh`). Attention only at red — a clean sweep ends
+in one line.
+
+1. **Gate red-check** — the self-testing gates prove they can still fail:
+   - `python3 scripts/check-behavior-trace.py --self-test`
+2. **Mutation sample** — pick the 2-3 modules with the most churn this week
+   (`git log --since=1.week --stat`), write 3-5 behavior mutations each,
+   run mutprove (references/mutprove.md). Survivors → new tests or a noted
+   acceptance.
+3. **Blind audit** — for plans merged this week, run the tautology audit
+   from references/behaviors.md on their Behaviors sections.
+4. **Attest ledger scan** — `tail .claude/attest.jsonl`: any week where
+   surfaces shipped but their smoke never ran attested is itself a finding.
+5. **Report** — findings to `docs/superpowers/drift-reports/` (gitignored),
+   one-line summary in chat. Recurring finding (≥3×) → promote a rule per
+   the loop-engineering playbook; a gate that never fired in 4 weeks →
+   candidate for retirement.

--- a/.claude/skills/run-wenlan/SKILL.md
+++ b/.claude/skills/run-wenlan/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: run-wenlan
+description: Build, launch, and stop the wenlan daemon (wenlan-server) for local dev and verification. Use when asked to run or restart the daemon, or before driving any surface (HTTP, CLI, MCP) against a live instance.
+---
+
+# Run wenlan-server (dev)
+
+Build: `cargo build -p wenlan-server -p wenlan` (add `-p wenlan-mcp` for the MCP bridge).
+
+## Isolated instance (default for verification)
+
+Never verify against the shared prod daemon on :7878 — dev and prod share the
+platform data dir by default.
+
+```bash
+WENLAN_PORT=17878 WENLAN_DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}/run.XXXXXX")" \
+  ./target/debug/wenlan-server &
+# ready:  curl -sf --max-time 2 http://127.0.0.1:17878/api/health  (poll up to ~120s)
+# stop:   lsof -ti :17878 | xargs kill -9
+```
+
+Sandbox gotcha: always give mktemp a template (`"${TMPDIR:-/tmp}/x.XXXXXX"`);
+bare `mktemp -d` lands in a denied dir on macOS.
+
+## Prod daemon (the user's real instance on :7878)
+
+Managed service: `wenlan background on` / `wenlan background off` / `wenlan restart`
+(launchd on macOS, systemd-user on Linux, schtasks on Windows). Other agents and the
+desktop app share it — never kill it casually.
+
+## Lifecycle checklist
+
+- **Which binary owns :7878** — launchd, the main checkout, a stale worktree, or a
+  previous session can all own it. `lsof -i :7878` for the PID, then
+  `lsof -p <PID> | grep "txt.*wenlan-server"` for the binary path and size. Kill and
+  restart from the current working tree when in doubt.
+- **Stale binary after merge/pull** — `cargo build -p wenlan-server` may report
+  "Finished" without recompiling after a fast-forward (source timestamps unchanged).
+  Force it: `touch crates/wenlan-server/src/router.rs && cargo build -p wenlan-server`,
+  then confirm the timestamp: `ls -la target/debug/wenlan-server`.
+- **kill vs kill -9** — plain `kill <PID>` may not terminate the daemon cleanly. Use
+  `kill -9 <PID>` and verify with `lsof -ti :7878`; if the port is still busy, another
+  process took over.
+- **Worktree target dirs are per-worktree** — a binary built inside `.worktrees/<name>`
+  lands in that worktree's `target/`, not the main repo's. Verify a running binary's
+  source with `lsof -p <PID> | grep wenlan-server`.
+- **Upgrading requires a restart** — installing a new binary never replaces a running
+  daemon: the new process detects the healthy incumbent on :7878 and exits
+  (`crates/wenlan-server/src/main.rs`). `wenlan background on` stops the running service
+  before reinstalling; `wenlan restart` (stop then start) reloads it explicitly. The MCP
+  version handshake surfaces a stale daemon (`VersionStatus::DaemonOutdated`) and points
+  users at `wenlan restart`.
+- **Reranker startup** — enabling the cross-encoder (`WENLAN_RERANKER_ENABLED=1`) blocks
+  startup on a one-time ~1.1GB model download and, on failure, serves with no rerank;
+  `/api/status` reports `reranker` as `disabled` / `active` / `failed` so the degraded
+  state is visible.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: verify
+description: Drive/evidence recipe for verifying wenlan changes at their real surfaces (daemon HTTP, CLI, MCP stdio). The handle file the built-in verify protocol expects; launch primitives live in the run-wenlan skill, deeper machinery (mutation audit, behavior trace, weekly sweep) in the prove skill.
+---
+
+# Verifying wenlan — drive the real surfaces
+
+Launch: use the `run-wenlan` skill — build, isolated boot on :17878, stop, and the
+daemon lifecycle checklist all live there. Never verify against the shared prod
+daemon on :7878.
+
+Drive by surface — these scripts ARE the drive recipes (read them for the flow,
+run them for a full round-trip):
+
+- Daemon HTTP: curl the changed route on the isolated port; recipe in
+  `.claude/skills/prove/references/daemon.md`.
+- CLI: `bash scripts/smoke-cli.sh` (capture → memories → search, black-box).
+- MCP: `bash scripts/smoke-mcp.sh` (stdio JSON-RPC initialize → capture → recall).
+
+Gotchas (drive-time):
+
+- Ingest is async (batcher + embedding): poll search up to ~60s before calling
+  a miss a failure.
+- Record evidence: prefix any check with `~/.claude/bin/attest.sh`.
+
+Deeper verification — mutation audit (`suite`), behavior trace (`behaviors`),
+weekly verify-the-verifier (`sweep`): invoke the `prove` skill.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,6 +1007,16 @@ jobs:
           echo "    Linux background on/off round-trip PASS"
       - name: E2E folder ingest over HTTP (Linux)
         run: bash scripts/smoke-folder-ingest.sh
+      # Surface smokes ride the non-PR backstop only: each boots its own
+      # daemon (~3-4 min like folder-ingest above), and the ordinary PR lane
+      # holds the sub-20-minute budget from #393. /prove runs them locally
+      # when a PR actually touches the CLI/MCP surface.
+      - name: E2E CLI surface smoke (Linux)
+        if: github.event_name != 'pull_request'
+        run: bash scripts/smoke-cli.sh
+      - name: E2E MCP stdio surface smoke (Linux)
+        if: github.event_name != 'pull_request'
+        run: bash scripts/smoke-mcp.sh
 
   # Build-only preflight for every shipped release target. Native/build/package
   # diffs prove their release profile before merge; main/manual runs and the

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,13 @@ crates/*/.fastembed_cache
 .claude/*
 !.claude/settings.json
 !.claude/hooks/
+# Skills are tracked selectively: verification skills ship with the repo,
+# personal/local skills stay local.
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/prove/
+!.claude/skills/run-wenlan/
+!.claude/skills/verify/
 .mcp.json
 
 # Coverage reports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ Where things live. Subtree `AGENTS.md` files load automatically when you work un
 | Eval internals — runner conventions, paired-A/B apparatus, the G3 gate | `crates/wenlan-core/src/eval/AGENTS.md` |
 | CLI (`wenlan`) | "Key Modules — wenlan (CLI)" below (no subtree doc) |
 | Wire types (`wenlan-types`), MCP server (`wenlan-mcp`) | Architecture → Workspace Layout below (no subtree doc) |
+| Running & verifying against live surfaces — daemon launch/lifecycle, per-surface drive recipes, mutation audit / behavior trace / weekly sweep | `.claude/skills/run-wenlan/SKILL.md` → `.claude/skills/verify/SKILL.md` → `.claude/skills/prove/SKILL.md` (tracked in-repo) |
 
 ## Design Philosophy
 
@@ -289,12 +290,7 @@ All post-store enrichment goes through the ONE canonical path (`wenlan_core::ing
 
 ### Dev environment gotchas
 
-**Daemon lifecycle:**
-- **Worktree daemon mismatch**: The daemon on port 7878 can be from launchd, main branch, a stale worktree, or a previous session. Always verify which binary is running: `lsof -i :7878` to get the PID, then `lsof -p <PID> | grep "txt.*wenlan-server"` to see the binary path and size. Kill and restart from the current working tree.
-- **Stale binary after merge/pull**: `cargo build -p wenlan-server` may report "0.64s Finished" without recompiling if the source timestamps haven't changed (e.g., after `git pull` fast-forward). Touch a source file to force recompilation: `touch crates/wenlan-server/src/router.rs && cargo build -p wenlan-server`. Verify the binary timestamp matches: `ls -la target/debug/wenlan-server`.
-- **kill vs kill -9**: `kill <PID>` may not terminate the daemon cleanly. Always use `kill -9 <PID>` and verify with `lsof -ti :7878` afterward. If the port is still in use, another process took over.
-- **Worktree target directories are per-worktree**: Each `.worktrees/<name>` checkout has its own `target/`. Building inside a worktree writes to that worktree's `target/`, not the main repo's. Verify a binary's source with `lsof -p <PID> | grep wenlan-server` so you don't run a stale binary from a different worktree.
-- **Upgrading the daemon requires a restart**: installing a new binary does NOT replace an already-running daemon -- the new process detects the healthy incumbent on port 7878 and exits (`wenlan-server/src/main.rs`). `wenlan background on` stops the running service before reinstalling, and `wenlan restart` (stop then start) reloads it explicitly. The MCP version handshake surfaces a stale daemon (`VersionStatus::DaemonOutdated`) and points users at `wenlan restart`. Enabling the cross-encoder (`WENLAN_RERANKER_ENABLED=1`) blocks startup on a one-time ~1.1GB model download and, on failure, serves with no rerank -- `/api/status` now reports `reranker` as `disabled` / `active` / `failed` so the degraded state is visible.
+**Daemon lifecycle** — which binary owns :7878, stale binaries after `git pull`, `kill -9` verification, per-worktree `target/` dirs, restart-after-upgrade, reranker startup states: the full checklist lives in the launch-primitive skill `.claude/skills/run-wenlan/SKILL.md` (tracked in-repo; any agent can read it).
 
 **Other:**
 - **Metal/ggml on macOS Tahoe 26.x**: `ggml_metal_init` may fail even though native Metal works. The daemon auto-degrades and continues without LLM. Not a code bug. Check for competing GPU processes: `pgrep -la wenlan`.

--- a/scripts/check-behavior-trace.py
+++ b/scripts/check-behavior-trace.py
@@ -31,13 +31,15 @@ import re
 import sys
 
 BEHAVIOR_RE = re.compile(r"^\s*[-*]\s+\**\b(B\d+)\**\s*:", re.MULTILINE)
-COVERS_RE = re.compile(r"covers:\s*(B\d+(?:\s*,\s*B\d+)*)")
+# Comment-anchored: a covers-tag must sit in a comment, so a tag inside a
+# string literal or prose neither covers nor dangles.
+COVERS_RE = re.compile(r"(?:<!--|--|//|/\*|\*|#)\s*covers:\s*(B\d+(?:\s*,\s*B\d+)*)")
 TEST_EXTS = (".rs", ".py", ".sh", ".ts", ".js", ".tsx", ".go")
 
 
 def parse_behaviors(plan_path):
     text = open(plan_path).read()
-    section = re.search(r"^##+\s+Behaviors\s*$(.*?)(?=^##+\s|\Z)",
+    section = re.search(r"^##+\s+Behaviors\b[^\n]*$(.*?)(?=^##+\s|\Z)",
                         text, re.MULTILINE | re.DOTALL)
     if not section:
         return None
@@ -54,7 +56,10 @@ def collect_covers(paths):
                           if n.endswith(TEST_EXTS)]
         else:
             files.append(p)
+    own_name = os.path.basename(__file__)
     for f in files:
+        if os.path.basename(f) == own_name:
+            continue  # the docstring's own covers: examples must not count
         try:
             lines = open(f, errors="replace").read().splitlines()
         except OSError:
@@ -67,7 +72,11 @@ def collect_covers(paths):
 
 
 def run(plan_path, test_paths):
-    behaviors = parse_behaviors(plan_path)
+    try:
+        behaviors = parse_behaviors(plan_path)
+    except OSError as e:
+        print(f"error: cannot read plan {plan_path}: {e}", file=sys.stderr)
+        return 2
     if behaviors is None:
         print(f"error: no '## Behaviors' section in {plan_path}", file=sys.stderr)
         return 2
@@ -140,10 +149,25 @@ def self_test():
         if run(plan, [td]) != 0:
             failures.append("multi-id covers tag should cover both")
 
+        # 6. tag inside a string literal (no comment marker) -> not a cover
+        write("## Behaviors\n- B1: x\n",
+              'fn a(){ let m = "covers: B1 is just prose"; }\n')
+        if run(plan, [td]) != 1:
+            failures.append("string-literal tag must not count as coverage")
+
+        # 7. heading with a suffix still parses
+        write("## Behaviors (contract)\n- B1: x\n", "// covers: B1\nfn a(){}\n")
+        if run(plan, [td]) != 0:
+            failures.append("suffixed Behaviors heading should parse")
+
+        # 8. unreadable plan path -> usage error, not a crash
+        if run(os.path.join(td, "no-such-plan.md"), [td]) != 2:
+            failures.append("missing plan file should return 2")
+
     if failures:
         print("SELF-TEST FAILED:\n  " + "\n  ".join(failures))
         return 1
-    print("self-test: 5/5 cases correct")
+    print("self-test: 8/8 cases correct")
     return 0
 
 

--- a/scripts/check-behavior-trace.py
+++ b/scripts/check-behavior-trace.py
@@ -72,6 +72,11 @@ def collect_covers(paths):
 
 
 def run(plan_path, test_paths):
+    missing = [p for p in test_paths if not os.path.exists(p)]
+    if missing:
+        print(f"error: test path(s) do not exist: {', '.join(missing)}",
+              file=sys.stderr)
+        return 2
     try:
         behaviors = parse_behaviors(plan_path)
     except OSError as e:
@@ -83,6 +88,11 @@ def run(plan_path, test_paths):
     if not behaviors:
         print(f"error: '## Behaviors' section in {plan_path} defines no "
               f"'- B<n>:' items", file=sys.stderr)
+        return 2
+    dupes = sorted({b for b in behaviors if behaviors.count(b) > 1})
+    if dupes:
+        print(f"error: duplicate behavior id(s) in {plan_path}: "
+              f"{', '.join(dupes)}", file=sys.stderr)
         return 2
 
     covers = collect_covers(test_paths)
@@ -164,10 +174,20 @@ def self_test():
         if run(os.path.join(td, "no-such-plan.md"), [td]) != 2:
             failures.append("missing plan file should return 2")
 
+        # 9. nonexistent test path -> usage error, not a silent skip
+        write("## Behaviors\n- B1: x\n", "// covers: B1\nfn a(){}\n")
+        if run(plan, [td, os.path.join(td, "no-such-dir")]) != 2:
+            failures.append("nonexistent test path should return 2")
+
+        # 10. duplicate behavior ids -> usage error
+        write("## Behaviors\n- B1: x\n- B1: y\n", "// covers: B1\nfn a(){}\n")
+        if run(plan, [td]) != 2:
+            failures.append("duplicate behavior ids should return 2")
+
     if failures:
         print("SELF-TEST FAILED:\n  " + "\n  ".join(failures))
         return 1
-    print("self-test: 8/8 cases correct")
+    print("self-test: 10/10 cases correct")
     return 0
 
 

--- a/scripts/check-behavior-trace.py
+++ b/scripts/check-behavior-trace.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""check-behavior-trace — enforce the plan-behaviors <-> tests mapping.
+
+The intent anchor for "is this the right test": the plan/spec carries a
+`## Behaviors` section (the contract IS the plan — no separate artifact):
+
+    ## Behaviors
+    - B1: given a stored memory, `wenlan memories` lists it
+    - B2: given a dirty tree, mutprove refuses to mutate
+
+Tests cite the behavior they protect with a `covers: B<n>` tag in a comment
+(any language, any test framework):
+
+    #[test]  // covers: B2
+    fn refuses_dirty_tree() { ... }
+
+This checker fails when the mapping breaks in either direction:
+  - a behavior no test covers  (untested intent)
+  - a covers-tag citing a behavior id the plan doesn't define (dangling tag —
+    usually a renamed/deleted behavior, i.e. the test now mirrors nothing)
+
+Usage:
+    check-behavior-trace.py <plan.md> <test-file-or-dir>...
+    check-behavior-trace.py --self-test
+
+Exit: 0 mapping intact · 1 gaps · 2 usage/parse error.
+"""
+
+import os
+import re
+import sys
+
+BEHAVIOR_RE = re.compile(r"^\s*[-*]\s+\**\b(B\d+)\**\s*:", re.MULTILINE)
+COVERS_RE = re.compile(r"covers:\s*(B\d+(?:\s*,\s*B\d+)*)")
+TEST_EXTS = (".rs", ".py", ".sh", ".ts", ".js", ".tsx", ".go")
+
+
+def parse_behaviors(plan_path):
+    text = open(plan_path).read()
+    section = re.search(r"^##+\s+Behaviors\s*$(.*?)(?=^##+\s|\Z)",
+                        text, re.MULTILINE | re.DOTALL)
+    if not section:
+        return None
+    return BEHAVIOR_RE.findall(section.group(1))
+
+
+def collect_covers(paths):
+    tags = {}  # id -> [file:line]
+    files = []
+    for p in paths:
+        if os.path.isdir(p):
+            for root, _, names in os.walk(p):
+                files += [os.path.join(root, n) for n in names
+                          if n.endswith(TEST_EXTS)]
+        else:
+            files.append(p)
+    for f in files:
+        try:
+            lines = open(f, errors="replace").read().splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines, 1):
+            for m in COVERS_RE.finditer(line):
+                for bid in re.findall(r"B\d+", m.group(1)):
+                    tags.setdefault(bid, []).append(f"{f}:{i}")
+    return tags
+
+
+def run(plan_path, test_paths):
+    behaviors = parse_behaviors(plan_path)
+    if behaviors is None:
+        print(f"error: no '## Behaviors' section in {plan_path}", file=sys.stderr)
+        return 2
+    if not behaviors:
+        print(f"error: '## Behaviors' section in {plan_path} defines no "
+              f"'- B<n>:' items", file=sys.stderr)
+        return 2
+
+    covers = collect_covers(test_paths)
+    uncovered = [b for b in behaviors if b not in covers]
+    dangling = {bid: locs for bid, locs in covers.items()
+                if bid not in behaviors}
+
+    for b in behaviors:
+        locs = covers.get(b, [])
+        mark = "OK  " if locs else "GAP "
+        print(f"{mark}{b}: {', '.join(locs) if locs else 'NO covering test'}")
+    for bid, locs in sorted(dangling.items()):
+        print(f"DANGLING {bid}: cited by {', '.join(locs)} but not defined "
+              f"in the plan")
+
+    if uncovered or dangling:
+        print(f"\nFAIL: {len(uncovered)} uncovered behavior(s), "
+              f"{len(dangling)} dangling tag(s)")
+        return 1
+    print(f"\nPASS: {len(behaviors)} behaviors all covered, no dangling tags")
+    return 0
+
+
+def self_test():
+    """Red proof: the checker must fail on gaps and pass on intact mappings."""
+    import tempfile
+
+    failures = []
+    with tempfile.TemporaryDirectory(
+            dir=os.environ.get("TMPDIR") or None) as td:
+        plan = os.path.join(td, "plan.md")
+        test = os.path.join(td, "t.rs")
+
+        def write(plan_body, test_body):
+            open(plan, "w").write(plan_body)
+            open(test, "w").write(test_body)
+
+        # 1. intact mapping -> 0
+        write("## Behaviors\n- B1: lists memories\n- B2: refuses dirty\n",
+              "// covers: B1\nfn a(){}\n// covers: B2\nfn b(){}\n")
+        if run(plan, [td]) != 0:
+            failures.append("intact mapping should pass")
+
+        # 2. uncovered behavior -> 1
+        write("## Behaviors\n- B1: lists\n- B2: refuses\n",
+              "// covers: B1\nfn a(){}\n")
+        if run(plan, [td]) != 1:
+            failures.append("uncovered behavior should fail")
+
+        # 3. dangling tag -> 1
+        write("## Behaviors\n- B1: lists\n",
+              "// covers: B1\nfn a(){}\n// covers: B9\nfn z(){}\n")
+        if run(plan, [td]) != 1:
+            failures.append("dangling tag should fail")
+
+        # 4. no Behaviors section -> 2
+        write("## Plan\nno behaviors here\n", "fn a(){}\n")
+        if run(plan, [td]) != 2:
+            failures.append("missing section should be a usage error")
+
+        # 5. multi-id tag 'covers: B1, B2' -> both covered
+        write("## Behaviors\n- B1: x\n- B2: y\n",
+              "// covers: B1, B2\nfn a(){}\n")
+        if run(plan, [td]) != 0:
+            failures.append("multi-id covers tag should cover both")
+
+    if failures:
+        print("SELF-TEST FAILED:\n  " + "\n  ".join(failures))
+        return 1
+    print("self-test: 5/5 cases correct")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        sys.exit(self_test())
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(run(sys.argv[1], sys.argv[2:]))

--- a/scripts/smoke-cli.sh
+++ b/scripts/smoke-cli.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Smoke test: the shipped `wenlan` CLI binary drives a real daemon over HTTP.
+# Black-box per-surface loop: capture -> memories -> search -> status, all
+# through the CLI, never curl. Isolated port + data dir per repo smoke-test
+# policy — never touches prod data (dev/prod share 7878 by default).
+set -euo pipefail
+
+PORT="${PORT:-17881}"
+HOST="http://127.0.0.1:${PORT}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/target/debug"
+
+# Explicit template: macOS mktemp ignores TMPDIR without one, and the
+# sandboxed dev loop can only write under TMPDIR.
+DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}/smoke-cli.XXXXXX")"
+DAEMON_PID=""
+
+cleanup() {
+    if [ -n "$DAEMON_PID" ]; then
+        kill -9 "$DAEMON_PID" >/dev/null 2>&1 || true
+        wait "$DAEMON_PID" 2>/dev/null || true
+    fi
+    for _ in $(seq 1 10); do
+        if ! lsof -ti ":${PORT}" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+    rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $1" >&2
+    echo "--- daemon log tail ---" >&2
+    tail -40 "$DATA_DIR/daemon.log" >&2 || true
+    exit 1
+}
+
+echo "==> Building wenlan-server + wenlan"
+(cd "$ROOT" && cargo build -p wenlan-server -p wenlan)
+
+if lsof -ti ":${PORT}" >/dev/null 2>&1; then
+    fail "port ${PORT} already in use; set PORT= to another free port"
+fi
+
+echo "==> Starting daemon on port ${PORT} (data dir ${DATA_DIR})"
+# cwd = repo root so the daemon finds the shared .fastembed_cache.
+(cd "$ROOT" && WENLAN_PORT="$PORT" WENLAN_DATA_DIR="$DATA_DIR" \
+    exec "$BIN/wenlan-server" >"$DATA_DIR/daemon.log" 2>&1) &
+DAEMON_PID=$!
+
+echo "==> Waiting for /api/health"
+healthy=""
+for i in $(seq 1 120); do
+    if curl -sf "$HOST/api/health" >/dev/null 2>&1; then
+        echo "    healthy after ${i}s"
+        healthy=1
+        break
+    fi
+    kill -0 "$DAEMON_PID" 2>/dev/null || fail "daemon exited during startup"
+    sleep 1
+done
+[ -n "$healthy" ] || fail "daemon did not become healthy within 120s"
+
+SENTINEL="kumquat-lighthouse-8231"
+CLI() { WENLAN_HOST="$HOST" "$BIN/wenlan" --format json "$@"; }
+
+echo "==> wenlan status"
+STATUS_OUT="$(CLI status)" || fail "wenlan status exited nonzero"
+[ -n "$STATUS_OUT" ] || fail "wenlan status printed nothing"
+
+echo "==> wenlan capture (sentinel)"
+CLI capture "The ${SENTINEL} sentinel sentence lives in the CLI smoke." \
+    --type fact >/dev/null || fail "wenlan capture exited nonzero"
+
+echo "==> wenlan memories contains the sentinel"
+CLI memories --limit 20 | grep -q "$SENTINEL" \
+    || fail "captured sentinel not listed by wenlan memories"
+
+echo "==> wenlan search finds the sentinel"
+hit=""
+for i in $(seq 1 30); do
+    if CLI search "kumquat lighthouse sentinel sentence" --limit 5 \
+        | grep -q "$SENTINEL"; then
+        echo "    hit after ${i} poll(s)"
+        hit=1
+        break
+    fi
+    sleep 2
+done
+[ -n "$hit" ] || fail "sentinel not retrievable via wenlan search within 60s"
+
+echo "PASS: CLI surface smoke (status, capture, memories, search) against isolated daemon"

--- a/scripts/smoke-cli.sh
+++ b/scripts/smoke-cli.sh
@@ -40,6 +40,9 @@ fail() {
 echo "==> Building wenlan-server + wenlan"
 (cd "$ROOT" && cargo build -p wenlan-server -p wenlan)
 
+# Without lsof a failed port check reads as "port free" — fail loud instead.
+command -v lsof >/dev/null 2>&1 || fail "lsof is required (port check + cleanup)"
+
 if lsof -ti ":${PORT}" >/dev/null 2>&1; then
     fail "port ${PORT} already in use; set PORT= to another free port"
 fi
@@ -53,7 +56,7 @@ DAEMON_PID=$!
 echo "==> Waiting for /api/health"
 healthy=""
 for i in $(seq 1 120); do
-    if curl -sf "$HOST/api/health" >/dev/null 2>&1; then
+    if curl -sf --max-time 2 "$HOST/api/health" >/dev/null 2>&1; then
         echo "    healthy after ${i}s"
         healthy=1
         break

--- a/scripts/smoke-cli.sh
+++ b/scripts/smoke-cli.sh
@@ -75,18 +75,25 @@ CLI capture "The ${SENTINEL} sentinel sentence lives in the CLI smoke." \
     --type fact >/dev/null || fail "wenlan capture exited nonzero"
 
 echo "==> wenlan memories contains the sentinel"
-CLI memories --limit 20 | grep -q "$SENTINEL" \
-    || fail "captured sentinel not listed by wenlan memories"
+# Capture then match: piping into grep -q can SIGPIPE the CLI under pipefail.
+MEMS_OUT="$(CLI memories --limit 20)" || fail "wenlan memories exited nonzero"
+case "$MEMS_OUT" in
+    *"$SENTINEL"*) ;;
+    *) fail "captured sentinel not listed by wenlan memories" ;;
+esac
 
 echo "==> wenlan search finds the sentinel"
 hit=""
 for i in $(seq 1 30); do
-    if CLI search "kumquat lighthouse sentinel sentence" --limit 5 \
-        | grep -q "$SENTINEL"; then
-        echo "    hit after ${i} poll(s)"
-        hit=1
-        break
-    fi
+    SEARCH_OUT="$(CLI search "kumquat lighthouse sentinel sentence" --limit 5)" \
+        || fail "wenlan search exited nonzero"
+    case "$SEARCH_OUT" in
+        *"$SENTINEL"*)
+            echo "    hit after ${i} poll(s)"
+            hit=1
+            break
+            ;;
+    esac
     sleep 2
 done
 [ -n "$hit" ] || fail "sentinel not retrievable via wenlan search within 60s"

--- a/scripts/smoke-mcp.sh
+++ b/scripts/smoke-mcp.sh
@@ -63,7 +63,8 @@ done
 [ -n "$healthy" ] || fail "daemon did not become healthy within 120s"
 
 echo "==> Driving wenlan-mcp over stdio JSON-RPC"
-# Keep the self-update probe off the network and out of the user cache.
+# Keep the self-update probe out of the user cache (the empty temp cache
+# still forces one GET to api.github.com; its 3s timeout is fail-soft).
 WENLAN_MCP_CACHE_DIR="$DATA_DIR/mcp-cache" \
 MCP_BIN="$BIN/wenlan-mcp" MCP_URL="$HOST" python3 - <<'EOF' \
     || fail "MCP stdio round-trip failed"
@@ -113,7 +114,7 @@ send({"jsonrpc": "2.0", "method": "notifications/initialized"})
 
 send({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
 tools = {t["name"] for t in expect_ok(recv(2), "tools/list")["tools"]}
-for needed in ("capture", "recall", "search_pages"):
+for needed in ("capture", "recall"):
     if needed not in tools:
         raise SystemExit(f"tools/list missing '{needed}' (got {sorted(tools)})")
 print(f"    tools/list ok: {len(tools)} tools")

--- a/scripts/smoke-mcp.sh
+++ b/scripts/smoke-mcp.sh
@@ -40,6 +40,9 @@ fail() {
 echo "==> Building wenlan-server + wenlan-mcp"
 (cd "$ROOT" && cargo build -p wenlan-server -p wenlan-mcp)
 
+# Without lsof a failed port check reads as "port free" — fail loud instead.
+command -v lsof >/dev/null 2>&1 || fail "lsof is required (port check + cleanup)"
+
 if lsof -ti ":${PORT}" >/dev/null 2>&1; then
     fail "port ${PORT} already in use; set PORT= to another free port"
 fi
@@ -52,7 +55,7 @@ DAEMON_PID=$!
 echo "==> Waiting for /api/health"
 healthy=""
 for i in $(seq 1 120); do
-    if curl -sf "$HOST/api/health" >/dev/null 2>&1; then
+    if curl -sf --max-time 2 "$HOST/api/health" >/dev/null 2>&1; then
         echo "    healthy after ${i}s"
         healthy=1
         break
@@ -74,29 +77,39 @@ SENTINEL = "walrus-observatory-5507"
 proc = subprocess.Popen(
     [os.environ["MCP_BIN"], "--origin-url", os.environ["MCP_URL"],
      "--agent-name", "smoke-mcp"],
-    stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True, bufsize=1,
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE,
 )
 
 def send(obj):
-    proc.stdin.write(json.dumps(obj) + "\n")
+    proc.stdin.write((json.dumps(obj) + "\n").encode())
     proc.stdin.flush()
 
+buf = b""
+
 def recv(want_id, timeout=60):
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        ready, _, _ = select.select([proc.stdout], [], [], 1)
-        if not ready:
-            continue
-        line = proc.stdout.readline()
-        if not line:
-            raise SystemExit("wenlan-mcp closed stdout")
-        try:
-            msg = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if msg.get("id") == want_id:
-            return msg
-    raise SystemExit(f"timeout waiting for response id={want_id}")
+    # Frame by hand: select() + buffered readline() can hang on a partial
+    # frame or strand a second frame already sitting in Python's buffer
+    # while select() waits on the drained fd.
+    global buf
+    deadline = time.monotonic() + timeout
+    while True:
+        while b"\n" in buf:
+            line, buf = buf.split(b"\n", 1)
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("id") == want_id:
+                return msg
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise SystemExit(f"timeout waiting for response id={want_id}")
+        ready, _, _ = select.select([proc.stdout], [], [], min(remaining, 1))
+        if ready:
+            chunk = os.read(proc.stdout.fileno(), 65536)
+            if not chunk:
+                raise SystemExit("wenlan-mcp closed stdout")
+            buf += chunk
 
 def expect_ok(msg, what):
     if "error" in msg:
@@ -125,12 +138,16 @@ send({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
 expect_ok(recv(3), "capture")
 print("    capture ok")
 
+# One monotonic window for the whole poll — per-retry timeouts would let
+# the advertised 60s stretch to 30 minutes against a hung daemon.
 found = False
-for _ in range(30):
+poll_deadline = time.monotonic() + 60
+while time.monotonic() < poll_deadline:
     send({"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
         "name": "recall",
         "arguments": {"query": "walrus observatory sentinel"}}})
-    result = expect_ok(recv(4), "recall")
+    result = expect_ok(
+        recv(4, timeout=max(1, poll_deadline - time.monotonic())), "recall")
     if SENTINEL in json.dumps(result):
         found = True
         break

--- a/scripts/smoke-mcp.sh
+++ b/scripts/smoke-mcp.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Smoke test: the shipped `wenlan-mcp` binary bridges a real MCP client to a
+# real daemon. Black-box per-surface loop over stdio JSON-RPC: initialize ->
+# tools/list -> capture tool call -> recall tool call. Isolated port + data
+# dir per repo smoke-test policy — never touches prod data.
+set -euo pipefail
+
+PORT="${PORT:-17882}"
+HOST="http://127.0.0.1:${PORT}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/target/debug"
+
+# Explicit template: macOS mktemp ignores TMPDIR without one, and the
+# sandboxed dev loop can only write under TMPDIR.
+DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}/smoke-mcp.XXXXXX")"
+DAEMON_PID=""
+
+cleanup() {
+    if [ -n "$DAEMON_PID" ]; then
+        kill -9 "$DAEMON_PID" >/dev/null 2>&1 || true
+        wait "$DAEMON_PID" 2>/dev/null || true
+    fi
+    for _ in $(seq 1 10); do
+        if ! lsof -ti ":${PORT}" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 1
+    done
+    rm -rf "$DATA_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $1" >&2
+    echo "--- daemon log tail ---" >&2
+    tail -40 "$DATA_DIR/daemon.log" >&2 || true
+    exit 1
+}
+
+echo "==> Building wenlan-server + wenlan-mcp"
+(cd "$ROOT" && cargo build -p wenlan-server -p wenlan-mcp)
+
+if lsof -ti ":${PORT}" >/dev/null 2>&1; then
+    fail "port ${PORT} already in use; set PORT= to another free port"
+fi
+
+echo "==> Starting daemon on port ${PORT} (data dir ${DATA_DIR})"
+(cd "$ROOT" && WENLAN_PORT="$PORT" WENLAN_DATA_DIR="$DATA_DIR" \
+    exec "$BIN/wenlan-server" >"$DATA_DIR/daemon.log" 2>&1) &
+DAEMON_PID=$!
+
+echo "==> Waiting for /api/health"
+healthy=""
+for i in $(seq 1 120); do
+    if curl -sf "$HOST/api/health" >/dev/null 2>&1; then
+        echo "    healthy after ${i}s"
+        healthy=1
+        break
+    fi
+    kill -0 "$DAEMON_PID" 2>/dev/null || fail "daemon exited during startup"
+    sleep 1
+done
+[ -n "$healthy" ] || fail "daemon did not become healthy within 120s"
+
+echo "==> Driving wenlan-mcp over stdio JSON-RPC"
+# Keep the self-update probe off the network and out of the user cache.
+WENLAN_MCP_CACHE_DIR="$DATA_DIR/mcp-cache" \
+MCP_BIN="$BIN/wenlan-mcp" MCP_URL="$HOST" python3 - <<'EOF' \
+    || fail "MCP stdio round-trip failed"
+import json, os, select, subprocess, sys, time
+
+SENTINEL = "walrus-observatory-5507"
+proc = subprocess.Popen(
+    [os.environ["MCP_BIN"], "--origin-url", os.environ["MCP_URL"],
+     "--agent-name", "smoke-mcp"],
+    stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True, bufsize=1,
+)
+
+def send(obj):
+    proc.stdin.write(json.dumps(obj) + "\n")
+    proc.stdin.flush()
+
+def recv(want_id, timeout=60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        ready, _, _ = select.select([proc.stdout], [], [], 1)
+        if not ready:
+            continue
+        line = proc.stdout.readline()
+        if not line:
+            raise SystemExit("wenlan-mcp closed stdout")
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("id") == want_id:
+            return msg
+    raise SystemExit(f"timeout waiting for response id={want_id}")
+
+def expect_ok(msg, what):
+    if "error" in msg:
+        raise SystemExit(f"{what} returned JSON-RPC error: {msg['error']}")
+    if msg.get("result", {}).get("isError"):
+        raise SystemExit(f"{what} returned tool error: {msg['result']}")
+    return msg["result"]
+
+send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {
+    "protocolVersion": "2024-11-05", "capabilities": {},
+    "clientInfo": {"name": "smoke", "version": "0"}}})
+init = expect_ok(recv(1), "initialize")
+print(f"    initialize ok: {init.get('serverInfo', {}).get('name', '?')}")
+send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+send({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+tools = {t["name"] for t in expect_ok(recv(2), "tools/list")["tools"]}
+for needed in ("capture", "recall", "search_pages"):
+    if needed not in tools:
+        raise SystemExit(f"tools/list missing '{needed}' (got {sorted(tools)})")
+print(f"    tools/list ok: {len(tools)} tools")
+
+send({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
+    "name": "capture",
+    "arguments": {"content": f"The {SENTINEL} sentinel lives in the MCP smoke."}}})
+expect_ok(recv(3), "capture")
+print("    capture ok")
+
+found = False
+for _ in range(30):
+    send({"jsonrpc": "2.0", "id": 4, "method": "tools/call", "params": {
+        "name": "recall",
+        "arguments": {"query": "walrus observatory sentinel"}}})
+    result = expect_ok(recv(4), "recall")
+    if SENTINEL in json.dumps(result):
+        found = True
+        break
+    time.sleep(2)
+if not found:
+    raise SystemExit("captured sentinel not present in recall output within 60s")
+print("    recall ok: sentinel round-tripped")
+
+proc.stdin.close()
+proc.wait(timeout=10)
+EOF
+
+echo "PASS: MCP surface smoke (initialize, tools/list, capture, recall) against isolated daemon"


### PR DESCRIPTION
Per-surface verification loops from the verification-loops build-out.

## What

- `scripts/smoke-cli.sh` — black-box CLI round-trip against an isolated daemon (status → capture sentinel → memories → search poll). Never touches prod data.
- `scripts/smoke-mcp.sh` — stdio JSON-RPC round-trip through the shipped `wenlan-mcp` binary (initialize → tools/list → capture → recall) against an isolated daemon.
- `scripts/check-behavior-trace.py` — enforces the plan `## Behaviors` ↔ test `covers: B<n>` bijection both directions; `--self-test` carries 8 red-proof cases.
- `ci.yml` — both smokes join `canonical-acceptance` on the **non-PR backstop only** (each boots its own daemon; the ordinary PR lane keeps the sub-20-minute budget from #393).

## Evidence

- Both smokes PASS locally on macOS against isolated daemons (ports 17881/17882), re-run after rebasing onto `5ba8a3b4`.
- Each smoke previously KILLED an injected endpoint mutation (`/api/memory/store` → `storex` in the CLI client and MCP tools), so the loops demonstrably go red.
- Post-rebase MCP run reports 29 tools — the #397 surface consolidation is visible in the smoke's own output; the `search_pages` assertion it deleted is gone.

## Review

Dual-model review (Claude investigator + Codex): 1 blocker (stale `search_pages` assertion vs #397 — fixed by rebase + tuple change), CI 20-min-budget conflict (fixed by moving smokes to the non-PR backstop), covers-tag string-literal false positives and exit-code contract in the checker (fixed, self-test 5 → 8 cases), `grep -q` SIGPIPE latent in smoke-cli (fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzkXvjCxDDTNPXSE8wiKLh