### PR TITLE
chore: pin rust-analyzer as a toolchain component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.95.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
One line: add `rust-analyzer` to the `rust-toolchain.toml` components so rustup installs it automatically with the pinned toolchain.

**Why:** the 2026-06 LSP crash-loop — `~/.cargo/bin/rust-analyzer` is a rustup shim that dispatches to the pinned toolchain; if the component isn't installed for that exact toolchain, the shim exits instantly and Claude Code's LSP plugin dies for the whole session (`exceeded max crash recovery attempts`). Today the component is only installed because it was added manually; any future channel bump would silently recreate the incident. Declaring it in the toolchain file makes the pin self-healing, locally and in every worktree.

**CI cost:** dtolnay/rust-toolchain installs the channel explicitly, then rustup adds the missing component on the first cargo invocation under the repo (~seconds per uncached job). rust-cache keys rotate once since installed-toolchain state feeds the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzkXvjCxDDTNPXSE8wiKLh