### PR TITLE
chore: switch release versioning to always-bump-patch

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
+      "versioning": "always-bump-patch",
       "skip-github-release": true,
       "extra-files": [
         {


### PR DESCRIPTION
One line in `release-please-config.json`: `"versioning": "always-bump-patch"`.

**What changes:** commit types stop driving the version bump. Every release is a patch — 0.15.x accumulates indefinitely — and `feat:`/`fix:` prefixes only decide changelog placement. Real features keep honest `feat:` titles without forcing a minor at cut time. A minor bump becomes a deliberate act: flip this line for one release, or run the manual `bump-version.sh` flow in RELEASING.md (touch all three version files per drift teeth #3).

**Why this flag should work where the others didn't:** `bump-patch-for-minor-pre-major` and `release-as` (both broken with release-please v17 + simple, per AGENTS.md) try to reinterpret conventional-commit semantics inside the default strategy. `versioning` swaps the bump strategy wholesale — commit types are never consulted.

**Zero-risk verification after merge:** the next auto-updated release PR title must show a patch version even with `feat:` commits pending. If it shows a minor, revert this one line — nothing releases until the release PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzkXvjCxDDTNPXSE8wiKLh