### PR TITLE
test: deflake the two timing-sensitive tests blocking Windows CI

### DIFF
--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -762,7 +762,16 @@ mod tests {
 
         child.kill().expect("kill process identity test child");
         child.wait().expect("reap process identity test child");
-        assert!(!identity.is_running(&mut system));
+        // Windows can keep a terminated process visible in the enumeration
+        // snapshot briefly after wait(); poll instead of racing one check.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while identity.is_running(&mut system) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child process still visible 10s after exit"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
     }
 
     #[test]

--- a/crates/wenlan-server/src/reflection_debounce.rs
+++ b/crates/wenlan-server/src/reflection_debounce.rs
@@ -321,12 +321,16 @@ mod tests {
         let deb = ReflectionDebouncer::new();
         let observed_cancel = Arc::new(AtomicUsize::new(0));
         let work2_done = Arc::new(AtomicUsize::new(0));
+        let work1_started = Arc::new(AtomicUsize::new(0));
 
         // work1 starts quickly, then polls the cancel flag in a loop.
         let oc = observed_cancel.clone();
+        let ws = work1_started.clone();
         deb.schedule("agentA", Duration::from_millis(10), move |cancel| {
             let oc = oc.clone();
+            let ws = ws.clone();
             async move {
+                ws.fetch_add(1, Ordering::Relaxed);
                 for _ in 0..200 {
                     if cancel.load(Ordering::SeqCst) {
                         oc.fetch_add(1, Ordering::Relaxed);
@@ -337,9 +341,10 @@ mod tests {
             }
         });
 
-        // Let work1 start running (past its 10ms delay) before rescheduling, so
-        // we exercise the in-flight AtomicBool path, not the pre-delay abort.
-        settle(40).await;
+        // Wait until work1 is provably past its delay and inside its body, so
+        // the reschedule exercises the in-flight AtomicBool path, not the
+        // pre-delay abort. A fixed settle(40) raced this on loaded CI runners.
+        wait_until(|| work1_started.load(Ordering::Relaxed) == 1).await;
 
         let wd = work2_done.clone();
         deb.schedule("agentA", Duration::from_millis(10), move |_c| {
@@ -349,7 +354,10 @@ mod tests {
             }
         });
 
-        settle(200).await;
+        wait_until(|| {
+            observed_cancel.load(Ordering::Relaxed) == 1 && work2_done.load(Ordering::Relaxed) == 1
+        })
+        .await;
         assert_eq!(
             observed_cancel.load(Ordering::Relaxed),
             1,


### PR DESCRIPTION
PR #401's `test (windows-2022)` job failed twice — each time on a **different** timing-sensitive test, which is the signature of a loaded/cold-cache Windows runner exposing latent flakes, not a defect in #401's one-line toolchain change. This PR deflakes both. Test-only diff; `test:` prefix so no version bump.

**1. `commands::service::tests::daemon_process_identity_observes_child_exit`** (wenlan-cli) — failed on the [first run](https://github.com/7xuanlu/wenlan/actions/runs/30329987898/job/90182978269) in 0.031s. After `kill()` + `wait()`, Windows can keep the terminated process visible in the sysinfo enumeration snapshot for a beat, so the single-shot `!identity.is_running(&mut system)` assert races. Fix: poll up to 10s (100ms interval). The property under test — the captured identity eventually observes the child exit, without PID-reuse false positives — is unchanged.

**2. `reflection_debounce::tests::test_reschedule_signals_cancel_to_inflight_work`** (wenlan-server) — failed on the [rerun](https://github.com/7xuanlu/wenlan/actions/runs/30329987898/job/90193880937): `assertion left == right failed: in-flight work1 must observe cancel and bail early`. The test raced a fixed `settle(40)` against work1's 10ms delay; on a slow runner the reschedule lands before work1 starts, taking the pre-delay-abort path so `observed_cancel` stays 0. Fix: gate the reschedule on a work1-started flag via the module's own event-driven `wait_until` helper (built exactly for this per its doc comment), and replace the fixed `settle(200)` result wait the same way.

Verified locally on macOS:
- `cargo test -p wenlan --lib daemon_process_identity_observes_child_exit` → 1 passed
- `cargo test -p wenlan-server --lib reflection_debounce` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BzkXvjCxDDTNPXSE8wiKLh