### PR TITLE
docs: define CI flake response policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ cargo test -p wenlan-core --test eval_harness save_longmemeval_baseline -- --ign
 # Baselines saved to <EVAL_BASELINES_DIR>/*.json (gitignored, default ~/.cache/origin-eval).
 ```
 
-Pre-commit auto-formats Rust and runs Clippy on changed crates. Pre-push runs workspace clippy + library tests.
+Pre-commit auto-formats Rust and runs Clippy on changed crates. Pre-push uses the CI planner to run Clippy and tests over the affected reverse-dependency closure.
 
 ## Cross-platform
 
@@ -136,10 +136,12 @@ Wenlan runs across several layers. The split is driven by three questions: **(1)
 | **L2 pre-commit** | `cargo fmt --all`; Clippy on directly changed crates only | Local | `git commit` | ~5s | Yes |
 | **L3 pre-push** | Planner-selected Clippy + lib tests over the affected reverse-dependency closure; a directly edited integration target runs alone | Local | `git push` | change-dependent | Yes |
 | **L4 CI on PR** | Fail-closed differential plan: affected lib, integration, contract, platform, and HTTP smoke owners only; aggregate `conclusion` verifies every expected job. Pushes to `main` retain the full workspace/platform/release backstop. | GitHub (`ci.yml`) | Every PR | target ≤20min | Yes (required) |
-| **L5 coverage on PR** | `cargo llvm-cov` on wenlan-core + wenlan-server only | GitHub (`coverage.yml`) | Every PR | ~10min | **No (informational)** |
+| **L5 coverage** | `cargo llvm-cov` on wenlan-core + wenlan-server only | GitHub (`coverage.yml`) | Push to `main` or manual dispatch | ~10min | **No (informational)** |
 | **L6 main canary** | Embedding-only eval (`cargo nextest run -p wenlan-core --lib --run-ignored=only eval::retrieval`) | GitHub (`main-canary.yml`) | Push to `main` | ~10min | No (post-merge) |
 | **L7 manual local** | `bash scripts/coverage.sh` (HTML coverage), GPU eval suite (`cargo test -- --ignored`), Anthropic batch judge (`ANTHROPIC_API_KEY=... cargo test ...`), live smokes with a real on-device judge (`bash scripts/live-smoke-doc-reconcile.sh`, `bash scripts/live-smoke-page-citations.sh`) — run the matching live smoke before merging a feature whose e2e stubs the LLM or never boots the daemon | Your laptop | On demand | minutes-hours | No |
 | **L8 pre-release** | Full eval suite vs saved baseline. Commit a **curated, env-stamped snapshot** of headline numbers to a results doc/README (single-run tagged "scaffold"; headline claims need N≥3 + stddev). Raw per-run baselines + history series stay gitignored. See "Commit policy" under Eval Citation Discipline. | Your laptop | Per release | hours | Soft gate |
+
+A required CI check failed intermittently? Follow [`docs/ci-flake-policy.md`](docs/ci-flake-policy.md) before rerunning, quarantining, rerouting, or reverting.
 
 ### What does NOT run in CI and why
 
@@ -154,7 +156,7 @@ Tried 90% `cargo llvm-cov` gate in pre-push, removed because:
 - **Not mirrored in CI:** `ci.yml` has no coverage gate, so local-only friction.
 - **Percentage gates rot:** new untestable surface forces busywork.
 
-Pre-push now runs clippy + non-instrumented tests only. Coverage = L5 (PR, informational) or L7 (manual).
+Pre-push now runs planner-selected Clippy + non-instrumented tests only. Coverage = L5 (main/manual, informational) or L7 (manual HTML).
 
 ### Eval cache, baselines & faithfulness benches → `app/eval/AGENTS.md`
 

--- a/docs/ci-flake-policy.md
+++ b/docs/ci-flake-policy.md
@@ -1,0 +1,33 @@
+# CI flake policy
+
+Use this response policy when a required CI check fails intermittently. A red
+job is not automatically a flake, and a green rerun is not automatically a fix.
+
+1. **Name the exact failure from the full job log.** Record the job, command,
+   test, assertion or timeout, runner OS, and run URL. Check-run annotations such
+   as "exit code 1" are not enough. First separate test failures from setup,
+   infrastructure, and CI time-budget failures.
+2. **Use at most one rerun for diagnosis.** Rerun only when the first log points
+   to timing or runner state. Compare both signatures. A pass strengthens the
+   flake hypothesis but does not close the defect; repeated failure points to a
+   deterministic problem and should be debugged without more reruns.
+3. **Two matching occurrences require an owner and a fix.** Two independent
+   occurrences of the same test and symptom, on any branches or runners, are
+   enough to open a tracking issue and prioritize deflaking. Prefer event-driven
+   waits (`wait_until`, as used in
+   `crates/wenlan-server/src/reflection_debounce.rs`) or poll-with-deadline (as
+   used in `crates/wenlan-cli/src/commands/service.rs`). Do not use bare sleeps
+   or single-shot assertions on asynchronous or process state.
+4. **Quarantine must fail closed.** Do not add `#[ignore]` or exclude a test from
+   its owning plan unless the same PR first wires that exact test into an
+   explicit, visible, non-blocking main-push or scheduled job. Link a tracking
+   issue with an owner, removal condition, and deadline. Without that replacement
+   execution path, fix the test or leave the required check red; never disable
+   or reroute an entire owning CI lane to hide one flaky test. The existing
+   [`main-canary.yml`](../.github/workflows/main-canary.yml) runs selected eval
+   tests only and is not a general quarantine lane.
+5. **Do not revert an innocent trigger.** Cold caches, rotated cache keys, or a
+   busy runner can expose an existing race. Revert only when the changed code or
+   CI route caused the failure; otherwise fix or quarantine the failing test.
+   PR #401 exposed two existing timing races after a toolchain cache rotation;
+   PR #403 fixed the tests instead of reverting the trigger.


### PR DESCRIPTION
## What changed

- Defines an evidence-first response for intermittent required checks: name the exact failure, use at most one diagnostic rerun, and compare the same test and symptom.
- Makes quarantine fail closed: a test cannot be ignored unless the same PR gives it an explicit, visible, non-blocking main-push or scheduled execution path with an owner and removal deadline.
- Clarifies that the existing main canary is eval-specific, not a general quarantine lane.
- Synchronizes the local pre-push and coverage documentation with the affected-test planner introduced by #423.

## Why

A green rerun does not fix a flake, while a blanket `#[ignore]` would now silently remove a test from both required CI and local affected checks. The policy records the safe response without reintroducing duplicate work or incorrect routing.

## Validation

- `python scripts/ci_test_plan.test.py` (58 tests)
- README translation and eval provenance checks
- `git diff --check`
- Referenced-path and root `AGENTS.md` byte-budget checks

The targeted Rust drift-guard test cannot compile on this Windows host because the required Vulkan SDK is absent; the referenced paths and byte budget were checked directly, and GitHub's docs provenance lane provides the clean runner verification.