### PR TITLE
fix: skip the setup runtime repair when the daemon is newer than the plugin

### DIFF
--- a/plugin-codex/skills/setup/SKILL.md
+++ b/plugin-codex/skills/setup/SKILL.md
@@ -53,7 +53,14 @@ fi
 - If the probe cannot run because the runtime is down: continue to bootstrap.
 - If `PLUGIN_JSON` is unreadable or `python3` is missing: continue to doctor;
   Codex will keep using this slice until the plugin cache is updated.
-- If mismatch, repair the runtime:
+- If mismatch, check the direction before repairing. Compare the release part
+  of `daemon=` (strip the `+g<sha>` suffix) against `release=`, numeric per
+  component, not lexicographic. Daemon release equal or newer → the plugin
+  cache is stale, not the runtime: skip the repair below (it would only
+  reinstall the same-or-latest runtime and restart a healthy daemon) and go
+  straight to the stop message in step 4 — update the plugin, restart, rerun.
+- Only if the daemon release is older than the plugin release, repair the
+  runtime:
 
 ```bash
 PLUGIN_JSON="${CODEX_PLUGIN_ROOT:-plugin-codex}/.codex-plugin/plugin.json"

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -53,7 +53,14 @@ fi
 - If the probe cannot run because the runtime is down: continue to bootstrap.
 - If `PLUGIN_JSON` is unreadable or `python3` is missing: continue to doctor;
   the session hook will keep surfacing a mismatch if one exists.
-- If mismatch, repair the runtime:
+- If mismatch, check the direction before repairing. Compare the release part
+  of `daemon=` (strip the `+g<sha>` suffix) against `release=`, numeric per
+  component, not lexicographic. Daemon release equal or newer → the plugin
+  cache is stale, not the runtime: skip the repair below (it would only
+  reinstall the same-or-latest runtime and restart a healthy daemon) and go
+  straight to the stop message in step 4 — update the plugin, restart, rerun.
+- Only if the daemon release is older than the plugin release, repair the
+  runtime:
 
 ```bash
 PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-plugin}/.claude-plugin/plugin.json"


### PR DESCRIPTION
## Why

`/setup`'s version-drift repair fires on **any** daemon↔plugin mismatch. When the daemon is *newer* than the plugin cache (the common case right after a runtime upgrade, seen live today: daemon 0.15.1 vs cached plugin 0.12.0), the repair cannot close the gap — `install.sh` targets the latest release, so it reinstalls what is already running and then restarts a healthy daemon (`wenlan background on`), dropping MCP connections for nothing. Step 4 only afterwards reaches the correct advice: update the plugin.

## What

Both plugin slices (`plugin/skills/setup/SKILL.md`, `plugin-codex/skills/setup/SKILL.md`) now check drift **direction** before repairing:

- daemon release ≥ plugin release → skip the installer, route straight to step 4's "update the plugin, restart, rerun" stop message
- daemon release < plugin release → repair the runtime as before

Doc-only change to the skill prose; no runtime code touched. Verified live on the daemon-newer case this change targets: skipping the repair and updating the plugin + `/reload-plugins` closed the skew (plugin 0.15.1 = daemon 0.15.1, MCP round-trip green) with zero daemon restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQRybpmQKqZioGXh1Hk6FU