### PR TITLE
ci: raise the non-Windows PR test timeout to 45 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,8 +518,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     # Pull requests keep a hard wall-clock budget. Windows needs the full
     # backstop because its Vulkan/native bootstrap plus integration suite can
-    # exceed 30 minutes on a cold hosted runner; other PR platforms stay at 30.
-    timeout-minutes: ${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 30 }}
+    # exceed 30 minutes on a cold hosted runner. Other PR platforms get 45:
+    # a release-please version bump invalidates the whole sccache, and the
+    # resulting cold compile plus full test suite exceeds 30 minutes on
+    # macos-14 (run 30684460494 was canceled at 30m17s twice, zero failures).
+    timeout-minutes: ${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 45 }}
     strategy:
       # Cancel the rest of the matrix when one OS fails. Saves ~20-30min
       # per PR when a real bug breaks all platforms — Linux/macOS catch

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -2158,10 +2158,10 @@ fn ci_routing_contract_violations(
         }
     }
     let differential_timeout =
-        "${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 30 }}";
+        "${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 45 }}";
     if ci["jobs"]["test"]["timeout-minutes"].as_str() != Some(differential_timeout) {
         violations.push(
-            "test does not enforce the 30-minute non-Windows PR budget while allowing a 60-minute Windows/non-PR backstop".into(),
+            "test does not enforce the 45-minute non-Windows PR budget while allowing a 60-minute Windows/non-PR backstop".into(),
         );
     }
     let release_preflight_condition = ci["jobs"]["release-preflight"]["if"]
@@ -3094,7 +3094,7 @@ jobs:
         "nextest config",
         "release-profile-sensitive",
         "native/build-sensitive",
-        "30-minute non-Windows PR budget",
+        "45-minute non-Windows PR budget",
         "release-sensitive PRs and release backstops",
         "rust-lld",
         "debug runtime artifacts",


### PR DESCRIPTION
Release PR #419 was blocked by `test (macos-14)` twice — both attempts canceled at exactly 30m17s with **zero test failures** (attempt 2 died at 207/277, all green). Root cause: release-please branches bump every crate version, which invalidates the sccache for the whole workspace, so release PRs always compile cold — and post-M5 the cold compile plus the full suite no longer fits the 30-minute PR budget on macos-14. Windows already gets 60 minutes for the same cold-runner reason.

One-line change: the PR-event timeout for non-Windows platforms goes 30 → 45. Timeouts only bound the worst case, so green runs cost nothing extra. Every future release PR hits the same cold-cache wall, so this is structural, not a one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91