### PR TITLE
ci: keep ordinary PR checks within 20 minutes

### DIFF
--- a/.github/workflows/ci-observer.yml
+++ b/.github/workflows/ci-observer.yml
@@ -10,8 +10,14 @@ permissions:
   contents: read
 
 concurrency:
+  # A fixed group can retain only one pending run, silently dropping receipts
+  # during bursts. Keep every completed CI run/attempt independently observable.
   group: ci-observer-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
   cancel-in-progress: false
+
+env:
+  CI_CACHE_BUDGET_GB: "10"
+  CI_REQUIRED_GATE_TARGET_MINUTES: "20"
 
 jobs:
   collect:
@@ -32,27 +38,37 @@ jobs:
           RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
         run: |
-          set -euo pipefail
-          [[ "$RUN_ID" =~ ^[0-9]+$ ]]
-          [[ "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]
+          set -uo pipefail
           out="$RUNNER_TEMP/ci-observer"
           mkdir -p "$out"
-          gh api --method GET \
+
+          if [[ ! "$RUN_ID" =~ ^[0-9]+$ ]] || [[ ! "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+            echo "::warning title=CI observer metadata::Invalid run identity; the receipt will record unavailable metadata."
+            exit 0
+          fi
+
+          fetch_metadata() {
+            local label="$1"
+            local destination="$2"
+            shift 2
+            local temporary="${destination}.tmp"
+            if "$@" > "$temporary"; then
+              mv "$temporary" "$destination"
+            else
+              rm -f "$temporary"
+              echo "::warning title=CI observer metadata::${label} metadata is unavailable; the receipt will record the failure."
+            fi
+          }
+
+          fetch_metadata "Jobs" "$out/jobs-pages.json" gh api --method GET \
             -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
             --paginate --slurp \
-            "/repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100" \
-            > "$out/jobs-pages.json"
-          gh api --method GET \
+            "/repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100"
+          fetch_metadata "Cache usage" "$out/cache-usage.json" gh api --method GET \
             -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "/repos/$GITHUB_REPOSITORY/actions/cache/usage" \
-            > "$out/cache-usage.json"
-          gh api --method GET \
-            -H 'Accept: application/vnd.github+json' \
-            -H 'X-GitHub-Api-Version: 2022-11-28' \
-            "/repos/$GITHUB_REPOSITORY/actions/cache/storage-limit" \
-            > "$out/cache-limit.json"
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/actions/cache/usage"
       - name: Build timing and cache receipt
         if: always()
         run: |
@@ -60,7 +76,8 @@ jobs:
             --event "$GITHUB_EVENT_PATH" \
             --jobs-pages "$RUNNER_TEMP/ci-observer/jobs-pages.json" \
             --cache-usage "$RUNNER_TEMP/ci-observer/cache-usage.json" \
-            --cache-limit "$RUNNER_TEMP/ci-observer/cache-limit.json" \
+            --cache-budget-gb "$CI_CACHE_BUDGET_GB" \
+            --required-gate-target-minutes "$CI_REQUIRED_GATE_TARGET_MINUTES" \
             --output "$RUNNER_TEMP/ci-observer/receipt.json"
       - name: Upload CI observer receipt
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
       rust:    ${{ steps.filter.outputs.rust }}
       docs:    ${{ steps.filter.outputs.docs }}
       plugin:  ${{ steps.filter.outputs.plugin }}
+      plugin-rust-contract: ${{ steps.filter.outputs.plugin-rust-contract }}
+      plugin-version-contract: ${{ steps.filter.outputs.plugin-version-contract }}
       npm:     ${{ steps.filter.outputs.npm }}
       macos:   ${{ steps.filter.outputs.macos }}
       windows: ${{ steps.filter.outputs.windows }}
@@ -46,9 +48,15 @@ jobs:
       workspace-platform: ${{ steps.filter.outputs.workspace-platform }}
       verified-release-merge: ${{ steps.release-proof.outputs.verified-release-merge }}
       test-plan: ${{ steps.test-plan.outputs.test-plan }}
+      workspace-lib-required: ${{ steps.test-plan.outputs.workspace-lib-required }}
+      cli-server-integration-required: ${{ steps.test-plan.outputs.cli-server-integration-required }}
+      core-integration-required: ${{ steps.test-plan.outputs.core-integration-required }}
+      canonical-smokes-required: ${{ steps.test-plan.outputs.canonical-smokes-required }}
+      canonical-acceptance-required: ${{ steps.test-plan.outputs.canonical-acceptance-required }}
+      rust-ci-required: ${{ steps.test-plan.outputs.rust-ci-required }}
       release-targets: ${{ steps.release-targets.outputs.release-targets }}
-      # Dynamic matrix includes two Linux nextest slices. On PRs, macOS and
-      # Windows are included only when their owned files change.
+      # Linux runs from one compile-once archive below. This dynamic matrix is
+      # only for platform-owned macOS and Windows behavior.
       test-matrix: ${{ steps.matrix.outputs.json }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -112,6 +120,7 @@ jobs:
               - '.github/workflows/ci-observer.yml'
               - '.github/workflows/ci-benchmark.yml'
               - '.github/workflows/coverage.yml'
+              - '.github/workflows/release-please.yml'
               - '.github/workflows/release.yml'
               - 'docker/**'
               - 'scripts/**'
@@ -121,11 +130,6 @@ jobs:
               # on the one PR class most likely to introduce drift.
               - 'version.txt'
               - '.release-please-manifest.json'
-              # Same hole, plugin edition: crates/wenlan-cli/tests/distribution.rs
-              # asserts on the plugin manifests, so a plugin-only PR could break
-              # it and still show green -- the rust tests never ran.
-              - 'plugin/**'
-              - '.claude-plugin/**'
             plugin:
               - 'plugin/**'
               - 'plugin-codex/**'
@@ -137,6 +141,17 @@ jobs:
               - 'scripts/validate-codex-plugin-slice.py'
               - 'scripts/validate-plugin-contract.py'
               - 'scripts/validate-plugin-contract.test.sh'
+            # Required Rust-side distribution contracts for plugin artifacts.
+            # Validator implementation changes remain owned by the fast plugin
+            # job above and are deliberately excluded from this compile lane.
+            plugin-rust-contract:
+              - 'plugin/**'
+              - 'plugin-codex/**'
+              - '.agents/plugins/**'
+              - '.claude-plugin/**'
+              - 'plugin-contract.json'
+            plugin-version-contract:
+              - 'plugin/.claude-plugin/plugin.json'
             docs:
               # Documentation is a repository-wide surface, not a fixed README
               # inventory. Root and nested Markdown (including AGENTS.md and
@@ -144,6 +159,7 @@ jobs:
               - '*.md'
               - '**/*.md'
               - 'docs/**'
+              - 'LICENSE'
               - 'scripts/check-readme-translations.py'
               - 'scripts/check-readme-translations.test.sh'
               - 'scripts/update-readme-eval.py'
@@ -373,32 +389,37 @@ jobs:
             --github-output "$GITHUB_OUTPUT"
       - id: matrix
         run: |
-          linux='{"os":"ubuntu-24.04","label":"ubuntu-24.04 shard 1/2","partition":"slice:1/2"},{"os":"ubuntu-24.04","label":"ubuntu-24.04 shard 2/2","partition":"slice:2/2"}'
-          macos=',{"os":"macos-14","label":"macos-14","partition":""}'
-          windows=',{"os":"windows-2022","label":"windows-2022","partition":""}'
+          macos='{"os":"macos-14","label":"macos-14"}'
+          windows='{"os":"windows-2022","label":"windows-2022"}'
           if [ "${{ github.event_name }}" != "pull_request" ] || [ "${{ startsWith(github.head_ref, 'release-please--branches--') }}" = "true" ]; then
-            extra="${macos}${windows}"
+            include="${macos},${windows}"
           elif [ "${{ steps.filter.outputs.macos }}" = "true" ] && [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
-            extra="${macos}${windows}"
+            include="${macos},${windows}"
           elif [ "${{ steps.filter.outputs.macos }}" = "true" ]; then
-            extra="$macos"
+            include="$macos"
           elif [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
-            extra="$windows"
+            include="$windows"
           else
-            extra=""
+            include=""
           fi
-          echo "json={\"include\":[${linux}${extra}]}" >> "$GITHUB_OUTPUT"
+          echo "json={\"include\":[${include}]}" >> "$GITHUB_OUTPUT"
+      - name: Verify CI observer and ORT contracts
+        run: |
+          python3 scripts/ci-observer.test.py
+          python3 scripts/ci-timed-command.test.py
+          python3 scripts/verify-ort-source-pin.test.py
+          python3 scripts/verify-ort-source-pin.py
       - name: Set up Rust for affected-test planning
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+        if: steps.release-proof.outputs.verified-release-merge != 'true'
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
         with:
           toolchain: 1.95.0
       - name: Test CI impact planner
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+        if: steps.release-proof.outputs.verified-release-merge != 'true'
         run: python3 scripts/ci_test_plan.test.py
       - name: Plan affected Rust tests
         id: test-plan
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+        if: steps.release-proof.outputs.verified-release-merge != 'true'
         env:
           CHANGED_FILES_JSON: ${{ steps.filter.outputs.impact_files }}
           CI_EVENT_NAME: ${{ github.event_name }}
@@ -420,26 +441,26 @@ jobs:
         run: python3 scripts/prepare-fastembed-cache.test.py
       - name: Restore portable FastEmbed model
         id: fastembed-portable-restore
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+        if: "steps.release-proof.outputs.verified-release-merge != 'true' && steps.test-plan.outputs.rust-ci-required == 'true'"
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .fastembed_cache
           key: fastembed-bge-base-en-v1.5-q-v3-portable
           enableCrossOsArchive: "true"
       - name: Restore legacy Linux FastEmbed model
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request') && steps.fastembed-portable-restore.outputs.cache-hit != 'true'"
+        if: "steps.release-proof.outputs.verified-release-merge != 'true' && steps.test-plan.outputs.rust-ci-required == 'true' && steps.fastembed-portable-restore.outputs.cache-hit != 'true'"
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.FASTEMBED_CACHE_DIR }}
           key: fastembed-bge-base-en-v1.5-q-v2
       - name: Prepare portable FastEmbed model
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+        if: "steps.release-proof.outputs.verified-release-merge != 'true' && steps.test-plan.outputs.rust-ci-required == 'true'"
         run: python3 scripts/prepare-fastembed-cache.py
       # Child jobs consume one run-scoped artifact instead of issuing five
       # concurrent cache-service restores. A cache 429 is an optimization miss,
       # not a reason to fail a prepared and locally verified model snapshot.
       - name: Publish portable FastEmbed model for this run
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+        if: "steps.release-proof.outputs.verified-release-merge != 'true' && steps.test-plan.outputs.rust-ci-required == 'true'"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}
@@ -450,7 +471,7 @@ jobs:
           if-no-files-found: error
           overwrite: true
       - name: Save portable FastEmbed model
-        if: "steps.release-proof.outputs.verified-release-merge != 'true' && (steps.filter.outputs.rust == 'true' || steps.filter.outputs.macos == 'true' || steps.filter.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request') && steps.fastembed-portable-restore.outputs.cache-hit != 'true'"
+        if: "steps.release-proof.outputs.verified-release-merge != 'true' && steps.test-plan.outputs.rust-ci-required == 'true' && steps.fastembed-portable-restore.outputs.cache-hit != 'true'"
         continue-on-error: true
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -466,7 +487,7 @@ jobs:
   fmt:
     name: fmt
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -479,7 +500,7 @@ jobs:
   lint:
     name: lint
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -511,10 +532,104 @@ jobs:
                      | .source // "PATH"')
           [[ "$SOURCE" == "PATH" ]] || { echo "ERROR: wenlan-mcp must use path dep for wenlan-types"; exit 1; }
 
+  # Compile the affected Linux workspace-lib inventory once, then fan the
+  # self-contained nextest archive out to two runners. Filterset test-name
+  # predicates are applied only by the consumers because nextest archives do
+  # not accept test predicates at build time.
+  linux-nextest-build:
+    name: linux-nextest archive
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 60 }}
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: Restore compiler inputs
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: test
+          cache-all-crates: "true"
+          cache-targets: "false"
+          save-if: "false"
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: cargo-nextest@0.9.140
+      - name: Build workspace-lib nextest archive
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
+        run: |
+          python3 scripts/ci_test_plan.py archive \
+            --plan-json "$CI_TEST_PLAN" \
+            --archive-file "$RUNNER_TEMP/wenlan-workspace-lib-${GITHUB_RUN_ID}.tar.zst"
+      - name: Publish workspace-lib nextest archive
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wenlan-workspace-lib-nextest-${{ github.run_id }}
+          path: ${{ runner.temp }}/wenlan-workspace-lib-${{ github.run_id }}.tar.zst
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
+  linux-nextest:
+    name: linux-nextest (${{ matrix.partition }})
+    needs: [detect-changes, linux-nextest-build]
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 60 }}
+    strategy:
+      fail-fast: true
+      matrix:
+        partition: [slice:1/2, slice:2/2]
+    env:
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: cargo-nextest@0.9.140
+      - name: Download workspace-lib nextest archive
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: wenlan-workspace-lib-nextest-${{ github.run_id }}
+          path: ${{ runner.temp }}/wenlan-nextest-archive
+      - name: Download portable FastEmbed model
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}
+          path: .fastembed_cache
+      - name: Run workspace-lib archive partition
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
+          CI_TEST_PARTITION: ${{ matrix.partition }}
+        run: |
+          python3 scripts/ci_test_plan.py run \
+            --suite workspace-lib \
+            --plan-json "$CI_TEST_PLAN" \
+            --archive-file "$RUNNER_TEMP/wenlan-nextest-archive/wenlan-workspace-lib-${GITHUB_RUN_ID}.tar.zst" \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --partition "$CI_TEST_PARTITION"
+
   test:
     name: test (${{ matrix.label }})
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
     runs-on: ${{ matrix.os }}
     # Pull requests keep a hard wall-clock budget. Windows needs the full
     # backstop because its Vulkan/native bootstrap plus integration suite can
@@ -524,14 +639,10 @@ jobs:
     # macos-14 (run 30684460494 was canceled at 30m17s twice, zero failures).
     timeout-minutes: ${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 45 }}
     strategy:
-      # Cancel the rest of the matrix when one OS fails. Saves ~20-30min
-      # per PR when a real bug breaks all platforms — Linux/macOS catch
-      # the same regression in 6-15min, Windows would have spent another
-      # ~30min hitting the identical failure.
+      # Cancel the sibling platform when one platform owner fails.
       fail-fast: true
-      # Built dynamically by detect-changes.test-matrix. Two Ubuntu slices
-      # divide the workspace lib suite; platform-owned paths add macOS or
-      # Windows entries without changing Linux coverage.
+      # Built dynamically by detect-changes.test-matrix. Linux fanout is owned
+      # by linux-nextest; this matrix contains only affected platform owners.
       matrix: ${{ fromJSON(needs.detect-changes.outputs.test-matrix) }}
     env:
       # Keep dev/test dependency fingerprints aligned and drop debuginfo. CI
@@ -539,9 +650,6 @@ jobs:
       # builds reuse more artifacts while trimming linker time + cache size.
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
-      # Pull requests may restore the default-branch cache but never create
-      # ref-scoped sccache entries that another PR cannot reuse.
-      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -572,31 +680,12 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Append
           "RUSTFLAGS=-C linker=$lld -C linker-flavor=lld-link" |
             Out-File -FilePath $env:GITHUB_ENV -Append
-      - name: Set up sccache
-        if: matrix.os == 'ubuntu-24.04'
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - name: Enable sccache (Linux)
-        if: matrix.os == 'ubuntu-24.04'
-        shell: bash
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: test
           cache-all-crates: "true"
-          # sccache is the single Linux owner of compiler outputs. rust-cache
-          # still restores registry/git data there, but does not duplicate
-          # target artifacts in the same 10 GB repository cache budget.
-          cache-targets: ${{ matrix.os != 'ubuntu-24.04' }}
+          cache-targets: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Verify ort-sys source pin
-        if: matrix.os == 'ubuntu-24.04'
-        run: |
-          python3 scripts/ci-observer.test.py
-          python3 scripts/ci-timed-command.test.py
-          python3 scripts/verify-ort-source-pin.test.py
-          python3 scripts/verify-ort-source-pin.py
       # Windows needs sqlite3.lib for libsql linking (libsql does not bundle
       # SQLite on Windows). vcpkg ships sqlite3 prebuilt; one-shot install
       # before any cargo step.
@@ -638,13 +727,13 @@ jobs:
           "ORT_DYLIB_PATH=$ortDll" | Out-File -FilePath $env:GITHUB_ENV -Append
           (Split-Path -Parent $ortDll) | Out-File -FilePath $env:GITHUB_PATH -Append
       # nextest runs tests as separate processes in parallel; ~2x faster
-      # than `cargo test` on multi-core runners. Install on all 3 OSes.
+      # than `cargo test` on multi-core runners. Install on both platforms.
       - name: Install cargo-nextest
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-nextest
       # detect-changes prepares one revision- and SHA-pinned snapshot before
-      # the matrix starts. Every OS downloads that run-scoped artifact without
+      # the matrix starts. Each platform downloads that run-scoped artifact without
       # contending on the repository cache API.
       - name: Download portable FastEmbed model
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -656,14 +745,8 @@ jobs:
       # Windows-specific behavior (paths, mcp_add, schtasks) is covered
       # by the Windows CLI/server integration step + the schtasks install
       # round-trip E2E further down.
-      - name: Workspace lib tests (Linux)
-        if: matrix.os == 'ubuntu-24.04'
-        env:
-          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
-          CI_TEST_PARTITION: ${{ matrix.partition }}
-        run: python3 scripts/ci_test_plan.py run --suite workspace-lib --plan-json "$CI_TEST_PLAN" --partition "$CI_TEST_PARTITION"
       - name: Workspace lib tests (macOS)
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14' && needs.detect-changes.outputs.workspace-lib-required == 'true'
         # nextest spawns one process per test by default — sidesteps the
         # ONNX atexit FFI race that required --test-threads=1 with cargo test.
         # FastEmbed initialization has its own cross-process file lock.
@@ -911,7 +994,8 @@ jobs:
           # A separate key prevents this short compile from winning the race
           # to save a partial cache before the full test matrix on main.
           shared-key: mcp-platform
-          cache-all-crates: "true"
+          cache-all-crates: "false"
+          cache-targets: "false"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Compile platform-owned MCP runtime
         if: needs.detect-changes.outputs.workspace-platform != 'true'
@@ -930,16 +1014,16 @@ jobs:
   canonical-acceptance:
     name: canonical-acceptance (ubuntu)
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.canonical-acceptance-required == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ github.event_name == 'pull_request' && 30 || 60 }}
     env:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
       SCCACHE_GHA_ENABLED: "true"
-      # Main warms the eval-harness and integration variants owned only by this
-      # lane. Pull requests restore those outputs but never write ref-local keys.
-      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+      # The compile-once Linux archive is the only main-owned Linux sccache
+      # writer. Canonical acceptance restores those objects without racing it.
+      SCCACHE_GHA_RW_MODE: READ_ONLY
       RUSTC_WRAPPER: sccache
       FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
     steps:
@@ -966,9 +1050,10 @@ jobs:
           name: fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}
           path: .fastembed_cache
       - name: Page lint scale gate (Linux time + RSS)
+        if: needs.detect-changes.outputs.canonical-smokes-required == 'true'
         run: bash scripts/lint-scale-gate.sh "$RUNNER_TEMP/task-19-memory-lint-debugger-linux.txt"
       - name: Upload Page lint scale receipt (Linux)
-        if: always()
+        if: always() && needs.detect-changes.outputs.canonical-smokes-required == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: task-19-lint-scale-ubuntu-24.04-${{ github.sha }}
@@ -976,10 +1061,12 @@ jobs:
           retention-days: 30
           if-no-files-found: error
       - name: Integration tests wenlan-cli + wenlan-server (Linux)
+        if: needs.detect-changes.outputs.cli-server-integration-required == 'true'
         env:
           CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
         run: python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json "$CI_TEST_PLAN"
       - name: Run integration tests (core) (Linux)
+        if: needs.detect-changes.outputs.core-integration-required == 'true'
         # --features eval-harness: selected eval_* targets compile to zero
         # tests without it. eval_harness.rs itself remains manual-only because
         # it requires external data or API credentials.
@@ -987,6 +1074,7 @@ jobs:
           CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
         run: python3 scripts/ci_test_plan.py run --suite core-integration --plan-json "$CI_TEST_PLAN"
       - name: E2E wenlan background on/off (Linux user-systemd)
+        if: needs.detect-changes.outputs.canonical-smokes-required == 'true'
         run: |
           set -euo pipefail
           sudo loginctl enable-linger "$(whoami)"
@@ -1026,16 +1114,17 @@ jobs:
           test "$active_state" = "inactive"
           echo "    Linux background on/off round-trip PASS"
       - name: E2E folder ingest over HTTP (Linux)
+        if: needs.detect-changes.outputs.canonical-smokes-required == 'true'
         run: bash scripts/smoke-folder-ingest.sh
       # Surface smokes ride the non-PR backstop only: each boots its own
       # daemon (~3-4 min like folder-ingest above), and the ordinary PR lane
       # holds the sub-20-minute budget from #393. /prove runs them locally
       # when a PR actually touches the CLI/MCP surface.
       - name: E2E CLI surface smoke (Linux)
-        if: github.event_name != 'pull_request'
+        if: needs.detect-changes.outputs.canonical-smokes-required == 'true' && github.event_name != 'pull_request'
         run: bash scripts/smoke-cli.sh
       - name: E2E MCP stdio surface smoke (Linux)
-        if: github.event_name != 'pull_request'
+        if: needs.detect-changes.outputs.canonical-smokes-required == 'true' && github.event_name != 'pull_request'
         run: bash scripts/smoke-mcp.sh
 
   # Build-only preflight for every shipped release target. Native/build/package
@@ -1130,12 +1219,12 @@ jobs:
         run: |
           & scripts/setup-msvc-ninja-windows.test.ps1
           & scripts/setup-msvc-ninja-windows.ps1
-      # Cargo remains serialized to cap peak native memory while Ninja owns
-      # dependency-correct ordering for llama.cpp's nested Vulkan build.
-      - name: Serialize native build (Windows)
+      # Cap Cargo at two concurrent units while Ninja keeps its own native
+      # parallelism at one for llama.cpp's memory-heavy Vulkan build.
+      - name: Bound native build concurrency (Windows)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
-        run: '"CARGO_BUILD_JOBS=1" | Out-File -FilePath $env:GITHUB_ENV -Append'
+        run: '"CARGO_BUILD_JOBS=2" | Out-File -FilePath $env:GITHUB_ENV -Append'
       # The shared build script launches each shipped executable immediately
       # after linking it. Stage load-time DLLs first; a later PATH update cannot
       # rescue process startup under Git Bash or Task Scheduler.
@@ -1166,13 +1255,13 @@ jobs:
   test-quarantine:
     name: test-quarantine
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')"
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true'
     runs-on: ubuntu-24.04
     continue-on-error: true
     env:
       CARGO_PROFILE_TEST_DEBUG: "0"
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: READ_ONLY
       RUSTC_WRAPPER: "sccache"
       FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
     steps:
@@ -1184,12 +1273,12 @@ jobs:
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # Own key — a 2-crate subset shouldn't share keys with the full
-          # `test`/`lint` caches.
-          shared-key: quarantine
+          # Reuse the required test lane's dependency inputs without producing
+          # a quarantine-specific cache or saving target artifacts.
+          shared-key: test
           cache-all-crates: "true"
           cache-targets: "false"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: "false"
       - name: Install cargo-nextest
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
@@ -1203,6 +1292,49 @@ jobs:
           path: .fastembed_cache
       - name: Quarantined tests (wenlan-mcp + wenlan-types)
         run: cargo nextest run -p wenlan-mcp -p wenlan-types
+
+  # Plugin artifacts have Rust-side consumers that are invisible to Cargo path
+  # ownership. Keep their exact contract tests required without routing a
+  # plugin-only PR through the full Rust workspace and canonical smokes.
+  plugin-rust-contract:
+    name: plugin Rust contracts
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin-rust-contract == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_RW_MODE: READ_ONLY
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - name: Restore compiler inputs
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: test
+          cache-all-crates: "true"
+          cache-targets: "false"
+          save-if: "false"
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: cargo-nextest
+      - name: Validate Claude plugin distribution
+        run: cargo nextest run -p wenlan --test distribution --no-tests=fail
+      - name: Validate cross-surface plugin distribution
+        run: cargo nextest run -p wenlan-types --test plugin_distribution --no-tests=fail
+      - name: Validate skill MCP tool references
+        run: cargo nextest run -p wenlan-mcp --lib -E 'test(/^tools::tests::skills_reference_only_live_tools$/)' --no-tests=fail
+      - name: Validate plugin release version sync
+        if: needs.detect-changes.outputs.plugin-version-contract == 'true'
+        run: cargo nextest run -p wenlan-core --lib -E 'test(/^drift_guard::version_files_are_in_sync$/)' --no-tests=fail
 
   docs:
     name: docs provenance
@@ -1229,7 +1361,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, fmt, lint, test, mcp-platform, canonical-acceptance, release-preflight, docs, plugin, npm]
+    needs: [detect-changes, fmt, lint, linux-nextest-build, linux-nextest, test, mcp-platform, canonical-acceptance, release-preflight, docs, plugin, plugin-rust-contract, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -1256,15 +1388,21 @@ jobs:
             exit 1
           fi
 
-          run_rust='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.rust == 'true' || needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request') }}'
+          run_rust='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' }}'
+          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request') }}'
+          run_workspace_lib='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true' }}'
+          run_canonical='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.canonical-acceptance-required == 'true' }}'
           expect_job fmt "$run_rust" '${{ needs.fmt.result }}'
           expect_job lint "$run_rust" '${{ needs.lint.result }}'
-          expect_job test "$run_rust" '${{ needs.test.result }}'
+          expect_job linux-nextest-build "$run_workspace_lib" '${{ needs.linux-nextest-build.result }}'
+          expect_job linux-nextest "$run_workspace_lib" '${{ needs.linux-nextest.result }}'
+          expect_job test "$run_platform" '${{ needs.test.result }}'
           expect_job mcp-platform '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.mcp-platform == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request') }}' '${{ needs.mcp-platform.result }}'
-          expect_job canonical-acceptance "$run_rust" '${{ needs.canonical-acceptance.result }}'
+          expect_job canonical-acceptance "$run_canonical" '${{ needs.canonical-acceptance.result }}'
           expect_job release-preflight '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.release-preflight == 'true') }}' '${{ needs.release-preflight.result }}'
           expect_job docs '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.docs == 'true' }}' '${{ needs.docs.result }}'
           expect_job plugin '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'
+          expect_job plugin-rust-contract '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin-rust-contract == 'true' }}' '${{ needs.plugin-rust-contract.result }}'
           expect_job npm '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.npm == 'true' }}' '${{ needs.npm.result }}'
 
   plugin:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,17 +59,18 @@ jobs:
           # Coverage builds with `-C instrument-coverage`, so artifacts are not
           # interchangeable with the `clippy` or `test` caches in ci.yml.
           shared-key: coverage
+          cache-targets: "false"
+          cache-all-crates: "false"
           # Manual feature-branch runs may restore main's cache but must not
           # create branch-scoped entries that no other ref can reuse.
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Cache fastembed model (Linux)
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      - name: Restore portable FastEmbed model
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.FASTEMBED_CACHE_DIR }}
-          key: fastembed-bge-base-en-v1.5-q-v2
-          restore-keys: |
-            fastembed-bge-base-en-v1.5-q-
+          key: fastembed-bge-base-en-v1.5-q-v3-portable
+          enableCrossOsArchive: "true"
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2

--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -43,13 +43,12 @@ jobs:
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-nextest
-      - name: Restore fastembed model
+      - name: Restore portable FastEmbed model
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.FASTEMBED_CACHE_DIR }}
-          key: fastembed-bge-base-en-v1.5-q-v2
-          restore-keys: |
-            fastembed-bge-base-en-v1.5-q-
+          key: fastembed-bge-base-en-v1.5-q-v3-portable
+          enableCrossOsArchive: "true"
       - name: Run embedding-only eval
         env:
           EVAL_BASELINES_DIR: ${{ runner.temp }}/origin-eval-canary

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,15 @@
 name: Release Please
 
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-please-main
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -10,6 +17,11 @@ permissions:
 
 jobs:
   release-please:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
@@ -18,6 +30,7 @@ jobs:
           # No release-type input — setting it makes the action ignore config-file.
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
+          target-branch: main
           # GITHUB_TOKEN events don't trigger other workflows (GitHub security policy).
           # A fine-grained PAT with contents:write lets the tag push trigger release.yml.
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,10 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-release.outputs.release-targets) }}
     runs-on: ${{ matrix.os }}
+    # Windows native release builds are deliberately bounded more generously;
+    # all other targets should fail closed instead of occupying a runner after
+    # an unexpected toolchain or linker hang.
+    timeout-minutes: ${{ matrix.target == 'x86_64-pc-windows-msvc' && 90 || 60 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -216,6 +220,67 @@ jobs:
           toolchain: 1.95.0
           targets: ${{ matrix.target }}
 
+      - name: Stabilize Windows Rust cache toolchain inputs
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: bash
+        run: bash scripts/stabilize-rust-cache-toolchains.sh
+
+      # rust-lld shipped with the Rust toolchain (~3-5min faster link
+      # than MSVC link.exe on our binary sizes). rustup does NOT proxy
+      # rust-lld, so its path must be discovered via `rustc --print
+      # sysroot`. Export the Cargo target linker for host build scripts plus
+      # RUSTFLAGS for target artifacts via $GITHUB_ENV so the Bash build step
+      # cannot resolve Git for Windows' unrelated usr/bin/link.exe.
+      - name: Configure rust-lld linker (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $sysroot = (rustc --print sysroot).Trim()
+          $lld = Join-Path $sysroot "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
+          if (-not (Test-Path $lld)) {
+            Write-Host "rust-lld.exe not found at $lld, listing sysroot:"
+            Get-ChildItem -Recurse -Filter rust-lld.exe -Path $sysroot
+            throw "rust-lld.exe missing"
+          }
+          $rustflags = "-C linker=$lld -C linker-flavor=lld-link"
+          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$lld" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+          "RUSTFLAGS=$rustflags" | Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "RUSTFLAGS=$rustflags"
+
+      - name: Select native Perl for vendored OpenSSL
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $nativePerl = $null
+          foreach ($candidate in Get-Command perl.exe -CommandType Application -All) {
+            if ($candidate.Source -match '[\\/]Git[\\/]') {
+              continue
+            }
+            & $candidate.Source "-MLocale::Maketext::Simple" "-e" "1"
+            if ($LASTEXITCODE -eq 0) {
+              $nativePerl = $candidate.Source
+              break
+            }
+          }
+          if (-not $nativePerl) {
+            throw "No native Perl can load Locale::Maketext::Simple"
+          }
+          "OPENSSL_SRC_PERL=$nativePerl" |
+            Out-File -FilePath $env:GITHUB_ENV -Append
+          Write-Host "OPENSSL_SRC_PERL=$nativePerl"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: release-${{ matrix.target }}
+          # Only Windows carries the costly coherent native Cargo target tree.
+          # Tag releases consume the main-owned preflight cache but never write
+          # a competing entry or evict ordinary CI caches.
+          cache-all-crates: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
+          cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
+          save-if: "false"
+
       # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
       # time and does not bundle SQLite on Windows. Mirrors ci.yml's test
       # step. GitHub `windows-2022` runner ships vcpkg preinstalled.
@@ -245,64 +310,13 @@ jobs:
         run: |
           & scripts/setup-msvc-ninja-windows.ps1
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: release-${{ matrix.target }}
-          cache-all-crates: "true"
-          # Keep the rare tag build from evicting ordinary CI caches. Every
-          # target still builds; only the costly Windows target is persisted.
-          cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
-
-      # rust-lld shipped with the Rust toolchain (~3-5min faster link
-      # than MSVC link.exe on our binary sizes). rustup does NOT proxy
-      # rust-lld, so its path must be discovered via `rustc --print
-      # sysroot`. Export the Cargo target linker for host build scripts plus
-      # RUSTFLAGS for target artifacts via $GITHUB_ENV so the Bash build step
-      # cannot resolve Git for Windows' unrelated usr/bin/link.exe.
-      - name: Configure rust-lld linker (Windows)
+      # Cargo may overlap two independent package builds. The setup step keeps
+      # nested CMake at one worker so concurrent MSVC shader probes cannot race
+      # while writing the same PDB.
+      - name: Cap Windows Cargo parallelism
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
-        run: |
-          $sysroot = (rustc --print sysroot).Trim()
-          $lld = Join-Path $sysroot "lib/rustlib/x86_64-pc-windows-msvc/bin/rust-lld.exe"
-          if (-not (Test-Path $lld)) {
-            Write-Host "rust-lld.exe not found at $lld, listing sysroot:"
-            Get-ChildItem -Recurse -Filter rust-lld.exe -Path $sysroot
-            throw "rust-lld.exe missing"
-          }
-          $rustflags = "-C linker=$lld -C linker-flavor=lld-link"
-          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$lld" |
-            Out-File -FilePath $env:GITHUB_ENV -Append
-          "RUSTFLAGS=$rustflags" | Out-File -FilePath $env:GITHUB_ENV -Append
-          Write-Host "RUSTFLAGS=$rustflags"
-
-      - name: Serialize native build (Windows)
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: '"CARGO_BUILD_JOBS=1" | Out-File -FilePath $env:GITHUB_ENV -Append'
-
-      - name: Select native Perl for vendored OpenSSL
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        shell: pwsh
-        run: |
-          $nativePerl = $null
-          foreach ($candidate in Get-Command perl.exe -CommandType Application -All) {
-            if ($candidate.Source -match '[\\/]Git[\\/]') {
-              continue
-            }
-            & $candidate.Source "-MLocale::Maketext::Simple" "-e" "1"
-            if ($LASTEXITCODE -eq 0) {
-              $nativePerl = $candidate.Source
-              break
-            }
-          }
-          if (-not $nativePerl) {
-            throw "No native Perl can load Locale::Maketext::Simple"
-          }
-          "OPENSSL_SRC_PERL=$nativePerl" |
-            Out-File -FilePath $env:GITHUB_ENV -Append
-          Write-Host "OPENSSL_SRC_PERL=$nativePerl"
+        run: '"CARGO_BUILD_JOBS=2" | Out-File -FilePath $env:GITHUB_ENV -Append'
 
       # CI release-preflight and the authoritative tag build share this exact
       # shipped-binary build/smoke contract. Packaging and publishing remain
@@ -462,7 +476,10 @@ jobs:
 
   docker:
     name: Build & Push Docker Image (${{ matrix.platform }})
-    needs: release
+    # Build architecture images alongside the binary matrix. If a binary leg
+    # fails, orphaned version-suffixed staging tags are accepted; the manifest
+    # job below still withholds the public version and latest tags.
+    needs: prepare-release
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
@@ -511,7 +528,7 @@ jobs:
 
   docker-manifest:
     name: Combine Docker Manifest (multi-arch)
-    needs: docker
+    needs: [docker, release]
     runs-on: ubuntu-24.04
     permissions:
       packages: write

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -3806,7 +3806,6 @@ jobs:
         "expected-vs-actual",
         "unnecessarily serialized",
         "dev/test artifact reuse",
-        "compiler-cache lane",
         "cache writes",
         "reusable target cache",
         "restore-only target-free rust-cache",

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -121,10 +121,10 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
     const CACHE_KEY: &str = "fastembed-bge-base-en-v1.5-q-v3-portable";
     const ARTIFACT_NAME: &str = "fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}";
     const JOBS: &[(&str, &[&str])] = &[
+        ("linux-nextest", &["Run workspace-lib archive partition"]),
         (
             "test",
             &[
-                "Workspace lib tests (Linux)",
                 "Workspace lib tests (macOS)",
                 "Integration tests wenlan-cli + wenlan-server (Windows)",
             ],
@@ -264,19 +264,34 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
     {
         violations.push("detect-changes does not run the pinned FastEmbed preparer".into());
     }
+    let rust_ci_condition = "steps.release-proof.outputs.verified-release-merge != 'true' && steps.test-plan.outputs.rust-ci-required == 'true'";
     for name in [
         "Restore portable FastEmbed model",
         "Prepare portable FastEmbed model",
         "Publish portable FastEmbed model for this run",
+    ] {
+        let condition = detect_index(name)
+            .and_then(|index| detect_steps.get(index).copied())
+            .and_then(|step| step["if"].as_str());
+        if condition != Some(rust_ci_condition) {
+            violations.push(format!(
+                "detect-changes {name:?} is not gated by the canonical rust-ci-required planner output"
+            ));
+        }
+    }
+    let cache_miss_condition = format!(
+        "{rust_ci_condition} && steps.fastembed-portable-restore.outputs.cache-hit != 'true'"
+    );
+    for name in [
+        "Restore legacy Linux FastEmbed model",
         "Save portable FastEmbed model",
     ] {
         let condition = detect_index(name)
             .and_then(|index| detect_steps.get(index).copied())
-            .and_then(|step| step["if"].as_str())
-            .unwrap_or_default();
-        if !condition.contains("startsWith(github.head_ref, 'release-please--branches--')") {
+            .and_then(|step| step["if"].as_str());
+        if condition != Some(cache_miss_condition.as_str()) {
             violations.push(format!(
-                "detect-changes {name:?} can skip the release-please full-proof path"
+                "detect-changes {name:?} is not gated by rust-ci-required plus the portable-cache miss"
             ));
         }
     }
@@ -330,10 +345,10 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
 }
 
 fn coverage_fastembed_cache_violations(workflow: &str) -> Vec<String> {
-    const CACHE_STEP: &str = "Cache fastembed model (Linux)";
+    const CACHE_STEP: &str = "Restore portable FastEmbed model";
     const CACHE_DIR: &str = "${{ github.workspace }}/.fastembed_cache";
     const CACHE_PATH: &str = "${{ env.FASTEMBED_CACHE_DIR }}";
-    const CACHE_KEY: &str = "fastembed-bge-base-en-v1.5-q-v2";
+    const CACHE_KEY: &str = "fastembed-bge-base-en-v1.5-q-v3-portable";
 
     let parsed: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse coverage.yml");
     let mut violations = Vec::new();
@@ -372,6 +387,21 @@ fn coverage_fastembed_cache_violations(workflow: &str) -> Vec<String> {
             "coverage uses FastEmbed cache key {actual_key:?}, expected {CACHE_KEY:?}"
         ));
     }
+    if cache_step["uses"]
+        .as_str()
+        .is_none_or(|uses| !uses.starts_with("actions/cache/restore@"))
+        || cache_step["with"]["enableCrossOsArchive"].as_str() != Some("true")
+    {
+        violations
+            .push("coverage does not restore the cross-OS portable FastEmbed v3 cache".into());
+    }
+    if steps.iter().any(|step| {
+        step["uses"].as_str().is_some_and(|uses| {
+            uses.starts_with("actions/cache/save@") || uses == "actions/cache@v4"
+        })
+    }) {
+        violations.push("coverage contains a FastEmbed cache writer".into());
+    }
 
     violations
 }
@@ -383,6 +413,13 @@ fn coverage_single_test_execution_violations(workflow: &str) -> Vec<String> {
     let mut violations = Vec::new();
     if rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some(main_owned_cache) {
         violations.push("coverage cache writes are not restricted to main".into());
+    }
+    if rust_cache.and_then(|step| step["with"]["cache-all-crates"].as_str()) != Some("false")
+        || rust_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some("false")
+    {
+        violations.push(
+            "coverage rust-cache footprint must exclude crates.io and instrumented targets".into(),
+        );
     }
     let Some(run) = parsed["jobs"]["coverage"]["steps"]
         .as_sequence()
@@ -481,10 +518,37 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     if rust_cache.is_none() {
         violations.push("release job removed its target-level rust-cache fallback".into());
     }
-    if rust_cache.and_then(|step| step["with"]["cache-targets"].as_str())
-        != Some("${{ matrix.target == 'x86_64-pc-windows-msvc' }}")
+    let windows_only = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
+    if rust_cache.and_then(|step| step["with"]["shared-key"].as_str())
+        != Some("release-${{ matrix.target }}")
+        || rust_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
+            != Some(windows_only)
+        || rust_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some(windows_only)
+        || rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
     {
-        violations.push("release target cache is not capacity-bounded to Windows".into());
+        violations.push(
+            "release target cache is not restore-only, target-scoped, and capacity-bounded to Windows"
+                .into(),
+        );
+    }
+    let stabilizer_index = steps.iter().position(|step| {
+        step["name"].as_str() == Some("Stabilize Windows Rust cache toolchain inputs")
+    });
+    let cache_index = steps.iter().position(|step| {
+        step["uses"]
+            .as_str()
+            .is_some_and(|uses| uses.contains("Swatinem/rust-cache"))
+    });
+    if !matches!((stabilizer_index, cache_index), (Some(stabilizer), Some(cache)) if stabilizer < cache)
+    {
+        violations.push(
+            "release does not stabilize Windows toolchain inputs before cache restore".into(),
+        );
+    }
+    if parsed["jobs"]["release"]["timeout-minutes"].as_str()
+        != Some("${{ matrix.target == 'x86_64-pc-windows-msvc' && 90 || 60 }}")
+    {
+        violations.push("release build matrix has no bounded 90/60-minute timeout".into());
     }
 
     violations
@@ -564,13 +628,20 @@ jobs:
   coverage:
     env: {}
     steps:
-      - name: Cache fastembed model (Linux)
+      - name: Restore portable FastEmbed model
+        uses: actions/cache@v4
         with:
           path: ~/.local/share/wenlan/memorydb/fastembed_cache
           key: fastembed-bge-base-en-v1.5-q-v1
 "#;
     let violations = coverage_fastembed_cache_violations(workflow);
-    for expected in ["FASTEMBED_CACHE_DIR", "coverage caches", "cache key"] {
+    for expected in [
+        "FASTEMBED_CACHE_DIR",
+        "coverage caches",
+        "cache key",
+        "cross-OS portable FastEmbed v3",
+        "FastEmbed cache writer",
+    ] {
         assert!(
             violations
                 .iter()
@@ -607,7 +678,12 @@ jobs:
           cargo llvm-cov --package wenlan-core --summary-only
 "#;
     let violations = coverage_single_test_execution_violations(workflow);
-    for expected in ["cache writes", "exactly once", "report-only commands"] {
+    for expected in [
+        "cache writes",
+        "rust-cache footprint",
+        "exactly once",
+        "report-only commands",
+    ] {
         assert!(
             violations
                 .iter()
@@ -652,11 +728,108 @@ jobs:
         "depends on sccache",
         "rust-cache fallback",
         "capacity-bounded",
+        "stabilize Windows toolchain inputs",
+        "90/60-minute timeout",
     ] {
         assert!(
             violations
                 .iter()
                 .any(|violation| violation.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
+fn release_please_trigger_violations(workflow: &str) -> Vec<String> {
+    let parsed: serde_yaml::Value =
+        serde_yaml::from_str(workflow).unwrap_or(serde_yaml::Value::Null);
+    let mut violations = Vec::new();
+    let workflows = parsed["on"]["workflow_run"]["workflows"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_yaml::Value::as_str)
+        .collect::<Vec<_>>();
+    let types = parsed["on"]["workflow_run"]["types"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_yaml::Value::as_str)
+        .collect::<Vec<_>>();
+    let branches = parsed["on"]["workflow_run"]["branches"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_yaml::Value::as_str)
+        .collect::<Vec<_>>();
+    if workflows != ["CI"] || types != ["completed"] || branches != ["main"] {
+        violations.push(
+            "release-please is not triggered by completed main-branch CI workflow runs".into(),
+        );
+    }
+    let trigger_names = parsed["on"]
+        .as_mapping()
+        .into_iter()
+        .flatten()
+        .filter_map(|(name, _)| name.as_str())
+        .collect::<BTreeSet<_>>();
+    if trigger_names != BTreeSet::from(["workflow_dispatch", "workflow_run"])
+        || parsed["on"].get("push").is_some()
+    {
+        violations.push("release-please retains a direct push trigger or an extra trigger".into());
+    }
+    let condition = parsed["jobs"]["release-please"]["if"]
+        .as_str()
+        .unwrap_or_default();
+    for required in [
+        "github.event_name == 'workflow_dispatch'",
+        "github.event.workflow_run.event == 'push'",
+        "github.event.workflow_run.head_branch == 'main'",
+        "github.event.workflow_run.conclusion == 'success'",
+    ] {
+        if !condition.contains(required) {
+            violations.push(format!(
+                "release-please job condition omits successful main push CI proof {required:?}"
+            ));
+        }
+    }
+    violations
+}
+
+#[test]
+fn release_please_runs_only_after_successful_main_push_ci() {
+    let workflow =
+        std::fs::read_to_string(repo_root().join(".github/workflows/release-please.yml"))
+            .expect("read release-please.yml");
+    let violations = release_please_trigger_violations(&workflow);
+    assert!(
+        violations.is_empty(),
+        "release-please trigger drift — automatic release bookkeeping must run only after the \
+         successful CI workflow for a main push. Fix .github/workflows/release-please.yml; an \
+         intentional contract change also updates release_please_trigger_violations() and its \
+         positive control:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn release_please_trigger_rejects_direct_or_failed_pushes() {
+    let workflow = r#"
+on:
+  push:
+    branches: [main]
+jobs:
+  release-please:
+    if: github.ref == 'refs/heads/main'
+"#;
+    let violations = release_please_trigger_violations(workflow);
+    for expected in [
+        "completed main-branch CI",
+        "direct push trigger",
+        "successful main push CI proof",
+    ] {
+        assert!(
+            violations.iter().any(|item| item.contains(expected)),
             "fixture must exercise {expected:?}: {violations:?}"
         );
     }
@@ -803,7 +976,7 @@ jobs:
     env:
       FASTEMBED_CACHE_DIR: /tmp/wrong-fastembed-cache
     steps:
-      - name: Workspace lib tests (Linux)
+      - name: Workspace lib tests (macOS)
         run: export WENLAN_TEST_FASTEMBED_CACHE=/tmp/stale-cache
       - name: Download portable FastEmbed model
         uses: actions/download-artifact@bad
@@ -1310,7 +1483,8 @@ fn windows_ort_distribution_violations(
         violations.push("PR CI does not build, stage, and exercise dynamic ORT on Windows".into());
     }
 
-    let source_pin = workflow_step_run(&ci, "Verify ort-sys source pin").unwrap_or_default();
+    let source_pin =
+        workflow_step_run(&ci, "Verify CI observer and ORT contracts").unwrap_or_default();
     if !source_pin.contains("scripts/verify-ort-source-pin.py") {
         violations.push("PR CI does not verify the actual crates.io ort-sys source pin".into());
     }
@@ -1917,6 +2091,7 @@ fn filter_routes_path(patterns: &BTreeSet<String>, path: &str) -> bool {
 
 fn ci_routing_contract_violations(
     workflow: &str,
+    planner_source: &str,
     platform_sensitive_paths: &[(String, &'static str, &'static str)],
     release_profile_sensitive_paths: &[String],
 ) -> Vec<String> {
@@ -1924,6 +2099,8 @@ fn ci_routing_contract_violations(
     let mut violations = Vec::new();
 
     for output in [
+        "plugin-rust-contract",
+        "plugin-version-contract",
         "macos",
         "windows",
         "windows-lint",
@@ -1931,6 +2108,12 @@ fn ci_routing_contract_violations(
         "mcp-platform",
         "workspace-platform",
         "test-plan",
+        "workspace-lib-required",
+        "cli-server-integration-required",
+        "core-integration-required",
+        "canonical-smokes-required",
+        "canonical-acceptance-required",
+        "rust-ci-required",
     ] {
         if ci["jobs"]["detect-changes"]["outputs"][output]
             .as_str()
@@ -1952,7 +2135,15 @@ fn ci_routing_contract_violations(
     if !impact_paths.contains("**") {
         violations.push("impact routing is not a fail-closed repository catch-all".into());
     }
-    let planner_test = job_step(&ci, "detect-changes", "Test CI impact planner")
+    let universal_planner_condition =
+        "steps.release-proof.outputs.verified-release-merge != 'true'";
+    let planner_setup = job_step(
+        &ci,
+        "detect-changes",
+        "Set up Rust for affected-test planning",
+    );
+    let planner_test_step = job_step(&ci, "detect-changes", "Test CI impact planner");
+    let planner_test = planner_test_step
         .and_then(|step| step["run"].as_str())
         .unwrap_or_default();
     if planner_test != "python3 scripts/ci_test_plan.test.py" {
@@ -1971,6 +2162,39 @@ fn ci_routing_contract_violations(
     let planner_condition = planner
         .and_then(|step| step["if"].as_str())
         .unwrap_or_default();
+    let detect_steps = ci["jobs"]["detect-changes"]["steps"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let detect_step_index = |name: &str| {
+        detect_steps
+            .iter()
+            .position(|step| step["name"].as_str() == Some(name))
+    };
+    let planner_order = (
+        detect_step_index("Set up Rust for affected-test planning"),
+        detect_step_index("Test CI impact planner"),
+        detect_step_index("Plan affected Rust tests"),
+    );
+    if planner_setup.and_then(|step| step["if"].as_str()) != Some(universal_planner_condition)
+        || planner_setup
+            .and_then(|step| step["uses"].as_str())
+            .is_none_or(|uses| !uses.starts_with("dtolnay/rust-toolchain@"))
+        || planner_setup.and_then(|step| step["with"]["toolchain"].as_str()) != Some("1.95.0")
+        || planner_test_step.and_then(|step| step["if"].as_str())
+            != Some(universal_planner_condition)
+        || planner_condition != universal_planner_condition
+        || planner_setup.is_some_and(|step| step.get("continue-on-error").is_some())
+        || planner_test_step.is_some_and(|step| step.get("continue-on-error").is_some())
+        || planner.is_some_and(|step| step.get("continue-on-error").is_some())
+        || !matches!(planner_order, (Some(setup), Some(test), Some(plan)) if setup < test && test < plan)
+    {
+        violations.push(
+            "affected-test planner setup/tests/plan do not run in order on every non-reused CI run"
+                .into(),
+        );
+    }
     if planner.and_then(|step| step["id"].as_str()) != Some("test-plan")
         || !planner_run.contains("cargo metadata --format-version 1 --locked --no-deps")
         || !planner_run.contains("python3 scripts/ci_test_plan.py plan")
@@ -1979,12 +2203,74 @@ fn ci_routing_contract_violations(
         || !planner_run.contains("--github-output \"$GITHUB_OUTPUT\"")
         || changed_files != "${{ steps.filter.outputs.impact_files }}"
         || event_name != "${{ github.event_name }}"
-        || !planner_condition.contains("startsWith(github.head_ref, 'release-please--branches--')")
     {
         violations.push(
             "detect-changes does not derive its test plan from Cargo metadata and the complete changed-file inventory"
                 .into(),
         );
+    }
+    for output in [
+        "test-plan",
+        "workspace-lib-required",
+        "cli-server-integration-required",
+        "core-integration-required",
+        "canonical-smokes-required",
+        "canonical-acceptance-required",
+        "rust-ci-required",
+    ] {
+        let expected = format!("${{{{ steps.test-plan.outputs.{output} }}}}");
+        if ci["jobs"]["detect-changes"]["outputs"][output].as_str() != Some(expected.as_str()) {
+            violations.push(format!(
+                "detect-changes output {output} does not come from the canonical test planner"
+            ));
+        }
+    }
+
+    let rust_ci_formula = r#"    required["rust-ci-required"] = (
+        required["workspace-lib-required"]
+        or required["canonical-acceptance-required"]
+    )"#;
+    if !planner_source.contains(rust_ci_formula) {
+        violations.push(
+            "planner rust-ci-required output is not the union of every required Rust suite".into(),
+        );
+    }
+    let plugin_owner = planner_source.find("if _plugin_job_owns(path):");
+    let npm_owner = planner_source.find("if _npm_job_owns(path):");
+    let docs_owner = planner_source.find("if _docs_job_owns(path):");
+    let cargo_owner = planner_source.find("owner = _owner(path, directories)");
+    let fast_owner_order = matches!(
+        (plugin_owner, npm_owner, docs_owner, cargo_owner),
+        (Some(plugin), Some(npm), Some(docs), Some(cargo))
+            if plugin < npm && npm < docs && docs < cargo
+    );
+    for required in [
+        "PLUGIN_JOB_PREFIXES = (",
+        "PLUGIN_JOB_FILES = {",
+        "DOCS_JOB_PREFIXES = (\"docs\",)",
+        "DOCS_JOB_FILES = {",
+        "def _npm_job_owns(path: str) -> bool:",
+        "return len(parts) >= 4 and parts[0] == \"crates\" and parts[2] == \"npm\"",
+        "def _rust_fixture_owns(path: str) -> bool:",
+        "return path.endswith(\".md\") and not _rust_fixture_owns(path)",
+    ] {
+        if !planner_source.contains(required) {
+            violations.push(format!(
+                "planner non-Rust fast-owner contract omits {required:?}"
+            ));
+        }
+    }
+    if !fast_owner_order {
+        violations
+            .push("planner non-Rust fast owners do not run before Cargo ownership fallback".into());
+    }
+    let unknown_owner = planner_source.find("if owner is None:");
+    let unknown_full = planner_source.find("return _full_plan(f\"unowned changed path: {path}\")");
+    if !matches!(
+        (cargo_owner, unknown_owner, unknown_full),
+        (Some(owner), Some(unknown), Some(full)) if owner < unknown && unknown < full
+    ) {
+        violations.push("planner unknown paths do not fail closed into the full Rust plan".into());
     }
 
     let rust_paths = detect_change_filter_paths(&ci, "rust");
@@ -2004,11 +2290,64 @@ fn ci_routing_contract_violations(
             "coverage workflow cannot bootstrap its FastEmbed cache contract through rust".into(),
         );
     }
+    if !rust_paths.contains(".github/workflows/release-please.yml") {
+        violations.push(
+            "release-please workflow cannot bootstrap its post-CI trigger contract through rust"
+                .into(),
+        );
+    }
     if !rust_paths.contains("clippy.toml") {
         violations.push(
             "clippy configuration cannot bootstrap its syntax-aware FastEmbed guard through rust"
                 .into(),
         );
+    }
+    for plugin_tree in [
+        "plugin/**",
+        "plugin-codex/**",
+        ".agents/plugins/**",
+        ".claude-plugin/**",
+        "plugin-contract.json",
+    ] {
+        if rust_paths.contains(plugin_tree) {
+            violations.push(format!(
+                "broad rust routing still claims plugin-only tree {plugin_tree}"
+            ));
+        }
+    }
+    let plugin_rust_contract = detect_change_filter_paths(&ci, "plugin-rust-contract");
+    let expected_plugin_rust_contract = BTreeSet::from([
+        ".agents/plugins/**".to_string(),
+        ".claude-plugin/**".to_string(),
+        "plugin-contract.json".to_string(),
+        "plugin-codex/**".to_string(),
+        "plugin/**".to_string(),
+    ]);
+    if plugin_rust_contract != expected_plugin_rust_contract {
+        violations.push(format!(
+            "plugin-rust-contract routing drifted: {plugin_rust_contract:?}"
+        ));
+    }
+    let expected_plugin = BTreeSet::from([
+        ".agents/plugins/**".to_string(),
+        ".claude-plugin/**".to_string(),
+        "plugin-contract.json".to_string(),
+        "plugin-codex/**".to_string(),
+        "plugin/**".to_string(),
+        "scripts/validate-codex-plugin-slice.py".to_string(),
+        "scripts/validate-plugin-contract.py".to_string(),
+        "scripts/validate-plugin-contract.test.sh".to_string(),
+    ]);
+    if detect_change_filter_paths(&ci, "plugin") != expected_plugin {
+        violations.push("plugin fast-owner routing is not exact".into());
+    }
+    if detect_change_filter_paths(&ci, "plugin-version-contract")
+        != BTreeSet::from(["plugin/.claude-plugin/plugin.json".to_string()])
+    {
+        violations.push("plugin version routing is not exact".into());
+    }
+    if detect_change_filter_paths(&ci, "npm") != BTreeSet::from(["crates/*/npm/**".to_string()]) {
+        violations.push("npm fast-owner routing is not exact".into());
     }
     let windows_paths = detect_change_filter_paths(&ci, "windows");
     let macos_paths = detect_change_filter_paths(&ci, "macos");
@@ -2188,78 +2527,76 @@ fn ci_routing_contract_violations(
             ));
         }
     }
-    let setup_sccache = job_step(&ci, "test", "Set up sccache");
-    let setup_condition = setup_sccache
-        .and_then(|step| step["if"].as_str())
-        .unwrap_or_default();
-    let enable_sccache = job_step(&ci, "test", "Enable sccache (Linux)");
-    let enable_condition = enable_sccache
-        .and_then(|step| step["if"].as_str())
-        .unwrap_or_default();
-    let enable_run = enable_sccache
-        .and_then(|step| step["run"].as_str())
-        .unwrap_or_default();
-    if setup_condition != "matrix.os == 'ubuntu-24.04'"
-        || enable_condition != "matrix.os == 'ubuntu-24.04'"
-        || !enable_run.contains("SCCACHE_GHA_ENABLED=true")
-        || !enable_run.contains("RUSTC_WRAPPER=sccache")
+    if job_step_using(&ci, "test", "sccache-action").is_some()
         || ci["jobs"]["test"]["env"]["RUSTC_WRAPPER"].as_str() == Some("sccache")
+        || ci["jobs"]["test"]["env"]["SCCACHE_GHA_RW_MODE"]
+            .as_str()
+            .is_some()
     {
-        violations.push(
-            "test matrix does not restrict sccache reads/writes to the proven Linux lane".into(),
-        );
+        violations.push("platform test matrix still owns a compiler-cache lane".into());
     }
     let main_owned_cache = "${{ github.ref == 'refs/heads/main' }}";
-    for job in [
-        "lint",
-        "test",
-        "mcp-platform",
-        "test-quarantine",
-        "release-preflight",
-    ] {
+    for job in ["lint", "test", "mcp-platform", "release-preflight"] {
         let rust_cache = job_step_using(&ci, job, "Swatinem/rust-cache");
         if rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some(main_owned_cache) {
             violations.push(format!("{job} cache writes are not restricted to main"));
         }
     }
     let test_rust_cache = job_step_using(&ci, "test", "Swatinem/rust-cache");
-    if test_rust_cache.and_then(|step| step["with"]["cache-targets"].as_str())
-        != Some("${{ matrix.os != 'ubuntu-24.04' }}")
-    {
-        violations.push("Linux sccache lane duplicates target artifacts in rust-cache".into());
+    if test_rust_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some("true") {
+        violations.push("platform test matrix does not retain its reusable target cache".into());
     }
     let quarantine_rust_cache = job_step_using(&ci, "test-quarantine", "Swatinem/rust-cache");
-    if quarantine_rust_cache.and_then(|step| step["with"]["cache-targets"].as_str())
-        != Some("false")
+    if quarantine_rust_cache.and_then(|step| step["with"]["shared-key"].as_str()) != Some("test")
+        || quarantine_rust_cache.and_then(|step| step["with"]["cache-targets"].as_str())
+            != Some("false")
+        || quarantine_rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
     {
-        violations.push("test-quarantine duplicates sccache target artifacts in rust-cache".into());
+        violations.push(
+            "test-quarantine does not reuse test inputs through a restore-only target-free rust-cache"
+                .into(),
+        );
     }
-    let sccache_mode = "${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}";
-    for job in ["test", "test-quarantine"] {
-        if ci["jobs"][job]["env"]["SCCACHE_GHA_RW_MODE"].as_str() != Some(sccache_mode) {
-            violations.push(format!("{job} sccache PR mode is not read-only"));
+    for job in [
+        "canonical-acceptance",
+        "test-quarantine",
+        "plugin-rust-contract",
+    ] {
+        if ci["jobs"][job]["env"]["SCCACHE_GHA_RW_MODE"].as_str() != Some("READ_ONLY") {
+            violations.push(format!("{job} sccache mode is not read-only"));
         }
     }
-    for job in ["fmt", "lint", "test", "test-quarantine"] {
-        let condition = ci["jobs"][job]["if"].as_str().unwrap_or_default();
-        for required in [
-            "needs.detect-changes.outputs.rust",
-            "needs.detect-changes.outputs.macos",
-            "needs.detect-changes.outputs.windows",
-            "startsWith(github.head_ref, 'release-please--branches--')",
-            "github.event_name != 'pull_request'",
-        ] {
-            if !condition.contains(required) {
-                violations.push(format!(
-                    "{job} condition omits CI scheduling trigger {required}"
-                ));
-            }
-        }
-        if condition.contains("github.event.head_commit.message") {
+    let rust_ci_job_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true'";
+    for job in ["fmt", "lint", "test-quarantine"] {
+        if ci["jobs"][job]["if"].as_str() != Some(rust_ci_job_condition) {
             violations.push(format!(
-                "{job} can skip a non-PR full backstop based on the head commit message"
+                "required Rust job {job} does not derive exactly from rust-ci-required"
             ));
         }
+    }
+    let platform_condition = ci["jobs"]["test"]["if"].as_str().unwrap_or_default();
+    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request')";
+    if platform_condition != expected_platform_condition {
+        violations.push(
+            "platform test job does not derive from rust-ci-required plus its platform owner"
+                .into(),
+        );
+    }
+    for required in [
+        "needs.detect-changes.outputs.rust-ci-required",
+        "needs.detect-changes.outputs.macos",
+        "needs.detect-changes.outputs.windows",
+        "startsWith(github.head_ref, 'release-please--branches--')",
+        "github.event_name != 'pull_request'",
+    ] {
+        if !platform_condition.contains(required) {
+            violations.push(format!(
+                "test condition omits platform scheduling trigger {required}"
+            ));
+        }
+    }
+    if platform_condition.contains("needs.detect-changes.outputs.rust == 'true'") {
+        violations.push("platform test matrix is still scheduled by broad Rust ownership".into());
     }
 
     let matrix_run = ci["jobs"]["detect-changes"]["steps"]
@@ -2273,7 +2610,6 @@ fn ci_routing_contract_violations(
         "github.event_name",
         "pull_request",
         "startsWith(github.head_ref, 'release-please--branches--')",
-        "ubuntu-24.04",
         "steps.filter.outputs.macos",
         "steps.filter.outputs.windows",
     ] {
@@ -2282,6 +2618,9 @@ fn ci_routing_contract_violations(
                 "dynamic OS matrix is missing differential/backstop routing marker {required:?}"
             ));
         }
+    }
+    if matrix_run.contains("ubuntu-24.04") {
+        violations.push("dynamic platform matrix still contains a duplicate Linux compiler".into());
     }
 
     let conclusion_run =
@@ -2293,7 +2632,7 @@ fn ci_routing_contract_violations(
         );
     }
     for required in [
-        "needs.detect-changes.outputs.rust",
+        "needs.detect-changes.outputs.rust-ci-required",
         "needs.detect-changes.outputs.macos",
         "needs.detect-changes.outputs.windows",
         "startsWith(github.head_ref, 'release-please--branches--')",
@@ -2305,6 +2644,19 @@ fn ci_routing_contract_violations(
             ));
         }
     }
+    let run_rust = "run_rust='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' }}'";
+    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name != 'pull_request') }}'";
+    for (name, expected) in [("run_rust", run_rust), ("run_platform", run_platform)] {
+        if !conclusion_run
+            .lines()
+            .map(str::trim)
+            .any(|line| line == expected)
+        {
+            violations.push(format!(
+                "conclusion {name} does not derive exactly from rust-ci-required"
+            ));
+        }
+    }
     if conclusion_run.contains("github.event.head_commit.message") {
         violations.push(
             "conclusion can accept skipped non-PR backstops based on the head commit message"
@@ -2312,7 +2664,14 @@ fn ci_routing_contract_violations(
         );
     }
     let conclusion_needs = job_needs(&ci, "conclusion");
-    for job in ["mcp-platform", "release-preflight"] {
+    for job in [
+        "linux-nextest-build",
+        "linux-nextest",
+        "mcp-platform",
+        "canonical-acceptance",
+        "release-preflight",
+        "plugin-rust-contract",
+    ] {
         if !conclusion_needs.iter().any(|candidate| candidate == job) {
             violations.push(format!("conclusion.needs omits {job}"));
         }
@@ -2320,11 +2679,21 @@ fn ci_routing_contract_violations(
     for (job, expected) in [
         ("fmt", "\"$run_rust\""),
         ("lint", "\"$run_rust\""),
-        ("test", "\"$run_rust\""),
-        ("mcp-platform", "needs.detect-changes.outputs.mcp-platform"),
+        ("linux-nextest-build", "\"$run_workspace_lib\""),
+        ("linux-nextest", "\"$run_workspace_lib\""),
+        ("test", "\"$run_platform\""),
+        (
+            "mcp-platform",
+            "needs.detect-changes.outputs.workspace-platform",
+        ),
+        ("canonical-acceptance", "\"$run_canonical\""),
         ("release-preflight", "startsWith(github.head_ref"),
         ("docs", "needs.detect-changes.outputs.docs"),
         ("plugin", "needs.detect-changes.outputs.plugin"),
+        (
+            "plugin-rust-contract",
+            "needs.detect-changes.outputs.plugin-rust-contract",
+        ),
         ("npm", "needs.detect-changes.outputs.npm"),
     ] {
         let result = format!("needs.{job}.result");
@@ -2423,6 +2792,7 @@ fn ci_routing_contract_violations(
         .filter_map(serde_yaml::Value::as_str)
         .collect::<BTreeSet<_>>();
     if mcp_oses != BTreeSet::from(["macos-14", "windows-2022"])
+        || !mcp_condition.contains("needs.detect-changes.outputs.workspace-platform == 'true'")
         || !mcp_condition.contains("needs.detect-changes.outputs.mcp-platform == 'true'")
         || !mcp_condition.contains("startsWith(github.head_ref, 'release-please--branches--')")
         || !mcp_condition.contains("github.event_name != 'pull_request'")
@@ -2432,6 +2802,9 @@ fn ci_routing_contract_violations(
         || ci["jobs"]["mcp-platform"]["env"]["CARGO_PROFILE_TEST_DEBUG"].as_str() != Some("0")
         || mcp_rust_cache.and_then(|step| step["with"]["shared-key"].as_str())
             != Some("mcp-platform")
+        || mcp_rust_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
+            != Some("false")
+        || mcp_rust_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some("false")
         || mcp_windows_linker.and_then(|step| step["if"].as_str())
             != Some("matrix.os == 'windows-2022'")
         || mcp_windows_linker
@@ -2439,13 +2812,12 @@ fn ci_routing_contract_violations(
             .is_none_or(|run| !run.contains("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER"))
     {
         violations.push(
-            "independent macOS/Windows ownership does not differentially compile every wenlan-mcp target"
+            "independent macOS/Windows ownership does not differentially compile every wenlan-mcp target with a bounded cache footprint"
                 .into(),
         );
     }
 
     for (job, step_name, suite) in [
-        ("test", "Workspace lib tests (Linux)", "workspace-lib"),
         ("test", "Workspace lib tests (macOS)", "workspace-lib"),
         (
             "canonical-acceptance",
@@ -2472,6 +2844,25 @@ fn ci_routing_contract_violations(
         {
             violations.push(format!(
                 "{job} {step_name} does not execute the validated impacted-test plan"
+            ));
+        }
+    }
+    for (step_name, output) in [
+        (
+            "Integration tests wenlan-cli + wenlan-server (Linux)",
+            "cli-server-integration-required",
+        ),
+        (
+            "Run integration tests (core) (Linux)",
+            "core-integration-required",
+        ),
+    ] {
+        let expected = format!("needs.detect-changes.outputs.{output} == 'true'");
+        if job_step(&ci, "canonical-acceptance", step_name).and_then(|step| step["if"].as_str())
+            != Some(expected.as_str())
+        {
+            violations.push(format!(
+                "canonical acceptance {step_name} is not gated by planner output {output}"
             ));
         }
     }
@@ -2547,10 +2938,13 @@ fn ci_routing_is_fail_closed_and_differential() {
     let root = repo_root();
     let workflow =
         std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let planner = std::fs::read_to_string(root.join("scripts/ci_test_plan.py"))
+        .expect("read CI test planner");
     let platform_sensitive_paths = platform_sensitive_paths(&root);
     let release_profile_sensitive_paths = release_profile_sensitive_paths(&root);
     let violations = ci_routing_contract_violations(
         &workflow,
+        &planner,
         &platform_sensitive_paths,
         &release_profile_sensitive_paths,
     );
@@ -2562,6 +2956,70 @@ fn ci_routing_is_fail_closed_and_differential() {
          change also updates ci_routing_contract_violations() and its positive control:\n{}",
         violations.join("\n")
     );
+}
+
+#[test]
+fn ci_planner_routing_rejects_optional_and_fail_open_mutations() {
+    let root = repo_root();
+    let workflow = std::fs::read_to_string(root.join(".github/workflows/ci.yml"))
+        .expect("read ci.yml")
+        .replacen(
+            "if: steps.release-proof.outputs.verified-release-merge != 'true'",
+            "if: false",
+            1,
+        )
+        .replacen(
+            "if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true'",
+            "if: needs.detect-changes.outputs.rust == 'true'",
+            1,
+        )
+        .replacen(
+            "steps.test-plan.outputs.rust-ci-required == 'true'",
+            "steps.filter.outputs.rust == 'true'",
+            1,
+        );
+    let planner = std::fs::read_to_string(root.join("scripts/ci_test_plan.py"))
+        .expect("read CI test planner")
+        .replacen("        if _docs_job_owns(path):", "        if False:", 1)
+        .replacen(
+            "return len(parts) >= 4 and parts[0] == \"crates\" and parts[2] == \"npm\"",
+            "return False",
+            1,
+        )
+        .replacen(
+            "return _full_plan(f\"unowned changed path: {path}\")",
+            "return {\"version\": 1, \"mode\": \"differential\"}",
+            1,
+        )
+        .replacen(
+            "        or required[\"canonical-acceptance-required\"]",
+            "        and required[\"canonical-acceptance-required\"]",
+            1,
+        );
+    let platform_sensitive_paths = platform_sensitive_paths(&root);
+    let release_profile_sensitive_paths = release_profile_sensitive_paths(&root);
+    let mut violations = ci_routing_contract_violations(
+        &workflow,
+        &planner,
+        &platform_sensitive_paths,
+        &release_profile_sensitive_paths,
+    );
+    violations.extend(fastembed_ci_cache_violations(&workflow));
+    for expected in [
+        "every non-reused CI run",
+        "required Rust job fmt",
+        "canonical rust-ci-required planner output",
+        "rust-ci-required output is not the union",
+        "non-Rust fast-owner",
+        "unknown paths",
+    ] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "mutation must exercise {expected:?}: {violations:?}"
+        );
+    }
 }
 
 #[test]
@@ -2589,6 +3047,7 @@ fn documentation_only_changes_take_the_docs_lane_without_runtime_backstops() {
         "app/eval/AGENTS.md",
         "crates/wenlan-core/AGENTS.md",
         "docs/technical-foundations.md",
+        "LICENSE",
     ] {
         assert!(
             filter_routes_path(&docs, path),
@@ -2600,6 +3059,20 @@ fn documentation_only_changes_take_the_docs_lane_without_runtime_backstops() {
                 "documentation-only path must not schedule {filter}: {path}"
             );
         }
+    }
+
+    for path in [
+        "scripts/check-readme-translations.py",
+        "scripts/check-readme-translations.test.sh",
+        "scripts/update-readme-eval.py",
+        "scripts/update-readme-eval.test.py",
+        "scripts/validate-versions.sh",
+        "scripts/validate-versions.test.sh",
+    ] {
+        assert!(
+            filter_routes_path(&docs, path),
+            "documentation validator must schedule docs checks: {path}"
+        );
     }
 
     let markdown_test_fixture = "crates/wenlan-core/tests/fixtures/folder/notes/linked.md";
@@ -2749,6 +3222,8 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
     let root = repo_root();
     let workflow =
         std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let planner = std::fs::read_to_string(root.join("scripts/ci_test_plan.py"))
+        .expect("read CI test planner");
     let ci: serde_yaml::Value = serde_yaml::from_str(&workflow).expect("parse ci.yml");
     let proof_output = "verified-release-merge";
     let proof_ref = "needs.detect-changes.outputs.verified-release-merge != 'true'";
@@ -2807,6 +3282,8 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
     for job in [
         "fmt",
         "lint",
+        "linux-nextest-build",
+        "linux-nextest",
         "test",
         "mcp-platform",
         "canonical-acceptance",
@@ -2814,6 +3291,7 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
         "release-preflight",
         "docs",
         "plugin",
+        "plugin-rust-contract",
         "npm",
     ] {
         let condition = ci["jobs"][job]["if"].as_str().unwrap_or_default();
@@ -2823,36 +3301,141 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
         );
     }
 
-    let matrix = ci["jobs"]["detect-changes"]["steps"]
+    let archive_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true'";
+    assert_eq!(
+        job_needs(&ci, "linux-nextest-build"),
+        ["detect-changes"],
+        "Linux archive producer must depend only on the planner"
+    );
+    assert_eq!(
+        ci["jobs"]["linux-nextest-build"]["if"].as_str(),
+        Some(archive_condition),
+        "Linux archive producer must use the canonical workspace-lib gate"
+    );
+    let archive = job_step(
+        &ci,
+        "linux-nextest-build",
+        "Build workspace-lib nextest archive",
+    )
+    .expect("single Linux workspace-lib archive producer");
+    let archive_run = archive["run"].as_str().unwrap_or_default();
+    for required in [
+        "python3 scripts/ci_test_plan.py archive",
+        "--plan-json \"$CI_TEST_PLAN\"",
+        "--archive-file \"$RUNNER_TEMP/wenlan-workspace-lib-${GITHUB_RUN_ID}.tar.zst\"",
+    ] {
+        assert!(
+            archive_run.contains(required),
+            "Linux archive producer omits {required:?}: {archive_run}"
+        );
+    }
+    let publish = job_step(
+        &ci,
+        "linux-nextest-build",
+        "Publish workspace-lib nextest archive",
+    )
+    .expect("Linux archive upload");
+    assert_eq!(
+        publish["with"]["name"].as_str(),
+        Some("wenlan-workspace-lib-nextest-${{ github.run_id }}")
+    );
+    assert_eq!(publish["with"]["compression-level"].as_u64(), Some(0));
+    assert_eq!(publish["with"]["retention-days"].as_u64(), Some(1));
+    assert_eq!(publish["with"]["if-no-files-found"].as_str(), Some("error"));
+    let producer_count = ci["jobs"]
+        .as_mapping()
+        .into_iter()
+        .flatten()
+        .flat_map(|(_, job)| job["steps"].as_sequence().into_iter().flatten())
+        .filter(|step| {
+            step["with"]["name"].as_str()
+                == Some("wenlan-workspace-lib-nextest-${{ github.run_id }}")
+                && step["uses"]
+                    .as_str()
+                    .is_some_and(|uses| uses.starts_with("actions/upload-artifact@"))
+        })
+        .count();
+    assert_eq!(
+        producer_count, 1,
+        "the workspace-lib archive must have exactly one producer"
+    );
+
+    assert_eq!(
+        job_needs(&ci, "linux-nextest"),
+        ["detect-changes", "linux-nextest-build"],
+        "Linux partition consumers must wait for the one archive producer"
+    );
+    assert_eq!(
+        ci["jobs"]["linux-nextest"]["if"].as_str(),
+        Some(archive_condition),
+        "Linux partition consumers must use the canonical workspace-lib gate"
+    );
+    let partitions = ci["jobs"]["linux-nextest"]["strategy"]["matrix"]["partition"]
         .as_sequence()
         .into_iter()
         .flatten()
-        .find(|step| step["id"].as_str() == Some("matrix"))
-        .and_then(|step| step["run"].as_str())
-        .expect("dynamic test matrix");
-    for shard in ["slice:1/2", "slice:2/2"] {
-        assert_eq!(
-            matrix.matches(shard).count(),
-            1,
-            "dynamic Linux matrix must contain {shard} exactly once"
+        .filter_map(serde_yaml::Value::as_str)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(partitions, BTreeSet::from(["slice:1/2", "slice:2/2"]));
+    assert_eq!(
+        planner.matches("--no-tests=pass").count(),
+        2,
+        "a globally non-empty filterset may still leave one nextest slice empty; the run must allow that shard while list validation strips the run-only flag"
+    );
+    let consumer_steps = ci["jobs"]["linux-nextest"]["steps"]
+        .as_sequence()
+        .expect("Linux archive consumer steps");
+    assert!(
+        consumer_steps
+            .iter()
+            .filter_map(|step| step["uses"].as_str())
+            .all(|uses| {
+                !uses.contains("rust-cache")
+                    && !uses.contains("sccache")
+                    && !uses.starts_with("actions/cache")
+            }),
+        "Linux archive consumers must be artifact-only and cache-free"
+    );
+    assert!(
+        ci["jobs"]["linux-nextest"]["env"]["RUSTC_WRAPPER"].is_null()
+            && ci["jobs"]["linux-nextest"]["env"]["SCCACHE_GHA_ENABLED"].is_null()
+            && ci["jobs"]["linux-nextest"]["env"]["CARGO_PROFILE_DEV_DEBUG"].is_null()
+            && ci["jobs"]["linux-nextest"]["env"]["CARGO_PROFILE_TEST_DEBUG"].is_null(),
+        "Linux archive consumers must not configure a compiler"
+    );
+    let archive_download = job_step(
+        &ci,
+        "linux-nextest",
+        "Download workspace-lib nextest archive",
+    )
+    .expect("Linux archive download");
+    assert_eq!(
+        archive_download["with"]["name"].as_str(),
+        Some("wenlan-workspace-lib-nextest-${{ github.run_id }}")
+    );
+    let linux = job_step(&ci, "linux-nextest", "Run workspace-lib archive partition")
+        .expect("Linux workspace archive partition");
+    let linux_run = linux["run"].as_str().unwrap_or_default();
+    for required in [
+        "--suite workspace-lib",
+        "--archive-file \"$RUNNER_TEMP/wenlan-nextest-archive/wenlan-workspace-lib-${GITHUB_RUN_ID}.tar.zst\"",
+        "--workspace-remap \"$GITHUB_WORKSPACE\"",
+        "--partition \"$CI_TEST_PARTITION\"",
+    ] {
+        assert!(
+            linux_run.contains(required),
+            "Linux archive consumer omits {required:?}: {linux_run}"
         );
     }
-    assert_eq!(
-        ci["jobs"]["test"]["name"].as_str(),
-        Some("test (${{ matrix.label }})"),
-        "matrix shards need unique check names"
-    );
-    let linux =
-        job_step(&ci, "test", "Workspace lib tests (Linux)").expect("Linux workspace tests");
-    assert_eq!(
-        linux["env"]["CI_TEST_PARTITION"].as_str(),
-        Some("${{ matrix.partition }}"),
-        "Linux must receive the matrix partition"
-    );
-    let linux_run = linux["run"].as_str().unwrap_or_default();
     assert!(
-        linux_run.contains("--partition \"$CI_TEST_PARTITION\""),
-        "Linux workspace tests do not execute their nextest partition"
+        consumer_steps
+            .iter()
+            .filter_map(|step| step["run"].as_str())
+            .all(|run| !run.contains("cargo build")
+                && !run.contains("cargo check")
+                && !run.contains("cargo test")
+                && !run.contains("nextest archive")),
+        "Linux archive consumers must not compile"
     );
     let macos_run = job_step(&ci, "test", "Workspace lib tests (macOS)")
         .and_then(|step| step["run"].as_str())
@@ -2868,6 +3451,15 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
         conclusion.contains(proof_ref),
         "conclusion can accept skipped main jobs without the verified release proof"
     );
+    for job in ["linux-nextest-build", "linux-nextest"] {
+        assert!(
+            conclusion.lines().any(|line| {
+                line.contains(&format!("expect_job {job} \"$run_workspace_lib\""))
+                    && line.contains(&format!("needs.{job}.result"))
+            }),
+            "conclusion does not fail closed on {job}"
+        );
+    }
 }
 
 #[test]
@@ -3000,13 +3592,24 @@ fn ci_fans_out_one_prepared_fastembed_artifact_per_run() {
         "re-running the full workflow must replace the run-scoped artifact"
     );
 
-    for job in ["test", "canonical-acceptance", "test-quarantine"] {
+    for job in [
+        "linux-nextest",
+        "test",
+        "canonical-acceptance",
+        "test-quarantine",
+    ] {
         assert!(
             job_step_using(&ci, job, "actions/cache/restore").is_none(),
             "{job} must not make a concurrent cache-service restore"
         );
-        let consumer = job_step_using(&ci, job, "actions/download-artifact")
+        let consumer = job_step(&ci, job, "Download portable FastEmbed model")
             .unwrap_or_else(|| panic!("{job} must download the prepared FastEmbed artifact"));
+        assert!(
+            consumer["uses"]
+                .as_str()
+                .is_some_and(|uses| uses.starts_with("actions/download-artifact@")),
+            "{job} FastEmbed consumer must use the artifact download action"
+        );
         assert_eq!(
             consumer["with"]["name"].as_str(),
             Some(artifact_name),
@@ -3016,6 +3619,126 @@ fn ci_fans_out_one_prepared_fastembed_artifact_per_run() {
             consumer["with"]["path"].as_str(),
             Some(".fastembed_cache"),
             "{job} FastEmbed artifact path"
+        );
+    }
+}
+
+fn plugin_rust_contract_violations(ci_workflow: &str) -> Vec<String> {
+    let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
+    let mut violations = Vec::new();
+    let condition = ci["jobs"]["plugin-rust-contract"]["if"]
+        .as_str()
+        .unwrap_or_default();
+    if job_needs(&ci, "plugin-rust-contract") != ["detect-changes"]
+        || condition
+            != "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin-rust-contract == 'true'"
+        || ci["jobs"]["plugin-rust-contract"]["continue-on-error"].as_bool() == Some(true)
+        || ci["jobs"]["plugin-rust-contract"]["runs-on"].as_str() != Some("ubuntu-24.04")
+        || ci["jobs"]["plugin-rust-contract"]["timeout-minutes"].as_u64() != Some(20)
+    {
+        violations.push("plugin-rust-contract job is not an exact required bounded owner".into());
+    }
+
+    let contracts = [
+        (
+            "Validate Claude plugin distribution",
+            "cargo nextest run -p wenlan --test distribution --no-tests=fail",
+            None,
+        ),
+        (
+            "Validate cross-surface plugin distribution",
+            "cargo nextest run -p wenlan-types --test plugin_distribution --no-tests=fail",
+            None,
+        ),
+        (
+            "Validate skill MCP tool references",
+            "cargo nextest run -p wenlan-mcp --lib -E 'test(/^tools::tests::skills_reference_only_live_tools$/)' --no-tests=fail",
+            None,
+        ),
+        (
+            "Validate plugin release version sync",
+            "cargo nextest run -p wenlan-core --lib -E 'test(/^drift_guard::version_files_are_in_sync$/)' --no-tests=fail",
+            Some("needs.detect-changes.outputs.plugin-version-contract == 'true'"),
+        ),
+    ];
+    for (name, command, condition) in contracts {
+        let step = job_step(&ci, "plugin-rust-contract", name);
+        if step.and_then(|step| step["run"].as_str()) != Some(command)
+            || step.and_then(|step| step["if"].as_str()) != condition
+        {
+            violations.push(format!(
+                "plugin-rust-contract lost exact consumer contract {name:?}"
+            ));
+        }
+    }
+    let cargo_contract_count = ci["jobs"]["plugin-rust-contract"]["steps"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(|step| step["run"].as_str())
+        .filter(|run| run.trim_start().starts_with("cargo nextest run"))
+        .count();
+    if cargo_contract_count != 4 {
+        violations.push(format!(
+            "plugin-rust-contract has {cargo_contract_count} Cargo consumer contracts, expected four"
+        ));
+    }
+    let conclusion_needs = job_needs(&ci, "conclusion");
+    let conclusion = workflow_step_run(&ci, "Aggregate expected CI results").unwrap_or_default();
+    if !conclusion_needs
+        .iter()
+        .any(|job| job == "plugin-rust-contract")
+        || !conclusion.lines().any(|line| {
+            line.contains("expect_job plugin-rust-contract")
+                && line.contains("needs.detect-changes.outputs.plugin-rust-contract")
+                && line.contains("needs.plugin-rust-contract.result")
+        })
+    {
+        violations.push("conclusion does not fail closed on plugin-rust-contract".into());
+    }
+    violations
+}
+
+#[test]
+fn plugin_trees_use_four_required_rust_consumer_contracts() {
+    let workflow =
+        std::fs::read_to_string(repo_root().join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let violations = plugin_rust_contract_violations(&workflow);
+    assert!(
+        violations.is_empty(),
+        "plugin Rust contract drift — plugin trees stay out of broad Rust ownership while their \
+         four exact Rust consumers remain required. Fix .github/workflows/ci.yml; an intentional \
+         contract change also updates plugin_rust_contract_violations() and its positive control:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn plugin_rust_contract_rejects_optional_or_incomplete_fixture() {
+    let workflow = r#"
+jobs:
+  plugin-rust-contract:
+    needs: docs
+    if: false
+    runs-on: windows-2022
+    timeout-minutes: 60
+    continue-on-error: true
+    steps:
+      - name: Validate Claude plugin distribution
+        run: cargo test
+  conclusion:
+    needs: [docs]
+"#;
+    let violations = plugin_rust_contract_violations(workflow);
+    for expected in [
+        "exact required bounded owner",
+        "exact consumer contract",
+        "expected four",
+        "conclusion does not fail closed",
+    ] {
+        assert!(
+            violations.iter().any(|item| item.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
         );
     }
 }
@@ -3072,6 +3795,7 @@ jobs:
     let release_profile_sensitive_paths = vec!["crates/release_only.rs".to_string()];
     let violations = ci_routing_contract_violations(
         workflow,
+        "",
         &platform_sensitive_paths,
         &release_profile_sensitive_paths,
     );
@@ -3082,13 +3806,14 @@ jobs:
         "expected-vs-actual",
         "unnecessarily serialized",
         "dev/test artifact reuse",
-        "proven Linux lane",
+        "compiler-cache lane",
         "cache writes",
-        "duplicates target artifacts",
-        "duplicates sccache target artifacts",
-        "sccache PR mode",
-        "condition omits CI scheduling trigger",
+        "reusable target cache",
+        "restore-only target-free rust-cache",
+        "sccache mode is not read-only",
+        "required Rust job",
         "coverage workflow",
+        "release-please workflow",
         "clippy configuration",
         "non-Rust test fixtures",
         "nextest config",
@@ -3108,7 +3833,13 @@ jobs:
         "changed-file inventory as JSON",
         "repository catch-all",
         "test the impact planner",
+        "every non-reused CI run",
         "derive its test plan",
+        "rust-ci-required output",
+        "non-Rust fast-owner",
+        "unknown paths",
+        "plugin fast-owner",
+        "npm fast-owner",
         "validated impacted-test plan",
     ] {
         assert!(
@@ -3266,6 +3997,20 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     {
         violations.push("tag release does not consume the canonical release matrix".into());
     }
+    if release["jobs"]["release"]["timeout-minutes"].as_str()
+        != Some("${{ matrix.target == 'x86_64-pc-windows-msvc' && 90 || 60 }}")
+    {
+        violations
+            .push("tag release does not enforce the bounded 90/60-minute matrix timeout".into());
+    }
+    if job_needs(&release, "docker") != ["prepare-release"]
+        || job_needs(&release, "docker-manifest") != ["docker", "release"]
+    {
+        violations.push(
+            "Docker DAG does not build per-arch images after prepare-release and gate the manifest on docker plus release"
+                .into(),
+        );
+    }
 
     for (workflow, job_name, expected) in [
         (
@@ -3417,6 +4162,21 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     {
         violations.push(
             "release-preflight cache is not target-scoped, capacity-bounded, and main-owned".into(),
+        );
+    }
+    let release_cache = job_step_using(&release, "release", "Swatinem/rust-cache");
+    let windows_cache = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
+    if release_cache.and_then(|step| step["with"]["shared-key"].as_str())
+        != cache.and_then(|step| step["with"]["shared-key"].as_str())
+        || release_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
+            != Some(windows_cache)
+        || release_cache.and_then(|step| step["with"]["cache-targets"].as_str())
+            != Some(windows_cache)
+        || release_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
+    {
+        violations.push(
+            "tag release cache does not restore the main-owned preflight key with a Windows-only footprint"
+                .into(),
         );
     }
     let windows_runtime_stage = job_step(
@@ -3612,15 +4372,28 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
         .replace(
             "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=",
             "REMOVED_WINDOWS_LINKER=",
+        )
+        .replace(
+            "    timeout-minutes: ${{ matrix.target == 'x86_64-pc-windows-msvc' && 90 || 60 }}",
+            "    timeout-minutes: 900",
+        )
+        .replace("    needs: prepare-release", "    needs: release")
+        .replace("    needs: [docker, release]", "    needs: docker")
+        .replace(
+            "          save-if: \"false\"",
+            "          save-if: \"true\"",
         );
     let violations = release_preflight_contract_violations(&ci, &release);
     for expected in [
         "release-sensitive PRs and release backstops",
         "fail-fast four-target",
         "canonical release matrix",
+        "bounded 90/60-minute",
+        "Docker DAG",
         "shared shipped-binary",
         "current main workflow ref",
         "target-scoped, capacity-bounded, and main-owned",
+        "Windows-only footprint",
         "truncated PR file inventory",
         "native Windows Perl",
         "target and host build artifacts",
@@ -3640,6 +4413,123 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
 
 // ── Teeth #10: canonical acceptance runs beside the long workspace-lib lane ──
 
+fn windows_native_parallelism_violations(
+    ci_workflow: &str,
+    release_workflow: &str,
+    msvc_setup: &str,
+) -> Vec<String> {
+    let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
+    let release: serde_yaml::Value =
+        serde_yaml::from_str(release_workflow).expect("parse release.yml");
+    let mut violations = Vec::new();
+    let windows_condition = "matrix.target == 'x86_64-pc-windows-msvc'";
+    for (workflow, job, step_name, owner) in [
+        (
+            &ci,
+            "release-preflight",
+            "Bound native build concurrency (Windows)",
+            "release preflight",
+        ),
+        (
+            &release,
+            "release",
+            "Cap Windows Cargo parallelism",
+            "tag release",
+        ),
+    ] {
+        let step = job_step(workflow, job, step_name);
+        let run = step
+            .and_then(|candidate| candidate["run"].as_str())
+            .unwrap_or_default();
+        if step.and_then(|candidate| candidate["if"].as_str()) != Some(windows_condition)
+            || !run.contains("CARGO_BUILD_JOBS=2")
+            || run.contains("CARGO_BUILD_JOBS=1")
+        {
+            violations.push(format!(
+                "{owner} does not cap outer Windows Cargo work at exactly two jobs"
+            ));
+        }
+        let steps = workflow["jobs"][job]["steps"].as_sequence();
+        let cap_index = steps.and_then(|items| {
+            items
+                .iter()
+                .position(|candidate| candidate["name"].as_str() == Some(step_name))
+        });
+        let build_index = steps.and_then(|items| {
+            items.iter().position(|candidate| {
+                candidate["name"].as_str() == Some("Build and smoke shipped release binaries")
+            })
+        });
+        if !matches!((cap_index, build_index), (Some(cap), Some(build)) if cap < build) {
+            violations.push(format!("{owner} applies its Cargo cap after the build"));
+        }
+    }
+    if msvc_setup
+        .matches("$env:CMAKE_BUILD_PARALLEL_LEVEL = \"1\"")
+        .count()
+        != 1
+        || !msvc_setup.contains("\"CMAKE_BUILD_PARALLEL_LEVEL\"")
+        || msvc_setup.contains("$env:CMAKE_BUILD_PARALLEL_LEVEL = \"2\"")
+        || msvc_setup.contains("CARGO_BUILD_JOBS")
+    {
+        violations.push(
+            "MSVC Ninja setup does not keep nested CMake at one worker independently of Cargo"
+                .into(),
+        );
+    }
+    violations
+}
+
+#[test]
+fn windows_cargo_uses_two_jobs_while_nested_cmake_stays_serial() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let release =
+        std::fs::read_to_string(root.join(".github/workflows/release.yml")).expect("read release");
+    let setup = std::fs::read_to_string(root.join("scripts/setup-msvc-ninja-windows.ps1"))
+        .expect("read Windows MSVC Ninja setup");
+    let violations = windows_native_parallelism_violations(&ci, &release, &setup);
+    assert!(
+        violations.is_empty(),
+        "Windows native parallelism drift — Cargo may run exactly two outer jobs while nested \
+         CMake remains serialized at one worker. Fix the CI/release caps or the MSVC Ninja setup; \
+         an intentional change also updates this guard and its positive control:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn windows_native_parallelism_rejects_reversed_limits() {
+    let ci = r#"
+jobs:
+  release-preflight:
+    steps:
+      - name: Bound native build concurrency (Windows)
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: CARGO_BUILD_JOBS=1
+      - name: Build and smoke shipped release binaries
+        run: build
+"#;
+    let release = r#"
+jobs:
+  release:
+    steps:
+      - name: Build and smoke shipped release binaries
+        run: build
+      - name: Cap Windows Cargo parallelism
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        run: CARGO_BUILD_JOBS=1
+"#;
+    let setup = "$env:CMAKE_BUILD_PARALLEL_LEVEL = \"2\"\nCARGO_BUILD_JOBS=2";
+    let violations = windows_native_parallelism_violations(ci, release, setup);
+    for expected in ["exactly two jobs", "after the build", "nested CMake"] {
+        assert!(
+            violations.iter().any(|item| item.contains(expected)),
+            "fixture must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
 fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
     let mut violations = Vec::new();
@@ -3648,9 +4538,13 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     if job_needs(&ci, "canonical-acceptance") != ["detect-changes"] {
         violations.push("Canonical acceptance is serialized behind another required job".into());
     }
-    if job["if"].as_str() != ci["jobs"]["test"]["if"].as_str() {
+    if job["if"].as_str()
+        != Some(
+            "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.canonical-acceptance-required == 'true'",
+        )
+    {
         violations.push(
-            "Canonical acceptance does not share the fail-closed Rust routing condition".into(),
+            "Canonical acceptance does not use the planner's canonical aggregate gate".into(),
         );
     }
     if job["runs-on"].as_str() != Some("ubuntu-24.04")
@@ -3662,10 +4556,7 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     for (name, expected) in [
         ("CARGO_PROFILE_DEV_DEBUG", "0"),
         ("CARGO_PROFILE_TEST_DEBUG", "0"),
-        (
-            "SCCACHE_GHA_RW_MODE",
-            "${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}",
-        ),
+        ("SCCACHE_GHA_RW_MODE", "READ_ONLY"),
         (
             "FASTEMBED_CACHE_DIR",
             "${{ github.workspace }}/.fastembed_cache",
@@ -3697,26 +4588,29 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
             ));
         }
     }
-    for (step_name, expected_run, violation) in [
+    for (step_name, expected_run, expected_condition, violation) in [
         (
             "Page lint scale gate (Linux time + RSS)",
             r#"bash scripts/lint-scale-gate.sh "$RUNNER_TEMP/task-19-memory-lint-debugger-linux.txt""#,
+            "needs.detect-changes.outputs.canonical-smokes-required == 'true'",
             "Canonical acceptance page lint command is not executable",
         ),
         (
             "Integration tests wenlan-cli + wenlan-server (Linux)",
             "python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json \"$CI_TEST_PLAN\"",
+            "needs.detect-changes.outputs.cli-server-integration-required == 'true'",
             "Canonical acceptance CLI/server integration command is not executable",
         ),
         (
             "E2E folder ingest over HTTP (Linux)",
             "bash scripts/smoke-folder-ingest.sh",
-            "Canonical acceptance folder ingest smoke is not unconditional",
+            "needs.detect-changes.outputs.canonical-smokes-required == 'true'",
+            "Canonical acceptance folder ingest smoke is not planner-gated",
         ),
     ] {
         let step = job_step(&ci, "canonical-acceptance", step_name);
         if step.and_then(|step| step["run"].as_str()) != Some(expected_run)
-            || step.is_some_and(|step| step.get("if").is_some())
+            || step.and_then(|step| step["if"].as_str()) != Some(expected_condition)
         {
             violations.push(violation.into());
         }
@@ -3739,8 +4633,10 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
             ));
         }
     }
-    if core_integration.is_some_and(|step| step.get("if").is_some()) {
-        violations.push("Linux core integration coverage is conditionally disabled".into());
+    if core_integration.and_then(|step| step["if"].as_str())
+        != Some("needs.detect-changes.outputs.core-integration-required == 'true'")
+    {
+        violations.push("Linux core integration coverage is not planner-gated".into());
     }
     let systemd = job_step(
         &ci,
@@ -3755,7 +4651,8 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .collect::<BTreeSet<_>>();
-    if systemd.is_some_and(|step| step.get("if").is_some())
+    if systemd.and_then(|step| step["if"].as_str())
+        != Some("needs.detect-changes.outputs.canonical-smokes-required == 'true'")
         || [
             r#"sudo loginctl enable-linger "$(whoami)""#,
             "cargo build -p wenlan -p wenlan-server",
@@ -3775,7 +4672,8 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         "canonical-acceptance",
         "Upload Page lint scale receipt (Linux)",
     );
-    if lint_upload.and_then(|step| step["if"].as_str()) != Some("always()")
+    if lint_upload.and_then(|step| step["if"].as_str())
+        != Some("always() && needs.detect-changes.outputs.canonical-smokes-required == 'true'")
         || lint_upload
             .and_then(|step| step["uses"].as_str())
             .is_none_or(|uses| !uses.starts_with("actions/upload-artifact@"))
@@ -3791,6 +4689,20 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     );
     if macos_integration.and_then(|step| step["if"].as_str()) != Some("matrix.os == 'macos-14'") {
         violations.push("macOS lost its shared CLI/server integration owner".into());
+    }
+    for step_name in [
+        "E2E CLI surface smoke (Linux)",
+        "E2E MCP stdio surface smoke (Linux)",
+    ] {
+        if job_step(&ci, "canonical-acceptance", step_name).and_then(|step| step["if"].as_str())
+            != Some(
+                "needs.detect-changes.outputs.canonical-smokes-required == 'true' && github.event_name != 'pull_request'",
+            )
+        {
+            violations.push(format!(
+                "Canonical acceptance surface smoke {step_name} is not backstop-only and planner-gated"
+            ));
+        }
     }
 
     let acceptance_steps = job["steps"]
@@ -3858,7 +4770,7 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     let conclusion = workflow_step_run(&ci, "Aggregate expected CI results").unwrap_or_default();
     if !conclusion.lines().map(str::trim).any(|line| {
         line.starts_with("expect_job canonical-acceptance ")
-            && line.contains("\"$run_rust\"")
+            && line.contains("\"$run_canonical\"")
             && line.contains("needs.canonical-acceptance.result")
     }) {
         violations.push("conclusion does not fail closed on canonical acceptance".into());
@@ -3912,7 +4824,7 @@ jobs:
     let violations = canonical_acceptance_contract_violations(ci);
     for expected in [
         "serialized",
-        "fail-closed Rust routing",
+        "canonical aggregate gate",
         "canonical Linux runner",
         "env",
         "does not own required step",
@@ -3939,16 +4851,16 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
     let ci = ci
         .replace(
-            "      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}",
             "      SCCACHE_GHA_RW_MODE: READ_ONLY",
+            "      SCCACHE_GHA_RW_MODE: READ_WRITE",
         )
         .replace(
             "        run: python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json \"$CI_TEST_PLAN\"",
             "        run: \"true\"",
         )
         .replace(
-            "      - name: E2E folder ingest over HTTP (Linux)\n        run: bash scripts/smoke-folder-ingest.sh",
-            "      - name: E2E folder ingest over HTTP (Linux)\n        if: \"false\"\n        run: bash scripts/smoke-folder-ingest.sh",
+            "        if: needs.detect-changes.outputs.canonical-smokes-required == 'true'\n        run: bash scripts/smoke-folder-ingest.sh",
+            "        if: \"false\"\n        run: bash scripts/smoke-folder-ingest.sh",
         )
         .replace(
             "          test \"$active_state\" = \"inactive\"",
@@ -3959,8 +4871,8 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
             "      - uses: Swatinem/rust-cache@v2\n        with:\n          save-if: \"true\"\n      - name: Install cargo-nextest",
         )
         .replace(
-            "          expect_job canonical-acceptance \"$run_rust\" '${{ needs.canonical-acceptance.result }}'",
-            "          # expect_job canonical-acceptance \"$run_rust\" '${{ needs.canonical-acceptance.result }}'",
+            "          expect_job canonical-acceptance \"$run_canonical\" '${{ needs.canonical-acceptance.result }}'",
+            "          # expect_job canonical-acceptance \"$run_canonical\" '${{ needs.canonical-acceptance.result }}'",
         );
     let violations = canonical_acceptance_contract_violations(&ci);
     for expected in [
@@ -3992,13 +4904,13 @@ fn core_integration_contract_violations(ci_workflow: &str) -> Vec<String> {
         return vec!["required Linux core integration step is missing".into()];
     };
 
-    let expected =
-        "python3 scripts/ci_test_plan.py run --suite core-integration --plan-json \"$CI_TEST_PLAN\"";
+    let expected = "python3 scripts/ci_test_plan.py run --suite core-integration --plan-json \"$CI_TEST_PLAN\"";
     let mut violations = Vec::new();
     if step["run"].as_str() != Some(expected)
         || step["env"]["CI_TEST_PLAN"].as_str()
             != Some("${{ needs.detect-changes.outputs.test-plan }}")
-        || step.get("if").is_some()
+        || step["if"].as_str()
+            != Some("needs.detect-changes.outputs.core-integration-required == 'true'")
     {
         violations.push(
             "required Linux core integration step does not execute the validated fail-closed planner"
@@ -4227,9 +5139,13 @@ fn main_canary_contract_violations(ci_workflow: &str, canary_workflow: &str) -> 
         || fastembed_restore.and_then(|step| step["with"]["path"].as_str())
             != Some("${{ env.FASTEMBED_CACHE_DIR }}")
         || fastembed_restore.and_then(|step| step["with"]["key"].as_str())
-            != Some("fastembed-bge-base-en-v1.5-q-v2")
+            != Some("fastembed-bge-base-en-v1.5-q-v3-portable")
+        || fastembed_restore.and_then(|step| step["with"]["enableCrossOsArchive"].as_str())
+            != Some("true")
     {
-        violations.push("main canary FastEmbed cache is not restore-only".into());
+        violations.push(
+            "main canary FastEmbed cache is not the restore-only cross-OS portable v3 cache".into(),
+        );
     }
     if canary_steps
         .clone()
@@ -4346,7 +5262,7 @@ jobs:
         "sccache is not read-only",
         "FastEmbed cache directory",
         "rust-cache is not restore-only",
-        "FastEmbed cache is not restore-only",
+        "portable v3 cache",
         "FastEmbed cache writer",
         "exact embedding-only eval",
         "always-uploaded baseline receipt",
@@ -4425,7 +5341,11 @@ fn main_canary_contract_rejects_eval_inside_conclusion_itself() {
 
 // ── Teeth #13: CI measurements stay read-only and off the required path ──
 
-fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -> Vec<String> {
+fn ci_observer_contract_violations(
+    ci_workflow: &str,
+    observer_workflow: &str,
+    observer_script: &str,
+) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
     let observer: serde_yaml::Value =
         serde_yaml::from_str(observer_workflow).unwrap_or(serde_yaml::Value::Null);
@@ -4448,6 +5368,14 @@ fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -
     }
     if observer["on"].as_mapping().is_none_or(|on| on.len() != 1) {
         violations.push("CI observer has triggers beyond workflow_run".into());
+    }
+    if observer["concurrency"]["group"].as_str()
+        != Some(
+            "ci-observer-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}",
+        )
+        || observer["concurrency"]["cancel-in-progress"].as_bool() != Some(false)
+    {
+        violations.push("CI observer does not preserve every run-attempt receipt".into());
     }
     if observer["permissions"]["actions"].as_str() != Some("read")
         || observer["permissions"]["contents"].as_str() != Some("read")
@@ -4472,7 +5400,11 @@ fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -
     if !detect_change_filter_paths(&ci, "rust").contains(".github/workflows/ci-observer.yml") {
         violations.push("Rust routing omits the CI observer contract".into());
     }
-    let required_script_step = job_step(&ci, "test", "Verify ort-sys source pin");
+    let required_script_step = job_step(
+        &ci,
+        "detect-changes",
+        "Verify CI observer and ORT contracts",
+    );
     let required_script_lines = required_script_step
         .and_then(|step| step["run"].as_str())
         .into_iter()
@@ -4486,10 +5418,11 @@ fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -
         "python3 scripts/verify-ort-source-pin.test.py",
         "python3 scripts/verify-ort-source-pin.py",
     ];
-    if !required_job_closure(&ci).contains("test")
-        || ci["jobs"]["test"].get("continue-on-error").is_some()
-        || required_script_step.and_then(|step| step["if"].as_str())
-            != Some("matrix.os == 'ubuntu-24.04'")
+    if !required_job_closure(&ci).contains("detect-changes")
+        || ci["jobs"]["detect-changes"]
+            .get("continue-on-error")
+            .is_some()
+        || required_script_step.is_some_and(|step| step.get("if").is_some())
         || required_script_step.is_some_and(|step| step.get("continue-on-error").is_some())
         || required_script_lines != expected_script_lines
     {
@@ -4515,6 +5448,13 @@ fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -
     }
     if job.get("environment").is_some() || job.get("permissions").is_some() {
         violations.push("CI observer adds environment or job-level permissions".into());
+    }
+    if observer["env"]["CI_CACHE_BUDGET_GB"].as_str() != Some("10") {
+        violations
+            .push("CI observer does not use the current 10 GB repository cache policy".into());
+    }
+    if observer["env"]["CI_REQUIRED_GATE_TARGET_MINUTES"].as_str() != Some("20") {
+        violations.push("CI observer does not encode the 20-minute required gate target".into());
     }
     let steps = job["steps"].as_sequence().into_iter().flatten();
     let checkouts = steps
@@ -4596,15 +5536,33 @@ fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -
     for required in [
         "/actions/runs/$RUN_ID/attempts/$RUN_ATTEMPT/jobs?per_page=100",
         "/actions/cache/usage",
-        "/actions/cache/storage-limit",
         "--method GET",
         "--paginate --slurp",
+        "X-GitHub-Api-Version: 2026-03-10",
         "scripts/ci-observer.py",
         "--event \"$GITHUB_EVENT_PATH\"",
+        "--cache-budget-gb \"$CI_CACHE_BUDGET_GB\"",
+        "--required-gate-target-minutes \"$CI_REQUIRED_GATE_TARGET_MINUTES\"",
     ] {
         if !run.contains(required) {
             violations.push(format!("CI observer omits required evidence {required:?}"));
         }
+    }
+    for forbidden in [
+        "/actions/cache/storage-limit",
+        "cache-limit.json",
+        "--cache-limit",
+    ] {
+        if run.contains(forbidden) || observer_script.contains(forbidden) {
+            violations.push(format!(
+                "CI observer still depends on removed cache-limit evidence {forbidden:?}"
+            ));
+        }
+    }
+    if run.matches("X-GitHub-Api-Version: 2026-03-10").count() != 2 {
+        violations.push(
+            "CI observer does not pin both GitHub metadata reads to API version 2026-03-10".into(),
+        );
     }
     let receipt_builder = job_step(&observer, "collect", "Build timing and cache receipt");
     if receipt_builder.and_then(|step| step["if"].as_str()) != Some("always()") {
@@ -4619,9 +5577,53 @@ fn ci_observer_contract_violations(ci_workflow: &str, observer_workflow: &str) -
         || upload.and_then(|step| step["with"]["path"].as_str())
             != Some("${{ runner.temp }}/ci-observer/receipt.json")
         || upload.and_then(|step| step["with"]["if-no-files-found"].as_str()) != Some("error")
+        || upload.and_then(|step| step["with"]["retention-days"].as_u64()) != Some(30)
     {
         violations.push(
             "CI observer receipt is not always uploaded from runner.temp with missing files fatal"
+                .into(),
+        );
+    }
+
+    for required in [
+        "CACHE_BUDGET_SOURCE = \"repository_policy\"",
+        "parser.add_argument(\"--cache-budget-gb\", required=True)",
+        "parser.add_argument(\"--required-gate-target-minutes\", required=True)",
+        "\"schema_version\": 2",
+        "\"required_gate_target\"",
+        "\"scope\": \"ordinary_pull_request\"",
+        "\"applicable\": ordinary_pr",
+        "SLO_EXEMPT_JOB_PREFIXES = (\"release-preflight (\",)",
+        "\"CI required gate target exceeded\"",
+        "\"budget_gb\": budget_gb",
+        "\"budget_source\": CACHE_BUDGET_SOURCE",
+        "def warning(title, message):",
+        "::warning title={title}",
+        "write_receipt(args.output, error_receipt(args, error))",
+    ] {
+        if !observer_script.contains(required) {
+            violations.push(format!(
+                "CI observer schema-v2 warning receipt omits {required:?}"
+            ));
+        }
+    }
+    if observer_script.contains("\"schema_version\": 1")
+        || observer_script.contains("raise SystemExit(1)")
+        || observer_script.contains("raise SystemExit(2)")
+        || observer_script.matches("raise SystemExit(0)").count() < 2
+    {
+        violations
+            .push("CI observer receipt can gate CI or regress from warning-only schema v2".into());
+    }
+    let invalid_write =
+        observer_script.find("write_receipt(args.output, error_receipt(args, error))");
+    let invalid_warning = observer_script.find("warning(\"CI observer invalid input\"");
+    let over_budget_warning = observer_script.find("\"CI cache budget exceeded\"");
+    if !matches!((invalid_write, invalid_warning), (Some(write), Some(warning)) if write < warning)
+        || over_budget_warning.is_none()
+    {
+        violations.push(
+            "CI observer does not persist invalid/over-budget receipts before non-gating warnings"
                 .into(),
         );
     }
@@ -4635,7 +5637,8 @@ fn ci_observer_is_out_of_band_read_only_and_never_executes_measured_code() {
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
     let observer =
         std::fs::read_to_string(root.join(".github/workflows/ci-observer.yml")).unwrap_or_default();
-    let violations = ci_observer_contract_violations(&ci, &observer);
+    let script = std::fs::read_to_string(root.join("scripts/ci-observer.py")).unwrap_or_default();
+    let violations = ci_observer_contract_violations(&ci, &observer, &script);
     assert!(
         violations.is_empty(),
         "CI observer contract drift — the observer stays out-of-band, read-only, and never \
@@ -4682,7 +5685,7 @@ jobs:
     steps:
       - run: echo extra
 "#;
-    let violations = ci_observer_contract_violations(ci, observer);
+    let violations = ci_observer_contract_violations(ci, observer, "");
     for expected in [
         "completed CI runs",
         "triggers beyond",
@@ -4719,12 +5722,13 @@ fn ci_observer_contract_rejects_short_circuited_or_optional_measurement_tests() 
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
     let observer =
         std::fs::read_to_string(root.join(".github/workflows/ci-observer.yml")).unwrap_or_default();
+    let script = std::fs::read_to_string(root.join("scripts/ci-observer.py")).unwrap_or_default();
     let ci = ci
         .replace(
-            "        if: matrix.os == 'ubuntu-24.04'\n        run: |\n          python3 scripts/ci-observer.test.py",
-            "        if: \"false\"\n        run: |\n          exit 0\n          python3 scripts/ci-observer.test.py",
+            "      - name: Verify CI observer and ORT contracts\n        run: |\n          python3 scripts/ci-observer.test.py",
+            "      - name: Verify CI observer and ORT contracts\n        if: \"false\"\n        run: |\n          exit 0\n          python3 scripts/ci-observer.test.py",
         );
-    let violations = ci_observer_contract_violations(&ci, &observer);
+    let violations = ci_observer_contract_violations(&ci, &observer, &script);
     assert!(
         violations
             .iter()
@@ -4739,11 +5743,12 @@ fn ci_observer_contract_rejects_non_blocking_measurement_tests() {
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
     let observer =
         std::fs::read_to_string(root.join(".github/workflows/ci-observer.yml")).unwrap_or_default();
+    let script = std::fs::read_to_string(root.join("scripts/ci-observer.py")).unwrap_or_default();
     let ci = ci.replace(
-        "        run: |\n          python3 scripts/ci-observer.test.py",
-        "        continue-on-error: true\n        run: |\n          python3 scripts/ci-observer.test.py",
+        "      - name: Verify CI observer and ORT contracts\n        run: |\n          python3 scripts/ci-observer.test.py",
+        "      - name: Verify CI observer and ORT contracts\n        continue-on-error: true\n        run: |\n          python3 scripts/ci-observer.test.py",
     );
-    let violations = ci_observer_contract_violations(&ci, &observer);
+    let violations = ci_observer_contract_violations(&ci, &observer, &script);
     assert!(
         violations
             .iter()
@@ -4753,6 +5758,49 @@ fn ci_observer_contract_rejects_non_blocking_measurement_tests() {
 }
 
 // ── Teeth #14: hosted optimization experiments stay manual and restore-only ──
+
+#[test]
+fn ci_observer_schema_v2_contract_rejects_gating_limit_metadata() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let observer =
+        std::fs::read_to_string(root.join(".github/workflows/ci-observer.yml")).unwrap_or_default();
+    let script = std::fs::read_to_string(root.join("scripts/ci-observer.py")).unwrap_or_default();
+    let observer = observer
+        .replace("CI_CACHE_BUDGET_GB: \"10\"", "CI_CACHE_BUDGET_GB: \"20\"")
+        .replace(
+            "CI_REQUIRED_GATE_TARGET_MINUTES: \"20\"",
+            "CI_REQUIRED_GATE_TARGET_MINUTES: \"30\"",
+        )
+        .replace("2026-03-10", "2022-11-28")
+        .replace("/actions/cache/usage\"", "/actions/cache/storage-limit\"")
+        .replace(
+            "ci-observer-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}",
+            "ci-observer",
+        )
+        .replace("cancel-in-progress: false", "cancel-in-progress: true")
+        .replace("retention-days: 30", "retention-days: 7");
+    let script = script
+        .replace("\"schema_version\": 2", "\"schema_version\": 1")
+        .replace("raise SystemExit(0)", "raise SystemExit(2)")
+        .replace("--cache-budget-gb", "--cache-limit");
+    let violations = ci_observer_contract_violations(&ci, &observer, &script);
+    for expected in [
+        "current 10 GB",
+        "20-minute required gate target",
+        "preserve every run-attempt receipt",
+        "receipt is not always uploaded",
+        "API version 2026-03-10",
+        "removed cache-limit evidence",
+        "schema-v2 warning receipt",
+        "warning-only schema v2",
+    ] {
+        assert!(
+            violations.iter().any(|item| item.contains(expected)),
+            "mutation must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
 
 fn ci_benchmark_contract_violations(ci_workflow: &str, benchmark_workflow: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");

--- a/docs/windows-vulkan.md
+++ b/docs/windows-vulkan.md
@@ -58,9 +58,10 @@ Get-Item $gitBash
 # generator after setup-msvc-ninja-windows.ps1 selects Ninja.
 $env:CARGO_TARGET_DIR = "C:\wl-target"
 
-# MSVC's nested Vulkan shader probes can concurrently write the same PDB.
-# Serialize release builds so cl.exe does not fail with C1041.
-$env:CARGO_BUILD_JOBS = "1"
+# Cargo can overlap two independent package builds. Keep nested CMake at one
+# worker so MSVC Vulkan shader probes cannot race while writing the same PDB.
+$env:CARGO_BUILD_JOBS = "2"
+$env:CMAKE_BUILD_PARALLEL_LEVEL = "1"
 ```
 
 If libclang is not on its standard path, set `LIBCLANG_PATH` to the directory
@@ -98,7 +99,7 @@ cargo test -p wenlan-server status_reports_selected_vulkan_device
 & scripts\stage-vulkan-loader-windows.ps1 `
   -DestinationDirectory $releaseDir
 & $gitBash scripts\build-release-binaries.sh $target
-cargo build --release --target $target --jobs 1 `
+cargo build --release --target $target --jobs 2 `
   -p wenlan-core --bin model_probe
 
 & scripts\setup-vulkan-sdk-windows.test.ps1
@@ -321,9 +322,9 @@ link alone is not the release gate.
   `CARGO_TARGET_DIR=C:\wl-target`, then rebuild; enabling Windows long paths
   does not make every older MSVC/CMake child tool long-path aware.
 - `C1041: cannot open program database`: concurrent nested MSVC probes wrote
-  the same PDB. Set `CARGO_BUILD_JOBS=1` and pass `--jobs 1` to the release
-  build. The Windows CI and release jobs intentionally use this slower,
-  deterministic path.
+  the same PDB. Run `scripts\setup-msvc-ninja-windows.ps1` and keep
+  `CMAKE_BUILD_PARALLEL_LEVEL=1`. Windows CI and release allow two outer Cargo
+  jobs, but they deliberately do not lift this nested CMake/PDB protection.
 - Vulkan builds but the daemon reports CPU: inspect `fallback_reason`, update
   the GPU driver, run `vulkaninfo.exe --summary`, then retry the live smoke.
 - A hybrid laptop picks the integrated GPU: inspect the device indexes printed

--- a/scripts/ci-observer.py
+++ b/scripts/ci-observer.py
@@ -12,7 +12,9 @@ from pathlib import Path
 MAX_INPUT_BYTES = 16 * 1024 * 1024
 MAX_GITHUB_CLOCK_SKEW_MS = 5_000
 CACHE_ALERT_RATIO_PPM = 1_150_000
+CACHE_BUDGET_SOURCE = "repository_policy"
 FULL_SHA = re.compile(r"[0-9a-f]{40}")
+SLO_EXEMPT_JOB_PREFIXES = ("release-preflight (",)
 
 
 def require_object(value, label):
@@ -26,7 +28,8 @@ def parse_args():
     parser.add_argument("--event", type=Path, required=True)
     parser.add_argument("--jobs-pages", type=Path, required=True)
     parser.add_argument("--cache-usage", type=Path, required=True)
-    parser.add_argument("--cache-limit", type=Path, required=True)
+    parser.add_argument("--cache-budget-gb", required=True)
+    parser.add_argument("--required-gate-target-minutes", required=True)
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
 
@@ -67,6 +70,10 @@ def validate_run(run):
         raise ValueError("run id and attempt must be integers")
     if not FULL_SHA.fullmatch(run.get("head_sha", "")):
         raise ValueError("head SHA must be 40 lowercase hexadecimal characters")
+    if not isinstance(run.get("event"), str) or not run["event"]:
+        raise ValueError("workflow event must be a non-empty string")
+    if run.get("head_branch") is not None and not isinstance(run["head_branch"], str):
+        raise ValueError("head branch must be a string or null")
     duration_ms(run.get("run_started_at"), run.get("updated_at"))
 
 
@@ -145,28 +152,73 @@ def normalize_jobs(pages, run):
     return sorted(jobs, key=lambda job: (job["name"] or "", job["id"]))
 
 
-def build_receipt(event_payload, pages, usage, limit):
+def parse_positive_integer(value, label):
+    if not isinstance(value, str) or not re.fullmatch(r"[1-9][0-9]*", value):
+        raise ValueError(f"{label} must be a positive integer")
+    return int(value)
+
+
+def parse_budget_gb(value):
+    return parse_positive_integer(value, "cache budget in GB")
+
+
+def require_nonnegative_integer(value, label):
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{label} must be a non-negative integer")
+    return value
+
+
+def build_receipt(event_payload, pages, usage, budget_gb, gate_target_minutes):
     event_payload = require_object(event_payload, "event payload")
     usage = require_object(usage, "cache usage")
-    limit = require_object(limit, "cache limit")
     run = event_payload.get("workflow_run", {})
     validate_run(run)
     jobs = normalize_jobs(pages, run)
     gates = [job for job in jobs if job["name"] == "conclusion"]
-    if len(gates) != 1:
+    if run.get("conclusion") == "cancelled":
+        if len(gates) > 1:
+            raise ValueError("expected at most one conclusion job for a cancelled run")
+    elif len(gates) != 1:
         raise ValueError("expected exactly one required conclusion job")
 
-    budget_bytes = int(limit["max_cache_size_gb"]) * 1_000_000_000
-    usage_bytes = int(usage["active_caches_size_in_bytes"])
-    active_count = int(usage["active_caches_count"])
-    if budget_bytes <= 0 or usage_bytes < 0 or active_count < 0:
-        raise ValueError("cache usage and limit must be non-negative")
+    budget_bytes = budget_gb * 1_000_000_000
+    usage_bytes = require_nonnegative_integer(
+        usage.get("active_caches_size_in_bytes"), "active cache size"
+    )
+    active_count = require_nonnegative_integer(
+        usage.get("active_caches_count"), "active cache count"
+    )
     over_by = max(0, usage_bytes - budget_bytes)
     ratio_ppm = usage_bytes * 1_000_000 // budget_bytes
     alert = usage_bytes * 1_000_000 > budget_bytes * CACHE_ALERT_RATIO_PPM
+    gate_elapsed_ms = (
+        duration_ms(run.get("run_started_at"), gates[0]["completed_at"])
+        if gates
+        else None
+    )
+    gate_target_ms = gate_target_minutes * 60_000
+    exempt_jobs = sorted(
+        job["name"]
+        for job in jobs
+        if isinstance(job["name"], str)
+        and job["conclusion"] != "skipped"
+        and job["name"].startswith(SLO_EXEMPT_JOB_PREFIXES)
+    )
+    ordinary_pr = (
+        run["event"] == "pull_request"
+        and not (run.get("head_branch") or "").startswith(
+            "release-please--branches--"
+        )
+        and not exempt_jobs
+    )
+    gate_over_by_ms = (
+        max(0, gate_elapsed_ms - gate_target_ms)
+        if gate_elapsed_ms is not None
+        else None
+    )
 
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "observed_run": {
             "id": run["id"],
             "attempt": run["run_attempt"],
@@ -174,17 +226,35 @@ def build_receipt(event_payload, pages, usage, limit):
             "status": run["status"],
             "conclusion": run.get("conclusion"),
             "head_sha": run["head_sha"],
+            "event": run["event"],
+            "head_branch": run.get("head_branch"),
             "run_started_at": run.get("run_started_at"),
             "updated_at": run.get("updated_at"),
         },
-        "required_gate_elapsed_ms": duration_ms(
-            run.get("run_started_at"), gates[0]["completed_at"]
-        ),
+        "required_gate_elapsed_ms": gate_elapsed_ms,
+        "required_gate_target": {
+            "minutes": gate_target_minutes,
+            "milliseconds": gate_target_ms,
+            "scope": "ordinary_pull_request",
+            "applicable": ordinary_pr,
+            "exempt_jobs": exempt_jobs,
+            "status": (
+                "not_applicable"
+                if not ordinary_pr
+                else "unavailable"
+                if gate_elapsed_ms is None
+                else "over_target"
+                if gate_over_by_ms
+                else "within_target"
+            ),
+            "over_by_ms": gate_over_by_ms,
+        },
         "jobs": jobs,
         "cache": {
             "usage_bytes": usage_bytes,
             "active_count": active_count,
-            "limit_gb": int(limit["max_cache_size_gb"]),
+            "budget_gb": budget_gb,
+            "budget_source": CACHE_BUDGET_SOURCE,
             "budget_bytes": budget_bytes,
             "ratio_ppm": ratio_ppm,
             "alert_ratio_ppm": CACHE_ALERT_RATIO_PPM,
@@ -213,17 +283,23 @@ def raw_input_ref(path):
 
 def error_receipt(args, error):
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "status": "invalid",
         "error": {
             "type": type(error).__name__,
             "message": str(error),
         },
+        "cache_budget": {
+            "configured_gb": args.cache_budget_gb,
+            "source": CACHE_BUDGET_SOURCE,
+        },
+        "required_gate_target": {
+            "configured_minutes": args.required_gate_target_minutes,
+        },
         "raw_refs": {
             "event": raw_input_ref(args.event),
             "jobs_pages": raw_input_ref(args.jobs_pages),
             "cache_usage": raw_input_ref(args.cache_usage),
-            "cache_limit": raw_input_ref(args.cache_limit),
         },
     }
 
@@ -237,22 +313,50 @@ def write_receipt(output, receipt):
     os.replace(temporary, output)
 
 
+def warning(title, message):
+    escaped = (
+        str(message)
+        .replace("%", "%25")
+        .replace("\r", "%0D")
+        .replace("\n", "%0A")
+    )
+    print(f"::warning title={title}::{escaped}")
+
+
 def main():
     args = parse_args()
     try:
+        budget_gb = parse_budget_gb(args.cache_budget_gb)
+        gate_target_minutes = parse_positive_integer(
+            args.required_gate_target_minutes, "required gate target minutes"
+        )
         receipt = build_receipt(
             load_json(args.event),
             load_json(args.jobs_pages),
             load_json(args.cache_usage),
-            load_json(args.cache_limit),
+            budget_gb,
+            gate_target_minutes,
         )
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         print(f"ci-observer: invalid input: {error}", file=sys.stderr)
         write_receipt(args.output, error_receipt(args, error))
-        raise SystemExit(1)
+        warning("CI observer invalid input", error)
+        raise SystemExit(0)
 
     write_receipt(args.output, receipt)
-    raise SystemExit(2 if receipt["cache"]["alert"] else 0)
+    if receipt["cache"]["status"] == "over_budget":
+        warning(
+            "CI cache budget exceeded",
+            f"Cache usage is {receipt['cache']['usage_bytes']} bytes against the "
+            f"{receipt['cache']['budget_gb']} GB repository budget.",
+        )
+    if receipt["required_gate_target"]["status"] == "over_target":
+        warning(
+            "CI required gate target exceeded",
+            f"Required conclusion completed in {receipt['required_gate_elapsed_ms']} ms "
+            f"against the {receipt['required_gate_target']['minutes']}-minute target.",
+        )
+    raise SystemExit(0)
 
 
 if __name__ == "__main__":

--- a/scripts/ci-observer.test.py
+++ b/scripts/ci-observer.test.py
@@ -21,6 +21,8 @@ def event():
             "status": "completed",
             "conclusion": "success",
             "head_sha": SHA,
+            "event": "pull_request",
+            "head_branch": "fix/ordinary-pr",
             "run_started_at": "2026-07-24T01:00:00Z",
             "updated_at": "2026-07-24T01:21:00Z",
         }
@@ -52,7 +54,9 @@ def job(job_id=101, name="test ($(whoami))"):
 
 
 class CiObserverTests(unittest.TestCase):
-    def run_observer(self, event_payload, pages, usage, limit):
+    def run_observer(
+        self, event_payload, pages, usage, budget="10", gate_target="20", missing=()
+    ):
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         root = Path(tmp.name)
@@ -60,13 +64,13 @@ class CiObserverTests(unittest.TestCase):
             "event": event_payload,
             "jobs-pages": pages,
             "cache-usage": usage,
-            "cache-limit": limit,
         }
         paths = {}
         for name, payload in inputs.items():
             path = root / f"{name}.json"
-            path.write_text(json.dumps(payload))
             paths[name] = path
+            if name not in missing:
+                path.write_text(json.dumps(payload))
         output = root / "receipt.json"
         result = subprocess.run(
             [
@@ -78,8 +82,10 @@ class CiObserverTests(unittest.TestCase):
                 str(paths["jobs-pages"]),
                 "--cache-usage",
                 str(paths["cache-usage"]),
-                "--cache-limit",
-                str(paths["cache-limit"]),
+                "--cache-budget-gb",
+                str(budget),
+                "--required-gate-target-minutes",
+                str(gate_target),
                 "--output",
                 str(output),
             ],
@@ -91,20 +97,19 @@ class CiObserverTests(unittest.TestCase):
 
     def assert_error_receipt(self, receipt, message):
         self.assertIsNotNone(receipt)
-        self.assertEqual(receipt["schema_version"], 1)
+        self.assertEqual(receipt["schema_version"], 2)
         self.assertEqual(receipt["status"], "invalid")
         self.assertIn(message, receipt["error"]["message"])
         self.assertEqual(
             set(receipt["raw_refs"]),
-            {"event", "jobs_pages", "cache_usage", "cache_limit"},
+            {"event", "jobs_pages", "cache_usage"},
         )
-        for raw_ref in receipt["raw_refs"].values():
-            self.assertTrue(raw_ref["exists"])
-            self.assertGreater(raw_ref["size_bytes"], 0)
+        self.assertEqual(receipt["cache_budget"]["source"], "repository_policy")
+        self.assertIn("configured_minutes", receipt["required_gate_target"])
 
     def test_stable_receipt_preserves_untrusted_names_as_json_data(self):
         conclusion = job(102, "conclusion")
-        conclusion["completed_at"] = "2026-07-24T01:20:30Z"
+        conclusion["completed_at"] = "2026-07-24T01:19:30Z"
         result, receipt = self.run_observer(
             event(),
             [
@@ -112,14 +117,23 @@ class CiObserverTests(unittest.TestCase):
                 {"total_count": 2, "jobs": [job()]},
             ],
             {"active_caches_size_in_bytes": 9_000_000_000, "active_caches_count": 20},
-            {"max_cache_size_gb": 10},
         )
         self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(receipt["schema_version"], 2)
         self.assertEqual(receipt["observed_run"]["head_sha"], SHA)
         self.assertEqual(receipt["jobs"][1]["name"], "test ($(whoami))")
         self.assertEqual(receipt["jobs"][1]["duration_ms"], 1_140_000)
-        self.assertEqual(receipt["required_gate_elapsed_ms"], 1_230_000)
+        self.assertEqual(receipt["required_gate_elapsed_ms"], 1_170_000)
+        self.assertEqual(receipt["required_gate_target"]["status"], "within_target")
+        self.assertEqual(receipt["required_gate_target"]["minutes"], 20)
+        self.assertTrue(receipt["required_gate_target"]["applicable"])
+        self.assertEqual(
+            receipt["required_gate_target"]["scope"], "ordinary_pull_request"
+        )
+        self.assertEqual(receipt["required_gate_target"]["over_by_ms"], 0)
         self.assertEqual(receipt["cache"]["status"], "under_budget")
+        self.assertEqual(receipt["cache"]["budget_gb"], 10)
+        self.assertEqual(receipt["cache"]["budget_source"], "repository_policy")
 
     def test_normal_eviction_pressure_is_recorded_without_failing(self):
         result, receipt = self.run_observer(
@@ -129,14 +143,75 @@ class CiObserverTests(unittest.TestCase):
                 "active_caches_size_in_bytes": 10_000_000_001,
                 "active_caches_count": 21,
             },
-            {"max_cache_size_gb": 10},
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(receipt["cache"]["over_by_bytes"], 1)
         self.assertEqual(receipt["cache"]["status"], "over_budget")
         self.assertFalse(receipt["cache"]["alert"])
+        self.assertIn("::warning title=CI cache budget exceeded::", result.stdout)
 
-    def test_sustained_cache_overshoot_writes_receipt_then_exits_two(self):
+    def test_required_gate_over_target_warns_without_gating(self):
+        conclusion = job(102, "conclusion")
+        conclusion["completed_at"] = "2026-07-24T01:20:30Z"
+        result, receipt = self.run_observer(
+            event(),
+            [{"total_count": 1, "jobs": [conclusion]}],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(receipt["required_gate_elapsed_ms"], 1_230_000)
+        self.assertEqual(receipt["required_gate_target"]["status"], "over_target")
+        self.assertEqual(receipt["required_gate_target"]["over_by_ms"], 30_000)
+        self.assertIn(
+            "::warning title=CI required gate target exceeded::", result.stdout
+        )
+
+    def test_release_preflight_pr_is_not_an_ordinary_pr_slo_sample(self):
+        conclusion = job(102, "conclusion")
+        conclusion["completed_at"] = "2026-07-24T01:20:30Z"
+        result, receipt = self.run_observer(
+            event(),
+            [
+                {
+                    "total_count": 2,
+                    "jobs": [
+                        conclusion,
+                        job(103, "release-preflight (x86_64-pc-windows-msvc)"),
+                    ],
+                }
+            ],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(receipt["required_gate_target"]["applicable"])
+        self.assertEqual(receipt["required_gate_target"]["status"], "not_applicable")
+        self.assertEqual(
+            receipt["required_gate_target"]["exempt_jobs"],
+            ["release-preflight (x86_64-pc-windows-msvc)"],
+        )
+        self.assertNotIn("CI required gate target exceeded", result.stdout)
+
+    def test_main_and_release_please_runs_are_not_ordinary_pr_samples(self):
+        for run_event, head_branch in (
+            ("push", "main"),
+            ("pull_request", "release-please--branches--main"),
+        ):
+            with self.subTest(run_event=run_event, head_branch=head_branch):
+                payload = event()
+                payload["workflow_run"]["event"] = run_event
+                payload["workflow_run"]["head_branch"] = head_branch
+                result, receipt = self.run_observer(
+                    payload,
+                    [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
+                    {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertFalse(receipt["required_gate_target"]["applicable"])
+                self.assertEqual(
+                    receipt["required_gate_target"]["status"], "not_applicable"
+                )
+
+    def test_large_cache_overshoot_warns_without_failing(self):
         result, receipt = self.run_observer(
             event(),
             [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
@@ -144,11 +219,45 @@ class CiObserverTests(unittest.TestCase):
                 "active_caches_size_in_bytes": 11_500_000_001,
                 "active_caches_count": 21,
             },
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(receipt["cache"]["status"], "over_budget")
         self.assertTrue(receipt["cache"]["alert"])
+        self.assertIn("::warning title=CI cache budget exceeded::", result.stdout)
+
+        result, receipt = self.run_observer(
+            event(),
+            [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
+            {
+                "active_caches_size_in_bytes": 11_500_000_000,
+                "active_caches_count": 21,
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(receipt["cache"]["alert"])
+
+    def test_cancelled_run_may_have_no_conclusion_job(self):
+        cancelled = event()
+        cancelled["workflow_run"]["conclusion"] = "cancelled"
+        result, receipt = self.run_observer(
+            cancelled,
+            [{"total_count": 0, "jobs": []}],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(receipt["observed_run"]["conclusion"], "cancelled")
+        self.assertIsNone(receipt["required_gate_elapsed_ms"])
+        self.assertEqual(receipt["required_gate_target"]["status"], "unavailable")
+
+    def test_non_cancelled_run_without_conclusion_fails_closed(self):
+        result, receipt = self.run_observer(
+            event(),
+            [{"total_count": 1, "jobs": [job()]}],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assert_error_receipt(receipt, "exactly one required conclusion")
+        self.assertIn("::warning title=CI observer invalid input::", result.stdout)
 
     def test_rejects_short_sha_and_attempt_mismatch(self):
         bad_event = event()
@@ -157,9 +266,8 @@ class CiObserverTests(unittest.TestCase):
             bad_event,
             [{"total_count": 1, "jobs": [job()]}],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_error_receipt(receipt, "head SHA")
 
         mismatched = job()
@@ -168,9 +276,8 @@ class CiObserverTests(unittest.TestCase):
             event(),
             [{"total_count": 1, "jobs": [mismatched]}],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_error_receipt(receipt, "different run or attempt")
 
     def test_rejects_duplicate_jobs_and_inverted_timestamps(self):
@@ -179,9 +286,8 @@ class CiObserverTests(unittest.TestCase):
             event(),
             [{"total_count": 2, "jobs": [duplicate, duplicate]}],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_error_receipt(receipt, "unique integers")
 
         inverted = job()
@@ -190,9 +296,8 @@ class CiObserverTests(unittest.TestCase):
             event(),
             [{"total_count": 1, "jobs": [inverted]}],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_error_receipt(receipt, "completion timestamp precedes")
 
     def test_invalid_json_shapes_write_error_receipts(self):
@@ -200,19 +305,76 @@ class CiObserverTests(unittest.TestCase):
             [],
             [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_error_receipt(receipt, "event payload must be a JSON object")
 
         result, receipt = self.run_observer(
             event(),
             [42],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
-        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.returncode, 0, result.stderr)
         self.assert_error_receipt(receipt, "jobs page must be a JSON object")
+
+    def test_missing_metadata_writes_an_error_receipt_and_exits_zero(self):
+        result, receipt = self.run_observer(
+            event(),
+            [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+            missing={"cache-usage"},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(receipt["error"]["type"], "FileNotFoundError")
+        self.assertFalse(receipt["raw_refs"]["cache_usage"]["exists"])
+        self.assertIn("::warning title=CI observer invalid input::", result.stdout)
+
+    def test_rejects_malformed_cache_usage(self):
+        for usage, message in (
+            ({"active_caches_count": 1}, "active cache size"),
+            (
+                {"active_caches_size_in_bytes": "1", "active_caches_count": 1},
+                "active cache size",
+            ),
+            (
+                {"active_caches_size_in_bytes": 1, "active_caches_count": True},
+                "active cache count",
+            ),
+        ):
+            with self.subTest(usage=usage):
+                result, receipt = self.run_observer(
+                    event(),
+                    [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
+                    usage,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assert_error_receipt(receipt, message)
+
+    def test_rejects_non_positive_or_non_integer_budget(self):
+        for budget in ("0", "-1", "1.5", "ten"):
+            with self.subTest(budget=budget):
+                result, receipt = self.run_observer(
+                    event(),
+                    [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
+                    {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+                    budget=budget,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assert_error_receipt(receipt, "cache budget in GB must be a positive integer")
+
+    def test_rejects_non_positive_or_non_integer_gate_target(self):
+        for gate_target in ("0", "-1", "1.5", "twenty"):
+            with self.subTest(gate_target=gate_target):
+                result, receipt = self.run_observer(
+                    event(),
+                    [{"total_count": 1, "jobs": [job(102, "conclusion")]}],
+                    {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+                    gate_target=gate_target,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assert_error_receipt(
+                    receipt, "required gate target minutes must be a positive integer"
+                )
 
     def test_clamps_github_clock_skew_on_skipped_jobs(self):
         skipped = job()
@@ -225,7 +387,6 @@ class CiObserverTests(unittest.TestCase):
             event(),
             [{"total_count": 2, "jobs": [skipped, conclusion]}],
             {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
-            {"max_cache_size_gb": 10},
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         skipped_receipt = next(job for job in receipt["jobs"] if job["name"] == "skipped")

--- a/scripts/ci_test_plan.py
+++ b/scripts/ci_test_plan.py
@@ -59,6 +59,37 @@ NATIVE_SUFFIXES = {
 CLI_SERVER_PACKAGES = {"wenlan", "wenlan-server"}
 MANUAL_CORE_INTEGRATION = {"cached_scenario_db_check", "eval_harness"}
 
+PLUGIN_JOB_PREFIXES = (
+    "plugin",
+    "plugin-codex",
+    ".agents/plugins",
+    ".claude-plugin",
+)
+PLUGIN_JOB_FILES = {
+    "plugin-contract.json",
+    "scripts/validate-codex-plugin-slice.py",
+    "scripts/validate-plugin-contract.py",
+    "scripts/validate-plugin-contract.test.sh",
+}
+
+DOCS_JOB_PREFIXES = ("docs",)
+DOCS_JOB_FILES = {
+    "LICENSE",
+    "scripts/check-readme-translations.py",
+    "scripts/check-readme-translations.test.sh",
+    "scripts/update-readme-eval.py",
+    "scripts/update-readme-eval.test.py",
+    "scripts/validate-versions.sh",
+    "scripts/validate-versions.test.sh",
+}
+
+SUITE_OUTPUT_KEYS = {
+    "workspace-lib-required": "workspace_lib",
+    "cli-server-integration-required": "cli_server_integration",
+    "core-integration-required": "core_integration",
+    "canonical-smokes-required": "canonical_smokes",
+}
+
 
 def _cargo_executable() -> str:
     """Return Cargo's executable without parsing a shell command string."""
@@ -83,6 +114,7 @@ def _full_plan(reason: str) -> dict:
         "workspace_lib": {"mode": "full"},
         "cli_server_integration": {"mode": "full"},
         "core_integration": {"mode": "full"},
+        "canonical_smokes": {"mode": "full"},
     }
 
 
@@ -184,6 +216,38 @@ def _owner(path: str, directories: dict[str, str]) -> tuple[str, str] | None:
     return package, path[len(directory) + 1 :]
 
 
+def _plugin_job_owns(path: str) -> bool:
+    if path in PLUGIN_JOB_FILES:
+        return True
+    return any(
+        path == prefix or path.startswith(f"{prefix}/")
+        for prefix in PLUGIN_JOB_PREFIXES
+    )
+
+
+def _npm_job_owns(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    return len(parts) >= 4 and parts[0] == "crates" and parts[2] == "npm"
+
+
+def _rust_fixture_owns(path: str) -> bool:
+    parts = PurePosixPath(path).parts
+    if len(parts) < 4 or parts[0] != "crates":
+        return False
+    return "tests" in parts[2:-1] or parts[2] == "resources"
+
+
+def _docs_job_owns(path: str) -> bool:
+    if path in DOCS_JOB_FILES:
+        return True
+    if any(
+        path == prefix or path.startswith(f"{prefix}/")
+        for prefix in DOCS_JOB_PREFIXES
+    ):
+        return True
+    return path.endswith(".md") and not _rust_fixture_owns(path)
+
+
 def _integration_targets(package: dict) -> set[str]:
     targets = set()
     for target in package["targets"]:
@@ -246,9 +310,25 @@ def build_plan(
     cli_server_targets: dict[str, set[str]] = defaultdict(set)
     core_full = False
     core_targets: set[str] = set()
+    canonical_smokes = False
     reasons: list[str] = []
 
     for path in paths:
+        # Plugin distribution files have an explicit required CI owner. Check
+        # that ownership before Cargo/build classification so a mixed
+        # Rust-plus-plugin diff keeps the Rust portion's narrow plan.
+        if _plugin_job_owns(path):
+            reasons.append(f"plugin contract job owns changed path: {path}")
+            continue
+
+        if _npm_job_owns(path):
+            reasons.append(f"npm contract job owns changed path: {path}")
+            continue
+
+        if _docs_job_owns(path):
+            reasons.append(f"docs contract job owns changed path: {path}")
+            continue
+
         if (
             path in FULL_INPUTS
             or path.endswith("/Cargo.toml")
@@ -316,6 +396,7 @@ def build_plan(
             broad_packages.update(closure)
             cli_server_packages.update(closure & CLI_SERVER_PACKAGES)
             core_full = core_full or "wenlan-core" in closure
+            canonical_smokes = True
             reasons.append(f"source change selects reverse dependency closure: {path}")
             continue
 
@@ -354,7 +435,37 @@ def build_plan(
         "workspace_lib": _workspace_lib_plan(broad_packages, isolated_filters),
         "cli_server_integration": cli_server_plan,
         "core_integration": core_plan,
+        "canonical_smokes": {"mode": "full" if canonical_smokes else "skip"},
     }
+
+
+def required_suite_outputs(plan: object) -> dict[str, bool]:
+    """Return validated booleans used by workflow job and step gates."""
+
+    if not isinstance(plan, dict) or plan.get("version") != 1:
+        raise PlanError("unsupported or malformed test plan")
+    required: dict[str, bool] = {}
+    for output_name, suite_name in SUITE_OUTPUT_KEYS.items():
+        suite = plan.get(suite_name)
+        if not isinstance(suite, dict):
+            raise PlanError(f"test plan has no suite {suite_name!r}")
+        mode = suite.get("mode")
+        if not isinstance(mode, str) or not mode:
+            raise PlanError(f"test plan suite {suite_name!r} has no mode")
+        required[output_name] = mode != "skip"
+    required["canonical-acceptance-required"] = any(
+        required[name]
+        for name in (
+            "cli-server-integration-required",
+            "core-integration-required",
+            "canonical-smokes-required",
+        )
+    )
+    required["rust-ci-required"] = (
+        required["workspace-lib-required"]
+        or required["canonical-acceptance-required"]
+    )
+    return required
 
 
 def _validated_package_names(
@@ -385,12 +496,65 @@ def _package_args(package_names: Iterable[str]) -> list[str]:
     return arguments
 
 
+def _validated_path_argument(raw_path: object, *, name: str) -> str:
+    if (
+        not isinstance(raw_path, str)
+        or not raw_path
+        or "\n" in raw_path
+        or "\r" in raw_path
+        or raw_path.startswith("-")
+    ):
+        raise PlanError(f"{name} must be a non-empty path argument")
+    return raw_path
+
+
+def archive_command_for(
+    plan: object,
+    cargo_metadata: object,
+    *,
+    archive_file: str,
+) -> list[str]:
+    """Build one workspace-lib archive without applying test predicates."""
+
+    if not isinstance(plan, dict) or plan.get("version") != 1:
+        raise PlanError("unsupported or malformed test plan")
+    packages, _directories = _workspace(cargo_metadata)
+    suite = plan.get("workspace_lib")
+    if not isinstance(suite, dict):
+        raise PlanError("test plan has no suite 'workspace-lib'")
+    mode = suite.get("mode")
+    if mode == "skip":
+        return []
+
+    cargo = [
+        "cargo",
+        "nextest",
+        "archive",
+        "--archive-file",
+        _validated_path_argument(archive_file, name="archive-file"),
+    ]
+    if mode == "full":
+        return [*cargo, "--workspace", "--lib"]
+    if mode in {"packages", "filterset"}:
+        if mode == "filterset":
+            filterset = suite.get("filterset")
+            if not isinstance(filterset, str) or not filterset:
+                raise PlanError("workspace filterset is empty")
+        names = _validated_package_names(suite.get("packages"), packages)
+        # Filterset plans archive each selected package's complete lib test
+        # binary. Test-name predicates are valid only when the archive runs.
+        return [*cargo, *_package_args(names), "--lib"]
+    raise PlanError(f"unknown workspace-lib mode: {mode!r}")
+
+
 def command_groups_for(
     suite_name: str,
     plan: object,
     cargo_metadata: object,
     *,
     partition: str | None = None,
+    archive_file: str | None = None,
+    workspace_remap: str | None = None,
 ) -> list[list[str]]:
     """Translate a plan suite into validated argv vectors."""
 
@@ -413,12 +577,52 @@ def command_groups_for(
         if suite_name != "workspace-lib":
             raise PlanError("nextest partition is only supported for workspace-lib")
 
+    if archive_file is None and workspace_remap is not None:
+        raise PlanError("workspace-remap requires an archive-file")
+    if archive_file is not None:
+        if suite_name != "workspace-lib":
+            raise PlanError("nextest archives are only supported for workspace-lib")
+        if workspace_remap is None:
+            raise PlanError("archive-file requires workspace-remap")
+        archive_file = _validated_path_argument(
+            archive_file,
+            name="archive-file",
+        )
+        workspace_remap = _validated_path_argument(
+            workspace_remap,
+            name="workspace-remap",
+        )
+
     def workspace_command(arguments: list[str]) -> list[str]:
         if partition is None:
             return arguments
         return [*arguments, "--partition", partition]
 
     if suite_name == "workspace-lib":
+        if archive_file is not None:
+            archived = [
+                *cargo,
+                "--archive-file",
+                archive_file,
+                "--workspace-remap",
+                workspace_remap,
+            ]
+            if mode == "full":
+                return [workspace_command(archived)]
+            if mode == "packages":
+                _validated_package_names(suite.get("packages"), packages)
+                return [workspace_command(archived)]
+            if mode == "filterset":
+                filterset = suite.get("filterset")
+                if not isinstance(filterset, str) or not filterset:
+                    raise PlanError("workspace filterset is empty")
+                _validated_package_names(suite.get("packages"), packages)
+                return [
+                    workspace_command(
+                        [*archived, "-E", filterset, "--no-tests=pass"]
+                    )
+                ]
+            raise PlanError(f"unknown workspace-lib mode: {mode!r}")
         if mode == "full":
             return [workspace_command([*cargo, "--workspace", "--lib"])]
         if mode == "packages":
@@ -571,6 +775,11 @@ def _require_filterset_match(command: list[str]) -> None:
         if index + 1 >= len(command):
             raise PlanError("nextest partition has no value")
         unpartitioned = [*command[:index], *command[index + 2 :]]
+    # The run may legitimately have an empty shard after the unpartitioned
+    # selector was proven non-empty. `nextest list` does not accept this flag.
+    unpartitioned = [
+        argument for argument in unpartitioned if argument != "--no-tests=pass"
+    ]
     list_command = [
         _cargo_executable(),
         "nextest",
@@ -612,11 +821,14 @@ def _require_filterset_match(command: list[str]) -> None:
     print(f"workspace-lib filterset matched {matched} tests")
 
 
-def _write_github_output(path: str, plan_json: str) -> None:
+def _write_github_output(path: str, plan: object, plan_json: str) -> None:
     if "\n" in plan_json or "\r" in plan_json:
         raise PlanError("compact plan JSON unexpectedly contains a newline")
+    required = required_suite_outputs(plan)
     with Path(path).open("a", encoding="utf-8") as output:
         output.write(f"test-plan={plan_json}\n")
+        for name, value in required.items():
+            output.write(f"{name}={'true' if value else 'false'}\n")
 
 
 def _main(argv: list[str]) -> int:
@@ -628,6 +840,10 @@ def _main(argv: list[str]) -> int:
     plan_parser.add_argument("--metadata-file", required=True)
     plan_parser.add_argument("--event-name", required=True)
     plan_parser.add_argument("--github-output")
+
+    archive_parser = subparsers.add_parser("archive")
+    archive_parser.add_argument("--plan-json", required=True)
+    archive_parser.add_argument("--archive-file", required=True)
 
     run_parser = subparsers.add_parser("run")
     run_parser.add_argument(
@@ -641,6 +857,8 @@ def _main(argv: list[str]) -> int:
     )
     run_parser.add_argument("--plan-json", required=True)
     run_parser.add_argument("--partition")
+    run_parser.add_argument("--archive-file")
+    run_parser.add_argument("--workspace-remap")
 
     arguments = parser.parse_args(argv)
     if arguments.command == "plan":
@@ -658,18 +876,35 @@ def _main(argv: list[str]) -> int:
         plan_json = json.dumps(plan, separators=(",", ":"), sort_keys=True)
         print(plan_json)
         if arguments.github_output:
-            _write_github_output(arguments.github_output, plan_json)
+            _write_github_output(arguments.github_output, plan, plan_json)
         return 0
 
     try:
         plan = json.loads(arguments.plan_json)
     except json.JSONDecodeError as error:
         raise PlanError("plan-json is invalid") from error
+    metadata = _cargo_metadata()
+    if arguments.command == "archive":
+        command = archive_command_for(
+            plan,
+            metadata,
+            archive_file=arguments.archive_file,
+        )
+        if not command:
+            print("workspace-lib: no affected tests to archive")
+            return 0
+        executable_command = _executable_command(command)
+        print("+", " ".join(executable_command), flush=True)
+        subprocess.run(executable_command, check=True)
+        return 0
+
     commands = command_groups_for(
         arguments.suite,
         plan,
-        _cargo_metadata(),
+        metadata,
         partition=arguments.partition,
+        archive_file=arguments.archive_file,
+        workspace_remap=arguments.workspace_remap,
     )
     if not commands:
         print(f"{arguments.suite}: no affected tests")

--- a/scripts/ci_test_plan.test.py
+++ b/scripts/ci_test_plan.test.py
@@ -11,7 +11,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from ci_test_plan import PlanError, build_plan, command_groups_for
+from ci_test_plan import (
+    PlanError,
+    archive_command_for,
+    build_plan,
+    command_groups_for,
+    required_suite_outputs,
+)
 
 
 WORKSPACE_ROOT = "/repo"
@@ -298,6 +304,24 @@ class PackageClosureTests(unittest.TestCase):
 
 
 class NarrowOwnerTests(unittest.TestCase):
+    def test_explicit_isolated_test_module_selects_its_real_prefix(self) -> None:
+        path = "crates/wenlan-core/src/lint/pages/security_test.rs"
+        plan = plan_for(path)
+
+        self.assertEqual(
+            plan["workspace_lib"],
+            {
+                "mode": "filterset",
+                "packages": ["wenlan-core"],
+                "filterset": (
+                    "package(wenlan-core) "
+                    "& test(/^lint::pages::fs::tests::security_cases::/)"
+                ),
+            },
+        )
+        self.assertEqual(plan["cli_server_integration"], {"mode": "skip"})
+        self.assertEqual(plan["core_integration"], {"mode": "skip"})
+
     def test_extant_core_integration_file_selects_only_its_test_target(self) -> None:
         path = "crates/wenlan-core/tests/folder_ingest_e2e.rs"
         plan = plan_for(path)
@@ -323,24 +347,210 @@ class NarrowOwnerTests(unittest.TestCase):
         )
         self.assertEqual(plan["core_integration"], {"mode": "skip"})
 
-    def test_explicit_isolated_test_module_selects_its_real_prefix(self) -> None:
-        path = "crates/wenlan-core/src/lint/pages/security_test.rs"
-        plan = plan_for(path)
 
-        self.assertEqual(
-            plan["workspace_lib"],
-            {
-                "mode": "filterset",
-                "packages": ["wenlan-core"],
-                "filterset": (
-                    "package(wenlan-core) "
-                    "& test(/^lint::pages::fs::tests::security_cases::/)"
-                ),
-            },
-        )
+class PluginOwnerTests(unittest.TestCase):
+    PR_415_PATHS = (
+        "plugin-codex/skills/setup/SKILL.md",
+        "plugin/skills/setup/SKILL.md",
+    )
+
+    def test_pr_415_exact_paths_are_owned_without_full_rust_fallback(self) -> None:
+        plan = plan_for(*self.PR_415_PATHS)
+
+        self.assertEqual(plan["mode"], "differential")
+        self.assertEqual(plan["workspace_lib"], {"mode": "skip"})
         self.assertEqual(plan["cli_server_integration"], {"mode": "skip"})
         self.assertEqual(plan["core_integration"], {"mode": "skip"})
+        self.assertEqual(plan["canonical_smokes"], {"mode": "skip"})
 
+    def test_mixed_rust_and_pr_415_diff_keeps_the_rust_only_plan(self) -> None:
+        rust_path = "crates/wenlan-server/src/routes.rs"
+        rust_only = plan_for(rust_path)
+        mixed = plan_for(rust_path, *self.PR_415_PATHS)
+
+        for suite in (
+            "workspace_lib",
+            "cli_server_integration",
+            "core_integration",
+            "canonical_smokes",
+        ):
+            self.assertEqual(mixed[suite], rust_only[suite])
+        self.assertEqual(mixed["mode"], "differential")
+
+    def test_every_plugin_job_owned_path_is_ignored_by_cargo_ownership(self) -> None:
+        paths = (
+            "plugin/skills/setup/SKILL.md",
+            "plugin-codex/skills/setup/SKILL.md",
+            ".agents/plugins/wenlan/skills/setup/SKILL.md",
+            ".claude-plugin/marketplace.json",
+            "plugin-contract.json",
+            "scripts/validate-codex-plugin-slice.py",
+            "scripts/validate-plugin-contract.py",
+            "scripts/validate-plugin-contract.test.sh",
+        )
+
+        for path in paths:
+            with self.subTest(path=path):
+                plan = plan_for(path)
+                self.assertEqual(plan["mode"], "differential")
+                self.assertFalse(any(required_suite_outputs(plan).values()))
+
+
+class NonRustOwnerTests(unittest.TestCase):
+    def assert_non_rust_owner(self, *paths: str) -> None:
+        plan = plan_for(*paths)
+        self.assertEqual(plan["mode"], "differential")
+        self.assertEqual(plan["workspace_lib"], {"mode": "skip"})
+        self.assertEqual(plan["cli_server_integration"], {"mode": "skip"})
+        self.assertEqual(plan["core_integration"], {"mode": "skip"})
+        self.assertEqual(plan["canonical_smokes"], {"mode": "skip"})
+        self.assertFalse(any(required_suite_outputs(plan).values()))
+
+    def test_exact_docs_only_paths_have_no_rust_suites(self) -> None:
+        paths = (
+            "README.md",
+            "docs/windows-vulkan.md",
+            "crates/wenlan-core/AGENTS.md",
+            "LICENSE",
+            "scripts/check-readme-translations.py",
+            "scripts/check-readme-translations.test.sh",
+            "scripts/update-readme-eval.py",
+            "scripts/update-readme-eval.test.py",
+            "scripts/validate-versions.sh",
+            "scripts/validate-versions.test.sh",
+        )
+
+        for path in paths:
+            with self.subTest(path=path):
+                self.assert_non_rust_owner(path)
+
+    def test_exact_npm_only_paths_have_no_rust_suites(self) -> None:
+        for path in (
+            "crates/wenlan-cli/npm/package.json",
+            "crates/wenlan-mcp/npm/install.js",
+        ):
+            with self.subTest(path=path):
+                self.assert_non_rust_owner(path)
+
+    def test_docs_npm_and_plugin_only_diff_stays_on_fast_lanes(self) -> None:
+        self.assert_non_rust_owner(
+            "docs/windows-vulkan.md",
+            "crates/wenlan-mcp/npm/install.js",
+            "plugin/skills/setup/SKILL.md",
+        )
+
+    def test_non_rust_owners_do_not_widen_a_mixed_rust_plan(self) -> None:
+        rust_path = "crates/wenlan-server/src/routes.rs"
+        rust_only = plan_for(rust_path)
+        mixed = plan_for(
+            rust_path,
+            "docs/windows-vulkan.md",
+            "crates/wenlan-mcp/npm/install.js",
+            "plugin/skills/setup/SKILL.md",
+        )
+
+        for suite in (
+            "workspace_lib",
+            "cli_server_integration",
+            "core_integration",
+            "canonical_smokes",
+        ):
+            self.assertEqual(mixed[suite], rust_only[suite])
+
+    def test_markdown_test_fixture_is_not_misclassified_as_docs_only(self) -> None:
+        plan = plan_for("crates/wenlan-core/tests/fixtures/example.md")
+
+        self.assertEqual(plan["mode"], "full")
+        self.assertTrue(required_suite_outputs(plan)["rust-ci-required"])
+
+
+class SuiteOutputTests(unittest.TestCase):
+    def test_behavioral_source_requires_lib_integration_and_canonical_smokes(
+        self,
+    ) -> None:
+        outputs = required_suite_outputs(
+            plan_for("crates/wenlan-server/src/routes.rs")
+        )
+
+        self.assertEqual(
+            outputs,
+            {
+                "workspace-lib-required": True,
+                "cli-server-integration-required": True,
+                "core-integration-required": False,
+                "canonical-smokes-required": True,
+                "canonical-acceptance-required": True,
+                "rust-ci-required": True,
+            },
+        )
+
+    def test_direct_integration_requires_only_its_canonical_suite(self) -> None:
+        outputs = required_suite_outputs(
+            plan_for("crates/wenlan-cli/tests/distribution.rs")
+        )
+
+        self.assertFalse(outputs["workspace-lib-required"])
+        self.assertTrue(outputs["cli-server-integration-required"])
+        self.assertFalse(outputs["core-integration-required"])
+        self.assertFalse(outputs["canonical-smokes-required"])
+        self.assertTrue(outputs["canonical-acceptance-required"])
+        self.assertTrue(outputs["rust-ci-required"])
+
+    def test_isolated_and_plugin_paths_do_not_require_canonical_acceptance(
+        self,
+    ) -> None:
+        isolated = required_suite_outputs(
+            plan_for("crates/wenlan-core/src/lint/pages/security_test.rs")
+        )
+        plugin = required_suite_outputs(
+            plan_for("plugin-codex/skills/setup/SKILL.md")
+        )
+
+        self.assertTrue(isolated["workspace-lib-required"])
+        self.assertFalse(isolated["canonical-acceptance-required"])
+        self.assertFalse(any(plugin.values()))
+
+    def test_full_plan_requires_every_suite(self) -> None:
+        self.assertTrue(
+            all(required_suite_outputs(plan_for("Cargo.lock")).values())
+        )
+
+    def test_plan_command_writes_each_required_suite_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = Path(directory) / "metadata.json"
+            output_path = Path(directory) / "github-output.txt"
+            metadata_path.write_text(json.dumps(cargo_metadata()), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("ci_test_plan.py")),
+                    "plan",
+                    "--changed-files-json",
+                    json.dumps(["Cargo.lock"]),
+                    "--metadata-file",
+                    str(metadata_path),
+                    "--event-name",
+                    "pull_request",
+                    "--github-output",
+                    str(output_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                cwd=Path(__file__).parent.parent,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = output_path.read_text(encoding="utf-8")
+            for name in (
+                "workspace-lib-required",
+                "cli-server-integration-required",
+                "core-integration-required",
+                "canonical-smokes-required",
+                "canonical-acceptance-required",
+                "rust-ci-required",
+            ):
+                self.assertIn(f"{name}=true\n", output)
 
 class FailClosedTests(unittest.TestCase):
     def test_deleted_integration_target_falls_back_to_owning_package_suite(self) -> None:
@@ -364,6 +574,13 @@ class FailClosedTests(unittest.TestCase):
         plan = plan_for("crates/new-crate/src/lib.rs")
 
         self.assertEqual(plan["mode"], "full")
+
+    def test_unknown_non_plugin_repository_path_stays_fail_closed(self) -> None:
+        plan = plan_for("config/new-ci-input.json")
+
+        self.assertEqual(plan["mode"], "full")
+        self.assertEqual(plan["canonical_smokes"], {"mode": "full"})
+        self.assertTrue(all(required_suite_outputs(plan).values()))
 
     def test_cargo_build_native_and_ci_inputs_fall_back_to_all_suites(self) -> None:
         for path in [
@@ -478,6 +695,123 @@ class CommandGenerationTests(unittest.TestCase):
                 ]
             ],
         )
+
+    def test_full_workspace_archive_compiles_the_complete_lib_inventory(self) -> None:
+        plan = plan_for("Cargo.lock")
+
+        self.assertEqual(
+            archive_command_for(
+                plan,
+                cargo_metadata(),
+                archive_file="/tmp/workspace-lib.tar.zst",
+            ),
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                "/tmp/workspace-lib.tar.zst",
+                "--workspace",
+                "--lib",
+            ],
+        )
+
+    def test_package_archive_compiles_only_selected_package_libs(self) -> None:
+        plan = plan_for("crates/wenlan-server/src/routes.rs")
+
+        self.assertEqual(
+            archive_command_for(
+                plan,
+                cargo_metadata(),
+                archive_file="/tmp/workspace-lib.tar.zst",
+            ),
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                "/tmp/workspace-lib.tar.zst",
+                "-p",
+                "wenlan-mcp",
+                "-p",
+                "wenlan-server",
+                "--lib",
+            ],
+        )
+
+    def test_filterset_archive_defers_test_selector_until_partition_run(self) -> None:
+        plan = plan_for(
+            "crates/wenlan-core/src/lint/pages/security_test.rs"
+        )
+        filterset = (
+            "package(wenlan-core) "
+            "& test(/^lint::pages::fs::tests::security_cases::/)"
+        )
+
+        archive = archive_command_for(
+            plan,
+            cargo_metadata(),
+            archive_file="/tmp/workspace-lib.tar.zst",
+        )
+        run = command_groups_for(
+            "workspace-lib",
+            plan,
+            cargo_metadata(),
+            partition="slice:2/2",
+            archive_file="/tmp/workspace-lib.tar.zst",
+            workspace_remap="/repo",
+        )
+
+        self.assertEqual(
+            archive,
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                "/tmp/workspace-lib.tar.zst",
+                "-p",
+                "wenlan-core",
+                "--lib",
+            ],
+        )
+        self.assertNotIn("-E", archive)
+        self.assertEqual(
+            run,
+            [
+                [
+                    "cargo",
+                    "nextest",
+                    "run",
+                    "--archive-file",
+                    "/tmp/workspace-lib.tar.zst",
+                    "--workspace-remap",
+                    "/repo",
+                    "-E",
+                    filterset,
+                    "--no-tests=pass",
+                    "--partition",
+                    "slice:2/2",
+                ]
+            ],
+        )
+
+    def test_archive_run_requires_a_safe_workspace_remap(self) -> None:
+        plan = plan_for("Cargo.lock")
+
+        with self.assertRaisesRegex(PlanError, "requires workspace-remap"):
+            command_groups_for(
+                "workspace-lib",
+                plan,
+                cargo_metadata(),
+                archive_file="/tmp/workspace-lib.tar.zst",
+            )
+        with self.assertRaisesRegex(PlanError, "non-empty path argument"):
+            archive_command_for(
+                plan,
+                cargo_metadata(),
+                archive_file="--unexpected-option",
+            )
 
     def test_isolated_module_uses_literal_nextest_filterset_argument(self) -> None:
         plan = plan_for(


### PR DESCRIPTION
## What changed

- compile Linux workspace-library tests once into a run-scoped cargo-nextest archive, then execute two artifact-only partitions
- make affected-test planning universal and fail closed for unknown paths while preserving docs, npm, and plugin fast owners
- add focused plugin Rust contract coverage without broad workspace CI
- route all required Rust jobs and FastEmbed production through the planner's `rust-ci-required` output
- make CI observer receipts deterministic, warning-only, cache-budget aware, and explicit about the 20-minute ordinary-PR SLO
- reduce target-cache writers and restore-only cache footprint
- run release-please only after successful main CI
- overlap Docker staging with binary release while keeping manifest publication atomic
- canary Windows outer Cargo parallelism at 2 while preserving nested CMake parallelism at 1

## Root cause

Recent PRs repeatedly rebuilt the same Rust workspace across Linux shards, plugin-only diffs fell through to the full Rust plan, cache writers exceeded the repository cache budget, Windows release builds were fully serialized, and Docker release work was unnecessarily downstream of all binary builds. The observer also depended on metadata the workflow token could not read.

## 20-minute target

The receipt now classifies only ordinary pull requests as SLO samples. Runs with a real `release-preflight (...)` job, release-please branches, main pushes, and manual backstops are explicitly non-applicable. This CI-bootstrap PR intentionally exercises the full platform/release canary and is therefore an exempt sample; ordinary PR evidence will be taken from a subsequent post-merge receipt.

## Validation

### Hosted GitHub Actions — latest main base

- rebased onto `main` at `b195a27` (release 0.15.3), head `ba0de7f`
- CI run [30693261408](https://github.com/7xuanlu/wenlan/actions/runs/30693261408): **success**, including required `conclusion`
- full bootstrap/native run: **35m51s**; correctly observer-exempt because all four `release-preflight (...)` jobs ran
- Linux compile-once archive + both artifact-only nextest partitions: **15m09s workflow critical path**
- canonical Ubuntu: **T+16m13s**
- Windows platform compile: **T+18m54s**
- all non-release/full-platform jobs: **T+22m45s**; this is a native bootstrap backstop, not an ordinary SLO sample
- Windows release build/smoke: **32m26s**, down from the pre-change 53m42s–56m03s step range; native ORT smoke: **6s**
- no Windows PDB/C1041 race with `CARGO_BUILD_JOBS=2` and nested CMake parallelism 1

The first hosted run exposed one stale empty-workflow mutation expectation; commit `ba0de7f` contains the non-weakening one-line correction, which Opus 5 approved and both subsequent hosted runs passed.

Observer run [30694439272](https://github.com/7xuanlu/wenlan/actions/runs/30694439272) still used the default-branch implementation (GitHub `workflow_run` semantics) and reproduced the old token-403/parser failure. The PR version removes that inaccessible dependency and can only produce its new deterministic receipt after this bootstrap change reaches `main`.

### Local and delegated review

- Opus 5 final blocker review: **APPROVE**
- planner tests: 44 passed
- observer tests: 16 passed
- nextest archive/remap/two-slice smoke passed, including an empty filterset slice
- release, ORT, FastEmbed, MSVC Ninja, Vulkan SDK, and Vulkan loader helper suites passed
- plugin distribution contract: 4 passed
- all workflow YAML parsed
- Python compilation, cargo fmt, and git diff checks passed

Local `wenlan-core` Cargo drift-test execution remains unavailable because this Windows machine has no installed Vulkan SDK; the hosted Windows lane is the native proof.