### PR TITLE
test: prove ordinary CI SLO classification

### DIFF
--- a/scripts/ci-observer.test.py
+++ b/scripts/ci-observer.test.py
@@ -191,6 +191,28 @@ class CiObserverTests(unittest.TestCase):
         )
         self.assertNotIn("CI required gate target exceeded", result.stdout)
 
+    def test_skipped_release_preflight_keeps_ordinary_pr_in_slo_sample(self):
+        conclusion = job(102, "conclusion")
+        conclusion["completed_at"] = "2026-07-24T01:19:30Z"
+        skipped_preflight = job(
+            103, "release-preflight (x86_64-pc-windows-msvc)"
+        )
+        skipped_preflight["conclusion"] = "skipped"
+        result, receipt = self.run_observer(
+            event(),
+            [
+                {
+                    "total_count": 2,
+                    "jobs": [conclusion, skipped_preflight],
+                }
+            ],
+            {"active_caches_size_in_bytes": 1, "active_caches_count": 1},
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(receipt["required_gate_target"]["applicable"])
+        self.assertEqual(receipt["required_gate_target"]["status"], "within_target")
+        self.assertEqual(receipt["required_gate_target"]["exempt_jobs"], [])
+
     def test_main_and_release_please_runs_are_not_ordinary_pr_samples(self):
         for run_event, head_branch in (
             ("push", "main"),


### PR DESCRIPTION
## Purpose

Produce the post-merge ordinary-PR hosted-runner and observer receipt required to validate the 20-minute required `conclusion` SLO.

## Change

Add a regression test proving that a skipped `release-preflight (...)` job does not exempt an otherwise ordinary pull request from SLO measurement. The adjacent non-skipped test proves the opposite branch.

## Why this is an ordinary sample

- changed path: `scripts/ci-observer.test.py`
- fail-closed planner result: `mode=full`
- required Linux suites: workspace lib, CLI/server integration, core integration, canonical smokes — all `full`
- macOS, Windows, MCP platform, workspace platform, and release-preflight path filters: not matched
- no production code or workflow change

## Local verification

- `python scripts/ci-observer.test.py`: 17 passed
- Python compilation: passed
- exact planner probe: all four Linux required suites `full`
- `git diff --check`: passed
- Opus 5 exact-test review: APPROVE

## Hosted verification — complete

- [CI run 30704041518](https://github.com/7xuanlu/wenlan/actions/runs/30704041518): success
- required `conclusion`: 2026-08-01 14:34:12 → 14:49:47 UTC = **15m35s**, within the 20-minute SLO
- ordinary routing confirmed: Windows/platform/release/plugin/npm/docs jobs were skipped
- [default-branch observer run 30704597199](https://github.com/7xuanlu/wenlan/actions/runs/30704597199): success
- schema-v2 artifact `ci-observer-30704041518-1` (artifact 8819911592):
  - `scope=ordinary_pull_request`
  - `applicable=true`
  - `status=within_target`
  - `required_gate_elapsed_ms=935000`
  - `exempt_jobs=[]`

The receipt also reports Actions cache usage at 10.70 GB against the 10 GB nominal budget, below the configured 1.15 alert ratio (`alert=false`).