### PR TITLE
ci: stabilize Windows release smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1239,6 +1239,8 @@ jobs:
       # `mcp-platform`; compiling the same graph again in release profile is
       # the measured >20-minute duplicate. Full release backstops keep it.
       matrix: ${{ fromJSON(needs.detect-changes.outputs.release-preflight-targets) }}
+    env:
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
@@ -1332,12 +1334,22 @@ jobs:
             -DestinationDirectory "target\${{ matrix.target }}\release"
           & scripts/stage-onnxruntime-windows.ps1 `
             -DestinationDirectory "target\${{ matrix.target }}\release"
+      # The native smoke starts a fresh daemon. Give it the model prepared by
+      # detect-changes so health does not depend on a cold Hugging Face fetch.
+      - name: Download portable FastEmbed model
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}
+          path: .fastembed_cache
       - name: Build and smoke shipped release binaries
         shell: bash
         run: bash scripts/build-release-binaries.sh "${{ matrix.target }}"
       - name: Native ORT smoke (Windows release preflight)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
+        env:
+          WENLAN_TEST_FASTEMBED_CACHE: ${{ env.FASTEMBED_CACHE_DIR }}
         run: |
           & scripts/smoke-windows.ps1 `
             -ExePath "target\${{ matrix.target }}\release\wenlan-server.exe"

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -137,6 +137,10 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
             "contract-integration",
             &["Affected wenlan-mcp + wenlan-types integrations"],
         ),
+        (
+            "release-preflight",
+            &["Native ORT smoke (Windows release preflight)"],
+        ),
     ];
 
     let parsed: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse ci.yml");
@@ -212,6 +216,12 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
         if *job_name == "test" && !download["if"].is_null() {
             violations.push("test downloads the model only on a subset of matrix OSes".into());
         }
+        if *job_name == "release-preflight"
+            && download["if"].as_str() != Some("matrix.target == 'x86_64-pc-windows-msvc'")
+        {
+            violations
+                .push("release-preflight does not scope the FastEmbed download to Windows".into());
+        }
 
         for consumer_name in *consumer_names {
             let consumer_index = steps
@@ -225,6 +235,16 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
                 None => violations.push(format!(
                     "job {job_name} is missing consumer step {consumer_name:?}"
                 )),
+            }
+            if *job_name == "release-preflight" {
+                let cache_override = consumer_index
+                    .and_then(|index| steps.get(index))
+                    .and_then(|step| step["env"]["WENLAN_TEST_FASTEMBED_CACHE"].as_str());
+                if cache_override != Some("${{ env.FASTEMBED_CACHE_DIR }}") {
+                    violations.push(format!(
+                        "release-preflight consumer {consumer_name:?} does not use the prepared FastEmbed cache"
+                    ));
+                }
             }
         }
     }

--- a/scripts/smoke-windows.ps1
+++ b/scripts/smoke-windows.ps1
@@ -1,5 +1,6 @@
 param(
-    [string]$ExePath = "target\release\wenlan-server.exe"
+    [string]$ExePath = "target\release\wenlan-server.exe",
+    [int]$HealthTimeoutSeconds = 60
 )
 
 $ErrorActionPreference = "Stop"
@@ -19,19 +20,28 @@ $ExpectedVulkanLoader = (
 $Marker = "ORT_VECTOR_$([System.Guid]::NewGuid().ToString('N'))"
 $DataDir = $null
 $proc = $null
+$StdoutLog = $null
+$StderrLog = $null
 
 try {
     $DataDir = New-Item -ItemType Directory -Path "$env:TEMP\origin-smoke-$([System.Guid]::NewGuid())"
     $env:WENLAN_BIND_ADDR = "127.0.0.1:$Port"
     $env:WENLAN_DATA_DIR = $DataDir.FullName
     Remove-Item Env:ORT_DYLIB_PATH -ErrorAction SilentlyContinue
+    $StdoutLog = Join-Path $DataDir.FullName "wenlan-server.stdout.log"
+    $StderrLog = Join-Path $DataDir.FullName "wenlan-server.stderr.log"
 
     Write-Host "==> Starting daemon"
-    $proc = Start-Process -FilePath $ExePath -PassThru -WindowStyle Hidden
+    $proc = Start-Process -FilePath $ExePath -PassThru -WindowStyle Hidden `
+        -RedirectStandardOutput $StdoutLog -RedirectStandardError $StderrLog
 
     Write-Host "==> Waiting for /api/health"
     $healthy = $false
-    for ($i = 0; $i -lt 30; $i++) {
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($HealthTimeoutSeconds)
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        if ($proc.HasExited) {
+            break
+        }
         try {
             $resp = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/api/health" -UseBasicParsing -TimeoutSec 1
             if ($resp.StatusCode -eq 200) {
@@ -43,7 +53,10 @@ try {
         Start-Sleep -Seconds 1
     }
     if (-not $healthy) {
-        throw "daemon did not become healthy"
+        $exit = if ($proc.HasExited) { "exit=$($proc.ExitCode)" } else { "still-running" }
+        $stdout = if (Test-Path $StdoutLog) { (Get-Content $StdoutLog -Tail 40) -join "`n" } else { "<missing>" }
+        $stderr = if (Test-Path $StderrLog) { (Get-Content $StderrLog -Tail 40) -join "`n" } else { "<missing>" }
+        throw "daemon did not become healthy ($exit)`nstdout:`n$stdout`nstderr:`n$stderr"
     }
 
     $LoadedVulkanModules = @(


### PR DESCRIPTION
## Summary
- feed the prepared portable FastEmbed artifact into the Windows release preflight
- pin the native smoke to that prepared cache instead of a cold network fetch
- emit daemon exit/stdout/stderr when the health check fails
- extend drift defense so this consumer cannot silently disappear

## Verification
- CI planner: 58/58
- release targets: 6/6
- cache planner: 6/6
- release workflow contracts: pass
- PowerShell parse, YAML contract, cargo fmt, git diff: pass
- targeted Rust drift test reaches the local llama.cpp build but is blocked by the machine's missing VULKAN_SDK; hosted CI is authoritative