### PR TITLE
ci: preserve Windows release target cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1290,8 +1290,14 @@ jobs:
       - name: Cache release artifacts (main-owned)
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          shared-key: release-${{ matrix.target }}
+          # `cargo --target` writes below target/<triple>/release. Point the
+          # cache cleaner at that triple root explicitly; otherwise it treats
+          # the triple as a Cargo profile and removes the release directory.
+          # v2 rotates the immutable cache that was saved after that cleanup.
+          shared-key: release-v2-${{ matrix.target }}
+          workspaces: . -> target/${{ matrix.target }}
           cache-all-crates: "true"
+          cache-workspace-crates: "false"
           # The repository cache is already at its 10 GB ceiling. Preserve the
           # expensive Windows release target only; other legs cache dependency
           # inputs without adding three more large target archives.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,11 +295,16 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          shared-key: release-${{ matrix.target }}
+          # Keep this contract identical to ci.yml's main-owned producer.
+          # Explicit-target builds live below target/<triple>/release; v2
+          # bypasses the immutable cache created before that mapping existed.
+          shared-key: release-v2-${{ matrix.target }}
+          workspaces: . -> target/${{ matrix.target }}
           # Only Windows carries the costly coherent native Cargo target tree.
           # Tag releases consume the main-owned preflight cache but never write
           # a competing entry or evict ordinary CI caches.
           cache-all-crates: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
+          cache-workspace-crates: "false"
           cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
           save-if: "false"
 

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -540,9 +540,13 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     }
     let windows_only = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
     if rust_cache.and_then(|step| step["with"]["shared-key"].as_str())
-        != Some("release-${{ matrix.target }}")
+        != Some("release-v2-${{ matrix.target }}")
+        || rust_cache.and_then(|step| step["with"]["workspaces"].as_str())
+            != Some(". -> target/${{ matrix.target }}")
         || rust_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
             != Some(windows_only)
+        || rust_cache.and_then(|step| step["with"]["cache-workspace-crates"].as_str())
+            != Some("false")
         || rust_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some(windows_only)
         || rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
     {
@@ -4412,8 +4416,11 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     }
     let cache = job_step_using(&ci, "release-preflight", "Swatinem/rust-cache");
     if cache.and_then(|step| step["with"]["shared-key"].as_str())
-        != Some("release-${{ matrix.target }}")
+        != Some("release-v2-${{ matrix.target }}")
+        || cache.and_then(|step| step["with"]["workspaces"].as_str())
+            != Some(". -> target/${{ matrix.target }}")
         || cache.and_then(|step| step["with"]["cache-all-crates"].as_str()) != Some("true")
+        || cache.and_then(|step| step["with"]["cache-workspace-crates"].as_str()) != Some("false")
         || cache.and_then(|step| step["with"]["cache-targets"].as_str())
             != Some("${{ matrix.target == 'x86_64-pc-windows-msvc' }}")
         || cache.and_then(|step| step["with"]["save-if"].as_str())
@@ -4427,8 +4434,12 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     let windows_cache = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
     if release_cache.and_then(|step| step["with"]["shared-key"].as_str())
         != cache.and_then(|step| step["with"]["shared-key"].as_str())
+        || release_cache.and_then(|step| step["with"]["workspaces"].as_str())
+            != cache.and_then(|step| step["with"]["workspaces"].as_str())
         || release_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
             != Some(windows_cache)
+        || release_cache.and_then(|step| step["with"]["cache-workspace-crates"].as_str())
+            != Some("false")
         || release_cache.and_then(|step| step["with"]["cache-targets"].as_str())
             != Some(windows_cache)
         || release_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
@@ -4672,6 +4683,26 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
             "mutation must exercise {expected:?}: {violations:?}"
         );
     }
+}
+
+#[test]
+fn release_preflight_contract_rejects_implicit_cross_target_cache_root() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml"))
+        .expect("read ci.yml")
+        .replace(
+            "          workspaces: . -> target/${{ matrix.target }}",
+            "          workspaces: . -> target",
+        );
+    let release =
+        std::fs::read_to_string(root.join(".github/workflows/release.yml")).expect("read release");
+    let violations = release_preflight_contract_violations(&ci, &release);
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("target-scoped, capacity-bounded, and main-owned")),
+        "mutation must reject an implicit cross-target cache root: {violations:?}"
+    );
 }
 
 // ── Teeth #10: canonical acceptance runs beside the long workspace-lib lane ──

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 RELEASE_PATH = REPO_ROOT / ".github" / "workflows" / "release.yml"
 RELEASE_PLEASE_PATH = REPO_ROOT / ".github" / "workflows" / "release-please.yml"
 
@@ -113,6 +114,44 @@ def contract_violations(release: str, release_please: str) -> list[str]:
     return violations
 
 
+def release_cache_contract_violations(ci: str, release: str) -> list[str]:
+    """Keep the main-owned release cache usable by the tag consumer."""
+
+    violations: list[str] = []
+    producer = job_body(ci, "release-preflight")
+    consumer = job_body(release, "release")
+    shared_markers = [
+        "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
+        "shared-key: release-v2-${{ matrix.target }}",
+        "workspaces: . -> target/${{ matrix.target }}",
+        'cache-workspace-crates: "false"',
+    ]
+    for owner, body in (("CI producer", producer), ("tag consumer", consumer)):
+        missing = [marker for marker in shared_markers if marker not in body]
+        if missing:
+            violations.append(
+                f"{owner} Windows release cache contract is incomplete: {', '.join(missing)}"
+            )
+
+    producer_markers = [
+        'cache-all-crates: "true"',
+        "cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}",
+        "save-if: ${{ github.ref == 'refs/heads/main' }}",
+    ]
+    if any(marker not in producer for marker in producer_markers):
+        violations.append("CI no longer owns the bounded Windows release target cache")
+
+    consumer_markers = [
+        "cache-all-crates: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}",
+        "cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}",
+        'save-if: "false"',
+    ]
+    if any(marker not in consumer for marker in consumer_markers):
+        violations.append("tag release no longer restores the Windows cache read-only")
+
+    return violations
+
+
 def assert_mutation_detected(
     release: str,
     release_please: str,
@@ -136,9 +175,11 @@ def assert_mutation_detected(
 
 
 def main() -> None:
+    ci = CI_PATH.read_text(encoding="utf-8")
     release = RELEASE_PATH.read_text(encoding="utf-8")
     release_please = RELEASE_PLEASE_PATH.read_text(encoding="utf-8")
     violations = contract_violations(release, release_please)
+    violations.extend(release_cache_contract_violations(ci, release))
     if violations:
         raise AssertionError("release workflow contract drift:\n" + "\n".join(violations))
 
@@ -178,6 +219,17 @@ def main() -> None:
         "mutable or unexpected",
         mutate_release_please=True,
     )
+    mutated_ci = ci.replace(
+        "workspaces: . -> target/${{ matrix.target }}",
+        "workspaces: . -> target",
+        1,
+    )
+    cache_violations = release_cache_contract_violations(mutated_ci, release)
+    if not any("CI producer" in violation for violation in cache_violations):
+        raise AssertionError(
+            "mutation did not exercise explicit-target cache mapping: "
+            f"{cache_violations!r}"
+        )
     print("PASS: release promotion, Homebrew, and Node 24 action contracts")
 
 


### PR DESCRIPTION
## What changed

- point `rust-cache` at Cargo's explicit Windows triple directory so `release/{deps,build,.fingerprint}` survives cache cleanup
- rotate the immutable cache generation from `release-*` to `release-v2-*`
- keep workspace crates excluded to avoid spending the 10 GB cache budget on artifacts Cargo 1.95 will commonly invalidate by source mtime
- add a fail-loud CI/tag cache contract and mutation test

## Root cause

`cargo build --target x86_64-pc-windows-msvc` writes under `target/<triple>/release`. The pinned `rust-cache` cleaner only recursively recognizes a nested target directory when it contains `CACHEDIR.TAG` or `.rustc_info.json`; otherwise it treats the triple directory as a profile and removes its `release` subtree before saving. This produced a 357 MB exact cache hit while all 437 compile events still reran. GitHub caches are immutable, so the corrected layout also requires a new shared-key generation.

## Impact

The trusted main preflight should now retain Windows release dependency artifacts, and the tag workflow restores the identical cache contract read-only. Correctness still comes from Cargo plus the native shipped-binary smoke; the cache remains an optional acceleration layer.

## Validation

Passed locally:

- `python scripts/release-workflow-contract.test.py`
- `bash scripts/stabilize-rust-cache-toolchains.test.sh`
- `bash scripts/build-release-binaries.test.sh`
- YAML parse for `ci.yml` and `release.yml`
- `python -m py_compile scripts/release-workflow-contract.test.py`
- `git diff --check`

Environment-limited locally:

- `validate-versions.test.sh` requires `jq`, which is absent from this Windows shell
- Rust `drift_guard` compilation requires the Vulkan SDK for `llama-cpp-sys`; CI owns that platform setup

## Runtime proof after merge

The first trusted main run must miss `release-v2-*` and save it. A second run of the same SHA must exact-hit and show a material reduction from the current 437 `Compiling` events; `cache-hit=true` alone will not count as success.