### PR TITLE
ci: cache Windows host release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1287,15 +1287,28 @@ jobs:
           "OPENSSL_SRC_PERL=$nativePerl" |
             Out-File -FilePath $env:GITHUB_ENV -Append
           Write-Host "OPENSSL_SRC_PERL=$nativePerl"
+      - name: Mark Windows explicit target as nested Cargo cache
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $targetRoot = "target\${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+          $marker = Join-Path $targetRoot "CACHEDIR.TAG"
+          $contents = @"
+          Signature: 8a477f597d28d172789f06886806bc55
+          # This file is a cache directory tag created by Cargo.
+          # For information about cache directory tags see https://bford.info/cachedir/
+          "@
+          [IO.File]::WriteAllText($marker, $contents, [Text.UTF8Encoding]::new($false))
       - name: Cache release artifacts (main-owned)
+        id: windows-release-cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # `cargo --target` writes below target/<triple>/release. Point the
-          # cache cleaner at that triple root explicitly; otherwise it treats
-          # the triple as a Cargo profile and removes the release directory.
-          # v2 rotates the immutable cache that was saved after that cleanup.
-          shared-key: release-v2-${{ matrix.target }}
-          workspaces: . -> target/${{ matrix.target }}
+          # The nested CACHEDIR.TAG makes rust-cache preserve the explicit
+          # target while this top-level root also carries host build artifacts.
+          # v3 rotates the immutable cache to the coherent host+target layout.
+          shared-key: release-v3-${{ matrix.target }}
+          workspaces: . -> target
           cache-all-crates: "true"
           cache-workspace-crates: "false"
           # The repository cache is already at its 10 GB ceiling. Preserve the
@@ -1303,6 +1316,34 @@ jobs:
           # inputs without adding three more large target archives.
           cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Probe Windows host and target cache restore
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $marker = "target\${{ matrix.target }}\CACHEDIR.TAG"
+          $hostDeps = "target\release\deps"
+          $targetDeps = "target\${{ matrix.target }}\release\deps"
+          $exactHit = '${{ steps.windows-release-cache.outputs.cache-hit }}'
+          if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            throw "nested Cargo cache marker missing after restore: $marker"
+          }
+          $hostCount = if (Test-Path -LiteralPath $hostDeps -PathType Container) {
+            @(Get-ChildItem -LiteralPath $hostDeps -Force).Count
+          } else { 0 }
+          $targetCount = if (Test-Path -LiteralPath $targetDeps -PathType Container) {
+            @(Get-ChildItem -LiteralPath $targetDeps -Force).Count
+          } else { 0 }
+          if ($hostCount -eq 0 -and $targetCount -eq 0) {
+            $state = "cold-miss"
+          } elseif ($hostCount -gt 0 -and $targetCount -gt 0) {
+            $state = "warm-or-fallback-restore"
+          } else {
+            throw "partial Windows cache restore: exact=$exactHit host=$hostCount target=$targetCount"
+          }
+          if ($exactHit -eq "true" -and $state -ne "warm-or-fallback-restore") {
+            throw "exact cache hit restored no coherent host+target artifacts"
+          }
+          Write-Host "Windows cache restore receipt: action_exact=$exactHit state=$state host_deps=$hostCount target_deps=$targetCount marker=present"
       - name: Install sqlite3 (Windows only)
         if: matrix.target == 'x86_64-pc-windows-msvc'
         shell: pwsh
@@ -1359,6 +1400,22 @@ jobs:
         run: |
           & scripts/smoke-windows.ps1 `
             -ExePath "target\${{ matrix.target }}\release\wenlan-server.exe"
+      - name: Verify Windows host and target cache layout
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $marker = "target\${{ matrix.target }}\CACHEDIR.TAG"
+          $hostDeps = "target\release\deps"
+          $targetDeps = "target\${{ matrix.target }}\release\deps"
+          if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            throw "nested Cargo cache marker missing: $marker"
+          }
+          $hostCount = @(Get-ChildItem -LiteralPath $hostDeps -Force -ErrorAction Stop).Count
+          $targetCount = @(Get-ChildItem -LiteralPath $targetDeps -Force -ErrorAction Stop).Count
+          if ($hostCount -eq 0 -or $targetCount -eq 0) {
+            throw "incomplete Windows cache layout: host=$hostCount target=$targetCount"
+          }
+          Write-Host "Windows cache layout receipt: marker=present host_deps=$hostCount target_deps=$targetCount"
 
   # Required contract integrations for wenlan-mcp / wenlan-types. The planner
   # selects affected packages through reverse dependency closure, or an exact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,14 +292,29 @@ jobs:
             Out-File -FilePath $env:GITHUB_ENV -Append
           Write-Host "OPENSSL_SRC_PERL=$nativePerl"
 
+      - name: Mark Windows explicit target as nested Cargo cache
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $targetRoot = "target\${{ matrix.target }}"
+          New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+          $marker = Join-Path $targetRoot "CACHEDIR.TAG"
+          $contents = @"
+          Signature: 8a477f597d28d172789f06886806bc55
+          # This file is a cache directory tag created by Cargo.
+          # For information about cache directory tags see https://bford.info/cachedir/
+          "@
+          [IO.File]::WriteAllText($marker, $contents, [Text.UTF8Encoding]::new($false))
+
       - name: Cache Rust dependencies
+        id: windows-release-cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           # Keep this contract identical to ci.yml's main-owned producer.
-          # Explicit-target builds live below target/<triple>/release; v2
-          # bypasses the immutable cache created before that mapping existed.
-          shared-key: release-v2-${{ matrix.target }}
-          workspaces: . -> target/${{ matrix.target }}
+          # The nested marker preserves target/<triple>, while the top-level
+          # root restores the matching host build artifacts. v3 rotates it.
+          shared-key: release-v3-${{ matrix.target }}
+          workspaces: . -> target
           # Only Windows carries the costly coherent native Cargo target tree.
           # Tag releases consume the main-owned preflight cache but never write
           # a competing entry or evict ordinary CI caches.
@@ -307,6 +322,35 @@ jobs:
           cache-workspace-crates: "false"
           cache-targets: ${{ matrix.target == 'x86_64-pc-windows-msvc' }}
           save-if: "false"
+
+      - name: Probe Windows host and target cache restore
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $marker = "target\${{ matrix.target }}\CACHEDIR.TAG"
+          $hostDeps = "target\release\deps"
+          $targetDeps = "target\${{ matrix.target }}\release\deps"
+          $exactHit = '${{ steps.windows-release-cache.outputs.cache-hit }}'
+          if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            throw "nested Cargo cache marker missing after restore: $marker"
+          }
+          $hostCount = if (Test-Path -LiteralPath $hostDeps -PathType Container) {
+            @(Get-ChildItem -LiteralPath $hostDeps -Force).Count
+          } else { 0 }
+          $targetCount = if (Test-Path -LiteralPath $targetDeps -PathType Container) {
+            @(Get-ChildItem -LiteralPath $targetDeps -Force).Count
+          } else { 0 }
+          if ($hostCount -eq 0 -and $targetCount -eq 0) {
+            $state = "cold-miss"
+          } elseif ($hostCount -gt 0 -and $targetCount -gt 0) {
+            $state = "warm-or-fallback-restore"
+          } else {
+            throw "partial Windows cache restore: exact=$exactHit host=$hostCount target=$targetCount"
+          }
+          if ($exactHit -eq "true" -and $state -ne "warm-or-fallback-restore") {
+            throw "exact cache hit restored no coherent host+target artifacts"
+          }
+          Write-Host "Windows cache restore receipt: action_exact=$exactHit state=$state host_deps=$hostCount target_deps=$targetCount marker=present"
 
       # vcpkg sqlite3 for Windows — libsql 0.9 needs `sqlite3.lib` at link
       # time and does not bundle SQLite on Windows. Mirrors ci.yml's test
@@ -363,6 +407,23 @@ jobs:
         env:
           WENLAN_REPO_ROOT: ${{ github.workspace }}
         run: bash .release-tools/scripts/build-release-binaries.sh "${{ matrix.target }}"
+
+      - name: Verify Windows host and target cache layout
+        if: matrix.target == 'x86_64-pc-windows-msvc'
+        shell: pwsh
+        run: |
+          $marker = "target\${{ matrix.target }}\CACHEDIR.TAG"
+          $hostDeps = "target\release\deps"
+          $targetDeps = "target\${{ matrix.target }}\release\deps"
+          if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) {
+            throw "nested Cargo cache marker missing: $marker"
+          }
+          $hostCount = @(Get-ChildItem -LiteralPath $hostDeps -Force -ErrorAction Stop).Count
+          $targetCount = @(Get-ChildItem -LiteralPath $targetDeps -Force -ErrorAction Stop).Count
+          if ($hostCount -eq 0 -or $targetCount -eq 0) {
+            throw "incomplete Windows cache layout: host=$hostCount target=$targetCount"
+          }
+          Write-Host "Windows cache layout receipt: marker=present host_deps=$hostCount target_deps=$targetCount"
 
       - name: List Windows build artifacts
         if: matrix.target == 'x86_64-pc-windows-msvc'

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -538,6 +538,7 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     if rust_cache.is_none() {
         violations.push("release job removed its target-level rust-cache fallback".into());
     }
+    let windows_condition = "matrix.target == 'x86_64-pc-windows-msvc'";
     let windows_only = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
     if rust_cache.and_then(|step| step["with"]["shared-key"].as_str())
         != Some("release-v3-${{ matrix.target }}")
@@ -561,7 +562,7 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     let marker_run = marker
         .and_then(|step| step["run"].as_str())
         .unwrap_or_default();
-    if marker.and_then(|step| step["if"].as_str()) != Some(windows_only)
+    if marker.and_then(|step| step["if"].as_str()) != Some(windows_condition)
         || !marker_run.contains("CACHEDIR.TAG")
         || !marker_run.contains("Signature: 8a477f597d28d172789f06886806bc55")
     {

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -540,9 +540,8 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     }
     let windows_only = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
     if rust_cache.and_then(|step| step["with"]["shared-key"].as_str())
-        != Some("release-v2-${{ matrix.target }}")
-        || rust_cache.and_then(|step| step["with"]["workspaces"].as_str())
-            != Some(". -> target/${{ matrix.target }}")
+        != Some("release-v3-${{ matrix.target }}")
+        || rust_cache.and_then(|step| step["with"]["workspaces"].as_str()) != Some(". -> target")
         || rust_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
             != Some(windows_only)
         || rust_cache.and_then(|step| step["with"]["cache-workspace-crates"].as_str())
@@ -551,22 +550,44 @@ fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
         || rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some("false")
     {
         violations.push(
-            "release target cache is not restore-only, target-scoped, and capacity-bounded to Windows"
+            "release target cache is not restore-only, host+target coherent, and capacity-bounded to Windows"
+                .into(),
+        );
+    }
+    let marker_name = "Mark Windows explicit target as nested Cargo cache";
+    let marker = steps
+        .iter()
+        .find(|step| step["name"].as_str() == Some(marker_name));
+    let marker_run = marker
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    if marker.and_then(|step| step["if"].as_str()) != Some(windows_only)
+        || !marker_run.contains("CACHEDIR.TAG")
+        || !marker_run.contains("Signature: 8a477f597d28d172789f06886806bc55")
+    {
+        violations.push(
+            "release does not create a valid nested Cargo target marker before cache restore"
                 .into(),
         );
     }
     let stabilizer_index = steps.iter().position(|step| {
         step["name"].as_str() == Some("Stabilize Windows Rust cache toolchain inputs")
     });
+    let marker_index = steps
+        .iter()
+        .position(|step| step["name"].as_str() == Some(marker_name));
     let cache_index = steps.iter().position(|step| {
         step["uses"]
             .as_str()
             .is_some_and(|uses| uses.contains("Swatinem/rust-cache"))
     });
-    if !matches!((stabilizer_index, cache_index), (Some(stabilizer), Some(cache)) if stabilizer < cache)
-    {
+    if !matches!(
+        (stabilizer_index, marker_index, cache_index),
+        (Some(stabilizer), Some(marker), Some(cache)) if stabilizer < marker && marker < cache
+    ) {
         violations.push(
-            "release does not stabilize Windows toolchain inputs before cache restore".into(),
+            "release does not stabilize Windows toolchain inputs and mark the nested target before cache restore"
+                .into(),
         );
     }
     if parsed["jobs"]["release"]["timeout-minutes"].as_str()
@@ -753,6 +774,7 @@ jobs:
         "rust-cache fallback",
         "capacity-bounded",
         "stabilize Windows toolchain inputs",
+        "nested Cargo target marker",
         "90/60-minute timeout",
     ] {
         assert!(
@@ -4324,6 +4346,7 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     for step_name in [
         "Stabilize Windows Rust cache toolchain inputs",
         "Configure rust-lld linker (Windows release preflight)",
+        "Mark Windows explicit target as nested Cargo cache",
         "Install sqlite3 (Windows only)",
         "Stage Windows release runtimes before smoke",
         "Native ORT smoke (Windows release preflight)",
@@ -4414,11 +4437,53 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
             ));
         }
     }
+    let marker_name = "Mark Windows explicit target as nested Cargo cache";
+    let mut marker_runs = Vec::new();
+    for (workflow, job_name, owner) in [
+        (&ci, "release-preflight", "release-preflight"),
+        (&release, "release", "tag release"),
+    ] {
+        let marker = job_step(workflow, job_name, marker_name);
+        let marker_run = marker
+            .and_then(|step| step["run"].as_str())
+            .unwrap_or_default();
+        if marker.and_then(|step| step["if"].as_str()) != Some(windows_condition)
+            || !marker_run.contains("CACHEDIR.TAG")
+            || !marker_run.contains("Signature: 8a477f597d28d172789f06886806bc55")
+        {
+            violations.push(format!(
+                "{owner} does not create a valid nested Cargo target marker"
+            ));
+        }
+        let steps = workflow["jobs"][job_name]["steps"].as_sequence();
+        let marker_index = steps.and_then(|items| {
+            items
+                .iter()
+                .position(|step| step["name"].as_str() == Some(marker_name))
+        });
+        let cache_index = steps.and_then(|items| {
+            items.iter().position(|step| {
+                step["uses"]
+                    .as_str()
+                    .is_some_and(|uses| uses.contains("Swatinem/rust-cache"))
+            })
+        });
+        if !matches!(
+            (marker_index, cache_index),
+            (Some(marker), Some(cache)) if marker < cache
+        ) {
+            violations.push(format!(
+                "{owner} creates the nested target marker after cache restore"
+            ));
+        }
+        marker_runs.push(marker_run);
+    }
+    if marker_runs.len() != 2 || marker_runs[0] != marker_runs[1] {
+        violations.push("producer/consumer nested target marker parity has drifted".into());
+    }
     let cache = job_step_using(&ci, "release-preflight", "Swatinem/rust-cache");
     if cache.and_then(|step| step["with"]["shared-key"].as_str())
-        != Some("release-v2-${{ matrix.target }}")
-        || cache.and_then(|step| step["with"]["workspaces"].as_str())
-            != Some(". -> target/${{ matrix.target }}")
+        != Some("release-v3-${{ matrix.target }}")
         || cache.and_then(|step| step["with"]["cache-all-crates"].as_str()) != Some("true")
         || cache.and_then(|step| step["with"]["cache-workspace-crates"].as_str()) != Some("false")
         || cache.and_then(|step| step["with"]["cache-targets"].as_str())
@@ -4427,15 +4492,20 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
             != Some("${{ github.ref == 'refs/heads/main' }}")
     {
         violations.push(
-            "release-preflight cache is not target-scoped, capacity-bounded, and main-owned".into(),
+            "release-preflight cache is not host+target coherent, capacity-bounded, and main-owned"
+                .into(),
+        );
+    }
+    if cache.and_then(|step| step["with"]["workspaces"].as_str()) != Some(". -> target") {
+        violations.push(
+            "release-preflight cache must use one top-level target root; overlapping cache roots are forbidden"
+                .into(),
         );
     }
     let release_cache = job_step_using(&release, "release", "Swatinem/rust-cache");
     let windows_cache = "${{ matrix.target == 'x86_64-pc-windows-msvc' }}";
     if release_cache.and_then(|step| step["with"]["shared-key"].as_str())
         != cache.and_then(|step| step["with"]["shared-key"].as_str())
-        || release_cache.and_then(|step| step["with"]["workspaces"].as_str())
-            != cache.and_then(|step| step["with"]["workspaces"].as_str())
         || release_cache.and_then(|step| step["with"]["cache-all-crates"].as_str())
             != Some(windows_cache)
         || release_cache.and_then(|step| step["with"]["cache-workspace-crates"].as_str())
@@ -4448,6 +4518,19 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
             "tag release cache does not restore the main-owned preflight key with a Windows-only footprint"
                 .into(),
         );
+    }
+    if release_cache.and_then(|step| step["with"]["workspaces"].as_str()) != Some(". -> target") {
+        violations.push(
+            "tag release cache must use one top-level target root; overlapping cache roots are forbidden"
+                .into(),
+        );
+    }
+    if release_cache.and_then(|step| step["with"]["shared-key"].as_str())
+        != cache.and_then(|step| step["with"]["shared-key"].as_str())
+        || release_cache.and_then(|step| step["with"]["workspaces"].as_str())
+            != cache.and_then(|step| step["with"]["workspaces"].as_str())
+    {
+        violations.push("release cache producer/consumer parity has drifted".into());
     }
     let windows_runtime_stage = job_step(
         &ci,
@@ -4607,6 +4690,10 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
             "          save-if: \"true\"",
         )
         .replace(
+            "          shared-key: release-v3-${{ matrix.target }}",
+            "          shared-key: release-v3-ci-only-${{ matrix.target }}",
+        )
+        .replace(
             "        run: bash scripts/build-release-binaries.sh \"${{ matrix.target }}\"",
             "        run: gh release create unsafe",
         )
@@ -4625,6 +4712,10 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
         .replace(
             "      - name: Select native Perl for vendored OpenSSL",
             "      - name: Native Perl removed",
+        )
+        .replace(
+            "      - name: Mark Windows explicit target as nested Cargo cache",
+            "      - name: Nested Cargo target marker removed",
         )
         .replace(
             "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=",
@@ -4666,8 +4757,10 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
         "Docker DAG",
         "shared shipped-binary",
         "current main workflow ref",
-        "target-scoped, capacity-bounded, and main-owned",
+        "host+target coherent, capacity-bounded, and main-owned",
         "Windows-only footprint",
+        "nested Cargo target marker",
+        "producer/consumer",
         "truncated PR file inventory",
         "native Windows Perl",
         "target and host build artifacts",
@@ -4686,13 +4779,13 @@ fn release_preflight_contract_rejects_drift_and_side_effects() {
 }
 
 #[test]
-fn release_preflight_contract_rejects_implicit_cross_target_cache_root() {
+fn release_preflight_contract_rejects_overlapping_cache_roots() {
     let root = repo_root();
     let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml"))
         .expect("read ci.yml")
         .replace(
-            "          workspaces: . -> target/${{ matrix.target }}",
             "          workspaces: . -> target",
+            "          workspaces: |\n            . -> target\n            . -> target/${{ matrix.target }}",
         );
     let release =
         std::fs::read_to_string(root.join(".github/workflows/release.yml")).expect("read release");
@@ -4700,8 +4793,8 @@ fn release_preflight_contract_rejects_implicit_cross_target_cache_root() {
     assert!(
         violations
             .iter()
-            .any(|violation| violation.contains("target-scoped, capacity-bounded, and main-owned")),
-        "mutation must reject an implicit cross-target cache root: {violations:?}"
+            .any(|violation| violation.contains("overlapping cache roots")),
+        "mutation must reject overlapping cache roots: {violations:?}"
     );
 }
 

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -34,6 +34,15 @@ def job_body(workflow: str, job_name: str) -> str:
     return match.group("body") if match else ""
 
 
+def named_step_body(job: str, step_name: str) -> str:
+    match = re.search(
+        rf"^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - (?:name:|uses:)|^      #|^  #|\Z)",
+        job,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body").strip() if match else ""
+
+
 def contract_violations(release: str, release_please: str) -> list[str]:
     violations: list[str] = []
     docker = job_body(release, "docker")
@@ -121,9 +130,9 @@ def release_cache_contract_violations(ci: str, release: str) -> list[str]:
     producer = job_body(ci, "release-preflight")
     consumer = job_body(release, "release")
     shared_markers = [
+        "id: windows-release-cache",
         "uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32",
-        "shared-key: release-v2-${{ matrix.target }}",
-        "workspaces: . -> target/${{ matrix.target }}",
+        "shared-key: release-v3-${{ matrix.target }}",
         'cache-workspace-crates: "false"',
     ]
     for owner, body in (("CI producer", producer), ("tag consumer", consumer)):
@@ -132,6 +141,102 @@ def release_cache_contract_violations(ci: str, release: str) -> list[str]:
             violations.append(
                 f"{owner} Windows release cache contract is incomplete: {', '.join(missing)}"
             )
+
+    marker_name = "Mark Windows explicit target as nested Cargo cache"
+    producer_marker = named_step_body(producer, marker_name)
+    consumer_marker = named_step_body(consumer, marker_name)
+    marker_contract = [
+        "if: matrix.target == 'x86_64-pc-windows-msvc'",
+        "shell: pwsh",
+        '$targetRoot = "target\\${{ matrix.target }}"',
+        'Join-Path $targetRoot "CACHEDIR.TAG"',
+        '$contents = @"\n          Signature: 8a477f597d28d172789f06886806bc55',
+        "[IO.File]::WriteAllText($marker, $contents, [Text.UTF8Encoding]::new($false))",
+    ]
+    for owner, body, marker in (
+        ("CI producer", producer, producer_marker),
+        ("tag consumer", consumer, consumer_marker),
+    ):
+        if any(item not in marker for item in marker_contract):
+            violations.append(
+                f"{owner} does not create a valid nested Cargo target marker"
+            )
+        marker_index = body.find(f"- name: {marker_name}")
+        cache_index = body.find("uses: Swatinem/rust-cache@")
+        if marker_index < 0 or cache_index < 0 or marker_index >= cache_index:
+            violations.append(f"{owner} creates the nested target marker after cache restore")
+
+    if producer_marker != consumer_marker:
+        violations.append("producer/consumer nested target marker parity has drifted")
+
+    probe_name = "Probe Windows host and target cache restore"
+    producer_probe = named_step_body(producer, probe_name)
+    consumer_probe = named_step_body(consumer, probe_name)
+    probe_contract = [
+        "if: matrix.target == 'x86_64-pc-windows-msvc'",
+        "shell: pwsh",
+        '$marker = "target\\${{ matrix.target }}\\CACHEDIR.TAG"',
+        '$hostDeps = "target\\release\\deps"',
+        '$targetDeps = "target\\${{ matrix.target }}\\release\\deps"',
+        "$exactHit = '${{ steps.windows-release-cache.outputs.cache-hit }}'",
+        "if ($hostCount -eq 0 -and $targetCount -eq 0)",
+        "elseif ($hostCount -gt 0 -and $targetCount -gt 0)",
+        "partial Windows cache restore:",
+        'if ($exactHit -eq "true" -and $state -ne "warm-or-fallback-restore")',
+        "Windows cache restore receipt: action_exact=$exactHit state=$state host_deps=$hostCount target_deps=$targetCount marker=present",
+    ]
+    for owner, body, probe in (
+        ("CI producer", producer, producer_probe),
+        ("tag consumer", consumer, consumer_probe),
+    ):
+        if any(item not in probe for item in probe_contract):
+            violations.append(f"{owner} omits the fail-loud Windows cache restore probe")
+        cache_index = body.find("uses: Swatinem/rust-cache@")
+        tail = body[cache_index:] if cache_index >= 0 else ""
+        next_step = re.search(r"^      - name: (.+)$", tail, re.MULTILINE)
+        if next_step is None or next_step.group(1) != probe_name:
+            violations.append(f"{owner} does not probe the Windows cache immediately after restore")
+    if producer_probe != consumer_probe:
+        violations.append("producer/consumer Windows cache restore probe parity has drifted")
+
+    receipt_name = "Verify Windows host and target cache layout"
+    producer_receipt = named_step_body(producer, receipt_name)
+    consumer_receipt = named_step_body(consumer, receipt_name)
+    receipt_contract = [
+        "if: matrix.target == 'x86_64-pc-windows-msvc'",
+        "shell: pwsh",
+        '$marker = "target\\${{ matrix.target }}\\CACHEDIR.TAG"',
+        '$hostDeps = "target\\release\\deps"',
+        '$targetDeps = "target\\${{ matrix.target }}\\release\\deps"',
+        "Get-ChildItem -LiteralPath $hostDeps",
+        "Get-ChildItem -LiteralPath $targetDeps",
+        "if ($hostCount -eq 0 -or $targetCount -eq 0)",
+        "Windows cache layout receipt:",
+    ]
+    for owner, body, receipt, proof_name in (
+        ("CI producer", producer, producer_receipt, "Native ORT smoke (Windows release preflight)"),
+        ("tag consumer", consumer, consumer_receipt, "Build and smoke shipped release binaries"),
+    ):
+        if any(item not in receipt for item in receipt_contract):
+            violations.append(f"{owner} omits the fail-loud Windows cache layout receipt")
+        proof_index = body.find(f"- name: {proof_name}")
+        receipt_index = body.find(f"- name: {receipt_name}")
+        if proof_index < 0 or receipt_index <= proof_index:
+            violations.append(f"{owner} records its cache layout receipt before build/smoke proof")
+    if producer_receipt != consumer_receipt:
+        violations.append("producer/consumer Windows cache layout receipt parity has drifted")
+
+    cache_configs: list[tuple[list[str], list[str]]] = []
+    for owner, body in (("CI producer", producer), ("tag consumer", consumer)):
+        keys = re.findall(r"^\s+shared-key:\s*(.+)$", body, re.MULTILINE)
+        workspaces = re.findall(r"^\s+workspaces:\s*(.*)$", body, re.MULTILINE)
+        cache_configs.append((keys, workspaces))
+        if workspaces != [". -> target"]:
+            violations.append(
+                f"{owner} must use one top-level target root; overlapping cache roots are forbidden"
+            )
+    if cache_configs[0] != cache_configs[1]:
+        violations.append("release cache producer/consumer parity has drifted")
 
     producer_markers = [
         'cache-all-crates: "true"',
@@ -220,14 +325,69 @@ def main() -> None:
         mutate_release_please=True,
     )
     mutated_ci = ci.replace(
-        "workspaces: . -> target/${{ matrix.target }}",
-        "workspaces: . -> target",
+        "          workspaces: . -> target",
+        "          workspaces: |\n            . -> target\n            . -> target/${{ matrix.target }}",
         1,
     )
     cache_violations = release_cache_contract_violations(mutated_ci, release)
-    if not any("CI producer" in violation for violation in cache_violations):
+    if not any("overlapping cache roots" in violation for violation in cache_violations):
         raise AssertionError(
-            "mutation did not exercise explicit-target cache mapping: "
+            "mutation did not reject overlapping cache roots: "
+            f"{cache_violations!r}"
+        )
+    mutated_ci = ci.replace(
+        "Signature: 8a477f597d28d172789f06886806bc55",
+        "Signature: invalid",
+        1,
+    )
+    cache_violations = release_cache_contract_violations(mutated_ci, release)
+    if not any("nested Cargo target marker" in violation for violation in cache_violations):
+        raise AssertionError(
+            "mutation did not exercise nested target marker validation: "
+            f"{cache_violations!r}"
+        )
+    mutated_ci = ci.replace(
+        "[IO.File]::WriteAllText($marker, $contents, [Text.UTF8Encoding]::new($false))",
+        "[IO.File]::WriteAllText($marker, $contents)",
+        1,
+    )
+    cache_violations = release_cache_contract_violations(mutated_ci, release)
+    if not any("nested Cargo target marker" in violation for violation in cache_violations):
+        raise AssertionError(
+            "mutation did not exercise no-BOM marker write validation: "
+            f"{cache_violations!r}"
+        )
+    mutated_ci = ci.replace(
+        "if ($hostCount -eq 0 -and $targetCount -eq 0)",
+        "if ($hostCount -eq 0 -or $targetCount -eq 0)",
+        1,
+    )
+    cache_violations = release_cache_contract_violations(mutated_ci, release)
+    if not any("cache restore probe" in violation for violation in cache_violations):
+        raise AssertionError(
+            "mutation did not exercise partial-restore probe validation: "
+            f"{cache_violations!r}"
+        )
+    mutated_release = release.replace(
+        "shared-key: release-v3-${{ matrix.target }}",
+        "shared-key: release-v3-consumer-${{ matrix.target }}",
+        1,
+    )
+    cache_violations = release_cache_contract_violations(ci, mutated_release)
+    if not any("producer/consumer parity" in violation for violation in cache_violations):
+        raise AssertionError(
+            "mutation did not exercise release cache parity: "
+            f"{cache_violations!r}"
+        )
+    mutated_ci = ci.replace(
+        "$hostCount = @(Get-ChildItem -LiteralPath $hostDeps -Force -ErrorAction Stop).Count",
+        "$hostCount = 0 # receipt disabled",
+        1,
+    )
+    cache_violations = release_cache_contract_violations(mutated_ci, release)
+    if not any("cache layout receipt" in violation for violation in cache_violations):
+        raise AssertionError(
+            "mutation did not exercise Windows cache layout receipt validation: "
             f"{cache_violations!r}"
         )
     print("PASS: release promotion, Homebrew, and Node 24 action contracts")


### PR DESCRIPTION
## Summary
- preserve both host-side `target/release` and explicit-target `target/<triple>/release` dependencies in the Windows release cache
- mark the explicit target as a nested Cargo cache so pinned `Swatinem/rust-cache` cleans both roots coherently
- add cold/warm/partial restore receipts plus mutation-tested producer/consumer workflow contracts

## Why
The merged v2 cache fixed the missing explicit-target artifacts, but a same-SHA warm main run still compiled 350 unique host-side proc-macro/build-script dependencies. Measured Windows release-preflight improved from 37m27s to 22m58s, still 2m58s over the 20-minute goal. This v3 layout includes the omitted host artifacts without caching workspace crates.

## Validation
- `python scripts/release-workflow-contract.test.py`
- YAML parse for `.github/workflows/ci.yml` and `.github/workflows/release.yml`
- `python -m py_compile scripts/release-workflow-contract.test.py`
- `cargo fmt --all -- --check`
- `bash scripts/stabilize-rust-cache-toolchains.test.sh`
- `bash scripts/build-release-binaries.test.sh`
- `git diff --check`
- independent review: no P0/P1 findings

Local `wenlan-core` compile cannot reach the Rust tests because `llama-cpp-sys-2` requires a configured Windows `VULKAN_SDK`; the GitHub Windows job owns that setup and is the platform validation for this change. Local commit/push hooks were skipped only for that known environment limitation after the checks above passed.

## Live proof after merge
The key is intentionally rotated to `release-v3`. A main cold run must save a coherent archive; then same-SHA warm and later cross-SHA/tag consumers must show both host and target restore receipts. We will compare compile events, Cargo time, total job time, cache size, ref scope, and quota before calling the performance target met.