### PR TITLE
ci: bound Linux service lifecycle smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1168,42 +1168,118 @@ jobs:
         if: needs.detect-changes.outputs.canonical-smokes-required == 'true'
         run: |
           set -euo pipefail
-          sudo loginctl enable-linger "$(whoami)"
-          uid="$(id -u)"
-          export XDG_RUNTIME_DIR="/run/user/$uid"
-          cargo build -p wenlan -p wenlan-server
-          STAGE=$(mktemp -d)
-          UNIT_PATH="$HOME/.config/systemd/user/wenlan-server.service"
-          cp target/debug/wenlan target/debug/wenlan-server "$STAGE/"
-          cleanup() {
-            "$STAGE/wenlan" background off 2>/dev/null || true
-            systemctl --user disable --now wenlan-server.service >/dev/null 2>&1 || true
-            rm -f "$UNIT_PATH"
-            systemctl --user daemon-reload >/dev/null 2>&1 || true
-            rm -rf "$STAGE"
+          receipt() {
+            printf '    receipt phase=%s status=%s%s\n' "$1" "$2" "${3:+ timeout=$3}"
           }
+          run_bounded() {
+            local phase="$1"
+            local limit="$2"
+            shift 2
+            receipt "$phase" start "$limit"
+            # Keep timeout's process group so a deadline also stops child processes.
+            if timeout --signal=TERM --kill-after=10s "$limit" "$@"; then
+              receipt "$phase" pass "$limit"
+            else
+              local status=$?
+              receipt "$phase" "fail(exit=$status)" "$limit"
+              return "$status"
+            fi
+          }
+          cleanup_bounded() {
+            local phase="$1"
+            shift
+            receipt "$phase" start 20s
+            if timeout --signal=TERM --kill-after=5s 20s "$@"; then
+              receipt "$phase" pass 20s
+              return 0
+            else
+              local status=$?
+              receipt "$phase" "fail(exit=$status)" 20s
+              return "$status"
+            fi
+          }
+
+          uid="$(id -u)"
+          # This same-session smoke already has an active login. Linger is only
+          # needed to keep the user manager alive after logout or start it at boot.
+          export XDG_RUNTIME_DIR="/run/user/$uid"
+          STAGE=""
+          UNIT_PATH="$HOME/.config/systemd/user/wenlan-server.service"
+          start_attempted=false
+          cleanup() {
+            local main_status=$?
+            local cleanup_status=0
+            trap - EXIT
+            set +e
+            receipt cleanup start
+            if [ "$start_attempted" = true ] && [ -x "$STAGE/wenlan" ]; then
+              if ! cleanup_bounded cleanup-stop "$STAGE/wenlan" background off; then
+                cleanup_status=1
+              fi
+            fi
+            if ! cleanup_bounded cleanup-disable systemctl --user disable --now wenlan-server.service; then
+              cleanup_status=1
+            fi
+            if ! cleanup_bounded cleanup-unit-remove bash -c 'rm -f -- "$1"' _ "$UNIT_PATH"; then
+              cleanup_status=1
+            fi
+            if ! cleanup_bounded cleanup-reload systemctl --user daemon-reload; then
+              cleanup_status=1
+            fi
+            if [ -n "$STAGE" ]; then
+              if ! cleanup_bounded cleanup-stage-remove bash -c 'rm -rf -- "$1"' _ "$STAGE"; then
+                cleanup_status=1
+              fi
+            fi
+            if [ "$cleanup_status" -eq 0 ]; then
+              receipt cleanup pass
+            else
+              receipt cleanup fail
+            fi
+            if [ "$main_status" -ne 0 ]; then
+              exit "$main_status"
+            fi
+            if [ "$cleanup_status" -eq 0 ]; then
+              echo "    Linux background on/off round-trip PASS"
+            fi
+            exit "$cleanup_status"
+          }
+
+          run_bounded manager-probe 20s bash -c 'systemctl --user show-environment >/dev/null'
+          run_bounded build 12m cargo build -p wenlan -p wenlan-server
+          receipt stage start
+          STAGE="$(mktemp -d)"
+          cp target/debug/wenlan target/debug/wenlan-server "$STAGE/"
+          receipt stage pass
           trap cleanup EXIT
-          "$STAGE/wenlan" background on
+
+          start_attempted=true
+          run_bounded start 45s "$STAGE/wenlan" background on
+          receipt probe-registration start 20s
           test -f "$UNIT_PATH"
-          systemctl --user is-enabled wenlan-server
-          for i in $(seq 1 90); do
-            if curl -sf http://127.0.0.1:7878/api/health >/dev/null; then
-              echo "    daemon healthy after ${i}s"
-              break
-            fi
-            sleep 1
-            if [ "$i" = "90" ]; then
-              echo "FAIL: daemon did not start under systemd user service" >&2
-              journalctl --user -u wenlan-server --no-pager | tail -50 >&2 || true
-              exit 1
-            fi
-          done
-          "$STAGE/wenlan" background off
+          run_bounded probe-enabled-after-start 20s systemctl --user is-enabled wenlan-server
+          receipt probe-registration pass 20s
+
+          if ! run_bounded health 90s bash -c '
+            until curl --connect-timeout 1 --max-time 2 -sf \
+              http://127.0.0.1:7878/api/health >/dev/null; do
+              sleep 1
+            done
+          '; then
+            echo "FAIL: daemon did not start under systemd user service" >&2
+            timeout --signal=TERM --kill-after=5s 20s \
+              journalctl --user -u wenlan-server --no-pager -n 50 >&2 || true
+            exit 1
+          fi
+
+          run_bounded stop 45s "$STAGE/wenlan" background off
+          receipt probe-persistence start 20s
           test -f "$UNIT_PATH"
-          systemctl --user is-enabled wenlan-server
-          active_state="$(systemctl --user show wenlan-server --property=ActiveState --value)"
+          run_bounded probe-enabled-after-stop 20s systemctl --user is-enabled wenlan-server
+          active_state="$(timeout --signal=TERM --kill-after=5s 20s \
+            systemctl --user show wenlan-server --property=ActiveState --value)"
           test "$active_state" = "inactive"
-          echo "    Linux background on/off round-trip PASS"
+          receipt probe-persistence pass 20s
       - name: E2E folder ingest over HTTP (Linux)
         if: needs.detect-changes.outputs.canonical-smokes-required == 'true'
         run: bash scripts/smoke-folder-ingest.sh

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -5039,21 +5039,58 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
         .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
         .collect::<BTreeSet<_>>();
+    let manager_probe_offset = systemd_run.find(
+        "run_bounded manager-probe 20s bash -c 'systemctl --user show-environment >/dev/null'",
+    );
+    let build_offset = systemd_run.find("run_bounded build 12m cargo build");
+    let trap_offset = systemd_run.find("trap cleanup EXIT");
+    let start_attempt_offset = systemd_run.find("start_attempted=true");
+    let start_offset = systemd_run.find("run_bounded start 45s");
     if systemd.and_then(|step| step["if"].as_str())
         != Some("needs.detect-changes.outputs.canonical-smokes-required == 'true'")
+        || systemd_run.contains("loginctl enable-linger")
+        || systemd_run.matches(r#"return "$status""#).count() < 2
+        || !matches!((manager_probe_offset, build_offset), (Some(probe), Some(build)) if probe < build)
+        || !matches!(
+            (trap_offset, start_attempt_offset, start_offset),
+            (Some(trap), Some(attempt), Some(start)) if trap < attempt && attempt < start
+        )
         || [
-            r#"sudo loginctl enable-linger "$(whoami)""#,
-            "cargo build -p wenlan -p wenlan-server",
-            "\"$STAGE/wenlan\" background on",
-            "systemctl --user is-enabled wenlan-server",
-            "\"$STAGE/wenlan\" background off",
-            r#"active_state="$(systemctl --user show wenlan-server --property=ActiveState --value)""#,
+            r#"if timeout --signal=TERM --kill-after=10s "$limit" "$@"; then"#,
+            r#"if timeout --signal=TERM --kill-after=5s 20s "$@"; then"#,
+            "return \"$status\"",
+            "run_bounded manager-probe 20s bash -c 'systemctl --user show-environment >/dev/null'",
+            "run_bounded build 12m cargo build -p wenlan -p wenlan-server",
+            "trap cleanup EXIT",
+            "start_attempted=false",
+            "start_attempted=true",
+            "run_bounded start 45s \"$STAGE/wenlan\" background on",
+            "run_bounded probe-enabled-after-start 20s systemctl --user is-enabled wenlan-server",
+            "if ! run_bounded health 90s bash -c '",
+            r#"until curl --connect-timeout 1 --max-time 2 -sf \"#,
+            "run_bounded stop 45s \"$STAGE/wenlan\" background off",
+            "run_bounded probe-enabled-after-stop 20s systemctl --user is-enabled wenlan-server",
+            r#"active_state="$(timeout --signal=TERM --kill-after=5s 20s \"#,
+            "systemctl --user show wenlan-server --property=ActiveState --value)\"",
             "test \"$active_state\" = \"inactive\"",
+            r#"if ! cleanup_bounded cleanup-stop "$STAGE/wenlan" background off; then"#,
+            r#"if [ "$start_attempted" = true ] && [ -x "$STAGE/wenlan" ]; then"#,
+            "if ! cleanup_bounded cleanup-disable systemctl --user disable --now wenlan-server.service; then",
+            r#"if ! cleanup_bounded cleanup-unit-remove bash -c 'rm -f -- "$1"' _ "$UNIT_PATH"; then"#,
+            "if ! cleanup_bounded cleanup-reload systemctl --user daemon-reload; then",
+            "local cleanup_status=0",
+            "cleanup_status=1",
+            "receipt cleanup fail",
+            "trap - EXIT",
+            "if [ \"$main_status\" -ne 0 ]; then",
+            "exit \"$main_status\"",
+            "exit \"$cleanup_status\"",
         ]
         .iter()
         .any(|command| !systemd_active_lines.contains(command))
     {
-        violations.push("Linux systemd acceptance command lost a lifecycle assertion".into());
+        violations
+            .push("Linux systemd acceptance command lost a bounded lifecycle assertion".into());
     }
     let lint_upload = job_step(
         &ci,
@@ -5253,8 +5290,8 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
             "        if: \"false\"\n        run: bash scripts/smoke-folder-ingest.sh",
         )
         .replace(
-            "          test \"$active_state\" = \"inactive\"",
-            "          # test \"$active_state\" = \"inactive\"",
+            "          run_bounded stop 45s \"$STAGE/wenlan\" background off",
+            "          \"$STAGE/wenlan\" background off",
         )
         .replace(
             "      - name: Install cargo-nextest",
@@ -5278,6 +5315,36 @@ fn canonical_acceptance_contract_rejects_semantic_noops_and_secondary_writers() 
                 .iter()
                 .any(|violation| violation.contains(expected)),
             "semantic mutation must exercise {expected:?}: {violations:?}"
+        );
+    }
+}
+
+#[test]
+fn canonical_acceptance_contract_rejects_missing_trap_or_fail_open_cleanup() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    for (mutation, expected) in [
+        (
+            ci.replace(
+                "          trap cleanup EXIT",
+                "          # trap cleanup EXIT",
+            ),
+            "missing EXIT trap",
+        ),
+        (
+            ci.replace(
+                "            exit \"$cleanup_status\"",
+                "            exit 0 # cleanup failure ignored",
+            ),
+            "fail-open cleanup",
+        ),
+    ] {
+        let violations = canonical_acceptance_contract_violations(&mutation);
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains("systemd acceptance command")),
+            "fixture must reject {expected}: {violations:?}"
         );
     }
 }


### PR DESCRIPTION
## What changed

- remove the unnecessary CI-only `loginctl enable-linger` host mutation
- put hard process-group deadlines and deterministic receipts around the Linux user-systemd build/start/health/stop/probe/cleanup phases
- bound each health request with connect/max time and the whole health loop to 90 seconds
- make EXIT cleanup fail closed, while preserving an original nonzero test status
- add an early bounded user-manager probe and drift mutations for missing traps, fail-open cleanup, and unbounded lifecycle commands

## Why

Main run [30727255408](https://github.com/7xuanlu/wenlan/actions/runs/30727255408) built and started the service successfully, then an individual unbounded health `curl` hung from 01:43:48 until the run was cancelled at 02:20:10. Cancellation then exposed the unbounded cleanup `systemctl` as an orphan. The same-SHA rerun passed the old smoke in 63 seconds, confirming an intermittent I/O hang rather than a deterministic service failure.

The smoke now retains its real registration, enabled-state, health, stop, persistence, and inactive-state assertions, but no single command can consume the job''s 60-minute ceiling.

## Validation

- independent review after the first draft found and fixed fail-open cleanup
- extracted Bash proof: main=0 + cleanup failure => 1; main=37 + cleanup failure => 37; all success => 0
- `python scripts/release-workflow-contract.test.py`
- `python scripts/ci_test_plan.test.py` (58 tests)
- CI workflow YAML parse and extracted Bash syntax
- `cargo fmt --all -- --check`
- `git diff --check`

The targeted Rust drift test cannot compile on this Windows checkout because the existing `llama-cpp-sys-2` build requires `VULKAN_SDK`. The authoritative Ubuntu CI lane is the native proof. Commit and push hooks were skipped only for that known local platform prerequisite; the precise non-native checks above passed.