### PR TITLE
feat: land M6 deterministic identity primitives and genesis substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,6 +5742,7 @@ dependencies = [
  "tokio",
  "toml",
  "unicode-normalization",
+ "unicode-properties",
  "uuid",
  "wenlan-types",
  "zip",

--- a/crates/wenlan-core/Cargo.toml
+++ b/crates/wenlan-core/Cargo.toml
@@ -91,6 +91,12 @@ leiden-rs = { version = "=0.8.1", default-features = false }
 # graph. Root Cargo.toml is release-please-locked, so this is a per-crate
 # dep like text-splitter/tiktoken-rs above rather than a workspace one.
 unicode-normalization = "0.1"
+# Unicode general categories for the M6 wikilink-key gate (S0-38: reject every
+# Cc *and* Cf scalar). std only offers `char::is_control()` = Cc, which would
+# miss the entire Cf class — RLO, ZWSP, and the BOM are all Cf, and Cf is where
+# the invisible-label attacks live. Already in the lock file transitively, so
+# this pins it as a direct dep rather than growing the resolved graph.
+unicode-properties = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 fastembed = { workspace = true, features = ["ort-load-dynamic"] }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -36,6 +36,7 @@ mod eval_paired_guard;
 mod eval_pipeline_reads;
 mod eval_substrate_guard;
 mod eval_temporal_seed;
+mod genesis_schema;
 mod kg_quality_diagnostics;
 mod kg_quality_duplicate_candidates;
 mod kg_quality_embedding_refresh;
@@ -100,6 +101,8 @@ mod eval_pipeline_reads_test;
 mod eval_substrate_guard_test;
 #[cfg(test)]
 mod eval_temporal_seed_test;
+#[cfg(test)]
+mod genesis_schema_test;
 #[cfg(test)]
 mod kg_quality_diagnostics_test;
 #[cfg(test)]
@@ -689,7 +692,9 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-pub const SCHEMA_VERSION: u32 = 107;
+/// Migration 108 is M6 PR-A's genesis substrate. It follows the M5 Truth
+/// migrations 105/106 and the page-kind repair at 107.
+pub const SCHEMA_VERSION: u32 = 108;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8414,6 +8419,15 @@ impl MemoryDB {
             if version < 107 {
                 self.migrate_107_page_kind_repair(version).await?;
             }
+
+            // Migration 108 (M6 PR-A): the genesis substrate — five empty
+            // tables and the two partial unique indexes that are D4's whole
+            // exclusion mechanism. Nothing in this build writes to any of
+            // them; the writers are later rungs. PARTIAL BY DESIGN, see
+            // migrate_108_genesis_substrate. See ensure_genesis_tables.
+            if version < 108 {
+                self.migrate_108_genesis_substrate(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -12121,6 +12135,49 @@ impl MemoryDB {
             "[migration] Migration 107 applied: {repaired} page(s) moved off the silent \
              kind='concept' default"
         );
+        Ok(())
+    }
+
+    /// Migration 108 (M6 PR-A): the genesis substrate.
+    ///
+    /// Additive `IF NOT EXISTS` DDL, same shape as 101 and for the same
+    /// reason: the tables have to exist before the first writer can, and a
+    /// control that appears at the same moment as the thing it controls has a
+    /// window where it does not. Every table starts empty, and an empty
+    /// `genesis_coverage_state` means genesis is disabled for every space
+    /// (state-machines §7, D1) — so this migration changes no behavior.
+    ///
+    /// **This is PARTIAL BY DESIGN and is not the complete genesis
+    /// substrate.** It creates exactly five objects' worth of tables —
+    /// `genesis_candidates`, `genesis_candidate_roots`,
+    /// `genesis_coverage_state`, `genesis_group_coverage`, `genesis_frontier`
+    /// — plus the two partial unique indexes of §5. Those are the objects
+    /// whose shape the Stage-0 artifacts actually fix. Everything else the M6
+    /// contracts name is deliberately absent, including the durable homes for
+    /// machine F's `suppressed` and `quarantined` states and every `m6_*`
+    /// table of the relevance, overview, and refresh contracts: their column
+    /// types, keys, or liveness rules are unresolved or mutually contradictory
+    /// across artifacts. They land in a later additive migration once those
+    /// questions are adjudicated — see the PR-A schema-questions triage in the
+    /// drive record. Do not read this migration as the finished substrate.
+    ///
+    /// Number 108 follows the merged M5 Truth migrations 105/106 and the
+    /// page-kind repair at 107.
+    async fn migrate_108_genesis_substrate(&self, _prior: i64) -> Result<(), WenlanError> {
+        let conn = self.conn.lock().await;
+        let tx = conn
+            .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m108 begin: {error}")))?;
+        Self::ensure_genesis_tables(&tx).await?;
+        tx.commit()
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m108 commit: {error}")))?;
+
+        conn.execute("PRAGMA user_version = 108", ())
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m108 bump: {error}")))?;
+        log::info!("[migration] Migration 108 applied: M6 genesis substrate (partial by design)");
         Ok(())
     }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -63,6 +63,7 @@ mod scoped_entities;
 mod scoped_pages;
 mod source_sync;
 mod space_context;
+mod space_rename;
 mod truth_exposure;
 
 pub(crate) use community_grouping_state::CommunityGroupingLeaseCleanup;
@@ -147,6 +148,8 @@ mod scoped_entities_test;
 mod scoped_pages_test;
 #[cfg(test)]
 mod scoped_records_test;
+#[cfg(test)]
+mod space_rename_test;
 #[cfg(test)]
 #[path = "db/test_support_test.rs"]
 pub(crate) mod test_support;
@@ -19627,6 +19630,12 @@ impl MemoryDB {
             .map_err(|e| {
                 WenlanError::VectorDb(format!("update_space cascade pages scope: {}", e))
             })?;
+
+            // S0-162: close the rename over the community and genesis substrate
+            // too, so no M6-reachable row is left naming a space that does not
+            // resolve.
+            space_rename::cascade_space_rename(&tx, name, new_name).await?;
+
             #[cfg(test)]
             page_drafts_test::transaction_test_hooks::after_space_cascade(&format!(
                 "update_space:{name}"

--- a/crates/wenlan-core/src/db/genesis_schema.rs
+++ b/crates/wenlan-core/src/db/genesis_schema.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Migration 108 DDL: the M6 genesis substrate.
+//!
+//! Five tables and the two partial unique indexes that are D4's entire
+//! exclusion mechanism. Every table starts empty and **nothing in this build
+//! writes to any of them** — the writers are later rungs. The tables exist
+//! first for the same reason migration 101's audit log did: a control that
+//! appears at the same moment as the thing it controls has a window where it
+//! does not.
+//!
+//! Contract sources, all on this branch:
+//! - `docs/plans/2026-08-01-m6-state-machines.md` §4 (machine A, the candidate
+//!   column list), §5 (machine B, the claim row and both partial unique
+//!   indexes, quoted verbatim below), §7 (machine D, `genesis_coverage_state`),
+//!   §9 (machine F, `genesis_frontier` + `genesis_group_coverage`).
+//!
+//! What the artifacts fix, and what this file decided:
+//! - Column *names* are the artifacts'. Column *types*, primary keys, and the
+//!   CHECK constraints are this file's, because §4/§9 name columns without
+//!   typing them. Each choice is commented where it is not mechanical.
+//! - The two partial unique indexes are byte-for-byte the artifact's SQL with
+//!   `IF NOT EXISTS` added, which the idempotent-`ensure_` pattern requires.
+//! - `genesis_frontier`'s key is D7's ordering triple; §9 names the ordering
+//!   (`next_scan_at, first_seen_at, group_id`) and the key (space, group,
+//!   epoch) but not an index, so the covering index here is derived from the
+//!   stated ordering rather than quoted.
+//!
+//! Deliberately NOT created here: the suppression and quarantine homes for
+//! machine F's `suppressed`/`quarantined` states. The artifacts contradict
+//! themselves on whether those are keyed rows or repeatable entries, and a
+//! table shape guessed under a contradiction is worse than a later additive
+//! migration. Same for every `m6_*` table of the relevance, overview, and
+//! refresh contracts. See the rung-2 open-question list in the PR-A report.
+
+use super::MemoryDB;
+use crate::WenlanError;
+
+impl MemoryDB {
+    /// Migration 108 DDL. Additive and idempotent.
+    pub(super) async fn ensure_genesis_tables(tx: &libsql::Transaction) -> Result<(), WenlanError> {
+        tx.execute_batch(
+            "
+            -- Machine A (§4). One attempt at one slot. The row is STABLE
+            -- across retries (I-8): `attempt`, `state`, and `next_attempt_at`
+            -- move, identity does not.
+            CREATE TABLE IF NOT EXISTS genesis_candidates (
+                -- m6_digest('m6-candidate-v1', [slot_id, coverage_epoch]) —
+                -- S0-40. Derived, so it is the natural key rather than a
+                -- surrogate: a retry that minted a second row would be I-8's
+                -- failure made storable.
+                candidate_id          TEXT    PRIMARY KEY,
+                slot_id               TEXT    NOT NULL,
+                page_id               TEXT    NOT NULL,
+                space                 TEXT    NOT NULL,
+                -- The four D5 signals, spelled exactly as `m6::constants`
+                -- spells them. A fifth signal is a contract change, not a
+                -- value change, so the constraint is here rather than in a
+                -- Rust match a caller can forget to run.
+                signal_kind           TEXT    NOT NULL CHECK (signal_kind IN (
+                                          'evidence-cluster', 'orphan-wikilink',
+                                          'community-overview', 'space-overview')),
+                coverage_epoch        INTEGER NOT NULL,
+                input_generation      INTEGER NOT NULL,
+                active_root_digest    TEXT    NOT NULL,
+                -- D3 fixes the state set at ten, and S0-12 says exhausted
+                -- retry is NOT an eleventh state — it is `stale` carrying a
+                -- reason. The CHECK is the mechanical form of that sentence.
+                state                 TEXT    NOT NULL CHECK (state IN (
+                                          'observed', 'prepared', 'inferencing',
+                                          'validating', 'published', 'retry_wait',
+                                          'stale', 'review_required', 'suppressed',
+                                          'superseded')),
+                -- NULL until a transition carries one. Stored as NULL rather
+                -- than '' so `reason IS NULL` distinguishes 'no reason yet'
+                -- from a reason that failed to write.
+                reason                TEXT,
+                attempt               INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at       INTEGER,
+                lease_token           TEXT,
+                receipt_id            TEXT,
+                -- The candidate's OUTPUT. D7 compaction at 90 days nulls this
+                -- and stamps `payload_compacted_at` (S0-10); the row itself is
+                -- never deleted.
+                payload               TEXT,
+                payload_compacted_at  INTEGER,
+                created_at            INTEGER NOT NULL,
+                updated_at            INTEGER NOT NULL
+            );
+            -- The recovery scan (§11 step 2) reads in-flight candidates by
+            -- state; the frontier reads them by slot.
+            CREATE INDEX IF NOT EXISTS idx_genesis_candidates_space_state
+                ON genesis_candidates(space, state);
+            CREATE INDEX IF NOT EXISTS idx_genesis_candidates_slot
+                ON genesis_candidates(slot_id, coverage_epoch);
+
+            -- Machine B (§5). One (candidate, root) pair.
+            CREATE TABLE IF NOT EXISTS genesis_candidate_roots (
+                candidate_id           TEXT    NOT NULL
+                                           REFERENCES genesis_candidates(candidate_id),
+                root_id                TEXT    NOT NULL,
+                independence_group_id  TEXT    NOT NULL,
+                coverage_epoch         INTEGER NOT NULL,
+                -- I-3: a witness row must never be readable as coverage. Both
+                -- partial indexes below exclude witnesses by predicate, so the
+                -- only way a third role could break that is by existing.
+                claim_role             TEXT    NOT NULL
+                                           CHECK (claim_role IN ('concept', 'witness')),
+                -- S0-6: 'active' is a STORED bit, not a join to the lease,
+                -- because a SQLite partial index may only reference columns of
+                -- its own table. The recovery scan is the sole reconciler.
+                released_at            INTEGER,
+                released_reason        TEXT,
+                consumed               INTEGER NOT NULL DEFAULT 0,
+                retained               INTEGER NOT NULL DEFAULT 0,
+                created_at             INTEGER NOT NULL,
+                PRIMARY KEY(candidate_id, root_id)
+            );
+            -- Verbatim from §5, plus IF NOT EXISTS. These two indexes are the
+            -- ENTIRE exclusion mechanism (I-2); a code-level check would be a
+            -- second, weaker one.
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_root_claim
+                ON genesis_candidate_roots(root_id, coverage_epoch)
+                WHERE claim_role = 'concept' AND released_at IS NULL;
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_group_claim
+                ON genesis_candidate_roots(independence_group_id, coverage_epoch)
+                WHERE claim_role = 'concept' AND released_at IS NULL;
+
+            -- Machine D (§7). One space's identity-contract era. The column
+            -- list is quoted from §7; the defaults are D1's insert values, so
+            -- a row created by naming only its space is already correct.
+            CREATE TABLE IF NOT EXISTS genesis_coverage_state (
+                space             TEXT    PRIMARY KEY,
+                coverage_epoch    INTEGER NOT NULL DEFAULT 1,
+                epoch_state       TEXT    NOT NULL DEFAULT 'active'
+                                      CHECK (epoch_state IN ('active', 'migrating')),
+                opened_at         INTEGER NOT NULL,
+                -- The resumable position of D3's forward mapping. TEXT because
+                -- what it resumes over is group identity, which is text.
+                migration_cursor  TEXT,
+                -- D1 inserts 0, and a space with NO ROW is genesis-disabled —
+                -- so an empty table means nothing runs.
+                genesis_enabled   INTEGER NOT NULL DEFAULT 0
+            );
+
+            -- Machine F (§9), permanent half. I-7: no transition deletes a
+            -- coverage row, and the epoch never decreases. Keyed by epoch so
+            -- D3's forward mapping writes new rows rather than rewriting these.
+            CREATE TABLE IF NOT EXISTS genesis_group_coverage (
+                space                  TEXT    NOT NULL,
+                independence_group_id  TEXT    NOT NULL,
+                coverage_epoch         INTEGER NOT NULL,
+                page_id                TEXT    NOT NULL,
+                candidate_id           TEXT    NOT NULL,
+                covered_at             INTEGER NOT NULL,
+                PRIMARY KEY(space, independence_group_id, coverage_epoch)
+            );
+
+            -- Machine F (§9), re-derivable half. F1 says frontier rows are
+            -- re-derivable from the differential query, which is why they need
+            -- atomicity with nothing.
+            CREATE TABLE IF NOT EXISTS genesis_frontier (
+                space                  TEXT    NOT NULL,
+                independence_group_id  TEXT    NOT NULL,
+                coverage_epoch         INTEGER NOT NULL,
+                first_seen_at          INTEGER NOT NULL,
+                next_scan_at           INTEGER NOT NULL,
+                PRIMARY KEY(space, independence_group_id, coverage_epoch)
+            );
+            -- D7's ordering, made an index so the scan does not sort.
+            CREATE INDEX IF NOT EXISTS idx_genesis_frontier_scan
+                ON genesis_frontier(space, next_scan_at, first_seen_at,
+                                    independence_group_id);
+            ",
+        )
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("m108 genesis tables: {error}")))?;
+        Ok(())
+    }
+}

--- a/crates/wenlan-core/src/db/genesis_schema_test.rs
+++ b/crates/wenlan-core/src/db/genesis_schema_test.rs
@@ -146,6 +146,42 @@ async fn the_schema_version_constant_matches_what_the_chain_stamps() {
     );
 }
 
+/// Rebase integration tooth: Kind owns migration 107, so a database already
+/// stamped 107 must still run PR-A's additive genesis migration at 108.
+#[tokio::test]
+async fn schema_107_upgrades_through_genesis_migration_108() {
+    let (db, _tmp) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute_batch(
+            "DROP TABLE genesis_candidate_roots;
+             DROP TABLE genesis_candidates;
+             DROP TABLE genesis_coverage_state;
+             DROP TABLE genesis_group_coverage;
+             DROP TABLE genesis_frontier;
+             PRAGMA user_version = 107;",
+        )
+        .await
+        .expect("restore the post-Kind, pre-genesis schema boundary");
+    }
+
+    assert!(
+        !object_exists(&db, "table", "genesis_candidates").await,
+        "the control did not remove the genesis substrate"
+    );
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("schema 107 must advance through migration 108");
+
+    assert_eq!(user_version(&db).await, 108);
+    for table in GENESIS_TABLES {
+        assert!(object_exists(&db, "table", table).await, "{table} missing");
+    }
+    for index in GENESIS_INDEXES {
+        assert!(object_exists(&db, "index", index).await, "{index} missing");
+    }
+}
+
 /// Both indexes must keep their predicates. An index that lost its `WHERE`
 /// would still exist under the same name, and would then forbid the witness
 /// coexistence D4 requires — so existence alone is not the assertion.

--- a/crates/wenlan-core/src/db/genesis_schema_test.rs
+++ b/crates/wenlan-core/src/db/genesis_schema_test.rs
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Teeth for migration 108.
+//!
+//! Two halves. The first is migration discipline: a migrated database carries
+//! every object, the constant matches what the chain stamps, a replay is inert,
+//! and a database from a newer daemon is refused. The second is the only
+//! behavior this migration actually has — the two partial unique indexes of
+//! §5, which are D4's entire exclusion mechanism (I-2) and the reason a witness
+//! row can never be read as coverage (I-3).
+//!
+//! Every index test asserts against a REJECTION, not against a query result: an
+//! exclusion mechanism that is merely queried correctly is a convention, and a
+//! convention is what the contract says must not be the enforcement.
+
+use crate::db::tests::test_db;
+use crate::db::{MemoryDB, SCHEMA_VERSION};
+
+/// Every object migration 108 promises, by name and by kind.
+const GENESIS_TABLES: [&str; 5] = [
+    "genesis_candidates",
+    "genesis_candidate_roots",
+    "genesis_coverage_state",
+    "genesis_group_coverage",
+    "genesis_frontier",
+];
+
+const GENESIS_INDEXES: [&str; 2] = ["idx_genesis_root_claim", "idx_genesis_group_claim"];
+
+async fn object_exists(db: &MemoryDB, kind: &str, name: &str) -> bool {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM sqlite_master WHERE type = ?1 AND name = ?2",
+            libsql::params![kind, name],
+        )
+        .await
+        .expect("query sqlite_master");
+    rows.next().await.expect("read sqlite_master").is_some()
+}
+
+/// The stored SQL of an index, so a test can assert on its PREDICATE rather
+/// than merely on its existence — an index that lost its `WHERE` is still an
+/// index with the right name.
+async fn index_sql(db: &MemoryDB, name: &str) -> String {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+            libsql::params![name],
+        )
+        .await
+        .expect("query index sql");
+    let row = rows
+        .next()
+        .await
+        .expect("read index sql")
+        .unwrap_or_else(|| panic!("index {name} does not exist"));
+    row.get::<String>(0).expect("index sql column")
+}
+
+async fn user_version(db: &MemoryDB) -> i64 {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query("PRAGMA user_version", ())
+        .await
+        .expect("read user_version");
+    rows.next()
+        .await
+        .expect("user_version row")
+        .expect("user_version present")
+        .get::<i64>(0)
+        .expect("user_version int")
+}
+
+/// A candidate row, minimal but valid. The claim tests need one because
+/// `genesis_candidate_roots.candidate_id` is a foreign key and the test
+/// database opens with `PRAGMA foreign_keys=ON`.
+async fn insert_candidate(db: &MemoryDB, candidate_id: &str) {
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO genesis_candidates (
+             candidate_id, slot_id, page_id, space, signal_kind, coverage_epoch,
+             input_generation, active_root_digest, state, attempt,
+             created_at, updated_at
+         ) VALUES (?1, ?2, ?3, 'space-1', 'evidence-cluster', 1, 1, 'digest', 'observed', 0,
+                   unixepoch(), unixepoch())",
+        libsql::params![
+            candidate_id,
+            format!("slot-for-{candidate_id}"),
+            format!("m6p_{candidate_id}")
+        ],
+    )
+    .await
+    .expect("insert candidate");
+}
+
+/// One claim row. Returns the raw result so a test can assert on a rejection.
+async fn insert_claim(
+    db: &MemoryDB,
+    candidate_id: &str,
+    root_id: &str,
+    group_id: &str,
+    epoch: i64,
+    claim_role: &str,
+) -> Result<u64, libsql::Error> {
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO genesis_candidate_roots (
+             candidate_id, root_id, independence_group_id, coverage_epoch,
+             claim_role, created_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, unixepoch())",
+        libsql::params![candidate_id, root_id, group_id, epoch, claim_role],
+    )
+    .await
+}
+
+// ---------------------------------------------------------------- discipline
+
+#[tokio::test]
+async fn a_migrated_database_carries_every_genesis_object() {
+    let (db, _tmp) = test_db().await;
+    for table in GENESIS_TABLES {
+        assert!(
+            object_exists(&db, "table", table).await,
+            "migration 108 promised table {table} and it is not there"
+        );
+    }
+    for index in GENESIS_INDEXES {
+        assert!(
+            object_exists(&db, "index", index).await,
+            "migration 108 promised index {index} and it is not there"
+        );
+    }
+}
+
+/// The defect this catches is real and recent: a migration that stamps
+/// `user_version = N` while `SCHEMA_VERSION` still reads `N-1` makes the
+/// refuse-newer guard hard-fail every boot after the first migrated restart.
+#[tokio::test]
+async fn the_schema_version_constant_matches_what_the_chain_stamps() {
+    let (db, _tmp) = test_db().await;
+    assert_eq!(
+        user_version(&db).await,
+        i64::from(SCHEMA_VERSION),
+        "the migration chain and SCHEMA_VERSION disagree about the current schema"
+    );
+}
+
+/// Both indexes must keep their predicates. An index that lost its `WHERE`
+/// would still exist under the same name, and would then forbid the witness
+/// coexistence D4 requires — so existence alone is not the assertion.
+#[tokio::test]
+async fn both_exclusion_indexes_are_partial_and_unique() {
+    let (db, _tmp) = test_db().await;
+    for index in GENESIS_INDEXES {
+        let sql = index_sql(&db, index).await.to_lowercase();
+        assert!(
+            sql.contains("unique"),
+            "{index} is not UNIQUE; the exclusion mechanism is gone: {sql}"
+        );
+        assert!(
+            sql.contains("where") && sql.contains("claim_role = 'concept'"),
+            "{index} lost its concept-only predicate: {sql}"
+        );
+        assert!(
+            sql.contains("released_at is null"),
+            "{index} lost its active-only predicate: {sql}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn replaying_the_migration_chain_changes_nothing() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-replay").await;
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("replaying the migration chain must succeed");
+
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
+    for table in GENESIS_TABLES {
+        assert!(object_exists(&db, "table", table).await, "{table} vanished");
+    }
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query("SELECT COUNT(*) FROM genesis_candidates", ())
+        .await
+        .expect("count candidates");
+    let count: i64 = rows
+        .next()
+        .await
+        .expect("count row")
+        .expect("count present")
+        .get(0)
+        .expect("count int");
+    assert_eq!(count, 1, "a replay dropped and recreated a populated table");
+}
+
+/// The refuse-newer guard has been correct since it was written and has never
+/// had a test. A database migrated by a newer daemon is not ours to write to.
+#[tokio::test]
+async fn a_database_from_a_newer_daemon_is_refused() {
+    let (db, _tmp) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(&format!("PRAGMA user_version = {}", SCHEMA_VERSION + 1), ())
+            .await
+            .expect("stamp a newer version");
+    }
+
+    let refusal = db.run_migrations(&crate::events::NoopEmitter).await;
+    let error = refusal.expect_err("a newer schema must be refused, not written to");
+    let message = error.to_string();
+    assert!(
+        message.contains("newer than this build supports"),
+        "refused for the wrong reason: {message}"
+    );
+}
+
+// ------------------------------------------------------------------ exclusion
+
+#[tokio::test]
+async fn two_live_concept_claims_on_one_root_cannot_coexist() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-a").await;
+    insert_candidate(&db, "cand-b").await;
+
+    insert_claim(&db, "cand-a", "root-1", "group-a", 1, "concept")
+        .await
+        .expect("the first concept claim takes the root");
+    let second = insert_claim(&db, "cand-b", "root-1", "group-b", 1, "concept").await;
+    assert!(
+        second.is_err(),
+        "two live concept candidates both claimed root-1; I-2 says one slot publishes at most one page"
+    );
+}
+
+#[tokio::test]
+async fn two_live_concept_claims_on_one_group_cannot_coexist() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-a").await;
+    insert_candidate(&db, "cand-b").await;
+
+    insert_claim(&db, "cand-a", "root-1", "group-a", 1, "concept")
+        .await
+        .expect("the first concept claim takes the group");
+    let second = insert_claim(&db, "cand-b", "root-2", "group-a", 1, "concept").await;
+    assert!(
+        second.is_err(),
+        "two live concept candidates both claimed group-a; overlapping candidates must not both mint"
+    );
+}
+
+/// B4/B6: a released reservation returns its group to the frontier, and the
+/// next candidate must be able to claim it. If `released_at` did not leave the
+/// index predicate, every crash would permanently burn a root.
+#[tokio::test]
+async fn releasing_a_concept_claim_frees_its_root_and_group() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-a").await;
+    insert_candidate(&db, "cand-b").await;
+    insert_claim(&db, "cand-a", "root-1", "group-a", 1, "concept")
+        .await
+        .expect("first claim");
+
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE genesis_candidate_roots SET released_at = unixepoch()
+             WHERE candidate_id = 'cand-a'",
+            (),
+        )
+        .await
+        .expect("release the claim");
+    }
+
+    insert_claim(&db, "cand-b", "root-1", "group-a", 1, "concept")
+        .await
+        .expect("a released root and group must be claimable again");
+}
+
+/// I-3, the positive control for the predicate: witness rows fall outside both
+/// indexes, which is the mechanical form of D4's "witness-only overview
+/// candidates may coexist without stealing evidence."
+#[tokio::test]
+async fn witness_claims_coexist_on_a_root_a_concept_already_holds() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-concept").await;
+    insert_candidate(&db, "cand-witness-1").await;
+    insert_candidate(&db, "cand-witness-2").await;
+
+    insert_claim(&db, "cand-concept", "root-1", "group-a", 1, "concept")
+        .await
+        .expect("concept claim");
+    insert_claim(&db, "cand-witness-1", "root-1", "group-a", 1, "witness")
+        .await
+        .expect("a witness must not be excluded by a concept claim");
+    insert_claim(&db, "cand-witness-2", "root-1", "group-a", 1, "witness")
+        .await
+        .expect("witnesses must not exclude each other");
+}
+
+/// The claims are epoch-keyed (S0-7). A new epoch's claim is a different
+/// claim, which is what makes D3's forward mapping possible at all.
+#[tokio::test]
+async fn a_concept_claim_in_another_epoch_is_not_excluded() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-a").await;
+    insert_candidate(&db, "cand-b").await;
+
+    insert_claim(&db, "cand-a", "root-1", "group-a", 1, "concept")
+        .await
+        .expect("epoch 1 claim");
+    insert_claim(&db, "cand-b", "root-1", "group-a", 2, "concept")
+        .await
+        .expect("epoch 2 is a different claim");
+}
+
+// -------------------------------------------------------------- value domains
+
+#[tokio::test]
+async fn a_third_claim_role_is_rejected() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-a").await;
+    let rejected = insert_claim(&db, "cand-a", "root-1", "group-a", 1, "observer").await;
+    assert!(
+        rejected.is_err(),
+        "a third claim_role would be invisible to both index predicates"
+    );
+}
+
+#[tokio::test]
+async fn an_eleventh_candidate_state_is_rejected() {
+    let (db, _tmp) = test_db().await;
+    insert_candidate(&db, "cand-a").await;
+    let conn = db.conn.lock().await;
+    let rejected = conn
+        .execute(
+            "UPDATE genesis_candidates SET state = 'retry_exhausted' WHERE candidate_id = 'cand-a'",
+            (),
+        )
+        .await;
+    assert!(
+        rejected.is_err(),
+        "S0-12: exhausted retry is `stale` carrying a reason, never an eleventh state"
+    );
+}
+
+#[tokio::test]
+async fn an_unknown_signal_kind_is_rejected() {
+    let (db, _tmp) = test_db().await;
+    let conn = db.conn.lock().await;
+    let rejected = conn
+        .execute(
+            "INSERT INTO genesis_candidates (
+                 candidate_id, slot_id, page_id, space, signal_kind, coverage_epoch,
+                 input_generation, active_root_digest, state, attempt, created_at, updated_at
+             ) VALUES ('cand-x', 'slot-x', 'm6p_x', 'space-1', 'entity-cluster', 1, 1,
+                       'digest', 'observed', 0, unixepoch(), unixepoch())",
+            (),
+        )
+        .await;
+    assert!(
+        rejected.is_err(),
+        "the signal set is D5's four; a fifth is a contract change"
+    );
+}
+
+/// D1: a space row is created genesis-DISABLED at epoch 1, and a space with no
+/// row at all is disabled too. Both halves are what make an empty table mean
+/// "nothing runs".
+#[tokio::test]
+async fn a_new_space_row_defaults_to_disabled_at_epoch_one() {
+    let (db, _tmp) = test_db().await;
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO genesis_coverage_state (space, opened_at) VALUES ('space-1', unixepoch())",
+        (),
+    )
+    .await
+    .expect("insert coverage state naming only the space");
+
+    let mut rows = conn
+        .query(
+            "SELECT coverage_epoch, epoch_state, genesis_enabled
+             FROM genesis_coverage_state WHERE space = 'space-1'",
+            (),
+        )
+        .await
+        .expect("read coverage state");
+    let row = rows
+        .next()
+        .await
+        .expect("coverage row")
+        .expect("coverage row present");
+    assert_eq!(row.get::<i64>(0).unwrap(), 1, "epochs start at 1");
+    assert_eq!(row.get::<String>(1).unwrap(), "active");
+    assert_eq!(
+        row.get::<i64>(2).unwrap(),
+        0,
+        "a space must be genesis-disabled until its own cutover enables it"
+    );
+}
+
+/// I-7: coverage rows are epoch-keyed and immortal, so D3's forward mapping
+/// writes the new epoch's row beside the old one rather than over it.
+#[tokio::test]
+async fn coverage_rows_of_two_epochs_coexist() {
+    let (db, _tmp) = test_db().await;
+    let conn = db.conn.lock().await;
+    for epoch in [1, 2] {
+        conn.execute(
+            "INSERT INTO genesis_group_coverage (
+                 space, independence_group_id, coverage_epoch, page_id, candidate_id, covered_at
+             ) VALUES ('space-1', 'group-a', ?1, 'm6p_a', 'cand-a', unixepoch())",
+            libsql::params![epoch],
+        )
+        .await
+        .unwrap_or_else(|error| panic!("coverage row for epoch {epoch}: {error}"));
+    }
+}

--- a/crates/wenlan-core/src/db/space_rename.rs
+++ b/crates/wenlan-core/src/db/space_rename.rs
@@ -36,9 +36,10 @@ use crate::WenlanError;
 /// invokes this only after the memories/entities/pages cascade has run.
 ///
 /// A `true` in the second field means a row already keyed to the destination
-/// name would collide on the PRIMARY KEY, so that row is retired before the
-/// rewrite. This is not defensive: the ORDINARY rename hits it. The pre-existing
-/// `pages` cascade fires `m4_page_community_page_invalidate`, which does
+/// name would collide on the PRIMARY KEY. Re-derivable community control rows
+/// are retired before the rewrite. This is not defensive: the ORDINARY rename
+/// hits it. The pre-existing `pages` cascade fires
+/// `m4_page_community_page_invalidate`, which does
 /// `INSERT OR IGNORE INTO community_route_space_inputs (NEW.space, 0)`
 /// (`db.rs:11014`) — so by the time this runs, a row under the destination name
 /// already exists, created by this very rename.
@@ -50,10 +51,11 @@ use crate::WenlanError;
 ///
 /// Rows that predate the rename are orphans by construction. `spaces.name` is
 /// UNIQUE, so a rename to a live space fails before the cascade runs and any
-/// surviving row under that name names no live space; every table here holds
-/// derived state its producer re-derives (Leiden recomputes communities and
-/// members, leases expire, receipts are re-proven, genesis coverage is
-/// re-derived per epoch).
+/// surviving community row under that name names no live space. The genesis
+/// rows are different: they carry permanent provenance/coverage and may never
+/// be retired merely because their space name does not currently resolve. The
+/// destination fence below therefore refuses the entire rename when any such
+/// row exists.
 const CLOSURE: &[(&str, bool)] = &[
     ("communities", false),
     ("community_members", true),
@@ -85,6 +87,13 @@ const CLOSURE: &[(&str, bool)] = &[
     ("genesis_frontier", true),
 ];
 
+const PERMANENT_GENESIS_TABLES: &[&str] = &[
+    "genesis_candidates",
+    "genesis_coverage_state",
+    "genesis_group_coverage",
+    "genesis_frontier",
+];
+
 /// Rewrite every space-keyed row from `old_name` to `new_name` inside the
 /// caller's transaction. The caller must already have renamed the `spaces` row
 /// and cascaded `memories`, `entities`, and `pages` (see the `edges` fence
@@ -96,6 +105,34 @@ pub(super) async fn cascade_space_rename(
 ) -> Result<(), WenlanError> {
     // Table names come from `CLOSURE`, never from a caller; the space names are
     // parameterized.
+    for table in PERMANENT_GENESIS_TABLES {
+        let mut rows = tx
+            .query(
+                &format!("SELECT 1 FROM {table} WHERE space = ?1 LIMIT 1"),
+                libsql::params![new_name],
+            )
+            .await
+            .map_err(|e| {
+                WenlanError::VectorDb(format!(
+                    "update_space inspect destination genesis {table}: {e}"
+                ))
+            })?;
+        if rows
+            .next()
+            .await
+            .map_err(|e| {
+                WenlanError::VectorDb(format!(
+                    "update_space inspect destination genesis {table}: {e}"
+                ))
+            })?
+            .is_some()
+        {
+            return Err(WenlanError::Validation(format!(
+                "destination genesis table {table} already has rows for space {new_name:?}"
+            )));
+        }
+    }
+
     for (table, space_in_primary_key) in CLOSURE {
         if !space_in_primary_key {
             continue;

--- a/crates/wenlan-core/src/db/space_rename.rs
+++ b/crates/wenlan-core/src/db/space_rename.rs
@@ -1,0 +1,127 @@
+//! S0-162: renaming a space closes over every space-keyed row M6 genesis can
+//! reach.
+//!
+//! `update_space` cascades over `memories`, `entities`, and `pages`/`workspace`
+//! and historically stopped there, while the M4 community substrate and the M6
+//! genesis substrate key on the same mutable string. A stale name is not
+//! self-healing: the scheduler claims dirty spaces with
+//! `SELECT space FROM space_graph_state WHERE dirty = 1` and no join to a live
+//! `spaces` row (`db/community_grouping_state.rs:84`), so an orphaned row can be
+//! selected indefinitely.
+//!
+//! The postcondition is S0-162's, stated over rows rather than over statements:
+//! after a rename, no M6-reachable row names a space that does not resolve.
+//! Every row keyed by the old name is either updated to the new name or retired.
+//!
+//! One space-keyed table is deliberately excluded and the exclusion is the scope
+//! line: `page_draft_create_requests` (`db.rs:7783`). The old name it keeps is
+//! not stale data, it is replay history, and its immutability is the table's
+//! purpose — migration 76 says so at `db.rs:7771`, the create path matches a
+//! replay against the stored request before validating the space against the
+//! live row (`db/page_drafts.rs:246`), and
+//! `create_replay_returns_the_server_mutated_scope_after_space_rename` locks it
+//! down. Rewriting those rows would break delayed-create replay.
+
+use crate::WenlanError;
+
+/// The closure, in **dependency order**, each table paired with whether `space`
+/// sits inside its PRIMARY KEY.
+///
+/// The order is load-bearing and is not alphabetical. `community_members` and
+/// `page_community_assignments` both carry a BEFORE UPDATE fence that re-checks
+/// the row's community against `communities.space` (`db.rs:11204`, `db.rs:10978`),
+/// so `communities` has to be carrying the new name before either is rewritten
+/// or the fence aborts the rename. `edges` carries the matching AFTER UPDATE
+/// fence against its endpoint's space (`db.rs:8932`), which is why the caller
+/// invokes this only after the memories/entities/pages cascade has run.
+///
+/// A `true` in the second field means a row already keyed to the destination
+/// name would collide on the PRIMARY KEY, so that row is retired before the
+/// rewrite. This is not defensive: the ORDINARY rename hits it. The pre-existing
+/// `pages` cascade fires `m4_page_community_page_invalidate`, which does
+/// `INSERT OR IGNORE INTO community_route_space_inputs (NEW.space, 0)`
+/// (`db.rs:11014`) — so by the time this runs, a row under the destination name
+/// already exists, created by this very rename.
+///
+/// Retiring it and moving the old row over is also the right direction rather
+/// than merely the convenient one: the trigger's row starts at generation 0
+/// while the old-name row carries the accumulated routing generation, and
+/// keeping the fresh row would walk that counter backwards.
+///
+/// Rows that predate the rename are orphans by construction. `spaces.name` is
+/// UNIQUE, so a rename to a live space fails before the cascade runs and any
+/// surviving row under that name names no live space; every table here holds
+/// derived state its producer re-derives (Leiden recomputes communities and
+/// members, leases expire, receipts are re-proven, genesis coverage is
+/// re-derived per epoch).
+const CLOSURE: &[(&str, bool)] = &[
+    ("communities", false),
+    ("community_members", true),
+    ("page_community_assignments", false),
+    ("page_community_route_inputs", false),
+    ("community_route_space_inputs", true),
+    ("space_graph_state", true),
+    ("grouping_leases", true),
+    // `community_reader_parity` is NOT here, and its absence is a correction to
+    // S0-162 rather than an omission. The artifact's closed enumeration lists it
+    // as the eleventh table and cites its DDL, but that DDL (`db.rs:10926`) is
+    // undone by the later "retire local-only community parity model" migration,
+    // which does `DROP TABLE IF EXISTS community_reader_parity` (`db.rs:11659`)
+    // and replaces the per-space table with the global singleton
+    // `community_parity_input_state` — which has no `space` column at all. The
+    // table does not exist in a migrated database, so closing over it raises
+    // `no such table`. Ten of the eleven are real; this one is a citation to a
+    // statement a later migration takes back.
+    ("community_reader_space_proof", true),
+    ("community_publication_receipts", true),
+    ("edges", false),
+    // PR-A's own genesis substrate (migration 107). Empty in this build, but
+    // the postcondition is stated over M6-reachable rows and these are the most
+    // M6-reachable rows there are; leaving them out would mean the rung that
+    // starts writing them has to remember to come back.
+    ("genesis_candidates", false),
+    ("genesis_coverage_state", true),
+    ("genesis_group_coverage", true),
+    ("genesis_frontier", true),
+];
+
+/// Rewrite every space-keyed row from `old_name` to `new_name` inside the
+/// caller's transaction. The caller must already have renamed the `spaces` row
+/// and cascaded `memories`, `entities`, and `pages` (see the `edges` fence
+/// above).
+pub(super) async fn cascade_space_rename(
+    tx: &libsql::Transaction,
+    old_name: &str,
+    new_name: &str,
+) -> Result<(), WenlanError> {
+    // Table names come from `CLOSURE`, never from a caller; the space names are
+    // parameterized.
+    for (table, space_in_primary_key) in CLOSURE {
+        if !space_in_primary_key {
+            continue;
+        }
+        tx.execute(
+            &format!("DELETE FROM {table} WHERE space = ?1"),
+            libsql::params![new_name],
+        )
+        .await
+        .map_err(|e| {
+            WenlanError::VectorDb(format!("update_space retire orphan {table} rows: {e}"))
+        })?;
+    }
+    for (table, _) in CLOSURE {
+        tx.execute(
+            &format!("UPDATE {table} SET space = ?1 WHERE space = ?2"),
+            libsql::params![new_name, old_name],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("update_space cascade {table}: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Every table the closure covers, for the teeth.
+#[cfg(test)]
+pub(super) fn closed_tables() -> Vec<&'static str> {
+    CLOSURE.iter().map(|(table, _)| *table).collect()
+}

--- a/crates/wenlan-core/src/db/space_rename.rs
+++ b/crates/wenlan-core/src/db/space_rename.rs
@@ -77,7 +77,7 @@ const CLOSURE: &[(&str, bool)] = &[
     ("community_reader_space_proof", true),
     ("community_publication_receipts", true),
     ("edges", false),
-    // PR-A's own genesis substrate (migration 107). Empty in this build, but
+    // PR-A's own genesis substrate (migration 108). Empty in this build, but
     // the postcondition is stated over M6-reachable rows and these are the most
     // M6-reachable rows there are; leaving them out would mean the rung that
     // starts writing them has to remember to come back.

--- a/crates/wenlan-core/src/db/space_rename_test.rs
+++ b/crates/wenlan-core/src/db/space_rename_test.rs
@@ -1,0 +1,373 @@
+//! Teeth for S0-162's rename closure — mutation-catalog gates `G8.11a`-`c`.
+//!
+//! One scenario asserted several ways: rename a space that carries community
+//! and genesis substrate, then check that identity is unchanged, that the new
+//! name resolves, and that no row still names the old space.
+
+use super::space_rename::closed_tables;
+use crate::db::tests::test_db;
+use crate::db::MemoryDB;
+
+const OLD: &str = "Research Notes";
+const NEW: &str = "Field Notes";
+
+/// Tables that carry a `space` column and are closed over by the cascade that
+/// already existed before S0-162 (`update_space`, `db.rs:19327`-`:19360`).
+const PRE_EXISTING_CASCADE: &[&str] = &["memories", "entities", "pages"];
+
+/// Tables that carry a `space` column and are deliberately left alone.
+///
+/// `page_draft_create_requests` is S0-162's one recorded exclusion: its stored
+/// name is replay history, not stale data (`db.rs:7771`).
+const DELIBERATE_EXCLUSIONS: &[&str] = &["page_draft_create_requests"];
+
+async fn seed_substrate(conn: &libsql::Connection, space: &str) {
+    let stmts: Vec<(&str, Vec<libsql::Value>)> = vec![
+        (
+            "INSERT INTO entities (id, name, entity_type, space, created_at, updated_at)
+             VALUES ('ent-1', 'Anchor', 'concept', ?1, 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO pages (id, title, content, space, created_at, last_compiled, last_modified)
+             VALUES ('page-1', 'Anchor', 'body', ?1, '2024-01-01T00:00:00Z',
+                     '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z')",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO communities
+                 (community_id, space, algo_version, projection_version, created_at, updated_at)
+             VALUES ('com-1', ?1, 'leiden-v1', 'proj-v1', 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO community_members
+                 (space, node_id, node_kind, community_id, published_generation, attachment)
+             VALUES (?1, 'ent-1', 'entity', 'com-1', 1, 'core')",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO page_community_assignments
+                 (page_id, space, community_id, state, score, page_version,
+                  routing_input_generation, routing_space_generation,
+                  community_published_generation, route_version, updated_at)
+             VALUES ('page-1', ?1, 'com-1', 'assigned', 0.9, 1, 0, 0, 1, 'route-v1', 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO page_community_route_inputs (page_id, space, generation)
+             VALUES ('page-1', ?1, 0)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO community_route_space_inputs (space, generation) VALUES (?1, 0)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO space_graph_state (space, dirty) VALUES (?1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO grouping_leases (phase, space, input_generation, token, expires_at)
+             VALUES ('grouping', ?1, 1, 'tok-1', 9999999999)",
+            vec![space.into()],
+        ),
+        // No `community_reader_parity` row: the table is dropped by the
+        // "retire local-only community parity model" migration (`db.rs:11659`),
+        // which is why it is not in the closure either.
+        (
+            "INSERT OR REPLACE INTO community_reader_space_proof
+                 (consumer, space, proven_published_generation, proven_membership_digest)
+             VALUES ('scoped_pages', ?1, 1, 'digest-1')",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO community_publication_receipts
+                 (space, published_generation, membership_digest, algo_version,
+                  projection_version, published_at)
+             VALUES (?1, 1, 'digest-1', 'leiden-v1', 'proj-v1', 1)",
+            vec![space.into()],
+        ),
+        // A NON-legacy edge, so `edges_space_fence_update` (db.rs:8932) is live
+        // on the rewrite. Its endpoint is the seeded entity, which the
+        // pre-existing cascade renames first — this row is what proves the
+        // ordering rather than merely assuming it.
+        (
+            "INSERT INTO edges
+                 (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage,
+                  grounded, space, created_at)
+             VALUES ('edge-1', 'ent-1', 'entity', 'ent-1', 'entity', 'relates',
+                     'assertion', 0, ?1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO genesis_candidates
+                 (candidate_id, slot_id, page_id, space, signal_kind, coverage_epoch,
+                  input_generation, active_root_digest, state, created_at, updated_at)
+             VALUES ('cand-1', 'slot-1', 'page-1', ?1, 'evidence-cluster', 1, 1,
+                     'rootdigest', 'observed', 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO genesis_coverage_state (space, opened_at) VALUES (?1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO genesis_group_coverage
+                 (space, independence_group_id, coverage_epoch, page_id, candidate_id, covered_at)
+             VALUES (?1, 'grp-1', 1, 'page-1', 'cand-1', 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT OR REPLACE INTO genesis_frontier
+                 (space, independence_group_id, coverage_epoch, first_seen_at, next_scan_at)
+             VALUES (?1, 'grp-1', 1, 1, 1)",
+            vec![space.into()],
+        ),
+    ];
+    for (sql, params) in stmts {
+        conn.execute(sql, params)
+            .await
+            .unwrap_or_else(|e| panic!("seed failed: {sql}\n{e}"));
+    }
+}
+
+async fn rows_naming(conn: &libsql::Connection, table: &str, space: &str) -> i64 {
+    let mut rows = conn
+        .query(
+            &format!("SELECT COUNT(*) FROM {table} WHERE space = ?1"),
+            libsql::params![space],
+        )
+        .await
+        .unwrap_or_else(|e| panic!("count {table}: {e}"));
+    rows.next().await.unwrap().unwrap().get(0).unwrap()
+}
+
+async fn seeded_db() -> (MemoryDB, tempfile::TempDir) {
+    let (db, dir) = test_db().await;
+    db.create_space(OLD, None, false).await.unwrap();
+    {
+        let conn = db.conn.lock().await;
+        seed_substrate(&conn, OLD).await;
+    }
+    (db, dir)
+}
+
+#[tokio::test]
+async fn every_space_keyed_row_follows_the_rename() {
+    let (db, _dir) = seeded_db().await;
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    for table in closed_tables() {
+        assert_eq!(
+            rows_naming(&conn, table, NEW).await,
+            1,
+            "{table} should carry exactly one row under the new name"
+        );
+    }
+}
+
+#[tokio::test]
+async fn no_substrate_row_still_names_the_old_space() {
+    // G8.11c stated once over the whole closure: a row keyed to the old name
+    // must not survive the rename and stay claimable.
+    let (db, _dir) = seeded_db().await;
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    for table in closed_tables() {
+        assert_eq!(
+            rows_naming(&conn, table, OLD).await,
+            0,
+            "{table} still names the old space after the rename"
+        );
+    }
+}
+
+#[tokio::test]
+async fn the_page_draft_ledger_keeps_the_old_name() {
+    // The one deliberate exclusion. Rewriting it would break delayed-create
+    // replay, which is the failure the ledger exists to prevent.
+    let (db, _dir) = seeded_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO page_draft_create_requests (page_id, title, content, space)
+             VALUES ('draft-1', 'Draft', 'body', ?1)",
+            libsql::params![OLD],
+        )
+        .await
+        .unwrap();
+    }
+
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    assert_eq!(
+        rows_naming(&conn, "page_draft_create_requests", OLD).await,
+        1,
+        "the create-request ledger must keep the name the request was made under"
+    );
+}
+
+#[tokio::test]
+async fn an_orphan_row_under_the_new_name_is_retired() {
+    // `spaces.name` is UNIQUE, so a row already keyed to the destination name
+    // names no live space. It must not block the rename.
+    let (db, _dir) = seeded_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT OR REPLACE INTO space_graph_state (space, graph_generation, dirty) VALUES (?1, 77, 0)",
+            libsql::params![NEW],
+        )
+        .await
+        .unwrap();
+    }
+
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*), MAX(graph_generation), MAX(dirty) FROM space_graph_state
+             WHERE space = ?1",
+            libsql::params![NEW],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    let count: i64 = row.get(0).unwrap();
+    let generation: i64 = row.get(1).unwrap();
+    let dirty: i64 = row.get(2).unwrap();
+    assert_eq!(count, 1, "the orphan must be retired, not kept alongside");
+    assert_eq!(generation, 0, "the renamed row must be the survivor");
+    assert_eq!(dirty, 1, "the renamed row must be the survivor");
+}
+
+#[tokio::test]
+async fn a_rename_does_not_change_the_space_id() {
+    // G8.11a. M6 identity digests `spaces.id`, so a rename that leaves the id
+    // alone leaves `slot_id`, `page_id`, and candidate identity alone with it.
+    let (db, _dir) = seeded_db().await;
+    let before = db.get_space(OLD).await.unwrap().unwrap();
+    db.update_space(OLD, NEW, None).await.unwrap();
+    let after = db.get_space(NEW).await.unwrap().unwrap();
+
+    assert_eq!(before.id, after.id, "a rename must not re-key the space");
+
+    let slot_before = crate::m6::identity::slot_id_space_overview(&before.id);
+    let slot_after = crate::m6::identity::slot_id_space_overview(&after.id);
+    assert_eq!(slot_before, slot_after);
+    assert_eq!(
+        crate::m6::identity::page_id(&slot_before),
+        crate::m6::identity::page_id(&slot_after)
+    );
+    assert_eq!(
+        crate::m6::identity::candidate_id(&slot_before, 1),
+        crate::m6::identity::candidate_id(&slot_after, 1)
+    );
+}
+
+#[tokio::test]
+async fn the_new_name_resolves_and_the_old_one_does_not() {
+    // G8.11b's reachable half. S0-161 refuses a mint whose stored space does
+    // not resolve; a routine rename must not be what makes it refuse.
+    let (db, _dir) = seeded_db().await;
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    assert!(db.get_space(NEW).await.unwrap().is_some());
+    assert!(db.get_space(OLD).await.unwrap().is_none());
+
+    // Every substrate row now names a space that resolves.
+    let conn = db.conn.lock().await;
+    for table in closed_tables() {
+        let mut rows = conn
+            .query(
+                &format!(
+                    "SELECT COUNT(*) FROM {table} t
+                     WHERE NOT EXISTS (SELECT 1 FROM spaces s WHERE s.name = t.space)"
+                ),
+                (),
+            )
+            .await
+            .unwrap();
+        let unresolvable: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(unresolvable, 0, "{table} holds a row naming no live space");
+    }
+}
+
+#[tokio::test]
+async fn renaming_a_space_with_no_substrate_is_a_no_op() {
+    // The catalog's suite-level control.
+    let (db, _dir) = test_db().await;
+    db.create_space(OLD, None, false).await.unwrap();
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    for table in closed_tables() {
+        assert_eq!(rows_naming(&conn, table, NEW).await, 0, "{table}");
+        assert_eq!(rows_naming(&conn, table, OLD).await, 0, "{table}");
+    }
+}
+
+#[tokio::test]
+async fn every_space_keyed_table_is_accounted_for() {
+    // The enumeration S0-162 calls closed is only closed if something checks
+    // it. A new table carrying a `space` column must land in the closure, in
+    // the pre-existing cascade, or in the recorded exclusions — never silently
+    // outside all three.
+    let (db, _dir) = test_db().await;
+    let conn = db.conn.lock().await;
+
+    let mut tables: Vec<String> = Vec::new();
+    let mut rows = conn
+        .query(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'
+             ORDER BY name",
+            (),
+        )
+        .await
+        .unwrap();
+    while let Some(row) = rows.next().await.unwrap() {
+        tables.push(row.get(0).unwrap());
+    }
+
+    let mut space_keyed: Vec<String> = Vec::new();
+    for table in tables {
+        let mut cols = conn
+            .query(&format!("PRAGMA table_info({table})"), ())
+            .await
+            .unwrap();
+        while let Some(col) = cols.next().await.unwrap() {
+            let name: String = col.get(1).unwrap();
+            if name == "space" {
+                space_keyed.push(table.clone());
+                break;
+            }
+        }
+    }
+
+    let accounted: Vec<&str> = closed_tables()
+        .into_iter()
+        .chain(PRE_EXISTING_CASCADE.iter().copied())
+        .chain(DELIBERATE_EXCLUSIONS.iter().copied())
+        .collect();
+
+    let unaccounted: Vec<&String> = space_keyed
+        .iter()
+        .filter(|t| !accounted.contains(&t.as_str()))
+        .collect();
+    assert!(
+        unaccounted.is_empty(),
+        "these tables carry a `space` column and are in no S0-162 bucket: {unaccounted:?}"
+    );
+
+    for table in closed_tables() {
+        assert!(
+            space_keyed.iter().any(|t| t == table),
+            "{table} is in the closure but carries no `space` column"
+        );
+    }
+}

--- a/crates/wenlan-core/src/db/space_rename_test.rs
+++ b/crates/wenlan-core/src/db/space_rename_test.rs
@@ -132,6 +132,42 @@ async fn seed_substrate(conn: &libsql::Connection, space: &str) {
     }
 }
 
+async fn seed_destination_genesis(conn: &libsql::Connection) {
+    let stmts = [
+        "INSERT INTO genesis_candidates
+             (candidate_id, slot_id, page_id, space, signal_kind, coverage_epoch,
+              input_generation, active_root_digest, state, created_at, updated_at)
+         VALUES ('cand-destination', 'slot-destination', 'page-destination', ?1,
+                 'evidence-cluster', 7, 11, 'destination-root', 'published', 2, 3)",
+        "INSERT INTO genesis_coverage_state
+             (space, coverage_epoch, epoch_state, opened_at, genesis_enabled)
+         VALUES (?1, 7, 'active', 2, 1)",
+        "INSERT INTO genesis_group_coverage
+             (space, independence_group_id, coverage_epoch, page_id, candidate_id, covered_at)
+         VALUES (?1, 'grp-destination', 7, 'page-destination', 'cand-destination', 4)",
+        "INSERT INTO genesis_frontier
+             (space, independence_group_id, coverage_epoch, first_seen_at, next_scan_at)
+         VALUES (?1, 'grp-destination', 7, 5, 6)",
+    ];
+    for sql in stmts {
+        conn.execute(sql, libsql::params![NEW])
+            .await
+            .unwrap_or_else(|e| panic!("seed destination genesis failed: {sql}\n{e}"));
+    }
+}
+
+async fn seed_source_evidence(conn: &libsql::Connection) {
+    conn.execute(
+        "INSERT INTO genesis_candidate_roots
+             (candidate_id, root_id, independence_group_id, coverage_epoch,
+              claim_role, consumed, retained, created_at)
+         VALUES ('cand-1', 'root-source', 'grp-source', 1, 'concept', 1, 1, 7)",
+        (),
+    )
+    .await
+    .expect("seed source genesis evidence");
+}
+
 async fn rows_naming(conn: &libsql::Connection, table: &str, space: &str) -> i64 {
     let mut rows = conn
         .query(
@@ -244,6 +280,78 @@ async fn an_orphan_row_under_the_new_name_is_retired() {
     assert_eq!(count, 1, "the orphan must be retired, not kept alongside");
     assert_eq!(generation, 0, "the renamed row must be the survivor");
     assert_eq!(dirty, 1, "the renamed row must be the survivor");
+}
+
+#[tokio::test]
+async fn destination_genesis_rows_refuse_the_rename_without_mutating_either_side() {
+    let (db, _dir) = seeded_db().await;
+    {
+        let conn = db.conn.lock().await;
+        seed_source_evidence(&conn).await;
+        seed_destination_genesis(&conn).await;
+    }
+
+    let error = db
+        .update_space(OLD, NEW, Some("renamed"))
+        .await
+        .expect_err("permanent destination genesis rows must refuse the rename");
+    assert!(
+        error.to_string().contains("destination genesis"),
+        "rename was refused for the wrong reason: {error}"
+    );
+
+    assert!(db.get_space(OLD).await.unwrap().is_some());
+    assert!(db.get_space(NEW).await.unwrap().is_none());
+
+    let conn = db.conn.lock().await;
+    for table in closed_tables() {
+        assert_eq!(
+            rows_naming(&conn, table, OLD).await,
+            1,
+            "source row in {table} was not rolled back"
+        );
+    }
+    for table in [
+        "genesis_candidates",
+        "genesis_coverage_state",
+        "genesis_group_coverage",
+        "genesis_frontier",
+    ] {
+        assert_eq!(
+            rows_naming(&conn, table, NEW).await,
+            1,
+            "destination row in {table} changed during the refused rename"
+        );
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT candidate_id, coverage_epoch, input_generation, active_root_digest, state
+             FROM genesis_candidates WHERE space = ?1",
+            libsql::params![NEW],
+        )
+        .await
+        .unwrap();
+    let candidate = rows.next().await.unwrap().unwrap();
+    assert_eq!(candidate.get::<String>(0).unwrap(), "cand-destination");
+    assert_eq!(candidate.get::<i64>(1).unwrap(), 7);
+    assert_eq!(candidate.get::<i64>(2).unwrap(), 11);
+    assert_eq!(candidate.get::<String>(3).unwrap(), "destination-root");
+    assert_eq!(candidate.get::<String>(4).unwrap(), "published");
+
+    let mut rows = conn
+        .query(
+            "SELECT root_id, independence_group_id, consumed, retained
+             FROM genesis_candidate_roots WHERE candidate_id = 'cand-1'",
+            (),
+        )
+        .await
+        .unwrap();
+    let evidence = rows.next().await.unwrap().unwrap();
+    assert_eq!(evidence.get::<String>(0).unwrap(), "root-source");
+    assert_eq!(evidence.get::<String>(1).unwrap(), "grp-source");
+    assert_eq!(evidence.get::<i64>(2).unwrap(), 1);
+    assert_eq!(evidence.get::<i64>(3).unwrap(), 1);
 }
 
 #[tokio::test]

--- a/crates/wenlan-core/src/lib.rs
+++ b/crates/wenlan-core/src/lib.rs
@@ -44,6 +44,7 @@ pub mod kg_quality;
 pub mod lint;
 pub mod llm_classifier;
 pub mod llm_provider;
+pub mod m6;
 pub mod maintenance;
 pub mod memory_schema;
 pub mod migrate_rename;

--- a/crates/wenlan-core/src/m6/constants.rs
+++ b/crates/wenlan-core/src/m6/constants.rs
@@ -1,0 +1,66 @@
+//! Frozen M6 constants that PR-A consumes.
+//!
+//! Every value here is fixed by a Stage-0 contract artifact and cited to its
+//! decision. Changing one is a contract amendment, not a tuning knob — the
+//! digest domains and signal tags in particular are hashed inputs, so editing a
+//! byte re-keys every `slot_id`, hence every `page_id` and `candidate_id`.
+//!
+//! Constants belonging to later rungs (D9 relevance weights, D8 admission
+//! thresholds, lease TTLs) are deliberately not here: PR-A has no code that
+//! reads them, and a constant with no consumer is a value nothing checks.
+
+// ---------------------------------------------------------------------------
+// Digest domain tags (artifact 4)
+// ---------------------------------------------------------------------------
+
+/// Domain tag for `slot_id` (artifact 4 §3.1).
+pub const DOMAIN_SLOT: &str = "m6-slot-v1";
+
+/// Domain tag for `page_id` (artifact 4 §4, S0-32).
+pub const DOMAIN_PAGE: &str = "m6-page-v1";
+
+/// Domain tag for `candidate_id` (S0-40).
+pub const DOMAIN_CANDIDATE: &str = "m6-candidate-v1";
+
+/// Domain tag for `candidate_fingerprint` (artifact 4 §5).
+pub const DOMAIN_FINGERPRINT: &str = "m6-fingerprint-v1";
+
+/// Domain tag for the active-root digest, fingerprint field 8.
+///
+/// **Disclosed gap-closure.** Artifact 4 §5 specifies field 8 as "a `m6_digest`
+/// over `sorted_set` of `(root_id, status)` pairs" but never names its domain
+/// tag. PR-A picks this spelling to match the `m6-<thing>-v1` family. Nothing
+/// downstream has been built against another value.
+pub const DOMAIN_ACTIVE_ROOTS: &str = "m6-active-roots-v1";
+
+/// `page_id` prefix (S0-32). The full 64-hex digest follows and is never
+/// truncated — the orphan-wikilink slot derives from an attacker-written label,
+/// so a 64-bit ID would be grindable at ~2^32 work.
+pub const PAGE_ID_PREFIX: &str = "m6p_";
+
+// ---------------------------------------------------------------------------
+// Signal tags (artifact 4 §3.1) — frozen because they are digest inputs
+// ---------------------------------------------------------------------------
+
+/// Signal tag literal (artifact 4 §3.1).
+pub const SIGNAL_TAG_EVIDENCE_CLUSTER: &str = "evidence-cluster";
+/// See [`SIGNAL_TAG_EVIDENCE_CLUSTER`].
+pub const SIGNAL_TAG_ORPHAN_WIKILINK: &str = "orphan-wikilink";
+/// See [`SIGNAL_TAG_EVIDENCE_CLUSTER`].
+pub const SIGNAL_TAG_COMMUNITY_OVERVIEW: &str = "community-overview";
+/// See [`SIGNAL_TAG_EVIDENCE_CLUSTER`].
+pub const SIGNAL_TAG_SPACE_OVERVIEW: &str = "space-overview";
+
+// ---------------------------------------------------------------------------
+// D8 wikilink normalization bounds (artifact 4 §6)
+// ---------------------------------------------------------------------------
+
+/// R0 pre-cap: reject a raw target longer than this many Unicode scalars,
+/// before any normalization work (S0-37). 8x the post-normalization cap.
+pub const LABEL_RAW_PRECAP_SCALARS: usize = 1024;
+
+/// R3 lower bound, measured after normalization.
+pub const LABEL_KEY_MIN_SCALARS: usize = 1;
+
+/// R3 upper bound, measured after normalization (artifact 4 §6.1 step 7).
+pub const LABEL_KEY_MAX_SCALARS: usize = 128;

--- a/crates/wenlan-core/src/m6/digest.rs
+++ b/crates/wenlan-core/src/m6/digest.rs
@@ -1,0 +1,76 @@
+//! The M6 digest primitive.
+//!
+//! Every M6 identity is a SHA-256 over **length-prefixed** parts under a
+//! **domain tag**. Both properties are load-bearing:
+//!
+//! * Length prefixing makes the part boundaries unambiguous. Separator framing
+//!   collides — `["x\0", "y"]` and `["x", "\0y"]` serialize identically under a
+//!   NUL separator but are different inputs. A collision here is an identity
+//!   collision, which is a wrong-page write.
+//! * The domain tag keeps one part list from meaning two things in two
+//!   namespaces, so a `slot_id` can never equal a `page_id` built from the same
+//!   bytes.
+//!
+//! The digest is the full 64 lowercase hex characters. It is never truncated:
+//! truncation trades collision resistance for column width, and these values
+//! are primary keys.
+
+use sha2::{Digest, Sha256};
+
+/// Hash `parts` under `domain`, returning 64 lowercase hex characters.
+pub fn m6_digest(domain: &str, parts: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    write_part(&mut hasher, domain.as_bytes());
+    for part in parts {
+        write_part(&mut hasher, part);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Same as [`m6_digest`] for callers that built owned parts.
+pub fn m6_digest_owned(domain: &str, parts: &[Vec<u8>]) -> String {
+    let refs: Vec<&[u8]> = parts.iter().map(Vec::as_slice).collect();
+    m6_digest(domain, &refs)
+}
+
+/// Absorb one part: an 8-byte little-endian length, then the bytes.
+fn write_part(hasher: &mut Sha256, bytes: &[u8]) {
+    hasher.update((bytes.len() as u64).to_le_bytes());
+    hasher.update(bytes);
+}
+
+/// Integer part encoding: ASCII decimal, no leading zeros, `-` for negatives.
+/// `i64::to_string` is exactly that.
+pub fn int_part(value: i64) -> Vec<u8> {
+    value.to_string().into_bytes()
+}
+
+/// Boolean part encoding.
+pub fn bool_part(value: bool) -> &'static [u8] {
+    if value {
+        b"t"
+    } else {
+        b"f"
+    }
+}
+
+/// An absent optional field is a zero-length part — distinct from a present
+/// empty string only because the *arity* of the part list is fixed, so position
+/// carries the field identity.
+pub const ABSENT_PART: &[u8] = b"";
+
+/// Canonical set encoding: byte-lexicographic sort, exact dedup, then a count
+/// part followed by one part per element.
+///
+/// The leading count is what makes this unambiguous when a set is embedded in a
+/// longer part list — without it, a reader cannot tell where the set ends.
+pub fn sorted_set<S: AsRef<str>>(items: &[S]) -> Vec<Vec<u8>> {
+    let mut sorted: Vec<&[u8]> = items.iter().map(|s| s.as_ref().as_bytes()).collect();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    let mut parts = Vec::with_capacity(sorted.len() + 1);
+    parts.push(int_part(sorted.len() as i64));
+    parts.extend(sorted.into_iter().map(<[u8]>::to_vec));
+    parts
+}

--- a/crates/wenlan-core/src/m6/digest_test.rs
+++ b/crates/wenlan-core/src/m6/digest_test.rs
@@ -200,6 +200,50 @@ fn boolean_parts_are_the_literal_t_and_f() {
     );
 }
 
+/// Mutant for S0-28, the *partial* form: the domain is concatenated raw while
+/// the parts keep their length prefixes.
+///
+/// This is the mutation a reviewer is most likely to write by accident —
+/// dropping `write_part` from the domain line alone — and the fully-raw mutant
+/// above does not catch it, because differing part lengths keep the two byte
+/// streams apart. It needs its own colliding input.
+fn mutant_raw_domain_framed_parts(domain: &str, parts: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(domain.as_bytes());
+    for part in parts {
+        hasher.update((part.len() as u64).to_le_bytes());
+        hasher.update(part);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[test]
+fn s0_28_raw_domain_prefix_collides_even_when_the_parts_are_framed() {
+    // The construction: an unframed domain lets its own trailing bytes be read
+    // as the next part's length prefix.
+    //
+    //   ("d",      [0x00]) -> "d" ++ [1,0,0,0,0,0,0,0] ++ [0x00]
+    //   ("d\x01",  [])     -> "d" ++ [1] ++ [0,0,0,0,0,0,0,0]
+    //
+    // Both are the nine bytes `d 01 00 00 00 00 00 00 00`.
+    let domain_a = "d";
+    let parts_a: [&[u8]; 1] = [b"\x00"];
+    let domain_b = "d\u{1}";
+    let parts_b: [&[u8]; 1] = [b""];
+
+    assert_eq!(
+        mutant_raw_domain_framed_parts(domain_a, &parts_a),
+        mutant_raw_domain_framed_parts(domain_b, &parts_b),
+        "control failed: an unframed domain was expected to alias these"
+    );
+
+    assert_ne!(
+        m6_digest(domain_a, &parts_a),
+        m6_digest(domain_b, &parts_b),
+        "the domain tag must be absorbed through write_part like any other part"
+    );
+}
+
 #[test]
 fn digest_is_stable_across_calls() {
     // Guards against any accidental nondeterminism (hasher state, iteration

--- a/crates/wenlan-core/src/m6/digest_test.rs
+++ b/crates/wenlan-core/src/m6/digest_test.rs
@@ -1,0 +1,210 @@
+//! Teeth for the M6 digest primitive (S0-26 through S0-30).
+//!
+//! Each test follows the S0-135 shape: build the *mutant* the decision forbids,
+//! assert the mutant really does exhibit the defect (the discriminating
+//! positive control — without it a test can pass because the input was too weak
+//! to distinguish anything), then assert the contract implementation does not.
+
+use super::constants::{DOMAIN_PAGE, DOMAIN_SLOT};
+use super::digest::{bool_part, int_part, m6_digest, m6_digest_owned, sorted_set, ABSENT_PART};
+use sha2::{Digest, Sha256};
+
+/// Mutant for S0-26: NUL-separator framing instead of length prefixes.
+fn mutant_separator_framed(domain: &str, parts: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(domain.as_bytes());
+    for part in parts {
+        hasher.update(b"\0");
+        hasher.update(part);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+/// Mutant for S0-28: the `source_page_id` shape — a raw domain prefix followed
+/// by raw content, no length framing anywhere
+/// (`document_enrichment.rs:763`). That construction is safe there only because
+/// its tag is a single compile-time constant; M6 has several tags and a version
+/// axis, so the ambiguity is reachable.
+fn mutant_raw_prefix_domain(domain: &str, parts: &[&[u8]]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(domain.as_bytes());
+    for part in parts {
+        hasher.update(part);
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+#[test]
+fn s0_26_length_prefixing_separates_parts_that_separator_framing_aliases() {
+    // Two genuinely different part vectors whose NUL-separated serializations
+    // are byte-identical.
+    let a: [&[u8]; 2] = [b"x\0", b"y"];
+    let b: [&[u8]; 2] = [b"x", b"\0y"];
+
+    // Control: the mutation really does collide. If this ever fails, the test
+    // below is proving nothing.
+    assert_eq!(
+        mutant_separator_framed(DOMAIN_SLOT, &a),
+        mutant_separator_framed(DOMAIN_SLOT, &b),
+        "control failed: separator framing was expected to alias these inputs"
+    );
+
+    // Contract: length prefixing keeps them apart.
+    assert_ne!(
+        m6_digest(DOMAIN_SLOT, &a),
+        m6_digest(DOMAIN_SLOT, &b),
+        "length-prefixed framing must not alias distinct part vectors"
+    );
+}
+
+#[test]
+fn s0_28_domain_tag_is_length_prefixed_not_a_raw_prefix() {
+    // `("m6-page-v1", "Xabc")` vs `("m6-page-v1X", "abc")` — same byte stream
+    // under a raw prefix.
+    let domain_a = "m6-page-v1";
+    let parts_a: [&[u8]; 1] = [b"Xabc"];
+    let domain_b = "m6-page-v1X";
+    let parts_b: [&[u8]; 1] = [b"abc"];
+
+    assert_eq!(
+        mutant_raw_prefix_domain(domain_a, &parts_a),
+        mutant_raw_prefix_domain(domain_b, &parts_b),
+        "control failed: a raw domain prefix was expected to alias these"
+    );
+
+    assert_ne!(
+        m6_digest(domain_a, &parts_a),
+        m6_digest(domain_b, &parts_b),
+        "the domain tag must be absorbed as its own length-prefixed part"
+    );
+}
+
+#[test]
+fn s0_28_same_parts_under_different_domains_never_collide() {
+    let parts: [&[u8]; 1] = [b"the-same-bytes"];
+    assert_ne!(
+        m6_digest(DOMAIN_SLOT, &parts),
+        m6_digest(DOMAIN_PAGE, &parts),
+        "a slot_id and a page_id built from identical parts must differ"
+    );
+}
+
+#[test]
+fn s0_27_digest_is_full_64_lowercase_hex() {
+    let digest = m6_digest(DOMAIN_SLOT, &[b"anything"]);
+
+    assert_eq!(digest.len(), 64, "digest must not be truncated");
+    assert!(
+        digest
+            .chars()
+            .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+        "digest must be lowercase hex, got {digest}"
+    );
+}
+
+#[test]
+fn s0_30_set_encoding_dedups_before_counting() {
+    let with_duplicate = [
+        "src:alpha".to_string(),
+        "src:beta".to_string(),
+        "src:alpha".to_string(),
+    ];
+    let without = ["src:alpha".to_string(), "src:beta".to_string()];
+
+    assert_eq!(
+        sorted_set(&with_duplicate),
+        sorted_set(&without),
+        "a duplicated group must not inflate the set"
+    );
+    // The count part leads, and it counts the deduped set.
+    assert_eq!(sorted_set(&with_duplicate)[0], int_part(2));
+}
+
+#[test]
+fn s0_30_set_encoding_is_order_independent() {
+    let forward = ["turn:a".to_string(), "batch:b".to_string()];
+    let reverse = ["batch:b".to_string(), "turn:a".to_string()];
+
+    // Control: insertion order really does differ, so sorting is doing work.
+    assert_ne!(
+        forward.as_slice(),
+        reverse.as_slice(),
+        "control failed: the two inputs were expected to differ in order"
+    );
+
+    assert_eq!(
+        m6_digest_owned(DOMAIN_SLOT, &sorted_set(&forward)),
+        m6_digest_owned(DOMAIN_SLOT, &sorted_set(&reverse)),
+        "set encoding must be order-independent"
+    );
+}
+
+#[test]
+fn s0_30_set_encoding_sorts_by_bytes_not_by_length() {
+    // A length-first ordering would put "z" before "aa"; byte-lexicographic
+    // puts "aa" first. Assert the emitted element order directly.
+    let items = ["z".to_string(), "aa".to_string()];
+    let parts = sorted_set(&items);
+
+    assert_eq!(parts[0], int_part(2));
+    assert_eq!(
+        parts[1],
+        b"aa".to_vec(),
+        "byte-lexicographic order expected"
+    );
+    assert_eq!(parts[2], b"z".to_vec());
+}
+
+#[test]
+fn s0_30_disjoint_sets_do_not_alias_a_concatenated_element() {
+    // {a, b} must not collide with {ab}.
+    let two = ["a".to_string(), "b".to_string()];
+    let one = ["ab".to_string()];
+
+    assert_ne!(
+        m6_digest_owned(DOMAIN_SLOT, &sorted_set(&two)),
+        m6_digest_owned(DOMAIN_SLOT, &sorted_set(&one)),
+        "{{a,b}} and {{ab}} must not alias"
+    );
+}
+
+#[test]
+fn absent_part_is_distinct_from_the_literal_string_none() {
+    // The absent encoding must be a zero-length part, not a sentinel word a
+    // real value could equal.
+    assert!(ABSENT_PART.is_empty());
+    assert_ne!(
+        m6_digest(DOMAIN_SLOT, &[ABSENT_PART]),
+        m6_digest(DOMAIN_SLOT, &[b"none"]),
+        "an absent optional must not collide with the literal value \"none\""
+    );
+}
+
+#[test]
+fn integer_parts_are_ascii_decimal_without_leading_zeros() {
+    assert_eq!(int_part(0), b"0".to_vec());
+    assert_eq!(int_part(1), b"1".to_vec());
+    assert_eq!(int_part(-7), b"-7".to_vec());
+    assert_eq!(int_part(1_234_567), b"1234567".to_vec());
+    // No `+`, and no zero padding that would make 01 and 1 distinct inputs.
+    assert_ne!(int_part(1), b"01".to_vec());
+}
+
+#[test]
+fn boolean_parts_are_the_literal_t_and_f() {
+    assert_eq!(bool_part(true), b"t");
+    assert_eq!(bool_part(false), b"f");
+    assert_ne!(
+        m6_digest(DOMAIN_SLOT, &[bool_part(true)]),
+        m6_digest(DOMAIN_SLOT, &[bool_part(false)])
+    );
+}
+
+#[test]
+fn digest_is_stable_across_calls() {
+    // Guards against any accidental nondeterminism (hasher state, iteration
+    // order) creeping into the primitive.
+    let once = m6_digest(DOMAIN_SLOT, &[b"alpha", b"beta"]);
+    let twice = m6_digest(DOMAIN_SLOT, &[b"alpha", b"beta"]);
+    assert_eq!(once, twice);
+}

--- a/crates/wenlan-core/src/m6/identity.rs
+++ b/crates/wenlan-core/src/m6/identity.rs
@@ -1,0 +1,214 @@
+//! M6 deterministic identity derivations (artifact 4 §3-§5).
+//!
+//! Three identities, each a pure function of contract-named inputs:
+//!
+//! * `slot_id` — what a page *is*. Stable across restarts, recomputation, and
+//!   root lifecycle.
+//! * `page_id` — `m6p_` + a digest of the slot, so slot and page identity can
+//!   version independently.
+//! * `candidate_fingerprint` — whether a slot's answer is *stale*. This is the
+//!   freshness axis, deliberately separate from the identity axis.
+//!
+//! Every space input is `spaces.id`, the daemon-minted UUID — never the mutable
+//! name stored in `communities.space`. Digesting the stable ID is exactly what
+//! makes a space rename unable to re-key a slot or a page (S0-161).
+
+use super::constants::{
+    DOMAIN_ACTIVE_ROOTS, DOMAIN_CANDIDATE, DOMAIN_FINGERPRINT, DOMAIN_PAGE, DOMAIN_SLOT,
+    PAGE_ID_PREFIX, SIGNAL_TAG_COMMUNITY_OVERVIEW, SIGNAL_TAG_EVIDENCE_CLUSTER,
+    SIGNAL_TAG_ORPHAN_WIKILINK, SIGNAL_TAG_SPACE_OVERVIEW,
+};
+use super::digest::{int_part, m6_digest_owned, sorted_set, ABSENT_PART};
+
+/// The four D5 signals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalKind {
+    /// Evidence cluster — keyed on the *initial* independence-group set.
+    EvidenceCluster,
+    /// Orphan wikilink — keyed on the normalized label.
+    OrphanWikilink,
+    /// Community overview — keyed on the durable M4 community ID.
+    CommunityOverview,
+    /// Space overview — keyed on the space alone.
+    SpaceOverview,
+}
+
+impl SignalKind {
+    /// The frozen tag literal. This is a hashed input, so it is read from
+    /// [`super::constants`] rather than spelled inline at each call site.
+    pub fn tag(self) -> &'static str {
+        match self {
+            SignalKind::EvidenceCluster => SIGNAL_TAG_EVIDENCE_CLUSTER,
+            SignalKind::OrphanWikilink => SIGNAL_TAG_ORPHAN_WIKILINK,
+            SignalKind::CommunityOverview => SIGNAL_TAG_COMMUNITY_OVERVIEW,
+            SignalKind::SpaceOverview => SIGNAL_TAG_SPACE_OVERVIEW,
+        }
+    }
+}
+
+/// `slot_id` for an evidence cluster.
+///
+/// `groups` is the set snapshotted at the machine-A `observed` transition and
+/// never recomputed (S0-29): a slot that tracked the live set would change
+/// identity every time the cluster gained evidence, which is backwards. Growth
+/// is a *fingerprint* input instead.
+pub fn slot_id_evidence_cluster(space_id: &str, groups: &[String]) -> String {
+    let mut parts = common_frame(SignalKind::EvidenceCluster, space_id);
+    parts.extend(sorted_set(groups));
+    m6_digest_owned(DOMAIN_SLOT, &parts)
+}
+
+/// `slot_id` for an orphan wikilink. `label_key` must already have passed
+/// [`super::label_key::normalize_label_key`].
+pub fn slot_id_orphan_wikilink(space_id: &str, label_key: &str) -> String {
+    let mut parts = common_frame(SignalKind::OrphanWikilink, space_id);
+    parts.push(label_key.as_bytes().to_vec());
+    m6_digest_owned(DOMAIN_SLOT, &parts)
+}
+
+/// `slot_id` for a community overview.
+///
+/// Stable exactly as long as M4's rebinding keeps `community_id` stable, and no
+/// longer. A split half treated as new gets a fresh UUID, hence a new slot and
+/// a new page; machine F's detach rule retires the old one, not a subscription
+/// (S0-71).
+pub fn slot_id_community_overview(space_id: &str, community_id: &str) -> String {
+    let mut parts = common_frame(SignalKind::CommunityOverview, space_id);
+    parts.push(community_id.as_bytes().to_vec());
+    m6_digest_owned(DOMAIN_SLOT, &parts)
+}
+
+/// `slot_id` for a space overview — one per space, empty per-signal vector.
+///
+/// The empty vector is why the signal tag must be its own part: without it this
+/// slot would collide with any other zero-part signal for the same space.
+pub fn slot_id_space_overview(space_id: &str) -> String {
+    let parts = common_frame(SignalKind::SpaceOverview, space_id);
+    m6_digest_owned(DOMAIN_SLOT, &parts)
+}
+
+/// `page_id = "m6p_" + m6_digest("m6-page-v1", [slot_id])` (S0-32).
+pub fn page_id(slot_id: &str) -> String {
+    format!(
+        "{PAGE_ID_PREFIX}{}",
+        m6_digest_owned(DOMAIN_PAGE, &[slot_id.as_bytes().to_vec()])
+    )
+}
+
+/// `candidate_id = m6_digest("m6-candidate-v1", [slot_id, coverage_epoch])`
+/// (S0-40).
+///
+/// Depends on nothing a crash or a lease expiry changes, which is what lets a
+/// re-prepare after staleness land on the same row rather than colliding with a
+/// durable one (machine A, transition A19).
+pub fn candidate_id(slot_id: &str, coverage_epoch: i64) -> String {
+    m6_digest_owned(
+        DOMAIN_CANDIDATE,
+        &[slot_id.as_bytes().to_vec(), int_part(coverage_epoch)],
+    )
+}
+
+/// Fingerprint field 8 — a digest over the `(root_id, status)` pairs.
+///
+/// Field 6 carries the root IDs alone, so a root going `active -> failed`
+/// changes the answer without changing field 6. This field is what notices.
+///
+/// **Disclosed gap-closure.** Artifact 4 §5 says "`sorted_set` of
+/// `(root_id, status)` pairs" without fixing how a pair renders as a set
+/// element. PR-A sorts the pairs, dedups them, emits the pair count as one
+/// integer part, then emits **two** parts per pair. Fixed arity plus the
+/// leading count keeps this unambiguous, and it avoids joining the two fields
+/// with a separator — which would reintroduce exactly the collision the
+/// length-prefix framing exists to remove.
+pub fn active_root_digest(roots: &[(String, String)]) -> String {
+    let mut sorted: Vec<(&str, &str)> = roots
+        .iter()
+        .map(|(id, status)| (id.as_str(), status.as_str()))
+        .collect();
+    sorted.sort_unstable();
+    sorted.dedup();
+
+    let mut parts = Vec::with_capacity(sorted.len() * 2 + 1);
+    parts.push(int_part(sorted.len() as i64));
+    for (root_id, status) in sorted {
+        parts.push(root_id.as_bytes().to_vec());
+        parts.push(status.as_bytes().to_vec());
+    }
+
+    m6_digest_owned(DOMAIN_ACTIVE_ROOTS, &parts)
+}
+
+/// The eleven fixed-arity fingerprint fields (artifact 4 §5).
+///
+/// Fields 3 and 4 are `Option` because they apply only to evidence-cluster and
+/// community-overview signals. They serialize as a zero-length part when
+/// absent and are **never omitted** — omitting a part shortens the vector, so
+/// an orphan-wikilink fingerprint could align its remaining fields with a
+/// community-overview one. Length-prefixing does not save you from a different
+/// number of parts; fixed arity does (S0-34).
+#[derive(Debug, Clone)]
+pub struct CandidateFingerprint<'a> {
+    /// 1 — binds the fingerprint to its slot.
+    pub slot_id: &'a str,
+    /// 2 — per-signal Stage-0 constant; a signal-logic change invalidates every
+    /// candidate it produced.
+    pub signal_version: i64,
+    /// 3 — M4 community ID, absent for the two non-community signals.
+    pub community_id: Option<&'a str>,
+    /// 4 — M4 published generation, absent alongside field 3.
+    pub published_generation: Option<i64>,
+    /// 5 — coverage epoch; a contract-version epoch change invalidates all.
+    pub coverage_epoch: i64,
+    /// 6 — the actual evidence, not just its group summary.
+    pub root_ids: &'a [String],
+    /// 7 — the M4 lease/CAS generation the prepare read under.
+    pub input_generation: i64,
+    /// 8 — see [`active_root_digest`].
+    pub active_root_digest: &'a str,
+    /// 9 — the pinned LLM identifier; a model swap must re-derive.
+    pub model_version: &'a str,
+    /// 10 — `communities.projection_version`, M4's own re-derivation axis.
+    pub projection_version: &'a str,
+    /// 11 — opaque monotone prompt tag. D13 forbids the prompt *text* from
+    /// entering anything durable, so a version tag is the only legal carrier
+    /// (S0-33).
+    pub prompt_version: &'a str,
+}
+
+impl CandidateFingerprint<'_> {
+    /// `m6_digest("m6-fingerprint-v1", [11 fields])`.
+    pub fn digest(&self) -> String {
+        // Field order is the contract. Fields 1-5 are fixed-arity scalars, 6 is
+        // a variable-length set, 7-11 are fixed-arity scalars again.
+        let mut parts: Vec<Vec<u8>> = vec![
+            self.slot_id.as_bytes().to_vec(), // 1
+            int_part(self.signal_version),    // 2
+            match self.community_id {
+                Some(id) => id.as_bytes().to_vec(),
+                None => ABSENT_PART.to_vec(),
+            }, // 3
+            match self.published_generation {
+                Some(generation) => int_part(generation),
+                None => ABSENT_PART.to_vec(),
+            }, // 4
+            int_part(self.coverage_epoch),    // 5
+        ];
+
+        parts.extend(sorted_set(self.root_ids)); // 6
+        parts.push(int_part(self.input_generation)); // 7
+        parts.push(self.active_root_digest.as_bytes().to_vec()); // 8
+        parts.push(self.model_version.as_bytes().to_vec()); // 9
+        parts.push(self.projection_version.as_bytes().to_vec()); // 10
+        parts.push(self.prompt_version.as_bytes().to_vec()); // 11
+
+        m6_digest_owned(DOMAIN_FINGERPRINT, &parts)
+    }
+}
+
+/// `[signal_tag, space]` — the frame every slot shares (artifact 4 §3.1).
+fn common_frame(signal: SignalKind, space_id: &str) -> Vec<Vec<u8>> {
+    vec![
+        signal.tag().as_bytes().to_vec(),
+        space_id.as_bytes().to_vec(),
+    ]
+}

--- a/crates/wenlan-core/src/m6/identity_test.rs
+++ b/crates/wenlan-core/src/m6/identity_test.rs
@@ -364,7 +364,8 @@ fn every_fingerprint_field_moves_the_digest() {
     v.input_generation = 2;
     variants.push(("input_generation", v));
 
-    let mut v = base_fingerprint(&slot, &other_roots);
+    // Field 8 varies via the constructor argument, so this one needs no mutation.
+    let v = base_fingerprint(&slot, &other_roots);
     variants.push(("active_root_digest", v));
 
     let mut v = base_fingerprint(&slot, &roots_digest);

--- a/crates/wenlan-core/src/m6/identity_test.rs
+++ b/crates/wenlan-core/src/m6/identity_test.rs
@@ -1,0 +1,408 @@
+//! Teeth for the M6 identity derivations (S0-29, S0-32, S0-34, S0-40, S0-161).
+
+use super::constants::{DOMAIN_FINGERPRINT, PAGE_ID_PREFIX};
+use super::digest::{int_part, m6_digest_owned, sorted_set, ABSENT_PART};
+use super::identity::{
+    active_root_digest, candidate_id, page_id, slot_id_community_overview,
+    slot_id_evidence_cluster, slot_id_orphan_wikilink, slot_id_space_overview,
+    CandidateFingerprint, SignalKind,
+};
+
+const SPACE: &str = "0f9c5a2e-1b3d-4c6f-8a90-2d4e6f8a0b1c";
+const OTHER_SPACE: &str = "7e2b1c4d-5a6f-4b8c-9d0e-1f2a3b4c5d6e";
+
+fn groups(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| (*s).to_string()).collect()
+}
+
+// ---------------------------------------------------------------------------
+// slot_id
+// ---------------------------------------------------------------------------
+
+#[test]
+fn signal_tags_are_all_distinct() {
+    let tags = [
+        SignalKind::EvidenceCluster.tag(),
+        SignalKind::OrphanWikilink.tag(),
+        SignalKind::CommunityOverview.tag(),
+        SignalKind::SpaceOverview.tag(),
+    ];
+    let mut sorted = tags;
+    sorted.sort_unstable();
+    let mut deduped = sorted.to_vec();
+    deduped.dedup();
+    assert_eq!(deduped.len(), tags.len(), "signal tags must be distinct");
+}
+
+#[test]
+fn the_four_signals_never_share_a_slot_for_one_space() {
+    // The space-overview slot has an empty per-signal vector, which is why the
+    // signal tag must be its own part rather than folded into the domain.
+    let ids = [
+        slot_id_evidence_cluster(SPACE, &[]),
+        slot_id_orphan_wikilink(SPACE, ""),
+        slot_id_community_overview(SPACE, ""),
+        slot_id_space_overview(SPACE),
+    ];
+
+    let mut deduped = ids.to_vec();
+    deduped.sort_unstable();
+    deduped.dedup();
+    assert_eq!(
+        deduped.len(),
+        ids.len(),
+        "two signals collided on one slot_id for the same space"
+    );
+}
+
+#[test]
+fn s0_161_slot_identity_follows_the_stable_space_id_not_a_name() {
+    // A rename changes `spaces.name`; `spaces.id` is what we digest, so
+    // re-derivation after a rename reproduces the same slot. Modelled here as
+    // "same id in, same slot out" — the schema-level rename closure is tested
+    // against the database in the migration teeth.
+    let before = slot_id_evidence_cluster(SPACE, &groups(&["src:a", "turn:b"]));
+    let after = slot_id_evidence_cluster(SPACE, &groups(&["src:a", "turn:b"]));
+    assert_eq!(before, after);
+
+    // Two different spaces must never share a slot.
+    assert_ne!(
+        slot_id_evidence_cluster(SPACE, &groups(&["src:a"])),
+        slot_id_evidence_cluster(OTHER_SPACE, &groups(&["src:a"])),
+    );
+}
+
+#[test]
+fn s0_29_evidence_cluster_slot_ignores_group_order_and_duplicates() {
+    let canonical = slot_id_evidence_cluster(SPACE, &groups(&["src:a", "turn:b", "batch:c"]));
+    let shuffled = slot_id_evidence_cluster(SPACE, &groups(&["turn:b", "batch:c", "src:a"]));
+    let duplicated =
+        slot_id_evidence_cluster(SPACE, &groups(&["src:a", "turn:b", "batch:c", "src:a"]));
+
+    assert_eq!(canonical, shuffled, "slot must not depend on group order");
+    assert_eq!(canonical, duplicated, "a duplicate group must not re-key");
+}
+
+#[test]
+fn evidence_cluster_slot_changes_when_the_initial_group_set_changes() {
+    assert_ne!(
+        slot_id_evidence_cluster(SPACE, &groups(&["src:a"])),
+        slot_id_evidence_cluster(SPACE, &groups(&["src:a", "src:b"])),
+    );
+}
+
+#[test]
+fn orphan_wikilink_slot_is_keyed_on_the_normalized_label() {
+    assert_ne!(
+        slot_id_orphan_wikilink(SPACE, "rust ownership"),
+        slot_id_orphan_wikilink(SPACE, "rust borrowing"),
+    );
+    assert_eq!(
+        slot_id_orphan_wikilink(SPACE, "rust ownership"),
+        slot_id_orphan_wikilink(SPACE, "rust ownership"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// page_id — S0-32
+// ---------------------------------------------------------------------------
+
+#[test]
+fn s0_32_page_id_is_the_prefix_plus_a_full_64_hex_digest() {
+    let slot = slot_id_space_overview(SPACE);
+    let page = page_id(&slot);
+
+    assert!(page.starts_with(PAGE_ID_PREFIX));
+    let digest = page.strip_prefix(PAGE_ID_PREFIX).expect("prefix checked");
+
+    // The refusal to truncate is the substantive half of S0-32: the
+    // orphan-wikilink slot derives from an attacker-written label, so a 64-bit
+    // page ID would be grindable at ~2^32 work.
+    assert_eq!(
+        digest.len(),
+        64,
+        "page_id digest must be full length, never truncated to 16 hex"
+    );
+    assert!(digest
+        .chars()
+        .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+}
+
+#[test]
+fn page_id_is_a_function_of_the_slot_alone() {
+    let slot_a = slot_id_orphan_wikilink(SPACE, "alpha");
+    let slot_b = slot_id_orphan_wikilink(SPACE, "beta");
+
+    assert_eq!(page_id(&slot_a), page_id(&slot_a));
+    assert_ne!(page_id(&slot_a), page_id(&slot_b));
+}
+
+#[test]
+fn page_id_is_not_the_slot_id_wearing_a_prefix() {
+    // The indirection is deliberate: it lets an `m6-page-v2` re-derive page IDs
+    // without disturbing slot identity.
+    let slot = slot_id_space_overview(SPACE);
+    assert_ne!(page_id(&slot), format!("{PAGE_ID_PREFIX}{slot}"));
+}
+
+// ---------------------------------------------------------------------------
+// candidate_id — S0-40
+// ---------------------------------------------------------------------------
+
+#[test]
+fn s0_40_candidate_id_is_keyed_on_slot_and_coverage_epoch() {
+    let slot = slot_id_space_overview(SPACE);
+
+    assert_eq!(candidate_id(&slot, 1), candidate_id(&slot, 1));
+    assert_ne!(
+        candidate_id(&slot, 1),
+        candidate_id(&slot, 2),
+        "a coverage-epoch change must produce a new candidate"
+    );
+}
+
+#[test]
+fn candidate_id_re_derives_identically_after_a_crash_or_expiry() {
+    // Nothing a crash or a lease expiry changes is an input, which is what
+    // lets a re-prepare after staleness land on the same durable row.
+    let slot = slot_id_evidence_cluster(SPACE, &groups(&["src:a", "src:b"]));
+    let first_pass = candidate_id(&slot, 3);
+    let after_restart = candidate_id(
+        &slot_id_evidence_cluster(SPACE, &groups(&["src:b", "src:a"])),
+        3,
+    );
+    assert_eq!(first_pass, after_restart);
+}
+
+// ---------------------------------------------------------------------------
+// active-root digest — fingerprint field 8
+// ---------------------------------------------------------------------------
+
+fn roots(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
+    pairs
+        .iter()
+        .map(|(a, b)| ((*a).to_string(), (*b).to_string()))
+        .collect()
+}
+
+#[test]
+fn field_8_notices_a_status_change_that_field_6_cannot() {
+    let ids = groups(&["root:1", "root:2"]);
+    let all_active = roots(&[("root:1", "active"), ("root:2", "active")]);
+    let one_failed = roots(&[("root:1", "active"), ("root:2", "failed")]);
+
+    // Control: field 6 (the root-ID set) is identical across the two, so
+    // without field 8 the fingerprint would not move.
+    assert_eq!(
+        sorted_set(&ids),
+        sorted_set(&ids),
+        "control: the root-id set is unchanged by a status flip"
+    );
+
+    assert_ne!(
+        active_root_digest(&all_active),
+        active_root_digest(&one_failed),
+        "a root going active -> failed must change the active-root digest"
+    );
+}
+
+#[test]
+fn field_8_is_order_independent_and_dedups() {
+    let forward = roots(&[("root:1", "active"), ("root:2", "failed")]);
+    let reverse = roots(&[("root:2", "failed"), ("root:1", "active")]);
+    let duplicated = roots(&[
+        ("root:1", "active"),
+        ("root:2", "failed"),
+        ("root:1", "active"),
+    ]);
+
+    assert_eq!(active_root_digest(&forward), active_root_digest(&reverse));
+    assert_eq!(
+        active_root_digest(&forward),
+        active_root_digest(&duplicated)
+    );
+}
+
+#[test]
+fn field_8_does_not_alias_across_the_pair_boundary() {
+    // ("ab", "c") and ("a", "bc") must not collide — the failure a separator
+    // join would reintroduce.
+    assert_ne!(
+        active_root_digest(&roots(&[("ab", "c")])),
+        active_root_digest(&roots(&[("a", "bc")])),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// candidate fingerprint — S0-34 fixed arity
+// ---------------------------------------------------------------------------
+
+fn base_fingerprint<'a>(slot: &'a str, roots_digest: &'a str) -> CandidateFingerprint<'a> {
+    CandidateFingerprint {
+        slot_id: slot,
+        signal_version: 1,
+        community_id: None,
+        published_generation: None,
+        coverage_epoch: 1,
+        root_ids: &[],
+        input_generation: 1,
+        active_root_digest: roots_digest,
+        model_version: "qwen3-4b-instruct-2507",
+        projection_version: "proj-1",
+        prompt_version: "m6-genesis-prompt-v1",
+    }
+}
+
+/// Mutant for S0-34: absent optionals are *omitted* rather than emitted as
+/// zero-length parts, so the part vector changes arity.
+fn mutant_omitting_absent_fields(fp: &CandidateFingerprint<'_>) -> String {
+    let mut parts: Vec<Vec<u8>> = Vec::new();
+    parts.push(fp.slot_id.as_bytes().to_vec());
+    parts.push(int_part(fp.signal_version));
+    if let Some(id) = fp.community_id {
+        parts.push(id.as_bytes().to_vec());
+    }
+    if let Some(gen) = fp.published_generation {
+        parts.push(int_part(gen));
+    }
+    parts.push(int_part(fp.coverage_epoch));
+    parts.extend(sorted_set(fp.root_ids));
+    parts.push(int_part(fp.input_generation));
+    parts.push(fp.active_root_digest.as_bytes().to_vec());
+    parts.push(fp.model_version.as_bytes().to_vec());
+    parts.push(fp.projection_version.as_bytes().to_vec());
+    parts.push(fp.prompt_version.as_bytes().to_vec());
+    m6_digest_owned(DOMAIN_FINGERPRINT, &parts)
+}
+
+#[test]
+fn s0_34_absent_optionals_are_emitted_not_omitted() {
+    let slot = slot_id_space_overview(SPACE);
+    let roots_digest = active_root_digest(&[]);
+
+    // Two genuinely different candidates. Under omission both collapse to the
+    // same part vector, because the text "5" and the integer 5 encode to the
+    // same bytes and the omitted field shifts the other into its position.
+    let mut absent_id_present_gen = base_fingerprint(&slot, &roots_digest);
+    absent_id_present_gen.community_id = None;
+    absent_id_present_gen.published_generation = Some(5);
+
+    let mut present_id_absent_gen = base_fingerprint(&slot, &roots_digest);
+    present_id_absent_gen.community_id = Some("5");
+    present_id_absent_gen.published_generation = None;
+
+    // Control: the forbidden encoding really does alias them.
+    assert_eq!(
+        mutant_omitting_absent_fields(&absent_id_present_gen),
+        mutant_omitting_absent_fields(&present_id_absent_gen),
+        "control failed: omitting absent parts was expected to alias these"
+    );
+
+    // Contract: fixed arity keeps them apart.
+    assert_ne!(
+        absent_id_present_gen.digest(),
+        present_id_absent_gen.digest(),
+        "fixed-arity encoding must keep these fingerprints distinct"
+    );
+}
+
+#[test]
+fn absent_optional_is_a_zero_length_part() {
+    assert!(ABSENT_PART.is_empty());
+
+    let slot = slot_id_space_overview(SPACE);
+    let roots_digest = active_root_digest(&[]);
+
+    let absent = base_fingerprint(&slot, &roots_digest);
+    let mut empty_string = base_fingerprint(&slot, &roots_digest);
+    empty_string.community_id = Some("");
+
+    // A present empty string and an absent field encode to the same bytes at
+    // the same position. That is acceptable precisely because arity is fixed —
+    // asserted here so the equivalence is a recorded property, not a surprise.
+    assert_eq!(absent.digest(), empty_string.digest());
+}
+
+#[test]
+fn every_fingerprint_field_moves_the_digest() {
+    let slot = slot_id_space_overview(SPACE);
+    let other_slot = slot_id_orphan_wikilink(SPACE, "other");
+    let roots_digest = active_root_digest(&[]);
+    let other_roots = active_root_digest(&roots(&[("root:9", "active")]));
+    let root_ids = groups(&["root:1"]);
+
+    let base = base_fingerprint(&slot, &roots_digest);
+    let baseline = base.digest();
+
+    let mut variants: Vec<(&str, CandidateFingerprint<'_>)> = Vec::new();
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.slot_id = &other_slot;
+    variants.push(("slot_id", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.signal_version = 2;
+    variants.push(("signal_version", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.community_id = Some("c-1");
+    variants.push(("community_id", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.published_generation = Some(7);
+    variants.push(("published_generation", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.coverage_epoch = 2;
+    variants.push(("coverage_epoch", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.root_ids = &root_ids;
+    variants.push(("root_ids", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.input_generation = 2;
+    variants.push(("input_generation", v));
+
+    let mut v = base_fingerprint(&slot, &other_roots);
+    variants.push(("active_root_digest", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.model_version = "qwen3.5-9b";
+    variants.push(("model_version", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.projection_version = "proj-2";
+    variants.push(("projection_version", v));
+
+    let mut v = base_fingerprint(&slot, &roots_digest);
+    v.prompt_version = "m6-genesis-prompt-v2";
+    variants.push(("prompt_version", v));
+
+    assert_eq!(variants.len(), 11, "all eleven fields must be covered");
+
+    for (field, variant) in variants {
+        assert_ne!(
+            baseline,
+            variant.digest(),
+            "changing field {field} did not change the fingerprint"
+        );
+    }
+}
+
+#[test]
+fn fingerprint_is_stable_for_identical_inputs() {
+    let slot = slot_id_space_overview(SPACE);
+    let roots_digest = active_root_digest(&[]);
+    assert_eq!(
+        base_fingerprint(&slot, &roots_digest).digest(),
+        base_fingerprint(&slot, &roots_digest).digest(),
+    );
+}
+
+#[test]
+fn fingerprint_never_equals_the_slot_it_describes() {
+    let slot = slot_id_space_overview(SPACE);
+    let roots_digest = active_root_digest(&[]);
+    assert_ne!(base_fingerprint(&slot, &roots_digest).digest(), slot);
+}

--- a/crates/wenlan-core/src/m6/label_key.rs
+++ b/crates/wenlan-core/src/m6/label_key.rs
@@ -1,0 +1,141 @@
+//! D8 wikilink key normalization (artifact 4 §6).
+//!
+//! Turns the raw `target` capture of `WIKILINK_RE`
+//! (`crates/wenlan-core/src/sources/obsidian.rs:16`-`:17`) into a `label_key`,
+//! or rejects it. A rejected link is **dropped** — the page still writes, the
+//! raw link text still survives in the body, and no `page_links` row appears
+//! (S0-39). Rejection is never an ingest failure.
+//!
+//! The step order is not free-form. Two orderings are load-bearing:
+//!
+//! * NFKC runs **before** lowercasing, because `U+FF21` (fullwidth `A`)
+//!   lowercases to fullwidth `ａ`; folding first gives `a`.
+//! * The structural rejection runs **after** NFKC, because NFKC folds the
+//!   fullwidth forms of `#`, `|`, `[`, `]` into their ASCII counterparts. The
+//!   parser's own guards run on pre-normalization bytes, so `[[Rust＃Ownership]]`
+//!   reaches normalization intact and only then becomes `rust#ownership` — a key
+//!   containing a fragment separator the parser cannot itself produce (S0-36).
+
+use unicode_normalization::UnicodeNormalization;
+use unicode_properties::{GeneralCategory, UnicodeGeneralCategory};
+
+use super::constants::{LABEL_KEY_MAX_SCALARS, LABEL_KEY_MIN_SCALARS, LABEL_RAW_PRECAP_SCALARS};
+
+/// Why a raw wikilink target did not become a `label_key`.
+///
+/// The variants carry no payload on purpose: D13 forbids user content in logs,
+/// and a wikilink label is user content by definition. Callers log the code and
+/// the page ID, never the label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LabelRejection {
+    /// R0 — raw target exceeded the pre-cap, before any normalization work.
+    TooLongRaw,
+    /// R1 — `#`, `|`, `[`, or `]` present after normalization.
+    Structural,
+    /// R2 — a scalar in general category `Cc` or `Cf`.
+    ControlOrFormat,
+    /// R3 — normalized length outside `1..=128` scalars.
+    Length,
+}
+
+impl LabelRejection {
+    /// Stable short code for counters and debug logs (`R0`..`R3`).
+    pub fn code(self) -> &'static str {
+        match self {
+            LabelRejection::TooLongRaw => "R0",
+            LabelRejection::Structural => "R1",
+            LabelRejection::ControlOrFormat => "R2",
+            LabelRejection::Length => "R3",
+        }
+    }
+}
+
+/// Characters rejected at step 4. All four are parser-structural.
+const STRUCTURAL_CHARS: [char; 4] = ['#', '|', '[', ']'];
+
+/// Normalize a raw wikilink target into its `label_key`.
+pub fn normalize_label_key(raw: &str) -> Result<String, LabelRejection> {
+    // 0. PRE-CAP — bound the work before doing any of it. Without this, a
+    //    megabyte-long target pays for full normalization only to fail on
+    //    length. 1024 is 8x the post-normalization cap (S0-37).
+    if raw.chars().count() > LABEL_RAW_PRECAP_SCALARS {
+        return Err(LabelRejection::TooLongRaw);
+    }
+
+    // 1-3. NFKC, lowercase, NFKC again. The second pass is not redundant:
+    //      `U+0130`.to_lowercase() yields `U+0069 U+0307`, which is not in NFKC
+    //      form, so without it the pipeline's output is not a fixed point of the
+    //      pipeline (S0-35).
+    let normalized: String = raw
+        .nfkc()
+        .collect::<String>()
+        .to_lowercase()
+        .nfkc()
+        .collect();
+
+    // 4. STRUCTURAL — reject, never strip. By this point the parser has already
+    //    split off any legitimate fragment or alias, so a separator surviving
+    //    here means the input was built to smuggle one. Stripping would make
+    //    `[[A#B]]` and `[[A]]` the same key (S0-36).
+    if normalized.contains(STRUCTURAL_CHARS) {
+        return Err(LabelRejection::Structural);
+    }
+
+    // 5. WS COLLAPSE — every maximal White_Space run becomes one U+0020, both
+    //    ends trimmed. `char::is_whitespace` is exactly the White_Space
+    //    property. NBSP and IDEOGRAPHIC SPACE arrive here already folded to
+    //    U+0020 by NFKC.
+    let collapsed = collapse_whitespace(&normalized);
+
+    // 6. CONTROL/BIDI — no exceptions (S0-38). This runs after the collapse, so
+    //    a scalar that is both Cc and White_Space (tab, newline) has already
+    //    become a space. What survives to here is the invisible-but-not-space
+    //    class: RLO, ZWSP, BOM, ZWNJ.
+    if collapsed.chars().any(is_control_or_format) {
+        return Err(LabelRejection::ControlOrFormat);
+    }
+
+    // 7. LENGTH — measured last, on the normalized result. A single scalar can
+    //    expand 1->18 under NFKC (`U+FDFA`), so measuring the raw input here
+    //    would let 128 accepted scalars become 2304 stored ones (S0-37).
+    let scalars = collapsed.chars().count();
+    if !(LABEL_KEY_MIN_SCALARS..=LABEL_KEY_MAX_SCALARS).contains(&scalars) {
+        return Err(LabelRejection::Length);
+    }
+
+    Ok(collapsed)
+}
+
+/// Collapse every maximal `White_Space` run to a single `U+0020` and trim.
+fn collapse_whitespace(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut pending_space = false;
+
+    for ch in input.chars() {
+        if ch.is_whitespace() {
+            // Only emit once the run ends and something follows, which also
+            // drops leading and trailing runs without a separate trim pass.
+            pending_space = !out.is_empty();
+        } else {
+            if pending_space {
+                out.push(' ');
+                pending_space = false;
+            }
+            out.push(ch);
+        }
+    }
+
+    out
+}
+
+/// True for general category `Cc` (control) or `Cf` (format).
+///
+/// Rust's standard library offers `char::is_control()`, which is `Cc` only —
+/// it would miss every `Cf` scalar, and `Cf` is where the whole attack lives
+/// (RLO, ZWSP, BOM are all `Cf`).
+fn is_control_or_format(ch: char) -> bool {
+    matches!(
+        ch.general_category(),
+        GeneralCategory::Control | GeneralCategory::Format
+    )
+}

--- a/crates/wenlan-core/src/m6/label_key_test.rs
+++ b/crates/wenlan-core/src/m6/label_key_test.rs
@@ -1,0 +1,290 @@
+//! Teeth for D8 wikilink key normalization (artifact 4 §6).
+//!
+//! W1-W9 and A1-A9 are the artifact's own worked examples, named here by their
+//! artifact IDs so a reviewer can diff the table against the tests one row at a
+//! time.
+//!
+//! Note on W4/W5: `WIKILINK_RE` splits the fragment (group 3) and the alias
+//! (group 4) off before normalization ever runs, so the input reaching
+//! `normalize_label_key` is the target group alone. The tests assert that
+//! contract at the function boundary — the parser's split is exercised by the
+//! obsidian source tests, not re-tested here.
+
+use super::label_key::{normalize_label_key, LabelRejection};
+
+fn key(raw: &str) -> String {
+    normalize_label_key(raw).expect("expected this label to normalize")
+}
+
+fn rejection(raw: &str) -> LabelRejection {
+    normalize_label_key(raw).expect_err("expected this label to be rejected")
+}
+
+// ---------------------------------------------------------------------------
+// W1-W9 — accepted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn w1_plain_label_lowercases() {
+    assert_eq!(key("Rust Ownership"), "rust ownership");
+}
+
+#[test]
+fn w2_internal_whitespace_run_collapses() {
+    assert_eq!(key("Rust  Ownership"), "rust ownership");
+}
+
+#[test]
+fn w3_leading_and_trailing_whitespace_is_trimmed() {
+    assert_eq!(key(" Rust Ownership "), "rust ownership");
+}
+
+#[test]
+fn w4_fragment_is_split_by_the_parser_before_normalization() {
+    // The target group the regex hands over carries no fragment.
+    assert_eq!(key("Rust Ownership"), "rust ownership");
+    // And a `#` that somehow survived into the target is rejected, not folded.
+    assert_eq!(
+        rejection("Rust Ownership#borrowing"),
+        LabelRejection::Structural
+    );
+}
+
+#[test]
+fn w5_alias_is_split_by_the_parser_before_normalization() {
+    assert_eq!(key("Rust Ownership"), "rust ownership");
+    assert_eq!(
+        rejection("Rust Ownership|borrowing rules"),
+        LabelRejection::Structural
+    );
+}
+
+#[test]
+fn w6_fullwidth_letters_fold_before_lowercasing() {
+    // NFKC first gives `A B`, then lowercase gives `a b`. Lowercasing first
+    // would yield fullwidth `a b` and a different key.
+    assert_eq!(key("\u{FF21} \u{FF22}"), "a b");
+}
+
+#[test]
+fn w7_single_scalar_expansion_normalizes() {
+    // U+3392 SQUARE MHZ expands 1 -> 3 under NFKC.
+    assert_eq!(key("\u{3392}"), "mhz");
+}
+
+#[test]
+fn w8_sharp_s_is_not_case_folded_so_the_keys_stay_distinct() {
+    // `to_lowercase` is not case folding: neither form becomes `ss`. This is an
+    // accepted ceiling, asserted so a future switch to real case folding is a
+    // deliberate change and not a silent one.
+    assert_eq!(key("STRASSE"), "strasse");
+    assert_eq!(key("Stra\u{00DF}e"), "stra\u{00DF}e");
+    assert_ne!(key("STRASSE"), key("Stra\u{00DF}e"));
+    // LATIN CAPITAL LETTER SHARP S lowercases to the same sharp s.
+    assert_eq!(key("STRA\u{1E9E}E"), "stra\u{00DF}e");
+}
+
+#[test]
+fn w9_nfc_and_nfd_spellings_produce_one_key() {
+    let nfc = "Caf\u{00E9}"; // é precomposed
+    let nfd = "Cafe\u{0301}"; // e + combining acute
+
+    // Control: the two inputs really are different byte sequences.
+    assert_ne!(nfc, nfd, "control failed: inputs were expected to differ");
+    assert_eq!(key(nfc), key(nfd));
+    assert_eq!(key(nfc), "caf\u{00E9}");
+}
+
+// ---------------------------------------------------------------------------
+// A1-A9 — rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a1_bidi_override_is_rejected() {
+    assert_eq!(
+        rejection("Rust\u{202E}Ownership"),
+        LabelRejection::ControlOrFormat
+    );
+}
+
+#[test]
+fn a2_zero_width_space_is_rejected() {
+    // An invisible split of one visible label into two keys.
+    assert_eq!(
+        rejection("Rust\u{200B}Ownership"),
+        LabelRejection::ControlOrFormat
+    );
+}
+
+#[test]
+fn a3_fullwidth_number_sign_is_rejected_after_nfkc() {
+    // Passes WIKILINK_RE (which excludes only ASCII `#`) and the bracket guard,
+    // then NFKC turns it into a real `#`.
+    let raw = "Rust\u{FF03}Ownership";
+
+    // Control: the raw input carries no ASCII `#`, so the upstream guards that
+    // run on pre-normalization bytes genuinely do not catch it.
+    assert!(
+        !raw.contains('#'),
+        "control failed: the smuggled form already contained an ASCII #"
+    );
+    assert_eq!(rejection(raw), LabelRejection::Structural);
+}
+
+#[test]
+fn a4_fullwidth_vertical_line_is_rejected_after_nfkc() {
+    let raw = "Rust\u{FF5C}Ownership";
+    assert!(
+        !raw.contains('|'),
+        "control failed: raw already contained |"
+    );
+    assert_eq!(rejection(raw), LabelRejection::Structural);
+}
+
+#[test]
+fn a5_fullwidth_left_bracket_is_rejected_after_nfkc() {
+    let raw = "Rust\u{FF3B}Ownership";
+    assert!(
+        !raw.contains('['),
+        "control failed: raw already contained ["
+    );
+    assert_eq!(rejection(raw), LabelRejection::Structural);
+}
+
+#[test]
+fn a5b_fullwidth_right_bracket_is_rejected_after_nfkc() {
+    let raw = "Rust\u{FF3D}Ownership";
+    assert!(
+        !raw.contains(']'),
+        "control failed: raw already contained ]"
+    );
+    assert_eq!(rejection(raw), LabelRejection::Structural);
+}
+
+#[test]
+fn a6_expansion_over_the_post_normalization_cap_is_rejected() {
+    // 44 x U+FDFA: 44 raw scalars (under the 1024 pre-cap) expanding to 792
+    // normalized scalars (over the 128 cap). This is the case that proves the
+    // length check is measured *after* normalization.
+    let raw: String = "\u{FDFA}".repeat(44);
+
+    assert!(
+        raw.chars().count() <= super::constants::LABEL_RAW_PRECAP_SCALARS,
+        "control failed: this input should pass the R0 pre-cap and fail on R3"
+    );
+    assert_eq!(rejection(&raw), LabelRejection::Length);
+}
+
+#[test]
+fn a7_oversized_raw_target_is_rejected_by_the_precap() {
+    let raw = "a".repeat(2000);
+    assert_eq!(rejection(&raw), LabelRejection::TooLongRaw);
+}
+
+#[test]
+fn a8_leading_bom_is_rejected_because_it_is_not_whitespace() {
+    // The BOM is Cf, not White_Space, so the step-5 collapse does not remove it
+    // and it reaches the step-6 rejection.
+    assert!(
+        !'\u{FEFF}'.is_whitespace(),
+        "control failed: BOM was expected not to be White_Space"
+    );
+    assert_eq!(rejection("\u{FEFF}Rust"), LabelRejection::ControlOrFormat);
+}
+
+#[test]
+fn a9_whitespace_only_target_is_rejected_on_length() {
+    assert_eq!(rejection("   "), LabelRejection::Length);
+    assert_eq!(rejection(""), LabelRejection::Length);
+}
+
+// ---------------------------------------------------------------------------
+// Ordering and property teeth
+// ---------------------------------------------------------------------------
+
+#[test]
+fn s0_38_zero_width_non_joiner_is_rejected_with_no_exceptions() {
+    // Documented cost of the no-exceptions rule: ZWNJ is orthographically
+    // required in Persian and some Indic spellings, so those labels cannot be
+    // wikilink keys. Asserted so lifting the rule is a deliberate change.
+    assert_eq!(
+        rejection("Rust\u{200C}Ownership"),
+        LabelRejection::ControlOrFormat
+    );
+    assert_eq!(
+        rejection("Rust\u{200D}Ownership"),
+        LabelRejection::ControlOrFormat
+    );
+}
+
+#[test]
+fn nbsp_and_ideographic_space_fold_to_a_plain_space() {
+    // Both are Zs, both fold to U+0020 under NFKC, so both are accepted rather
+    // than hitting the Cc/Cf rejection.
+    assert_eq!(key("Rust\u{00A0}Ownership"), "rust ownership");
+    assert_eq!(key("Rust\u{3000}Ownership"), "rust ownership");
+}
+
+#[test]
+fn line_separator_collapses_rather_than_rejecting() {
+    // U+2028 is Zl and White_Space, so step 5 consumes it before step 6 runs.
+    assert!('\u{2028}'.is_whitespace());
+    assert_eq!(key("Rust\u{2028}Ownership"), "rust ownership");
+}
+
+#[test]
+fn kelvin_sign_lowercases_to_k() {
+    assert_eq!(key("\u{212A}"), "k");
+}
+
+#[test]
+fn structural_rejection_beats_silent_folding() {
+    // `[[A#B]]` must not become the same key as `[[A]]`. The failure this
+    // guards against is a *strip* implementation rather than a reject.
+    let smuggled = normalize_label_key("A\u{FF03}B");
+    assert!(smuggled.is_err());
+    assert_eq!(key("A"), "a");
+}
+
+#[test]
+fn normalization_output_is_a_fixed_point_of_normalization() {
+    // The pipeline's own output must re-normalize to itself. This is the
+    // property the second NFKC pass exists to preserve (S0-35): without a
+    // re-normalization step somewhere, the pipeline can emit a string that is
+    // not in NFKC form, and two inputs that should fold end up as different
+    // keys depending on which case they arrived in.
+    let corpus = [
+        "Rust Ownership",
+        " Rust  Ownership ",
+        "\u{FF21} \u{FF22}",
+        "\u{3392}",
+        "Caf\u{00E9}",
+        "Cafe\u{0301}",
+        "\u{0130}stanbul",
+        "STRA\u{1E9E}E",
+        "\u{212A}elvin",
+    ];
+
+    for raw in corpus {
+        let once = key(raw);
+        let twice = key(&once);
+        assert_eq!(once, twice, "normalization is not idempotent for {raw:?}");
+    }
+}
+
+#[test]
+fn rejection_codes_are_stable() {
+    assert_eq!(LabelRejection::TooLongRaw.code(), "R0");
+    assert_eq!(LabelRejection::Structural.code(), "R1");
+    assert_eq!(LabelRejection::ControlOrFormat.code(), "R2");
+    assert_eq!(LabelRejection::Length.code(), "R3");
+}
+
+#[test]
+fn a_label_exactly_at_the_cap_is_accepted_and_one_over_is_not() {
+    let at_cap = "a".repeat(super::constants::LABEL_KEY_MAX_SCALARS);
+    let over_cap = "a".repeat(super::constants::LABEL_KEY_MAX_SCALARS + 1);
+
+    assert_eq!(key(&at_cap).chars().count(), 128);
+    assert_eq!(rejection(&over_cap), LabelRejection::Length);
+}

--- a/crates/wenlan-core/src/m6/mod.rs
+++ b/crates/wenlan-core/src/m6/mod.rs
@@ -1,0 +1,22 @@
+//! M6 genesis substrate.
+//!
+//! PR-A lands the additive schema, the deterministic-identity primitives, and
+//! the teeth that guard them. **Nothing in this module runs automatically.**
+//! `genesis_coverage_state.genesis_enabled` defaults to `0` and a space with no
+//! row is treated as genesis-disabled, so an empty table means nothing runs.
+//!
+//! The Stage-0 contract artifacts under `docs/plans/2026-08-01-m6-*.md` are
+//! normative for everything here; `S0-NN` references in doc comments point at
+//! their decision numbers.
+
+pub mod constants;
+pub mod digest;
+pub mod identity;
+pub mod label_key;
+
+#[cfg(test)]
+mod digest_test;
+#[cfg(test)]
+mod identity_test;
+#[cfg(test)]
+mod label_key_test;

--- a/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
+++ b/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
@@ -871,35 +871,35 @@ carrying the authority of agreement.
 
 | Address | Function | Visibility | Exposure |
 |---|---|---|---|
-| `core/db.rs:3641` | `run_migrations` | `pub` | internal-only |
-| `core/db.rs:9168` | `migrate_89_page_kind_fold` | `private` | internal-only |
-| `core/db.rs:17379` | `reconcile_entity_page_parity` | `pub` | **exposure** — `server/scheduler/ambient.rs:532` |
-| `core/db.rs:27046` | `rebind_source_page_in_transaction` | `private` | internal-only |
-| `core/db.rs:34696` | `oldest_active_page` | `pub` | internal-only |
-| `core/db.rs:39892` | `list_recent_retrievals` | `pub` | internal-only |
-| `core/db.rs:40032` | `list_recent_retrievals_scoped` | `pub` | **exposure** — `server/routes.rs:948` |
-| `core/db.rs:40238` | `list_recent_changes` | `pub` | internal-only |
-| `core/db.rs:40541` | `list_recent_pages_with_badges` | `pub` | internal-only |
-| `core/db.rs:41454` | `append_page_history` | `private` | internal-only |
-| `core/db.rs:41615` | `insert_page_with_kind_inner` | `private` | internal-only |
-| `core/db.rs:42158` | `get_page_inner` | `private` | internal-only |
-| `core/db.rs:42187` | `get_page_by_entity` | `pub` | internal-only |
-| `core/db.rs:42262` | `list_pages_inner` | `private` | internal-only |
-| `core/db.rs:42295` | `list_pages_stale` | `pub` | internal-only |
-| `core/db.rs:42340` | `list_pages_by_space` | `pub` | internal-only |
-| `core/db.rs:43401` | `find_matching_page` | `pub` | internal-only |
-| `core/db.rs:43458` | `find_matching_page_scoped` | `pub` | internal-only |
-| `core/db.rs:43825` | `page_merge_row` | `private` | internal-only |
-| `core/db.rs:43874` | `load_page_source_index` | `pub` | **exposure** — `server/routes.rs:693` |
-| `core/db.rs:44008` | `list_active_page_titles_scoped` | `pub` | internal-only |
-| `core/db.rs:44055` | `list_relevant_active_page_titles` | `pub` | internal-only |
-| `core/db.rs:44122` | `find_active_page_id_by_title` | `pub` | internal-only |
-| `core/db.rs:44157` | `find_unique_active_page_id_by_title_scoped` | `pub` | internal-only |
-| `core/db.rs:44708` | `backfill_page_embeddings` | `pub` | internal-only |
-| `core/db.rs:45786` | `get_pages_for_memory` | `pub` | internal-only |
-| `core/db.rs:46685` | `get_stale_page_after` | `pub` | internal-only |
-| `core/db.rs:46722` | `list_stale_pages_scoped` | `pub` | **exposure** — `server/routes.rs:772` |
-| `core/db.rs:46762` | `find_stale_archived_pages` | `pub` | **exposure** — `server/cmd_backfill.rs:49` |
+| `core/db.rs:3649` | `run_migrations` | `pub` | internal-only |
+| `core/db.rs:9185` | `migrate_89_page_kind_fold` | `private` | internal-only |
+| `core/db.rs:17439` | `reconcile_entity_page_parity` | `pub` | **exposure** — `server/scheduler/ambient.rs:532` |
+| `core/db.rs:27112` | `rebind_source_page_in_transaction` | `private` | internal-only |
+| `core/db.rs:34762` | `oldest_active_page` | `pub` | internal-only |
+| `core/db.rs:39958` | `list_recent_retrievals` | `pub` | internal-only |
+| `core/db.rs:40098` | `list_recent_retrievals_scoped` | `pub` | **exposure** — `server/routes.rs:948` |
+| `core/db.rs:40304` | `list_recent_changes` | `pub` | internal-only |
+| `core/db.rs:40607` | `list_recent_pages_with_badges` | `pub` | internal-only |
+| `core/db.rs:41520` | `append_page_history` | `private` | internal-only |
+| `core/db.rs:41681` | `insert_page_with_kind_inner` | `private` | internal-only |
+| `core/db.rs:42224` | `get_page_inner` | `private` | internal-only |
+| `core/db.rs:42253` | `get_page_by_entity` | `pub` | internal-only |
+| `core/db.rs:42328` | `list_pages_inner` | `private` | internal-only |
+| `core/db.rs:42361` | `list_pages_stale` | `pub` | internal-only |
+| `core/db.rs:42406` | `list_pages_by_space` | `pub` | internal-only |
+| `core/db.rs:43467` | `find_matching_page` | `pub` | internal-only |
+| `core/db.rs:43524` | `find_matching_page_scoped` | `pub` | internal-only |
+| `core/db.rs:43891` | `page_merge_row` | `private` | internal-only |
+| `core/db.rs:43940` | `load_page_source_index` | `pub` | **exposure** — `server/routes.rs:693` |
+| `core/db.rs:44074` | `list_active_page_titles_scoped` | `pub` | internal-only |
+| `core/db.rs:44121` | `list_relevant_active_page_titles` | `pub` | internal-only |
+| `core/db.rs:44188` | `find_active_page_id_by_title` | `pub` | internal-only |
+| `core/db.rs:44223` | `find_unique_active_page_id_by_title_scoped` | `pub` | internal-only |
+| `core/db.rs:44774` | `backfill_page_embeddings` | `pub` | internal-only |
+| `core/db.rs:45852` | `get_pages_for_memory` | `pub` | internal-only |
+| `core/db.rs:46751` | `get_stale_page_after` | `pub` | internal-only |
+| `core/db.rs:46788` | `list_stale_pages_scoped` | `pub` | **exposure** — `server/routes.rs:772` |
+| `core/db.rs:46828` | `find_stale_archived_pages` | `pub` | **exposure** — `server/cmd_backfill.rs:49` |
 | `core/db/claim_derivation.rs:1756` | `evaluate_support_on` | `private` | internal-only |
 | `core/db/maintenance_duplicate_reads.rs:35` | `embedding_near_duplicate_pairs` | `pub(crate)` | internal-only |
 | `core/db/maintenance_duplicate_reads.rs:108` | `scan_near_duplicate_slice` | `pub(crate)` | internal-only |
@@ -934,23 +934,23 @@ carrying the authority of agreement.
 
 | Address | Function | Visibility | Reaches prose via |
 |---|---|---|---|
-| `core/db.rs:3302` | `new` | `pub` | `run_migrations` |
-| `core/db.rs:3514` | `new_with_shared_embedder` | `pub` | `run_migrations` |
-| `core/db.rs:24470` | `augment_with_graph_gated` | `private` | `search_entities_by_vector_scoped` |
-| `core/db.rs:26548` | `rebind_source_id_inner` | `private` | `rebind_source_page_in_transaction` |
-| `core/db.rs:41545` | `insert_page_with_kind` | `pub(crate)` | `insert_page_with_kind_inner` |
-| `core/db.rs:41584` | `insert_document_source_page_at_hash` | `pub(crate)` | `insert_page_with_kind_inner` |
-| `core/db.rs:41864` | `replace_source_page_inner` | `private` | `append_page_history` |
-| `core/db.rs:42145` | `get_page` | `pub` | `get_page_inner` |
-| `core/db.rs:42154` | `get_page_browse` | `pub` | `get_page_inner` |
-| `core/db.rs:42240` | `list_pages` | `pub` | `list_pages_inner` |
-| `core/db.rs:42253` | `list_pages_browse` | `pub` | `list_pages_inner` |
-| `core/db.rs:42746` | `try_update_page_content` | `private` | `append_page_history` |
-| `core/db.rs:43630` | `accept_page_merge` | `pub` | `page_merge_row` |
-| `core/db.rs:43862` | `find_best_overlapping_page` | `pub` | `load_page_source_index` |
-| `core/db.rs:43995` | `list_active_page_titles` | `pub` | `list_active_page_titles_scoped` |
-| `core/db.rs:44436` | `resolve_orphan_page_links` | `pub` | `find_unique_active_page_id_by_title_scoped` |
-| `core/db.rs:46675` | `list_stale_pages` | `pub` | `list_stale_pages_scoped` |
+| `core/db.rs:3310` | `new` | `pub` | `run_migrations` |
+| `core/db.rs:3522` | `new_with_shared_embedder` | `pub` | `run_migrations` |
+| `core/db.rs:24536` | `augment_with_graph_gated` | `private` | `search_entities_by_vector_scoped` |
+| `core/db.rs:26614` | `rebind_source_id_inner` | `private` | `rebind_source_page_in_transaction` |
+| `core/db.rs:41611` | `insert_page_with_kind` | `pub(crate)` | `insert_page_with_kind_inner` |
+| `core/db.rs:41650` | `insert_document_source_page_at_hash` | `pub(crate)` | `insert_page_with_kind_inner` |
+| `core/db.rs:41930` | `replace_source_page_inner` | `private` | `append_page_history` |
+| `core/db.rs:42211` | `get_page` | `pub` | `get_page_inner` |
+| `core/db.rs:42220` | `get_page_browse` | `pub` | `get_page_inner` |
+| `core/db.rs:42306` | `list_pages` | `pub` | `list_pages_inner` |
+| `core/db.rs:42319` | `list_pages_browse` | `pub` | `list_pages_inner` |
+| `core/db.rs:42812` | `try_update_page_content` | `private` | `append_page_history` |
+| `core/db.rs:43696` | `accept_page_merge` | `pub` | `page_merge_row` |
+| `core/db.rs:43928` | `find_best_overlapping_page` | `pub` | `load_page_source_index` |
+| `core/db.rs:44061` | `list_active_page_titles` | `pub` | `list_active_page_titles_scoped` |
+| `core/db.rs:44502` | `resolve_orphan_page_links` | `pub` | `find_unique_active_page_id_by_title_scoped` |
+| `core/db.rs:46741` | `list_stale_pages` | `pub` | `list_stale_pages_scoped` |
 | `core/db/claim_derivation.rs:959` | `reconcile_supported_pages` | `pub` | `evaluate_support_on` |
 | `core/db/claim_derivation.rs:1503` | `evaluate_page_support` | `pub` | `evaluate_support_on` |
 | `core/db/claim_derivation.rs:2389` | `finalize_page_support` | `pub` | `evaluate_support_on` |
@@ -997,25 +997,25 @@ carrying the authority of agreement.
 | Address | Function | Visibility | Reaches prose via |
 |---|---|---|---|
 | `core/citations.rs:419` | `run_citation_backfill_with_page_limit` | `private` | `get_page` |
-| `core/db.rs:22115` | `search_memory_with_cue` | `private` | `augment_with_graph_gated` |
-| `core/db.rs:24453` | `augment_with_graph` | `pub` | `augment_with_graph_gated` |
-| `core/db.rs:25003` | `augment_with_graph_seeded_scoped` | `private` | `augment_with_graph_gated` |
-| `core/db.rs:26518` | `rebind_source_id` | `pub` | `rebind_source_id_inner` |
-| `core/db.rs:26531` | `rebind_source_id_with_source_page` | `pub` | `rebind_source_id_inner` |
-| `core/db.rs:34687` | `first_active_page` | `pub` | `list_pages` |
-| `core/db.rs:41507` | `insert_page` | `pub(crate)` | `insert_page_with_kind` |
-| `core/db.rs:41808` | `replace_source_page` | `pub(crate)` | `replace_source_page_inner` |
-| `core/db.rs:41833` | `replace_source_page_at_document_hash` | `pub(crate)` | `replace_source_page_inner` |
-| `core/db.rs:42207` | `find_page_by_source_memory` | `pub` | `get_page` |
-| `core/db.rs:42496` | `update_page_content` | `pub` | `try_update_page_content` |
-| `core/db.rs:42529` | `try_update_page_content_if_stale` | `pub` | `try_update_page_content` |
-| `core/db.rs:42555` | `try_update_page_content_with_changelog_at_source_revision` | `pub` | `try_update_page_content` |
-| `core/db.rs:42603` | `try_update_page_content_with_changelog` | `pub` | `try_update_page_content` |
-| `core/db.rs:42637` | `try_update_page_content_with_changelog_at_version` | `pub` | `try_update_page_content` |
-| `core/db.rs:42672` | `try_update_page_growth_at_versions` | `pub` | `try_update_page_content` |
-| `core/db.rs:42710` | `try_accept_page_revision` | `pub(crate)` | `try_update_page_content` |
-| `core/db.rs:43384` | `refresh_page_wikilinks` | `pub` | `get_page` |
-| `core/db.rs:43914` | `max_page_overlap` | `pub` | `find_best_overlapping_page` |
+| `core/db.rs:22181` | `search_memory_with_cue` | `private` | `augment_with_graph_gated` |
+| `core/db.rs:24519` | `augment_with_graph` | `pub` | `augment_with_graph_gated` |
+| `core/db.rs:25069` | `augment_with_graph_seeded_scoped` | `private` | `augment_with_graph_gated` |
+| `core/db.rs:26584` | `rebind_source_id` | `pub` | `rebind_source_id_inner` |
+| `core/db.rs:26597` | `rebind_source_id_with_source_page` | `pub` | `rebind_source_id_inner` |
+| `core/db.rs:34753` | `first_active_page` | `pub` | `list_pages` |
+| `core/db.rs:41573` | `insert_page` | `pub(crate)` | `insert_page_with_kind` |
+| `core/db.rs:41874` | `replace_source_page` | `pub(crate)` | `replace_source_page_inner` |
+| `core/db.rs:41899` | `replace_source_page_at_document_hash` | `pub(crate)` | `replace_source_page_inner` |
+| `core/db.rs:42273` | `find_page_by_source_memory` | `pub` | `get_page` |
+| `core/db.rs:42562` | `update_page_content` | `pub` | `try_update_page_content` |
+| `core/db.rs:42595` | `try_update_page_content_if_stale` | `pub` | `try_update_page_content` |
+| `core/db.rs:42621` | `try_update_page_content_with_changelog_at_source_revision` | `pub` | `try_update_page_content` |
+| `core/db.rs:42669` | `try_update_page_content_with_changelog` | `pub` | `try_update_page_content` |
+| `core/db.rs:42703` | `try_update_page_content_with_changelog_at_version` | `pub` | `try_update_page_content` |
+| `core/db.rs:42738` | `try_update_page_growth_at_versions` | `pub` | `try_update_page_content` |
+| `core/db.rs:42776` | `try_accept_page_revision` | `pub(crate)` | `try_update_page_content` |
+| `core/db.rs:43450` | `refresh_page_wikilinks` | `pub` | `get_page` |
+| `core/db.rs:43980` | `max_page_overlap` | `pub` | `find_best_overlapping_page` |
 | `core/db/presence_review.rs:75` | `review_page_with_presence` | `pub` | `review_in_txn` |
 | `core/db/repair_page_regenerate.rs:123` | `regenerate_page_projection_cas` | `pub(crate)` | `get_page` |
 | `core/db/repair_page_rename.rs:412` | `recover_rename_page_title_apply_receipt` | `pub(crate)` | `rename_page_projection_matches_post` |
@@ -1098,11 +1098,11 @@ carrying the authority of agreement.
 |---|---|---|---|
 | `core/citations.rs:398` | `run_citation_backfill_tick` | `pub` | `run_citation_backfill_with_page_limit` |
 | `core/citations.rs:411` | `run_citation_backfill_slice` | `pub` | `run_citation_backfill_with_page_limit` |
-| `core/db.rs:22078` | `search_memory` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:22891` | `search_memory_temporal` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:23402` | `search_memory_cross_rerank_cued` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:23871` | `search_memory_expanded` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:24986` | `augment_with_graph_seeded` | `pub` | `augment_with_graph_seeded_scoped` |
+| `core/db.rs:22144` | `search_memory` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:22957` | `search_memory_temporal` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:23468` | `search_memory_cross_rerank_cued` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:23937` | `search_memory_expanded` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:25052` | `augment_with_graph_seeded` | `pub` | `augment_with_graph_seeded_scoped` |
 | `core/db/repair_verification.rs:162` | `record_repair_verification_atomic` | `pub(crate)` | `projection_page_row_on_connection` |
 | `core/db/scoped_pages.rs:445` | `list_pages_scoped` | `pub` | `list_pages_scoped_inner` |
 | `core/db/scoped_pages.rs:461` | `list_pages_scoped_browse` | `pub` | `list_pages_scoped_inner` |


### PR DESCRIPTION
## Summary

- add M6 deterministic digest, identity, and label-key primitives with executable controls
- add the additive genesis substrate as schema migration 108, after the Truth and page-kind migrations
- close space rename across community/genesis state while refusing to overwrite permanent destination genesis
- regenerate the reader-sweep inventory against the rebased tree

## Verification

- RED mutation control: changing the migration-108 dispatcher boundary left `user_version` at 107 and failed the focused integration test (`left: 107`, `right: 108`)
- focused GREEN: migration integration 1 passed; genesis schema 16 passed; space rename 9 passed
- inventory: 285 readers; depths 58/57/95/75; exposure 45
- Rust LSP diagnostics: 0 errors in the touched DB/genesis/rename modules
- `cargo fmt --all -- --check`
- `cargo clippy -p wenlan-core --lib -- -D warnings`
- fresh independent Sol integration review: `CLOSED`
- post-rebase `cargo clippy --workspace --all-targets -- -D warnings`
- post-rebase `cargo test --workspace`: core 3708 passed / 0 failed / 33 ignored; server lib 378 passed / 0 failed / 2 ignored; all other workspace suites 0 failed
