### PR TITLE
feat: complete M6 migration 109 substrate follow-up

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -115,6 +115,8 @@ mod kg_quality_vocabulary_test;
 #[cfg(test)]
 mod lint_snapshot_test;
 #[cfg(test)]
+mod m6_followup_schema_test;
+#[cfg(test)]
 mod maintenance_duplicate_reads_test;
 #[cfg(test)]
 mod maintenance_queue_test;
@@ -695,9 +697,9 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-/// Migration 108 is M6 PR-A's genesis substrate. It follows the M5 Truth
-/// migrations 105/106 and the page-kind repair at 107.
-pub const SCHEMA_VERSION: u32 = 108;
+/// Migration 109 completes M6 PR-A's additive substrate after the user-ratified
+/// D1-D8 contract amendment. It follows the partial genesis substrate at 108.
+pub const SCHEMA_VERSION: u32 = 109;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8431,6 +8433,15 @@ impl MemoryDB {
             if version < 108 {
                 self.migrate_108_genesis_substrate(version).await?;
             }
+
+            // Migration 109 (M6 PR-A follow-up): the fourteen remaining
+            // durable tables plus the per-space mutation counter whose shapes
+            // were blocked on the D1-D8 contract-defect rulings. The tables
+            // start empty and the counter backfills to zero, so no M6 writer or
+            // reader is enabled by this migration.
+            if version < 109 {
+                self.migrate_109_m6_substrate_followup(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -12181,6 +12192,42 @@ impl MemoryDB {
             .await
             .map_err(|error| WenlanError::VectorDb(format!("m108 bump: {error}")))?;
         log::info!("[migration] Migration 108 applied: M6 genesis substrate (partial by design)");
+        Ok(())
+    }
+
+    /// Migration 109 (M6 PR-A follow-up): complete the inert M6 substrate.
+    ///
+    /// The preceding migration deliberately stopped at the five objects whose
+    /// Stage-0 contracts were internally coherent. The user has since ratified
+    /// the D1-D8 amendment that fixes the remaining liveness, identity, and
+    /// readiness contradictions. All fourteen new tables and the one added
+    /// `genesis_coverage_state.m6_mutation_count` column land in one additive
+    /// transaction. Nothing here schedules work or changes a reader/writer
+    /// fence; later M6 rungs remain responsible for every behavior switch.
+    async fn migrate_109_m6_substrate_followup(&self, _prior: i64) -> Result<(), WenlanError> {
+        let conn = self.conn.lock().await;
+        let tx = conn
+            .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m109 begin: {error}")))?;
+
+        crate::m6::frontier_policy::ensure_frontier_policy_tables(&tx)
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m109 frontier: {error}")))?;
+        crate::m6::overview_subscriptions::ensure_overview_subscription_tables(&tx).await?;
+        crate::m6::refresh_readiness::ensure_refresh_readiness_tables(&tx)
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m109 refresh: {error}")))?;
+        crate::m6::relevance::ensure_relevance_tables(&tx).await?;
+        crate::m6::remaining_substrate::ensure_remaining_substrate(&tx).await?;
+
+        tx.commit()
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m109 commit: {error}")))?;
+        conn.execute("PRAGMA user_version = 109", ())
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("m109 bump: {error}")))?;
+        log::info!("[migration] Migration 109 applied: M6 substrate follow-up (inert)");
         Ok(())
     }
 

--- a/crates/wenlan-core/src/db/genesis_schema_test.rs
+++ b/crates/wenlan-core/src/db/genesis_schema_test.rs
@@ -149,7 +149,7 @@ async fn the_schema_version_constant_matches_what_the_chain_stamps() {
 /// Rebase integration tooth: Kind owns migration 107, so a database already
 /// stamped 107 must still run PR-A's additive genesis migration at 108.
 #[tokio::test]
-async fn schema_107_upgrades_through_genesis_migration_108() {
+async fn schema_107_upgrades_through_genesis_and_the_current_followup() {
     let (db, _tmp) = test_db().await;
     {
         let conn = db.conn.lock().await;
@@ -171,9 +171,9 @@ async fn schema_107_upgrades_through_genesis_migration_108() {
     );
     db.run_migrations(&crate::events::NoopEmitter)
         .await
-        .expect("schema 107 must advance through migration 108");
+        .expect("schema 107 must advance through migrations 108 and 109");
 
-    assert_eq!(user_version(&db).await, 108);
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
     for table in GENESIS_TABLES {
         assert!(object_exists(&db, "table", table).await, "{table} missing");
     }
@@ -409,9 +409,11 @@ async fn an_unknown_signal_kind_is_rejected() {
 #[tokio::test]
 async fn a_new_space_row_defaults_to_disabled_at_epoch_one() {
     let (db, _tmp) = test_db().await;
+    db.create_space("space-1", None, false).await.unwrap();
     let conn = db.conn.lock().await;
     conn.execute(
-        "INSERT INTO genesis_coverage_state (space, opened_at) VALUES ('space-1', unixepoch())",
+        "INSERT INTO genesis_coverage_state (space, opened_at, space_id)
+         SELECT name, unixepoch(), id FROM spaces WHERE name = 'space-1'",
         (),
     )
     .await

--- a/crates/wenlan-core/src/db/m6_followup_schema_test.rs
+++ b/crates/wenlan-core/src/db/m6_followup_schema_test.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Migration-109 integration teeth for the complete inert M6 substrate.
+
+use crate::db::tests::test_db;
+use crate::db::{MemoryDB, SCHEMA_VERSION};
+
+const FOLLOWUP_TABLES: [&str; 14] = [
+    "genesis_suppression",
+    "genesis_card_binding",
+    "genesis_quarantine",
+    "genesis_refresh_jobs",
+    "m6_refresh_dependencies",
+    "m6_readiness",
+    "m6_readiness_soak_receipts",
+    "m6_overview_subscriptions",
+    "m6_pair_stats",
+    "m6_adjacency",
+    "m6_deploy_attestation",
+    "m6_genesis_provenance",
+    "page_projection_outbox",
+    "m6_counters",
+];
+
+async fn table_exists(db: &MemoryDB, table: &str) -> bool {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            libsql::params![table],
+        )
+        .await
+        .expect("inspect migration-109 table");
+    rows.next().await.expect("read table existence").is_some()
+}
+
+async fn column_exists(db: &MemoryDB, table: &str, expected: &str) -> bool {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(&format!("PRAGMA table_info({table})"), ())
+        .await
+        .expect("inspect migration-109 column");
+    while let Some(row) = rows.next().await.expect("read table column") {
+        if row.get::<String>(1).expect("column name") == expected {
+            return true;
+        }
+    }
+    false
+}
+
+async fn user_version(db: &MemoryDB) -> i64 {
+    let conn = db.conn.lock().await;
+    let mut rows = conn.query("PRAGMA user_version", ()).await.unwrap();
+    rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+}
+
+#[tokio::test]
+async fn migrated_database_carries_all_fourteen_followup_tables_and_counter() {
+    let (db, _temp) = test_db().await;
+    assert_eq!(SCHEMA_VERSION, 109);
+    assert_eq!(user_version(&db).await, 109);
+    for table in FOLLOWUP_TABLES {
+        assert!(
+            table_exists(&db, table).await,
+            "migration 109 omitted {table}"
+        );
+    }
+    assert!(
+        column_exists(&db, "genesis_coverage_state", "m6_mutation_count").await,
+        "migration 109 omitted the per-space monotone M6 mutation counter"
+    );
+    assert!(
+        column_exists(&db, "genesis_coverage_state", "space_id").await,
+        "migration 109 omitted the stable space identity binding"
+    );
+}
+
+#[tokio::test]
+async fn schema_108_upgrades_through_the_whole_followup_inventory() {
+    let (db, _temp) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        for table in FOLLOWUP_TABLES {
+            conn.execute(&format!("DROP TABLE {table}"), ())
+                .await
+                .unwrap_or_else(|error| panic!("drop {table}: {error}"));
+        }
+        conn.execute("PRAGMA user_version = 108", ())
+            .await
+            .expect("restore the pre-followup schema boundary");
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("schema 108 must advance through migration 109");
+
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
+    for table in FOLLOWUP_TABLES {
+        assert!(
+            table_exists(&db, table).await,
+            "{table} missing after upgrade"
+        );
+    }
+}
+
+#[tokio::test]
+async fn replay_after_schema_commit_before_version_bump_preserves_rows() {
+    let (db, _temp) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO m6_deploy_attestation
+                 (attestation_id, attested_at, signature, binary_digest)
+             VALUES ('attestation-replay', 100, 'signed', 'binary')",
+            (),
+        )
+        .await
+        .expect("seed durable migration-109 evidence");
+        conn.execute("PRAGMA user_version = 108", ())
+            .await
+            .expect("simulate a crash before the version bump");
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("idempotent migration-109 replay");
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query("SELECT COUNT(*) FROM m6_deploy_attestation", ())
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        1
+    );
+}

--- a/crates/wenlan-core/src/db/space_rename.rs
+++ b/crates/wenlan-core/src/db/space_rename.rs
@@ -85,6 +85,21 @@ const CLOSURE: &[(&str, bool)] = &[
     ("genesis_coverage_state", true),
     ("genesis_group_coverage", true),
     ("genesis_frontier", true),
+    // Migration 109 completes the M6 substrate. Relevance rows and refresh
+    // jobs are re-derivable; human decisions, readiness evidence, exact
+    // dependency snapshots, retained subscriptions, and monotone counters are
+    // permanent and are fenced below before any destination cleanup occurs.
+    ("m6_pair_stats", true),
+    ("m6_adjacency", true),
+    ("genesis_refresh_jobs", false),
+    ("m6_refresh_dependencies", true),
+    ("m6_readiness", true),
+    ("m6_readiness_soak_receipts", true),
+    ("genesis_suppression", true),
+    ("genesis_card_binding", true),
+    ("genesis_quarantine", true),
+    ("m6_overview_subscriptions", false),
+    ("m6_counters", false),
 ];
 
 const PERMANENT_GENESIS_TABLES: &[&str] = &[
@@ -92,7 +107,21 @@ const PERMANENT_GENESIS_TABLES: &[&str] = &[
     "genesis_coverage_state",
     "genesis_group_coverage",
     "genesis_frontier",
+    "m6_refresh_dependencies",
+    "m6_readiness",
+    "m6_readiness_soak_receipts",
+    "genesis_suppression",
+    "genesis_card_binding",
+    "genesis_quarantine",
+    "m6_overview_subscriptions",
+    "m6_counters",
 ];
+
+/// Re-derivable rows whose `space` is not part of their primary key. They do
+/// not collide mechanically with the renamed source row, but leaving an orphan
+/// under the destination name would make unrelated stale work live when the
+/// space rename creates that name.
+const DESTINATION_ORPHANS_TO_RETIRE: &[&str] = &["genesis_refresh_jobs"];
 
 /// Rewrite every space-keyed row from `old_name` to `new_name` inside the
 /// caller's transaction. The caller must already have renamed the `spaces` row
@@ -133,6 +162,17 @@ pub(super) async fn cascade_space_rename(
         }
     }
 
+    for table in DESTINATION_ORPHANS_TO_RETIRE {
+        tx.execute(
+            &format!("DELETE FROM {table} WHERE space = ?1"),
+            libsql::params![new_name],
+        )
+        .await
+        .map_err(|e| {
+            WenlanError::VectorDb(format!("update_space retire orphan {table} rows: {e}"))
+        })?;
+    }
+
     for (table, space_in_primary_key) in CLOSURE {
         if !space_in_primary_key {
             continue;
@@ -161,4 +201,11 @@ pub(super) async fn cascade_space_rename(
 #[cfg(test)]
 pub(super) fn closed_tables() -> Vec<&'static str> {
     CLOSURE.iter().map(|(table, _)| *table).collect()
+}
+
+/// Permanent M6 rows for which a destination-name orphan refuses the rename
+/// instead of being silently discarded.
+#[cfg(test)]
+pub(super) fn permanent_tables() -> Vec<&'static str> {
+    PERMANENT_GENESIS_TABLES.to_vec()
 }

--- a/crates/wenlan-core/src/db/space_rename_test.rs
+++ b/crates/wenlan-core/src/db/space_rename_test.rs
@@ -4,7 +4,7 @@
 //! and genesis substrate, then check that identity is unchanged, that the new
 //! name resolves, and that no row still names the old space.
 
-use super::space_rename::closed_tables;
+use super::space_rename::{closed_tables, permanent_tables};
 use crate::db::tests::test_db;
 use crate::db::MemoryDB;
 
@@ -20,6 +20,25 @@ const PRE_EXISTING_CASCADE: &[&str] = &["memories", "entities", "pages"];
 /// `page_draft_create_requests` is S0-162's one recorded exclusion: its stored
 /// name is replay history, not stale data (`db.rs:7771`).
 const DELIBERATE_EXCLUSIONS: &[&str] = &["page_draft_create_requests"];
+
+#[test]
+fn permanent_destination_fence_covers_retained_migration_109_history() {
+    for table in [
+        "genesis_suppression",
+        "genesis_card_binding",
+        "genesis_quarantine",
+        "m6_overview_subscriptions",
+        "m6_refresh_dependencies",
+        "m6_readiness",
+        "m6_readiness_soak_receipts",
+        "m6_counters",
+    ] {
+        assert!(
+            permanent_tables().contains(&table),
+            "retained M6 history in {table} would be deleted on a destination-name collision"
+        );
+    }
+}
 
 async fn seed_substrate(conn: &libsql::Connection, space: &str) {
     let stmts: Vec<(&str, Vec<libsql::Value>)> = vec![
@@ -109,7 +128,8 @@ async fn seed_substrate(conn: &libsql::Connection, space: &str) {
             vec![space.into()],
         ),
         (
-            "INSERT OR REPLACE INTO genesis_coverage_state (space, opened_at) VALUES (?1, 1)",
+            "INSERT OR REPLACE INTO genesis_coverage_state (space, opened_at, space_id)
+             SELECT name, 1, id FROM spaces WHERE name = ?1",
             vec![space.into()],
         ),
         (
@@ -122,6 +142,84 @@ async fn seed_substrate(conn: &libsql::Connection, space: &str) {
             "INSERT OR REPLACE INTO genesis_frontier
                  (space, independence_group_id, coverage_epoch, first_seen_at, next_scan_at)
              VALUES (?1, 'grp-1', 1, 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_pair_stats
+                 (space, page_a, page_b, n11, n10, n01, n00,
+                  distinct_group_count, updated_generation)
+             VALUES (?1, 'page-a', 'page-b', 1.0, 0.0, 0.0, 1.0, 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_adjacency
+                 (space, endpoint_kind, endpoint_id, neighbor_id, rank)
+             VALUES (?1, 'page', 'page-a', 'neighbor-a', 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO genesis_refresh_jobs
+                 (job_id, page_id, base_page_version, base_source_revision, space,
+                  dependency_generation, active_root_digest, state, attempt,
+                  readiness_epoch, schema_version, reason, created_at, updated_at)
+             VALUES (1, 'page-refresh', 1, 1, ?1, 1, 'roots', 'finalized', 0,
+                     0, 109, 'source_updated', 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_refresh_dependencies
+                 (space, page_id, page_version, claim_revision_id, root_id, created_at)
+             VALUES (?1, 'page-refresh', 1, 'claim-1', 'root-1', 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_readiness
+                 (space, stage, signal, epoch, phase, operation_state, updated_at)
+             VALUES (?1, 'A', '-', 0, 'off', 'active', 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_readiness_soak_receipts
+                 (space, stage, signal, readiness_epoch, window_started_at,
+                  window_ended_at, observed_turns, daemon_starts,
+                  old_writer_mutations, work_bound_violations,
+                  support_regressions, recorded_at)
+             VALUES (?1, 'A', '-', 0, 0, 259200, 20, 1, 0, 0, 0, 259200)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO genesis_suppression
+                 (space, independence_group_id, coverage_epoch, page_id, reason,
+                  first_seen_at, suppressed_at, expires_at)
+             VALUES (?1, 'grp-suppressed', 1, 'page-suppressed', 'human choice',
+                     1, 1, 2)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO genesis_card_binding
+                 (space, independence_group_id, coverage_epoch, card_id, page_id,
+                  first_seen_at, created_at)
+             VALUES (?1, 'grp-card', 1, 'card-1', 'page-card', 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO genesis_quarantine
+                 (space, independence_group_id, coverage_epoch, reason,
+                  first_seen_at, quarantined_at)
+             VALUES (?1, 'grp-quarantine', 1, 'needs review', 1, 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_overview_subscriptions
+                 (subscription_id, scope_kind, scope_id, page_id, space, state,
+                  created_at)
+             VALUES ('subscription-1', 'community', 'com-1', 'page-overview',
+                     ?1, 'active', 1)",
+            vec![space.into()],
+        ),
+        (
+            "INSERT INTO m6_counters(space_id, space, name, value)
+             SELECT id, name, 'relevance_generation', 1 FROM spaces WHERE name = ?1",
             vec![space.into()],
         ),
     ];
@@ -140,8 +238,8 @@ async fn seed_destination_genesis(conn: &libsql::Connection) {
          VALUES ('cand-destination', 'slot-destination', 'page-destination', ?1,
                  'evidence-cluster', 7, 11, 'destination-root', 'published', 2, 3)",
         "INSERT INTO genesis_coverage_state
-             (space, coverage_epoch, epoch_state, opened_at, genesis_enabled)
-         VALUES (?1, 7, 'active', 2, 1)",
+             (space, coverage_epoch, epoch_state, opened_at, genesis_enabled, space_id)
+         SELECT name, 7, 'active', 2, 1, id FROM spaces WHERE name = ?1",
         "INSERT INTO genesis_group_coverage
              (space, independence_group_id, coverage_epoch, page_id, candidate_id, covered_at)
          VALUES (?1, 'grp-destination', 7, 'page-destination', 'cand-destination', 4)",
@@ -283,13 +381,205 @@ async fn an_orphan_row_under_the_new_name_is_retired() {
 }
 
 #[tokio::test]
+async fn an_orphan_refresh_job_does_not_become_live_under_the_renamed_space() {
+    let (db, _dir) = seeded_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO genesis_refresh_jobs
+                 (job_id, page_id, base_page_version, base_source_revision, space,
+                  dependency_generation, active_root_digest, state, attempt,
+                  readiness_epoch, schema_version, reason, created_at, updated_at)
+             VALUES (2, 'orphan-page', 1, 1, ?1, 1, 'orphan-roots', 'finalized', 0,
+                     0, 109, 'source_updated', 1, 1)",
+            libsql::params![NEW],
+        )
+        .await
+        .unwrap();
+    }
+
+    db.update_space(OLD, NEW, None).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*), MIN(job_id), MAX(job_id)
+               FROM genesis_refresh_jobs WHERE space = ?1",
+            libsql::params![NEW],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 1);
+    assert_eq!(row.get::<i64>(1).unwrap(), 1);
+    assert_eq!(row.get::<i64>(2).unwrap(), 1);
+}
+
+#[tokio::test]
+async fn delete_keep_cannot_authorize_proof_parking_and_zero_reset() {
+    let (db, _dir) = seeded_db().await;
+    let old_space_id = db.get_space(OLD).await.unwrap().unwrap().id;
+    db.create_space(NEW, None, false).await.unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE genesis_coverage_state SET m6_mutation_count = 5 WHERE space = ?1",
+            libsql::params![OLD],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "UPDATE m6_counters SET value = 5
+              WHERE space = ?1 AND name = 'relevance_generation'",
+            libsql::params![OLD],
+        )
+        .await
+        .unwrap();
+    }
+
+    db.delete_space(OLD, "keep").await.unwrap();
+
+    let conn = db.conn.lock().await;
+    let genesis_move = conn
+        .execute(
+            "UPDATE OR REPLACE genesis_coverage_state
+                SET space = ?1, m6_mutation_count = 6
+              WHERE space = ?2",
+            libsql::params![NEW, OLD],
+        )
+        .await;
+    let genesis_reset = conn
+        .execute(
+            "INSERT INTO genesis_coverage_state
+                 (space, opened_at, m6_mutation_count, space_id)
+             VALUES (?1, 100, 0, ?2)",
+            libsql::params![OLD, old_space_id.clone()],
+        )
+        .await;
+    let counter_move = conn
+        .execute(
+            "UPDATE OR REPLACE m6_counters
+                SET space = ?1, value = 6
+              WHERE space = ?2 AND name = 'relevance_generation'",
+            libsql::params![NEW, OLD],
+        )
+        .await;
+    let counter_reset = conn
+        .execute(
+            "INSERT INTO m6_counters(space_id, space, name, value)
+             VALUES (?1, ?2, 'relevance_generation', 0)",
+            libsql::params![old_space_id.clone(), OLD],
+        )
+        .await;
+
+    assert!(
+        genesis_move.is_err() && genesis_reset.is_err(),
+        "delete-keep must not turn an unrelated live space into proof-move authorization"
+    );
+    assert!(
+        counter_move.is_err() && counter_reset.is_err(),
+        "delete-keep must not permit a named counter to park and reset"
+    );
+
+    let mut rows = conn
+        .query(
+            "SELECT space, space_id, m6_mutation_count FROM genesis_coverage_state",
+            (),
+        )
+        .await
+        .unwrap();
+    let genesis = rows.next().await.unwrap().unwrap();
+    assert_eq!(genesis.get::<String>(0).unwrap(), OLD);
+    assert_eq!(genesis.get::<String>(1).unwrap(), old_space_id);
+    assert_eq!(genesis.get::<i64>(2).unwrap(), 5);
+    assert!(rows.next().await.unwrap().is_none());
+
+    let mut rows = conn
+        .query("SELECT space_id, space, name, value FROM m6_counters", ())
+        .await
+        .unwrap();
+    let counter = rows.next().await.unwrap().unwrap();
+    assert_eq!(counter.get::<String>(0).unwrap(), old_space_id);
+    assert_eq!(counter.get::<String>(1).unwrap(), OLD);
+    assert_eq!(counter.get::<String>(2).unwrap(), "relevance_generation");
+    assert_eq!(counter.get::<i64>(3).unwrap(), 5);
+    assert!(rows.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn recreated_space_name_cannot_adopt_retained_proof_identity() {
+    let (db, _dir) = seeded_db().await;
+    let old_space_id = db.get_space(OLD).await.unwrap().unwrap().id;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE genesis_coverage_state SET m6_mutation_count = 5 WHERE space = ?1",
+            libsql::params![OLD],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "UPDATE m6_counters SET value = 5
+              WHERE space = ?1 AND name = 'relevance_generation'",
+            libsql::params![OLD],
+        )
+        .await
+        .unwrap();
+    }
+    db.delete_space(OLD, "keep").await.unwrap();
+    let recreated = db.create_space(OLD, None, false).await.unwrap();
+    assert_ne!(recreated.id, old_space_id);
+
+    let conn = db.conn.lock().await;
+    let genesis_replace = conn
+        .execute(
+            "INSERT OR REPLACE INTO genesis_coverage_state
+                 (space, opened_at, m6_mutation_count, space_id)
+             VALUES (?1, 100, 0, ?2)",
+            libsql::params![OLD, recreated.id.clone()],
+        )
+        .await;
+    let counter_replace = conn
+        .execute(
+            "INSERT OR REPLACE INTO m6_counters(space_id, space, name, value)
+             VALUES (?1, ?2, 'relevance_generation', 0)",
+            libsql::params![recreated.id, OLD],
+        )
+        .await;
+    assert!(
+        genesis_replace.is_err() && counter_replace.is_err(),
+        "recreating a name with a new spaces.id cannot adopt or reset retained proofs"
+    );
+
+    let mut rows = conn
+        .query(
+            "SELECT space_id, m6_mutation_count FROM genesis_coverage_state",
+            (),
+        )
+        .await
+        .unwrap();
+    let genesis = rows.next().await.unwrap().unwrap();
+    assert_eq!(genesis.get::<String>(0).unwrap(), old_space_id);
+    assert_eq!(genesis.get::<i64>(1).unwrap(), 5);
+    let mut rows = conn
+        .query("SELECT space_id, value FROM m6_counters", ())
+        .await
+        .unwrap();
+    let counter = rows.next().await.unwrap().unwrap();
+    assert_eq!(counter.get::<String>(0).unwrap(), old_space_id);
+    assert_eq!(counter.get::<i64>(1).unwrap(), 5);
+}
+
+#[tokio::test]
 async fn destination_genesis_rows_refuse_the_rename_without_mutating_either_side() {
     let (db, _dir) = seeded_db().await;
+    db.create_space(NEW, None, false).await.unwrap();
     {
         let conn = db.conn.lock().await;
         seed_source_evidence(&conn).await;
         seed_destination_genesis(&conn).await;
     }
+    db.delete_space(NEW, "keep").await.unwrap();
 
     let error = db
         .update_space(OLD, NEW, Some("renamed"))

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_raw_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_raw_manifest.txt
@@ -5,3 +5,9 @@ crates/wenlan-core/src/lint/pages/diagnostic_scale_test.rs|crate::lint::pages::d
 crates/wenlan-core/src/lint/pages/diagnostic_scale_test.rs|crate::lint::pages::diagnostic_scale_test::run_fixture|StandaloneLibsqlOrigin|1
 crates/wenlan-core/src/lint/pages/link_checks_test/orphans.rs|crate::lint::pages::link_checks::tests::orphans::query_failure_propagates_without_a_mutating_fallback|StandaloneLibsqlOrigin|1
 crates/wenlan-core/src/lint/test_support_tests.rs|crate::lint::test_support::tests::semantic_fingerprint_detects_same_count_mutation_in_every_catalogued_table|StandaloneLibsqlOrigin|1
+crates/wenlan-core/src/m6/frontier_policy_test.rs|crate::m6::frontier_policy_test::TestDb::new|StandaloneLibsqlOrigin|1
+crates/wenlan-core/src/m6/overview_subscriptions_test.rs|crate::m6::overview_subscriptions_test::test_connection|StandaloneLibsqlOrigin|1
+crates/wenlan-core/src/m6/refresh_readiness_test.rs|crate::m6::refresh_readiness_test::connection|StandaloneLibsqlOrigin|1
+crates/wenlan-core/src/m6/relevance_test.rs|crate::m6::relevance_test::relevance_db|StandaloneLibsqlOrigin|1
+crates/wenlan-core/src/m6/remaining_substrate_test.rs|crate::m6::remaining_substrate_test::j5_migration_refuses_an_unresolvable_existing_space_identity|StandaloneLibsqlOrigin|1
+crates/wenlan-core/src/m6/remaining_substrate_test.rs|crate::m6::remaining_substrate_test::test_connection|StandaloneLibsqlOrigin|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3207,7 +3207,7 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
             .get(&RawShape::StandaloneLibsqlOrigin)
             .copied()
             .unwrap_or(0),
-        7
+        13
     );
     assert!(
         analysis.raw_uses.iter().all(|raw_use| raw_use.test_only),

--- a/crates/wenlan-core/src/m6/frontier_policy.rs
+++ b/crates/wenlan-core/src/m6/frontier_policy.rs
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: Apache-2.0
+//! D2/D3 plus J1 frontier-policy substrate for migration 109.
+//!
+//! This module deliberately owns no transaction. Migration setup and every
+//! state transition take a caller-owned transaction so the marker change and
+//! the replacement live reason cannot be observed separately.
+
+use std::fmt;
+
+/// A suppression remains live until the reconciler stores its lapse.
+/// Wall-clock expiry is only eligibility for that transition.
+pub const LIVE_SUPPRESSION_PREDICATE: &str = "lapsed_at IS NULL";
+
+/// A retained card binding remains live until dismissal or expiry closes it.
+pub const LIVE_CARD_BINDING_PREDICATE: &str = "closed_at IS NULL";
+
+/// A retained quarantine remains live until an explicit lift stores its marker.
+pub const LIVE_QUARANTINE_PREDICATE: &str = "lifted_at IS NULL";
+
+/// Retained frontier histories that the space-rename closure must rewrite.
+pub const SPACE_RENAME_TABLES: [&str; 3] = [
+    "genesis_suppression",
+    "genesis_card_binding",
+    "genesis_quarantine",
+];
+
+const SUPPRESSION_SECONDS: i64 = 180 * 86_400;
+
+#[derive(Debug)]
+pub enum FrontierPolicyError {
+    Database(libsql::Error),
+    Invariant(String),
+    #[cfg(test)]
+    Injected(DismissFailpoint),
+}
+
+impl fmt::Display for FrontierPolicyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Database(error) => write!(formatter, "frontier policy database error: {error}"),
+            Self::Invariant(message) => write!(formatter, "frontier policy invariant: {message}"),
+            #[cfg(test)]
+            Self::Injected(failpoint) => {
+                write!(formatter, "injected dismissal failure: {failpoint:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrontierPolicyError {}
+
+impl From<libsql::Error> for FrontierPolicyError {
+    fn from(error: libsql::Error) -> Self {
+        Self::Database(error)
+    }
+}
+
+pub type FrontierPolicyResult<T> = Result<T, FrontierPolicyError>;
+
+/// One frontier group that a shared surfaced card names.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CardGroup<'a> {
+    pub independence_group_id: &'a str,
+    pub page_id: &'a str,
+}
+
+impl<'a> CardGroup<'a> {
+    pub const fn new(independence_group_id: &'a str, page_id: &'a str) -> Self {
+        Self {
+            independence_group_id,
+            page_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OpenCardBinding {
+    space: String,
+    independence_group_id: String,
+    coverage_epoch: i64,
+    page_id: String,
+    first_seen_at: i64,
+}
+
+/// Additive D2/D3/J1 DDL. The migration-109 orchestrator calls this once inside
+/// its shared transaction.
+pub async fn ensure_frontier_policy_tables(tx: &libsql::Transaction) -> FrontierPolicyResult<()> {
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS genesis_suppression (
+             space                  TEXT    NOT NULL,
+             independence_group_id  TEXT    NOT NULL,
+             coverage_epoch         INTEGER NOT NULL,
+             page_id                TEXT    NOT NULL CHECK(length(trim(page_id)) > 0),
+             reason                 TEXT    NOT NULL CHECK(length(trim(reason)) > 0),
+             first_seen_at          INTEGER NOT NULL,
+             suppressed_at          INTEGER NOT NULL,
+             expires_at             INTEGER NOT NULL,
+             lapsed_at              INTEGER,
+             CHECK(expires_at > suppressed_at),
+             CHECK(lapsed_at IS NULL OR lapsed_at >= expires_at),
+             PRIMARY KEY(space, independence_group_id, coverage_epoch, suppressed_at)
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_suppression_one_live
+             ON genesis_suppression(space, independence_group_id, coverage_epoch)
+             WHERE lapsed_at IS NULL;
+         CREATE INDEX IF NOT EXISTS idx_genesis_suppression_lapse
+             ON genesis_suppression(space, coverage_epoch, expires_at)
+             WHERE lapsed_at IS NULL;
+
+         CREATE TABLE IF NOT EXISTS genesis_card_binding (
+             space                  TEXT    NOT NULL,
+             independence_group_id  TEXT    NOT NULL,
+             coverage_epoch         INTEGER NOT NULL,
+             card_id                TEXT    NOT NULL CHECK(length(trim(card_id)) > 0),
+             page_id                TEXT    NOT NULL CHECK(length(trim(page_id)) > 0),
+             first_seen_at          INTEGER NOT NULL,
+             created_at             INTEGER NOT NULL,
+             closed_at              INTEGER,
+             CHECK(closed_at IS NULL OR closed_at >= created_at),
+             PRIMARY KEY(space, independence_group_id, coverage_epoch, card_id)
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_card_binding_one_live
+             ON genesis_card_binding(space, independence_group_id, coverage_epoch)
+             WHERE closed_at IS NULL;
+         CREATE INDEX IF NOT EXISTS idx_genesis_card_binding_open_card
+             ON genesis_card_binding(card_id)
+             WHERE closed_at IS NULL;
+
+         CREATE TABLE IF NOT EXISTS genesis_quarantine (
+             space                  TEXT    NOT NULL,
+             independence_group_id  TEXT    NOT NULL,
+             coverage_epoch         INTEGER NOT NULL,
+             reason                 TEXT    NOT NULL CHECK(length(trim(reason)) > 0),
+             first_seen_at          INTEGER NOT NULL,
+             quarantined_at         INTEGER NOT NULL,
+             lifted_at              INTEGER,
+             CHECK(lifted_at IS NULL OR lifted_at >= quarantined_at),
+             PRIMARY KEY(space, independence_group_id, coverage_epoch, quarantined_at)
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_quarantine_one_live
+             ON genesis_quarantine(space, independence_group_id, coverage_epoch)
+             WHERE lifted_at IS NULL;",
+    )
+    .await?;
+    Ok(())
+}
+
+/// F7 from the frontier: retire its re-derivable row and append one live
+/// suppression. The page ID is the suppression identity; it is not an opaque
+/// free-form identity string.
+pub async fn suppress_frontier_group(
+    tx: &libsql::Transaction,
+    space: &str,
+    independence_group_id: &str,
+    coverage_epoch: i64,
+    page_id: &str,
+    reason: &str,
+) -> FrontierPolicyResult<()> {
+    let first_seen_at =
+        frontier_first_seen_at(tx, space, independence_group_id, coverage_epoch).await?;
+    let removed = tx
+        .execute(
+            "DELETE FROM genesis_frontier
+              WHERE space = ?1
+                AND independence_group_id = ?2
+                AND coverage_epoch = ?3",
+            libsql::params![space, independence_group_id, coverage_epoch],
+        )
+        .await?;
+    require_one(
+        removed,
+        "suppress transition did not retire exactly one frontier row",
+    )?;
+    insert_suppression(
+        tx,
+        space,
+        independence_group_id,
+        coverage_epoch,
+        page_id,
+        reason,
+        first_seen_at,
+    )
+    .await
+}
+
+/// F3: bind all named frontier groups to one retained shared-card history.
+/// Each deletion and binding is in the caller's transaction; an error leaves
+/// every group in its prior frontier state after rollback.
+pub async fn bind_frontier_groups_to_card(
+    tx: &libsql::Transaction,
+    space: &str,
+    coverage_epoch: i64,
+    card_id: &str,
+    groups: &[CardGroup<'_>],
+) -> FrontierPolicyResult<u64> {
+    for group in groups {
+        let first_seen_at =
+            frontier_first_seen_at(tx, space, group.independence_group_id, coverage_epoch).await?;
+        let removed = tx
+            .execute(
+                "DELETE FROM genesis_frontier
+                  WHERE space = ?1
+                    AND independence_group_id = ?2
+                    AND coverage_epoch = ?3",
+                libsql::params![space, group.independence_group_id, coverage_epoch],
+            )
+            .await?;
+        require_one(
+            removed,
+            "card transition did not retire exactly one frontier row",
+        )?;
+        tx.execute(
+            "INSERT INTO genesis_card_binding (
+                 space, independence_group_id, coverage_epoch, card_id, page_id,
+                 first_seen_at, created_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, unixepoch())",
+            libsql::params![
+                space,
+                group.independence_group_id,
+                coverage_epoch,
+                card_id,
+                group.page_id,
+                first_seen_at
+            ],
+        )
+        .await?;
+    }
+    Ok(groups.len() as u64)
+}
+
+/// F11: first stamp every observed expiry with the stable liveness marker,
+/// then restore its frontier row. Both statements share the caller's
+/// transaction, so G5 can observe either the suppression or the frontier but
+/// never a wall-clock-created gap between them.
+pub async fn reconcile_expired_suppressions(
+    tx: &libsql::Transaction,
+    space: &str,
+    coverage_epoch: i64,
+) -> FrontierPolicyResult<u64> {
+    let mut rows = tx
+        .query(
+            "SELECT independence_group_id, suppressed_at, first_seen_at
+               FROM genesis_suppression
+              WHERE space = ?1
+                AND coverage_epoch = ?2
+                AND lapsed_at IS NULL
+                AND expires_at <= unixepoch()
+              ORDER BY expires_at, independence_group_id, suppressed_at",
+            libsql::params![space, coverage_epoch],
+        )
+        .await?;
+    let mut expired = Vec::new();
+    while let Some(row) = rows.next().await? {
+        expired.push((
+            row.get::<String>(0)?,
+            row.get::<i64>(1)?,
+            row.get::<i64>(2)?,
+        ));
+    }
+    drop(rows);
+
+    for (independence_group_id, suppressed_at, first_seen_at) in &expired {
+        let lapsed = tx
+            .execute(
+                "UPDATE genesis_suppression
+                    SET lapsed_at = unixepoch()
+                  WHERE space = ?1
+                    AND independence_group_id = ?2
+                    AND coverage_epoch = ?3
+                    AND suppressed_at = ?4
+                    AND lapsed_at IS NULL
+                    AND expires_at <= unixepoch()",
+                libsql::params![
+                    space,
+                    independence_group_id.as_str(),
+                    coverage_epoch,
+                    suppressed_at
+                ],
+            )
+            .await?;
+        require_one(lapsed, "suppression lapse marker lost its live row")?;
+        tx.execute(
+            "INSERT INTO genesis_frontier (
+                 space, independence_group_id, coverage_epoch,
+                 first_seen_at, next_scan_at
+             ) VALUES (?1, ?2, ?3, ?4, unixepoch())",
+            libsql::params![
+                space,
+                independence_group_id.as_str(),
+                coverage_epoch,
+                first_seen_at
+            ],
+        )
+        .await?;
+    }
+    Ok(expired.len() as u64)
+}
+
+/// F9 from the frontier: retire the frontier row and append an explicit live
+/// quarantine. Fast lift/reactivation in one SQLite second remains repeatable:
+/// the stored identity clock advances to at least the preceding identity + 1.
+pub async fn quarantine_frontier_group(
+    tx: &libsql::Transaction,
+    space: &str,
+    independence_group_id: &str,
+    coverage_epoch: i64,
+    reason: &str,
+) -> FrontierPolicyResult<()> {
+    let first_seen_at =
+        frontier_first_seen_at(tx, space, independence_group_id, coverage_epoch).await?;
+    let removed = tx
+        .execute(
+            "DELETE FROM genesis_frontier
+              WHERE space = ?1
+                AND independence_group_id = ?2
+                AND coverage_epoch = ?3",
+            libsql::params![space, independence_group_id, coverage_epoch],
+        )
+        .await?;
+    require_one(
+        removed,
+        "quarantine transition did not retire exactly one frontier row",
+    )?;
+    tx.execute(
+        "INSERT INTO genesis_quarantine (
+             space, independence_group_id, coverage_epoch, reason,
+             first_seen_at, quarantined_at
+         ) VALUES (
+             ?1, ?2, ?3, ?4, ?5,
+             MAX(
+                 unixepoch(),
+                 COALESCE((
+                     SELECT MAX(quarantined_at) + 1
+                       FROM genesis_quarantine
+                      WHERE space = ?1
+                        AND independence_group_id = ?2
+                        AND coverage_epoch = ?3
+                 ), unixepoch())
+             )
+         )",
+        libsql::params![
+            space,
+            independence_group_id,
+            coverage_epoch,
+            reason,
+            first_seen_at
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+/// F12: stamp the stable lift marker before restoring frontier in the same
+/// caller-owned transaction. The retained row remains queryable forever.
+pub async fn lift_quarantine_to_frontier(
+    tx: &libsql::Transaction,
+    space: &str,
+    independence_group_id: &str,
+    coverage_epoch: i64,
+) -> FrontierPolicyResult<u64> {
+    let mut rows = tx
+        .query(
+            "SELECT quarantined_at, first_seen_at
+               FROM genesis_quarantine
+              WHERE space = ?1
+                AND independence_group_id = ?2
+                AND coverage_epoch = ?3
+                AND lifted_at IS NULL",
+            libsql::params![space, independence_group_id, coverage_epoch],
+        )
+        .await?;
+    let row = rows.next().await?.ok_or_else(|| {
+        FrontierPolicyError::Invariant(format!(
+            "group {independence_group_id:?} in {space:?} epoch {coverage_epoch} has no live quarantine"
+        ))
+    })?;
+    let quarantined_at = row.get::<i64>(0)?;
+    let first_seen_at = row.get::<i64>(1)?;
+    drop(rows);
+
+    let lifted = tx
+        .execute(
+            "UPDATE genesis_quarantine
+                SET lifted_at = MAX(unixepoch(), quarantined_at)
+              WHERE space = ?1
+                AND independence_group_id = ?2
+                AND coverage_epoch = ?3
+                AND quarantined_at = ?4
+                AND lifted_at IS NULL",
+            libsql::params![space, independence_group_id, coverage_epoch, quarantined_at],
+        )
+        .await?;
+    require_one(lifted, "quarantine lift marker lost its live row")?;
+    tx.execute(
+        "INSERT INTO genesis_frontier (
+             space, independence_group_id, coverage_epoch,
+             first_seen_at, next_scan_at
+         ) VALUES (?1, ?2, ?3, ?4, unixepoch())",
+        libsql::params![space, independence_group_id, coverage_epoch, first_seen_at],
+    )
+    .await?;
+    Ok(1)
+}
+
+/// F7 from a shared card: close every live per-group binding for `card_id`
+/// first, then append each group's suppression reason. The ordering is
+/// deliberate and the entire operation remains one caller-owned transaction.
+pub async fn dismiss_card_to_suppression(
+    tx: &libsql::Transaction,
+    card_id: &str,
+    reason: &str,
+) -> FrontierPolicyResult<u64> {
+    dismiss_card_to_suppression_impl(tx, card_id, reason, None).await
+}
+
+async fn dismiss_card_to_suppression_impl(
+    tx: &libsql::Transaction,
+    card_id: &str,
+    reason: &str,
+    #[cfg(test)] failpoint: Option<DismissFailpoint>,
+    #[cfg(not(test))] _failpoint: Option<()>,
+) -> FrontierPolicyResult<u64> {
+    let bindings = open_card_bindings(tx, card_id).await?;
+    if bindings.is_empty() {
+        return Ok(0);
+    }
+
+    let closed = tx
+        .execute(
+            "UPDATE genesis_card_binding
+                SET closed_at = unixepoch()
+              WHERE card_id = ?1 AND closed_at IS NULL",
+            libsql::params![card_id],
+        )
+        .await?;
+    if closed != bindings.len() as u64 {
+        return Err(FrontierPolicyError::Invariant(format!(
+            "card {card_id:?} selected {} open bindings but closed {closed}",
+            bindings.len()
+        )));
+    }
+
+    #[cfg(test)]
+    if failpoint == Some(DismissFailpoint::AfterBindingsClosed) {
+        return Err(FrontierPolicyError::Injected(
+            DismissFailpoint::AfterBindingsClosed,
+        ));
+    }
+
+    #[cfg(test)]
+    let mut completed = 0usize;
+    for binding in &bindings {
+        insert_suppression(
+            tx,
+            &binding.space,
+            &binding.independence_group_id,
+            binding.coverage_epoch,
+            &binding.page_id,
+            reason,
+            binding.first_seen_at,
+        )
+        .await?;
+        #[cfg(test)]
+        {
+            completed += 1;
+        }
+        #[cfg(test)]
+        if failpoint == Some(DismissFailpoint::AfterSuppression(completed)) {
+            return Err(FrontierPolicyError::Injected(
+                DismissFailpoint::AfterSuppression(completed),
+            ));
+        }
+    }
+    Ok(bindings.len() as u64)
+}
+
+async fn insert_suppression(
+    tx: &libsql::Transaction,
+    space: &str,
+    independence_group_id: &str,
+    coverage_epoch: i64,
+    page_id: &str,
+    reason: &str,
+    first_seen_at: i64,
+) -> FrontierPolicyResult<()> {
+    tx.execute(
+        "INSERT INTO genesis_suppression (
+             space, independence_group_id, coverage_epoch, page_id, reason,
+             first_seen_at, suppressed_at, expires_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6,
+                   unixepoch(), unixepoch() + ?7)",
+        libsql::params![
+            space,
+            independence_group_id,
+            coverage_epoch,
+            page_id,
+            reason,
+            first_seen_at,
+            SUPPRESSION_SECONDS
+        ],
+    )
+    .await?;
+    Ok(())
+}
+
+async fn frontier_first_seen_at(
+    tx: &libsql::Transaction,
+    space: &str,
+    independence_group_id: &str,
+    coverage_epoch: i64,
+) -> FrontierPolicyResult<i64> {
+    let mut rows = tx
+        .query(
+            "SELECT first_seen_at FROM genesis_frontier
+              WHERE space = ?1
+                AND independence_group_id = ?2
+                AND coverage_epoch = ?3",
+            libsql::params![space, independence_group_id, coverage_epoch],
+        )
+        .await?;
+    let row = rows.next().await?.ok_or_else(|| {
+        FrontierPolicyError::Invariant(format!(
+            "group {independence_group_id:?} in {space:?} epoch {coverage_epoch} is not in frontier"
+        ))
+    })?;
+    Ok(row.get::<i64>(0)?)
+}
+
+async fn open_card_bindings(
+    tx: &libsql::Transaction,
+    card_id: &str,
+) -> FrontierPolicyResult<Vec<OpenCardBinding>> {
+    let mut rows = tx
+        .query(
+            "SELECT space, independence_group_id, coverage_epoch, page_id, first_seen_at
+               FROM genesis_card_binding
+              WHERE card_id = ?1 AND closed_at IS NULL
+              ORDER BY space, coverage_epoch, independence_group_id",
+            libsql::params![card_id],
+        )
+        .await?;
+    let mut bindings = Vec::new();
+    while let Some(row) = rows.next().await? {
+        bindings.push(OpenCardBinding {
+            space: row.get(0)?,
+            independence_group_id: row.get(1)?,
+            coverage_epoch: row.get(2)?,
+            page_id: row.get(3)?,
+            first_seen_at: row.get(4)?,
+        });
+    }
+    Ok(bindings)
+}
+
+fn require_one(affected: u64, message: &str) -> FrontierPolicyResult<()> {
+    if affected == 1 {
+        Ok(())
+    } else {
+        Err(FrontierPolicyError::Invariant(format!(
+            "{message}; affected {affected} rows"
+        )))
+    }
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DismissFailpoint {
+    AfterBindingsClosed,
+    AfterSuppression(usize),
+}
+
+#[cfg(test)]
+pub async fn dismiss_card_to_suppression_with_failpoint(
+    tx: &libsql::Transaction,
+    card_id: &str,
+    reason: &str,
+    failpoint: DismissFailpoint,
+) -> FrontierPolicyResult<u64> {
+    dismiss_card_to_suppression_impl(tx, card_id, reason, Some(failpoint)).await
+}

--- a/crates/wenlan-core/src/m6/frontier_policy_test.rs
+++ b/crates/wenlan-core/src/m6/frontier_policy_test.rs
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Executable controls for the D2/D3 frontier-policy amendment.
+
+use super::frontier_policy::{
+    bind_frontier_groups_to_card, dismiss_card_to_suppression,
+    dismiss_card_to_suppression_with_failpoint, ensure_frontier_policy_tables,
+    lift_quarantine_to_frontier, quarantine_frontier_group, reconcile_expired_suppressions,
+    suppress_frontier_group, CardGroup, DismissFailpoint, LIVE_CARD_BINDING_PREDICATE,
+    LIVE_QUARANTINE_PREDICATE, LIVE_SUPPRESSION_PREDICATE, SPACE_RENAME_TABLES,
+};
+
+struct TestDb {
+    _database: libsql::Database,
+    connection: libsql::Connection,
+}
+
+impl TestDb {
+    async fn new() -> Self {
+        let database = libsql::Builder::new_local(":memory:")
+            .build()
+            .await
+            .expect("build in-memory database");
+        let connection = database.connect().expect("connect in-memory database");
+        let tx = connection
+            .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+            .await
+            .expect("begin schema transaction");
+        tx.execute_batch(
+            "CREATE TABLE genesis_frontier (
+                 space TEXT NOT NULL,
+                 independence_group_id TEXT NOT NULL,
+                 coverage_epoch INTEGER NOT NULL,
+                 first_seen_at INTEGER NOT NULL,
+                 next_scan_at INTEGER NOT NULL,
+                 PRIMARY KEY(space, independence_group_id, coverage_epoch)
+             );",
+        )
+        .await
+        .expect("create migration-108 frontier prerequisite");
+        ensure_frontier_policy_tables(&tx)
+            .await
+            .expect("create D2/D3 substrate");
+        tx.commit().await.expect("commit schema transaction");
+        Self {
+            _database: database,
+            connection,
+        }
+    }
+
+    async fn seed_frontier(&self, group: &str, first_seen_at: i64) {
+        self.connection
+            .execute(
+                "INSERT INTO genesis_frontier (
+                     space, independence_group_id, coverage_epoch,
+                     first_seen_at, next_scan_at
+                 ) VALUES ('space-a', ?1, 7, ?2, unixepoch())",
+                libsql::params![group, first_seen_at],
+            )
+            .await
+            .expect("seed frontier group");
+    }
+
+    async fn live_reason_count(&self, group: &str) -> i64 {
+        let sql = format!(
+            "SELECT
+                 EXISTS(
+                     SELECT 1 FROM genesis_frontier
+                      WHERE space = 'space-a'
+                        AND independence_group_id = ?1
+                        AND coverage_epoch = 7
+                 )
+               + EXISTS(
+                     SELECT 1 FROM genesis_card_binding
+                      WHERE space = 'space-a'
+                        AND independence_group_id = ?1
+                        AND coverage_epoch = 7
+                        AND {LIVE_CARD_BINDING_PREDICATE}
+                 )
+               + EXISTS(
+                     SELECT 1 FROM genesis_suppression
+                      WHERE space = 'space-a'
+                        AND independence_group_id = ?1
+                        AND coverage_epoch = 7
+                        AND {LIVE_SUPPRESSION_PREDICATE}
+                 )
+               + EXISTS(
+                     SELECT 1 FROM genesis_quarantine
+                      WHERE space = 'space-a'
+                        AND independence_group_id = ?1
+                        AND coverage_epoch = 7
+                        AND {LIVE_QUARANTINE_PREDICATE}
+                 )"
+        );
+        scalar(&self.connection, &sql, libsql::params![group]).await
+    }
+}
+
+async fn scalar(
+    connection: &libsql::Connection,
+    sql: &str,
+    params: impl libsql::params::IntoParams,
+) -> i64 {
+    let mut rows = connection.query(sql, params).await.expect("scalar query");
+    rows.next()
+        .await
+        .expect("read scalar row")
+        .expect("scalar row present")
+        .get(0)
+        .expect("scalar integer")
+}
+
+#[tokio::test]
+async fn suppression_lapses_before_frontier_restore_and_can_repeat() {
+    let db = TestDb::new().await;
+    db.seed_frontier("group-a", 123).await;
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    suppress_frontier_group(&tx, "space-a", "group-a", 7, "m6p_topic", "dismissed")
+        .await
+        .expect("first suppression");
+    tx.commit().await.unwrap();
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+
+    db.connection
+        .execute(
+            "UPDATE genesis_suppression
+                SET suppressed_at = unixepoch() - 15552001,
+                    expires_at = unixepoch() - 1
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7
+                AND lapsed_at IS NULL",
+            (),
+        )
+        .await
+        .expect("age first suppression past expiry");
+
+    assert_eq!(
+        db.live_reason_count("group-a").await,
+        1,
+        "wall-clock expiry alone must not create a zero-reason window"
+    );
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    assert_eq!(
+        reconcile_expired_suppressions(&tx, "space-a", 7)
+            .await
+            .expect("lapse then restore frontier"),
+        1
+    );
+    tx.commit().await.unwrap();
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT first_seen_at FROM genesis_frontier
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7",
+            (),
+        )
+        .await,
+        123,
+        "F11 must preserve the original within-epoch surfacing clock"
+    );
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    suppress_frontier_group(&tx, "space-a", "group-a", 7, "m6p_topic", "dismissed-again")
+        .await
+        .expect("repeat suppression in the same epoch");
+    tx.commit().await.unwrap();
+
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT COUNT(*) FROM genesis_suppression
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7
+                AND page_id = 'm6p_topic'",
+            (),
+        )
+        .await,
+        2,
+        "both page-ID suppression identities must remain queryable"
+    );
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT COUNT(*) FROM genesis_suppression
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7
+                AND lapsed_at IS NULL",
+            (),
+        )
+        .await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn the_partial_unique_indexes_reject_second_live_reasons() {
+    let db = TestDb::new().await;
+    db.connection
+        .execute(
+            "INSERT INTO genesis_suppression (
+                 space, independence_group_id, coverage_epoch, page_id, reason,
+                 first_seen_at, suppressed_at, expires_at
+             ) VALUES ('space-a', 'group-a', 7, 'm6p_a', 'first', 10,
+                       unixepoch(), unixepoch() + 15552000)",
+            (),
+        )
+        .await
+        .expect("first live suppression");
+    let duplicate_suppression = db
+        .connection
+        .execute(
+            "INSERT INTO genesis_suppression (
+                 space, independence_group_id, coverage_epoch, page_id, reason,
+                 first_seen_at, suppressed_at, expires_at
+             ) VALUES ('space-a', 'group-a', 7, 'm6p_a', 'second', 10,
+                       unixepoch() + 1, unixepoch() + 15552001)",
+            (),
+        )
+        .await;
+    assert!(
+        duplicate_suppression.is_err(),
+        "at most one unlapsed suppression may exist per group/epoch"
+    );
+    let blank_page_identity = db
+        .connection
+        .execute(
+            "INSERT INTO genesis_suppression (
+                 space, independence_group_id, coverage_epoch, page_id, reason,
+                 first_seen_at, suppressed_at, expires_at
+             ) VALUES ('space-a', 'group-page-id', 7, '  ', 'dismissed', 10,
+                       unixepoch(), unixepoch() + 15552000)",
+            (),
+        )
+        .await;
+    assert!(
+        blank_page_identity.is_err(),
+        "suppression identity must be a non-empty page ID"
+    );
+
+    db.connection
+        .execute(
+            "INSERT INTO genesis_card_binding (
+                 space, independence_group_id, coverage_epoch, card_id, page_id,
+                 first_seen_at, created_at
+             ) VALUES ('space-a', 'group-b', 7, 'card-a', 'm6p_b', 20, unixepoch())",
+            (),
+        )
+        .await
+        .expect("first live card binding");
+    let duplicate_binding = db
+        .connection
+        .execute(
+            "INSERT INTO genesis_card_binding (
+                 space, independence_group_id, coverage_epoch, card_id, page_id,
+                 first_seen_at, created_at
+             ) VALUES ('space-a', 'group-b', 7, 'card-b', 'm6p_b', 20, unixepoch())",
+            (),
+        )
+        .await;
+    assert!(
+        duplicate_binding.is_err(),
+        "at most one open card binding may exist per group/epoch"
+    );
+}
+
+#[tokio::test]
+async fn shared_card_dismissal_is_atomic_at_every_post_card_boundary() {
+    let db = TestDb::new().await;
+    db.seed_frontier("group-a", 101).await;
+    db.seed_frontier("group-b", 202).await;
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    bind_frontier_groups_to_card(
+        &tx,
+        "space-a",
+        7,
+        "card-shared",
+        &[
+            CardGroup::new("group-a", "m6p_a"),
+            CardGroup::new("group-b", "m6p_b"),
+        ],
+    )
+    .await
+    .expect("bind both groups to one card");
+    tx.commit().await.unwrap();
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+    assert_eq!(db.live_reason_count("group-b").await, 1);
+
+    for failpoint in [
+        DismissFailpoint::AfterBindingsClosed,
+        DismissFailpoint::AfterSuppression(1),
+        DismissFailpoint::AfterSuppression(2),
+    ] {
+        let tx = db
+            .connection
+            .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+            .await
+            .unwrap();
+        let failure = dismiss_card_to_suppression_with_failpoint(
+            &tx,
+            "card-shared",
+            "card-dismissed",
+            failpoint,
+        )
+        .await;
+        assert!(failure.is_err(), "failpoint {failpoint:?} must abort");
+        tx.rollback().await.expect("roll back injected dismissal");
+
+        assert_eq!(
+            db.live_reason_count("group-a").await,
+            1,
+            "group-a lost or doubled its reason at {failpoint:?}"
+        );
+        assert_eq!(
+            db.live_reason_count("group-b").await,
+            1,
+            "group-b lost or doubled its reason at {failpoint:?}"
+        );
+        assert_eq!(
+            scalar(
+                &db.connection,
+                "SELECT COUNT(*) FROM genesis_card_binding
+                  WHERE card_id = 'card-shared' AND closed_at IS NULL",
+                (),
+            )
+            .await,
+            2,
+            "an injected failure must retain every live binding"
+        );
+    }
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    assert_eq!(
+        dismiss_card_to_suppression(&tx, "card-shared", "card-dismissed")
+            .await
+            .expect("dismiss shared card"),
+        2
+    );
+    tx.commit().await.unwrap();
+
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+    assert_eq!(db.live_reason_count("group-b").await, 1);
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT COUNT(*) FROM genesis_card_binding
+              WHERE card_id = 'card-shared' AND closed_at IS NOT NULL",
+            (),
+        )
+        .await,
+        2,
+        "one dismissal must close every retained per-group binding"
+    );
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT COUNT(*) FROM genesis_suppression
+              WHERE reason = 'card-dismissed' AND lapsed_at IS NULL",
+            (),
+        )
+        .await,
+        2,
+        "every closed binding must receive its post-card live reason"
+    );
+}
+
+#[tokio::test]
+async fn quarantine_lift_retains_history_and_allows_reactivation() {
+    assert_eq!(
+        SPACE_RENAME_TABLES,
+        [
+            "genesis_suppression",
+            "genesis_card_binding",
+            "genesis_quarantine"
+        ]
+    );
+    let db = TestDb::new().await;
+    db.seed_frontier("group-a", 303).await;
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    quarantine_frontier_group(&tx, "space-a", "group-a", 7, "policy violation")
+        .await
+        .expect("first quarantine");
+    tx.commit().await.unwrap();
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+
+    let duplicate = db
+        .connection
+        .execute(
+            "INSERT INTO genesis_quarantine (
+                 space, independence_group_id, coverage_epoch, reason,
+                 first_seen_at, quarantined_at
+             ) VALUES ('space-a', 'group-a', 7, 'duplicate', 303, unixepoch() + 1)",
+            (),
+        )
+        .await;
+    assert!(
+        duplicate.is_err(),
+        "a second live quarantine must be rejected"
+    );
+
+    let blank_reason = db
+        .connection
+        .execute(
+            "INSERT INTO genesis_quarantine (
+                 space, independence_group_id, coverage_epoch, reason,
+                 first_seen_at, quarantined_at
+             ) VALUES ('space-a', 'group-b', 7, '  ', 404, unixepoch())",
+            (),
+        )
+        .await;
+    assert!(blank_reason.is_err(), "quarantine reason must be explicit");
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    assert_eq!(
+        lift_quarantine_to_frontier(&tx, "space-a", "group-a", 7)
+            .await
+            .expect("lift quarantine into frontier"),
+        1
+    );
+    tx.commit().await.unwrap();
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT first_seen_at FROM genesis_frontier
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7",
+            (),
+        )
+        .await,
+        303
+    );
+
+    let tx = db
+        .connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .unwrap();
+    quarantine_frontier_group(&tx, "space-a", "group-a", 7, "repeat violation")
+        .await
+        .expect("repeat quarantine");
+    tx.commit().await.unwrap();
+
+    assert_eq!(db.live_reason_count("group-a").await, 1);
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT COUNT(*) FROM genesis_quarantine
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7",
+            (),
+        )
+        .await,
+        2,
+        "lifted quarantine history must remain queryable"
+    );
+    assert_eq!(
+        scalar(
+            &db.connection,
+            "SELECT COUNT(*) FROM genesis_quarantine
+              WHERE space = 'space-a'
+                AND independence_group_id = 'group-a'
+                AND coverage_epoch = 7
+                AND lifted_at IS NULL",
+            (),
+        )
+        .await,
+        1
+    );
+}

--- a/crates/wenlan-core/src/m6/mod.rs
+++ b/crates/wenlan-core/src/m6/mod.rs
@@ -13,10 +13,31 @@ pub mod constants;
 pub mod digest;
 pub mod identity;
 pub mod label_key;
+// Migration 109 is schema-first: PR-B/PR-C wire these transaction-scoped
+// writers. Keep the staged APIs crate-private without exposing speculative
+// public surface solely to satisfy dead-code linting.
+#[allow(dead_code)]
+pub(crate) mod frontier_policy;
+pub(crate) mod overview_subscriptions;
+#[allow(dead_code)]
+pub(crate) mod refresh_readiness;
+#[allow(dead_code)]
+pub(crate) mod relevance;
+pub(crate) mod remaining_substrate;
 
 #[cfg(test)]
 mod digest_test;
 #[cfg(test)]
+mod frontier_policy_test;
+#[cfg(test)]
 mod identity_test;
 #[cfg(test)]
 mod label_key_test;
+#[cfg(test)]
+mod overview_subscriptions_test;
+#[cfg(test)]
+mod refresh_readiness_test;
+#[cfg(test)]
+mod relevance_test;
+#[cfg(test)]
+mod remaining_substrate_test;

--- a/crates/wenlan-core/src/m6/overview_subscriptions.rs
+++ b/crates/wenlan-core/src/m6/overview_subscriptions.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Migration-109 substrate for M6 overview subscriptions.
+
+use crate::WenlanError;
+
+/// Add the overview-subscription tables and exclusion indexes to the caller's
+/// migration transaction.
+pub(crate) async fn ensure_overview_subscription_tables(
+    tx: &libsql::Transaction,
+) -> Result<(), WenlanError> {
+    tx.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS m6_overview_subscriptions (
+            subscription_id  TEXT    NOT NULL PRIMARY KEY,
+            scope_kind       TEXT    NOT NULL
+                                CHECK (scope_kind IN ('install', 'space', 'community')),
+            scope_id         TEXT    NOT NULL,
+            page_id          TEXT    NOT NULL,
+            space            TEXT,
+            state            TEXT    NOT NULL
+                                CHECK (state IN ('active', 'detached')),
+            created_at       INTEGER NOT NULL,
+            detached_at      INTEGER,
+            CHECK (
+                (scope_kind = 'install' AND space IS NULL) OR
+                (scope_kind <> 'install' AND space IS NOT NULL)
+            )
+        );
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_m6_overview_sub_scope_active
+            ON m6_overview_subscriptions(scope_kind, scope_id)
+            WHERE state = 'active';
+
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_m6_overview_sub_page_active
+            ON m6_overview_subscriptions(page_id)
+            WHERE state = 'active';
+        ",
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| WenlanError::VectorDb(format!("m109 overview subscriptions: {error}")))
+}

--- a/crates/wenlan-core/src/m6/overview_subscriptions_test.rs
+++ b/crates/wenlan-core/src/m6/overview_subscriptions_test.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::overview_subscriptions::ensure_overview_subscription_tables;
+
+async fn test_connection() -> (libsql::Database, libsql::Connection) {
+    let db = libsql::Builder::new_local(":memory:")
+        .build()
+        .await
+        .expect("build overview schema database");
+    let conn = db.connect().expect("connect overview schema database");
+    let tx = conn.transaction().await.expect("begin overview schema");
+    ensure_overview_subscription_tables(&tx)
+        .await
+        .expect("install overview schema");
+    tx.commit().await.expect("commit overview schema");
+    (db, conn)
+}
+
+async fn insert_subscription(
+    conn: &libsql::Connection,
+    subscription_id: &str,
+    scope_kind: &str,
+    scope_id: &str,
+    page_id: &str,
+    space: Option<&str>,
+    state: &str,
+) -> Result<u64, libsql::Error> {
+    conn.execute(
+        "INSERT INTO m6_overview_subscriptions (
+             subscription_id, scope_kind, scope_id, page_id, space, state,
+             created_at, detached_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 100, NULL)",
+        libsql::params![subscription_id, scope_kind, scope_id, page_id, space, state],
+    )
+    .await
+}
+
+#[tokio::test]
+async fn install_scope_and_space_nullability_are_bidirectional() {
+    let (_db, conn) = test_connection().await;
+
+    insert_subscription(
+        &conn,
+        "sub-install",
+        "install",
+        "install",
+        "page-install",
+        None,
+        "active",
+    )
+    .await
+    .expect("an install subscription has no space");
+
+    assert!(
+        insert_subscription(
+            &conn,
+            "sub-install-with-space",
+            "install",
+            "install-2",
+            "page-install-2",
+            Some("space-a"),
+            "active",
+        )
+        .await
+        .is_err(),
+        "install iff NULL must reject an install row carrying a space"
+    );
+    assert!(
+        insert_subscription(
+            &conn,
+            "sub-space-without-space",
+            "space",
+            "space-a",
+            "page-space-a",
+            None,
+            "active",
+        )
+        .await
+        .is_err(),
+        "install iff NULL must reject a non-install row without a space"
+    );
+}
+
+#[tokio::test]
+async fn retained_subscription_identity_rejects_null_rows() {
+    let (_db, conn) = test_connection().await;
+
+    for suffix in ["a", "b"] {
+        assert!(
+            conn.execute(
+                "INSERT INTO m6_overview_subscriptions (
+                     subscription_id, scope_kind, scope_id, page_id, space, state,
+                     created_at, detached_at
+                 ) VALUES (NULL, 'install', ?1, ?2, NULL, 'detached', 100, 100)",
+                libsql::params![format!("install-{suffix}"), format!("page-{suffix}")],
+            )
+            .await
+            .is_err(),
+            "NULL must not create a second identity-less retained row"
+        );
+    }
+}
+
+#[tokio::test]
+async fn detached_history_allows_resubscription_but_only_one_live_scope() {
+    let (_db, conn) = test_connection().await;
+
+    insert_subscription(
+        &conn,
+        "sub-old",
+        "community",
+        "community-a",
+        "page-old",
+        Some("space-a"),
+        "active",
+    )
+    .await
+    .expect("first active subscription");
+    conn.execute(
+        "UPDATE m6_overview_subscriptions
+            SET state = 'detached', detached_at = 200
+          WHERE subscription_id = 'sub-old'",
+        (),
+    )
+    .await
+    .expect("detach while retaining history");
+
+    insert_subscription(
+        &conn,
+        "sub-new",
+        "community",
+        "community-a",
+        "page-new",
+        Some("space-a"),
+        "active",
+    )
+    .await
+    .expect("same scope can subscribe again after detach");
+    assert!(
+        insert_subscription(
+            &conn,
+            "sub-duplicate-live",
+            "community",
+            "community-a",
+            "page-third",
+            Some("space-a"),
+            "active",
+        )
+        .await
+        .is_err(),
+        "a second simultaneous active subscription for one scope must fail"
+    );
+
+    let mut rows = conn
+        .query(
+            "SELECT state, COUNT(*)
+               FROM m6_overview_subscriptions
+              WHERE scope_kind = 'community' AND scope_id = 'community-a'
+              GROUP BY state ORDER BY state",
+            (),
+        )
+        .await
+        .expect("read retained subscription history");
+    let detached = rows.next().await.unwrap().unwrap();
+    assert_eq!(detached.get::<String>(0).unwrap(), "active");
+    assert_eq!(detached.get::<i64>(1).unwrap(), 1);
+    let active = rows.next().await.unwrap().unwrap();
+    assert_eq!(active.get::<String>(0).unwrap(), "detached");
+    assert_eq!(active.get::<i64>(1).unwrap(), 1);
+}
+
+#[tokio::test]
+async fn one_page_cannot_serve_two_live_scopes() {
+    let (_db, conn) = test_connection().await;
+
+    insert_subscription(
+        &conn,
+        "sub-a",
+        "community",
+        "community-a",
+        "shared-page",
+        Some("space-a"),
+        "active",
+    )
+    .await
+    .expect("first live page binding");
+    assert!(
+        insert_subscription(
+            &conn,
+            "sub-b",
+            "community",
+            "community-b",
+            "shared-page",
+            Some("space-a"),
+            "active",
+        )
+        .await
+        .is_err(),
+        "the active-page partial unique index must reject a shared page"
+    );
+}

--- a/crates/wenlan-core/src/m6/refresh_readiness.rs
+++ b/crates/wenlan-core/src/m6/refresh_readiness.rs
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: Apache-2.0
+//! M6 refresh-job, dependency-snapshot, and readiness substrate.
+//!
+//! This module deliberately owns no transaction boundary. Migration 109 calls
+//! [`ensure_refresh_readiness_tables`] from its shared transaction, refresh
+//! finalization calls [`replace_refresh_dependencies`] from the existing outer
+//! page transaction, and readiness checks/transitions use that same pattern.
+
+/// Install the additive D4, D7, and D8 schema inside migration 109's shared
+/// transaction.
+pub async fn ensure_refresh_readiness_tables(
+    tx: &libsql::Transaction,
+) -> Result<(), libsql::Error> {
+    tx.execute_batch(
+        "CREATE TABLE IF NOT EXISTS genesis_refresh_jobs (
+             job_id                 INTEGER PRIMARY KEY,
+             page_id                TEXT    NOT NULL,
+             base_page_version      INTEGER NOT NULL CHECK(base_page_version >= 0),
+             base_source_revision   INTEGER NOT NULL CHECK(base_source_revision >= 0),
+             space                  TEXT    NOT NULL,
+             dependency_generation  INTEGER NOT NULL CHECK(dependency_generation >= 0),
+             active_root_digest     TEXT    NOT NULL,
+             -- `queued` is the stale-page selection and `generated` is an
+             -- in-memory value. Neither may become a durable state.
+             state                  TEXT    NOT NULL CHECK(state IN (
+                                        'leased', 'retry', 'finalized', 'revision_card')),
+             lease_token            TEXT,
+             lease_expires_at       INTEGER,
+             attempt                INTEGER NOT NULL DEFAULT 0 CHECK(attempt >= 0),
+             next_attempt_at        INTEGER,
+             readiness_epoch        INTEGER NOT NULL CHECK(readiness_epoch >= 0),
+             schema_version         INTEGER NOT NULL CHECK(schema_version > 0),
+             reason                 TEXT    NOT NULL,
+             created_at             INTEGER NOT NULL,
+             updated_at             INTEGER NOT NULL
+         );
+         CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_refresh_jobs_active
+             ON genesis_refresh_jobs(page_id, base_page_version)
+             WHERE state IN ('leased','retry');
+         CREATE INDEX IF NOT EXISTS idx_genesis_refresh_jobs_space_compatibility
+             ON genesis_refresh_jobs(space, readiness_epoch, schema_version, state);
+
+         -- This is the CURRENT exact dependency snapshot for a page. A
+         -- finalizer replaces every row for that page in its outer transaction.
+         -- root_id intentionally has no FK: deleting a live provenance root
+         -- must leave the missing identity observable to the readiness anti-join.
+         CREATE TABLE IF NOT EXISTS m6_refresh_dependencies (
+             space              TEXT    NOT NULL,
+             page_id            TEXT    NOT NULL,
+             page_version       INTEGER NOT NULL CHECK(page_version >= 0),
+             claim_revision_id  TEXT    NOT NULL,
+             root_id            TEXT    NOT NULL,
+             created_at         INTEGER NOT NULL DEFAULT (unixepoch()),
+             PRIMARY KEY(space, page_id, page_version, claim_revision_id, root_id)
+         );
+         CREATE INDEX IF NOT EXISTS idx_m6_refresh_dependencies_space_root
+             ON m6_refresh_dependencies(space, root_id);
+
+         -- `stage`, the epoch/phase fence, and operational disposition are
+         -- independent axes. Composite diagram labels are presentation only.
+         CREATE TABLE IF NOT EXISTS m6_readiness (
+             space             TEXT    NOT NULL,
+             stage             TEXT    NOT NULL CHECK(stage IN ('A','B','C','D','E')),
+             signal            TEXT    NOT NULL,
+             epoch             INTEGER NOT NULL CHECK(epoch >= 0),
+             phase             TEXT    NOT NULL CHECK(phase IN ('off','preparing','committed')),
+             operation_state   TEXT    NOT NULL DEFAULT 'active'
+                                      CHECK(operation_state IN (
+                                          'active','disabled','forward_fix')),
+             operation_reason  TEXT,
+             updated_at        INTEGER NOT NULL,
+             PRIMARY KEY(space, stage, signal),
+             CHECK(
+                 (stage IN ('A','B','C','D') AND signal = '-') OR
+                 (stage = 'E' AND signal IN (
+                     'evidence-cluster', 'orphan-wikilink',
+                     'community-overview', 'space-overview'))
+             )
+         );
+
+         -- Soak is evidence about one readiness epoch, never a phase or stage.
+         -- A passing row mechanically carries all three evidence components
+         -- and the ratified 72h/20-turn/one-start minimum.
+         CREATE TABLE IF NOT EXISTS m6_readiness_soak_receipts (
+             space                   TEXT    NOT NULL,
+             stage                   TEXT    NOT NULL CHECK(stage IN ('A','B','C','D','E')),
+             signal                  TEXT    NOT NULL,
+             readiness_epoch         INTEGER NOT NULL CHECK(readiness_epoch >= 0),
+             window_started_at       INTEGER NOT NULL,
+             window_ended_at         INTEGER NOT NULL,
+             observed_turns          INTEGER NOT NULL CHECK(observed_turns >= 0),
+             daemon_starts           INTEGER NOT NULL CHECK(daemon_starts >= 0),
+             old_writer_mutations    INTEGER NOT NULL CHECK(old_writer_mutations >= 0),
+             work_bound_violations   INTEGER NOT NULL CHECK(work_bound_violations >= 0),
+             support_regressions     INTEGER NOT NULL CHECK(support_regressions >= 0),
+             recorded_at             INTEGER NOT NULL,
+             PRIMARY KEY(space, stage, signal, readiness_epoch),
+             CHECK(
+                 (stage IN ('A','B','C','D') AND signal = '-') OR
+                 (stage = 'E' AND signal IN (
+                     'evidence-cluster', 'orphan-wikilink',
+                     'community-overview', 'space-overview'))
+             ),
+             CHECK(window_ended_at - window_started_at >= 259200),
+             CHECK(observed_turns >= 20),
+             CHECK(daemon_starts >= 1),
+             CHECK(old_writer_mutations = 0),
+             CHECK(work_bound_violations = 0),
+             CHECK(support_regressions = 0)
+         );
+         CREATE TRIGGER IF NOT EXISTS m6_soak_receipt_fence_guard
+         BEFORE INSERT ON m6_readiness_soak_receipts
+         WHEN NOT EXISTS (
+             SELECT 1 FROM m6_readiness r
+              WHERE r.space = NEW.space
+                AND r.stage = NEW.stage
+                AND r.signal = NEW.signal
+                AND r.epoch = NEW.readiness_epoch
+         )
+         BEGIN
+             SELECT RAISE(ABORT, 'm6 soak receipt does not name the current readiness fence');
+         END;",
+    )
+    .await
+    .map(|_| ())
+}
+
+/// Everything the stale-page sweep has already selected and the lease
+/// transaction must durably capture before any model work starts.
+#[derive(Clone, Copy, Debug)]
+pub struct RefreshLeaseRequest<'a> {
+    pub page_id: &'a str,
+    pub base_page_version: i64,
+    pub base_source_revision: i64,
+    pub space: &'a str,
+    pub dependency_generation: i64,
+    pub active_root_digest: &'a str,
+    pub lease_token: &'a str,
+    pub lease_expires_at: i64,
+    pub readiness_epoch: i64,
+    pub schema_version: i64,
+    pub reason: &'a str,
+    pub now: i64,
+}
+
+/// Atomically insert a new leased job, or claim a due retry, under the one
+/// partial unique constraint. `true` is the caller's permission to begin model
+/// work; `false` means another sweep owns this page/base-version.
+pub async fn acquire_refresh_lease(
+    tx: &libsql::Transaction,
+    request: &RefreshLeaseRequest<'_>,
+) -> Result<bool, libsql::Error> {
+    let inserted = tx
+        .execute(
+            "INSERT OR IGNORE INTO genesis_refresh_jobs (
+                 page_id, base_page_version, base_source_revision, space,
+                 dependency_generation, active_root_digest, state, lease_token,
+                 lease_expires_at, attempt, readiness_epoch, schema_version, reason,
+                 created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'leased', ?7, ?8, 0, ?9, ?10, ?11,
+                       ?12, ?12)",
+            libsql::params![
+                request.page_id,
+                request.base_page_version,
+                request.base_source_revision,
+                request.space,
+                request.dependency_generation,
+                request.active_root_digest,
+                request.lease_token,
+                request.lease_expires_at,
+                request.readiness_epoch,
+                request.schema_version,
+                request.reason,
+                request.now,
+            ],
+        )
+        .await?;
+    if inserted == 1 {
+        return Ok(true);
+    }
+
+    let claimed_retry = tx
+        .execute(
+            "UPDATE genesis_refresh_jobs
+                SET base_source_revision = ?3,
+                    space = ?4,
+                    dependency_generation = ?5,
+                    active_root_digest = ?6,
+                    state = 'leased',
+                    lease_token = ?7,
+                    lease_expires_at = ?8,
+                    next_attempt_at = NULL,
+                    readiness_epoch = ?9,
+                    schema_version = ?10,
+                    reason = ?11,
+                    updated_at = ?12
+              WHERE page_id = ?1
+                AND base_page_version = ?2
+                AND state = 'retry'
+                AND COALESCE(next_attempt_at, 0) <= ?12",
+            libsql::params![
+                request.page_id,
+                request.base_page_version,
+                request.base_source_revision,
+                request.space,
+                request.dependency_generation,
+                request.active_root_digest,
+                request.lease_token,
+                request.lease_expires_at,
+                request.readiness_epoch,
+                request.schema_version,
+                request.reason,
+                request.now,
+            ],
+        )
+        .await?;
+    Ok(claimed_retry == 1)
+}
+
+/// One claim/root pair in the exact dependency snapshot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RefreshDependency<'a> {
+    pub claim_revision_id: &'a str,
+    pub root_id: &'a str,
+}
+
+/// Replace one page's current dependency snapshot inside the caller's outer
+/// genesis/refresh finalize transaction. This function never commits.
+pub async fn replace_refresh_dependencies(
+    tx: &libsql::Transaction,
+    space: &str,
+    page_id: &str,
+    page_version: i64,
+    dependencies: &[RefreshDependency<'_>],
+) -> Result<(), libsql::Error> {
+    tx.execute(
+        "DELETE FROM m6_refresh_dependencies WHERE space = ?1 AND page_id = ?2",
+        libsql::params![space, page_id],
+    )
+    .await?;
+    for dependency in dependencies {
+        tx.execute(
+            "INSERT INTO m6_refresh_dependencies (
+                 space, page_id, page_version, claim_revision_id, root_id
+             ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            libsql::params![
+                space,
+                page_id,
+                page_version,
+                dependency.claim_revision_id,
+                dependency.root_id,
+            ],
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// PR-D precondition 5. The anti-join deliberately treats both a missing root
+/// and any non-active root as incompatible.
+pub async fn space_refresh_dependencies_ready(
+    tx: &libsql::Transaction,
+    space: &str,
+) -> Result<bool, libsql::Error> {
+    let mut rows = tx
+        .query(
+            "SELECT NOT EXISTS (
+                 SELECT 1
+                   FROM m6_refresh_dependencies d
+                   LEFT JOIN provenance_roots r ON r.root_id = d.root_id
+                  WHERE d.space = ?1
+                    AND (r.root_id IS NULL OR r.status <> 'active')
+             )",
+            libsql::params![space],
+        )
+        .await?;
+    let row = rows
+        .next()
+        .await?
+        .ok_or(libsql::Error::QueryReturnedNoRows)?;
+    Ok(row.get::<i64>(0)? != 0)
+}
+
+/// Durable readiness identity. The database CHECK is the final authority over
+/// legal stage/signal combinations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReadinessKey<'a> {
+    pub space: &'a str,
+    pub stage: &'a str,
+    pub signal: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReadinessPhase {
+    Off,
+    Preparing,
+    Committed,
+}
+
+impl ReadinessPhase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Preparing => "preparing",
+            Self::Committed => "committed",
+        }
+    }
+
+    fn parse(value: &str) -> Result<Self, libsql::Error> {
+        match value {
+            "off" => Ok(Self::Off),
+            "preparing" => Ok(Self::Preparing),
+            "committed" => Ok(Self::Committed),
+            other => Err(libsql::Error::Misuse(format!(
+                "unreadable M6 readiness phase: {other}"
+            ))),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReadinessFence {
+    pub epoch: i64,
+    pub phase: ReadinessPhase,
+}
+
+/// Create the initial `(epoch=0, phase=off)` fence. Returns false when the key
+/// already exists, including D/`-` duplicate initialization.
+pub async fn initialize_readiness(
+    tx: &libsql::Transaction,
+    key: ReadinessKey<'_>,
+    now: i64,
+) -> Result<bool, libsql::Error> {
+    Ok(tx
+        .execute(
+            "INSERT OR IGNORE INTO m6_readiness (
+                 space, stage, signal, epoch, phase, operation_state, updated_at
+             ) VALUES (?1, ?2, ?3, 0, 'off', 'active', ?4)",
+            libsql::params![key.space, key.stage, key.signal, now],
+        )
+        .await?
+        == 1)
+}
+
+/// Read and parse the durable fence. An unparseable row is an error, never an
+/// inert/default-permitting value.
+pub async fn readiness_fence(
+    tx: &libsql::Transaction,
+    key: ReadinessKey<'_>,
+) -> Result<Option<ReadinessFence>, libsql::Error> {
+    let mut rows = tx
+        .query(
+            "SELECT epoch, phase FROM m6_readiness
+              WHERE space = ?1 AND stage = ?2 AND signal = ?3",
+            libsql::params![key.space, key.stage, key.signal],
+        )
+        .await?;
+    let Some(row) = rows.next().await? else {
+        return Ok(None);
+    };
+    Ok(Some(ReadinessFence {
+        epoch: row.get(0)?,
+        phase: ReadinessPhase::parse(&row.get::<String>(1)?)?,
+    }))
+}
+
+fn transition_is_legal(from: ReadinessPhase, to: ReadinessPhase) -> bool {
+    matches!(
+        (from, to),
+        (ReadinessPhase::Off, ReadinessPhase::Preparing)
+            | (ReadinessPhase::Preparing, ReadinessPhase::Off)
+            | (ReadinessPhase::Preparing, ReadinessPhase::Committed)
+    )
+}
+
+/// Compare-and-transition the independent epoch/phase fence. Every successful
+/// transition increments the epoch, including a preparing->off abort.
+pub async fn transition_readiness(
+    tx: &libsql::Transaction,
+    key: ReadinessKey<'_>,
+    expected: ReadinessFence,
+    next_phase: ReadinessPhase,
+    now: i64,
+) -> Result<Option<ReadinessFence>, libsql::Error> {
+    if !transition_is_legal(expected.phase, next_phase) {
+        return Err(libsql::Error::Misuse(format!(
+            "illegal M6 readiness transition: {} -> {}",
+            expected.phase.as_str(),
+            next_phase.as_str()
+        )));
+    }
+    let next_epoch = expected
+        .epoch
+        .checked_add(1)
+        .ok_or_else(|| libsql::Error::Misuse("M6 readiness epoch overflow".to_string()))?;
+    let changed = tx
+        .execute(
+            "UPDATE m6_readiness
+                SET epoch = ?4, phase = ?5, updated_at = ?6
+              WHERE space = ?1 AND stage = ?2 AND signal = ?3
+                AND epoch = ?7 AND phase = ?8",
+            libsql::params![
+                key.space,
+                key.stage,
+                key.signal,
+                next_epoch,
+                next_phase.as_str(),
+                now,
+                expected.epoch,
+                expected.phase.as_str(),
+            ],
+        )
+        .await?;
+    Ok((changed == 1).then_some(ReadinessFence {
+        epoch: next_epoch,
+        phase: next_phase,
+    }))
+}
+
+/// The three-component soak proof plus its ratified activity minimum.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SoakEvidence {
+    pub window_started_at: i64,
+    pub window_ended_at: i64,
+    pub observed_turns: i64,
+    pub daemon_starts: i64,
+    pub old_writer_mutations: i64,
+    pub work_bound_violations: i64,
+    pub support_regressions: i64,
+    pub recorded_at: i64,
+}
+
+/// Record a passing soak as separate durable evidence. Weak evidence is
+/// rejected before the insert and again by the table CHECKs.
+pub async fn record_soak_receipt(
+    tx: &libsql::Transaction,
+    key: ReadinessKey<'_>,
+    readiness_epoch: i64,
+    evidence: &SoakEvidence,
+) -> Result<(), libsql::Error> {
+    let duration = evidence
+        .window_ended_at
+        .checked_sub(evidence.window_started_at)
+        .ok_or_else(|| libsql::Error::Misuse("M6 soak window overflow".to_string()))?;
+    if duration < 259_200
+        || evidence.observed_turns < 20
+        || evidence.daemon_starts < 1
+        || evidence.old_writer_mutations != 0
+        || evidence.work_bound_violations != 0
+        || evidence.support_regressions != 0
+    {
+        return Err(libsql::Error::Misuse(
+            "M6 soak evidence does not satisfy the passing contract".to_string(),
+        ));
+    }
+    tx.execute(
+        "INSERT INTO m6_readiness_soak_receipts (
+             space, stage, signal, readiness_epoch,
+             window_started_at, window_ended_at, observed_turns, daemon_starts,
+             old_writer_mutations, work_bound_violations, support_regressions,
+             recorded_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+        libsql::params![
+            key.space,
+            key.stage,
+            key.signal,
+            readiness_epoch,
+            evidence.window_started_at,
+            evidence.window_ended_at,
+            evidence.observed_turns,
+            evidence.daemon_starts,
+            evidence.old_writer_mutations,
+            evidence.work_bound_violations,
+            evidence.support_regressions,
+            evidence.recorded_at,
+        ],
+    )
+    .await?;
+    Ok(())
+}

--- a/crates/wenlan-core/src/m6/refresh_readiness_test.rs
+++ b/crates/wenlan-core/src/m6/refresh_readiness_test.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Amendment controls for M6 D4, D7, and D8.
+
+use super::refresh_readiness::{
+    acquire_refresh_lease, ensure_refresh_readiness_tables, initialize_readiness, readiness_fence,
+    record_soak_receipt, replace_refresh_dependencies, space_refresh_dependencies_ready,
+    transition_readiness, ReadinessFence, ReadinessKey, ReadinessPhase, RefreshDependency,
+    RefreshLeaseRequest, SoakEvidence,
+};
+
+async fn connection() -> libsql::Connection {
+    let database = libsql::Builder::new_local(":memory:")
+        .build()
+        .await
+        .expect("build test database");
+    let connection = database.connect().expect("connect test database");
+    connection
+        .execute("PRAGMA foreign_keys=ON", ())
+        .await
+        .expect("enable production foreign-key behavior");
+    connection
+}
+
+async fn install(conn: &libsql::Connection) {
+    let tx = conn.transaction().await.expect("begin install");
+    ensure_refresh_readiness_tables(&tx)
+        .await
+        .expect("install D4/D7/D8 substrate");
+    tx.commit().await.expect("commit install");
+}
+
+async fn scalar_i64(conn: &libsql::Connection, sql: &str) -> i64 {
+    let mut rows = conn.query(sql, ()).await.expect("scalar query");
+    rows.next()
+        .await
+        .expect("read scalar row")
+        .expect("scalar row exists")
+        .get(0)
+        .expect("scalar is integer")
+}
+
+async fn index_sql(conn: &libsql::Connection, name: &str) -> String {
+    let mut rows = conn
+        .query(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?1",
+            libsql::params![name],
+        )
+        .await
+        .expect("query index");
+    rows.next()
+        .await
+        .expect("read index row")
+        .expect("index exists")
+        .get(0)
+        .expect("index SQL is text")
+}
+
+fn lease<'a>(page_id: &'a str, token: &'a str) -> RefreshLeaseRequest<'a> {
+    RefreshLeaseRequest {
+        page_id,
+        base_page_version: 7,
+        base_source_revision: 11,
+        space: "space-a",
+        dependency_generation: 23,
+        active_root_digest: "roots-v23",
+        lease_token: token,
+        lease_expires_at: 1_000,
+        readiness_epoch: 5,
+        schema_version: 109,
+        reason: "source_updated",
+        now: 100,
+    }
+}
+
+#[tokio::test]
+async fn d4_rowless_queue_acquires_exactly_one_durable_lease_before_work() {
+    let conn = connection().await;
+    install(&conn).await;
+
+    let first = {
+        let tx = conn.transaction().await.expect("first sweep transaction");
+        let acquired = acquire_refresh_lease(&tx, &lease("page-a", "lease-1"))
+            .await
+            .expect("first lease attempt");
+        tx.commit().await.expect("commit first lease");
+        acquired
+    };
+    let second = {
+        let tx = conn.transaction().await.expect("second sweep transaction");
+        let acquired = acquire_refresh_lease(&tx, &lease("page-a", "lease-2"))
+            .await
+            .expect("second lease attempt");
+        tx.commit().await.expect("commit second lease");
+        acquired
+    };
+
+    assert!(first, "the first stale-page sweep must own the model call");
+    assert!(
+        !second,
+        "a sweep that selected the same page/version must not own a second model call/card"
+    );
+    let model_calls = [first, second].into_iter().filter(|owned| *owned).count();
+    let cards_opened = model_calls;
+    assert_eq!(model_calls, 1, "only the lease owner may call the model");
+    assert_eq!(cards_opened, 1, "only the lease owner may open a card");
+    assert_eq!(
+        scalar_i64(&conn, "SELECT count(*) FROM genesis_refresh_jobs").await,
+        1
+    );
+
+    let mut rows = conn
+        .query(
+            "SELECT state, base_source_revision, dependency_generation,
+                    active_root_digest, space, readiness_epoch, schema_version, reason
+               FROM genesis_refresh_jobs",
+            (),
+        )
+        .await
+        .expect("read leased job");
+    let row = rows
+        .next()
+        .await
+        .expect("read leased row")
+        .expect("leased row exists");
+    assert_eq!(row.get::<String>(0).unwrap(), "leased");
+    assert_eq!(row.get::<i64>(1).unwrap(), 11);
+    assert_eq!(row.get::<i64>(2).unwrap(), 23);
+    assert_eq!(row.get::<String>(3).unwrap(), "roots-v23");
+    assert_eq!(row.get::<String>(4).unwrap(), "space-a");
+    assert_eq!(row.get::<i64>(5).unwrap(), 5);
+    assert_eq!(row.get::<i64>(6).unwrap(), 109);
+    assert_eq!(row.get::<String>(7).unwrap(), "source_updated");
+
+    conn.execute(
+        "UPDATE genesis_refresh_jobs
+            SET state = 'retry', lease_token = NULL, lease_expires_at = NULL,
+                next_attempt_at = 50
+          WHERE page_id = 'page-a' AND base_page_version = 7",
+        (),
+    )
+    .await
+    .expect("make the durable job a due retry");
+    let tx = conn.transaction().await.expect("retry claim transaction");
+    assert!(
+        acquire_refresh_lease(&tx, &lease("page-a", "lease-3"))
+            .await
+            .expect("claim due retry"),
+        "the same durable retry row must be claimable without inserting a second job"
+    );
+    tx.commit().await.unwrap();
+    assert_eq!(
+        scalar_i64(&conn, "SELECT count(*) FROM genesis_refresh_jobs").await,
+        1
+    );
+}
+
+#[tokio::test]
+async fn d4_unique_predicate_names_only_durable_active_states() {
+    let conn = connection().await;
+    install(&conn).await;
+
+    let sql = index_sql(&conn, "idx_genesis_refresh_jobs_active")
+        .await
+        .to_lowercase();
+    assert!(
+        sql.contains("unique"),
+        "coalescing index must be UNIQUE: {sql}"
+    );
+    assert!(
+        sql.contains("state in ('leased','retry')"),
+        "coalescing predicate must be exactly leased/retry: {sql}"
+    );
+    assert!(
+        !sql.contains("queued"),
+        "queued must remain row-less: {sql}"
+    );
+    assert!(
+        !sql.contains("generated"),
+        "generated must remain in memory while the row stays leased: {sql}"
+    );
+
+    let queued = conn
+        .execute(
+            "INSERT INTO genesis_refresh_jobs (
+                 job_id, page_id, base_page_version, base_source_revision, space,
+                 dependency_generation, active_root_digest, state, lease_token,
+                 lease_expires_at, attempt, readiness_epoch, schema_version, reason,
+                 created_at, updated_at
+             ) VALUES (999, 'page-b', 1, 1, 'space-a', 1, 'digest', 'queued',
+                       'lease', 10, 0, 1, 109, 'source_updated', 1, 1)",
+            (),
+        )
+        .await;
+    assert!(queued.is_err(), "queued must not be a durable job state");
+}
+
+async fn install_provenance_roots(conn: &libsql::Connection) {
+    conn.execute_batch(
+        "CREATE TABLE provenance_roots (
+             root_id TEXT PRIMARY KEY,
+             status TEXT NOT NULL CHECK(status IN ('active','failed'))
+         );
+         CREATE TABLE finalized_pages (
+             page_id TEXT PRIMARY KEY,
+             page_version INTEGER NOT NULL
+         );",
+    )
+    .await
+    .expect("install test-owned existing substrate");
+}
+
+#[tokio::test]
+async fn d7_root_retraction_and_disappearance_both_block_readiness() {
+    let conn = connection().await;
+    install_provenance_roots(&conn).await;
+    install(&conn).await;
+    conn.execute(
+        "INSERT INTO provenance_roots(root_id, status) VALUES ('root-a', 'active')",
+        (),
+    )
+    .await
+    .unwrap();
+
+    {
+        let tx = conn.transaction().await.unwrap();
+        replace_refresh_dependencies(
+            &tx,
+            "space-a",
+            "page-a",
+            1,
+            &[RefreshDependency {
+                claim_revision_id: "claim-a-v1",
+                root_id: "root-a",
+            }],
+        )
+        .await
+        .unwrap();
+        assert!(space_refresh_dependencies_ready(&tx, "space-a")
+            .await
+            .unwrap());
+        tx.commit().await.unwrap();
+    }
+
+    conn.execute(
+        "UPDATE provenance_roots SET status = 'failed' WHERE root_id = 'root-a'",
+        (),
+    )
+    .await
+    .unwrap();
+    {
+        let tx = conn.transaction().await.unwrap();
+        assert!(
+            !space_refresh_dependencies_ready(&tx, "space-a")
+                .await
+                .unwrap(),
+            "a non-active root must fail precondition 5"
+        );
+        tx.commit().await.unwrap();
+    }
+
+    conn.execute("DELETE FROM provenance_roots WHERE root_id = 'root-a'", ())
+        .await
+        .unwrap();
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT count(*) FROM m6_refresh_dependencies WHERE root_id = 'root-a'"
+        )
+        .await,
+        1,
+        "root identity must remain after the live provenance row disappears"
+    );
+    {
+        let tx = conn.transaction().await.unwrap();
+        assert!(
+            !space_refresh_dependencies_ready(&tx, "space-a")
+                .await
+                .unwrap(),
+            "a missing root must fail the anti-join"
+        );
+        tx.commit().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn d7_dependency_snapshot_commits_with_the_callers_outer_finalize_transaction() {
+    let conn = connection().await;
+    install_provenance_roots(&conn).await;
+    install(&conn).await;
+    conn.execute_batch(
+        "INSERT INTO provenance_roots(root_id, status) VALUES ('root-old', 'active');
+         INSERT INTO provenance_roots(root_id, status) VALUES ('root-new', 'active');
+         INSERT INTO finalized_pages(page_id, page_version) VALUES ('page-a', 1);",
+    )
+    .await
+    .unwrap();
+    {
+        let tx = conn.transaction().await.unwrap();
+        replace_refresh_dependencies(
+            &tx,
+            "space-a",
+            "page-a",
+            1,
+            &[RefreshDependency {
+                claim_revision_id: "claim-old",
+                root_id: "root-old",
+            }],
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    {
+        let tx = conn.transaction().await.unwrap();
+        tx.execute(
+            "UPDATE finalized_pages SET page_version = 2 WHERE page_id = 'page-a'",
+            (),
+        )
+        .await
+        .unwrap();
+        replace_refresh_dependencies(
+            &tx,
+            "space-a",
+            "page-a",
+            2,
+            &[RefreshDependency {
+                claim_revision_id: "claim-new",
+                root_id: "root-new",
+            }],
+        )
+        .await
+        .unwrap();
+        tx.rollback().await.unwrap();
+    }
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT page_version FROM finalized_pages WHERE page_id = 'page-a'"
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT page_version FROM m6_refresh_dependencies WHERE page_id = 'page-a'"
+        )
+        .await,
+        1,
+        "dependency replacement must roll back with the page finalize"
+    );
+
+    {
+        let tx = conn.transaction().await.unwrap();
+        tx.execute(
+            "UPDATE finalized_pages SET page_version = 2 WHERE page_id = 'page-a'",
+            (),
+        )
+        .await
+        .unwrap();
+        replace_refresh_dependencies(
+            &tx,
+            "space-a",
+            "page-a",
+            2,
+            &[RefreshDependency {
+                claim_revision_id: "claim-new",
+                root_id: "root-new",
+            }],
+        )
+        .await
+        .unwrap();
+        tx.commit().await.unwrap();
+    }
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT page_version FROM m6_refresh_dependencies WHERE page_id = 'page-a'"
+        )
+        .await,
+        2
+    );
+    assert_eq!(
+        scalar_i64(
+            &conn,
+            "SELECT count(*) FROM m6_refresh_dependencies WHERE page_id = 'page-a'"
+        )
+        .await,
+        1,
+        "the current dependency snapshot must replace the incompatible one"
+    );
+}
+
+fn key<'a>(stage: &'a str, signal: &'a str) -> ReadinessKey<'a> {
+    ReadinessKey {
+        space: "space-a",
+        stage,
+        signal,
+    }
+}
+
+#[tokio::test]
+async fn d8_stage_signal_domain_is_structural_and_e_signals_are_independent() {
+    let conn = connection().await;
+    install(&conn).await;
+
+    let tx = conn.transaction().await.unwrap();
+    initialize_readiness(&tx, key("D", "-"), 10).await.unwrap();
+    let duplicate_d = initialize_readiness(&tx, key("D", "-"), 11).await.unwrap();
+    assert!(!duplicate_d, "a duplicate D/'-' row must be rejected");
+
+    for signal in [
+        "evidence-cluster",
+        "orphan-wikilink",
+        "community-overview",
+        "space-overview",
+    ] {
+        assert!(initialize_readiness(&tx, key("E", signal), 10)
+            .await
+            .unwrap());
+    }
+    tx.commit().await.unwrap();
+    assert_eq!(
+        scalar_i64(&conn, "SELECT count(*) FROM m6_readiness WHERE stage = 'E'").await,
+        4
+    );
+
+    let invalid = conn
+        .execute(
+            "INSERT INTO m6_readiness (
+                 space, stage, signal, epoch, phase, operation_state, updated_at
+             ) VALUES ('space-a', 'D_preparing', '-', 0, 'off', 'active', 1)",
+            (),
+        )
+        .await;
+    assert!(
+        invalid.is_err(),
+        "a composite presentation label must not enter the stage column"
+    );
+}
+
+#[tokio::test]
+async fn d8_phase_transitions_bump_epoch_and_close_aba() {
+    let conn = connection().await;
+    install(&conn).await;
+    let readiness_key = key("D", "-");
+
+    let tx = conn.transaction().await.unwrap();
+    initialize_readiness(&tx, readiness_key, 1).await.unwrap();
+    let initial = ReadinessFence {
+        epoch: 0,
+        phase: ReadinessPhase::Off,
+    };
+    let preparing = transition_readiness(&tx, readiness_key, initial, ReadinessPhase::Preparing, 2)
+        .await
+        .unwrap()
+        .expect("off -> preparing");
+    assert_eq!(preparing.epoch, 1);
+    let aborted = transition_readiness(&tx, readiness_key, preparing, ReadinessPhase::Off, 3)
+        .await
+        .unwrap()
+        .expect("preparing -> off abort");
+    assert_eq!(aborted.epoch, 2);
+    assert_eq!(aborted.phase, ReadinessPhase::Off);
+
+    let stale_aba = transition_readiness(&tx, readiness_key, initial, ReadinessPhase::Preparing, 4)
+        .await
+        .unwrap();
+    assert!(
+        stale_aba.is_none(),
+        "the first off fence must not match the later off fence"
+    );
+    assert_eq!(
+        readiness_fence(&tx, readiness_key).await.unwrap(),
+        Some(aborted)
+    );
+    tx.commit().await.unwrap();
+}
+
+#[tokio::test]
+async fn d8_soak_evidence_is_separate_from_stage_phase_and_operation_state() {
+    let conn = connection().await;
+    install(&conn).await;
+    let readiness_key = key("D", "-");
+    let tx = conn.transaction().await.unwrap();
+    initialize_readiness(&tx, readiness_key, 1).await.unwrap();
+
+    let ghost_epoch = record_soak_receipt(
+        &tx,
+        readiness_key,
+        99,
+        &SoakEvidence {
+            window_started_at: 0,
+            window_ended_at: 259_200,
+            observed_turns: 20,
+            daemon_starts: 1,
+            old_writer_mutations: 0,
+            work_bound_violations: 0,
+            support_regressions: 0,
+            recorded_at: 259_200,
+        },
+    )
+    .await;
+    assert!(
+        ghost_epoch.is_err(),
+        "soak evidence must bind to the current epoch/phase fence"
+    );
+
+    let weak = record_soak_receipt(
+        &tx,
+        readiness_key,
+        0,
+        &SoakEvidence {
+            window_started_at: 0,
+            window_ended_at: 259_200,
+            observed_turns: 19,
+            daemon_starts: 1,
+            old_writer_mutations: 0,
+            work_bound_violations: 0,
+            support_regressions: 0,
+            recorded_at: 259_200,
+        },
+    )
+    .await;
+    assert!(
+        weak.is_err(),
+        "a weak soak must not be recordable as passed"
+    );
+
+    record_soak_receipt(
+        &tx,
+        readiness_key,
+        0,
+        &SoakEvidence {
+            window_started_at: 0,
+            window_ended_at: 259_200,
+            observed_turns: 20,
+            daemon_starts: 1,
+            old_writer_mutations: 0,
+            work_bound_violations: 0,
+            support_regressions: 0,
+            recorded_at: 259_200,
+        },
+    )
+    .await
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    assert_eq!(
+        scalar_i64(&conn, "SELECT count(*) FROM m6_readiness_soak_receipts").await,
+        1
+    );
+    conn.execute(
+        "UPDATE m6_readiness SET operation_state = 'disabled',
+                                  operation_reason = 'gate_failed'
+          WHERE space = 'space-a' AND stage = 'D' AND signal = '-'",
+        (),
+    )
+    .await
+    .expect("disable is a separate operational state");
+    conn.execute(
+        "UPDATE m6_readiness SET operation_state = 'forward_fix'
+          WHERE space = 'space-a' AND stage = 'D' AND signal = '-'
+            AND operation_state = 'disabled'",
+        (),
+    )
+    .await
+    .expect("forward-fix follows disabled without rewriting the fence");
+    let mut state_rows = conn
+        .query(
+            "SELECT stage, phase, epoch, operation_state FROM m6_readiness
+              WHERE space = 'space-a' AND stage = 'D' AND signal = '-'",
+            (),
+        )
+        .await
+        .unwrap();
+    let state = state_rows.next().await.unwrap().unwrap();
+    assert_eq!(state.get::<String>(0).unwrap(), "D");
+    assert_eq!(state.get::<String>(1).unwrap(), "off");
+    assert_eq!(state.get::<i64>(2).unwrap(), 0);
+    assert_eq!(state.get::<String>(3).unwrap(), "forward_fix");
+
+    let stage_soaked = conn
+        .execute(
+            "UPDATE m6_readiness SET stage = 'D_soaked' WHERE space = 'space-a'",
+            (),
+        )
+        .await;
+    assert!(
+        stage_soaked.is_err(),
+        "soak must not be smuggled into stage"
+    );
+    let phase_disabled = conn
+        .execute(
+            "UPDATE m6_readiness SET phase = 'disabled' WHERE space = 'space-a'",
+            (),
+        )
+        .await;
+    assert!(
+        phase_disabled.is_err(),
+        "disabled/forward-fix belong to operation_state, not phase"
+    );
+}

--- a/crates/wenlan-core/src/m6/relevance.rs
+++ b/crates/wenlan-core/src/m6/relevance.rs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+//! M6 relevance substrate (D1 and D6).
+//!
+//! The tables are additive and inert until a later rung wires producers and
+//! readers. This module nevertheless owns the invariants those later writers
+//! must not be able to weaken: the raw currently-eligible co-supporting group
+//! count, deterministic pair-stat normalization, bounded adjacency slots, and
+//! neighbor uniqueness within an endpoint kind.
+
+use crate::m6::digest::m6_digest_owned;
+use crate::WenlanError;
+
+/// D1's undecayed, unsmoothed distinct-group floor (S0-88).
+pub const QUALIFIED_CO_CITATION_GROUP_FLOOR: i64 = 3;
+
+/// S0-91's frozen normalized-snapshot domain.
+pub const PAIR_STATS_DIGEST_DOMAIN: &str = "m6-pairstats-v1";
+
+/// D9's hard caps for query (c).
+pub const MAX_CANDIDATE_ENDPOINTS: usize = 32;
+pub const MAX_NEIGHBORS_PER_ENDPOINT: usize = 64;
+
+/// Install the D1/D6 relevance tables and their fixed indexes.
+///
+/// This is deliberately a transaction-scoped entrypoint: migration 109's
+/// root-owned orchestrator composes it with the other approved D1-D8 homes and
+/// advances `user_version` only after the whole additive schema commits.
+pub async fn ensure_relevance_tables(tx: &libsql::Transaction) -> Result<(), WenlanError> {
+    tx.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS m6_pair_stats (
+            space                 TEXT    NOT NULL,
+            page_a                TEXT    NOT NULL,
+            page_b                TEXT    NOT NULL,
+            n11                   REAL    NOT NULL CHECK (n11 >= 0),
+            n10                   REAL    NOT NULL CHECK (n10 >= 0),
+            n01                   REAL    NOT NULL CHECK (n01 >= 0),
+            n00                   REAL    NOT NULL CHECK (n00 >= 0),
+            distinct_group_count  INTEGER NOT NULL CHECK (distinct_group_count >= 0),
+            updated_generation    INTEGER NOT NULL CHECK (updated_generation >= 0),
+            PRIMARY KEY(space, page_a, page_b),
+            CHECK (page_a < page_b)
+        );
+        CREATE INDEX IF NOT EXISTS idx_m6_pair_stats_space_page_a_generation
+            ON m6_pair_stats(space, page_a, updated_generation);
+
+        CREATE TABLE IF NOT EXISTS m6_adjacency (
+            space          TEXT    NOT NULL,
+            endpoint_kind  TEXT    NOT NULL,
+            endpoint_id    TEXT    NOT NULL,
+            neighbor_id    TEXT    NOT NULL,
+            rank            INTEGER NOT NULL CHECK (rank BETWEEN 1 AND 64),
+            PRIMARY KEY(space, endpoint_kind, endpoint_id, rank),
+            UNIQUE(space, endpoint_kind, endpoint_id, neighbor_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_m6_adjacency_space_neighbor
+            ON m6_adjacency(space, neighbor_id);
+        ",
+    )
+    .await
+    .map_err(|error| WenlanError::VectorDb(format!("m109 relevance tables: {error}")))?;
+    Ok(())
+}
+
+/// The four decayed estimator cells plus D1's raw co-support count.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PairStatsValues {
+    pub n11: f64,
+    pub n10: f64,
+    pub n01: f64,
+    pub n00: f64,
+    /// Currently eligible distinct groups in `n11`; never a historical count.
+    pub distinct_group_count: i64,
+}
+
+/// One normalized pair-stat row at a fixed relevance generation.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PairStatsSnapshotRow<'a> {
+    pub page_a: &'a str,
+    pub page_b: &'a str,
+    pub values: PairStatsValues,
+}
+
+/// Which estimator cell a group currently contributes to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairCell {
+    Both,
+    LeftOnly,
+    RightOnly,
+    Neither,
+}
+
+/// A group-level eligibility transition after all roots in the group collapse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EligibilityChange {
+    Retracted,
+    Reactivated,
+}
+
+/// Derive D1's floor at read time from the raw count.
+pub fn qualified_co_citation(values: &PairStatsValues) -> bool {
+    values.distinct_group_count >= QUALIFIED_CO_CITATION_GROUP_FLOOR
+}
+
+/// Apply one collapsed group's eligibility transition to an in-memory row.
+///
+/// Callers must invoke this only when a group as a whole becomes ineligible or
+/// eligible, not for each root: several roots in one independence group still
+/// count once. Retraction and reactivation update the decayed cell and the raw
+/// count together; only an `n11` group participates in D1's co-support floor.
+pub fn apply_group_eligibility_change(
+    values: &mut PairStatsValues,
+    cell: PairCell,
+    decayed_contribution: f64,
+    change: EligibilityChange,
+) -> Result<(), &'static str> {
+    if !decayed_contribution.is_finite() || decayed_contribution < 0.0 {
+        return Err("decayed contribution must be finite and non-negative");
+    }
+
+    let target = match cell {
+        PairCell::Both => &mut values.n11,
+        PairCell::LeftOnly => &mut values.n10,
+        PairCell::RightOnly => &mut values.n01,
+        PairCell::Neither => &mut values.n00,
+    };
+
+    match change {
+        EligibilityChange::Retracted => {
+            if *target < decayed_contribution {
+                return Err("retraction would make a decayed cell negative");
+            }
+            if cell == PairCell::Both && values.distinct_group_count == 0 {
+                return Err("retraction would make the distinct-group count negative");
+            }
+            *target -= decayed_contribution;
+            if cell == PairCell::Both {
+                values.distinct_group_count -= 1;
+            }
+        }
+        EligibilityChange::Reactivated => {
+            if cell == PairCell::Both && values.distinct_group_count == i64::MAX {
+                return Err("reactivation would overflow the distinct-group count");
+            }
+            let reactivated = *target + decayed_contribution;
+            if !reactivated.is_finite() {
+                return Err("reactivation would make a decayed cell non-finite");
+            }
+            *target = reactivated;
+            if cell == PairCell::Both {
+                values.distinct_group_count += 1;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Digest S0-91's normalized pair table, including D1's raw count.
+///
+/// Rows are encoded as length-framed tuples, byte-sorted, deduplicated as the
+/// frozen `sorted_set` construction requires, then hashed under
+/// `m6-pairstats-v1`. Decayed cells are rounded to exactly nine decimal places
+/// before encoding (S0-92). `updated_generation` is absent because the caller
+/// snapshots at one fixed generation.
+pub fn normalized_pair_stats_digest(
+    rows: &[PairStatsSnapshotRow<'_>],
+) -> Result<String, &'static str> {
+    let mut encoded_rows = Vec::with_capacity(rows.len());
+    for row in rows {
+        validate_snapshot_row(row)?;
+        let fields = [
+            row.page_a.as_bytes().to_vec(),
+            row.page_b.as_bytes().to_vec(),
+            rounded_cell_part(row.values.n11),
+            rounded_cell_part(row.values.n10),
+            rounded_cell_part(row.values.n01),
+            rounded_cell_part(row.values.n00),
+            row.values.distinct_group_count.to_string().into_bytes(),
+        ];
+        encoded_rows.push(length_frame_tuple(&fields));
+    }
+    encoded_rows.sort_unstable();
+    encoded_rows.dedup();
+
+    let mut parts = Vec::with_capacity(encoded_rows.len() + 1);
+    parts.push(encoded_rows.len().to_string().into_bytes());
+    parts.extend(encoded_rows);
+    Ok(m6_digest_owned(PAIR_STATS_DIGEST_DOMAIN, &parts))
+}
+
+fn validate_snapshot_row(row: &PairStatsSnapshotRow<'_>) -> Result<(), &'static str> {
+    if row.page_a >= row.page_b {
+        return Err("pair-stat rows require page_a < page_b");
+    }
+    if row.values.distinct_group_count < 0 {
+        return Err("distinct-group count must be non-negative");
+    }
+    for cell in [
+        row.values.n11,
+        row.values.n10,
+        row.values.n01,
+        row.values.n00,
+    ] {
+        if !cell.is_finite() || cell < 0.0 {
+            return Err("pair-stat cells must be finite and non-negative");
+        }
+    }
+    Ok(())
+}
+
+fn rounded_cell_part(value: f64) -> Vec<u8> {
+    // Fixed-precision formatting performs the specified 9-dp rounding without
+    // multiplying first (which could overflow for an otherwise finite value).
+    let normalized_zero = if value == 0.0 { 0.0 } else { value };
+    format!("{normalized_zero:.9}").into_bytes()
+}
+
+fn length_frame_tuple(fields: &[Vec<u8>]) -> Vec<u8> {
+    let mut encoded = Vec::new();
+    for field in fields {
+        encoded.extend_from_slice(&(field.len() as u64).to_le_bytes());
+        encoded.extend_from_slice(field);
+    }
+    encoded
+}
+
+/// Query (c): aggregate common neighbors for all candidate endpoints in one
+/// statement while keeping endpoint kinds isolated.
+///
+/// The `endpoint_kind` predicate and grouping key are both intentional. IDs
+/// can be shared across kinds; omitting either makes a page's count depend on
+/// entity adjacency with the same opaque ID.
+pub async fn common_neighbor_counts<C, N>(
+    connection: &libsql::Connection,
+    space: &str,
+    endpoint_kind: &str,
+    candidate_endpoint_ids: &[C],
+    source_neighbor_ids: &[N],
+) -> Result<Vec<(String, i64)>, WenlanError>
+where
+    C: AsRef<str>,
+    N: AsRef<str>,
+{
+    if candidate_endpoint_ids.len() > MAX_CANDIDATE_ENDPOINTS {
+        return Err(WenlanError::VectorDb(format!(
+            "M6 relevance query has {} candidates; cap is {MAX_CANDIDATE_ENDPOINTS}",
+            candidate_endpoint_ids.len()
+        )));
+    }
+    if source_neighbor_ids.len() > MAX_NEIGHBORS_PER_ENDPOINT {
+        return Err(WenlanError::VectorDb(format!(
+            "M6 relevance query has {} source neighbors; cap is {MAX_NEIGHBORS_PER_ENDPOINT}",
+            source_neighbor_ids.len()
+        )));
+    }
+    if candidate_endpoint_ids.is_empty() || source_neighbor_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let candidate_placeholders = positional_placeholders(3, candidate_endpoint_ids.len());
+    let neighbor_start = 3 + candidate_endpoint_ids.len();
+    let neighbor_placeholders = positional_placeholders(neighbor_start, source_neighbor_ids.len());
+    let sql = format!(
+        "SELECT endpoint_kind, endpoint_id, COUNT(*)
+           FROM m6_adjacency
+          WHERE space = ?1
+            AND endpoint_kind = ?2
+            AND endpoint_id IN ({candidate_placeholders})
+            AND neighbor_id IN ({neighbor_placeholders})
+          GROUP BY endpoint_kind, endpoint_id
+          ORDER BY endpoint_kind, endpoint_id"
+    );
+
+    let mut params =
+        Vec::with_capacity(2 + candidate_endpoint_ids.len() + source_neighbor_ids.len());
+    params.push(libsql::Value::Text(space.to_string()));
+    params.push(libsql::Value::Text(endpoint_kind.to_string()));
+    params.extend(
+        candidate_endpoint_ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.as_ref().to_string())),
+    );
+    params.extend(
+        source_neighbor_ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.as_ref().to_string())),
+    );
+
+    let mut rows = connection
+        .query(&sql, libsql::params_from_iter(params))
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("M6 query (c): {error}")))?;
+    let mut counts = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("M6 query (c) row: {error}")))?
+    {
+        let returned_kind = row
+            .get::<String>(0)
+            .map_err(|error| WenlanError::VectorDb(format!("M6 query (c) kind: {error}")))?;
+        if returned_kind != endpoint_kind {
+            return Err(WenlanError::VectorDb(format!(
+                "M6 query (c) returned endpoint kind {returned_kind:?} for {endpoint_kind:?}"
+            )));
+        }
+        let endpoint_id = row
+            .get::<String>(1)
+            .map_err(|error| WenlanError::VectorDb(format!("M6 query (c) endpoint: {error}")))?;
+        let count = row
+            .get::<i64>(2)
+            .map_err(|error| WenlanError::VectorDb(format!("M6 query (c) count: {error}")))?;
+        counts.push((endpoint_id, count));
+    }
+    Ok(counts)
+}
+
+fn positional_placeholders(start: usize, count: usize) -> String {
+    (start..start + count)
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/crates/wenlan-core/src/m6/relevance_test.rs
+++ b/crates/wenlan-core/src/m6/relevance_test.rs
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Amendment teeth for M6 relevance D1 and D6.
+//!
+//! These controls live under `src/` so the workspace library-test floor runs
+//! them; an arbitrary integration test would not be guaranteed in L3/L4.
+
+use super::relevance::{
+    apply_group_eligibility_change, common_neighbor_counts, ensure_relevance_tables,
+    normalized_pair_stats_digest, qualified_co_citation, EligibilityChange, PairCell,
+    PairStatsSnapshotRow, PairStatsValues,
+};
+
+async fn relevance_db() -> (libsql::Database, libsql::Connection) {
+    let database = libsql::Builder::new_local(":memory:")
+        .build()
+        .await
+        .expect("build in-memory relevance database");
+    let connection = database.connect().expect("connect relevance database");
+    let transaction = connection
+        .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+        .await
+        .expect("begin relevance schema transaction");
+    ensure_relevance_tables(&transaction)
+        .await
+        .expect("install relevance schema");
+    transaction.commit().await.expect("commit relevance schema");
+    (database, connection)
+}
+
+async fn table_columns(connection: &libsql::Connection, table: &str) -> Vec<(String, i64)> {
+    let mut rows = connection
+        .query(&format!("PRAGMA table_info({table})"), ())
+        .await
+        .expect("inspect table columns");
+    let mut columns = Vec::new();
+    while let Some(row) = rows.next().await.expect("read table column") {
+        columns.push((
+            row.get::<String>(1).expect("column name"),
+            row.get::<i64>(3).expect("not-null bit"),
+        ));
+    }
+    columns
+}
+
+#[tokio::test]
+async fn d1_schema_stores_the_raw_current_group_count_and_not_floor_cleared() {
+    let (_database, connection) = relevance_db().await;
+    let columns = table_columns(&connection, "m6_pair_stats").await;
+
+    assert!(
+        columns
+            .iter()
+            .any(|(name, not_null)| name == "distinct_group_count" && *not_null == 1),
+        "D1 requires a NOT NULL raw count of currently eligible distinct groups"
+    );
+    assert!(
+        !columns.iter().any(|(name, _)| name == "floor_cleared"),
+        "floor-cleared is derived at read time, never stored"
+    );
+}
+
+#[test]
+fn d1_three_unequal_weighted_groups_qualify_then_retract_and_reactivate() {
+    // Mutation control: a route that guesses the raw floor from decayed n11
+    // rejects these three groups because their unequal aged/weighted total is
+    // below 3. The raw count is the only field that can answer correctly.
+    let mut stats = PairStatsValues {
+        n11: 0.5 + 0.25 + 0.125,
+        n10: 0.0,
+        n01: 0.0,
+        n00: 0.0,
+        distinct_group_count: 3,
+    };
+    let mutant_uses_decayed_n11 = stats.n11 >= 3.0;
+    assert!(
+        !mutant_uses_decayed_n11,
+        "control failed: decayed n11 unexpectedly revealed the raw group count"
+    );
+    assert!(
+        qualified_co_citation(&stats),
+        "three currently eligible groups must clear the raw floor"
+    );
+
+    apply_group_eligibility_change(
+        &mut stats,
+        PairCell::Both,
+        0.25,
+        EligibilityChange::Retracted,
+    )
+    .expect("retract one currently eligible group");
+    assert_eq!(stats.distinct_group_count, 2);
+    assert_eq!(stats.n11, 0.625);
+    assert!(
+        !qualified_co_citation(&stats),
+        "retraction must immediately remove the group from floor eligibility"
+    );
+
+    apply_group_eligibility_change(
+        &mut stats,
+        PairCell::Both,
+        0.25,
+        EligibilityChange::Reactivated,
+    )
+    .expect("reactivate the same group");
+    assert_eq!(stats.distinct_group_count, 3);
+    assert_eq!(stats.n11, 0.875);
+    assert!(
+        qualified_co_citation(&stats),
+        "reactivation must restore the group to floor eligibility"
+    );
+}
+
+#[test]
+fn d1_normalized_digest_includes_distinct_group_count() {
+    let two_groups = [PairStatsSnapshotRow {
+        page_a: "page-a",
+        page_b: "page-b",
+        values: PairStatsValues {
+            n11: 0.875,
+            n10: 1.25,
+            n01: 2.5,
+            n00: 10.0,
+            distinct_group_count: 2,
+        },
+    }];
+    let three_groups = [PairStatsSnapshotRow {
+        values: PairStatsValues {
+            distinct_group_count: 3,
+            ..two_groups[0].values
+        },
+        ..two_groups[0]
+    }];
+
+    assert_ne!(
+        normalized_pair_stats_digest(&two_groups).expect("digest two-group snapshot"),
+        normalized_pair_stats_digest(&three_groups).expect("digest three-group snapshot"),
+        "removing the D1 raw count from normalization must be observable"
+    );
+}
+
+#[test]
+fn d1_only_current_both_groups_change_the_raw_floor_count() {
+    let mut stats = PairStatsValues {
+        n11: 1.0,
+        n10: 2.0,
+        n01: 3.0,
+        n00: 4.0,
+        distinct_group_count: 1,
+    };
+    for (cell, contribution) in [
+        (PairCell::LeftOnly, 0.5),
+        (PairCell::RightOnly, 0.25),
+        (PairCell::Neither, 0.125),
+    ] {
+        apply_group_eligibility_change(
+            &mut stats,
+            cell,
+            contribution,
+            EligibilityChange::Retracted,
+        )
+        .expect("retract non-co-supporting group");
+        apply_group_eligibility_change(
+            &mut stats,
+            cell,
+            contribution,
+            EligibilityChange::Reactivated,
+        )
+        .expect("reactivate non-co-supporting group");
+    }
+
+    assert_eq!(stats.distinct_group_count, 1);
+    assert_eq!(
+        (stats.n11, stats.n10, stats.n01, stats.n00),
+        (1.0, 2.0, 3.0, 4.0)
+    );
+}
+
+#[tokio::test]
+async fn d6_database_rejects_duplicate_neighbors_at_different_ranks() {
+    let (_database, connection) = relevance_db().await;
+    connection
+        .execute(
+            "INSERT INTO m6_adjacency
+                 (space, endpoint_kind, endpoint_id, neighbor_id, rank)
+             VALUES ('space-1', 'page', 'page-a', 'neighbor-1', 1)",
+            (),
+        )
+        .await
+        .expect("insert first adjacency slot");
+
+    let duplicate_neighbor = connection
+        .execute(
+            "INSERT INTO m6_adjacency
+                 (space, endpoint_kind, endpoint_id, neighbor_id, rank)
+             VALUES ('space-1', 'page', 'page-a', 'neighbor-1', 2)",
+            (),
+        )
+        .await;
+    assert!(
+        duplicate_neighbor.is_err(),
+        "D6 requires database-enforced neighbor uniqueness, not a producer convention"
+    );
+
+    let duplicate_rank = connection
+        .execute(
+            "INSERT INTO m6_adjacency
+                 (space, endpoint_kind, endpoint_id, neighbor_id, rank)
+             VALUES ('space-1', 'page', 'page-a', 'neighbor-2', 1)",
+            (),
+        )
+        .await;
+    assert!(
+        duplicate_rank.is_err(),
+        "D6 retains rank as the deterministic primary-key slot"
+    );
+
+    let out_of_bounds_rank = connection
+        .execute(
+            "INSERT INTO m6_adjacency
+                 (space, endpoint_kind, endpoint_id, neighbor_id, rank)
+             VALUES ('space-1', 'page', 'page-b', 'neighbor-3', 65)",
+            (),
+        )
+        .await;
+    assert!(
+        out_of_bounds_rank.is_err(),
+        "the retained rank slot must enforce the frozen top-64 bound"
+    );
+}
+
+#[tokio::test]
+async fn d6_query_c_filters_and_groups_the_intended_endpoint_kind() {
+    let (_database, connection) = relevance_db().await;
+    for (kind, endpoint, neighbor, rank) in [
+        ("page", "shared-id", "neighbor-page", 1_i64),
+        ("entity", "shared-id", "neighbor-entity", 1_i64),
+        ("page", "page-only", "neighbor-page", 1_i64),
+    ] {
+        connection
+            .execute(
+                "INSERT INTO m6_adjacency
+                     (space, endpoint_kind, endpoint_id, neighbor_id, rank)
+                 VALUES ('space-1', ?1, ?2, ?3, ?4)",
+                libsql::params![kind, endpoint, neighbor, rank],
+            )
+            .await
+            .expect("seed cross-kind adjacency");
+    }
+
+    let candidates = ["shared-id", "page-only"];
+    let source_neighbors = ["neighbor-page", "neighbor-entity"];
+    let page_counts = common_neighbor_counts(
+        &connection,
+        "space-1",
+        "page",
+        &candidates,
+        &source_neighbors,
+    )
+    .await
+    .expect("aggregate page common-neighbor counts");
+
+    assert_eq!(
+        page_counts,
+        vec![("page-only".to_string(), 1), ("shared-id".to_string(), 1)],
+        "the entity row sharing endpoint_id must not inflate the page count"
+    );
+
+    let entity_counts = common_neighbor_counts(
+        &connection,
+        "space-1",
+        "entity",
+        &["shared-id"],
+        &source_neighbors,
+    )
+    .await
+    .expect("aggregate entity common-neighbor counts");
+    assert_eq!(entity_counts, vec![("shared-id".to_string(), 1)]);
+}

--- a/crates/wenlan-core/src/m6/remaining_substrate.rs
+++ b/crates/wenlan-core/src/m6/remaining_substrate.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Uncontested migration-109 homes from the PR-A schema inventory.
+
+use crate::WenlanError;
+
+/// Install the additive J4-J7/J10 substrate in the caller's shared migration
+/// transaction.
+pub(crate) async fn ensure_remaining_substrate(
+    tx: &libsql::Transaction,
+) -> Result<(), WenlanError> {
+    if !table_has_column(tx, "genesis_coverage_state", "m6_mutation_count").await? {
+        tx.execute(
+            "ALTER TABLE genesis_coverage_state
+             ADD COLUMN m6_mutation_count INTEGER NOT NULL DEFAULT 0
+                 CHECK (m6_mutation_count >= 0)",
+            (),
+        )
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("m109 mutation counter: {error}")))?;
+    }
+    if !table_has_column(tx, "genesis_coverage_state", "space_id").await? {
+        tx.execute(
+            "ALTER TABLE genesis_coverage_state ADD COLUMN space_id TEXT",
+            (),
+        )
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("m109 stable space id: {error}")))?;
+    }
+    tx.execute(
+        "UPDATE genesis_coverage_state
+            SET space_id = (
+                SELECT spaces.id FROM spaces WHERE spaces.name = genesis_coverage_state.space
+            )
+          WHERE space_id IS NULL",
+        (),
+    )
+    .await
+    .map_err(|error| WenlanError::VectorDb(format!("m109 bind stable space ids: {error}")))?;
+    if !genesis_space_bindings_are_valid(tx).await? {
+        return Err(WenlanError::VectorDb(
+            "m109 genesis coverage row does not resolve to its stable space id".to_string(),
+        ));
+    }
+
+    tx.execute_batch(
+        "
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_genesis_coverage_state_space_id
+            ON genesis_coverage_state(space_id);
+
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_mutation_count_monotone
+        BEFORE UPDATE OF m6_mutation_count ON genesis_coverage_state
+        WHEN NEW.m6_mutation_count < OLD.m6_mutation_count
+        BEGIN
+            SELECT RAISE(ABORT, 'm6_mutation_count cannot decrease');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_mutation_count_identity_insert
+        BEFORE INSERT ON genesis_coverage_state
+        WHEN NEW.space IS NULL OR NEW.space_id IS NULL OR
+             NOT EXISTS (
+                 SELECT 1 FROM spaces
+                  WHERE id = NEW.space_id AND name = NEW.space
+             ) OR
+             EXISTS (
+                 SELECT 1 FROM genesis_coverage_state AS old
+                  WHERE old.space = NEW.space OR old.space_id = NEW.space_id
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'genesis mutation proof requires one live stable space identity');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_mutation_count_replace_monotone
+        BEFORE INSERT ON genesis_coverage_state
+        WHEN EXISTS (
+            SELECT 1 FROM genesis_coverage_state AS old
+             WHERE old.space = NEW.space
+               AND old.m6_mutation_count > NEW.m6_mutation_count
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'm6_mutation_count cannot decrease');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_mutation_count_identity_update
+        BEFORE UPDATE OF space, space_id ON genesis_coverage_state
+        WHEN NEW.space IS NULL OR NEW.space_id IS NULL OR
+             NEW.space_id <> OLD.space_id OR
+             NOT EXISTS (
+                 SELECT 1 FROM spaces
+                  WHERE id = OLD.space_id AND name = NEW.space
+             ) OR
+             EXISTS (
+                 SELECT 1 FROM genesis_coverage_state AS destination
+                  WHERE destination.space = NEW.space
+                    AND destination.space_id <> OLD.space_id
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'genesis mutation proof identity change is unauthorized');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_mutation_count_no_delete
+        BEFORE DELETE ON genesis_coverage_state
+        BEGIN
+            SELECT RAISE(ABORT, 'm6_mutation_count cannot be erased');
+        END;
+
+        CREATE TABLE IF NOT EXISTS m6_deploy_attestation (
+            attestation_id  TEXT    NOT NULL PRIMARY KEY
+                                      CHECK (length(trim(attestation_id)) > 0),
+            attested_at     INTEGER NOT NULL,
+            signature       TEXT    NOT NULL CHECK (length(trim(signature)) > 0),
+            binary_digest   TEXT    NOT NULL CHECK (length(trim(binary_digest)) > 0)
+        );
+
+        CREATE TABLE IF NOT EXISTS m6_genesis_provenance (
+            page_id         TEXT    NOT NULL PRIMARY KEY,
+            content_digest  TEXT    NOT NULL CHECK (length(trim(content_digest)) > 0),
+            page_version    INTEGER NOT NULL CHECK (page_version >= 0),
+            minted_at       INTEGER NOT NULL
+        );
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_provenance_no_replace
+        BEFORE INSERT ON m6_genesis_provenance
+        WHEN EXISTS (
+            SELECT 1 FROM m6_genesis_provenance AS old
+             WHERE old.page_id = NEW.page_id
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'genesis provenance cannot be replaced');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_provenance_no_update
+        BEFORE UPDATE ON m6_genesis_provenance
+        BEGIN
+            SELECT RAISE(ABORT, 'genesis provenance cannot be updated');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_genesis_provenance_no_delete
+        BEFORE DELETE ON m6_genesis_provenance
+        BEGIN
+            SELECT RAISE(ABORT, 'genesis provenance cannot be deleted');
+        END;
+
+        CREATE TABLE IF NOT EXISTS page_projection_outbox (
+            page_id         TEXT    NOT NULL,
+            page_version    INTEGER NOT NULL CHECK (page_version >= 0),
+            state           TEXT    NOT NULL
+                                CHECK (state IN ('pending', 'handed_off', 'complete')),
+            content_digest  TEXT    NOT NULL CHECK (length(trim(content_digest)) > 0),
+            PRIMARY KEY(page_id, page_version)
+        );
+        CREATE INDEX IF NOT EXISTS idx_page_projection_outbox_state
+            ON page_projection_outbox(state, page_id, page_version);
+
+        CREATE TABLE IF NOT EXISTS m6_counters (
+            space_id  TEXT    NOT NULL,
+            space     TEXT    NOT NULL,
+            name      TEXT    NOT NULL,
+            value     INTEGER NOT NULL CHECK (value >= 0),
+            PRIMARY KEY(space_id, name),
+            UNIQUE(space, name)
+        );
+        CREATE TRIGGER IF NOT EXISTS m6_counters_monotone
+        BEFORE UPDATE OF value ON m6_counters
+        WHEN NEW.value < OLD.value
+        BEGIN
+            SELECT RAISE(ABORT, 'M6 counter cannot decrease');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_counters_replace_monotone
+        BEFORE INSERT ON m6_counters
+        WHEN EXISTS (
+            SELECT 1 FROM m6_counters AS old
+             WHERE old.space = NEW.space
+               AND old.name = NEW.name
+               AND old.value > NEW.value
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'M6 counter cannot decrease');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_counters_identity_insert
+        BEFORE INSERT ON m6_counters
+        WHEN NOT EXISTS (
+                 SELECT 1 FROM spaces
+                  WHERE id = NEW.space_id AND name = NEW.space
+             ) OR EXISTS (
+                 SELECT 1 FROM m6_counters AS old
+                  WHERE old.space = NEW.space
+                    AND old.name = NEW.name
+                    AND old.space_id <> NEW.space_id
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'M6 counter requires one live stable space identity');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_counters_identity_update
+        BEFORE UPDATE OF space_id, space, name ON m6_counters
+        WHEN NEW.space_id <> OLD.space_id OR NEW.name <> OLD.name OR
+             NOT EXISTS (
+                 SELECT 1 FROM spaces
+                  WHERE id = OLD.space_id AND name = NEW.space
+             ) OR
+             EXISTS (
+                 SELECT 1 FROM m6_counters AS destination
+                  WHERE destination.space = NEW.space
+                    AND destination.name = NEW.name
+                    AND destination.space_id <> OLD.space_id
+             )
+        BEGIN
+            SELECT RAISE(ABORT, 'M6 counter identity change is unauthorized');
+        END;
+        CREATE TRIGGER IF NOT EXISTS m6_counters_no_delete
+        BEFORE DELETE ON m6_counters
+        BEGIN
+            SELECT RAISE(ABORT, 'M6 counter cannot be erased');
+        END;
+        ",
+    )
+    .await
+    .map_err(|error| WenlanError::VectorDb(format!("m109 remaining substrate: {error}")))?;
+    Ok(())
+}
+
+async fn genesis_space_bindings_are_valid(tx: &libsql::Transaction) -> Result<bool, WenlanError> {
+    let mut rows = tx
+        .query(
+            "SELECT 1
+               FROM genesis_coverage_state AS coverage
+              WHERE coverage.space_id IS NULL OR NOT EXISTS (
+                    SELECT 1 FROM spaces
+                     WHERE spaces.id = coverage.space_id
+                       AND spaces.name = coverage.space
+              )
+              LIMIT 1",
+            (),
+        )
+        .await
+        .map_err(|error| {
+            WenlanError::VectorDb(format!("m109 validate stable space ids: {error}"))
+        })?;
+    Ok(rows
+        .next()
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("m109 read stable space ids: {error}")))?
+        .is_none())
+}
+
+async fn table_has_column(
+    tx: &libsql::Transaction,
+    table: &str,
+    expected_column: &str,
+) -> Result<bool, WenlanError> {
+    let mut rows = tx
+        .query(&format!("PRAGMA table_info({table})"), ())
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("m109 inspect {table}: {error}")))?;
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| WenlanError::VectorDb(format!("m109 inspect {table} row: {error}")))?
+    {
+        let column = row.get::<String>(1).map_err(|error| {
+            WenlanError::VectorDb(format!("m109 inspect {table} column: {error}"))
+        })?;
+        if column == expected_column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}

--- a/crates/wenlan-core/src/m6/remaining_substrate_test.rs
+++ b/crates/wenlan-core/src/m6/remaining_substrate_test.rs
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::remaining_substrate::ensure_remaining_substrate;
+
+async fn test_connection() -> (libsql::Database, libsql::Connection) {
+    let db = libsql::Builder::new_local(":memory:")
+        .build()
+        .await
+        .expect("build remaining-substrate database");
+    let conn = db.connect().expect("connect remaining-substrate database");
+    conn.execute_batch(
+        "CREATE TABLE spaces (
+             id    TEXT PRIMARY KEY,
+             name  TEXT NOT NULL UNIQUE
+         );
+         INSERT INTO spaces(id, name) VALUES
+             ('space-id-existing', 'existing-space'),
+             ('space-id-a', 'space-a');
+         CREATE TABLE genesis_coverage_state (
+             space             TEXT    PRIMARY KEY,
+             coverage_epoch    INTEGER NOT NULL DEFAULT 1,
+             epoch_state       TEXT    NOT NULL DEFAULT 'active',
+             opened_at         INTEGER NOT NULL,
+             migration_cursor  TEXT,
+             genesis_enabled   INTEGER NOT NULL DEFAULT 0
+         );
+         INSERT INTO genesis_coverage_state (space, opened_at)
+         VALUES ('existing-space', 10);",
+    )
+    .await
+    .expect("install migration-108 coverage table");
+    let tx = conn.transaction().await.expect("begin remaining substrate");
+    ensure_remaining_substrate(&tx)
+        .await
+        .expect("install remaining substrate");
+    tx.commit().await.expect("commit remaining substrate");
+    (db, conn)
+}
+
+#[tokio::test]
+async fn j5_migration_refuses_an_unresolvable_existing_space_identity() {
+    let db = libsql::Builder::new_local(":memory:")
+        .build()
+        .await
+        .unwrap();
+    let conn = db.connect().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE spaces (
+             id TEXT PRIMARY KEY,
+             name TEXT NOT NULL UNIQUE
+         );
+         CREATE TABLE genesis_coverage_state (
+             space TEXT PRIMARY KEY,
+             coverage_epoch INTEGER NOT NULL DEFAULT 1,
+             epoch_state TEXT NOT NULL DEFAULT 'active',
+             opened_at INTEGER NOT NULL,
+             migration_cursor TEXT,
+             genesis_enabled INTEGER NOT NULL DEFAULT 0
+         );
+         INSERT INTO genesis_coverage_state(space, opened_at)
+         VALUES ('deleted-space', 10);",
+    )
+    .await
+    .unwrap();
+    let tx = conn.transaction().await.unwrap();
+    let error = ensure_remaining_substrate(&tx)
+        .await
+        .expect_err("migration must not invent a stable id for an orphan proof");
+    assert!(error.to_string().contains("stable space id"), "{error}");
+    tx.rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn j4_deploy_attestation_identity_is_collision_safe() {
+    let (_db, conn) = test_connection().await;
+    conn.execute(
+        "INSERT INTO m6_deploy_attestation
+             (attestation_id, attested_at, signature, binary_digest)
+         VALUES ('attestation-a', 100, 'signature-a', 'binary-a')",
+        (),
+    )
+    .await
+    .expect("first deploy attestation");
+    conn.execute(
+        "INSERT INTO m6_deploy_attestation
+             (attestation_id, attested_at, signature, binary_digest)
+         VALUES ('attestation-b', 100, 'signature-b', 'binary-b')",
+        (),
+    )
+    .await
+    .expect("two legitimate attestations may share one Unix second");
+    assert!(
+        conn.execute(
+            "INSERT INTO m6_deploy_attestation
+                 (attestation_id, attested_at, signature, binary_digest)
+             VALUES ('attestation-a', 101, 'signature-c', 'binary-c')",
+            (),
+        )
+        .await
+        .is_err(),
+        "one durable attestation identity cannot be reused"
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO m6_deploy_attestation
+                 (attestation_id, attested_at, signature, binary_digest)
+             VALUES ('attestation-without-time', NULL, 'signature-d', 'binary-d')",
+            (),
+        )
+        .await
+        .is_err(),
+        "attestation time is required data, never an implicit rowid"
+    );
+}
+
+#[tokio::test]
+async fn j5_mutation_counter_backfills_and_cannot_move_below_zero() {
+    let (_db, conn) = test_connection().await;
+    let mut rows = conn
+        .query(
+            "SELECT m6_mutation_count, space_id FROM genesis_coverage_state
+              WHERE space = 'existing-space'",
+            (),
+        )
+        .await
+        .expect("read backfilled M6 mutation counter");
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<i64>(0).unwrap(), 0);
+    assert_eq!(row.get::<String>(1).unwrap(), "space-id-existing");
+    conn.execute(
+        "UPDATE genesis_coverage_state SET m6_mutation_count = 2
+          WHERE space = 'existing-space'",
+        (),
+    )
+    .await
+    .expect("advance the durable mutation counter");
+    assert!(
+        conn.execute(
+            "UPDATE genesis_coverage_state SET m6_mutation_count = 1
+              WHERE space = 'existing-space'",
+            (),
+        )
+        .await
+        .is_err(),
+        "the durable mutation count may never decrease"
+    );
+    assert!(
+        conn.execute(
+            "INSERT OR REPLACE INTO genesis_coverage_state
+                 (space, opened_at, m6_mutation_count, space_id)
+             VALUES ('existing-space', 10, 1, 'space-id-existing')",
+            (),
+        )
+        .await
+        .is_err(),
+        "replacement may not bypass mutation-count monotonicity"
+    );
+    assert!(
+        conn.execute(
+            "DELETE FROM genesis_coverage_state WHERE space = 'existing-space'",
+            (),
+        )
+        .await
+        .is_err(),
+        "deletion may not erase the durable mutation proof"
+    );
+}
+
+#[tokio::test]
+async fn j5_mutation_counter_key_move_cannot_replace_destination_proof() {
+    let (_db, conn) = test_connection().await;
+    conn.execute(
+        "UPDATE genesis_coverage_state SET m6_mutation_count = 2
+          WHERE space = 'existing-space'",
+        (),
+    )
+    .await
+    .expect("advance source mutation proof");
+    conn.execute(
+        "INSERT INTO spaces(id, name)
+         VALUES ('space-id-destination', 'destination-space')",
+        (),
+    )
+    .await
+    .expect("register destination space without renaming the source");
+    conn.execute(
+        "INSERT INTO genesis_coverage_state
+             (space, opened_at, m6_mutation_count, space_id)
+         VALUES ('destination-space', 20, 100, 'space-id-destination')",
+        (),
+    )
+    .await
+    .expect("seed higher destination mutation proof");
+
+    assert!(
+        conn.execute(
+            "UPDATE OR REPLACE genesis_coverage_state
+                SET space = 'destination-space'
+              WHERE space = 'existing-space'",
+            (),
+        )
+        .await
+        .is_err(),
+        "moving a lower proof may not replace a higher destination proof"
+    );
+
+    let mut rows = conn
+        .query(
+            "SELECT space, m6_mutation_count
+               FROM genesis_coverage_state
+              ORDER BY space",
+            (),
+        )
+        .await
+        .expect("read both mutation proofs after refused move");
+    let destination = rows.next().await.unwrap().unwrap();
+    assert_eq!(destination.get::<String>(0).unwrap(), "destination-space");
+    assert_eq!(destination.get::<i64>(1).unwrap(), 100);
+    let source = rows.next().await.unwrap().unwrap();
+    assert_eq!(source.get::<String>(0).unwrap(), "existing-space");
+    assert_eq!(source.get::<i64>(1).unwrap(), 2);
+    assert!(rows.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn j5_mutation_counter_cannot_park_then_recreate_original_identity() {
+    let (_db, conn) = test_connection().await;
+    conn.execute(
+        "UPDATE genesis_coverage_state SET m6_mutation_count = 5
+          WHERE space = 'existing-space'",
+        (),
+    )
+    .await
+    .expect("advance original mutation proof");
+    conn.execute(
+        "INSERT INTO spaces(id, name)
+         VALUES ('space-id-parked', 'parked-space')",
+        (),
+    )
+    .await
+    .expect("register a non-colliding destination space");
+
+    let parked = conn
+        .execute(
+            "UPDATE OR REPLACE genesis_coverage_state
+                SET space = 'parked-space', m6_mutation_count = 6
+              WHERE space = 'existing-space'",
+            (),
+        )
+        .await;
+    let reset = conn
+        .execute(
+            "INSERT INTO genesis_coverage_state
+                 (space, opened_at, m6_mutation_count, space_id)
+             VALUES ('existing-space', 30, 0, 'space-id-existing')",
+            (),
+        )
+        .await;
+
+    assert!(
+        parked.is_err(),
+        "a normal DML statement cannot park a proof under an unoccupied key"
+    );
+    assert!(
+        reset.is_err(),
+        "the original identity must remain occupied and reject a zero reset"
+    );
+    let mut rows = conn
+        .query(
+            "SELECT space, m6_mutation_count FROM genesis_coverage_state",
+            (),
+        )
+        .await
+        .expect("read immutable mutation-proof identity");
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<String>(0).unwrap(), "existing-space");
+    assert_eq!(row.get::<i64>(1).unwrap(), 5);
+    assert!(rows.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn j5_mutation_counter_requires_nonnull_space_identity() {
+    let (_insert_db, insert_conn) = test_connection().await;
+    let null_insert = insert_conn
+        .execute(
+            "INSERT INTO genesis_coverage_state (space, opened_at)
+             VALUES (NULL, 20)",
+            (),
+        )
+        .await;
+
+    let (_update_db, update_conn) = test_connection().await;
+    let null_update = update_conn
+        .execute(
+            "UPDATE genesis_coverage_state SET space = NULL
+              WHERE space = 'existing-space'",
+            (),
+        )
+        .await;
+
+    assert!(
+        null_insert.is_err(),
+        "a NULL space cannot create an identity-less mutation proof"
+    );
+    assert!(
+        null_update.is_err(),
+        "a space-key update cannot discard the mutation-proof identity"
+    );
+}
+
+#[tokio::test]
+async fn j6_genesis_provenance_retains_one_origin_per_page() {
+    let (_db, conn) = test_connection().await;
+    conn.execute(
+        "INSERT INTO m6_genesis_provenance
+             (page_id, content_digest, page_version, minted_at)
+         VALUES ('page-a', 'digest-a', 3, 100)",
+        (),
+    )
+    .await
+    .expect("first genesis provenance row");
+    assert!(
+        conn.execute(
+            "INSERT INTO m6_genesis_provenance
+                 (page_id, content_digest, page_version, minted_at)
+             VALUES ('page-a', 'digest-b', 4, 200)",
+            (),
+        )
+        .await
+        .is_err(),
+        "genesis provenance is immutable page identity, not replaceable current state"
+    );
+    assert!(
+        conn.execute(
+            "UPDATE m6_genesis_provenance
+                SET content_digest = 'rewritten'
+              WHERE page_id = 'page-a'",
+            (),
+        )
+        .await
+        .is_err(),
+        "genesis provenance content cannot be rewritten"
+    );
+    assert!(
+        conn.execute(
+            "DELETE FROM m6_genesis_provenance WHERE page_id = 'page-a'",
+            (),
+        )
+        .await
+        .is_err(),
+        "genesis provenance cannot be discarded"
+    );
+    assert!(
+        conn.execute(
+            "INSERT OR REPLACE INTO m6_genesis_provenance
+                 (page_id, content_digest, page_version, minted_at)
+             VALUES ('page-a', 'replacement', 4, 200)",
+            (),
+        )
+        .await
+        .is_err(),
+        "replacement syntax cannot bypass immutable provenance"
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO m6_genesis_provenance
+                 (page_id, content_digest, page_version, minted_at)
+             VALUES (NULL, 'digest-null', 1, 100)",
+            (),
+        )
+        .await
+        .is_err(),
+        "a NULL page identity cannot enter provenance"
+    );
+}
+
+#[tokio::test]
+async fn j7_projection_outbox_is_version_keyed_and_state_checked() {
+    let (_db, conn) = test_connection().await;
+    for version in [1_i64, 2_i64] {
+        conn.execute(
+            "INSERT INTO page_projection_outbox
+                 (page_id, page_version, state, content_digest)
+             VALUES ('page-a', ?1, 'pending', ?2)",
+            libsql::params![version, format!("digest-{version}")],
+        )
+        .await
+        .expect("one projection intent per page version");
+    }
+    assert!(
+        conn.execute(
+            "INSERT INTO page_projection_outbox
+                 (page_id, page_version, state, content_digest)
+             VALUES ('page-a', 2, 'pending', 'duplicate')",
+            (),
+        )
+        .await
+        .is_err(),
+        "a retry must reuse the durable projection intent"
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO page_projection_outbox
+                 (page_id, page_version, state, content_digest)
+             VALUES ('page-b', 1, 'unknown', 'digest-b')",
+            (),
+        )
+        .await
+        .is_err(),
+        "only pending, handed_off, and complete are durable states"
+    );
+}
+
+#[tokio::test]
+async fn j10_counters_are_unique_and_nonnegative_per_space_and_name() {
+    let (_db, conn) = test_connection().await;
+    conn.execute(
+        "INSERT INTO m6_counters(space_id, space, name, value)
+         VALUES ('space-id-a', 'space-a', 'relevance_generation', 2)",
+        (),
+    )
+    .await
+    .expect("first named counter");
+    assert!(
+        conn.execute(
+            "INSERT INTO m6_counters(space_id, space, name, value)
+             VALUES ('space-id-a', 'space-a', 'relevance_generation', 1)",
+            (),
+        )
+        .await
+        .is_err(),
+        "one counter identity must not fork into two rows"
+    );
+    assert!(
+        conn.execute(
+            "UPDATE m6_counters SET value = 1
+              WHERE space = 'space-a' AND name = 'relevance_generation'",
+            (),
+        )
+        .await
+        .is_err(),
+        "named counters may never decrease"
+    );
+    assert!(
+        conn.execute(
+            "INSERT OR REPLACE INTO m6_counters(space_id, space, name, value)
+             VALUES ('space-id-a', 'space-a', 'relevance_generation', 1)",
+            (),
+        )
+        .await
+        .is_err(),
+        "replacement may not bypass named-counter monotonicity"
+    );
+    assert!(
+        conn.execute(
+            "DELETE FROM m6_counters
+              WHERE space = 'space-a' AND name = 'relevance_generation'",
+            (),
+        )
+        .await
+        .is_err(),
+        "deletion may not erase a named counter"
+    );
+    assert!(
+        conn.execute(
+            "INSERT INTO m6_counters(space_id, space, name, value)
+             VALUES ('space-id-a', 'space-a', 'normalization_rejection:R2', -1)",
+            (),
+        )
+        .await
+        .is_err(),
+        "counters may never move below zero"
+    );
+}
+
+#[tokio::test]
+async fn j10_counter_key_moves_cannot_replace_destination_proofs() {
+    let (_db, conn) = test_connection().await;
+    conn.execute_batch(
+        "INSERT INTO spaces(id, name) VALUES
+             ('space-id-source', 'source-space'),
+             ('space-id-destination', 'destination-space');
+         INSERT INTO m6_counters(space_id, space, name, value) VALUES
+             ('space-id-source', 'source-space', 'generation', 2),
+             ('space-id-destination', 'destination-space', 'generation', 100),
+             ('space-id-source', 'source-space', 'other', 200);",
+    )
+    .await
+    .expect("seed source and destination counter proofs");
+
+    assert!(
+        conn.execute(
+            "UPDATE OR REPLACE m6_counters
+                SET space = 'destination-space'
+              WHERE space = 'source-space' AND name = 'generation'",
+            (),
+        )
+        .await
+        .is_err(),
+        "moving a counter may not replace an existing destination-space proof"
+    );
+    assert!(
+        conn.execute(
+            "UPDATE OR REPLACE m6_counters
+                SET name = 'other'
+              WHERE space = 'source-space' AND name = 'generation'",
+            (),
+        )
+        .await
+        .is_err(),
+        "renaming a counter may not replace an existing destination-name proof"
+    );
+
+    let mut rows = conn
+        .query(
+            "SELECT space, name, value FROM m6_counters
+              ORDER BY space, name",
+            (),
+        )
+        .await
+        .expect("read all counter proofs after refused moves");
+    let expected = [
+        ("destination-space", "generation", 100_i64),
+        ("source-space", "generation", 2_i64),
+        ("source-space", "other", 200_i64),
+    ];
+    for (expected_space, expected_name, expected_value) in expected {
+        let row = rows.next().await.unwrap().unwrap();
+        assert_eq!(row.get::<String>(0).unwrap(), expected_space);
+        assert_eq!(row.get::<String>(1).unwrap(), expected_name);
+        assert_eq!(row.get::<i64>(2).unwrap(), expected_value);
+    }
+    assert!(rows.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn j10_counter_cannot_park_then_recreate_original_identity() {
+    let (_db, conn) = test_connection().await;
+    conn.execute_batch(
+        "INSERT INTO spaces(id, name) VALUES
+             ('space-id-source', 'source-space'),
+             ('space-id-parked', 'parked-space');
+         INSERT INTO m6_counters(space_id, space, name, value)
+         VALUES ('space-id-source', 'source-space', 'generation', 5);",
+    )
+    .await
+    .expect("seed one counter proof and a non-colliding destination space");
+
+    let parked = conn
+        .execute(
+            "UPDATE OR REPLACE m6_counters
+                SET space = 'parked-space', name = 'parked', value = 6
+              WHERE space = 'source-space' AND name = 'generation'",
+            (),
+        )
+        .await;
+    let reset = conn
+        .execute(
+            "INSERT INTO m6_counters(space_id, space, name, value)
+             VALUES ('space-id-source', 'source-space', 'generation', 0)",
+            (),
+        )
+        .await;
+
+    assert!(
+        parked.is_err(),
+        "normal DML cannot change a counter's space/name identity to park it"
+    );
+    assert!(
+        reset.is_err(),
+        "the original counter identity must remain occupied and reject a zero reset"
+    );
+    let mut rows = conn
+        .query("SELECT space, name, value FROM m6_counters", ())
+        .await
+        .expect("read immutable counter identity");
+    let row = rows.next().await.unwrap().unwrap();
+    assert_eq!(row.get::<String>(0).unwrap(), "source-space");
+    assert_eq!(row.get::<String>(1).unwrap(), "generation");
+    assert_eq!(row.get::<i64>(2).unwrap(), 5);
+    assert!(rows.next().await.unwrap().is_none());
+}

--- a/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
+++ b/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
@@ -871,35 +871,35 @@ carrying the authority of agreement.
 
 | Address | Function | Visibility | Exposure |
 |---|---|---|---|
-| `core/db.rs:3649` | `run_migrations` | `pub` | internal-only |
-| `core/db.rs:9185` | `migrate_89_page_kind_fold` | `private` | internal-only |
-| `core/db.rs:17439` | `reconcile_entity_page_parity` | `pub` | **exposure** — `server/scheduler/ambient.rs:532` |
-| `core/db.rs:27112` | `rebind_source_page_in_transaction` | `private` | internal-only |
-| `core/db.rs:34762` | `oldest_active_page` | `pub` | internal-only |
-| `core/db.rs:39958` | `list_recent_retrievals` | `pub` | internal-only |
-| `core/db.rs:40098` | `list_recent_retrievals_scoped` | `pub` | **exposure** — `server/routes.rs:948` |
-| `core/db.rs:40304` | `list_recent_changes` | `pub` | internal-only |
-| `core/db.rs:40607` | `list_recent_pages_with_badges` | `pub` | internal-only |
-| `core/db.rs:41520` | `append_page_history` | `private` | internal-only |
-| `core/db.rs:41681` | `insert_page_with_kind_inner` | `private` | internal-only |
-| `core/db.rs:42224` | `get_page_inner` | `private` | internal-only |
-| `core/db.rs:42253` | `get_page_by_entity` | `pub` | internal-only |
-| `core/db.rs:42328` | `list_pages_inner` | `private` | internal-only |
-| `core/db.rs:42361` | `list_pages_stale` | `pub` | internal-only |
-| `core/db.rs:42406` | `list_pages_by_space` | `pub` | internal-only |
-| `core/db.rs:43467` | `find_matching_page` | `pub` | internal-only |
-| `core/db.rs:43524` | `find_matching_page_scoped` | `pub` | internal-only |
-| `core/db.rs:43891` | `page_merge_row` | `private` | internal-only |
-| `core/db.rs:43940` | `load_page_source_index` | `pub` | **exposure** — `server/routes.rs:693` |
-| `core/db.rs:44074` | `list_active_page_titles_scoped` | `pub` | internal-only |
-| `core/db.rs:44121` | `list_relevant_active_page_titles` | `pub` | internal-only |
-| `core/db.rs:44188` | `find_active_page_id_by_title` | `pub` | internal-only |
-| `core/db.rs:44223` | `find_unique_active_page_id_by_title_scoped` | `pub` | internal-only |
-| `core/db.rs:44774` | `backfill_page_embeddings` | `pub` | internal-only |
-| `core/db.rs:45852` | `get_pages_for_memory` | `pub` | internal-only |
-| `core/db.rs:46751` | `get_stale_page_after` | `pub` | internal-only |
-| `core/db.rs:46788` | `list_stale_pages_scoped` | `pub` | **exposure** — `server/routes.rs:772` |
-| `core/db.rs:46828` | `find_stale_archived_pages` | `pub` | **exposure** — `server/cmd_backfill.rs:49` |
+| `core/db.rs:3651` | `run_migrations` | `pub` | internal-only |
+| `core/db.rs:9196` | `migrate_89_page_kind_fold` | `private` | internal-only |
+| `core/db.rs:17486` | `reconcile_entity_page_parity` | `pub` | **exposure** — `server/scheduler/ambient.rs:532` |
+| `core/db.rs:27159` | `rebind_source_page_in_transaction` | `private` | internal-only |
+| `core/db.rs:34809` | `oldest_active_page` | `pub` | internal-only |
+| `core/db.rs:40005` | `list_recent_retrievals` | `pub` | internal-only |
+| `core/db.rs:40145` | `list_recent_retrievals_scoped` | `pub` | **exposure** — `server/routes.rs:948` |
+| `core/db.rs:40351` | `list_recent_changes` | `pub` | internal-only |
+| `core/db.rs:40654` | `list_recent_pages_with_badges` | `pub` | internal-only |
+| `core/db.rs:41567` | `append_page_history` | `private` | internal-only |
+| `core/db.rs:41728` | `insert_page_with_kind_inner` | `private` | internal-only |
+| `core/db.rs:42271` | `get_page_inner` | `private` | internal-only |
+| `core/db.rs:42300` | `get_page_by_entity` | `pub` | internal-only |
+| `core/db.rs:42375` | `list_pages_inner` | `private` | internal-only |
+| `core/db.rs:42408` | `list_pages_stale` | `pub` | internal-only |
+| `core/db.rs:42453` | `list_pages_by_space` | `pub` | internal-only |
+| `core/db.rs:43514` | `find_matching_page` | `pub` | internal-only |
+| `core/db.rs:43571` | `find_matching_page_scoped` | `pub` | internal-only |
+| `core/db.rs:43938` | `page_merge_row` | `private` | internal-only |
+| `core/db.rs:43987` | `load_page_source_index` | `pub` | **exposure** — `server/routes.rs:693` |
+| `core/db.rs:44121` | `list_active_page_titles_scoped` | `pub` | internal-only |
+| `core/db.rs:44168` | `list_relevant_active_page_titles` | `pub` | internal-only |
+| `core/db.rs:44235` | `find_active_page_id_by_title` | `pub` | internal-only |
+| `core/db.rs:44270` | `find_unique_active_page_id_by_title_scoped` | `pub` | internal-only |
+| `core/db.rs:44821` | `backfill_page_embeddings` | `pub` | internal-only |
+| `core/db.rs:45899` | `get_pages_for_memory` | `pub` | internal-only |
+| `core/db.rs:46798` | `get_stale_page_after` | `pub` | internal-only |
+| `core/db.rs:46835` | `list_stale_pages_scoped` | `pub` | **exposure** — `server/routes.rs:772` |
+| `core/db.rs:46875` | `find_stale_archived_pages` | `pub` | **exposure** — `server/cmd_backfill.rs:49` |
 | `core/db/claim_derivation.rs:1756` | `evaluate_support_on` | `private` | internal-only |
 | `core/db/maintenance_duplicate_reads.rs:35` | `embedding_near_duplicate_pairs` | `pub(crate)` | internal-only |
 | `core/db/maintenance_duplicate_reads.rs:108` | `scan_near_duplicate_slice` | `pub(crate)` | internal-only |
@@ -934,23 +934,23 @@ carrying the authority of agreement.
 
 | Address | Function | Visibility | Reaches prose via |
 |---|---|---|---|
-| `core/db.rs:3310` | `new` | `pub` | `run_migrations` |
-| `core/db.rs:3522` | `new_with_shared_embedder` | `pub` | `run_migrations` |
-| `core/db.rs:24536` | `augment_with_graph_gated` | `private` | `search_entities_by_vector_scoped` |
-| `core/db.rs:26614` | `rebind_source_id_inner` | `private` | `rebind_source_page_in_transaction` |
-| `core/db.rs:41611` | `insert_page_with_kind` | `pub(crate)` | `insert_page_with_kind_inner` |
-| `core/db.rs:41650` | `insert_document_source_page_at_hash` | `pub(crate)` | `insert_page_with_kind_inner` |
-| `core/db.rs:41930` | `replace_source_page_inner` | `private` | `append_page_history` |
-| `core/db.rs:42211` | `get_page` | `pub` | `get_page_inner` |
-| `core/db.rs:42220` | `get_page_browse` | `pub` | `get_page_inner` |
-| `core/db.rs:42306` | `list_pages` | `pub` | `list_pages_inner` |
-| `core/db.rs:42319` | `list_pages_browse` | `pub` | `list_pages_inner` |
-| `core/db.rs:42812` | `try_update_page_content` | `private` | `append_page_history` |
-| `core/db.rs:43696` | `accept_page_merge` | `pub` | `page_merge_row` |
-| `core/db.rs:43928` | `find_best_overlapping_page` | `pub` | `load_page_source_index` |
-| `core/db.rs:44061` | `list_active_page_titles` | `pub` | `list_active_page_titles_scoped` |
-| `core/db.rs:44502` | `resolve_orphan_page_links` | `pub` | `find_unique_active_page_id_by_title_scoped` |
-| `core/db.rs:46741` | `list_stale_pages` | `pub` | `list_stale_pages_scoped` |
+| `core/db.rs:3312` | `new` | `pub` | `run_migrations` |
+| `core/db.rs:3524` | `new_with_shared_embedder` | `pub` | `run_migrations` |
+| `core/db.rs:24583` | `augment_with_graph_gated` | `private` | `search_entities_by_vector_scoped` |
+| `core/db.rs:26661` | `rebind_source_id_inner` | `private` | `rebind_source_page_in_transaction` |
+| `core/db.rs:41658` | `insert_page_with_kind` | `pub(crate)` | `insert_page_with_kind_inner` |
+| `core/db.rs:41697` | `insert_document_source_page_at_hash` | `pub(crate)` | `insert_page_with_kind_inner` |
+| `core/db.rs:41977` | `replace_source_page_inner` | `private` | `append_page_history` |
+| `core/db.rs:42258` | `get_page` | `pub` | `get_page_inner` |
+| `core/db.rs:42267` | `get_page_browse` | `pub` | `get_page_inner` |
+| `core/db.rs:42353` | `list_pages` | `pub` | `list_pages_inner` |
+| `core/db.rs:42366` | `list_pages_browse` | `pub` | `list_pages_inner` |
+| `core/db.rs:42859` | `try_update_page_content` | `private` | `append_page_history` |
+| `core/db.rs:43743` | `accept_page_merge` | `pub` | `page_merge_row` |
+| `core/db.rs:43975` | `find_best_overlapping_page` | `pub` | `load_page_source_index` |
+| `core/db.rs:44108` | `list_active_page_titles` | `pub` | `list_active_page_titles_scoped` |
+| `core/db.rs:44549` | `resolve_orphan_page_links` | `pub` | `find_unique_active_page_id_by_title_scoped` |
+| `core/db.rs:46788` | `list_stale_pages` | `pub` | `list_stale_pages_scoped` |
 | `core/db/claim_derivation.rs:959` | `reconcile_supported_pages` | `pub` | `evaluate_support_on` |
 | `core/db/claim_derivation.rs:1503` | `evaluate_page_support` | `pub` | `evaluate_support_on` |
 | `core/db/claim_derivation.rs:2389` | `finalize_page_support` | `pub` | `evaluate_support_on` |
@@ -997,25 +997,25 @@ carrying the authority of agreement.
 | Address | Function | Visibility | Reaches prose via |
 |---|---|---|---|
 | `core/citations.rs:419` | `run_citation_backfill_with_page_limit` | `private` | `get_page` |
-| `core/db.rs:22181` | `search_memory_with_cue` | `private` | `augment_with_graph_gated` |
-| `core/db.rs:24519` | `augment_with_graph` | `pub` | `augment_with_graph_gated` |
-| `core/db.rs:25069` | `augment_with_graph_seeded_scoped` | `private` | `augment_with_graph_gated` |
-| `core/db.rs:26584` | `rebind_source_id` | `pub` | `rebind_source_id_inner` |
-| `core/db.rs:26597` | `rebind_source_id_with_source_page` | `pub` | `rebind_source_id_inner` |
-| `core/db.rs:34753` | `first_active_page` | `pub` | `list_pages` |
-| `core/db.rs:41573` | `insert_page` | `pub(crate)` | `insert_page_with_kind` |
-| `core/db.rs:41874` | `replace_source_page` | `pub(crate)` | `replace_source_page_inner` |
-| `core/db.rs:41899` | `replace_source_page_at_document_hash` | `pub(crate)` | `replace_source_page_inner` |
-| `core/db.rs:42273` | `find_page_by_source_memory` | `pub` | `get_page` |
-| `core/db.rs:42562` | `update_page_content` | `pub` | `try_update_page_content` |
-| `core/db.rs:42595` | `try_update_page_content_if_stale` | `pub` | `try_update_page_content` |
-| `core/db.rs:42621` | `try_update_page_content_with_changelog_at_source_revision` | `pub` | `try_update_page_content` |
-| `core/db.rs:42669` | `try_update_page_content_with_changelog` | `pub` | `try_update_page_content` |
-| `core/db.rs:42703` | `try_update_page_content_with_changelog_at_version` | `pub` | `try_update_page_content` |
-| `core/db.rs:42738` | `try_update_page_growth_at_versions` | `pub` | `try_update_page_content` |
-| `core/db.rs:42776` | `try_accept_page_revision` | `pub(crate)` | `try_update_page_content` |
-| `core/db.rs:43450` | `refresh_page_wikilinks` | `pub` | `get_page` |
-| `core/db.rs:43980` | `max_page_overlap` | `pub` | `find_best_overlapping_page` |
+| `core/db.rs:22228` | `search_memory_with_cue` | `private` | `augment_with_graph_gated` |
+| `core/db.rs:24566` | `augment_with_graph` | `pub` | `augment_with_graph_gated` |
+| `core/db.rs:25116` | `augment_with_graph_seeded_scoped` | `private` | `augment_with_graph_gated` |
+| `core/db.rs:26631` | `rebind_source_id` | `pub` | `rebind_source_id_inner` |
+| `core/db.rs:26644` | `rebind_source_id_with_source_page` | `pub` | `rebind_source_id_inner` |
+| `core/db.rs:34800` | `first_active_page` | `pub` | `list_pages` |
+| `core/db.rs:41620` | `insert_page` | `pub(crate)` | `insert_page_with_kind` |
+| `core/db.rs:41921` | `replace_source_page` | `pub(crate)` | `replace_source_page_inner` |
+| `core/db.rs:41946` | `replace_source_page_at_document_hash` | `pub(crate)` | `replace_source_page_inner` |
+| `core/db.rs:42320` | `find_page_by_source_memory` | `pub` | `get_page` |
+| `core/db.rs:42609` | `update_page_content` | `pub` | `try_update_page_content` |
+| `core/db.rs:42642` | `try_update_page_content_if_stale` | `pub` | `try_update_page_content` |
+| `core/db.rs:42668` | `try_update_page_content_with_changelog_at_source_revision` | `pub` | `try_update_page_content` |
+| `core/db.rs:42716` | `try_update_page_content_with_changelog` | `pub` | `try_update_page_content` |
+| `core/db.rs:42750` | `try_update_page_content_with_changelog_at_version` | `pub` | `try_update_page_content` |
+| `core/db.rs:42785` | `try_update_page_growth_at_versions` | `pub` | `try_update_page_content` |
+| `core/db.rs:42823` | `try_accept_page_revision` | `pub(crate)` | `try_update_page_content` |
+| `core/db.rs:43497` | `refresh_page_wikilinks` | `pub` | `get_page` |
+| `core/db.rs:44027` | `max_page_overlap` | `pub` | `find_best_overlapping_page` |
 | `core/db/presence_review.rs:75` | `review_page_with_presence` | `pub` | `review_in_txn` |
 | `core/db/repair_page_regenerate.rs:123` | `regenerate_page_projection_cas` | `pub(crate)` | `get_page` |
 | `core/db/repair_page_rename.rs:412` | `recover_rename_page_title_apply_receipt` | `pub(crate)` | `rename_page_projection_matches_post` |
@@ -1098,11 +1098,11 @@ carrying the authority of agreement.
 |---|---|---|---|
 | `core/citations.rs:398` | `run_citation_backfill_tick` | `pub` | `run_citation_backfill_with_page_limit` |
 | `core/citations.rs:411` | `run_citation_backfill_slice` | `pub` | `run_citation_backfill_with_page_limit` |
-| `core/db.rs:22144` | `search_memory` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:22957` | `search_memory_temporal` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:23468` | `search_memory_cross_rerank_cued` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:23937` | `search_memory_expanded` | `pub` | `search_memory_with_cue` |
-| `core/db.rs:25052` | `augment_with_graph_seeded` | `pub` | `augment_with_graph_seeded_scoped` |
+| `core/db.rs:22191` | `search_memory` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:23004` | `search_memory_temporal` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:23515` | `search_memory_cross_rerank_cued` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:23984` | `search_memory_expanded` | `pub` | `search_memory_with_cue` |
+| `core/db.rs:25099` | `augment_with_graph_seeded` | `pub` | `augment_with_graph_seeded_scoped` |
 | `core/db/repair_verification.rs:162` | `record_repair_verification_atomic` | `pub(crate)` | `projection_page_row_on_connection` |
 | `core/db/scoped_pages.rs:445` | `list_pages_scoped` | `pub` | `list_pages_scoped_inner` |
 | `core/db/scoped_pages.rs:461` | `list_pages_scoped_browse` | `pub` | `list_pages_scoped_inner` |

--- a/docs/plans/2026-08-01-m6-frontier-policy.md
+++ b/docs/plans/2026-08-01-m6-frontier-policy.md
@@ -7,6 +7,13 @@ which fixed the six states and twelve transitions; this artifact fixes the
 queries, the clocks, the scopes, and the exhaustion behaviour that machine F left
 open.
 
+**Approved amendment (2026-08-02, D2=A and D3=A).** Suppression history is
+append-only and repeatable, with stored liveness (`lapsed_at IS NULL`), and
+card bindings are retained per group with stored liveness
+(`closed_at IS NULL`). Every reference below to "exactly one reason" means
+exactly one **live** reason; closed/lapsed history remains queryable and does
+not count.
+
 **Grounding (rev 2, findings 2 and 15).** In-repo `file:line` citations were read
 on branch `kg-m6-stage0`, based on **`origin/main` `1c903bec`** — PR #418, *"close
 the M5 daemon gaps"*. Rev 1 was written against `e39048c7` (release 0.15.2), which
@@ -37,25 +44,27 @@ could park evidence, with the guard that stops it.
 
 ### 1.1 Six states, six durable homes
 
-Machine F's six states are not a `state` column. Each is the presence of a row in
-a different table, and "exactly one durable reason" is literally "exactly one of
-these six has a row for this group."
+Machine F's six states are not a `state` column. Each is the presence of a
+**live** row in a different table, and "exactly one durable reason" is literally
+"exactly one of these six has a live row for this group." Retained closed card
+bindings and lapsed suppressions are history, not current reasons.
 
 | State | Durable home | New? |
 |---|---|---|
 | `covered` | `genesis_group_coverage` | PR-A-new |
 | `exclusively_claimed` | `genesis_candidate_roots` with a live reservation | PR-A-new (D4) |
 | `waiting_frontier` | `genesis_frontier` | PR-A-new |
-| `surfaced_card` | `genesis_card_binding` → `refinement_queue` (`crates/wenlan-core/src/db/migrations_v004_v009.rs:49`) | binding new; queue **exists** |
-| `suppressed` | `genesis_suppression` | PR-A-new |
+| `surfaced_card` | `genesis_card_binding WHERE closed_at IS NULL` → `refinement_queue` (`crates/wenlan-core/src/db/migrations_v004_v009.rs:49`) | binding new; queue **exists** |
+| `suppressed` | `genesis_suppression WHERE lapsed_at IS NULL` | PR-A-new |
 | `quarantined` | `genesis_quarantine` | PR-A-new |
 
 > **Decision S0-42 — the six states are six tables, not one enum column.** A
 > single `state` column would make the invariant true by construction and
 > therefore untestable: the row would always have exactly one value, including
 > when the *reason* behind it had been rolled back. Six tables make "exactly one"
-> a real count over real rows, which is what G5 has to assert. It also matches
-> what the transitions already are — F4 writes a coverage row, F7 writes a
+> a real count over live rows, which is what G5 has to assert. Historical rows
+> remain in those same tables but are excluded by their stable liveness marker.
+> It also matches what the transitions already are — F4 writes a coverage row, F7 writes a
 > suppression row — so no transition gains a second write.
 
 ### 1.2 The eligible set
@@ -93,20 +102,21 @@ the space, not with groups.
 
 ```sql
 SELECT e.gid,
-       (cov.gid  IS NOT NULL)
-     + (clm.gid  IS NOT NULL)
-     + (fro.gid  IS NOT NULL)
-     + (crd.gid  IS NOT NULL)
-     + (sup.gid  IS NOT NULL)
-     + (qua.gid  IS NOT NULL) AS reason_count
+       (cov.independence_group_id IS NOT NULL)
+     + (clm.independence_group_id IS NOT NULL)
+     + (fro.independence_group_id IS NOT NULL)
+     + (crd.independence_group_id IS NOT NULL)
+     + (sup.independence_group_id IS NOT NULL)
+     + (qua.independence_group_id IS NOT NULL) AS reason_count
   FROM eligible e
-  LEFT JOIN genesis_group_coverage  cov ON cov.gid = e.gid AND cov.space = :space AND cov.coverage_epoch = :epoch
-  LEFT JOIN live_reservations      clm ON clm.gid = e.gid AND clm.space = :space AND clm.coverage_epoch = :epoch
-  LEFT JOIN genesis_frontier       fro ON fro.gid = e.gid AND fro.space = :space AND fro.coverage_epoch = :epoch
-  LEFT JOIN genesis_card_binding   crd ON crd.gid = e.gid AND crd.space = :space AND crd.coverage_epoch = :epoch
-  LEFT JOIN genesis_suppression    sup ON sup.gid = e.gid AND sup.space = :space AND sup.coverage_epoch = :epoch
-                                      AND sup.expires_at > unixepoch()
-  LEFT JOIN genesis_quarantine     qua ON qua.gid = e.gid AND qua.space = :space AND qua.coverage_epoch = :epoch
+  LEFT JOIN genesis_group_coverage  cov ON cov.independence_group_id = e.gid AND cov.space = :space AND cov.coverage_epoch = :epoch
+  LEFT JOIN live_reservations      clm ON clm.independence_group_id = e.gid AND clm.space = :space AND clm.coverage_epoch = :epoch
+  LEFT JOIN genesis_frontier       fro ON fro.independence_group_id = e.gid AND fro.space = :space AND fro.coverage_epoch = :epoch
+  LEFT JOIN genesis_card_binding   crd ON crd.independence_group_id = e.gid AND crd.space = :space AND crd.coverage_epoch = :epoch
+                                      AND crd.closed_at IS NULL
+  LEFT JOIN genesis_suppression    sup ON sup.independence_group_id = e.gid AND sup.space = :space AND sup.coverage_epoch = :epoch
+                                      AND sup.lapsed_at IS NULL
+  LEFT JOIN genesis_quarantine     qua ON qua.independence_group_id = e.gid AND qua.space = :space AND qua.coverage_epoch = :epoch
                                       AND qua.lifted_at IS NULL
  WHERE reason_count <> 1;
 ```
@@ -115,6 +125,14 @@ SELECT e.gid,
 and filtered to candidates in a non-terminal state — the reservation is only a
 *reason* while the candidate is alive, which is exactly what makes F5 (reservation
 released → back to frontier) mandatory rather than housekeeping.
+
+The card and suppression predicates are stored markers on purpose. A wall-clock
+predicate such as `expires_at > unixepoch()` cannot be a safe partial-index
+predicate, and it would let the same committed database change from one reason
+to zero without a transaction. The reconciler first stamps `lapsed_at`, then
+restores `genesis_frontier`, in one transaction. The partial unique indexes on
+each table permit at most one open/unlapsed row per `(space,
+independence_group_id, coverage_epoch)`.
 
 **Two failure shapes, two different meanings.**
 
@@ -210,6 +228,12 @@ unformed-topic card. The dispatch asks: one per what?
 The card lists the below-floor groups by count and by their nearest-miss floor,
 never by content. See §3.4.
 
+The durable binding is one retained row per group and card:
+`genesis_card_binding(space, independence_group_id, coverage_epoch, card_id,
+page_id, first_seen_at, created_at, closed_at)`. One shared card therefore has
+many rows. Only `closed_at IS NULL` rows count in §1.3, and a partial unique
+index permits at most one open binding per group/epoch.
+
 ### 3.2 Card identity and the write that must not be used
 
 Card ID: `m6_unformed_topic_<space-digest>_<epoch>`, where the space digest is an
@@ -273,6 +297,16 @@ The 7-day timer starts at `genesis_frontier.first_seen_at`. Transitions F5
 > violate D7 while every individual transition looks correct. A new coverage epoch
 > does reset it, because the epoch is a new accounting era by construction.
 
+### 3.6 Shared-card closure
+
+Dismissal reads every live binding for the shared `card_id`, closes **all** of
+them, and only then writes each group's post-card transition. Closure and all
+replacement reasons share one transaction. A crash after all bindings close or
+after any individual suppression insert rolls the whole transaction back, so
+every group still has its open card reason; a commit leaves every binding
+closed and every group with its suppression reason. Binding rows are retained
+after closure.
+
 ---
 
 ## 4. Suppression (180 days)
@@ -281,21 +315,25 @@ Written by F7 when a candidate is suppressed or a human dismisses a card.
 
 | Property | Value |
 |---|---|
-| Row | `genesis_suppression(space, gid, coverage_epoch, reason, suppressed_at, expires_at, identity)` |
+| Row | `genesis_suppression(space, independence_group_id, coverage_epoch, page_id, reason, first_seen_at, suppressed_at, expires_at, lapsed_at)` |
 | Clock | `expires_at = unixepoch() + 180*86400`, set in-statement (S0-11) |
-| Lapse | F11: `expires_at <= unixepoch()` → the row stops counting as a reason, and the differential query's `0` result re-inserts the frontier row |
-| Identity | durable **forever**, past both lapse and compaction (D7, D14) |
+| Lapse | F11: the reconciler observes `expires_at <= unixepoch()`, stamps `lapsed_at`, then re-inserts the frontier row in the same transaction |
+| Identity | `page_id`, durable **forever**, past both lapse and compaction (D7, D14) |
 
-> **Decision S0-51 — lapse is expiry, not deletion.** The join in §1.3 carries
-> `AND sup.expires_at > unixepoch()`, so a lapsed suppression stops being a reason
-> without the row going away. Deleting it would erase the record that a human
+> **Decision S0-51 — lapse is a stored marker, not deletion.** The join in §1.3
+> carries `AND sup.lapsed_at IS NULL`; `expires_at <= unixepoch()` makes a row
+> eligible for reconciliation but does not itself change liveness. The
+> reconciler stamps `lapsed_at` before restoring frontier, in the same
+> transaction. Deleting the suppression would erase the record that a human
 > already said no once, which D7 ("suppression identities remain durable") and D14
 > (forward-safe rollback) both require to survive.
 
-A consequence worth stating: because lapse is expiry and F11 is driven by the
-differential query rather than a timer job, **there is no scheduled work at the
-180-day mark.** The group simply starts reading as `reason_count = 0` on the next
-scan and gets its frontier row back. Nothing to crash, nothing to miss.
+A consequence worth stating: there is no zero-reason wall-clock edge at the
+180-day mark. Until the next differential reconciliation, the unlapsed row is
+still the one live reason. That reconciliation commits the marker and frontier
+replacement together. A later suppression in the same epoch appends a new row
+with a new `suppressed_at`; the lapsed identity remains queryable, and the
+partial unique index still allows at most one unlapsed row.
 
 ---
 
@@ -310,7 +348,14 @@ The only one of the six states that is never entered automatically.
 > handler happened to pass", and a group can then arrive in quarantine by
 > omission — which is parking with extra steps.
 
-Lifting (F12) sets `lifted_at`; the row is retained, same argument as §4.
+The retained row is
+`genesis_quarantine(space, independence_group_id, coverage_epoch, reason,
+first_seen_at, quarantined_at, lifted_at)`, keyed by `(space,
+independence_group_id, coverage_epoch, quarantined_at)`. Only
+`lifted_at IS NULL` counts in §1.3, and a partial unique index permits at most
+one live quarantine per group/epoch. Lifting (F12) stamps `lifted_at` before
+restoring frontier in the same transaction; the row is retained and a later
+quarantine appends a new history row, mirroring §4.
 
 ---
 
@@ -382,10 +427,10 @@ D7's closing rule, enumerated. "Parked" means the group is eligible and
 | P5 | Lease held by a dead process | no worker can claim the group | `grouping_leases.expires_at` + the reap arm (`crates/wenlan-core/src/db.rs:13432`-`:13434`) | existing M4 substrate |
 | P6 | Retry exhaustion | candidate stops retrying | S0-12: `attempt > 5` → `stale` with `reason='retry_exhausted'`, which releases the reservation (F5) and returns the group to the frontier | artifact 2 |
 | P7 | Quota exhaustion (any of 5 caps) | work not started | no cap may terminalize or retire | S0-54 |
-| P8 | Suppression never lapsing | group suppressed forever | `expires_at` is set in-statement at write time and the join filters on it; there is no path that writes an unbounded expiry | §4, S0-51 |
-| P9 | Quarantine never lifted | group quarantined forever | quarantine requires an explicit human/policy reason and is visible as a distinct state in the differential query; it is a *deliberate* park, which D7 permits as one of its six states | S0-52 |
+| P8 | Suppression never lapsing | group suppressed forever | `expires_at` is set in-statement; reconciliation stamps `lapsed_at` before restoring frontier, and the live join uses that stable marker | §4, S0-51 |
+| P9 | Quarantine never lifted | group quarantined forever | quarantine requires an explicit human/policy reason and is visible as a distinct state in the differential query; lift stamps the stable marker before restoring frontier, and reactivation appends history | S0-52 |
 | P10 | Below-floor forever in a small space | group never reaches the admission floor | the 7-day card fires regardless of floor (F3); this is G5's positive control | §3 |
-| P11 | Card dismissed, never re-emitted | user dismissed once, silence forever | dismissal writes a **suppression** row with a 180-day expiry, not a permanent card state; §4's lapse returns the group | S0-49 + §4 |
+| P11 | Card dismissed, never re-emitted | user dismissed once, silence forever | dismissal atomically closes every live binding for the shared card and writes one suppression per group; §4's marked lapse returns each group | §3.6 + §4 |
 | P12 | Compaction deletes the reason | terminal candidate row removed → `reason_count = 0` → rediscovery loop | compaction nulls the payload only | S0-53 |
 | P13 | Timer reset by re-entry churn | claim/release cycling keeps resetting the 7-day clock | `first_seen_at` preserved across re-entry | S0-50 |
 | P14 | Epoch change disables genesis | new-epoch genesis blocked pending migration (D5) | the block is on *new genesis*, not on the frontier; groups keep their frontier rows and the differential query keeps running under the old epoch until the migration completes | machine D, artifact 2 |
@@ -441,7 +486,7 @@ how a full-pass scan degrades foreground latency on this daemon's one connection
 
 | Gate | What this artifact hands it |
 |---|---|
-| G5 (`m6_frontier_has_no_missing_root`) | §1.3's query verbatim as the assertion body; the `0` vs `> 1` split (S0-43) as two distinct failure modes; S0-46's `next_scan_at` ceiling as a second assertion |
+| G5 (`m6_frontier_has_no_missing_root`) | §1.3's live-row query verbatim as the assertion body; the `0` vs `> 1` split (S0-43) as two distinct failure modes; suppress → lapse → frontier → suppress again while both histories remain queryable; shared-card failure injection after closure and after every replacement reason; S0-46's `next_scan_at` ceiling as a second assertion |
 | G6 (abuse bounds) | §7's table — one case per cap, each asserting the excess is still in `waiting_frontier` |
 | G-catalog | P1–P16 (§8) as one crash/adversarial case each; P10 as the positive control for a permanently small space; P12 as the retention-policy regression test |
 | G10 (epoch) | P14: the frontier keeps running under the old epoch while new-epoch genesis is blocked |
@@ -450,7 +495,7 @@ how a full-pass scan degrades foreground latency on this daemon's one connection
 
 ## 11. Decisions introduced here
 
-`S0-42` six states are six tables, not an enum column ·
+`S0-42` six states are six tables, and G5 counts exactly one live row rather than all retained history ·
 `S0-43` reconciler repairs `reason_count = 0`, refuses `> 1` ·
 `S0-44` the cursor is a pure optimization ·
 `S0-45` one `app_metadata` cursor key, cleared to `""` on wrap ·
@@ -459,7 +504,7 @@ how a full-pass scan degrades foreground latency on this daemon's one connection
 `S0-48` card written with `INSERT OR IGNORE`, never `INSERT OR REPLACE` ·
 `S0-49` every M6 clock is an INTEGER `unixepoch()` on an M6 table ·
 `S0-50` `first_seen_at` survives re-entry within an epoch ·
-`S0-51` suppression lapses by expiry, never by deletion ·
-`S0-52` quarantine reason is non-empty and never defaulted ·
+`S0-51` suppression is repeatable append-only history; the reconciler marks expiry with `lapsed_at` before restoring frontier ·
+`S0-52` quarantine reason is non-empty and never defaulted; retained rows use `lifted_at` as stable liveness and may repeat ·
 `S0-53` compaction nulls the payload, never deletes the row ·
 `S0-54` no cap may terminalize a candidate or retire a frontier row.

--- a/docs/plans/2026-08-01-m6-overview-matrix.md
+++ b/docs/plans/2026-08-01-m6-overview-matrix.md
@@ -145,26 +145,34 @@ it single is a title lookup.
 
 D11: *"At most one active subscription per `(scope_kind, scope_id)`."*
 
-> **Decision S0-74 — the constraint is a primary key on the active-subscription
-> table, not a uniqueness check in code.**
+> **Decision S0-74 — retained subscription history has its own collision-safe
+> identity; live exclusivity is enforced by partial unique indexes, not a
+> uniqueness check in code.**
 >
 > ```sql
 > CREATE TABLE m6_overview_subscriptions (
+>     subscription_id TEXT PRIMARY KEY,
 >     scope_kind   TEXT NOT NULL CHECK(scope_kind IN ('install','space','community')),
 >     scope_id     TEXT NOT NULL,
 >     page_id      TEXT NOT NULL,
->     space        TEXT NOT NULL,
+>     space        TEXT,
 >     state        TEXT NOT NULL CHECK(state IN ('active','detached')),
 >     created_at   INTEGER NOT NULL,
 >     detached_at  INTEGER,
->     PRIMARY KEY (scope_kind, scope_id)
+>     CHECK ((scope_kind = 'install' AND space IS NULL) OR
+>            (scope_kind <> 'install' AND space IS NOT NULL))
 > );
+> CREATE UNIQUE INDEX idx_m6_overview_sub_scope_active
+>     ON m6_overview_subscriptions(scope_kind, scope_id)
+>     WHERE state = 'active';
 > CREATE UNIQUE INDEX idx_m6_overview_sub_page
 >     ON m6_overview_subscriptions(page_id) WHERE state = 'active';
 > ```
 >
-> The primary key gives D11's at-most-one directly. The second index gives the
-> converse — one active subscription per page — which D11 does not state but G8's
+> `subscription_id` makes `created_at` ordinary retained data and allows a scope
+> to subscribe again after an earlier row is detached. The first index gives
+> D11's at-most-one-live rule directly. The second gives the converse — one
+> active subscription per page — which D11 does not state but G8's
 > "duplicate subscription" case needs, because without it two scopes could both
 > point at one page and a detach of either would half-orphan it.
 >
@@ -517,7 +525,7 @@ here:
 | partitioner swap | S0-72 | changing the partitioner changes membership but the subscription is keyed on the community ID, so no subscription row is written |
 | label proposal | §5, S0-80 | accepting a display name updates `communities.display_name` and **not** `pages.title` |
 | stale-generation acceptance | §7 | a proposal carrying a `source_generation` older than the current one is rejected, and the loser stays detached rather than being retro-transferred |
-| duplicate subscription | S0-74 | the primary key and the partial unique index each reject their direction; assert both, since one index catches only one shape |
+| duplicate subscription | S0-74 | the scope and page partial unique indexes each reject their direction; assert both, since one index catches only one shape |
 | human-edited overview | S0-79 | the four prohibitions, asserted on a detached human-edited page |
 | detached loser | S0-78 | readable, not refreshed, **and not marked stale** |
 | space overview | S0-83 | no `scope_kind='space'` row written during a community event |
@@ -533,7 +541,7 @@ with no adversarial effort beyond choosing an ordinary word as a community name.
 `S0-71` no rebind subscription; an explicit merge-loser detach rule instead ·
 `S0-72` "maximum overlap" means M4's weighted metric, never recomputed ·
 `S0-73` the existing global Overview is its own `install` scope kind ·
-`S0-74` at-most-one is a primary key, plus a partial unique index for the converse ·
+`S0-74` retained rows use `subscription_id`; two partial unique indexes enforce the live scope and page directions ·
 `S0-75` split stages no M6 proposal ·
 `S0-76` detach is automatic; transfer and retire are not ·
 `S0-77` one proposal per (merge event, losing scope), with a derived coalescing ID ·

--- a/docs/plans/2026-08-01-m6-readiness-cutover.md
+++ b/docs/plans/2026-08-01-m6-readiness-cutover.md
@@ -23,6 +23,14 @@ window (finding 14); S0-129 gains its third condition (finding 6); S0-131's
 ledger-class count is reconciled (finding 16). No S0 number was reused or
 renumbered.
 
+**Approved amendment (2026-08-02; D8=A).** The stored `stage` domain is exactly
+`A|B|C|D|E`. Stages A-D use signal `'-'`; stage E uses one of the four signal
+names. The monotone `(epoch, phase)` fence remains an independent axis.
+Composite diagram labels such as `D_preparing` and `E1_committed` are
+presentation labels for `stage × signal × phase`, never `stage` values. Soak
+evidence and the `disabled`/`forward_fix` operational disposition remain in
+their separately named receipt/state fields.
+
 ### Citation conventions
 
 In-repo citations are read on branch `kg-m6-stage0`. Three files carry almost
@@ -84,6 +92,12 @@ zero-dimensional.
 > `signal` is **`NOT NULL DEFAULT '-'`**: the literal `'-'` for stages A–D, and
 > one of the four genesis signal names for stage E. G11's independence is then a
 > key property rather than a checked invariant.
+
+The table enforces `stage IN ('A','B','C','D','E')` and the bidirectional
+stage/signal rule: A-D iff signal is `'-'`; E iff signal is one of
+`evidence-cluster`, `orphan-wikilink`, `community-overview`, or
+`space-overview`. Four E rows can coexist, while a second D/`-` row conflicts on
+the primary key.
 
 > **Decision S0-152 *(rev 2, finding 5)* — the stage-A–D `signal` is a non-null
 > sentinel, never `NULL`.** Rev 1 wrote `NULL`, which silently made the key not a
@@ -183,6 +197,13 @@ stateDiagram-v2
 
 Two properties of this diagram are contract, not drawing:
 
+The node labels are presentation-only composites. For example,
+`D_preparing` is stored as `(stage='D', signal='-', phase='preparing')`, and
+`E1_committed` is stored as `(stage='E', signal='evidence-cluster',
+phase='committed')`. `soaked`, `disabled`, and `forward_fix` are not phase or
+stage values: soak is a separate durable receipt, while disable/forward-fix is
+the separate operational state.
+
 **Abort returns to the previous *soaked* state, never to `off`-as-if-nothing-
 happened.** The epoch still bumps on abort (S0-120), so a writer holding a
 pre-abort capture cannot win a later CAS.
@@ -219,7 +240,7 @@ inspection.
 | 2 | M6 reader manifest | the D12 manifest's structural CI test is green on the deployed commit |
 | 3 | M6 writer manifest | same test, writer half; every listed caller has its fence adapter |
 | 4 | relevance parity | incremental pair state equals full recomputation for this space (artifact 6 §5 oracle) |
-| 5 | dependency state | zero rows in the refresh dependency table for this space referencing a retracted or absent root |
+| 5 | dependency state | zero rows from `m6_refresh_dependencies d LEFT JOIN provenance_roots r ON r.root_id=d.root_id` for this space where `r.root_id IS NULL OR r.status <> 'active'` |
 | 6 | app availability | the app's compatibility manifest advertises a contract version this daemon supports (G1) |
 | 7 | zero pending incompatible jobs | zero rows in the genesis/refresh job tables for this space at a schema older than the current readiness epoch |
 

--- a/docs/plans/2026-08-01-m6-refresh-matrix.md
+++ b/docs/plans/2026-08-01-m6-refresh-matrix.md
@@ -7,6 +7,16 @@ finalization atomicity, and on the D12 writer manifest
 (`2026-08-01-m6-d12-writer-manifest.md`) for the enumeration of refresh writers.
 Gate: G7 (`m6_refresh_preserves_truth`).
 
+**Approved amendment (2026-08-02; D4=A, D7=A).** `queued` remains row-less and
+`generated` remains in memory. Lease acquisition atomically inserts or claims a
+durable `leased` row before model work, with the snapshot triple and the job's
+space, readiness epoch, schema version, and reason. The active-job unique
+predicate is exactly `state IN ('leased','retry')`. Finalization also replaces
+the page's exact durable `m6_refresh_dependencies` snapshot in its existing
+outer page/truth/history/receipt/outbox transaction. That snapshot records
+`(space, page_id, page_version, claim_revision_id, root_id)`; `root_id` has no
+cascade-away foreign key, so a missing root remains visible to readiness.
+
 **Grounding (rev 2, findings 2 and 15).** In-repo `file:line` citations were read
 on branch `kg-m6-stage0`, based on **`origin/main` `1c903bec`** — PR #418, *"close
 the M5 daemon gaps"*. Rev 1 was written against `e39048c7` (release 0.15.2), which
@@ -45,7 +55,7 @@ stateDiagram-v2
 |---|---|---|
 | `dirty` | `pages.stale_reason IS NOT NULL` | `set_page_stale` (`crates/wenlan-core/src/db.rs:46115`) |
 | `queued` | no row of its own — the page is in the sweep's selection | `list_stale_pages` (`crates/wenlan-core/src/db.rs:46351`); the sweep *is* the queue |
-| `leased` | `genesis_refresh_jobs` row holding the snapshot triple (PR-A-new) | §1.1 |
+| `leased` | `genesis_refresh_jobs` row holding the snapshot triple plus space/readiness-epoch/schema/reason (PR-A-new) | §1.1 |
 | `generated` | in-memory only; the model output is not durable until it anchors | — |
 | `anchoring` | in-memory; the claim map is computed before any write | §2 |
 | `finalized` | `pages` row advanced by the M5 finalizer | `try_update_page_content` (`crates/wenlan-core/src/db.rs:42422`) |
@@ -76,6 +86,10 @@ D10: *"Capture page version, dependency generation, and active-root-set digest."
 > job then holds a triple that never described a real state. Re-reading at
 > finalize rather than re-deriving means the finalize CAS compares stored values,
 > which is what makes a crash-restart test reproducible.
+
+The durable row stays `leased` while generation and anchoring happen. There is
+no durable `generated` transition: generated prose exists only in memory until
+the existing all-or-nothing finalizer commits it or the job moves to `retry`.
 
 ---
 
@@ -193,10 +207,39 @@ D10: *"Coalesce one active job/card per page and base version."*
 > **Decision S0-62 — the coalescing key is `(page_id, base_page_version)` and it
 > is enforced by a partial unique index on the job table, not by a
 > check-then-insert.** `CREATE UNIQUE INDEX … ON genesis_refresh_jobs(page_id,
-> base_page_version) WHERE state IN ('queued','leased','generated','retry')`. The
+> base_page_version) WHERE state IN ('leased','retry')`. The
 > index is the enforcement so a second sweep cannot open a duplicate job in the
 > window between a read and a write — the same hazard artifact 5's finding F1
 > found in the existing discovery-card path.
+
+This predicate is the amendment to the earlier four-state wording: `queued`
+cannot appear because selection is row-less, and `generated` cannot appear
+because the output remains in memory while its durable job remains `leased`.
+
+### 3.2.1 The durable dependency snapshot
+
+`m6_refresh_dependencies` is the current exact dependency snapshot for a page,
+not a view over current M5 support. Each row carries `space`, `page_id`,
+`page_version`, `claim_revision_id`, and `root_id`. Genesis and refresh
+finalization replace all rows for that page inside the same outer transaction
+that advances the page and writes truth, history, receipt, and outbox effects.
+There is no helper-owned commit, so a failed finalization rolls back the page and
+dependency replacement together.
+
+The `root_id` column intentionally does not reference `provenance_roots` with a
+delete cascade. PR-D precondition 5 is the fail-closed anti-join:
+
+```sql
+SELECT count(*)
+  FROM m6_refresh_dependencies d
+  LEFT JOIN provenance_roots r ON r.root_id = d.root_id
+ WHERE d.space = ?1
+   AND (r.root_id IS NULL OR r.status <> 'active');
+```
+
+Any non-zero result blocks cutover. A later successful finalization repairs the
+condition by atomically replacing the incompatible current snapshot with the
+new page-version/claim/root set.
 
 The revision card gets the same treatment: at most one open card per
 `(page_id, page_version)`. The card's structured payload already carries both

--- a/docs/plans/2026-08-01-m6-relevance-contract.md
+++ b/docs/plans/2026-08-01-m6-relevance-contract.md
@@ -295,10 +295,11 @@ The last row is a finding, not an illustration — see F1 in §12.
 >   rules bite: chunks and mirrors of one document collapse to one group
 >   (`provenance_roots.independence_group_id`, `db.rs:8792`), so a single source
 >   split into ten chunks cannot manufacture a floor-clearing pair.
-> - **Undecayed.** The floor is a statement about how much independent evidence
->   ever existed, not about how fresh it is. Applying decay first would let a
->   pair with ample old evidence silently drop below the floor and re-enter it
->   on any new touch, flapping the score.
+> - **Undecayed, currently eligible.** The floor is a statement about how many
+>   independent groups currently survive the eligibility spine, not about how
+>   fresh their surviving evidence is. Root retraction removes a group when its
+>   last eligible root disappears; reactivation restores it. Applying decay to
+>   the floor would still let ample old evidence silently fall below three.
 > - **Unsmoothed.** Smoothing exists to make the estimator well-defined, not to
 >   satisfy the floor. `0 + 0.5` must never read as support.
 
@@ -364,8 +365,11 @@ recomputation."*
 > single point.**
 >
 > - **What state.** The full pair table, normalized to
->   `sorted_set((page_a, page_b, n11, n10, n01, n00))` with `page_a < page_b`
->   lexicographically, at a fixed relevance generation.
+>   `sorted_set((page_a, page_b, n11, n10, n01, n00,
+>   distinct_group_count))` with `page_a < page_b` lexicographically, at a
+>   fixed relevance generation. `distinct_group_count` is the undecayed count
+>   of currently eligible distinct groups co-supporting the pair; the
+>   `floor_cleared` bit is derived at read time and is not stored.
 > - **Compared how.** Byte equality of `m6_digest("m6-pairstats-v1", …)` over
 >   that normalized set (artifact 4 §2), not a per-row float tolerance. The
 >   cells are sums of `f64` decay factors, so a tolerance-based comparison would
@@ -550,10 +554,11 @@ is 512. Two frozen numbers and one derived number that cannot all hold.
 > `|N(source) ∩ N(candidate)|` — a *count*, not the rows. Query (c) is
 >
 > ```sql
-> SELECT endpoint_id, count(*) FROM m6_adjacency
->  WHERE space = ?1 AND endpoint_id IN (<the ≤32 candidates>)
+> SELECT endpoint_kind, endpoint_id, count(*) FROM m6_adjacency
+>  WHERE space = ?1 AND endpoint_kind = ?2
+>    AND endpoint_id IN (<the ≤32 candidates>)
 >    AND neighbor_id IN (<the ≤64 source neighbours>)
->  GROUP BY endpoint_id
+>  GROUP BY endpoint_kind, endpoint_id
 > ```
 >
 > which materializes at most 32 rows. Whole-evaluation materialization is then
@@ -785,7 +790,7 @@ Against the two PR-A-new tables plus the existing `edges`:
 |---|---|---|
 | I1 | `m6_pair_stats(space, page_a, page_b)` PRIMARY KEY | query (d) |
 | I2 | `m6_pair_stats(space, page_a, updated_generation)` | incremental invalidation |
-| I3 | `m6_adjacency(space, endpoint_kind, endpoint_id, rank)` PRIMARY KEY | queries (b), (c); `rank` is the deterministic 1..64 slot from S0-89 |
+| I3 | `m6_adjacency(space, endpoint_kind, endpoint_id, rank)` PRIMARY KEY, plus `UNIQUE(space, endpoint_kind, endpoint_id, neighbor_id)` | queries (b), (c); `rank` is the deterministic 1..64 slot from S0-89, while neighbor uniqueness prevents Jaccard inflation |
 | I4 | `m6_adjacency(space, neighbor_id)` | reverse invalidation on root retraction |
 | I5 | `page_truth_state(support_status, page_id)` | candidate retrieval; extends the existing status-only index (`claim_identity.rs:301`-`:302`) |
 

--- a/docs/plans/2026-08-01-m6-state-machines.md
+++ b/docs/plans/2026-08-01-m6-state-machines.md
@@ -19,7 +19,18 @@ checkout is the user's; nothing in this work modifies it. Verify a citation with
 rather than terminal-final, adding transition A19 and decision S0-151. Rev 1's
 S0-numbers are unchanged; nothing was renumbered.
 
-**Status.** Contract only. No schema, no code. Per Stage 0, no M6 schema or production code begins until the prerequisite gate is current and green against post-M5 `main`.
+The approved 2026-08-02 D2=A/D3=A amendment makes suppression and card-binding
+rows retained history with stored liveness. In this artifact, "exactly one
+durable reason" therefore means exactly one **live** reason:
+`genesis_suppression.lapsed_at IS NULL` or
+`genesis_card_binding.closed_at IS NULL`. The authorized J1 judgment applies
+the same retained-history rule to quarantine (`lifted_at IS NULL`). Historical
+rows do not count.
+
+**Status.** Contract plus disabled additive substrate. Migrations 108 and 109
+install the state-machine tables and storage invariants, but no M6 writer,
+reader cutover, or automatic job is enabled. Runtime wiring remains owned by
+the later PR-B/PR-C rungs.
 
 ---
 
@@ -38,7 +49,7 @@ That sentence cannot be expressed in any of the other five machines — a candid
 | C | Lease | one (phase, space, input generation) operation | `grouping_leases` (**exists**) | G3 |
 | D | Coverage epoch | one space's identity-contract era | `genesis_coverage_state` (new) | G10 |
 | E | Finalization | one publish attempt's atomicity | the outer transaction + `page_projection_outbox` | G4 |
-| F | Group / frontier | one independence group in one epoch | `genesis_frontier` + `genesis_group_coverage` (new) | G5 |
+| F | Group / frontier | one independence group in one epoch | `genesis_frontier` + `genesis_group_coverage` + retained card/suppression histories (new) | G5 |
 
 Only machine C has an existing physical substrate. The other five are contract-first; PR-A introduces their tables disabled.
 
@@ -285,7 +296,13 @@ stateDiagram-v2
 
 ## 7. Machine D — coverage epoch
 
-**Object.** One space's identity-contract era. **Durable home.** `genesis_coverage_state(space PRIMARY KEY, coverage_epoch, epoch_state, opened_at, migration_cursor, genesis_enabled)`.
+**Object.** One space's identity-contract era. **Durable home.**
+`genesis_coverage_state(space PRIMARY KEY, space_id UNIQUE, coverage_epoch,
+epoch_state, opened_at, migration_cursor, genesis_enabled,
+m6_mutation_count)`. `space_id` is the immutable `spaces.id`; `space` is its
+renameable display-name projection. Migration 109 and storage triggers require
+the pair to resolve to the same live space on insert/name change, while a
+retained proof may remain deliberately orphaned after `delete_space("keep")`.
 
 Two orthogonal facts live here, and conflating them is the error this section exists to prevent:
 
@@ -395,7 +412,15 @@ This is a structural consequence of the machine as specified: the model call hap
 
 ## 9. Machine F — group / frontier reconciliation
 
-**Object.** One independence group in one coverage epoch, per space. **Durable home.** `genesis_frontier` (keyed by space, independence group, coverage epoch — D7) plus `genesis_group_coverage` for the permanent-coverage state. Frontier ordering is D7's `next_scan_at, first_seen_at, group_id`.
+**Object.** One independence group in one coverage epoch, per space. **Durable
+home.** `genesis_frontier` (keyed by space, independence group, coverage epoch
+— D7), `genesis_group_coverage` for permanent coverage,
+`genesis_card_binding` for retained per-group card history, and
+`genesis_suppression` for repeatable append-only suppression history, and
+`genesis_quarantine` for repeatable retained quarantine history. Frontier
+ordering is D7's `next_scan_at, first_seen_at, group_id`. Only open card
+bindings (`closed_at IS NULL`), unlapsed suppressions (`lapsed_at IS NULL`),
+and unlifted quarantines (`lifted_at IS NULL`) are live reasons.
 
 This is the machine that carries D4's closing rule.
 
@@ -424,16 +449,16 @@ stateDiagram-v2
 |---|---|---|---|---|---|
 | F1 | ∅ → `waiting_frontier` | differential query finds an eligible uncovered group | group passes D1's relaxed independence floor | frontier row, `first_seen_at = unixepoch()`, `next_scan_at` set | The differential query is the source of truth (G5). A crash simply means the group is found again on the next scan; frontier rows are re-derivable, which is why F1 needs no atomicity with anything. |
 | F2 | `waiting_frontier` → `exclusively_claimed` | concept prepare (B1) | partial unique indexes accept | frontier row retires; reservation row is the durable reason | Same transaction as A2/B1. |
-| F3 | `waiting_frontier` → `surfaced_card` | evidence below the admission floor for more than 7 days (D7) | — | **one coalesced unformed-topic card** for all such groups in the space | D7 says *one* card, not one per group: the card is coalesced. Crash-safe because card creation is idempotent on (space, epoch, card kind). |
+| F3 | `waiting_frontier` → `surfaced_card` | evidence below the admission floor for more than 7 days (D7) | — | **one coalesced unformed-topic card** for all such groups in the space, plus one retained open binding per group | D7 says *one* card, not one per group: the card is coalesced while its bindings remain per-group. Crash-safe because card creation is idempotent on (space, epoch, card kind), and a partial unique index permits at most one open binding per group/epoch. |
 | F4 | `exclusively_claimed` → `covered` | genesis finalize commits (B5, E2) | inside the one outer transaction | permanent `genesis_group_coverage` row | All-or-nothing with the page. |
 | F5 | `exclusively_claimed` → `waiting_frontier` | reservation released without publishing (B4 via A14/A15/A16, or B6) | — | frontier row re-inserted, `next_scan_at` per S0-2 backoff where applicable | **Same transaction as the release** (D4). This is the edge that keeps I-1 true across every terminal exit. |
-| F6 | `exclusively_claimed` → `surfaced_card` | candidate → `review_required` (A12) | — | group bound to the durable surfaced review card | Same transaction as the reservation release (A12). |
-| F7 | `exclusively_claimed` \| `surfaced_card` → `suppressed` | candidate suppressed, or card dismissed by a human (A17) | — | suppression row, `expires_at = unixepoch() + 180 days` (D7); suppression identity is durable (D14) | The suppression identity survives compaction (S0-10) and rollback (D14). |
-| F8 | `surfaced_card` → `waiting_frontier` | card expires (A18) | — | frontier row re-inserted | D4: expiry moves it through the normal frontier transition. |
-| F9 | any → `quarantined` | explicit quarantine | an operator or a policy rule records a reason | quarantine row with an explicit, durable reason string | D7 requires the reason to be explicit; a group may never arrive here by default or by omission. |
+| F6 | `exclusively_claimed` → `surfaced_card` | candidate → `review_required` (A12) | — | group bound to the durable surfaced review card with `created_at` and `closed_at=NULL` | Same transaction as the reservation release (A12). |
+| F7 | `exclusively_claimed` \| `surfaced_card` → `suppressed` | candidate suppressed, or card dismissed by a human (A17) | — | append suppression keyed by `(space, independence_group_id, coverage_epoch, suppressed_at)`, with `page_id` as identity and `lapsed_at=NULL` | For a shared card, one transaction closes **every** live binding for `card_id` before writing each replacement suppression. Failure after closure or after any per-group insert rolls everything back. Both card and suppression histories survive compaction and rollback. |
+| F8 | `surfaced_card` → `waiting_frontier` | card expires (A18) | — | close the binding and re-insert the frontier row in one transaction | D4: expiry moves it through the normal frontier transition; the closed binding remains history and no longer counts. |
+| F9 | any → `quarantined` | explicit quarantine | an operator or a policy rule records a reason | append a row keyed by `(space, independence_group_id, coverage_epoch, quarantined_at)` with non-empty reason and `lifted_at=NULL` | D7 requires the reason to be explicit; a partial unique index permits at most one live row per group/epoch, and the transition from the prior reason is atomic. |
 | F10 | `waiting_frontier` → `covered` | the group is a mirror of an already-covered group | a permanent coverage row exists for the group at this epoch | coverage recorded immediately, no candidate | D4: *"a durable group-coverage row makes future mirrors of an already-covered group covered immediately."* No LLM, no lease, no candidate. |
-| F11 | `suppressed` → `waiting_frontier` | 180 days elapse | — | frontier row re-inserted; **suppression identity is retained** | The row moves out of suppression; the identity of what was suppressed is not deleted (D7, D14). |
-| F12 | `quarantined` → `waiting_frontier` | quarantine explicitly lifted | — | frontier row re-inserted | Requires the same explicitness as F9. |
+| F11 | `suppressed` → `waiting_frontier` | reconciler observes `expires_at <= unixepoch()` | — | stamp `lapsed_at` **before** re-inserting frontier, in one transaction; suppression identity is retained | Wall-clock expiry alone does not change the live reason. The stored marker and frontier replacement commit together; a later same-epoch suppression appends a new row. |
+| F12 | `quarantined` → `waiting_frontier` | quarantine explicitly lifted | — | stamp `lifted_at` before restoring frontier, in one transaction | The retained row no longer counts; a later explicit quarantine appends a new row rather than overwriting history. |
 
 **Cursor wrap, restart, quota exhaustion, and a permanently small space may delay work but may never lose or silently park evidence** (D7). Structurally: F1 is driven by a differential query rather than an incremental queue, so a lost cursor costs a rescan and never a lost group; F3's 7-day rule guarantees that even a space that never reaches the admission floor surfaces once (G5's positive control); and S0-5's recovery scan guarantees F5 fires for every reservation orphaned by a crash.
 
@@ -445,7 +470,7 @@ These are the properties no single machine can state. Each names the gate that p
 
 | # | Invariant | Where it could break | Gate |
 |---|---|---|---|
-| **I-1** | **Every group outside `waiting_frontier` has exactly one durable reason** — an active bounded reservation, permanent coverage, surfaced review, time-bounded suppression, or explicit quarantine. Never zero, never two. | Any non-atomic pairing of a reservation release (B4/B6) with the group's next state (F5–F9). Every such pair is specified as one transaction for this reason. | G5, and G3's terminal-exit crash matrix |
+| **I-1** | **Every group outside `waiting_frontier` has exactly one live durable reason** — an active bounded reservation, permanent coverage, open surfaced review, unlapsed suppression, or unlifted quarantine. Never zero, never two. Closed/lapsed rows remain history and do not count. | Any non-atomic pairing of a reservation release or card closure with the group's next state (F5–F9/F11). Every such pair is specified as one transaction for this reason. | G5, and G3's terminal-exit crash matrix |
 | **I-2** | **One slot publishes at most one page.** Overlapping concept candidates cannot both mint. | The partial unique indexes of §5 are the only enforcement; a code-level check would be a second, weaker one. | G3 |
 | **I-3** | **A witness row is never readable as coverage.** Overview candidates never consume concept coverage. | Any query that reads `genesis_candidate_roots` without filtering `claim_role`. | G2, G3 |
 | **I-4** | **A published page and its coverage, claims, truth state, receipt, and lease consumption are one atomic fact.** | Any use of a self-committing M5 finalizer inside the genesis path, or any nested transaction. | G4 |
@@ -506,6 +531,6 @@ G3, G4, and G5 are the executable form of this artifact. The mapping is one-way 
 
 - **G3 `m6_overlapping_candidates_publish_once`** consumes machines A, B, and C. Its *"crash-test every reservation exit: published, bounded retry, review-required, stale, suppressed, superseded, exhausted retry, and compaction"* maps onto B5, B3, A12, A7/A14/A15, A17, A16, A14 with `reason='retry_exhausted'`, and §4's compaction paragraph. Each `stale` exit it crash-tests must also be driven through A19 to prove the slot is re-preparable — a terminal-looking exit that silently strands its group is exactly the rev-1 defect finding 3 caught. Its assertion that each transition *"must atomically leave every group in permanent coverage, an active bounded reservation, frontier, surfaced review, suppression, or quarantine"* is invariant I-1 over machine F.
 - **G4 `m6_finalize_is_all_or_nothing`** consumes machine E. Its injection points — *"failure and concurrent root retraction, dependency change, human edit, community generation change, lease expiry, and claim loss at every finalize boundary"* — map onto gates E-6, E-8, E-8, E-7, E-1, and E-5.
-- **G5 `m6_frontier_has_no_missing_root`** consumes machine F and invariant I-1, and its *"cover cursor wrap, restart, quota exhaustion, liveness transitions, compaction, and seven-day surfacing"* maps onto §11, S0-9's no-attempt-charge rule, F3, and S0-10.
+- **G5 `m6_frontier_has_no_missing_root`** consumes machine F and invariant I-1, and its *"cover cursor wrap, restart, quota exhaustion, liveness transitions, compaction, and seven-day surfacing"* maps onto §11, S0-9's no-attempt-charge rule, F3, and S0-10. The amendment adds suppress → lapse → frontier → suppress again with both suppression histories retained, plus one shared-card dismissal injected after closing all bindings and after each replacement suppression; every committed or rolled-back observation must leave exactly one live reason per group.
 
 Where a gate and this artifact disagree, the gate is right and this document is the thing to fix — the executable test is the contract's real teeth, and this is its seed.

--- a/docs/plans/2026-08-02-m6-pr-a-followup-schema.md
+++ b/docs/plans/2026-08-02-m6-pr-a-followup-schema.md
@@ -108,8 +108,8 @@ belongs to the app/secret-store rung rather than this database migration.
 | scoped Clippy (`-D warnings`) | passed |
 | rust-analyzer diagnostics on every changed Rust file | zero errors/warnings; one expected test-only inactive-code hint |
 | fresh independent Sol round 5 | `CLOSED` |
-| latest-main integration base | rebased cleanly onto `28ecda6d` |
-| reader inventory regeneration | `scripts/m5-reader-sweep.py --update-inventory`; 285 rows, mechanical line-number changes only |
+| latest-main integration base | rebased cleanly onto `9bc89a46` after the earlier `28ecda6d` receipt was invalidated by main advancing |
+| reader inventory regeneration | `scripts/m5-reader-sweep.py --update-inventory`; 285 rows, mechanical line-number changes only; unchanged on the final rebase |
 | first post-rebase workspace attempt | infrastructure-aborted during link: `No space left on device (os error 28)`; no test verdict claimed |
 | completed post-rebase workspace discovery run | 3751 core tests passed, 2 R4 test-support guards failed because the six new test-only libSQL helpers were absent from the frozen manifest/census |
 | R4 blocker focused repair | 35/35 R4 test-support guards passed; fmt/diff check, strict scoped Clippy, and LSP passed |
@@ -157,4 +157,7 @@ and canonical rename paths within this schema-first rung. The branch then
 rebased cleanly onto latest main, regenerated the reader inventory, repaired
 the fail-closed R4 test-support census exposed by the completed workspace run,
 received a fresh independent Sol `CLOSED` on that bounded repair, and finished
-with a green full workspace suite. Required PR CI remains the final gate.
+with a green full workspace suite. When main advanced again during the gate,
+the branch rebased a second time, regenerated the unchanged inventory, and
+repeated the full workspace suite successfully. Required PR CI remains the
+final gate.

--- a/docs/plans/2026-08-02-m6-pr-a-followup-schema.md
+++ b/docs/plans/2026-08-02-m6-pr-a-followup-schema.md
@@ -1,0 +1,151 @@
+# M6 PR-A follow-up — migration 109 substrate inventory
+
+Status: implementation receipt; fresh independent review, latest-main rebase,
+post-rebase workspace gates, CI, and merge remain pending.
+
+Migration 108 intentionally stopped at the five genesis objects whose Stage-0
+contracts were internally coherent. The D1-D8 amendment ratified on 2026-08-02
+resolved the remaining contradictions. The uncontested schema questions follow
+their recorded recommendations unless this PR's independent review rejects one.
+
+## Complete migration-109 inventory
+
+The earlier schema sweep counted fifteen remaining storage objects. Formal
+proof-reset review required one additional stable-space binding, so migration
+109 now creates fourteen tables and adds two columns to the existing coverage
+table:
+
+| # | Object | Contract responsibility |
+|---|---|---|
+| 1 | `genesis_suppression` | repeatable retained history; at most one live row |
+| 2 | `genesis_card_binding` | per-group retained card binding with explicit closure |
+| 3 | `genesis_quarantine` | repeatable retained quarantine with explicit lift |
+| 4 | `genesis_refresh_jobs` | row-less queue followed by atomic durable lease/retry |
+| 5 | `m6_refresh_dependencies` | exact page-version/claim/root snapshot; missing roots remain observable |
+| 6 | `m6_readiness` | stage/signal identity plus independent epoch/phase fence |
+| 7 | `m6_readiness_soak_receipts` | separately named, epoch-bound soak evidence |
+| 8 | `m6_overview_subscriptions` | retained subscription identity plus live scope/page exclusion |
+| 9 | `m6_pair_stats` | decayed cells plus current raw distinct-group count |
+| 10 | `m6_adjacency` | deterministic top-64 ranks plus neighbor uniqueness |
+| 11 | `m6_deploy_attestation` | durable signed deployment evidence |
+| 12 | `m6_genesis_provenance` | immutable genesis byte/version origin |
+| 13 | `page_projection_outbox` | version-keyed pending/handed-off/complete projection intent |
+| 14 | `m6_counters` | monotone per-space relevance and normalization counters |
+| 15 | `genesis_coverage_state.m6_mutation_count` | monotone per-space proof that no M6 mutation has occurred |
+| 16 | `genesis_coverage_state.space_id` | immutable `spaces.id` binding that survives a display-name rename |
+
+All objects are installed inside one migration-owned `IMMEDIATE` transaction.
+The tables start empty; the added counter backfills to zero. Migration 109 does
+not enable genesis, schedule work, or flip any reader/writer fence.
+
+## Load-bearing controls
+
+- Pair qualification derives the three-group floor from
+  `distinct_group_count`; the normalized digest includes that field.
+- Suppression, card, and quarantine history use stable nullable liveness
+  markers and partial unique indexes rather than wall-clock index predicates.
+- The refresh coalescing index names only durable `leased` and `retry` states.
+- Readiness stores `stage`, `signal`, `epoch`, and `phase` as independent axes;
+  soak evidence and operational disable/forward-fix state have separate homes.
+- Overview install rows require `space IS NULL`; every non-install row requires
+  a space. Subscription identity is explicitly non-null, and detached history
+  never occupies the live-scope unique key.
+- Deployment evidence has a collision-safe non-null `attestation_id`; its
+  required `attested_at` remains data, so two attestations in one second do not
+  collide.
+- Genesis provenance is non-null and immutable against update, delete, and
+  replacement. Both counter homes reject decreasing updates/replacements and
+  deletion, so their monotone proofs cannot be reset through alternate SQL
+  statement shapes.
+- Every monotone proof is bound to immutable `spaces.id`. Migration backfills
+  the binding from the live name and refuses an orphan it cannot resolve;
+  inserts require a live `id ↔ name` pair. A rename changes only the stored
+  name while retaining the same stable ID.
+- Root IDs in refresh dependencies have no cascading foreign key, so deletion
+  cannot make the readiness anti-join vacuously pass.
+- Space rename covers every new `space` column. Retained history refuses a
+  destination collision; re-derivable destination rows are retired before the
+  source rows move.
+
+### Proof-store DML guard matrix
+
+The two monotone proof stores are guarded by mutation mechanism, not by one
+expected writer statement:
+
+| Mutation shape | Storage guard | Causal control |
+|---|---|---|
+| lower `UPDATE` of the proof value | value-update trigger | direct decreasing update fails |
+| lower `INSERT OR REPLACE` on the same key | pre-insert comparison with the existing value | replace attempt fails |
+| `DELETE` followed by a reset insert | delete prohibition | direct delete fails |
+| key-moving `UPDATE OR REPLACE` onto an occupied identity | key-update destination-collision guard | attempted space/name moves fail and both rows retain their original values |
+| key-moving DML onto an unoccupied identity, followed by reset at the old key | counter name and `space_id` are immutable; the new name must resolve to the same `spaces.id` | combined space/name/value parking fails, zero reinsertion fails, and the original proof remains exact |
+| NULL genesis space through insert or key update | identity insert/update guards | both NULL statement shapes fail |
+| `delete_space("keep")`, then move/reset or recreate the same name | retained proof keeps its old stable ID; a different live ID cannot adopt it | real repository deletion path cannot park/reset, and same-name recreation cannot replace retained proof |
+| non-colliding authorized space rename | `update_space` renames the same live `spaces.id` first, then the destination-fenced proof cascade updates only the display name | complete space-rename suite remains green |
+
+The refused-mint review artifact remains owned by the later edge-grounding
+writer lane, as its Stage-0 decision states. The owner-only `card_handle_salt`
+belongs to the app/secret-store rung rather than this database migration.
+
+## Review-round-5 gate receipt
+
+| Gate | Result |
+|---|---|
+| D1/D6 relevance controls | 6 passed |
+| D2/D3/J1 frontier controls | 4 passed |
+| D4/D7/D8 refresh/readiness controls | 7 passed |
+| D5 overview controls | initial RED 0/3 missing table; review RED 3/4; GREEN 4/4 |
+| J4-J7/J10 remaining controls | initial RED 0/5 missing objects; review RED 1/5; GREEN 5/5 |
+| proof-store conflict matrix | round-2 RED 0/2 key moves and RED 0/1 NULL identity; GREEN 3/3 |
+| proof-store identity authorization | round-3 RED 0/2 non-colliding park/reset; GREEN 2/2 |
+| stable space identity | round-4 RED 0/1 repository delete-keep park/reset; GREEN 1/1; same-name recreation GREEN |
+| all M6 module tests | 91 passed |
+| migration-109 integration | 3 passed |
+| migration-107 through current follow-up | 1 passed |
+| genesis schema/migration module | 16 passed |
+| space-rename/delete closure | 13 passed |
+| Rustfmt / diff whitespace | passed |
+| scoped Clippy (`-D warnings`) | passed |
+| rust-analyzer diagnostics on every changed Rust file | zero errors/warnings; one expected test-only inactive-code hint |
+| fresh independent Sol round 5 | `CLOSED` |
+
+Round 1 returned `FIX`: decreasing `INSERT OR REPLACE` bypassed the two
+update-only monotonicity triggers; genesis provenance was mutable and nullable;
+subscription identity was nullable; deployment attestations collided at
+one-second resolution; one D4 control used an invalid key type; and the
+state-machine status was stale. The focused REDs above failed for those exact
+reasons. The current subject adds insert/delete guards around the monotone
+proofs, immutable provenance guards plus non-null identity, non-null retained
+subscription identity, a separate attestation identity, a numeric D4 control,
+and the corrected status. No runtime writer or reader was enabled.
+
+Round 2 resolved all round-1 findings, then found the same conflict-resolution
+class through a key-moving `UPDATE OR REPLACE`: SQLite could delete an occupied
+destination proof without firing Wenlan's delete trigger. Per the two-strike
+rule, the response is the bounded mechanism matrix above rather than another
+isolated statement patch. The new REDs reproduce destination erasure for both
+proof stores; the identity-update guards refuse any occupied destination while
+the existing rename fence remains the positive non-colliding path.
+
+Round 3 resolved the occupied-destination bypass, then showed that a proof could
+still be parked under an unoccupied key and recreated at zero under its old
+identity. The identity authorization now freezes `m6_counters.name` and permits
+a proof's `space` change only in the canonical `update_space` transaction state:
+the old registered name is already absent and the new registered name exists.
+The new controls combine space/name/value changes, attempt the zero reset, and
+assert the original proof remains byte-for-byte exact. The existing 11-test
+space-rename suite is the positive authorization control.
+
+Round 4 showed that old-absent/new-present was not exclusive to rename:
+`delete_space("keep")` creates the same state. The durable mechanism now binds
+both proof homes to immutable `spaces.id`; display-name changes must resolve to
+that same ID, and `m6_counters.name` is immutable. Migration backfills valid
+coverage rows and fails closed on an orphan. The repository deletion RED first
+reproduced the park/reset, then turned green; a same-name recreation control
+proves a new `spaces.id` cannot adopt retained proof.
+
+Round 5 returned `CLOSED`: the stable-ID binding closes delete-keep,
+space-ID swap, same-name recreation, replace/delete/reset, migration replay,
+and canonical rename paths within this schema-first rung. Latest-main rebase,
+inventory regeneration, and the one post-rebase full workspace suite remain
+pending at this receipt boundary.

--- a/docs/plans/2026-08-02-m6-pr-a-followup-schema.md
+++ b/docs/plans/2026-08-02-m6-pr-a-followup-schema.md
@@ -108,6 +108,13 @@ belongs to the app/secret-store rung rather than this database migration.
 | scoped Clippy (`-D warnings`) | passed |
 | rust-analyzer diagnostics on every changed Rust file | zero errors/warnings; one expected test-only inactive-code hint |
 | fresh independent Sol round 5 | `CLOSED` |
+| latest-main integration base | rebased cleanly onto `28ecda6d` |
+| reader inventory regeneration | `scripts/m5-reader-sweep.py --update-inventory`; 285 rows, mechanical line-number changes only |
+| first post-rebase workspace attempt | infrastructure-aborted during link: `No space left on device (os error 28)`; no test verdict claimed |
+| completed post-rebase workspace discovery run | 3751 core tests passed, 2 R4 test-support guards failed because the six new test-only libSQL helpers were absent from the frozen manifest/census |
+| R4 blocker focused repair | 35/35 R4 test-support guards passed; fmt/diff check, strict scoped Clippy, and LSP passed |
+| fresh independent Sol post-suite blocker review | `CLOSED`; exact 13-row census and six path/owner/shape/ordinal additions preserve the fail-closed guard |
+| final post-rebase full workspace suite | `cargo test --workspace --quiet` exited 0; core 3753 passed, 0 failed, 33 ignored; every remaining workspace target passed |
 
 Round 1 returned `FIX`: decreasing `INSERT OR REPLACE` bypassed the two
 update-only monotonicity triggers; genesis provenance was mutable and nullable;
@@ -146,6 +153,8 @@ proves a new `spaces.id` cannot adopt retained proof.
 
 Round 5 returned `CLOSED`: the stable-ID binding closes delete-keep,
 space-ID swap, same-name recreation, replace/delete/reset, migration replay,
-and canonical rename paths within this schema-first rung. Latest-main rebase,
-inventory regeneration, and the one post-rebase full workspace suite remain
-pending at this receipt boundary.
+and canonical rename paths within this schema-first rung. The branch then
+rebased cleanly onto latest main, regenerated the reader inventory, repaired
+the fail-closed R4 test-support census exposed by the completed workspace run,
+received a fresh independent Sol `CLOSED` on that bounded repair, and finished
+with a green full workspace suite. Required PR CI remains the final gate.


### PR DESCRIPTION
## What changed

- completes the schema-first M6 migration 109 follow-up substrate
- adds the fourteen M6 tables plus stable-space identity and monotone counter columns
- freezes relevance, frontier, refresh/readiness, overview subscription, deployment, provenance, projection-outbox, and counter contracts
- binds retained proof stores to immutable `spaces.id` across rename, delete-keep, and same-name recreation
- regenerates the 285-row M5 reader inventory and records the full gate receipt

## Why

PR-A reserved the M6 substrate but left the remaining schema/control contracts unmaterialized. This follow-up lands those contracts without enabling runtime readers or writers, so later PR-B through PR-E rungs can proceed against fail-closed storage and deterministic policy seams.

## Validation

- focused M6 tests: 91 passed
- migration 109 integration: 3 passed
- genesis schema/migration: 16 passed
- space rename/delete closure: 13 passed
- R4 test-support guards after inventory repair: 35 passed
- `cargo fmt --all --check`
- strict scoped Clippy with `-D warnings`
- rust-analyzer: no diagnostics on changed Rust files
- fresh independent read-only Sol reviews: CLOSED
- rebased onto latest main `9bc89a46`
- regenerated reader inventory: 285 rows
- final `cargo test --workspace --quiet`: exit 0; core 3753 passed, 0 failed, 33 ignored; all remaining workspace targets passed

Required cross-platform GitHub CI remains the merge gate.