### PR TITLE
fix: fence M5 derivation runs and bound reconciliation

### DIFF
--- a/crates/wenlan-core/src/db/claim_derivation.rs
+++ b/crates/wenlan-core/src/db/claim_derivation.rs
@@ -27,9 +27,9 @@
 //!
 //! Leases are the crash story. A worker takes a job with an expiry; if it dies,
 //! the expiry passes and another worker reclaims it. Every terminal transition
-//! is guarded on `lease_owner`, so a worker whose lease was reclaimed while it
-//! was stalled cannot finish the job out from under its new owner — it fails
-//! the guard and its write is a no-op.
+//! is guarded on the exact leased [`DerivationJob`], including its monotone run
+//! generation, so a worker whose lease was reclaimed while it was stalled
+//! cannot finish the successor even when both runs use the same owner string.
 
 use super::MemoryDB;
 use crate::WenlanError;
@@ -547,6 +547,11 @@ impl MemoryDB {
     /// One transaction makes the pair atomic: either the page is demoted and
     /// queued, or nothing changed and the error is the whole truth.
     pub async fn enqueue_stale_derivation_jobs(&self, limit: i64) -> Result<usize, WenlanError> {
+        if limit <= 0 {
+            return Err(WenlanError::Validation(format!(
+                "claim derivation sweep limit must be positive; got {limit}"
+            )));
+        }
         let now = chrono::Utc::now().timestamp();
         let conn = self.conn.lock().await;
         let tx = conn
@@ -575,74 +580,82 @@ impl MemoryDB {
         now: i64,
         limit: i64,
     ) -> Result<usize, WenlanError> {
-        // Freeze BOTH batches before any cleanup write. A `done` job is what
-        // makes stale completion block a new pending row, but deleting every
-        // stale `done` row before applying `limit` turns a nominal 25-page turn
-        // into a corpus-sized write. The connection-local temp tables bind job
-        // deletion, pending insertion, and drift demotion to the same captured
-        // sets. They participate in this transaction, so rollback loses the
-        // captures together with every queue and truth-state change.
+        // Freeze ONE distinct union before any cleanup write. A `done` job is
+        // what makes stale completion block a new pending row, but deleting
+        // every stale `done` row before applying `limit` turns a nominal
+        // 25-page turn into a corpus-sized write. Giving stale markers and
+        // drift separate limited tables is not bounded either: disjoint sets
+        // advance 2 * limit pages, while overlaps are counted twice. The one
+        // connection-local batch is the overall budget and carries the bit
+        // needed to demote only rows selected from the drift arm. It
+        // participates in this transaction, so rollback loses the capture
+        // together with every queue and truth-state change.
         conn.execute_batch(
-            "CREATE TEMP TABLE IF NOT EXISTS claim_derivation_backlog_batch (
+            "CREATE TEMP TABLE IF NOT EXISTS claim_derivation_sweep_batch (
                  page_id TEXT NOT NULL,
                  page_version INTEGER NOT NULL,
+                 needs_demotion INTEGER NOT NULL CHECK (needs_demotion IN (0, 1)),
                  PRIMARY KEY (page_id, page_version)
              ) WITHOUT ROWID;
-             CREATE TEMP TABLE IF NOT EXISTS claim_derivation_drift_batch (
-                 page_id TEXT NOT NULL,
-                 page_version INTEGER NOT NULL,
-                 PRIMARY KEY (page_id, page_version)
-             ) WITHOUT ROWID;
-             DELETE FROM claim_derivation_backlog_batch;
-             DELETE FROM claim_derivation_drift_batch;",
+             DELETE FROM claim_derivation_sweep_batch;",
         )
         .await
         .map_err(|error| WenlanError::VectorDb(format!("derivation batch setup: {error}")))?;
 
-        let stale = conn
-            .execute(
-                "INSERT INTO claim_derivation_backlog_batch (page_id, page_version)
-                 SELECT p.id, p.version
-                   FROM pages p
-                  WHERE p.status = 'active'
-                    AND p.kind <> 'entity'
-                    AND NOT EXISTS (
-                        SELECT 1 FROM claim_derivation_markers m
-                         WHERE m.page_id = p.id
-                           AND m.page_version = p.version
-                           AND m.extractor_version = ?1
-                    )
-                    AND (
-                        NOT EXISTS (
-                            SELECT 1 FROM claim_derivation_jobs j
-                             WHERE j.page_id = p.id AND j.page_version = p.version
-                        )
-                        OR EXISTS (
-                            SELECT 1 FROM claim_derivation_jobs j
-                             WHERE j.page_id = p.id AND j.page_version = p.version
-                               AND j.status = 'done'
-                        )
-                    )
-                  ORDER BY p.id
-                  LIMIT ?2",
-                libsql::params![EXTRACTOR_VERSION, limit],
-            )
-            .await
-            .map_err(|error| WenlanError::VectorDb(format!("derivation backlog batch: {error}")))?;
-
-        let drifted = conn
+        let captured = conn
             .execute(
                 &format!(
-                    "INSERT INTO claim_derivation_drift_batch (page_id, page_version)
-                     SELECT d.drifted_page_id, d.drifted_page_version
-                       FROM ({DRIFTED_SUPPORTED_PAGES}) d
-                      ORDER BY d.drifted_page_id
-                      LIMIT ?2"
+                    "INSERT INTO claim_derivation_sweep_batch
+                         (page_id, page_version, needs_demotion)
+                     WITH stale_candidates(page_id, page_version) AS (
+                         SELECT p.id, p.version
+                           FROM pages p
+                          WHERE p.status = 'active'
+                            AND p.kind <> 'entity'
+                            AND NOT EXISTS (
+                                SELECT 1 FROM claim_derivation_markers m
+                                 WHERE m.page_id = p.id
+                                   AND m.page_version = p.version
+                                   AND m.extractor_version = ?2
+                            )
+                            AND (
+                                NOT EXISTS (
+                                    SELECT 1 FROM claim_derivation_jobs j
+                                     WHERE j.page_id = p.id
+                                       AND j.page_version = p.version
+                                )
+                                OR EXISTS (
+                                    SELECT 1 FROM claim_derivation_jobs j
+                                     WHERE j.page_id = p.id
+                                       AND j.page_version = p.version
+                                       AND j.status = 'done'
+                                )
+                            )
+                     ),
+                     drift_candidates(page_id, page_version) AS (
+                         SELECT d.drifted_page_id, d.drifted_page_version
+                           FROM ({DRIFTED_SUPPORTED_PAGES}) d
+                     ),
+                     candidate_pages(page_id, page_version) AS (
+                         SELECT page_id, page_version FROM stale_candidates
+                         UNION
+                         SELECT page_id, page_version FROM drift_candidates
+                     )
+                     SELECT c.page_id,
+                            c.page_version,
+                            EXISTS (
+                                SELECT 1 FROM drift_candidates d
+                                 WHERE d.page_id = c.page_id
+                                   AND d.page_version = c.page_version
+                            )
+                       FROM candidate_pages c
+                      ORDER BY c.page_id, c.page_version
+                      LIMIT ?3"
                 ),
-                libsql::params![SUPPORT_THRESHOLD, limit],
+                libsql::params![SUPPORT_THRESHOLD, EXTRACTOR_VERSION, limit],
             )
             .await
-            .map_err(|error| WenlanError::VectorDb(format!("derivation drift batch: {error}")))?;
+            .map_err(|error| WenlanError::VectorDb(format!("derivation batch capture: {error}")))?;
 
         // A selected `done` row is a stale claim of completion. Delete only
         // rows captured above; everything beyond the bound must remain byte-for-
@@ -652,7 +665,7 @@ impl MemoryDB {
               WHERE status = 'done'
                 AND (page_id, page_version) IN (
                     SELECT page_id, page_version
-                      FROM claim_derivation_backlog_batch
+                      FROM claim_derivation_sweep_batch
                 )",
             (),
         )
@@ -660,23 +673,11 @@ impl MemoryDB {
         .map_err(|error| WenlanError::VectorDb(format!("derivation backlog sweep: {error}")))?;
 
         conn.execute(
-            "DELETE FROM claim_derivation_jobs
-              WHERE status = 'done'
-                AND (page_id, page_version) IN (
-                    SELECT page_id, page_version
-                      FROM claim_derivation_drift_batch
-                )",
-            (),
-        )
-        .await
-        .map_err(|error| WenlanError::VectorDb(format!("derivation drift sweep: {error}")))?;
-
-        conn.execute(
             "INSERT INTO claim_derivation_jobs
                  (job_id, page_id, page_version, status, attempts, created_at, updated_at)
              SELECT b.page_id || ':' || b.page_version,
                     b.page_id, b.page_version, 'pending', 0, ?1, ?1
-               FROM claim_derivation_backlog_batch b
+               FROM claim_derivation_sweep_batch b
               WHERE NOT EXISTS (
                   SELECT 1 FROM claim_derivation_jobs j
                    WHERE j.page_id = b.page_id AND j.page_version = b.page_version
@@ -685,22 +686,6 @@ impl MemoryDB {
         )
         .await
         .map_err(|error| WenlanError::VectorDb(format!("derivation backlog enqueue: {error}")))?;
-
-        conn.execute(
-            "INSERT INTO claim_derivation_jobs
-                         (job_id, page_id, page_version, status, attempts, created_at, updated_at)
-             SELECT d.page_id || ':' || d.page_version,
-                    d.page_id, d.page_version, 'pending', 0, ?1, ?1
-               FROM claim_derivation_drift_batch d
-                      WHERE NOT EXISTS (
-                          SELECT 1 FROM claim_derivation_jobs j
-                   WHERE j.page_id = d.page_id
-                     AND j.page_version = d.page_version
-              )",
-            libsql::params![now],
-        )
-        .await
-        .map_err(|error| WenlanError::VectorDb(format!("derivation drift enqueue: {error}")))?;
 
         // Demote NOW, not when a worker eventually reaches the job just queued.
         // Queueing answers "when will we know again"; it does not answer "what
@@ -731,14 +716,15 @@ impl MemoryDB {
                   WHERE support_status = 'supported'
                     AND (page_id, page_version) IN (
                         SELECT page_id, page_version
-                          FROM claim_derivation_drift_batch
+                          FROM claim_derivation_sweep_batch
+                         WHERE needs_demotion = 1
                     )",
             libsql::params![now],
         )
         .await
         .map_err(|error| WenlanError::VectorDb(format!("derivation drift demotion: {error}")))?;
 
-        Ok((stale + drifted) as usize)
+        Ok(captured as usize)
     }
 
     /// Run [`Self::enqueue_stale_derivation_jobs`] until the backlog is drained,
@@ -763,7 +749,6 @@ impl MemoryDB {
     /// pages a personal vault holds; if one ever outgrows that, the fix is a
     /// keyset cursor on `p.id`, not a bigger batch.
     pub async fn drain_stale_derivation_jobs(&self, batch: i64) -> Result<usize, WenlanError> {
-        let batch = batch.max(1);
         let mut total = 0usize;
         loop {
             let created = self.enqueue_stale_derivation_jobs(batch).await?;
@@ -1396,15 +1381,16 @@ impl MemoryDB {
         }))
     }
 
-    /// Mark a job done. Returns false when the caller no longer holds the lease.
+    /// Mark one exact run done. Returns false when the caller no longer holds
+    /// that run's lease.
     ///
-    /// The `lease_owner` guard is the whole point: a worker that stalled past
-    /// its lease, had the job reclaimed, and then woke up must not be able to
-    /// declare the job finished — the new owner is mid-derivation and the old
-    /// worker's result describes a turn nobody is waiting for.
+    /// Owner alone is not an identity: a restarted worker commonly reuses its
+    /// configured owner string. The whole [`DerivationJob`] tuple, including
+    /// `run_generation`, is therefore the fence between a stale attempt and the
+    /// successor that reclaimed the same durable job.
     pub async fn finish_derivation_job(
         &self,
-        job_id: &str,
+        job: &DerivationJob,
         owner: &str,
     ) -> Result<bool, WenlanError> {
         let now = chrono::Utc::now().timestamp();
@@ -1417,8 +1403,20 @@ impl MemoryDB {
                         lease_expires_at = NULL,
                         last_error = NULL,
                         updated_at = ?1
-                  WHERE job_id = ?2 AND status = 'leased' AND lease_owner = ?3",
-                libsql::params![now, job_id, owner],
+                  WHERE job_id = ?2
+                    AND page_id = ?3
+                    AND page_version = ?4
+                    AND run_generation = ?5
+                    AND status = 'leased'
+                    AND lease_owner = ?6",
+                libsql::params![
+                    now,
+                    job.job_id.as_str(),
+                    job.page_id.as_str(),
+                    job.page_version,
+                    job.run_generation,
+                    owner
+                ],
             )
             .await
             .map_err(|error| WenlanError::VectorDb(format!("derivation finish: {error}")))?;
@@ -1432,7 +1430,7 @@ impl MemoryDB {
     /// once the attempts are exhausted.
     pub async fn release_derivation_job(
         &self,
-        job_id: &str,
+        job: &DerivationJob,
         owner: &str,
         error_text: &str,
     ) -> Result<bool, WenlanError> {
@@ -1446,8 +1444,21 @@ impl MemoryDB {
                         lease_expires_at = NULL,
                         last_error = ?1,
                         updated_at = ?2
-                  WHERE job_id = ?3 AND status = 'leased' AND lease_owner = ?4",
-                libsql::params![error_text, now, job_id, owner],
+                  WHERE job_id = ?3
+                    AND page_id = ?4
+                    AND page_version = ?5
+                    AND run_generation = ?6
+                    AND status = 'leased'
+                    AND lease_owner = ?7",
+                libsql::params![
+                    error_text,
+                    now,
+                    job.job_id.as_str(),
+                    job.page_id.as_str(),
+                    job.page_version,
+                    job.run_generation,
+                    owner
+                ],
             )
             .await
             .map_err(|error| WenlanError::VectorDb(format!("derivation release: {error}")))?;
@@ -2366,8 +2377,8 @@ impl MemoryDB {
     /// **Publication is bound to the lease, and to evidence that has not moved.**
     /// Two guards run inside the transaction, before anything is written:
     ///
-    /// 1. The job named by `job_id` must still be `leased` by `owner`. The
-    ///    `lease_owner` guard on [`Self::finish_derivation_job`] protected only
+    /// 1. The exact job run must still be `leased` by `owner`. The
+    ///    owner guard on [`Self::finish_derivation_job`] protected only
     ///    the *queue*, not the truth row: a worker that stalled past its lease
     ///    could be reclaimed, overtaken by a worker that reached the opposite
     ///    verdict, and still overwrite that published verdict on waking. Its
@@ -2390,7 +2401,7 @@ impl MemoryDB {
         &self,
         page_id: &str,
         page_version: i64,
-        job_id: &str,
+        job: &DerivationJob,
         owner: &str,
         outcome: &SupportOutcome,
     ) -> Result<bool, WenlanError> {
@@ -2405,16 +2416,26 @@ impl MemoryDB {
             .map_err(|error| WenlanError::VectorDb(format!("support finalize begin: {error}")))?;
 
         let published = async {
-            // Guard 1: the lease. `page_id`/`page_version` are matched too, so a
-            // job id cannot be spent against a different page than the one it
-            // names.
+            // Guard 1: the exact lease. Every field in `DerivationJob` is
+            // matched, especially the run generation: owner strings can be
+            // reused by a restarted worker after reclaim.
             let holds_lease = {
                 let mut rows = tx
                     .query(
                         "SELECT 1 FROM claim_derivation_jobs
-                          WHERE job_id = ?1 AND page_id = ?2 AND page_version = ?3
-                            AND status = 'leased' AND lease_owner = ?4",
-                        libsql::params![job_id, page_id, page_version, owner],
+                          WHERE job_id = ?1
+                            AND page_id = ?2
+                            AND page_version = ?3
+                            AND run_generation = ?4
+                            AND status = 'leased'
+                            AND lease_owner = ?5",
+                        libsql::params![
+                            job.job_id.as_str(),
+                            job.page_id.as_str(),
+                            job.page_version,
+                            job.run_generation,
+                            owner
+                        ],
                     )
                     .await
                     .map_err(|error| {
@@ -2428,6 +2449,9 @@ impl MemoryDB {
                     .is_some()
             };
             if !holds_lease {
+                return Ok(false);
+            }
+            if job.page_id != page_id || job.page_version != page_version {
                 return Ok(false);
             }
 

--- a/crates/wenlan-core/src/db/claim_derivation_test.rs
+++ b/crates/wenlan-core/src/db/claim_derivation_test.rs
@@ -3,7 +3,8 @@
 //! guards; deleting the rule in the doc comment must turn the test RED.
 
 use super::claim_derivation::{
-    CandidateLocator, SupportOutcome, EXTRACTOR_VERSION, MAX_ATTEMPTS, SUPPORT_THRESHOLD,
+    CandidateLocator, DerivationJob, SupportOutcome, EXTRACTOR_VERSION, MAX_ATTEMPTS,
+    SUPPORT_THRESHOLD,
 };
 use super::tests::test_db;
 use super::MemoryDB;
@@ -318,20 +319,59 @@ async fn a_reclaimed_job_cannot_be_finished_by_its_old_owner() {
         .await
         .unwrap();
     }
-    db.lease_next_derivation_job("rescuer").await.unwrap();
+    let reclaimed = db
+        .lease_next_derivation_job("rescuer")
+        .await
+        .unwrap()
+        .unwrap();
 
     assert!(
-        !db.finish_derivation_job(&job.job_id, "zombie")
-            .await
-            .unwrap(),
+        !db.finish_derivation_job(&job, "zombie").await.unwrap(),
         "the old owner's finish must be a no-op"
     );
     assert_eq!(job_for(&db, "p1").await.unwrap().1, "leased");
     assert!(db
-        .finish_derivation_job(&job.job_id, "rescuer")
+        .finish_derivation_job(&reclaimed, "rescuer")
         .await
         .unwrap());
     assert_eq!(job_for(&db, "p1").await.unwrap().1, "done");
+}
+
+/// Owner names are labels, not run identities. A daemon may restart with the
+/// same configured owner after its old lease expires, so the successor needs a
+/// generation fence even though `lease_owner` did not change.
+#[tokio::test]
+async fn a_same_owner_reclaim_rejects_the_old_runs_finish() {
+    let (db, _temp) = db_with_queue().await;
+    add_page(&db, "p1").await;
+
+    let stale = db
+        .lease_next_derivation_job("worker")
+        .await
+        .unwrap()
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE claim_derivation_jobs SET lease_expires_at = 1 WHERE job_id = ?1",
+            libsql::params![stale.job_id.clone()],
+        )
+        .await
+        .unwrap();
+    }
+    let current = db
+        .lease_next_derivation_job("worker")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_ne!(stale.run_generation, current.run_generation);
+
+    assert!(
+        !db.finish_derivation_job(&stale, "worker").await.unwrap(),
+        "the old run must not finish a same-owner successor"
+    );
+    assert_eq!(job_for(&db, "p1").await.unwrap().1, "leased");
+    assert!(db.finish_derivation_job(&current, "worker").await.unwrap());
 }
 
 /// Candidate inventory is an assertion about one exact run, so a worker whose
@@ -473,7 +513,7 @@ async fn a_job_that_keeps_crashing_its_worker_parks() {
             .await
             .unwrap()
             .expect("job must stay claimable until attempts run out");
-        db.release_derivation_job(&job.job_id, "worker", "boom")
+        db.release_derivation_job(&job, "worker", "boom")
             .await
             .unwrap();
     }
@@ -487,6 +527,49 @@ async fn a_job_that_keeps_crashing_its_worker_parks() {
     );
     assert_eq!(db.park_exhausted_derivation_jobs().await.unwrap(), 1);
     assert_eq!(job_for(&db, "poison").await.unwrap().1, "parked");
+}
+
+/// Release has the same causal fence as finish: a stale attempt from a daemon
+/// incarnation with the same owner string may not put the current run back on
+/// the queue or overwrite its error.
+#[tokio::test]
+async fn a_same_owner_reclaim_rejects_the_old_runs_release() {
+    let (db, _temp) = db_with_queue().await;
+    add_page(&db, "p1").await;
+
+    let stale = db
+        .lease_next_derivation_job("worker")
+        .await
+        .unwrap()
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE claim_derivation_jobs SET lease_expires_at = 1 WHERE job_id = ?1",
+            libsql::params![stale.job_id.clone()],
+        )
+        .await
+        .unwrap();
+    }
+    let current = db
+        .lease_next_derivation_job("worker")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_ne!(stale.run_generation, current.run_generation);
+
+    assert!(
+        !db.release_derivation_job(&stale, "worker", "stale failure")
+            .await
+            .unwrap(),
+        "the old run must not release a same-owner successor"
+    );
+    assert_eq!(job_for(&db, "p1").await.unwrap().1, "leased");
+    assert!(db
+        .release_derivation_job(&current, "worker", "current failure")
+        .await
+        .unwrap());
+    assert_eq!(job_for(&db, "p1").await.unwrap().1, "pending");
 }
 
 /// A worker that cannot finish must never be the reason a page is called
@@ -1076,17 +1159,18 @@ async fn carry_seeded_judgements(db: &MemoryDB, page_id: &str, page_version: i64
     carry_attempts_forward(&conn, page_id, page_version, generation).await;
 }
 
-/// Put one page's job in the state a worker holds it in, and return its id.
+/// Put one page's job in the state a worker holds it in, and return its exact
+/// leased run handle.
 ///
 /// Publication is bound to the lease, so every test that finalizes has to hold
 /// one. Leasing by `(page_id, page_version)` rather than through
 /// `lease_next_derivation_job` keeps a multi-page test from having to guess the
 /// queue order, and keeps the version straight on a page that has jobs for two.
 /// The real lease path has its own teeth above; this is a fixture.
-async fn lease_page(db: &MemoryDB, page_id: &str, page_version: i64, owner: &str) -> String {
+async fn lease_page(db: &MemoryDB, page_id: &str, page_version: i64, owner: &str) -> DerivationJob {
     let conn = db.conn.lock().await;
     let generation = MemoryDB::allocate_run_generation(&conn).await.unwrap();
-    let job_id = {
+    let job = {
         let mut rows = conn
             .query(
                 "UPDATE claim_derivation_jobs
@@ -1094,7 +1178,7 @@ async fn lease_page(db: &MemoryDB, page_id: &str, page_version: i64, owner: &str
                         lease_expires_at = ?4, attempts = attempts + 1,
                         run_generation = ?5, updated_at = ?4
                   WHERE page_id = ?1 AND page_version = ?2
-                  RETURNING job_id",
+                  RETURNING job_id, page_id, page_version",
                 libsql::params![
                     page_id,
                     page_version,
@@ -1105,15 +1189,20 @@ async fn lease_page(db: &MemoryDB, page_id: &str, page_version: i64, owner: &str
             )
             .await
             .unwrap();
-        rows.next()
+        let row = rows
+            .next()
             .await
             .unwrap()
-            .expect("the page must have a queued job to lease")
-            .get::<String>(0)
-            .unwrap()
+            .expect("the page must have a queued job to lease");
+        DerivationJob {
+            job_id: row.get::<String>(0).unwrap(),
+            page_id: row.get::<String>(1).unwrap(),
+            page_version: row.get::<i64>(2).unwrap(),
+            run_generation: generation,
+        }
     };
     carry_attempts_forward(&conn, page_id, page_version, generation).await;
-    job_id
+    job
 }
 
 async fn truth_row(db: &MemoryDB, page_id: &str) -> Option<(String, Option<i64>, i64)> {
@@ -1689,12 +1778,12 @@ async fn a_reclaimed_job_cannot_publish_its_old_owners_verdict() {
         "got {fresh:?}"
     );
     assert!(db
-        .finalize_page_support("p1", 1, &reclaimed.job_id, "worker-b", &fresh)
+        .finalize_page_support("p1", 1, &reclaimed, "worker-b", &fresh)
         .await
         .unwrap());
 
     assert!(
-        !db.finalize_page_support("p1", 1, &job.job_id, "worker-a", &stale)
+        !db.finalize_page_support("p1", 1, &job, "worker-a", &stale)
             .await
             .unwrap(),
         "a worker whose lease was reclaimed must not publish over its successor"
@@ -1702,6 +1791,59 @@ async fn a_reclaimed_job_cannot_publish_its_old_owners_verdict() {
     let (status, evaluated, _) = truth_row(&db, "p1").await.unwrap();
     assert_eq!(status, "provisional", "worker B's verdict has to survive");
     assert!(evaluated.is_some());
+}
+
+/// The harder reclaim: both runs use the same stable owner string and the
+/// evidence stays byte-identical, so owner, job id, page version, and verdict
+/// all agree. Only the lease generation can distinguish the stale computation
+/// from the successor that currently holds the job.
+#[tokio::test]
+async fn a_same_owner_reclaim_rejects_the_old_runs_publication() {
+    let (db, _temp) = db_with_queue().await;
+    add_page(&db, "p1").await;
+    let revisions = derive_page(&db, "p1", 1).await;
+    support_claim(&db, "p1", &revisions[0], 0.9).await;
+
+    let stale = db
+        .lease_next_derivation_job("worker")
+        .await
+        .unwrap()
+        .unwrap();
+    carry_seeded_judgements(&db, "p1", 1).await;
+    let stale_outcome = db.evaluate_page_support("p1", 1).await.unwrap();
+    assert_eq!(stale_outcome, SupportOutcome::Supported);
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE claim_derivation_jobs SET lease_expires_at = 1 WHERE job_id = ?1",
+            libsql::params![stale.job_id.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    let current = db
+        .lease_next_derivation_job("worker")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_ne!(stale.run_generation, current.run_generation);
+    carry_seeded_judgements(&db, "p1", 1).await;
+    let current_outcome = db.evaluate_page_support("p1", 1).await.unwrap();
+    assert_eq!(current_outcome, stale_outcome);
+
+    assert!(
+        !db.finalize_page_support("p1", 1, &stale, "worker", &stale_outcome)
+            .await
+            .unwrap(),
+        "the old run must not publish through a same-owner successor's lease"
+    );
+    assert!(truth_row(&db, "p1").await.is_none());
+    assert!(db
+        .finalize_page_support("p1", 1, &current, "worker", &current_outcome)
+        .await
+        .unwrap());
+    assert_eq!(truth_row(&db, "p1").await.unwrap().0, "supported");
 }
 
 /// The lease guard, isolated. Here the evidence never changes, so the verdict
@@ -1737,7 +1879,7 @@ async fn a_parked_jobs_former_worker_cannot_publish() {
     assert_eq!(db.park_exhausted_derivation_jobs().await.unwrap(), 1);
 
     assert!(
-        !db.finalize_page_support("p1", 1, &job.job_id, "worker", &outcome)
+        !db.finalize_page_support("p1", 1, &job, "worker", &outcome)
             .await
             .unwrap(),
         "a parked job has no holder, so nobody may publish through it"
@@ -1780,7 +1922,7 @@ async fn evidence_that_moved_after_evaluation_is_not_published() {
     }
 
     assert!(
-        !db.finalize_page_support("p1", 1, &job.job_id, "worker", &outcome)
+        !db.finalize_page_support("p1", 1, &job, "worker", &outcome)
             .await
             .unwrap(),
         "a verdict whose evidence is gone must not be published on the strength \
@@ -1892,7 +2034,7 @@ async fn a_healthy_fifth_lease_is_not_parked() {
             .await
             .unwrap()
             .unwrap();
-        db.release_derivation_job(&job.job_id, "worker", "daemon restart")
+        db.release_derivation_job(&job, "worker", "daemon restart")
             .await
             .unwrap();
     }
@@ -1910,9 +2052,7 @@ async fn a_healthy_fifth_lease_is_not_parked() {
     );
     assert_eq!(job_for(&db, "p1").await.unwrap().1, "leased");
     assert!(
-        db.finish_derivation_job(&job.job_id, "worker")
-            .await
-            .unwrap(),
+        db.finish_derivation_job(&job, "worker").await.unwrap(),
         "and the healthy run's finish must still be accepted"
     );
 }
@@ -1931,7 +2071,7 @@ async fn an_expired_fifth_lease_still_parks() {
             .await
             .unwrap()
             .unwrap();
-        db.release_derivation_job(&job.job_id, "worker", "boom")
+        db.release_derivation_job(&job, "worker", "boom")
             .await
             .unwrap();
     }
@@ -2048,6 +2188,120 @@ async fn support_that_no_longer_clears_the_bar_is_re_enqueued() {
         "the scan has to see edge validity and the live bar, not only the marker"
     );
     assert_eq!(job_for(&db, "p1").await.unwrap().1, "pending");
+}
+
+/// A signed SQL LIMIT is not a bound: SQLite treats a negative value as "no
+/// limit", while zero can disguise a caller bug as a clean drain. Both are
+/// rejected before the transaction or its temp batch can mutate anything.
+#[tokio::test]
+async fn non_positive_sweep_limits_reject_without_mutation() {
+    let (db, _temp) = db_with_queue().await;
+    add_page(&db, "p1").await;
+    let revisions = derive_page(&db, "p1", 1).await;
+    support_claim(&db, "p1", &revisions[0], SUPPORT_THRESHOLD + 0.02).await;
+    publish_supported(&db, "p1").await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE edges SET payload = json_set(payload, '$.score', ?1)
+              WHERE edge_type = 'supports'",
+            libsql::params![SUPPORT_THRESHOLD - 0.05],
+        )
+        .await
+        .unwrap();
+    }
+
+    let before_job = job_for(&db, "p1").await.unwrap();
+    let before_truth = truth_row(&db, "p1").await.unwrap();
+    for invalid in [-1, 0] {
+        assert!(
+            matches!(
+                db.enqueue_stale_derivation_jobs(invalid).await,
+                Err(crate::WenlanError::Validation(_))
+            ),
+            "limit {invalid} must be rejected"
+        );
+        assert_eq!(job_for(&db, "p1").await.unwrap(), before_job);
+        assert_eq!(truth_row(&db, "p1").await.unwrap(), before_truth);
+    }
+}
+
+/// Stale-marker and support-drift work share one overall budget. Capturing a
+/// full batch from each class would advance four pages under a limit of two;
+/// ordering the distinct union first advances exactly two and leaves both kinds
+/// of tail byte-for-byte ready for the next turn.
+#[tokio::test]
+async fn mixed_disjoint_work_shares_one_bound_and_leaves_the_tail_unchanged() {
+    let (db, _temp) = db_with_queue().await;
+    for page_id in ["a_stale", "c_stale"] {
+        add_page(&db, page_id).await;
+        mark_derived(&db, page_id, 1, EXTRACTOR_VERSION - 1).await;
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE claim_derivation_jobs SET status = 'done' WHERE page_id = ?1",
+            libsql::params![page_id],
+        )
+        .await
+        .unwrap();
+    }
+    for page_id in ["b_drift", "d_drift"] {
+        add_page(&db, page_id).await;
+        let revisions = derive_page(&db, page_id, 1).await;
+        support_claim(&db, page_id, &revisions[0], SUPPORT_THRESHOLD + 0.02).await;
+        publish_supported(&db, page_id).await;
+    }
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE edges SET payload = json_set(payload, '$.score', ?1)
+              WHERE edge_type = 'supports'",
+            libsql::params![SUPPORT_THRESHOLD - 0.05],
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(db.enqueue_stale_derivation_jobs(2).await.unwrap(), 2);
+    assert_eq!(job_for(&db, "a_stale").await.unwrap().1, "pending");
+    assert_eq!(job_for(&db, "b_drift").await.unwrap().1, "pending");
+    assert_eq!(truth_row(&db, "b_drift").await.unwrap().0, "provisional");
+
+    assert_eq!(job_for(&db, "c_stale").await.unwrap().1, "done");
+    assert_eq!(job_for(&db, "d_drift").await.unwrap().1, "done");
+    assert_eq!(truth_row(&db, "d_drift").await.unwrap().0, "supported");
+}
+
+/// One page may be stale by extractor marker and drifted by evidence at once.
+/// The batch and its return value count pages, not candidate-class matches.
+#[tokio::test]
+async fn overlapping_stale_and_drift_work_is_counted_once() {
+    let (db, _temp) = db_with_queue().await;
+    add_page(&db, "overlap").await;
+    let revisions = derive_page(&db, "overlap", 1).await;
+    support_claim(&db, "overlap", &revisions[0], SUPPORT_THRESHOLD + 0.02).await;
+    publish_supported(&db, "overlap").await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE claim_derivation_markers SET extractor_version = ?1
+              WHERE page_id = 'overlap'",
+            libsql::params![EXTRACTOR_VERSION - 1],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "UPDATE edges SET payload = json_set(payload, '$.score', ?1)
+              WHERE edge_type = 'supports'",
+            libsql::params![SUPPORT_THRESHOLD - 0.05],
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(db.enqueue_stale_derivation_jobs(1).await.unwrap(), 1);
+    assert_eq!(job_for(&db, "overlap").await.unwrap().1, "pending");
+    assert_eq!(truth_row(&db, "overlap").await.unwrap().0, "provisional");
+    assert_eq!(db.enqueue_stale_derivation_jobs(1).await.unwrap(), 0);
 }
 
 /// Row 15's runtime bound must constrain the SAME set for enqueue and
@@ -2837,7 +3091,7 @@ async fn a_retried_job_does_not_inherit_the_previous_runs_conclusions() {
         SupportOutcome::Supported
     );
 
-    db.release_derivation_job(&first.job_id, "worker-a", "daemon restart")
+    db.release_derivation_job(&first, "worker-a", "daemon restart")
         .await
         .unwrap();
     let retry = db

--- a/crates/wenlan-core/src/db/truth_exposure_test.rs
+++ b/crates/wenlan-core/src/db/truth_exposure_test.rs
@@ -1147,6 +1147,9 @@ fn the_runtime_backlog_continuation_is_fenced_out_of_repair_mode() {
         ),
         "MemoryDB::new reaches migration 105, whose pre-serve queue seed must use the named bound"
     );
+    let enqueue_start = claim_derivation
+        .find("pub async fn enqueue_stale_derivation_jobs(")
+        .expect("the bounded sweep entry point must exist");
     let sweep_start = claim_derivation
         .find("async fn sweep_stale_derivation_jobs(")
         .expect("the bounded sweep implementation must exist");
@@ -1154,29 +1157,58 @@ fn the_runtime_backlog_continuation_is_fenced_out_of_repair_mode() {
         .find("pub async fn drain_stale_derivation_jobs(")
         .map(|offset| sweep_start + offset)
         .expect("the drain must follow the bounded sweep");
+    let enqueue = &claim_derivation[enqueue_start..sweep_start];
+    let validation = enqueue
+        .find("if limit <= 0")
+        .expect("the signed sweep bound must be validated");
+    let transaction = enqueue
+        .find("transaction_with_behavior")
+        .expect("the bounded sweep must remain transactional");
+    assert!(
+        validation < transaction,
+        "a non-positive limit must fail before any transactional or temp-table mutation"
+    );
+
     let sweep = &claim_derivation[sweep_start..sweep_end];
-    let stale_capture = sweep
-        .find("INSERT INTO claim_derivation_backlog_batch")
-        .expect("stale-marker cleanup must first capture a bounded batch");
-    let drift_capture = sweep
-        .find("INSERT INTO claim_derivation_drift_batch")
-        .expect("drift cleanup must first capture a bounded batch");
+    assert_eq!(
+        sweep.matches("CREATE TEMP TABLE").count(),
+        1,
+        "stale-marker and drift work must share one overall batch table"
+    );
+    assert!(
+        !sweep.contains("claim_derivation_backlog_batch")
+            && !sweep.contains("claim_derivation_drift_batch"),
+        "the former independently bounded batches must not return"
+    );
+    let capture = sweep
+        .find("INSERT INTO claim_derivation_sweep_batch")
+        .expect("all sweep candidates must first enter the unified batch");
     let first_cleanup = sweep
         .find("DELETE FROM claim_derivation_jobs")
-        .expect("the captured batches must replace stale done jobs");
+        .expect("the captured batch must replace stale done jobs");
     assert!(
-        stale_capture < first_cleanup && drift_capture < first_cleanup,
-        "both bounded sets must be captured before any cleanup write can touch jobs"
+        capture < first_cleanup,
+        "the unified bounded set must be captured before any cleanup write can touch jobs"
     );
-    for (batch, minimum_uses) in [
-        ("FROM claim_derivation_backlog_batch", 2),
-        ("FROM claim_derivation_drift_batch", 3),
-    ] {
-        assert!(
-            sweep.matches(batch).count() >= minimum_uses,
-            "{batch} must bind capture, done-job cleanup, and pending insertion/demotion"
-        );
-    }
+    assert!(
+        sweep.contains("UNION")
+            && sweep.contains("ORDER BY c.page_id, c.page_version")
+            && sweep.contains("LIMIT ?3"),
+        "the distinct stale/drift union needs one deterministic overall bound"
+    );
+    assert_eq!(
+        sweep.matches("FROM claim_derivation_sweep_batch").count(),
+        4,
+        "one batch reset plus done-job cleanup, pending insertion, and demotion must be the only unified-batch consumers"
+    );
+    assert!(
+        sweep.contains("WHERE needs_demotion = 1"),
+        "the unified batch must retain which captured rows need synchronous demotion"
+    );
+    assert!(
+        sweep.contains("Ok(captured as usize)"),
+        "the returned progress must count distinct rows in the unified batch"
+    );
     let fence = runtime
         .find("if optional_runtime_workers_allowed(repair_recovery_pending)")
         .expect("repair recovery must fence optional runtime workers");

--- a/crates/wenlan-server/src/daemon_structure_test.rs
+++ b/crates/wenlan-server/src/daemon_structure_test.rs
@@ -2033,18 +2033,15 @@ fn truth_reconciliation_work_runs_only_in_the_runtime_worker() {
         .map(|offset| sweep_start + offset)
         .expect("the drain must follow the bounded sweep");
     let sweep = &claim_derivation[sweep_start..sweep_end];
-    let backlog_capture = sweep
-        .find("INSERT INTO claim_derivation_backlog_batch")
-        .expect("constructor-time stale cleanup must have a captured bound");
-    let drift_capture = sweep
-        .find("INSERT INTO claim_derivation_drift_batch")
-        .expect("constructor-time drift cleanup must have a captured bound");
+    let capture = sweep
+        .find("INSERT INTO claim_derivation_sweep_batch")
+        .expect("constructor-time cleanup must have one captured overall bound");
     let first_cleanup = sweep
         .find("DELETE FROM claim_derivation_jobs")
         .expect("the sweep must replace selected done jobs");
     assert!(
-        backlog_capture < first_cleanup && drift_capture < first_cleanup,
-        "no pre-serve cleanup write may run before both bounded batches are captured"
+        capture < first_cleanup,
+        "no pre-serve cleanup write may run before the unified bounded batch is captured"
     );
 }
 

--- a/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
+++ b/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
@@ -900,7 +900,7 @@ carrying the authority of agreement.
 | `core/db.rs:46798` | `get_stale_page_after` | `pub` | internal-only |
 | `core/db.rs:46835` | `list_stale_pages_scoped` | `pub` | **exposure** — `server/routes.rs:772` |
 | `core/db.rs:46875` | `find_stale_archived_pages` | `pub` | **exposure** — `server/cmd_backfill.rs:49` |
-| `core/db/claim_derivation.rs:1756` | `evaluate_support_on` | `private` | internal-only |
+| `core/db/claim_derivation.rs:1767` | `evaluate_support_on` | `private` | internal-only |
 | `core/db/maintenance_duplicate_reads.rs:35` | `embedding_near_duplicate_pairs` | `pub(crate)` | internal-only |
 | `core/db/maintenance_duplicate_reads.rs:108` | `scan_near_duplicate_slice` | `pub(crate)` | internal-only |
 | `core/db/maintenance_retro_scan.rs:17` | `scan_automatic_retro_stub_slice` | `pub(crate)` | internal-only |
@@ -951,9 +951,9 @@ carrying the authority of agreement.
 | `core/db.rs:44108` | `list_active_page_titles` | `pub` | `list_active_page_titles_scoped` |
 | `core/db.rs:44549` | `resolve_orphan_page_links` | `pub` | `find_unique_active_page_id_by_title_scoped` |
 | `core/db.rs:46788` | `list_stale_pages` | `pub` | `list_stale_pages_scoped` |
-| `core/db/claim_derivation.rs:959` | `reconcile_supported_pages` | `pub` | `evaluate_support_on` |
-| `core/db/claim_derivation.rs:1503` | `evaluate_page_support` | `pub` | `evaluate_support_on` |
-| `core/db/claim_derivation.rs:2389` | `finalize_page_support` | `pub` | `evaluate_support_on` |
+| `core/db/claim_derivation.rs:944` | `reconcile_supported_pages` | `pub` | `evaluate_support_on` |
+| `core/db/claim_derivation.rs:1514` | `evaluate_page_support` | `pub` | `evaluate_support_on` |
+| `core/db/claim_derivation.rs:2400` | `finalize_page_support` | `pub` | `evaluate_support_on` |
 | `core/db/presence_review.rs:112` | `review_in_txn` | `private` | `page_binding` |
 | `core/db/repair_page_rename.rs:622` | `rename_page_projection_matches_post` | `private` | `page_on_connection` |
 | `core/db/scoped_pages.rs:280` | `list_recent_pages_with_badges_scoped` | `pub` | `list_recent_pages_with_badges` |


### PR DESCRIPTION
## Summary

- fence every terminal derivation operation by the exact leased run generation
- replace separate stale and drift passes with one bounded distinct-union TEMP sweep
- reject non-positive sweep limits before locking and keep server structure checks aligned
- regenerate the sealed M5 reader inventory after latest-main integration

## Verification

- focused claim derivation module: 72 passed, 0 failed
- core truth-exposure structural tooth: passed
- server daemon structure tooth: passed
- cargo fmt --all -- --check: passed
- cargo clippy --workspace --all-targets -- -D warnings: passed
- changed-file LSP diagnostics: clean
- fresh independent Sol review: CLOSED
- post-integration cargo test --workspace --quiet: exit 0; core lib 3760 passed, 33 ignored; all remaining workspace binaries passed
- inventory check: 285 rows; depth 58/57/95/75; exposure 45

## Scope

This is the safety follow-up required before implementing the production M5 promoter. It does not add an M6 producer or write permanent genesis coverage.