### PR TITLE
test: verify ordinary M4 routing canary

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -172,7 +172,7 @@ fn push_read_scope_filter(
     }
 }
 
-/// Same as `push_read_scope_filter`, but for columns migrated by the space-sentinel
+/// CI routing canary: same as `push_read_scope_filter`, for space-sentinel columns;
 /// fold (`memories.space`, `chunks.space`, `pages.workspace`): unfiled rows are
 /// stored as `UNFILED_SPACE_ID`, not SQL NULL, so `Uncategorized` must match either.
 fn push_read_scope_filter_folded(

--- a/crates/wenlan-core/src/m6/frontier_policy.rs
+++ b/crates/wenlan-core/src/m6/frontier_policy.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+// CI routing canary: cross-platform M6 source remains on canonical Linux.
 //! D2/D3 plus J1 frontier-policy substrate for migration 109.
 //!
 //! This module deliberately owns no transaction. Migration setup and every


### PR DESCRIPTION
Validation-only canary. This PR must never be merged.

It changes two comments to exercise the ordinary product routing that previously made #437 slow:
- `db.rs` should select only the focused macOS M4 owner.
- generic M6 source should remain on canonical Linux coverage.

Acceptance: required CI succeeds in under 20 minutes; no release-preflight; generic macOS/Windows platform plan does not expand to the whole impact inventory. Close and delete the branch after collecting receipts.