### PR TITLE
ci: count filtered canary inventory

### DIFF
--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -105,10 +105,13 @@ jobs:
               if case.get("filter-match", {}).get("status") == "matches"
               and case.get("ignored") is True
           }
-          if matched != expected or payload.get("test-count") != 2:
+          # nextest's top-level test-count is the full discovered inventory,
+          # not the number left after the filter expression.
+          if matched != expected or len(matched) != 2:
               raise SystemExit(
                   f"main canary inventory drift: expected={sorted(expected)!r} "
-                  f"matched={sorted(matched)!r} count={payload.get('test-count')!r}"
+                  f"matched={sorted(matched)!r} matched_count={len(matched)!r} "
+                  f"discovered_count={payload.get('test-count')!r}"
               )
           PY
       - name: Run embedding-only eval

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -6764,7 +6764,8 @@ fn main_canary_contract_violations(ci_workflow: &str, canary_workflow: &str) -> 
         || !inventory_run.contains("--ignore-default-filter")
         || !inventory_run.contains("-E \"$CANARY_FILTER\"")
         || !inventory_run.contains("--message-format json")
-        || !inventory_run.contains("payload.get(\"test-count\") != 2")
+        || !inventory_run.contains("len(matched) != 2")
+        || inventory_run.contains("payload.get(\"test-count\") != 2")
         || !inventory_run.contains("case.get(\"ignored\") is True")
         || !inventory_run.contains("eval::retrieval::tests::test_run_quality_cost_eval_basic")
         || !inventory_run.contains("eval::retrieval_drift::tests::ranking_drift_vs_golden")
@@ -6968,6 +6969,22 @@ fn main_canary_contract_rejects_eval_inside_conclusion_itself() {
             .iter()
             .any(|violation| violation.contains("required CI test critical path")),
         "fixture must reject an eval step inside conclusion itself: {violations:?}"
+    );
+}
+
+#[test]
+fn main_canary_contract_rejects_discovery_count_as_filter_count() {
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let canary = std::fs::read_to_string(root.join(".github/workflows/main-canary.yml"))
+        .expect("read main-canary.yml")
+        .replace("len(matched) != 2", "payload.get(\"test-count\") != 2");
+    let violations = main_canary_contract_violations(&ci, &canary);
+    assert!(
+        violations
+            .iter()
+            .any(|violation| violation.contains("exact two-test ignored inventory")),
+        "top-level discovery count must not masquerade as the filtered inventory: {violations:?}"
     );
 }
 


### PR DESCRIPTION
## What changed

- count the tests that actually match the exact nextest filter instead of comparing the top-level discovery count
- retain the full discovery count only as diagnostic context
- add a drift-guard mutation that rejects the old discovery-count interpretation

## Root cause

The first production Main Canary route selected exactly the intended two ignored tests, but nextest reported `test-count=3800` because that field is the full discovered inventory, not the filter result count. The workflow therefore failed before running the eval even though the matched set was correct.

## Validation

- production receipt: run 30762958689 logged the exact two expected matches and discovery count 3800
- hermetic fixture: discovery count 3800 with exactly two matching ignored tests — pass
- `python scripts/ci_measure_plan.test.py` — 14/14
- `python scripts/ci_test_plan.test.py` — 80/80
- workflow YAML parse, `cargo fmt --all --check`, and `git diff --check` — pass
- independent read-only review — no blocking findings
- targeted Rust execution remains delegated to Linux CI because this Windows host lacks the repository's Vulkan SDK prerequisite
