### PR TITLE
ci: shard macOS tests from reusable archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,10 +534,19 @@ jobs:
             # A same-looking but untrusted branch must get more work, never a
             # security-sensitive skip.
             include="${macos},${windows}"
-          elif [ "${{ steps.filter.outputs.macos }}" = "true" ] && [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+          elif [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ steps.filter.outputs.macos }}" = "true" ] && [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+            # Main keeps the historical native backstop for raw platform
+            # owners. PRs below use only direct macOS owners so an archive-
+            # owned change cannot allocate an otherwise empty macOS runner.
             include="${macos},${windows}"
-          elif [ "${{ steps.filter.outputs.macos }}" = "true" ]; then
+          elif [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ steps.filter.outputs.macos }}" = "true" ]; then
             include="$macos"
+          elif [ "${{ steps.filter.outputs.m5-platform }}" = "true" ] || [ "${{ steps.filter.outputs.nextest-config }}" = "true" ]; then
+            if [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
+              include="${macos},${windows}"
+            else
+              include="$macos"
+            fi
           elif [ "${{ steps.filter.outputs.windows }}" = "true" ]; then
             include="$windows"
           else
@@ -963,7 +972,7 @@ jobs:
   test:
     name: test (${{ matrix.label }})
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')"
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (github.event_name != 'pull_request' && needs.detect-changes.outputs.macos == 'true') || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')"
     runs-on: ${{ matrix.os }}
     # Pull requests keep a hard wall-clock budget. Windows needs the full
     # backstop because its Vulkan/native bootstrap plus integration suite can
@@ -2062,7 +2071,7 @@ jobs:
           run_fmt='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.fmt-required == 'true' }}'
           run_clippy='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.clippy-required == 'true' }}'
           run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'
-          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'
+          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (github.event_name != 'pull_request' && needs.detect-changes.outputs.macos == 'true') || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'
           run_workspace_lib='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true' }}'
           run_canonical='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.canonical-acceptance-required == 'true' }}'
           run_contract='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.contract-integration-required == 'true' }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,11 @@ jobs:
               # unrelated Windows or MCP platform owners.
               - 'scripts/ci_test_plan.py'
               - 'scripts/ci_test_plan.test.py'
+              - 'crates/wenlan-server/tests/common/daemon_binary.rs'
+              - 'crates/wenlan-server/tests/daemon_binary_path.rs'
+              - 'crates/wenlan-server/tests/graceful_shutdown.rs'
+              - 'crates/wenlan-server/tests/port_discovery.rs'
+              - 'crates/wenlan-server/tests/port_taken_no_db_init.rs'
 
       - name: Test release merge proof
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -851,18 +851,117 @@ jobs:
             --workspace-remap "$GITHUB_WORKSPACE" \
             --partition "$CI_TEST_PARTITION"
 
+  # macOS owns cfg-bearing behavior, but its broad unit suite can exceed the
+  # PR budget on a three-core hosted runner. Compile the no-feature graph once
+  # (affected libs, CLI/server integrations, and M4), then reuse those exact
+  # archives across three balanced nextest slices. M5 keeps its separate
+  # eval-harness feature graph in `test` below.
+  macos-nextest-build:
+    name: macos-nextest archive
+    needs: [detect-changes]
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))"
+    runs-on: macos-14
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: test
+          cache-all-crates: "true"
+          cache-targets: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: cargo-nextest
+      - name: Build exact macOS nextest archives
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.platform-test-plan }}
+          M4_REQUIRED: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}
+        run: |
+          python3 scripts/ci_test_plan.py macos-archive \
+            --plan-json "$CI_TEST_PLAN" \
+            --archive-dir "$RUNNER_TEMP/wenlan-macos-nextest-${GITHUB_RUN_ID}" \
+            --include-m4 "$M4_REQUIRED"
+      - name: Publish exact macOS nextest archives
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: wenlan-macos-nextest-${{ github.run_id }}
+          path: ${{ runner.temp }}/wenlan-macos-nextest-${{ github.run_id }}
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
+  macos-nextest:
+    name: macos-nextest (${{ matrix.partition }})
+    needs: [detect-changes, macos-nextest-build]
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))"
+    runs-on: macos-14
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
+    strategy:
+      fail-fast: true
+      matrix:
+        partition: [slice:1/3, slice:2/3, slice:3/3]
+    env:
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
+        with:
+          tool: cargo-nextest
+      - name: Download exact macOS nextest archives
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: wenlan-macos-nextest-${{ github.run_id }}
+          path: ${{ runner.temp }}/wenlan-macos-nextest-${{ github.run_id }}
+      - name: Download portable FastEmbed model
+        id: fastembed-download
+        continue-on-error: true
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}
+          path: .fastembed_cache
+      - name: Retry portable FastEmbed model download
+        if: steps.fastembed-download.outcome == 'failure'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/download-run-artifact.sh "$GITHUB_RUN_ID" "fastembed-bge-base-en-v1.5-q-v3-portable-${GITHUB_RUN_ID}" .fastembed_cache
+      - name: Run exact macOS archive partition
+        env:
+          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.platform-test-plan }}
+          CI_TEST_PARTITION: ${{ matrix.partition }}
+          M4_REQUIRED: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}
+        run: |
+          python3 scripts/ci_test_plan.py macos-run \
+            --plan-json "$CI_TEST_PLAN" \
+            --archive-dir "$RUNNER_TEMP/wenlan-macos-nextest-${GITHUB_RUN_ID}" \
+            --workspace-remap "$GITHUB_WORKSPACE" \
+            --partition "$CI_TEST_PARTITION" \
+            --include-m4 "$M4_REQUIRED"
+
   test:
     name: test (${{ matrix.label }})
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')"
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')"
     runs-on: ${{ matrix.os }}
     # Pull requests keep a hard wall-clock budget. Windows needs the full
     # backstop because its Vulkan/native bootstrap plus integration suite can
-    # exceed 30 minutes on a cold hosted runner. Other PR platforms get 45:
-    # a release-please version bump invalidates the whole sccache, and the
-    # resulting cold compile plus full test suite exceeds 30 minutes on
-    # macos-14 (run 30684460494 was canceled at 30m17s twice, zero failures).
-    timeout-minutes: ${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 45 }}
+    # exceed 30 minutes on a cold hosted runner. macOS's broad no-feature
+    # suite moved to the build-once archive fanout, leaving only bounded direct
+    # feature/compile controls here.
+    timeout-minutes: ${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 30 }}
     strategy:
       # Cancel the sibling platform when one platform owner fails.
       fail-fast: true
@@ -981,20 +1080,6 @@ jobs:
       # Windows-specific behavior (paths, mcp_add, schtasks) is covered
       # by the Windows CLI/server integration step + the schtasks install
       # round-trip E2E further down.
-      - name: Workspace lib tests (macOS)
-        if: matrix.os == 'macos-14' && needs.detect-changes.outputs.platform-workspace-lib-required == 'true'
-        # nextest spawns one process per test by default — sidesteps the
-        # ONNX atexit FFI race that required --test-threads=1 with cargo test.
-        # FastEmbed initialization has its own cross-process file lock.
-        env:
-          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.platform-test-plan }}
-        run: python3 scripts/ci_test_plan.py run --suite workspace-lib --plan-json "$CI_TEST_PLAN"
-      - name: M4 community gates (macOS-owned)
-        if: "matrix.os == 'macos-14' && (github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true')"
-        # This target contains cfg(macos) RSS probes. Linux owns the complete
-        # core-integration plan; this focused leg compiles and runs the actual
-        # macOS branches whenever its fail-closed owner filter schedules macOS.
-        run: cargo nextest run -p wenlan-core --test m4_community_gates
       - name: M5 bench platform controls
         if: "(matrix.os == 'macos-14' || matrix.os == 'windows-2022') && (github.event_name != 'pull_request' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.m5-platform == 'true')"
         # The cfg(unix) retarget control executes on macOS and compiles out on
@@ -1067,11 +1152,6 @@ jobs:
       # The drift guard inventories crates/wenlan-core/tests/*.rs so a newly
       # added integration target fails closed into the canonical lane unless
       # it is explicitly classified as manual-only with a reason.
-      - name: Integration tests wenlan-cli + wenlan-server (macOS)
-        if: matrix.os == 'macos-14' && needs.detect-changes.outputs.platform-cli-server-integration-required == 'true'
-        env:
-          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.platform-test-plan }}
-        run: python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-json "$CI_TEST_PLAN"
       - name: Integration tests wenlan-cli + wenlan-server (Windows)
         if: matrix.os == 'windows-2022' && needs.detect-changes.outputs.platform-cli-server-integration-required == 'true'
         env:
@@ -1945,7 +2025,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, release-base-proof, fmt, lint, linux-nextest-build, linux-nextest, test, mcp-platform, canonical-acceptance, contract-integration, release-preflight, docs, plugin, plugin-rust-contract, npm]
+    needs: [detect-changes, release-base-proof, fmt, lint, linux-nextest-build, linux-nextest, macos-nextest-build, macos-nextest, test, mcp-platform, canonical-acceptance, contract-integration, release-preflight, docs, plugin, plugin-rust-contract, npm]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -1974,7 +2054,8 @@ jobs:
 
           run_fmt='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.fmt-required == 'true' }}'
           run_clippy='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.clippy-required == 'true' }}'
-          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'
+          run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'
+          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'
           run_workspace_lib='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true' }}'
           run_canonical='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.canonical-acceptance-required == 'true' }}'
           run_contract='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.contract-integration-required == 'true' }}'
@@ -1983,6 +2064,8 @@ jobs:
           expect_job lint "$run_clippy" '${{ needs.lint.result }}'
           expect_job linux-nextest-build "$run_workspace_lib" '${{ needs.linux-nextest-build.result }}'
           expect_job linux-nextest "$run_workspace_lib" '${{ needs.linux-nextest.result }}'
+          expect_job macos-nextest-build "$run_macos_archive" '${{ needs.macos-nextest-build.result }}'
+          expect_job macos-nextest "$run_macos_archive" '${{ needs.macos-nextest.result }}'
           expect_job test "$run_platform" '${{ needs.test.result }}'
           expect_job mcp-platform '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.mcp-platform == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}' '${{ needs.mcp-platform.result }}'
           expect_job canonical-acceptance "$run_canonical" '${{ needs.canonical-acceptance.result }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       release-preflight: ${{ steps.filter.outputs.release-preflight }}
       mcp-platform: ${{ steps.filter.outputs.mcp-platform }}
       workspace-platform: ${{ steps.filter.outputs.workspace-platform }}
+      macos-archive-contract: ${{ steps.filter.outputs.macos-archive-contract }}
       trusted-release-candidate: ${{ steps.release-candidate-trust.outputs.trusted-release-candidate }}
       verified-release-merge: ${{ steps.release-proof.outputs.verified-release-merge }}
       release-gate-state: ${{ steps.release-proof.outputs.release-gate-state }}
@@ -476,6 +477,12 @@ jobs:
               - 'rust-toolchain.toml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
+            macos-archive-contract:
+              # These files define the archive inventory and its fail-closed
+              # execution contract. Prove them on macOS without waking the
+              # unrelated Windows or MCP platform owners.
+              - 'scripts/ci_test_plan.py'
+              - 'scripts/ci_test_plan.test.py'
 
       - name: Test release merge proof
         run: |
@@ -859,7 +866,7 @@ jobs:
   macos-nextest-build:
     name: macos-nextest archive
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))"
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))"
     runs-on: macos-14
     timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
     env:
@@ -882,7 +889,9 @@ jobs:
           tool: cargo-nextest
       - name: Build exact macOS nextest archives
         env:
-          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.platform-test-plan }}
+          # Workspace/archive contract inputs use the canonical fail-closed
+          # plan; ordinary native behavior keeps the narrower platform plan.
+          CI_TEST_PLAN: ${{ (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true') && needs.detect-changes.outputs.test-plan || needs.detect-changes.outputs.platform-test-plan }}
           M4_REQUIRED: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}
         run: |
           python3 scripts/ci_test_plan.py macos-archive \
@@ -902,7 +911,7 @@ jobs:
   macos-nextest:
     name: macos-nextest (${{ matrix.partition }})
     needs: [detect-changes, macos-nextest-build]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))"
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))"
     runs-on: macos-14
     timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
     strategy:
@@ -940,7 +949,7 @@ jobs:
         run: bash scripts/download-run-artifact.sh "$GITHUB_RUN_ID" "fastembed-bge-base-en-v1.5-q-v3-portable-${GITHUB_RUN_ID}" .fastembed_cache
       - name: Run exact macOS archive partition
         env:
-          CI_TEST_PLAN: ${{ needs.detect-changes.outputs.platform-test-plan }}
+          CI_TEST_PLAN: ${{ (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true') && needs.detect-changes.outputs.test-plan || needs.detect-changes.outputs.platform-test-plan }}
           CI_TEST_PARTITION: ${{ matrix.partition }}
           M4_REQUIRED: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}
         run: |
@@ -954,7 +963,7 @@ jobs:
   test:
     name: test (${{ matrix.label }})
     needs: [detect-changes]
-    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')"
+    if: "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')"
     runs-on: ${{ matrix.os }}
     # Pull requests keep a hard wall-clock budget. Windows needs the full
     # backstop because its Vulkan/native bootstrap plus integration suite can
@@ -1159,12 +1168,10 @@ jobs:
         # PowerShell/native argv processing strips the JSON property's quote
         # characters. Read the compact plan directly from the environment.
         run: python3 scripts/ci_test_plan.py run --suite cli-server-integration --plan-env CI_TEST_PLAN
-      # When this OS already owns behavioral tests, keep platform compile proof
-      # in the same target directory instead of rebuilding the native graph in
-      # mcp-platform. When the Apple release preflight is already scheduled, its
-      # shipped-binary build and launch smoke own the stronger macOS proof.
+      # Windows keeps platform compile proof in its behavioral target directory.
+      # The build-once archive producer owns the equivalent macOS graph.
       - name: Build CLI/server contract binaries (test owner)
-        if: needs.detect-changes.outputs.workspace-platform == 'true' && !(matrix.os == 'macos-14' && needs.detect-changes.outputs.release-preflight == 'true')
+        if: matrix.os == 'windows-2022' && needs.detect-changes.outputs.workspace-platform == 'true'
         run: cargo build -p wenlan -p wenlan-server --bins
       # Ordinary Windows PR proof uses debug artifacts already warmed by the
       # integration suite. Stage both pinned runtime DLLs next to the daemon
@@ -1283,7 +1290,7 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: "0"
       # Exact mirror of whether this OS appears in the behavioral test matrix.
       # When true, that job owns the Cargo proof and reuses its target directory.
-      TEST_OWNS_PLATFORM: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || (matrix.os == 'macos-14' && needs.detect-changes.outputs.macos == 'true') || (matrix.os == 'windows-2022' && needs.detect-changes.outputs.windows == 'true') }}
+      TEST_OWNS_PLATFORM: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || (matrix.os == 'macos-14' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.workspace-platform == 'true')) || (matrix.os == 'windows-2022' && needs.detect-changes.outputs.windows == 'true') }}
     strategy:
       fail-fast: true
       matrix:
@@ -2054,8 +2061,8 @@ jobs:
 
           run_fmt='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.fmt-required == 'true' }}'
           run_clippy='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.clippy-required == 'true' }}'
-          run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'
-          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'
+          run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'
+          run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'
           run_workspace_lib='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.workspace-lib-required == 'true' }}'
           run_canonical='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.canonical-acceptance-required == 'true' }}'
           run_contract='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.contract-integration-required == 'true' }}'

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -2023,6 +2023,7 @@ fn ci_routing_contract_violations(
         "release-preflight",
         "mcp-platform",
         "workspace-platform",
+        "macos-archive-contract",
         "trusted-release-candidate",
         "test-plan",
         "workspace-lib-required",
@@ -2850,7 +2851,7 @@ fn ci_routing_contract_violations(
         );
     }
     let platform_condition = ci["jobs"]["test"]["if"].as_str().unwrap_or_default();
-    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')";
+    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')";
     if platform_condition != expected_platform_condition {
         violations.push(
             "platform test job does not derive from rust-ci-required plus its platform owner"
@@ -2949,8 +2950,8 @@ fn ci_routing_contract_violations(
     }
     let run_fmt = "run_fmt='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.fmt-required == 'true' }}'";
     let run_clippy = "run_clippy='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.clippy-required == 'true' }}'";
-    let run_macos_archive = "run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'";
-    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'";
+    let run_macos_archive = "run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'";
+    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'";
     for (name, expected) in [
         ("run_fmt", run_fmt),
         ("run_clippy", run_clippy),
@@ -3142,7 +3143,7 @@ fn ci_routing_contract_violations(
         .and_then(|step| step["run"].as_str())
         .unwrap_or_default();
     let mcp_rust_cache = job_step_using(&ci, "mcp-platform", "Swatinem/rust-cache");
-    let test_owner_formula = "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || (matrix.os == 'macos-14' && needs.detect-changes.outputs.macos == 'true') || (matrix.os == 'windows-2022' && needs.detect-changes.outputs.windows == 'true') }}";
+    let test_owner_formula = "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || (matrix.os == 'macos-14' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.workspace-platform == 'true')) || (matrix.os == 'windows-2022' && needs.detect-changes.outputs.windows == 'true') }}";
     let mcp_windows_linker = job_step(
         &ci,
         "mcp-platform",
@@ -3199,7 +3200,7 @@ fn ci_routing_contract_violations(
     )
     .is_some()
         || transferred_workspace.and_then(|step| step["if"].as_str())
-            != Some("needs.detect-changes.outputs.workspace-platform == 'true' && !(matrix.os == 'macos-14' && needs.detect-changes.outputs.release-preflight == 'true')")
+            != Some("matrix.os == 'windows-2022' && needs.detect-changes.outputs.workspace-platform == 'true'")
         || transferred_workspace
             .and_then(|step| step["run"].as_str())
             .is_none_or(|run| {
@@ -3933,8 +3934,22 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
 fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
     let mut violations = Vec::new();
-    let condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))";
+    let condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))";
+    let archive_plan = "${{ (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true') && needs.detect-changes.outputs.test-plan || needs.detect-changes.outputs.platform-test-plan }}";
     let m4_required = "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}";
+
+    if ci["jobs"]["detect-changes"]["outputs"]["macos-archive-contract"].as_str()
+        != Some("${{ steps.filter.outputs.macos-archive-contract }}")
+        || detect_change_filter_paths(&ci, "macos-archive-contract")
+            != BTreeSet::from([
+                "scripts/ci_test_plan.py".to_string(),
+                "scripts/ci_test_plan.test.py".to_string(),
+            ])
+    {
+        violations.push(
+            "macOS archive contract inputs are not isolated from generic platform routing".into(),
+        );
+    }
 
     if job_needs(&ci, "macos-nextest-build") != ["detect-changes"]
         || ci["jobs"]["macos-nextest-build"]["if"].as_str() != Some(condition)
@@ -3978,8 +3993,7 @@ fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<St
             violations.push(format!("macOS archive producer omits {required:?}"));
         }
     }
-    if build.and_then(|step| step["env"]["CI_TEST_PLAN"].as_str())
-        != Some("${{ needs.detect-changes.outputs.platform-test-plan }}")
+    if build.and_then(|step| step["env"]["CI_TEST_PLAN"].as_str()) != Some(archive_plan)
         || build.and_then(|step| step["env"]["M4_REQUIRED"].as_str()) != Some(m4_required)
         || build.is_some_and(|step| step.get("continue-on-error").is_some())
     {
@@ -4059,8 +4073,7 @@ fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<St
             violations.push(format!("macOS archive consumer omits {required:?}"));
         }
     }
-    if run.and_then(|step| step["env"]["CI_TEST_PLAN"].as_str())
-        != Some("${{ needs.detect-changes.outputs.platform-test-plan }}")
+    if run.and_then(|step| step["env"]["CI_TEST_PLAN"].as_str()) != Some(archive_plan)
         || run.and_then(|step| step["env"]["CI_TEST_PARTITION"].as_str())
             != Some("${{ matrix.partition }}")
         || run.and_then(|step| step["env"]["M4_REQUIRED"].as_str()) != Some(m4_required)
@@ -4077,6 +4090,12 @@ fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<St
         if job_step(&ci, "test", removed).is_some() {
             violations.push(format!("direct test job still duplicates {removed}"));
         }
+    }
+    if job_step(&ci, "test", "Build CLI/server contract binaries (test owner)")
+        .and_then(|step| step["if"].as_str())
+        != Some("matrix.os == 'windows-2022' && needs.detect-changes.outputs.workspace-platform == 'true'")
+    {
+        violations.push("direct macOS test owner still duplicates the archive compile graph".into());
     }
     if job_step(&ci, "test", "M5 bench platform controls").and_then(|step| step["run"].as_str())
         != Some("cargo nextest run -p wenlan-core --features eval-harness --test m5_bench")
@@ -4170,6 +4189,26 @@ fn macos_nextest_archive_contract_rejects_routing_and_execution_mutations() {
         workflow.replacen(
             "expect_job macos-nextest \"$run_macos_archive\"",
             "expect_job macos-nextest false",
+            1,
+        ),
+        workflow.replacen(
+            "needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' ||",
+            "needs.detect-changes.outputs.macos-archive-contract == 'true' ||",
+            1,
+        ),
+        workflow.replacen(
+            "              - 'scripts/ci_test_plan.test.py'\n",
+            "",
+            1,
+        ),
+        workflow.replacen(
+            "${{ (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true') && needs.detect-changes.outputs.test-plan || needs.detect-changes.outputs.platform-test-plan }}",
+            "${{ needs.detect-changes.outputs.platform-test-plan }}",
+            1,
+        ),
+        workflow.replacen(
+            "matrix.os == 'windows-2022' && needs.detect-changes.outputs.workspace-platform == 'true'",
+            "needs.detect-changes.outputs.workspace-platform == 'true'",
             1,
         ),
     ];

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -1125,6 +1125,16 @@ fn clippy_syntax_guard_forbids_direct_text_embedding_initializers() {
 fn fastembed_ci_cache_contract_detects_wrong_path_and_order() {
     let workflow = r#"
 jobs:
+  macos-nextest:
+    env:
+      FASTEMBED_CACHE_DIR: ${{ github.workspace }}/.fastembed_cache
+    steps:
+      - name: Run exact macOS archive partition
+      - name: Download portable FastEmbed model
+        uses: actions/download-artifact@bad
+        with:
+          path: .fastembed_cache
+          name: stale
   test:
     env:
       FASTEMBED_CACHE_DIR: /tmp/wrong-fastembed-cache
@@ -1169,6 +1179,13 @@ jobs:
             .iter()
             .any(|violation| violation.contains("after consumer")),
         "fixture must violate restore ordering: {violations:?}"
+    );
+    assert!(
+        violations.iter().any(|violation| {
+            violation.contains("job macos-nextest downloads FastEmbed")
+                && violation.contains("after consumer")
+        }),
+        "fixture must keep the macOS archive consumer in restore-order coverage: {violations:?}"
     );
     assert!(
         violations
@@ -2765,10 +2782,10 @@ fn ci_routing_contract_violations(
         }
     }
     let differential_timeout =
-        "${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 45 }}";
+        "${{ (matrix.os == 'windows-2022' || github.event_name != 'pull_request') && 60 || 30 }}";
     if ci["jobs"]["test"]["timeout-minutes"].as_str() != Some(differential_timeout) {
         violations.push(
-            "test does not enforce the 45-minute non-Windows PR budget while allowing a 60-minute Windows/non-PR backstop".into(),
+            "test does not enforce the 30-minute macOS PR budget while allowing a 60-minute Windows/non-PR backstop".into(),
         );
     }
     let release_preflight_condition = ci["jobs"]["release-preflight"]["if"]
@@ -2851,7 +2868,7 @@ fn ci_routing_contract_violations(
         );
     }
     let platform_condition = ci["jobs"]["test"]["if"].as_str().unwrap_or_default();
-    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')";
+    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (github.event_name != 'pull_request' && needs.detect-changes.outputs.macos == 'true') || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')";
     if platform_condition != expected_platform_condition {
         violations.push(
             "platform test job does not derive from rust-ci-required plus its platform owner"
@@ -2897,10 +2914,16 @@ fn ci_routing_contract_violations(
         r#"include="""#,
         r#"elif [ "${{ startsWith(github.head_ref, 'release-please--branches--') }}" = "true" ]; then"#,
         r#"include="${macos},${windows}""#,
-        r#"elif [ "${{ steps.filter.outputs.macos }}" = "true" ] && [ "${{ steps.filter.outputs.windows }}" = "true" ]; then"#,
+        r#"elif [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ steps.filter.outputs.macos }}" = "true" ] && [ "${{ steps.filter.outputs.windows }}" = "true" ]; then"#,
         r#"include="${macos},${windows}""#,
-        r#"elif [ "${{ steps.filter.outputs.macos }}" = "true" ]; then"#,
+        r#"elif [ "${{ github.event_name }}" != "pull_request" ] && [ "${{ steps.filter.outputs.macos }}" = "true" ]; then"#,
         r#"include="$macos""#,
+        r#"elif [ "${{ steps.filter.outputs.m5-platform }}" = "true" ] || [ "${{ steps.filter.outputs.nextest-config }}" = "true" ]; then"#,
+        r#"if [ "${{ steps.filter.outputs.windows }}" = "true" ]; then"#,
+        r#"include="${macos},${windows}""#,
+        "else",
+        r#"include="$macos""#,
+        "fi",
         r#"elif [ "${{ steps.filter.outputs.windows }}" = "true" ]; then"#,
         r#"include="$windows""#,
         "else",
@@ -2910,8 +2933,8 @@ fn ci_routing_contract_violations(
     ];
     if matrix_lines != expected_matrix_lines {
         violations.push(
-            "dynamic OS matrix does not keep ordinary PR and main push on the same owner-driven \
-             route with workflow_dispatch as the only event-wide full-platform backstop"
+            "dynamic OS matrix does not reserve direct macOS PR runners for M5/nextest owners \
+             while preserving Windows routing and non-PR platform backstops"
                 .into(),
         );
     }
@@ -2951,7 +2974,7 @@ fn ci_routing_contract_violations(
     let run_fmt = "run_fmt='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.fmt-required == 'true' }}'";
     let run_clippy = "run_clippy='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.clippy-required == 'true' }}'";
     let run_macos_archive = "run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && (needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.macos-archive-contract == 'true' || (needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'";
-    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'";
+    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (github.event_name != 'pull_request' && needs.detect-changes.outputs.macos == 'true') || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'";
     for (name, expected) in [
         ("run_fmt", run_fmt),
         ("run_clippy", run_clippy),
@@ -3393,8 +3416,8 @@ fn ci_planner_routing_rejects_optional_and_fail_open_mutations() {
             1,
         )
         .replacen(
-            "if [ \"${{ github.event_name }}\" = \"workflow_dispatch\" ]; then",
-            "if [ \"${{ github.event_name }}\" != \"workflow_dispatch\" ]; then",
+            "elif [ \"${{ github.event_name }}\" != \"pull_request\" ] && [ \"${{ steps.filter.outputs.macos }}\" = \"true\" ] && [ \"${{ steps.filter.outputs.windows }}\" = \"true\" ]; then",
+            "elif [ \"${{ steps.filter.outputs.macos }}\" = \"true\" ] && [ \"${{ steps.filter.outputs.windows }}\" = \"true\" ]; then",
             1,
         )
         .replacen(
@@ -3442,7 +3465,7 @@ fn ci_planner_routing_rejects_optional_and_fail_open_mutations() {
         "exact generic macOS plus Windows filter inventories",
         "routes test-only drift_guard.rs into a native runner",
         "release-preflight is not isolated to release-sensitive changes",
-        "ordinary PR and main push on the same owner-driven route",
+        "reserve direct macOS PR runners for M5/nextest owners",
         "macos-m4 focused-owner allowlist has unreviewed path",
         "macos-m4 focused source crates/wenlan-core/src/db.rs acquired macos-specific cfg",
         "focused M5 platform owners",
@@ -3854,10 +3877,28 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
         ["slice:1/3", "slice:2/3", "slice:3/3"],
         "the shared Linux archive must fan out far enough to keep the PR tail below 20 minutes"
     );
+    let linux_command_helper = planner
+        .split("def command_groups_for")
+        .nth(1)
+        .and_then(|suffix| suffix.split("def _load_json_file").next())
+        .expect("Linux archive command helper");
+    let nextest_match_validator = planner
+        .split("def _require_nextest_match")
+        .nth(1)
+        .and_then(|suffix| suffix.split("def _require_filterset_match").next())
+        .expect("nextest match validator");
+    let linux_empty_shard_flags = linux_command_helper.matches("--no-tests=pass").count()
+        + nextest_match_validator.matches("--no-tests=pass").count();
     assert_eq!(
-        planner.matches("--no-tests=pass").count(),
+        linux_empty_shard_flags, 2,
+        "a globally non-empty Linux filterset may still leave one nextest slice empty; its run must allow that shard while list validation strips the run-only flag"
+    );
+    let linux_flag_mutation = linux_command_helper.replacen("--no-tests=pass", "", 1);
+    assert_ne!(
+        linux_flag_mutation.matches("--no-tests=pass").count()
+            + nextest_match_validator.matches("--no-tests=pass").count(),
         2,
-        "a globally non-empty filterset may still leave one nextest slice empty; the run must allow that shard while list validation strips the run-only flag"
+        "Linux archive empty-shard mutation unexpectedly passed"
     );
     let consumer_steps = ci["jobs"]["linux-nextest"]["steps"]
         .as_sequence()
@@ -4149,6 +4190,11 @@ fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<St
             violations.push(format!("macOS archive runner omits {required:?}"));
         }
     }
+    if run_helper.matches("--no-tests=pass").count() != 2 {
+        violations.push(
+            "macOS integration and M4 archive runners do not each allow an empty slice".into(),
+        );
+    }
     violations
 }
 
@@ -4228,6 +4274,17 @@ fn macos_nextest_archive_contract_rejects_routing_and_execution_mutations() {
             .iter()
             .any(|violation| violation.contains("feature-specific")),
         "feature-graph mutation unexpectedly passed"
+    );
+    let empty_slice_mutation = planner.replacen(
+        "                \"--no-tests=pass\",\n                \"--partition\",",
+        "                \"--partition\",",
+        1,
+    );
+    assert!(
+        macos_archive_contract_violations(&workflow, &empty_slice_mutation)
+            .iter()
+            .any(|violation| violation.contains("each allow an empty slice")),
+        "macOS empty-slice mutation unexpectedly passed"
     );
 }
 
@@ -4600,7 +4657,7 @@ jobs:
         "nextest config",
         "release-profile-sensitive",
         "native/build-sensitive",
-        "45-minute non-Windows PR budget",
+        "30-minute macOS PR budget",
         "release-sensitive changes and explicit release backstops",
         "rust-lld",
         "debug runtime artifacts",

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -127,12 +127,10 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
     const ARTIFACT_NAME: &str = "fastembed-bge-base-en-v1.5-q-v3-portable-${{ github.run_id }}";
     const JOBS: &[(&str, &[&str])] = &[
         ("linux-nextest", &["Run workspace-lib archive partition"]),
+        ("macos-nextest", &["Run exact macOS archive partition"]),
         (
             "test",
-            &[
-                "Workspace lib tests (macOS)",
-                "Integration tests wenlan-cli + wenlan-server (Windows)",
-            ],
+            &["Integration tests wenlan-cli + wenlan-server (Windows)"],
         ),
         (
             "canonical-acceptance",
@@ -2150,6 +2148,8 @@ fn ci_routing_contract_violations(
         "lint",
         "linux-nextest-build",
         "linux-nextest",
+        "macos-nextest-build",
+        "macos-nextest",
         "test",
         "mcp-platform",
         "canonical-acceptance",
@@ -2798,7 +2798,13 @@ fn ci_routing_contract_violations(
         violations.push("platform test matrix still owns a compiler-cache lane".into());
     }
     let main_owned_cache = "${{ github.ref == 'refs/heads/main' }}";
-    for job in ["lint", "test", "mcp-platform", "release-preflight"] {
+    for job in [
+        "lint",
+        "macos-nextest-build",
+        "test",
+        "mcp-platform",
+        "release-preflight",
+    ] {
         let rust_cache = job_step_using(&ci, job, "Swatinem/rust-cache");
         if rust_cache.and_then(|step| step["with"]["save-if"].as_str()) != Some(main_owned_cache) {
             violations.push(format!("{job} cache writes are not restricted to main"));
@@ -2844,7 +2850,7 @@ fn ci_routing_contract_violations(
         );
     }
     let platform_condition = ci["jobs"]["test"]["if"].as_str().unwrap_or_default();
-    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')";
+    let expected_platform_condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch')";
     if platform_condition != expected_platform_condition {
         violations.push(
             "platform test job does not derive from rust-ci-required plus its platform owner"
@@ -2943,10 +2949,12 @@ fn ci_routing_contract_violations(
     }
     let run_fmt = "run_fmt='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.fmt-required == 'true' }}'";
     let run_clippy = "run_clippy='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.clippy-required == 'true' }}'";
-    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.macos == 'true' || needs.detect-changes.outputs.windows == 'true' || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'";
+    let run_macos_archive = "run_macos_archive='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--')) }}'";
+    let run_platform = "run_platform='${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.rust-ci-required == 'true' && (needs.detect-changes.outputs.windows == 'true' || (needs.detect-changes.outputs.macos == 'true' && (github.event_name != 'pull_request' || needs.detect-changes.outputs.m5-platform == 'true' || needs.detect-changes.outputs.workspace-platform == 'true' || needs.detect-changes.outputs.nextest-config == 'true')) || startsWith(github.head_ref, 'release-please--branches--') || github.event_name == 'workflow_dispatch') }}'";
     for (name, expected) in [
         ("run_fmt", run_fmt),
         ("run_clippy", run_clippy),
+        ("run_macos_archive", run_macos_archive),
         ("run_platform", run_platform),
     ] {
         if !conclusion_run
@@ -2978,6 +2986,8 @@ fn ci_routing_contract_violations(
         "release-base-proof",
         "linux-nextest-build",
         "linux-nextest",
+        "macos-nextest-build",
+        "macos-nextest",
         "mcp-platform",
         "canonical-acceptance",
         "contract-integration",
@@ -2993,6 +3003,8 @@ fn ci_routing_contract_violations(
         ("lint", "\"$run_clippy\""),
         ("linux-nextest-build", "\"$run_workspace_lib\""),
         ("linux-nextest", "\"$run_workspace_lib\""),
+        ("macos-nextest-build", "\"$run_macos_archive\""),
+        ("macos-nextest", "\"$run_macos_archive\""),
         ("test", "\"$run_platform\""),
         (
             "mcp-platform",
@@ -3059,14 +3071,21 @@ fn ci_routing_contract_violations(
         );
     }
 
-    let m4_condition = "matrix.os == 'macos-14' && (github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true')";
-    if job_step(&ci, "test", "M4 community gates (macOS-owned)")
-        .and_then(|step| step["if"].as_str())
-        != Some(m4_condition)
-    {
-        violations.push(
-            "macOS M4 gate is not focused to community/provenance inputs plus backstops".into(),
-        );
+    let m4_required = "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}";
+    for (job, step_name) in [
+        ("macos-nextest-build", "Build exact macOS nextest archives"),
+        ("macos-nextest", "Run exact macOS archive partition"),
+    ] {
+        if job_step(&ci, job, step_name).and_then(|step| step["env"]["M4_REQUIRED"].as_str())
+            != Some(m4_required)
+        {
+            violations.push(format!(
+                "{job} M4 archive gate is not focused to community/provenance inputs plus backstops"
+            ));
+        }
+    }
+    if job_step(&ci, "test", "M4 community gates (macOS-owned)").is_some() {
+        violations.push("M4 still recompiles in the direct macOS platform job".into());
     }
     let windows_llm_condition = "matrix.os == 'windows-2022' && (github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.windows-llm-probe == 'true')";
     for step_name in [
@@ -3197,20 +3216,6 @@ fn ci_routing_contract_violations(
     for (job, step_name, suite, plan_argument, expected_plan) in [
         (
             "test",
-            "Workspace lib tests (macOS)",
-            "workspace-lib",
-            "--plan-json \"$CI_TEST_PLAN\"",
-            "${{ needs.detect-changes.outputs.platform-test-plan }}",
-        ),
-        (
-            "test",
-            "Integration tests wenlan-cli + wenlan-server (macOS)",
-            "cli-server-integration",
-            "--plan-json \"$CI_TEST_PLAN\"",
-            "${{ needs.detect-changes.outputs.platform-test-plan }}",
-        ),
-        (
-            "test",
             "Integration tests wenlan-cli + wenlan-server (Windows)",
             "cli-server-integration",
             "--plan-env CI_TEST_PLAN",
@@ -3267,25 +3272,21 @@ fn ci_routing_contract_violations(
             ));
         }
     }
-    for (step_name, expected_condition) in [
-        (
-            "Workspace lib tests (macOS)",
-            "matrix.os == 'macos-14' && needs.detect-changes.outputs.platform-workspace-lib-required == 'true'",
-        ),
-        (
-            "Integration tests wenlan-cli + wenlan-server (macOS)",
-            "matrix.os == 'macos-14' && needs.detect-changes.outputs.platform-cli-server-integration-required == 'true'",
-        ),
-        (
-            "Integration tests wenlan-cli + wenlan-server (Windows)",
-            "matrix.os == 'windows-2022' && needs.detect-changes.outputs.platform-cli-server-integration-required == 'true'",
-        ),
+    let windows_integration = "Integration tests wenlan-cli + wenlan-server (Windows)";
+    if job_step(&ci, "test", windows_integration).and_then(|step| step["if"].as_str())
+        != Some("matrix.os == 'windows-2022' && needs.detect-changes.outputs.platform-cli-server-integration-required == 'true'")
+    {
+        violations.push(format!(
+            "platform step {windows_integration} is not gated by its focused platform plan"
+        ));
+    }
+    for removed in [
+        "Workspace lib tests (macOS)",
+        "Integration tests wenlan-cli + wenlan-server (macOS)",
     ] {
-        if job_step(&ci, "test", step_name).and_then(|step| step["if"].as_str())
-            != Some(expected_condition)
-        {
+        if job_step(&ci, "test", removed).is_some() {
             violations.push(format!(
-                "platform step {step_name} is not gated by its focused platform plan"
+                "{removed} still recompiles instead of consuming the shared macOS archive"
             ));
         }
     }
@@ -3912,14 +3913,6 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
                 && !run.contains("nextest archive")),
         "Linux archive consumers must not compile"
     );
-    let macos_run = job_step(&ci, "test", "Workspace lib tests (macOS)")
-        .and_then(|step| step["run"].as_str())
-        .unwrap_or_default();
-    assert!(
-        !macos_run.contains("--partition"),
-        "macOS must retain its single complete test run"
-    );
-
     let conclusion =
         workflow_step_run(&ci, "Aggregate expected CI results").expect("conclusion script");
     assert!(
@@ -3935,6 +3928,268 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
             "conclusion does not fail closed on {job}"
         );
     }
+}
+
+fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<String> {
+    let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
+    let mut violations = Vec::new();
+    let condition = "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && ((needs.detect-changes.outputs.macos == 'true' && (needs.detect-changes.outputs.platform-workspace-lib-required == 'true' || needs.detect-changes.outputs.platform-cli-server-integration-required == 'true' || needs.detect-changes.outputs.macos-m4 == 'true')) || github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--'))";
+    let m4_required = "${{ github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.macos-m4 == 'true' }}";
+
+    if job_needs(&ci, "macos-nextest-build") != ["detect-changes"]
+        || ci["jobs"]["macos-nextest-build"]["if"].as_str() != Some(condition)
+        || ci["jobs"]["macos-nextest-build"]["runs-on"].as_str() != Some("macos-14")
+    {
+        violations
+            .push("macOS archive producer is not an independently routed native owner".into());
+    }
+    if job_needs(&ci, "macos-nextest") != ["detect-changes", "macos-nextest-build"]
+        || ci["jobs"]["macos-nextest"]["if"].as_str() != Some(condition)
+        || ci["jobs"]["macos-nextest"]["runs-on"].as_str() != Some("macos-14")
+    {
+        violations.push("macOS archive consumers do not wait for the exact producer".into());
+    }
+
+    let partitions = ci["jobs"]["macos-nextest"]["strategy"]["matrix"]["partition"]
+        .as_sequence()
+        .into_iter()
+        .flatten()
+        .filter_map(serde_yaml::Value::as_str)
+        .collect::<Vec<_>>();
+    if partitions != ["slice:1/3", "slice:2/3", "slice:3/3"] {
+        violations.push("macOS archive does not fan out over exactly three balanced slices".into());
+    }
+
+    let build = job_step(
+        &ci,
+        "macos-nextest-build",
+        "Build exact macOS nextest archives",
+    );
+    let build_run = build
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    for required in [
+        "python3 scripts/ci_test_plan.py macos-archive",
+        "--plan-json \"$CI_TEST_PLAN\"",
+        "--archive-dir \"$RUNNER_TEMP/wenlan-macos-nextest-${GITHUB_RUN_ID}\"",
+        "--include-m4 \"$M4_REQUIRED\"",
+    ] {
+        if !build_run.contains(required) {
+            violations.push(format!("macOS archive producer omits {required:?}"));
+        }
+    }
+    if build.and_then(|step| step["env"]["CI_TEST_PLAN"].as_str())
+        != Some("${{ needs.detect-changes.outputs.platform-test-plan }}")
+        || build.and_then(|step| step["env"]["M4_REQUIRED"].as_str()) != Some(m4_required)
+        || build.is_some_and(|step| step.get("continue-on-error").is_some())
+    {
+        violations.push("macOS archive producer does not fail closed on the platform plan".into());
+    }
+    let producer_cache = job_step_using(&ci, "macos-nextest-build", "Swatinem/rust-cache");
+    if producer_cache.and_then(|step| step["with"]["shared-key"].as_str()) != Some("test")
+        || producer_cache.and_then(|step| step["with"]["cache-targets"].as_str()) != Some("true")
+        || producer_cache.and_then(|step| step["with"]["save-if"].as_str())
+            != Some("${{ github.ref == 'refs/heads/main' }}")
+    {
+        violations
+            .push("macOS archive producer does not reuse the native test target cache".into());
+    }
+
+    let publish = job_step(
+        &ci,
+        "macos-nextest-build",
+        "Publish exact macOS nextest archives",
+    );
+    if publish.and_then(|step| step["with"]["name"].as_str())
+        != Some("wenlan-macos-nextest-${{ github.run_id }}")
+        || publish.and_then(|step| step["with"]["compression-level"].as_u64()) != Some(0)
+        || publish.and_then(|step| step["with"]["retention-days"].as_u64()) != Some(1)
+        || publish.and_then(|step| step["with"]["if-no-files-found"].as_str()) != Some("error")
+        || publish.is_some_and(|step| step.get("continue-on-error").is_some())
+    {
+        violations.push("macOS archive publication is not exact and fail-closed".into());
+    }
+
+    let consumer_steps = ci["jobs"]["macos-nextest"]["steps"]
+        .as_sequence()
+        .map(Vec::as_slice)
+        .unwrap_or_default();
+    if consumer_steps
+        .iter()
+        .filter_map(|step| step["uses"].as_str())
+        .any(|uses| {
+            uses.contains("rust-cache")
+                || uses.contains("sccache")
+                || uses.starts_with("actions/cache")
+        })
+        || consumer_steps
+            .iter()
+            .filter_map(|step| step["run"].as_str())
+            .any(|run| {
+                run.contains("cargo build")
+                    || run.contains("cargo check")
+                    || run.contains("cargo test")
+                    || run.contains("nextest archive")
+            })
+    {
+        violations.push("macOS archive consumers compile instead of running artifacts only".into());
+    }
+    let download = job_step(
+        &ci,
+        "macos-nextest",
+        "Download exact macOS nextest archives",
+    );
+    if download.and_then(|step| step["with"]["name"].as_str())
+        != Some("wenlan-macos-nextest-${{ github.run_id }}")
+    {
+        violations.push("macOS archive consumer downloads a non-run-scoped artifact".into());
+    }
+    let run = job_step(&ci, "macos-nextest", "Run exact macOS archive partition");
+    let run_script = run
+        .and_then(|step| step["run"].as_str())
+        .unwrap_or_default();
+    for required in [
+        "python3 scripts/ci_test_plan.py macos-run",
+        "--plan-json \"$CI_TEST_PLAN\"",
+        "--workspace-remap \"$GITHUB_WORKSPACE\"",
+        "--partition \"$CI_TEST_PARTITION\"",
+        "--include-m4 \"$M4_REQUIRED\"",
+    ] {
+        if !run_script.contains(required) {
+            violations.push(format!("macOS archive consumer omits {required:?}"));
+        }
+    }
+    if run.and_then(|step| step["env"]["CI_TEST_PLAN"].as_str())
+        != Some("${{ needs.detect-changes.outputs.platform-test-plan }}")
+        || run.and_then(|step| step["env"]["CI_TEST_PARTITION"].as_str())
+            != Some("${{ matrix.partition }}")
+        || run.and_then(|step| step["env"]["M4_REQUIRED"].as_str()) != Some(m4_required)
+        || run.is_some_and(|step| step.get("continue-on-error").is_some())
+    {
+        violations.push("macOS archive consumer does not fail closed on its exact slice".into());
+    }
+
+    for removed in [
+        "Workspace lib tests (macOS)",
+        "M4 community gates (macOS-owned)",
+        "Integration tests wenlan-cli + wenlan-server (macOS)",
+    ] {
+        if job_step(&ci, "test", removed).is_some() {
+            violations.push(format!("direct test job still duplicates {removed}"));
+        }
+    }
+    if job_step(&ci, "test", "M5 bench platform controls").and_then(|step| step["run"].as_str())
+        != Some("cargo nextest run -p wenlan-core --features eval-harness --test m5_bench")
+    {
+        violations.push("M5 no longer owns its separate eval-harness feature graph".into());
+    }
+
+    let conclusion = workflow_step_run(&ci, "Aggregate expected CI results").unwrap_or_default();
+    for job in ["macos-nextest-build", "macos-nextest"] {
+        if !job_needs(&ci, "conclusion")
+            .iter()
+            .any(|candidate| candidate == job)
+            || !conclusion.lines().any(|line| {
+                line.contains(&format!("expect_job {job} \"$run_macos_archive\""))
+                    && line.contains(&format!("needs.{job}.result"))
+            })
+        {
+            violations.push(format!("conclusion does not fail closed on {job}"));
+        }
+    }
+
+    let build_helper = planner
+        .split("def macos_archive_commands_for")
+        .nth(1)
+        .and_then(|suffix| suffix.split("def macos_archive_run_commands_for").next())
+        .unwrap_or_default();
+    for required in [
+        "archive_command_for(",
+        "\"cli-server-integration\"",
+        "\"m4_community_gates\"",
+    ] {
+        if !build_helper.contains(required) {
+            violations.push(format!("macOS archive planner omits {required:?}"));
+        }
+    }
+    if build_helper.contains("--features") {
+        violations.push("macOS shared archive mixes in a feature-specific graph".into());
+    }
+    let run_helper = planner
+        .split("def macos_archive_run_commands_for")
+        .nth(1)
+        .and_then(|suffix| suffix.split("def command_groups_for").next())
+        .unwrap_or_default();
+    for required in [
+        "command_groups_for(\n            \"workspace-lib\"",
+        "\"cli-server-integration\"",
+        "\"m4-community-gates.tar.zst\"",
+        "\"--no-tests=pass\"",
+    ] {
+        if !run_helper.contains(required) {
+            violations.push(format!("macOS archive runner omits {required:?}"));
+        }
+    }
+    violations
+}
+
+#[test]
+fn macos_nextest_archives_are_build_once_sharded_and_fail_closed() {
+    let root = repo_root();
+    let workflow =
+        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let planner = std::fs::read_to_string(root.join("scripts/ci_test_plan.py"))
+        .expect("read CI test planner");
+    let violations = macos_archive_contract_violations(&workflow, &planner);
+    assert!(
+        violations.is_empty(),
+        "macOS archive/shard contract drift:\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn macos_nextest_archive_contract_rejects_routing_and_execution_mutations() {
+    let root = repo_root();
+    let workflow =
+        std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let planner = std::fs::read_to_string(root.join("scripts/ci_test_plan.py"))
+        .expect("read CI test planner");
+    let mutations = [
+        workflow.replace("slice:3/3", "slice:2/3"),
+        workflow.replacen(
+            "      - name: Build exact macOS nextest archives\n",
+            "      - name: Build exact macOS nextest archives\n        continue-on-error: true\n",
+            1,
+        ),
+        workflow.replacen(
+            "python3 scripts/ci_test_plan.py macos-run",
+            "cargo test --workspace",
+            1,
+        ),
+        workflow.replacen(
+            "expect_job macos-nextest \"$run_macos_archive\"",
+            "expect_job macos-nextest false",
+            1,
+        ),
+    ];
+    for mutation in mutations {
+        assert!(
+            !macos_archive_contract_violations(&mutation, &planner).is_empty(),
+            "macOS archive mutation unexpectedly passed"
+        );
+    }
+    let feature_mutation = planner.replacen(
+        "\"--test\",\n                \"m4_community_gates\",",
+        "\"--features\",\n                \"eval-harness\",\n                \"--test\",\n                \"m4_community_gates\",",
+        1,
+    );
+    assert!(
+        macos_archive_contract_violations(&workflow, &feature_mutation)
+            .iter()
+            .any(|violation| violation.contains("feature-specific")),
+        "feature-graph mutation unexpectedly passed"
+    );
 }
 
 #[test]
@@ -6237,13 +6492,14 @@ fn canonical_acceptance_contract_violations(ci_workflow: &str) -> Vec<String> {
     }
     let macos_integration = job_step(
         &ci,
-        "test",
-        "Integration tests wenlan-cli + wenlan-server (macOS)",
+        "macos-nextest-build",
+        "Build exact macOS nextest archives",
     );
-    if macos_integration.and_then(|step| step["if"].as_str())
-        != Some("matrix.os == 'macos-14' && needs.detect-changes.outputs.platform-cli-server-integration-required == 'true'")
+    if macos_integration
+        .and_then(|step| step["run"].as_str())
+        .is_none_or(|run| !run.contains("scripts/ci_test_plan.py macos-archive"))
     {
-        violations.push("macOS lost its shared CLI/server integration owner".into());
+        violations.push("macOS lost its archived CLI/server integration owner".into());
     }
     for step_name in [
         "E2E CLI surface smoke (Linux)",

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -3972,6 +3972,42 @@ fn ci_release_reuse_and_linux_shards_are_fail_closed() {
     }
 }
 
+const ARCHIVE_SERVER_SPAWN_TARGETS: [(&str, usize); 3] = [
+    ("crates/wenlan-server/tests/graceful_shutdown.rs", 2),
+    ("crates/wenlan-server/tests/port_discovery.rs", 3),
+    ("crates/wenlan-server/tests/port_taken_no_db_init.rs", 2),
+];
+
+fn archive_server_binary_path_violations(
+    targets: &[(&str, String, usize)],
+    helper: &str,
+) -> Vec<String> {
+    let mut violations = Vec::new();
+    for required in [
+        "resolve_wenlan_server_binary(std::env::var_os(\"NEXTEST_BIN_EXE_wenlan_server\"))",
+        "env!(\"CARGO_BIN_EXE_wenlan-server\")",
+        "!path.as_os_str().is_empty()",
+    ] {
+        if !helper.contains(required) {
+            violations.push(format!("archive daemon binary resolver omits {required:?}"));
+        }
+    }
+    for (path, source, expected_calls) in targets {
+        if source.contains("env!(\"CARGO_BIN_EXE_")
+            || source
+                .matches("daemon_binary::wenlan_server_binary()")
+                .count()
+                != *expected_calls
+            || !source.contains("#[path = \"common/daemon_binary.rs\"]")
+        {
+            violations.push(format!(
+                "archive-owned server integration target {path} does not resolve every daemon spawn from the relocatable nextest runtime path"
+            ));
+        }
+    }
+    violations
+}
+
 fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<String> {
     let ci: serde_yaml::Value = serde_yaml::from_str(ci_workflow).expect("parse ci.yml");
     let mut violations = Vec::new();
@@ -3985,6 +4021,11 @@ fn macos_archive_contract_violations(ci_workflow: &str, planner: &str) -> Vec<St
             != BTreeSet::from([
                 "scripts/ci_test_plan.py".to_string(),
                 "scripts/ci_test_plan.test.py".to_string(),
+                "crates/wenlan-server/tests/common/daemon_binary.rs".to_string(),
+                "crates/wenlan-server/tests/daemon_binary_path.rs".to_string(),
+                "crates/wenlan-server/tests/graceful_shutdown.rs".to_string(),
+                "crates/wenlan-server/tests/port_discovery.rs".to_string(),
+                "crates/wenlan-server/tests/port_taken_no_db_init.rs".to_string(),
             ])
     {
         violations.push(
@@ -4205,7 +4246,25 @@ fn macos_nextest_archives_are_build_once_sharded_and_fail_closed() {
         std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
     let planner = std::fs::read_to_string(root.join("scripts/ci_test_plan.py"))
         .expect("read CI test planner");
-    let violations = macos_archive_contract_violations(&workflow, &planner);
+    let helper =
+        std::fs::read_to_string(root.join("crates/wenlan-server/tests/common/daemon_binary.rs"))
+            .expect("read archive daemon binary resolver");
+    let target_sources = ARCHIVE_SERVER_SPAWN_TARGETS
+        .iter()
+        .map(|(path, expected_calls)| {
+            (
+                *path,
+                std::fs::read_to_string(root.join(path))
+                    .unwrap_or_else(|error| panic!("read {path}: {error}")),
+                *expected_calls,
+            )
+        })
+        .collect::<Vec<_>>();
+    let mut violations = macos_archive_contract_violations(&workflow, &planner);
+    violations.extend(archive_server_binary_path_violations(
+        &target_sources,
+        &helper,
+    ));
     assert!(
         violations.is_empty(),
         "macOS archive/shard contract drift:\n{}",
@@ -4285,6 +4344,42 @@ fn macos_nextest_archive_contract_rejects_routing_and_execution_mutations() {
             .iter()
             .any(|violation| violation.contains("each allow an empty slice")),
         "macOS empty-slice mutation unexpectedly passed"
+    );
+
+    let helper =
+        std::fs::read_to_string(root.join("crates/wenlan-server/tests/common/daemon_binary.rs"))
+            .expect("read archive daemon binary resolver");
+    let mut target_sources = ARCHIVE_SERVER_SPAWN_TARGETS
+        .iter()
+        .map(|(path, expected_calls)| {
+            (
+                *path,
+                std::fs::read_to_string(root.join(path))
+                    .unwrap_or_else(|error| panic!("read {path}: {error}")),
+                *expected_calls,
+            )
+        })
+        .collect::<Vec<_>>();
+    target_sources[0].1 = target_sources[0].1.replacen(
+        "daemon_binary::wenlan_server_binary()",
+        "std::path::PathBuf::from(env!(\"CARGO_BIN_EXE_wenlan-server\"))",
+        1,
+    );
+    assert!(
+        archive_server_binary_path_violations(&target_sources, &helper)
+            .iter()
+            .any(|violation| violation.contains("relocatable nextest runtime path")),
+        "compile-time daemon spawn mutation unexpectedly passed"
+    );
+    let helper_mutation = helper.replace(
+        "NEXTEST_BIN_EXE_wenlan_server",
+        "CARGO_BIN_EXE_wenlan-server",
+    );
+    assert!(
+        archive_server_binary_path_violations(&target_sources, &helper_mutation)
+            .iter()
+            .any(|violation| violation.contains("resolver omits")),
+        "nextest runtime resolver mutation unexpectedly passed"
     );
 }
 

--- a/crates/wenlan-server/tests/common/daemon_binary.rs
+++ b/crates/wenlan-server/tests/common/daemon_binary.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Resolve the daemon binary for Cargo and relocatable nextest archives.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub fn resolve_wenlan_server_binary(nextest_binary: Option<OsString>) -> PathBuf {
+    let path = PathBuf::from(
+        nextest_binary.unwrap_or_else(|| OsString::from(env!("CARGO_BIN_EXE_wenlan-server"))),
+    );
+    assert!(
+        !path.as_os_str().is_empty(),
+        "wenlan-server binary path must not be empty"
+    );
+    path
+}
+
+pub fn wenlan_server_binary() -> PathBuf {
+    resolve_wenlan_server_binary(std::env::var_os("NEXTEST_BIN_EXE_wenlan_server"))
+}

--- a/crates/wenlan-server/tests/daemon_binary_path.rs
+++ b/crates/wenlan-server/tests/daemon_binary_path.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Contract tests for Cargo/nextest daemon binary resolution.
+
+#[allow(dead_code)]
+#[path = "common/daemon_binary.rs"]
+mod daemon_binary;
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+#[test]
+fn nextest_runtime_binary_overrides_the_cargo_build_path() {
+    let runtime = PathBuf::from("relocated-nextest-bin/wenlan-server");
+    assert_eq!(
+        daemon_binary::resolve_wenlan_server_binary(Some(runtime.clone().into_os_string())),
+        runtime
+    );
+}
+
+#[test]
+fn cargo_build_path_is_the_non_nextest_fallback() {
+    assert_eq!(
+        daemon_binary::resolve_wenlan_server_binary(None),
+        PathBuf::from(env!("CARGO_BIN_EXE_wenlan-server"))
+    );
+}
+
+#[test]
+#[should_panic(expected = "wenlan-server binary path must not be empty")]
+fn empty_runtime_binary_path_is_rejected() {
+    let _ = daemon_binary::resolve_wenlan_server_binary(Some(OsString::new()));
+}

--- a/crates/wenlan-server/tests/graceful_shutdown.rs
+++ b/crates/wenlan-server/tests/graceful_shutdown.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Process-level proof for graceful and bounded daemon shutdown.
 
+#[path = "common/daemon_binary.rs"]
+mod daemon_binary;
+
 use axum::{routing::post, Json, Router};
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -24,10 +27,6 @@ struct RunningDaemon {
     child: ChildGuard,
     port: u16,
     _tempdir: tempfile::TempDir,
-}
-
-fn binary_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_wenlan-server"))
 }
 
 fn prepare_isolated_data_dir(root: &Path) -> PathBuf {
@@ -99,7 +98,7 @@ async fn start_daemon() -> RunningDaemon {
     let port_file = tempdir.path().join("port");
     let stdout_path = tempdir.path().join("daemon.stdout.log");
     let stderr_path = tempdir.path().join("daemon.stderr.log");
-    let child = Command::new(binary_path())
+    let child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_BIND_ADDR", "127.0.0.1:0")
         // Keep the child isolated from both durable user config and data. The
         // reranker overrides below are safe only while this tempdir-scoped
@@ -283,7 +282,7 @@ async fn sigterm_after_bind_during_startup_uses_cooperative_shutdown() {
     let data_dir = prepare_isolated_data_dir(tempdir.path());
     let barrier = tempdir.path().join("startup-signal-barrier");
     std::fs::create_dir_all(&barrier).unwrap();
-    let child = Command::new(binary_path())
+    let child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_BIND_ADDR", "127.0.0.1:0")
         // Preserve the same isolated-config invariant as start_daemon(); the
         // removed parent reranker settings must not expose real user state.

--- a/crates/wenlan-server/tests/port_discovery.rs
+++ b/crates/wenlan-server/tests/port_discovery.rs
@@ -2,16 +2,15 @@
 //! Integration test: spawn origin-server with WENLAN_BIND_ADDR=127.0.0.1:0 and verify
 //! both port-discovery channels (stdout printline + WENLAN_PORT_FILE) work.
 
+#[path = "common/daemon_binary.rs"]
+mod daemon_binary;
+
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 const STARTUP_READY_TIMEOUT: Duration = Duration::from_secs(60);
-
-fn binary_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_wenlan-server"))
-}
 
 fn prepare_isolated_data_dir(root: &Path) -> PathBuf {
     let data_dir = root.join("data");
@@ -33,7 +32,7 @@ fn prepare_isolated_data_dir(root: &Path) -> PathBuf {
 fn port_discovery_via_stdout() {
     let tmp = tempfile::tempdir().unwrap();
     let data_dir = prepare_isolated_data_dir(tmp.path());
-    let mut child = Command::new(binary_path())
+    let mut child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_BIND_ADDR", "127.0.0.1:0")
         .env("WENLAN_DATA_DIR", data_dir)
         .stdout(Stdio::piped())
@@ -77,7 +76,7 @@ fn port_discovery_via_port_file() {
     let tmp = tempfile::tempdir().unwrap();
     let data_dir = prepare_isolated_data_dir(tmp.path());
     let port_file = tmp.path().join("port");
-    let mut child = Command::new(binary_path())
+    let mut child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_BIND_ADDR", "127.0.0.1:0")
         .env("WENLAN_DATA_DIR", data_dir)
         .env("WENLAN_PORT_FILE", &port_file)
@@ -110,7 +109,7 @@ fn port_file_is_published_only_after_startup_preparation() {
     let barrier = tmp.path().join("startup-signal-barrier");
     let port_file = tmp.path().join("port");
     std::fs::create_dir_all(&barrier).unwrap();
-    let mut child = Command::new(binary_path())
+    let mut child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_BIND_ADDR", "127.0.0.1:0")
         .env("WENLAN_DATA_DIR", data_dir)
         .env("WENLAN_PORT_FILE", &port_file)

--- a/crates/wenlan-server/tests/port_taken_no_db_init.rs
+++ b/crates/wenlan-server/tests/port_taken_no_db_init.rs
@@ -10,9 +10,8 @@ use std::net::TcpListener;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
-fn binary_path() -> std::path::PathBuf {
-    std::path::PathBuf::from(env!("CARGO_BIN_EXE_wenlan-server"))
-}
+#[path = "common/daemon_binary.rs"]
+mod daemon_binary;
 
 /// Minimal "healthy daemon": answers HTTP 200 to every request on an
 /// ephemeral port.
@@ -48,7 +47,7 @@ fn port_taken_by_mute_listener_errors_instead_of_hanging() {
     let tmp = tempfile::tempdir().unwrap();
     let data_dir = tmp.path().join("data");
 
-    let mut child = Command::new(binary_path())
+    let mut child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_PORT", port.to_string())
         .env_remove("WENLAN_BIND_ADDR")
         .env_remove("XPC_SERVICE_NAME")
@@ -87,7 +86,7 @@ fn port_taken_by_healthy_daemon_exits_before_db_init() {
     let tmp = tempfile::tempdir().unwrap();
     let data_dir = tmp.path().join("data");
 
-    let mut child = Command::new(binary_path())
+    let mut child = Command::new(daemon_binary::wenlan_server_binary())
         .env("WENLAN_PORT", port.to_string())
         .env_remove("WENLAN_BIND_ADDR")
         // Non-launchd path: a healthy daemon on the port means clean exit 0.

--- a/docs/ci-flake-policy.md
+++ b/docs/ci-flake-policy.md
@@ -31,3 +31,19 @@ job is not automatically a flake, and a green rerun is not automatically a fix.
    CI route caused the failure; otherwise fix or quarantine the failing test.
    PR #401 exposed two existing timing races after a toolchain cache rotation;
    PR #403 fixed the tests instead of reverting the trigger.
+
+## Multiple merge-ready PRs
+
+When several PRs are ready together, freeze their dependency order, merge every
+predecessor, then update the follower once against the final base. Use stacked
+PR bases only for real code dependencies. Let the workflow's
+[concurrency group](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency)
+cancel superseded heads, and never rerun a stale SHA. Keep
+[strict required checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches):
+repeated builds are the cost of proving each new merge result, not a reason to
+accept an untested combination.
+
+If this personal repository later moves to an eligible GitHub organization,
+prefer a [merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+and add the `merge_group` trigger to every required workflow. GitHub's native
+merge queue is not available to personal-owned repositories today.

--- a/scripts/ci_test_plan.py
+++ b/scripts/ci_test_plan.py
@@ -1040,6 +1040,146 @@ def archive_command_for(
     raise PlanError(f"unknown workspace-lib mode: {mode!r}")
 
 
+def macos_archive_commands_for(
+    plan: object,
+    cargo_metadata: object,
+    *,
+    archive_dir: str,
+    include_m4: bool,
+) -> list[list[str]]:
+    """Build the exact no-feature macOS inventory into reusable archives."""
+
+    packages, _directories = _workspace(cargo_metadata)
+    directory = Path(
+        _validated_path_argument(archive_dir, name="archive-dir")
+    )
+    commands: list[list[str]] = []
+
+    workspace_archive = str(directory / "workspace-lib.tar.zst")
+    workspace = archive_command_for(
+        plan,
+        cargo_metadata,
+        archive_file=workspace_archive,
+    )
+    if workspace:
+        commands.append(workspace)
+
+    integrations = command_groups_for(
+        "cli-server-integration",
+        plan,
+        cargo_metadata,
+    )
+    for index, run_command in enumerate(integrations, start=1):
+        if run_command[:3] != ["cargo", "nextest", "run"]:
+            raise PlanError("CLI/server integration command is not a nextest run")
+        commands.append(
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                str(directory / f"cli-server-integration-{index}.tar.zst"),
+                *run_command[3:],
+            ]
+        )
+
+    if include_m4:
+        if "wenlan-core" not in packages or "m4_community_gates" not in _integration_targets(
+            packages["wenlan-core"]
+        ):
+            raise PlanError("Cargo metadata has no m4_community_gates target")
+        commands.append(
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                str(directory / "m4-community-gates.tar.zst"),
+                "-p",
+                "wenlan-core",
+                "--test",
+                "m4_community_gates",
+            ]
+        )
+    return commands
+
+
+def macos_archive_run_commands_for(
+    plan: object,
+    cargo_metadata: object,
+    *,
+    archive_dir: str,
+    workspace_remap: str,
+    partition: str,
+    include_m4: bool,
+) -> list[list[str]]:
+    """Run each archived macOS suite once across the shared partition set."""
+
+    packages, _directories = _workspace(cargo_metadata)
+    match = re.fullmatch(r"slice:([1-9][0-9]*)/([1-9][0-9]*)", partition)
+    if match is None or int(match.group(1)) > int(match.group(2)):
+        raise PlanError(f"invalid nextest partition: {partition!r}")
+    directory = Path(
+        _validated_path_argument(archive_dir, name="archive-dir")
+    )
+    remap = _validated_path_argument(workspace_remap, name="workspace-remap")
+    commands: list[list[str]] = []
+
+    workspace_archive = str(directory / "workspace-lib.tar.zst")
+    commands.extend(
+        command_groups_for(
+            "workspace-lib",
+            plan,
+            cargo_metadata,
+            partition=partition,
+            archive_file=workspace_archive,
+            workspace_remap=remap,
+        )
+    )
+
+    integrations = command_groups_for(
+        "cli-server-integration",
+        plan,
+        cargo_metadata,
+    )
+    for index, _run_command in enumerate(integrations, start=1):
+        commands.append(
+            [
+                "cargo",
+                "nextest",
+                "run",
+                "--archive-file",
+                str(directory / f"cli-server-integration-{index}.tar.zst"),
+                "--workspace-remap",
+                remap,
+                "--no-tests=pass",
+                "--partition",
+                partition,
+            ]
+        )
+
+    if include_m4:
+        if "wenlan-core" not in packages or "m4_community_gates" not in _integration_targets(
+            packages["wenlan-core"]
+        ):
+            raise PlanError("Cargo metadata has no m4_community_gates target")
+        commands.append(
+            [
+                "cargo",
+                "nextest",
+                "run",
+                "--archive-file",
+                str(directory / "m4-community-gates.tar.zst"),
+                "--workspace-remap",
+                remap,
+                "--no-tests=pass",
+                "--partition",
+                partition,
+            ]
+        )
+    return commands
+
+
 def command_groups_for(
     suite_name: str,
     plan: object,
@@ -1311,7 +1451,7 @@ def _cargo_metadata() -> object:
         raise PlanError("cargo metadata emitted invalid JSON") from error
 
 
-def _require_filterset_match(command: list[str]) -> None:
+def _require_nextest_match(command: list[str], *, label: str) -> None:
     if command[:3] != ["cargo", "nextest", "run"]:
         raise PlanError(f"cannot validate non-nextest command: {command!r}")
     unpartitioned = command
@@ -1359,11 +1499,12 @@ def _require_filterset_match(command: list[str]) -> None:
                 for testcase in testcases.values()
             )
     if matched == 0:
-        raise PlanError(
-            "workspace-lib filterset selected zero tests; "
-            "isolated module ownership has drifted"
-        )
-    print(f"workspace-lib filterset matched {matched} tests")
+        raise PlanError(f"{label} selected zero tests; archived ownership has drifted")
+    print(f"{label} matched {matched} tests")
+
+
+def _require_filterset_match(command: list[str]) -> None:
+    _require_nextest_match(command, label="workspace-lib filterset")
 
 
 def _write_github_output(path: str, plan: object, plan_json: str) -> None:
@@ -1392,6 +1533,22 @@ def _main(argv: list[str]) -> int:
     archive_parser = subparsers.add_parser("archive")
     archive_parser.add_argument("--plan-json", required=True)
     archive_parser.add_argument("--archive-file", required=True)
+
+    macos_archive_parser = subparsers.add_parser("macos-archive")
+    macos_archive_parser.add_argument("--plan-json", required=True)
+    macos_archive_parser.add_argument("--archive-dir", required=True)
+    macos_archive_parser.add_argument(
+        "--include-m4", choices=("true", "false"), required=True
+    )
+
+    macos_run_parser = subparsers.add_parser("macos-run")
+    macos_run_parser.add_argument("--plan-json", required=True)
+    macos_run_parser.add_argument("--archive-dir", required=True)
+    macos_run_parser.add_argument("--workspace-remap", required=True)
+    macos_run_parser.add_argument("--partition", required=True)
+    macos_run_parser.add_argument(
+        "--include-m4", choices=("true", "false"), required=True
+    )
 
     run_parser = subparsers.add_parser("run")
     run_parser.add_argument(
@@ -1490,6 +1647,42 @@ def _main(argv: list[str]) -> int:
         executable_command = _executable_command(command)
         print("+", " ".join(executable_command), flush=True)
         subprocess.run(executable_command, check=True)
+        return 0
+    if arguments.command == "macos-archive":
+        archive_dir = _validated_path_argument(
+            arguments.archive_dir,
+            name="archive-dir",
+        )
+        Path(archive_dir).mkdir(parents=True, exist_ok=True)
+        commands = macos_archive_commands_for(
+            plan,
+            metadata,
+            archive_dir=archive_dir,
+            include_m4=arguments.include_m4 == "true",
+        )
+        if not commands:
+            raise PlanError("macOS archive route selected no tests")
+        for command in commands:
+            executable_command = _executable_command(command)
+            print("+", " ".join(executable_command), flush=True)
+            subprocess.run(executable_command, check=True)
+        return 0
+    if arguments.command == "macos-run":
+        commands = macos_archive_run_commands_for(
+            plan,
+            metadata,
+            archive_dir=arguments.archive_dir,
+            workspace_remap=arguments.workspace_remap,
+            partition=arguments.partition,
+            include_m4=arguments.include_m4 == "true",
+        )
+        if not commands:
+            raise PlanError("macOS archive route selected no tests")
+        for index, command in enumerate(commands, start=1):
+            _require_nextest_match(command, label=f"macOS archive {index}")
+            executable_command = _executable_command(command)
+            print("+", " ".join(executable_command), flush=True)
+            subprocess.run(executable_command, check=True)
         return 0
 
     commands = command_groups_for(

--- a/scripts/ci_test_plan.test.py
+++ b/scripts/ci_test_plan.test.py
@@ -22,6 +22,8 @@ from ci_test_plan import (
     clippy_command_for,
     command_groups_for,
     local_test_commands_for,
+    macos_archive_commands_for,
+    macos_archive_run_commands_for,
     required_suite_outputs,
 )
 
@@ -125,6 +127,21 @@ def cargo_metadata() -> dict:
             ),
         ],
     }
+
+
+def macos_metadata() -> dict:
+    metadata = cargo_metadata()
+    core = next(
+        package for package in metadata["packages"] if package["name"] == "wenlan-core"
+    )
+    core["targets"].append(
+        {
+            "name": "m4_community_gates",
+            "kind": ["test"],
+            "src_path": f"{WORKSPACE_ROOT}/crates/wenlan-core/tests/m4_community_gates.rs",
+        }
+    )
+    return metadata
 
 
 def plan_for(
@@ -1505,6 +1522,109 @@ class CommandGenerationTests(unittest.TestCase):
                 "wenlan-server",
             ],
         )
+
+    def test_macos_archive_builds_each_no_feature_owner_once(self) -> None:
+        plan = plan_for("Cargo.lock")
+
+        commands = macos_archive_commands_for(
+            plan,
+            macos_metadata(),
+            archive_dir="/tmp/macos-nextest",
+            include_m4=True,
+        )
+
+        self.assertEqual(len(commands), 3)
+        self.assertEqual(
+            commands[0],
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                str(Path("/tmp/macos-nextest/workspace-lib.tar.zst")),
+                "--workspace",
+                "--lib",
+                "--bin",
+                "wenlan-server",
+            ],
+        )
+        self.assertEqual(
+            commands[1],
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                str(Path("/tmp/macos-nextest/cli-server-integration-1.tar.zst")),
+                "-p",
+                "wenlan",
+                "-p",
+                "wenlan-server",
+                "-E",
+                "kind(test)",
+            ],
+        )
+        self.assertEqual(
+            commands[2],
+            [
+                "cargo",
+                "nextest",
+                "archive",
+                "--archive-file",
+                str(Path("/tmp/macos-nextest/m4-community-gates.tar.zst")),
+                "-p",
+                "wenlan-core",
+                "--test",
+                "m4_community_gates",
+            ],
+        )
+        self.assertNotIn("--features", [argument for command in commands for argument in command])
+
+    def test_macos_archive_runs_every_owner_over_the_same_three_slices(self) -> None:
+        plan = plan_for("Cargo.lock")
+
+        commands = macos_archive_run_commands_for(
+            plan,
+            macos_metadata(),
+            archive_dir="/tmp/macos-nextest",
+            workspace_remap="/repo",
+            partition="slice:2/3",
+            include_m4=True,
+        )
+
+        self.assertEqual(len(commands), 3)
+        self.assertTrue(
+            all(command[-2:] == ["--partition", "slice:2/3"] for command in commands)
+        )
+        self.assertEqual(
+            [
+                Path(command[command.index("--archive-file") + 1]).name
+                for command in commands
+            ],
+            [
+                "workspace-lib.tar.zst",
+                "cli-server-integration-1.tar.zst",
+                "m4-community-gates.tar.zst",
+            ],
+        )
+        self.assertTrue(all("--workspace-remap" in command for command in commands))
+
+    def test_macos_archive_rejects_a_missing_m4_target(self) -> None:
+        metadata = macos_metadata()
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "wenlan-core"
+        )
+        core["targets"] = [
+            target for target in core["targets"] if target["name"] != "m4_community_gates"
+        ]
+
+        with self.assertRaisesRegex(PlanError, "no m4_community_gates target"):
+            macos_archive_commands_for(
+                plan_for("Cargo.lock"),
+                metadata,
+                archive_dir="/tmp/macos-nextest",
+                include_m4=True,
+            )
 
     def test_package_archive_compiles_only_selected_package_libs(self) -> None:
         plan = plan_for("crates/wenlan-server/src/routes.rs")

--- a/scripts/ci_test_plan.test.py
+++ b/scripts/ci_test_plan.test.py
@@ -47,6 +47,10 @@ RUST_SUITE_OUTPUTS = (
     "canonical-acceptance-required",
     "rust-ci-required",
 )
+MACOS_ARCHIVE_CONTRACT_PATHS = (
+    "scripts/ci_test_plan.py",
+    "scripts/ci_test_plan.test.py",
+)
 
 
 def package(
@@ -419,6 +423,17 @@ class PlatformPlanTests(unittest.TestCase):
         self.assertEqual(plan["core_integration"], {"mode": "skip"})
         self.assertEqual(plan["contract_integration"], {"mode": "skip"})
         self.assertFalse(any(required_suite_outputs(plan).values()))
+
+    def test_archive_contract_uses_canonical_fail_closed_plan_only_when_routed(self) -> None:
+        canonical = plan_for(*MACOS_ARCHIVE_CONTRACT_PATHS)
+        platform = self.platform_plan_for(*MACOS_ARCHIVE_CONTRACT_PATHS)
+
+        self.assertEqual(canonical["mode"], "full")
+        self.assertEqual(canonical["workspace_lib"], {"mode": "full"})
+        self.assertEqual(canonical["cli_server_integration"], {"mode": "full"})
+        self.assertEqual(platform["workspace_lib"], {"mode": "skip"})
+        self.assertEqual(platform["cli_server_integration"], {"mode": "skip"})
+        self.assertFalse(any(required_suite_outputs(platform).values()))
 
     def test_m5_reader_inventory_diff_skips_platform_and_release_suites(self) -> None:
         plan = self.platform_plan_for(*M5_READER_PATHS)


### PR DESCRIPTION
## Summary
- compile the no-feature macOS test graph once into exact nextest archives
- execute workspace, CLI/server integration, and M4 ownership across three mutually exclusive slices
- keep M5 on its distinct eval-harness graph and remove the duplicate direct macOS workspace compile
- add fail-closed planner/drift contracts plus the documented multi-PR merge-train practice

## Validation
- `python scripts/ci_test_plan.test.py` (86 passed)
- CI measure planner (14 passed)
- CI observer (17 passed)
- YAML parse and Python compile
- `cargo fmt --all -- --check`
- `git diff --check`

The PR intentionally self-routes through `macos-archive-contract`, so the exact remote SHA must prove the producer and all three artifact-only consumers before merge.