### PR TITLE
fix: make release promotion and latest promotion fail closed

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -166,18 +166,34 @@ jobs:
             "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels?per_page=100")"
           pending="$(jq '[.[].name == "autorelease: pending"] | any' <<<"$labels")"
           tagged="$(jq '[.[].name == "autorelease: tagged"] | any' <<<"$labels")"
-          existing_sha="$(gh api --method GET \
+          set +e
+          tag_response="$(gh api --method GET \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2026-03-10' \
-            "/repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
-            --jq '.object.sha' 2>/dev/null || true)"
-          if [[ -n "$existing_sha" ]]; then
+            "/repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" 2>/dev/null)"
+          tag_lookup_status=$?
+          set -e
+          if [[ "$tag_lookup_status" -eq 0 ]]; then
+            if ! existing_sha="$(jq -er \
+              '.object.sha | strings | select(test("^[0-9a-f]{40}$"))' \
+              <<<"$tag_response")"; then
+              echo "Existing $RELEASE_TAG response has no canonical commit SHA."
+              exit 1
+            fi
             if [[ "$existing_sha" != "$MAIN_SHA" ]]; then
               echo "Existing $RELEASE_TAG points to $existing_sha, expected $MAIN_SHA."
               exit 1
             fi
             echo "$RELEASE_TAG already points to the exact validated merge commit."
             exit 0
+          fi
+          if ! tag_api_status="$(jq -er '.status | tostring' <<<"$tag_response" 2>/dev/null)"; then
+            echo "Unable to determine whether $RELEASE_TAG exists."
+            exit 1
+          fi
+          if [[ "$tag_api_status" != 404 ]]; then
+            echo "Tag lookup failed with API status $tag_api_status."
+            exit 1
           fi
           if [[ "$pending" != true || "$tagged" != false ]]; then
             echo "Release PR lifecycle is not exactly pending-before-tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,9 +445,13 @@ jobs:
       actions: read
       contents: write
     steps:
+      # Promotion tooling is control plane, not product: check out the same ref
+      # resolve-promotion uses so both run one promotion resolver. The promoted
+      # bytes come from the validated artifact and are verified against the
+      # closed receipt by size and SHA-256, never from this checkout.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ env.RELEASE_SHA }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -696,12 +696,24 @@ jobs:
             echo "$TAG is a prerelease tag; latest remains unchanged."
             exit 0
           fi
-          tags="$(gh api --paginate \
+          set +e
+          refs="$(gh api --paginate \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2026-03-10' \
             "/repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
-            --jq '.[].ref' | sed 's#^refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+            --jq '.[].ref')"
+          tag_list_status=$?
+          set -e
+          if [[ "$tag_list_status" -ne 0 ]]; then
+            echo "Unable to list release tags; refusing to decide latest."
+            exit 1
+          fi
+          tags="$(printf '%s\n' "$refs" | sed 's#^refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
           highest="$(printf '%s\n' "$tags" | sed '/^$/d' | sort -V | tail -1)"
+          if [[ -z "$highest" ]]; then
+            echo "No stable release tags resolved; refusing to decide latest."
+            exit 1
+          fi
           if [[ "$highest" != "$TAG" ]]; then
             echo "$TAG is not the highest stable tag ($highest); latest remains unchanged."
             exit 0
@@ -1062,12 +1074,24 @@ jobs:
           if [[ "$RELEASE_TAG" == *-* ]]; then
             echo "$RELEASE_TAG is a prerelease tag; leaving it unpromoted."
           else
-            tags="$(gh api --paginate \
+            set +e
+            refs="$(gh api --paginate \
               -H 'Accept: application/vnd.github+json' \
               -H 'X-GitHub-Api-Version: 2026-03-10' \
               "/repos/$GITHUB_REPOSITORY/git/matching-refs/tags/v" \
-              --jq '.[].ref' | sed 's#^refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
+              --jq '.[].ref')"
+            tag_list_status=$?
+            set -e
+            if [[ "$tag_list_status" -ne 0 ]]; then
+              echo "Unable to list release tags; refusing to decide latest." >&2
+              exit 1
+            fi
+            tags="$(printf '%s\n' "$refs" | sed 's#^refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true)"
             highest="$(printf '%s\n' "$tags" | sed '/^$/d' | sort -V | tail -1)"
+            if [[ -z "$highest" ]]; then
+              echo "No stable release tags resolved; refusing to decide latest." >&2
+              exit 1
+            fi
             latest_args=()
             if [[ "$highest" == "$RELEASE_TAG" ]]; then
               latest_args+=(--latest)

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -5970,13 +5970,18 @@ fn release_promotion_contract_violations(
             "release resolver is not pinned to its immutable read-only main control plane".into(),
         );
     }
-    for job_name in [
-        "prepare-release",
-        "promote-assets",
-        "docker",
-        "publish-crates",
-        "publish-npm",
-    ] {
+    // Promotion runs the same resolver as resolve-promotion, so it is control
+    // plane too. Pinning it to the release commit would run the release's own
+    // copy of the promotion tooling, so a resolver fix could never reach a
+    // recovery of that release.
+    let promote_text =
+        serde_yaml::to_string(&release["jobs"]["promote-assets"]).unwrap_or_default();
+    if !promote_text.contains("ref: ${{ github.sha }}")
+        || promote_text.contains("ref: ${{ env.RELEASE_SHA }}")
+    {
+        violations.push("asset promotion is not pinned to its immutable main control plane".into());
+    }
+    for job_name in ["prepare-release", "docker", "publish-crates", "publish-npm"] {
         let job_text = serde_yaml::to_string(&release["jobs"][job_name]).unwrap_or_default();
         if !job_text.contains("ref: ${{ env.RELEASE_SHA }}")
             || job_text.contains("ref: ${{ github.sha }}")

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -913,9 +913,15 @@ fn release_please_trigger_violations(workflow: &str) -> Vec<String> {
     if create["if"].as_str() != Some("needs.route-main.outputs.state == 'validated'")
         || !create_run.contains("refs/tags/$RELEASE_TAG")
         || !create_run.contains("sha=\"$MAIN_SHA\"")
+        || !create_run.contains("tag_lookup_status=$?")
+        || !create_run.contains("'.status | tostring'")
+        || !create_run.contains("[[ \"$tag_api_status\" != 404 ]]")
+        || create_run.contains("|| true")
     {
-        violations
-            .push("validated release route does not create only the exact receipt tag".into());
+        violations.push(
+            "validated release route does not fail closed before creating the exact receipt tag"
+                .into(),
+        );
     }
     violations
 }
@@ -6119,6 +6125,9 @@ fn release_promotion_contract_violations(
         if !promotion_script.contains(required) {
             violations.push(format!("promotion resolver omits {required:?}"));
         }
+    }
+    if promotion_script.contains("output_dir.mkdir(parents=True, exist_ok=False)") {
+        violations.push("promotion resolver pre-creates the safe extraction destination".into());
     }
     violations
 }

--- a/scripts/release-promotion.py
+++ b/scripts/release-promotion.py
@@ -1176,7 +1176,6 @@ def download_validated_assets(
     size = _positive_int(metadata.get("size_in_bytes"), "validated assets size")
     if size > MAX_ARCHIVE_BYTES:
         raise PromotionError("validated assets wrapper exceeds the archive bound")
-    output_dir.mkdir(parents=True, exist_ok=False)
     wrapper = output_dir.parent / f"validated-assets-{artifact_id}.zip"
     downloaded_size, downloaded_digest = api.download(
         f"/repos/{repository}/actions/artifacts/{artifact_id}/zip",

--- a/scripts/release-promotion.test.py
+++ b/scripts/release-promotion.test.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import io
+import hashlib
 import importlib.util
 import json
 import sys
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 from unittest import mock
 
@@ -36,6 +38,101 @@ class FakeApi:
 
 
 class ReleasePromotionTests(unittest.TestCase):
+    ASSET_NAME = "wenlan-test.zip"
+    ASSET_BYTES = b"exact validated release asset"
+
+    def _validated_assets_fixture(self) -> tuple[object, dict, dict]:
+        """Build an exact single-asset promotion plan and its download API."""
+
+        artifact_id = 77
+        wrapper_buffer = io.BytesIO()
+        with zipfile.ZipFile(wrapper_buffer, "w", zipfile.ZIP_STORED) as archive:
+            archive.writestr(self.ASSET_NAME, self.ASSET_BYTES)
+        wrapper_bytes = wrapper_buffer.getvalue()
+        wrapper_digest = hashlib.sha256(wrapper_bytes).hexdigest()
+        asset_digest = hashlib.sha256(self.ASSET_BYTES).hexdigest()
+
+        class DownloadApi:
+            def get_json(self, path: str, *, params=None):
+                self.assert_path = path
+                return {
+                    "id": artifact_id,
+                    "name": "validated-release-assets-100-1",
+                    "digest": f"sha256:{wrapper_digest}",
+                    "expired": False,
+                    "size_in_bytes": len(wrapper_bytes),
+                }
+
+            def download(self, path: str, destination: Path, maximum_bytes: int):
+                self.download_path = path
+                self.maximum_bytes = maximum_bytes
+                destination.write_bytes(wrapper_bytes)
+                return len(wrapper_bytes), wrapper_digest
+
+        plan = {
+            "receipt": {
+                "validated_assets_artifact": {
+                    "id": artifact_id,
+                    "name": "validated-release-assets-100-1",
+                    "digest": f"sha256:{wrapper_digest}",
+                },
+                "assets": [
+                    {
+                        "name": self.ASSET_NAME,
+                        "size": len(self.ASSET_BYTES),
+                        "sha256": asset_digest,
+                    }
+                ],
+            }
+        }
+        definition = {
+            "name": self.ASSET_NAME,
+            "archive": "zip",
+            "members": ["wenlan.exe"],
+        }
+        return DownloadApi(), plan, definition
+
+    def test_download_validated_assets_lets_safe_extractor_create_destination(self) -> None:
+        api, plan, definition = self._validated_assets_fixture()
+
+        with tempfile.TemporaryDirectory() as raw, mock.patch.object(
+            PROMOTION, "release_assets", return_value=[definition]
+        ), mock.patch.object(PROMOTION, "safe_extract_archive") as inspect:
+            output_dir = Path(raw) / "promoted-assets"
+            paths = PROMOTION.download_validated_assets(
+                api, REPOSITORY, plan, output_dir
+            )
+
+            self.assertEqual(paths, [output_dir / self.ASSET_NAME])
+            self.assertEqual(
+                (output_dir / self.ASSET_NAME).read_bytes(), self.ASSET_BYTES
+            )
+            inspect.assert_called_once_with(
+                output_dir / self.ASSET_NAME,
+                output_dir.parent / f"inspect-{self.ASSET_NAME}",
+                "zip",
+                ["wenlan.exe"],
+            )
+
+    def test_download_validated_assets_fails_closed_on_existing_destination(self) -> None:
+        api, plan, definition = self._validated_assets_fixture()
+
+        with tempfile.TemporaryDirectory() as raw, mock.patch.object(
+            PROMOTION, "release_assets", return_value=[definition]
+        ), mock.patch.object(PROMOTION, "safe_extract_archive") as inspect:
+            output_dir = Path(raw) / "promoted-assets"
+            output_dir.mkdir()
+
+            # The safe extractor owns the destination, so a destination that
+            # already exists is an anomaly that must still refuse to promote.
+            with self.assertRaises(FileExistsError):
+                PROMOTION.download_validated_assets(
+                    api, REPOSITORY, plan, output_dir
+                )
+
+            self.assertEqual(list(output_dir.iterdir()), [])
+            inspect.assert_not_called()
+
     def test_release_context_scopes_compatibility_client_to_pr_proof(self) -> None:
         main_sha = "2" * 40
         head_sha = "3" * 40

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -544,6 +544,18 @@ def contract_violations(
     ):
         violations.append("release lifecycle swallows a pending-label deletion failure")
 
+    # A swallowed tag listing yields an empty highest-tag, which silently drops
+    # the latest promotion while still reporting success.
+    for label, body in (("GHCR", manifest), ("GitHub release", finalize)):
+        if "tag_list_status=$?" not in body:
+            violations.append(
+                f"{label} latest decision does not branch on the tag listing exit status"
+            )
+        if re.search(r"matching-refs/tags/v[\s\S]{0,200}\|\| true", body):
+            violations.append(f"{label} latest decision swallows a tag listing failure")
+        if 'if [[ -z "$highest" ]]' not in body:
+            violations.append(f"{label} latest decision accepts an empty tag list")
+
     for marker in [
         'expected_name = f"validated-release-receipt-{run_id}-{run_attempt}"',
         "MAX_RECEIPT_CANDIDATES = 20",

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -200,6 +200,9 @@ def contract_violations(
         "needs.route-main.outputs.state == 'validated'",
         "GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}",
         "MAIN_SHA: ${{ github.event.workflow_run.head_sha }}",
+        "tag_lookup_status=$?",
+        "'.status | tostring'",
+        'if [[ "$tag_api_status" != 404 ]]',
         'if [[ "$pending" != true || "$tagged" != false ]]',
         'if [[ "$existing_sha" != "$MAIN_SHA" ]]',
         '-f ref="refs/tags/$RELEASE_TAG"',
@@ -207,6 +210,8 @@ def contract_violations(
     ]:
         if marker not in create_tag:
             violations.append(f"validated tag creation omits {marker!r}")
+    if re.search(r"git/ref/tags/\$RELEASE_TAG[\s\S]{0,240}\|\| true", create_tag):
+        violations.append("validated tag lookup swallows an API failure")
 
     trigger = re.search(
         r"^on:\n(?P<body>.*?)(?=^concurrency:)",
@@ -556,6 +561,8 @@ def contract_violations(
     ]:
         if marker not in promotion:
             violations.append(f"release promotion resolver omits fail-closed evidence {marker!r}")
+    if "output_dir.mkdir(parents=True, exist_ok=False)" in promotion:
+        violations.append("release promotion pre-creates the safe extraction destination")
 
     action_documents = release + "\n" + release_please
     seen: set[str] = set()

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -337,9 +337,18 @@ def contract_violations(
         or "ref: ${{ env.RELEASE_SHA }}" in resolver_checkout
     ):
         violations.append("release resolver is not pinned to its immutable main control SHA")
+    # Promotion runs the same resolver as resolve-promotion, so it is control
+    # plane too. Pinning it to the release commit would run the release's own
+    # copy of the promotion tooling, so a resolver fix could never reach a
+    # recovery of that release.
+    promote_checkout = job_body(release, "promote-assets")
+    if (
+        "ref: ${{ github.sha }}" not in promote_checkout
+        or "ref: ${{ env.RELEASE_SHA }}" in promote_checkout
+    ):
+        violations.append("asset promotion is not pinned to its immutable main control SHA")
     for job_name in [
         "prepare-release",
-        "promote-assets",
         "docker",
         "publish-crates",
         "publish-npm",

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -204,7 +204,9 @@ import sys
 from pathlib import Path
 
 workflow = Path(sys.argv[1]).read_text()
-for job in ["prepare-release", "promote-assets", "docker", "publish-crates", "publish-npm"]:
+
+
+def job_body(job):
     match = re.search(
         rf"^  {re.escape(job)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
         workflow,
@@ -212,7 +214,21 @@ for job in ["prepare-release", "promote-assets", "docker", "publish-crates", "pu
     )
     if not match:
         raise SystemExit(1)
-    body = match.group("body")
+    return match.group("body")
+
+
+# promote-assets runs the same promotion resolver as resolve-promotion, so it
+# is control plane: pinning it to the release commit would run the release's
+# own copy of the tooling, and a resolver fix could never reach a recovery of
+# that release. It still revalidates the receipt-derived tag.
+promote = job_body("promote-assets")
+if "ref: ${{ github.sha }}" not in promote or "ref: ${{ env.RELEASE_SHA }}" in promote:
+    raise SystemExit(1)
+if "/git/ref/tags/$RELEASE_TAG" not in promote or "RELEASE_SHA" not in promote:
+    raise SystemExit(1)
+
+for job in ["prepare-release", "docker", "publish-crates", "publish-npm"]:
+    body = job_body(job)
     if "ref: ${{ env.RELEASE_SHA }}" not in body or "ref: ${{ github.sha }}" in body:
         raise SystemExit(1)
     if "/git/ref/tags/$RELEASE_TAG" not in body or "RELEASE_SHA" not in body:
@@ -222,7 +238,7 @@ then
     echo "FAIL test 10: every release source/publish job must use RELEASE_SHA and revalidate the live tag"
     exit 1
 fi
-echo "PASS test 10: resolver keeps immutable main control code; source/publish jobs pin RELEASE_SHA and verify RELEASE_TAG"
+echo "PASS test 10: promotion keeps immutable main control code; source/publish jobs pin RELEASE_SHA and verify RELEASE_TAG"
 
 python3 "$REPO_ROOT/scripts/release-workflow-contract.test.py"
 echo "PASS test 11: release promotion and public install contracts"


### PR DESCRIPTION
## Why

Three defects of the same class — a swallowed failure or a mis-sourced file silently producing a wrong outcome — blocked the `v0.15.4` release, leaving a gated prerelease with zero assets while stable latest stayed at `v0.15.3`.

1. **Promotion crashed.** Release run `30781031872` failed with `FileExistsError: /home/runner/work/_temp/promoted-assets`. `download_validated_assets` created `output_dir`, then `safe_extract_zip` tried to create the same directory with `exist_ok=False`.
2. **Tag creation was skipped.** Release Please run `30780947858` never created the tag because `gh api ... --jq '.object.sha' 2>/dev/null || true` captured the 404 JSON body as if it were a SHA, so the "already exists, but points elsewhere" branch fired against a missing tag.
3. **The promotion fix could never have reached the recovery.** Found while verifying the recovery path: `promote-assets` checked out `env.RELEASE_SHA` and ran `scripts/release-promotion.py` *from that checkout*, so a recovery executes the release commit's own copy of the promotion tooling. Fixing the resolver on `main` would have left the `v0.15.4` recovery running the same crashing script.

## What changed

**Promotion destination** — `scripts/release-promotion.py`: drop the premature `output_dir.mkdir(...)`. The safe extractor owns its destination; a pre-existing destination still refuses to promote.

**Tag lookup** — `.github/workflows/release-please.yml`: branch the lookup on the `gh api` exit status. When the ref exists, require a canonical 40-hex commit SHA. Only an exact `404` means "missing" — empty, non-JSON, and every other API status now stop publication.

**Promotion is control plane** — `.github/workflows/release.yml`: pin `promote-assets` to `github.sha` like `resolve-promotion`, so both run one promotion resolver. The promoted bytes come from the validated assets artifact and are verified against the closed receipt by size and SHA-256, never from the checkout, and the job keeps its receipt-derived tag revalidation. Product jobs (`prepare-release`, `docker`, `publish-crates`, `publish-npm`) stay pinned to `RELEASE_SHA`.

**Latest promotion** — `.github/workflows/release.yml`: both latest-promotion decisions listed stable tags with `gh api ... | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true`. The `|| true` is required for grep's no-match exit, but it also swallowed a failed `gh api`: the tag list came back empty, `highest` came back empty, and the decision silently fell through to "not the highest stable tag". In `finalize-release` that drops `--latest` while still running `gh release edit --prerelease=false`, so the job reports success having published a stable release that `latest` never points at. The GHCR manifest job skipped its `latest` tag the same way. Both now branch on the listing exit status and refuse an empty resolved tag set, with `|| true` scoped to grep alone.

**Contracts** — `release-workflow-contract.test.py` and the `drift_guard` teeth forbid the prior `|| true` patterns and the premature `mkdir` from returning, require both latest-decision sites to branch on the listing status and reject an empty listing, and now require the control-plane ref for `promote-assets`. The previous contracts asserted the third defect, requiring `promote-assets` to be pinned to `RELEASE_SHA`; both the Python contract and the Rust teeth were corrected.

**Regression tests** — `release-promotion.test.py` covers extraction both ways: succeeds into a nonexistent destination, and fails closed on a pre-existing one without inspecting assets.

## Verification

- `python scripts/release-promotion.test.py` — 29 tests OK
- `python scripts/release-workflow-contract.test.py` — PASS
- `python scripts/release_archive.test.py` — 14 tests OK
- `cargo fmt --all -- --check` — clean
- All 11 workflows parse; all 131 bash `run:` blocks pass `bash -n`

Behavioral simulation against a stubbed `gh` + real `jq`:

- **Tag lookup**, 9 scenarios (missing / exact / mismatched / non-canonical ref, 500, 403, empty body, non-JSON body, already-tagged) — all pass. The pre-fix step fails the missing-tag case with the exact production error, and fails **open** on an empty body.
- **Latest decision**, 4 scenarios (highest tag, newer tag exists, listing fails, empty listing) — all pass. The pre-fix step exits 0 on both failure scenarios while silently skipping `--latest`.

`cargo test -p wenlan-core --lib drift_guard` could not run on this Windows host (missing Vulkan SDK blocks `llama-cpp-sys-2`); GitHub CI is authoritative. The teeth predicates were evaluated directly against the real files and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)