### PR TITLE
fix: give the release runtime image its OpenMP runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,9 +557,15 @@ jobs:
             tag-suffix: arm64
             target: aarch64-unknown-linux-gnu
     steps:
+      # This checkout supplies only tooling — the runtime Dockerfile and the
+      # verifier. The bytes that reach the image come from the validated
+      # artifact and are checked against the closed receipt by size and
+      # SHA-256, so packaging is control plane exactly like promotion is.
+      # Pinning it to the release commit would strand image fixes behind the
+      # very release that needs them, which is how v0.15.4 shipped no image.
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: ${{ env.RELEASE_SHA }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -5973,15 +5973,21 @@ fn release_promotion_contract_violations(
     // Promotion runs the same resolver as resolve-promotion, so it is control
     // plane too. Pinning it to the release commit would run the release's own
     // copy of the promotion tooling, so a resolver fix could never reach a
-    // recovery of that release.
-    let promote_text =
-        serde_yaml::to_string(&release["jobs"]["promote-assets"]).unwrap_or_default();
-    if !promote_text.contains("ref: ${{ github.sha }}")
-        || promote_text.contains("ref: ${{ env.RELEASE_SHA }}")
-    {
-        violations.push("asset promotion is not pinned to its immutable main control plane".into());
+    // recovery of that release. Docker packaging has the same shape: its
+    // checkout supplies only the runtime Dockerfile and the image verifier,
+    // while the bytes placed in the image come from the validated artifact and
+    // are checked against the closed receipt by size and SHA-256.
+    for job_name in ["promote-assets", "docker"] {
+        let job_text = serde_yaml::to_string(&release["jobs"][job_name]).unwrap_or_default();
+        if !job_text.contains("ref: ${{ github.sha }}")
+            || job_text.contains("ref: ${{ env.RELEASE_SHA }}")
+        {
+            violations.push(format!(
+                "release packaging job {job_name:?} is not pinned to its main control plane"
+            ));
+        }
     }
-    for job_name in ["prepare-release", "docker", "publish-crates", "publish-npm"] {
+    for job_name in ["prepare-release", "publish-crates", "publish-npm"] {
         let job_text = serde_yaml::to_string(&release["jobs"][job_name]).unwrap_or_default();
         if !job_text.contains("ref: ${{ env.RELEASE_SHA }}")
             || job_text.contains("ref: ${{ github.sha }}")

--- a/docker/Dockerfile.release-runtime
+++ b/docker/Dockerfile.release-runtime
@@ -5,10 +5,33 @@
 # validated Linux release archive. Never build or strip the binary here: the
 # bytes placed in this image must be the bytes that release CI already tested.
 #
+# wenlan-server links the GNU OpenMP runtime for its CPU inference path, so it
+# needs libgomp.so.1. distroless/cc ships only glibc, libgcc, and libstdc++,
+# and the validated release archive holds three binaries and no shared objects,
+# so the loader finds no libgomp and the daemon exits before it can serve.
+# Stage the library from a pinned Debian index; BuildKit builds this stage for
+# the same --platform as the final image, so the ABI always matches.
+FROM debian:13-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd AS libgomp
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends libgomp1; \
+    rm -rf /var/lib/apt/lists/*; \
+    mkdir -p /staged; \
+    for lib in /usr/lib/*-linux-gnu/libgomp.so.1*; do \
+      dir="$(dirname "$lib")"; \
+      mkdir -p "/staged$dir"; \
+      cp -a "$lib" "/staged$dir/"; \
+    done
+
 # Pin the multi-platform cc-debian13/nonroot index. BuildKit selects the child
 # manifest matching --platform (amd64 or arm64); changing this digest is a
 # reviewed runtime update, not an incidental release-time pull.
 FROM gcr.io/distroless/cc-debian13:nonroot@sha256:d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775
+
+# Staged under its original /usr/lib/<triplet>/ path so the loader resolves
+# libgomp.so.1 from the same directory it already resolves libstdc++ from,
+# without an ld.so.cache rebuild or an LD_LIBRARY_PATH override.
+COPY --from=libgomp --chown=0:0 /staged/ /
 
 COPY --chown=0:0 --chmod=0755 wenlan-server /usr/local/bin/wenlan-server
 

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -341,15 +341,20 @@ def contract_violations(
     # plane too. Pinning it to the release commit would run the release's own
     # copy of the promotion tooling, so a resolver fix could never reach a
     # recovery of that release.
-    promote_checkout = job_body(release, "promote-assets")
-    if (
-        "ref: ${{ github.sha }}" not in promote_checkout
-        or "ref: ${{ env.RELEASE_SHA }}" in promote_checkout
-    ):
-        violations.append("asset promotion is not pinned to its immutable main control SHA")
+    # Docker packaging is the same shape: its checkout supplies only the
+    # runtime Dockerfile and the image verifier, while the bytes placed in the
+    # image come from the receipt-verified artifact.
+    for job_name in ["promote-assets", "docker"]:
+        packaging = job_body(release, job_name)
+        if (
+            "ref: ${{ github.sha }}" not in packaging
+            or "ref: ${{ env.RELEASE_SHA }}" in packaging
+        ):
+            violations.append(
+                f"release packaging job {job_name!r} is not pinned to its main control SHA"
+            )
     for job_name in [
         "prepare-release",
-        "docker",
         "publish-crates",
         "publish-npm",
     ]:

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -221,13 +221,20 @@ def job_body(job):
 # is control plane: pinning it to the release commit would run the release's
 # own copy of the tooling, and a resolver fix could never reach a recovery of
 # that release. It still revalidates the receipt-derived tag.
-promote = job_body("promote-assets")
-if "ref: ${{ github.sha }}" not in promote or "ref: ${{ env.RELEASE_SHA }}" in promote:
-    raise SystemExit(1)
-if "/git/ref/tags/$RELEASE_TAG" not in promote or "RELEASE_SHA" not in promote:
-    raise SystemExit(1)
+# The docker job is the same shape: its checkout supplies only the runtime
+# Dockerfile and the image verifier, while the bytes placed in the image come
+# from the receipt-verified artifact.
+for job in ["promote-assets", "docker"]:
+    packaging = job_body(job)
+    if (
+        "ref: ${{ github.sha }}" not in packaging
+        or "ref: ${{ env.RELEASE_SHA }}" in packaging
+    ):
+        raise SystemExit(1)
+    if "/git/ref/tags/$RELEASE_TAG" not in packaging or "RELEASE_SHA" not in packaging:
+        raise SystemExit(1)
 
-for job in ["prepare-release", "docker", "publish-crates", "publish-npm"]:
+for job in ["prepare-release", "publish-crates", "publish-npm"]:
     body = job_body(job)
     if "ref: ${{ env.RELEASE_SHA }}" not in body or "ref: ${{ github.sha }}" in body:
         raise SystemExit(1)

--- a/scripts/verify-release-runtime-image.py
+++ b/scripts/verify-release-runtime-image.py
@@ -227,6 +227,20 @@ def _semantic_smoke(image: str) -> None:
             ],
             timeout=30,
         )
+        # A container that dies during startup publishes no port, so `docker
+        # port` fails with a message that describes the symptom and hides the
+        # cause. Check liveness first and surface the container's own output.
+        state = _run(
+            ["docker", "inspect", "--format", "{{.State.Running}} {{.State.ExitCode}}", name],
+            timeout=30,
+            check=False,
+        ).stdout.strip()
+        if not state.startswith("true"):
+            logs = _run(["docker", "logs", name], timeout=30, check=False).stdout
+            raise RuntimeImageError(
+                f"runtime image exited before serving (state: {state or 'unknown'})\n"
+                f"{(logs or '')[-4000:]}"
+            )
         port_result = _run(["docker", "port", name, "7878/tcp"], timeout=30)
         binding = port_result.stdout.strip().splitlines()[0]
         try:

--- a/scripts/verify-release-runtime-image.test.py
+++ b/scripts/verify-release-runtime-image.test.py
@@ -143,22 +143,40 @@ class RuntimeImageTests(unittest.TestCase):
             for line in dockerfile.splitlines()
             if line.strip() and not line.lstrip().startswith("#")
         ]
+        froms = [i for i, line in enumerate(active) if line.startswith("FROM ")]
+        # Exactly one bounded builder stage may stage a runtime shared library
+        # the release archive cannot carry. Both bases stay digest-pinned, and
+        # the final stage must never build, fetch, or mutate the released
+        # binary — that is what keeps the shipped bytes the tested bytes.
+        self.assertEqual(len(froms), 2)
         self.assertEqual(
-            active[0],
+            active[froms[0]],
+            "FROM debian:13-slim@sha256:"
+            "020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd AS libgomp",
+        )
+        self.assertEqual(
+            active[froms[1]],
             "FROM gcr.io/distroless/cc-debian13:nonroot@sha256:"
             "d97bc0a941b8d4be647dc0ee75b264ddbb772f1ac5ba690a4309c00723b23775",
         )
-        self.assertEqual(sum(line.startswith("FROM ") for line in active), 1)
+        builder = active[froms[0] + 1 : froms[1]]
+        final = active[froms[1] + 1 :]
+        # The builder exists only to stage libgomp; it never sees the release
+        # binary and carries no toolchain.
+        self.assertTrue(any("libgomp1" in line for line in builder))
+        for marker in ("cargo", "strip", "wenlan-server", "libonnxruntime"):
+            self.assertFalse(any(marker in line for line in builder), marker)
+        self.assertIn("COPY --from=libgomp --chown=0:0 /staged/ /", final)
         self.assertIn(
             "COPY --chown=0:0 --chmod=0755 wenlan-server /usr/local/bin/wenlan-server",
-            active,
+            final,
         )
-        self.assertIn("COPY --chown=65532:65532 data/ /data/", active)
-        self.assertIn("USER 65532:65532", active)
-        self.assertIn('VOLUME ["/data"]', active)
+        self.assertIn("COPY --chown=65532:65532 data/ /data/", final)
+        self.assertIn("USER 65532:65532", final)
+        self.assertIn('VOLUME ["/data"]', final)
         forbidden = ("RUN ", "ADD ", "cargo", "strip", "libonnxruntime")
         for marker in forbidden:
-            self.assertFalse(any(marker in line for line in active), marker)
+            self.assertFalse(any(marker in line for line in final), marker)
 
         script = SCRIPT.read_text(encoding="utf-8")
         for marker in (


### PR DESCRIPTION
## Why

`v0.15.4` published its assets, npm, crates.io, and Homebrew, but shipped **no container image** and is still a prerelease. Both Docker arches failed with:

```
RuntimeImageError: command failed (1): docker port
No public port '7878/tcp' published for wenlan-runtime-smoke-...
```

That message describes a symptom, not the cause. The container was already dead.

## Root cause

`wenlan-server` requires `libgomp.so.1` — the GNU OpenMP runtime for the CPU inference path. Confirmed by reading the released binary's ELF `DT_NEEDED`:

```
libgomp.so.1   <-- not provided by distroless/cc
libstdc++.so.6
libgcc_s.so.1
libm.so.6
libc.so.6
ld-linux-x86-64.so.2
```

`distroless/cc-debian13` ships glibc, libgcc, and libstdc++ only. The validated archive contains exactly three binaries and no shared objects, and the Dockerfile copies only `wenlan-server`. So the loader had no `libgomp` to find, the daemon exited immediately, and `docker port` then reported no published port.

This lane was **added after v0.15.3** (both the Dockerfile and the verifier are `new file` in `9951d5b`), so it has never worked. GHCR's current `latest` came from the older mechanism.

## Changes

1. **Stage `libgomp` from a digest-pinned Debian**, copied under its original `/usr/lib/<triplet>/` path so the loader resolves it from the same directory as `libstdc++`, with no `ld.so.cache` rebuild or `LD_LIBRARY_PATH` override. BuildKit builds the stage at the final image's `--platform`, so the ABI matches per-arch.

2. **Check container liveness before probing the port** and dump the container's own output. A startup crash now reports *why* instead of reporting that no port exists.

3. **Pin the docker job's checkout to the control plane.** That checkout supplies only the Dockerfile and the verifier; the bytes reaching the image come from the validated artifact and are verified against the closed receipt by size and SHA-256. Pinning it to the release commit stranded image fixes behind the release that needed them — the identical trap already fixed for `promote-assets` in #460.

## Contracts

The docker-pinning invariant lives in three places, all updated together: `release-workflow-contract.test.py`, `drift_guard.rs`, and `validate-versions.test.sh` (the `docs provenance` lane).

A **fourth** copy — `verify-release-runtime-image.test.py` — asserted the Dockerfile had exactly one `FROM`. Rather than relax it, it now enforces the minimal-image guarantee *per stage*: both bases stay digest-pinned, the builder never sees the release binary or a toolchain, and the final stage still may not build, fetch, or mutate anything.

## Verification

All release suites green locally, plus `cargo fmt`, YAML parse, `bash -n` over every extracted run block, the drift_guard teeth predicates, and the tag-lookup (9) and finalize-latest (4) behavioral simulations.

The image build itself is verified by CI — Docker Desktop was not running on the dev host, so the ELF evidence above is the local proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
