### PR TITLE
fix: nest the runtime data root inside its writable volume

### DIFF
--- a/docker/Dockerfile.release-runtime
+++ b/docker/Dockerfile.release-runtime
@@ -35,8 +35,8 @@ COPY --from=libgomp --chown=0:0 /staged/ /
 
 COPY --chown=0:0 --chmod=0755 wenlan-server /usr/local/bin/wenlan-server
 
-# The trusted preparation script creates this empty directory. Materializing
-# it with numeric ownership makes the anonymous /data volume writable by the
+# The trusted preparation script creates these empty directories. Materializing
+# them with numeric ownership makes the anonymous /data volume writable by the
 # distroless nonroot account without relying on name lookup or a shell.
 COPY --chown=65532:65532 data/ /data/
 
@@ -44,6 +44,9 @@ USER 65532:65532
 EXPOSE 7878
 ENV WENLAN_BIND_ADDR=0.0.0.0:7878
 ENV WENLAN_PORT=7878
-ENV WENLAN_DATA_DIR=/data
+# Nested one level inside the volume on purpose: the daemon writes its
+# data-root lock to the root's PARENT, so a root of /data would put the lock
+# at /.wenlan-daemon-*.lock, which the nonroot account cannot create.
+ENV WENLAN_DATA_DIR=/data/wenlan
 VOLUME ["/data"]
 ENTRYPOINT ["/usr/local/bin/wenlan-server"]

--- a/scripts/verify-release-runtime-image.py
+++ b/scripts/verify-release-runtime-image.py
@@ -127,10 +127,14 @@ def prepare_context(
     server_sha = sha256_file(server)
 
     build_context = context_dir / "context"
-    data_dir = build_context / "data"
+    # The daemon keeps its data-root lock in the root's PARENT, so the data
+    # root must be nested one level inside the volume: with a data root of
+    # /data the lock lands at /.wenlan-daemon-*.lock, which the nonroot
+    # account cannot create. Nesting puts the lock in /data, which it owns.
+    data_dir = build_context / "data" / "wenlan"
     data_dir.mkdir(parents=True)
-    # Keep the directory in BuildKit's context tar so COPY can materialize it
-    # with numeric nonroot ownership. This file is harmless inside /data.
+    # Keep both directories in BuildKit's context tar so COPY can materialize
+    # them with numeric nonroot ownership. This file is harmless inside /data.
     (data_dir / ".volume-seed").write_bytes(b"")
     destination = build_context / "wenlan-server"
     shutil.copyfile(server, destination)

--- a/scripts/verify-release-runtime-image.test.py
+++ b/scripts/verify-release-runtime-image.test.py
@@ -79,7 +79,9 @@ class RuntimeImageTests(unittest.TestCase):
             self.assertEqual(
                 evidence["server_sha256"], sha256(context / "wenlan-server")
             )
-            self.assertTrue((context / "data" / ".volume-seed").is_file())
+            # Nested so the daemon's data-root lock lands in /data, which the
+            # nonroot account owns, rather than at the filesystem root.
+            self.assertTrue((context / "data" / "wenlan" / ".volume-seed").is_file())
             self.assertTrue(os.access(context / "wenlan-server", os.X_OK))
 
     def test_prepare_context_rejects_archive_digest_mismatch(self) -> None:
@@ -174,6 +176,16 @@ class RuntimeImageTests(unittest.TestCase):
         self.assertIn("COPY --chown=65532:65532 data/ /data/", final)
         self.assertIn("USER 65532:65532", final)
         self.assertIn('VOLUME ["/data"]', final)
+        # The daemon writes its data-root lock to the root's PARENT, so the
+        # data root must be nested strictly inside the writable volume. A root
+        # of exactly /data puts the lock at / and the daemon cannot start.
+        data_root = next(
+            line.split("=", 1)[1]
+            for line in final
+            if line.startswith("ENV WENLAN_DATA_DIR=")
+        )
+        self.assertTrue(data_root.startswith("/data/"), data_root)
+        self.assertNotEqual(data_root.rstrip("/"), "/data")
         forbidden = ("RUN ", "ADD ", "cargo", "strip", "libonnxruntime")
         for marker in forbidden:
             self.assertFalse(any(marker in line for line in final), marker)


### PR DESCRIPTION
## Why

#462 fixed the missing `libgomp.so.1`, and it worked — the daemon now **starts**. It fails one step later, with an error the new liveness diagnostic surfaced cleanly:

```
wenlan-server terminated with an error:
open Wenlan data-root lock /.wenlan-daemon-<key>.lock: Permission denied (os error 13)
```

## Root cause

`DaemonDataLock::acquire` puts lock state in the canonical data root's **parent**, by design:

```rust
// Keep operational lock state in the canonical root's stable parent,
// not in process-dependent TMPDIR and not inside the data being
// verified.
let lock_path = canonical_root.parent()?.join(format!(".wenlan-daemon-{lock_key}.lock"));
```

With `WENLAN_DATA_DIR=/data`, that parent is `/`. The distroless nonroot account (65532) cannot create a file there, so the daemon exits before binding.

That lock placement is product behaviour baked into an immutable release binary, so the **container layout** is what adapts.

## Change

Nest the data root one level inside the volume — `WENLAN_DATA_DIR=/data/wenlan`. The lock then lands at `/data/.wenlan-daemon-<key>.lock`, inside the directory the image already materializes with numeric nonroot ownership.

The preparation script stages `data/wenlan/` so both directories are in the context tar and `COPY --chown=65532:65532` gives both the numeric owner — the daemon is not relied upon to create its own root.

## Contract

The assertion encodes the **invariant**, not the literal path: the data root must be a strict subdirectory of the volume. An edit back to exactly `/data` fails the suite instead of failing in a release.

## Verification

`verify-release-runtime-image.test.py` plus the full release suite, `cargo fmt`, YAML parse, `bash -n` over every extracted run block, drift_guard teeth predicates, and both behavioral simulations — all green.

Docker Desktop is not running on the dev host, so as with #462 the container itself is proven by CI. The failure mode is now well-instrumented either way: if it still cannot start, the liveness check reports the container's own output rather than a misleading `docker port` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
