### PR TITLE
fix: align the runtime image env contract with the nested data root

### DIFF
--- a/scripts/verify-release-runtime-image.py
+++ b/scripts/verify-release-runtime-image.py
@@ -56,7 +56,11 @@ ARCHIVE_MEMBERS = ["wenlan", "wenlan-server", "wenlan-mcp"]
 REQUIRED_ENV = {
     "WENLAN_BIND_ADDR=0.0.0.0:7878",
     "WENLAN_PORT=7878",
-    "WENLAN_DATA_DIR=/data",
+    # Nested one level inside the volume: the daemon writes its data-root lock
+    # to the root's PARENT, so a root of /data puts the lock at / where the
+    # nonroot account cannot create it. Must stay identical to the Dockerfile's
+    # ENV lines — the contract test asserts the two agree entry for entry.
+    "WENLAN_DATA_DIR=/data/wenlan",
 }
 
 

--- a/scripts/verify-release-runtime-image.test.py
+++ b/scripts/verify-release-runtime-image.test.py
@@ -176,6 +176,15 @@ class RuntimeImageTests(unittest.TestCase):
         self.assertIn("COPY --chown=65532:65532 data/ /data/", final)
         self.assertIn("USER 65532:65532", final)
         self.assertIn('VOLUME ["/data"]', final)
+        # The image verifier rejects any image whose Env lacks an entry in
+        # REQUIRED_ENV, so the Dockerfile and that constant are one contract in
+        # two files. Assert they agree entry for entry: editing only the
+        # Dockerfile builds an image its own verifier then refuses, which is a
+        # release-time failure for something both files already state.
+        self.assertEqual(
+            {line[len("ENV ") :] for line in final if line.startswith("ENV ")},
+            set(self.module.REQUIRED_ENV),
+        )
         # The daemon writes its data-root lock to the root's PARENT, so the
         # data root must be nested strictly inside the writable volume. A root
         # of exactly /data puts the lock at / and the daemon cannot start.


### PR DESCRIPTION
## Why

Release recovery run [30790197470](https://github.com/7xuanlu/wenlan/actions/runs/30790197470) failed on both docker arches with:

```
verify-release-runtime-image: RuntimeImageError: runtime image environment contract is incomplete
```

#463 nested the runtime data root at `/data/wenlan` — the daemon writes its data-root lock to the root's *parent*, so a root of `/data` puts the lock at `/`, which the nonroot account cannot create. That change touched `docker/Dockerfile.release-runtime` and `prepare_context`, but not `REQUIRED_ENV` in `scripts/verify-release-runtime-image.py`, which still asserted `WENLAN_DATA_DIR=/data`. The verifier rejected the image built from the Dockerfile it ships alongside.

## What

- `REQUIRED_ENV` now carries `WENLAN_DATA_DIR=/data/wenlan`.
- The contract test asserts the Dockerfile's final-stage `ENV` lines equal `REQUIRED_ENV` **entry for entry**. Nothing previously tied the two together — the inspect test read `REQUIRED_ENV` self-referentially, so the constant and the Dockerfile could disagree with no local signal until release time.

Verified the new assertion bites: reverting `REQUIRED_ENV` to `/data` fails the suite locally with `'WENLAN_DATA_DIR=/data'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)