### PR TITLE
fix: grant finalize-release the pull-requests scope it reads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1079,6 +1079,12 @@ jobs:
     permissions:
       contents: write
       issues: write
+      # Finding the merged release PR uses GET /commits/{sha}/pulls, which is a
+      # pull-requests read. An explicit permissions block sets every unlisted
+      # scope to none, so omitting this returned 403 after the release had
+      # already been promoted, leaving v0.15.4 stable but still labelled
+      # pending. Labels themselves are the issues scope above.
+      pull-requests: read
     steps:
       - name: Promote
         run: |

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -543,6 +543,28 @@ def contract_violations(
     finalize = job_body(release, "finalize-release")
     if "    needs: [docker-manifest, bind-release-tag]" not in finalize:
         violations.append("GitHub release finalization bypasses the GHCR promotion barrier")
+    # The lifecycle step resolves the merged release PR through
+    # GET /commits/{sha}/pulls, a pull-requests read. An explicit permissions
+    # block sets every unlisted scope to none, so dropping this scope returns
+    # 403 only AFTER `gh release edit` has already promoted the release —
+    # stable but still labelled pending, with no way to retry the half that
+    # ran. Assert every scope the step actually exercises.
+    finalize_permissions = re.search(
+        r"    permissions:\n(?P<body>(?:      [^\n]+\n)+)", finalize
+    )
+    granted = {
+        line.strip()
+        for line in (
+            finalize_permissions.group("body") if finalize_permissions else ""
+        ).splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    }
+    for scope in ["contents: write", "issues: write", "pull-requests: read"]:
+        if scope not in granted:
+            violations.append(
+                f"release finalization does not grant {scope!r} for the lifecycle step"
+            )
+
     tagged = finalize.find('"labels":["autorelease: tagged"]')
     pending = finalize.find("labels/autorelease%3A%20pending")
     if tagged < 0 or pending <= tagged:


### PR DESCRIPTION
## Why

Release recovery run [30810716540](https://github.com/7xuanlu/wenlan/actions/runs/30810716540) got every channel green — both docker arches, the multi-arch manifest, crates.io, npm, Homebrew — then failed in `finalize-release`:

```
https://github.com/7xuanlu/wenlan/releases/tag/v0.15.4
gh: Resource not accessible by integration (HTTP 403)
```

The release URL prints *before* the 403, so promotion succeeded and the failure is downstream. The failing call is the release-PR lookup:

```
GET /repos/$GITHUB_REPOSITORY/commits/$tag_sha/pulls
```

That is a `pull-requests` read. The job declared:

```yaml
permissions:
  contents: write
  issues: write
```

An explicit `permissions:` block sets every unlisted scope to `none`, so `pull-requests` was `none`. Labels were never the problem — `issues: write` covers those — only finding the PR number.

## Impact

v0.15.4 went stable and `latest` correctly, but PR #459 kept `autorelease: pending`. Per `AGENTS.md`, `autorelease: tagged` is what stops release-please re-releasing a version, so the gap risks a duplicate release rather than being cosmetic. #459's labels have been corrected by hand; this fixes the cause.

## Verified

- `scripts/release-workflow-contract.test.py` — pass
- `scripts/validate-versions.test.sh` — pass (all 12)

No contract pins this job's permission set, so no other copy needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)