### PR TITLE
ci: smoke the release runtime image on PRs that change it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       mcp-platform: ${{ steps.filter.outputs.mcp-platform }}
       workspace-platform: ${{ steps.filter.outputs.workspace-platform }}
       macos-archive-contract: ${{ steps.filter.outputs.macos-archive-contract }}
+      runtime-image: ${{ steps.filter.outputs.runtime-image }}
       trusted-release-candidate: ${{ steps.release-candidate-trust.outputs.trusted-release-candidate }}
       verified-release-merge: ${{ steps.release-proof.outputs.verified-release-merge }}
       release-gate-state: ${{ steps.release-proof.outputs.release-gate-state }}
@@ -488,6 +489,16 @@ jobs:
               - 'crates/wenlan-server/tests/graceful_shutdown.rs'
               - 'crates/wenlan-server/tests/port_discovery.rs'
               - 'crates/wenlan-server/tests/port_taken_no_db_init.rs'
+
+            runtime-image:
+              # The release runtime image is assembled and smoked only by
+              # release.yml, so every packaging defect in it used to surface
+              # mid-release, one per release round-trip. These files decide
+              # whether the shipped image starts and serves; prove them here.
+              - 'docker/Dockerfile.release-runtime'
+              - 'scripts/verify-release-runtime-image.py'
+              - 'scripts/verify-release-runtime-image.test.py'
+              - 'scripts/release_archive.py'
 
       - name: Test release merge proof
         run: |
@@ -2036,6 +2047,58 @@ jobs:
           python3 scripts/update-readme-eval.test.py
           bash scripts/validate-versions.test.sh
 
+  runtime-image:
+    name: runtime image smoke
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.runtime-image == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      # The image needs a real wenlan-server, and PR CI has no validated
+      # release archive. Take the newest published release's Linux x64 asset
+      # and bind it to the digest GitHub reports for that asset: immutable,
+      # already public, and never a receipt, so nothing here can mint release
+      # provenance. amd64 only — arm64 under QEMU costs far more than the
+      # coverage adds, and both arches carry identical DT_NEEDED sets.
+      - name: Resolve newest published release asset
+        id: asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
+          read -r digest size < <(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$tag" \
+            --jq '.assets[] | select(.name=="wenlan-linux-x64.tar.gz") | "\(.digest) \(.size)"')
+          if [[ -z "${digest:-}" || -z "${size:-}" || "$digest" != sha256:* ]]; then
+            echo "no digest for wenlan-linux-x64.tar.gz on $tag"
+            exit 1
+          fi
+          mkdir -p "$RUNNER_TEMP/assets"
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+            --pattern wenlan-linux-x64.tar.gz --dir "$RUNNER_TEMP/assets"
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "digest=$digest" >>"$GITHUB_OUTPUT"
+          echo "size=$size" >>"$GITHUB_OUTPUT"
+      - name: Build and smoke the runtime image
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-release-runtime-image.py \
+            --published-digest '${{ steps.asset.outputs.digest }}' \
+            --published-size '${{ steps.asset.outputs.size }}' \
+            --assets-dir "$RUNNER_TEMP/assets" \
+            --target x86_64-unknown-linux-gnu \
+            --image "wenlan-runtime-ci:${{ github.sha }}" \
+            --dockerfile docker/Dockerfile.release-runtime \
+            --output "$RUNNER_TEMP/runtime-image-evidence.json"
+      - name: Test the runtime image contracts
+        run: python3 scripts/verify-release-runtime-image.test.py
+
   # Aggregate gate for branch protection. `if: always()` lets docs-only PRs
   # (where the test matrix skips via detect-changes) report success instead
   # of stalling forever on a never-run required check.
@@ -2046,7 +2109,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, release-base-proof, fmt, lint, linux-nextest-build, linux-nextest, macos-nextest-build, macos-nextest, test, mcp-platform, canonical-acceptance, contract-integration, release-preflight, docs, plugin, plugin-rust-contract, npm]
+    needs: [detect-changes, release-base-proof, fmt, lint, linux-nextest-build, linux-nextest, macos-nextest-build, macos-nextest, test, mcp-platform, canonical-acceptance, contract-integration, release-preflight, docs, plugin, plugin-rust-contract, npm, runtime-image]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -2096,6 +2159,7 @@ jobs:
           expect_job plugin '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'
           expect_job plugin-rust-contract '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin-rust-contract == 'true' }}' '${{ needs.plugin-rust-contract.result }}'
           expect_job npm '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.npm == 'true' }}' '${{ needs.npm.result }}'
+          expect_job runtime-image '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate != 'true' && needs.detect-changes.outputs.runtime-image == 'true' }}' '${{ needs.runtime-image.result }}'
 
   plugin:
     needs: detect-changes

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -508,6 +508,11 @@ def contract_violations(
             violations.append(f"runtime image lane omits binary-reuse proof {marker!r}")
     if "docker/Dockerfile.daemon" in docker or "cargo build" in docker:
         violations.append("runtime image lane can compile a different server binary")
+    # The verifier also accepts a published-release-asset digest so CI can smoke
+    # the image on a PR. That source is immutable but it is not a receipt, and a
+    # release must bind its bytes to the receipt that validated them.
+    if "--receipt" not in docker or "--published-digest" in docker:
+        violations.append("release runtime image lane does not bind bytes to the closed receipt")
     for job_name, artifact_name in [
         ("promote-assets", "homebrew-artifacts"),
         ("promote-assets", "docker-runtime-inputs"),

--- a/scripts/verify-release-runtime-image.py
+++ b/scripts/verify-release-runtime-image.py
@@ -290,13 +290,13 @@ def _semantic_smoke(image: str) -> None:
 
 
 def verify_runtime_image(
-    receipt_path: Path,
+    receipt: dict,
     assets_dir: Path,
     target: str,
     image: str,
     dockerfile: Path,
+    provenance: str,
 ) -> dict:
-    receipt = VALIDATOR.read_closed_receipt(receipt_path)
     if not dockerfile.is_file() or dockerfile.is_symlink():
         raise RuntimeImageError("release runtime Dockerfile is missing or not regular")
     with tempfile.TemporaryDirectory(prefix="wenlan-release-runtime-") as raw:
@@ -324,12 +324,25 @@ def verify_runtime_image(
         _semantic_smoke(image)
         return {
             key: value for key, value in evidence.items() if key != "build_context"
-        } | {"image": image, "image_id": image_info["Id"], "status": "passed"}
+        } | {
+            "image": image,
+            "image_id": image_info["Id"],
+            "provenance": provenance,
+            "status": "passed",
+        }
 
 
 def _main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--receipt", required=True, type=Path)
+    # Exactly one provenance source. --receipt is the release path and binds the
+    # archive to a closed validation receipt. --published-digest is the CI
+    # regression path: it binds the archive to the digest GitHub itself reports
+    # for an already-published release asset, which is immutable and needs no
+    # receipt to be minted outside a release. Neither path can be inferred, so
+    # a caller that supplies both or neither is rejected rather than defaulted.
+    parser.add_argument("--receipt", type=Path)
+    parser.add_argument("--published-digest")
+    parser.add_argument("--published-size", type=int)
     parser.add_argument("--assets-dir", required=True, type=Path)
     parser.add_argument("--target", required=True, choices=sorted(TARGETS))
     parser.add_argument("--image", required=True)
@@ -338,8 +351,42 @@ def _main(argv: list[str]) -> int:
     args = parser.parse_args(argv)
     if args.output.exists() or not args.output.parent.is_dir():
         raise RuntimeImageError("output must be a new file in an existing directory")
+    published = args.published_digest is not None or args.published_size is not None
+    if (args.receipt is None) == (not published):
+        raise RuntimeImageError(
+            "pass exactly one of --receipt or --published-digest/--published-size"
+        )
+    if published:
+        if args.published_digest is None or args.published_size is None:
+            raise RuntimeImageError(
+                "--published-digest and --published-size must be given together"
+            )
+        digest = args.published_digest.removeprefix("sha256:")
+        if len(digest) != 64 or not all(c in "0123456789abcdef" for c in digest):
+            raise RuntimeImageError("published digest is not a lowercase sha256 hex")
+        # Shaped exactly like the receipt's asset claim so prepare_context runs
+        # one comparison path for both provenance sources.
+        receipt = {
+            "assets": [
+                {
+                    "name": TARGETS[args.target]["archive"],
+                    "sha256": digest,
+                    "size": args.published_size,
+                    "target": args.target,
+                }
+            ]
+        }
+        provenance = "published-release-asset"
+    else:
+        receipt = VALIDATOR.read_closed_receipt(args.receipt)
+        provenance = "closed-receipt"
     result = verify_runtime_image(
-        args.receipt, args.assets_dir, args.target, args.image, args.dockerfile
+        receipt,
+        args.assets_dir,
+        args.target,
+        args.image,
+        args.dockerfile,
+        provenance,
     )
     args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(json.dumps(result, sort_keys=True))


### PR DESCRIPTION
## Why

`docker/Dockerfile.release-runtime` and `scripts/verify-release-runtime-image.py` were referenced **only** by `release.yml`. Nothing built the image or ran its smoke until a release was already in flight, so every packaging defect surfaced mid-release at the cost of a merge + dispatch + full run — and each one hid the next.

v0.15.4 shipped four that way, in sequence: artifact nesting (#461), missing `libgomp.so.1` (#462), a data root whose lock landed at `/` (#463), and an env contract that disagreed with its own Dockerfile (#464). Running this job locally found the remainder in about two minutes.

The existing `verify-release-runtime-image.test.py` only reads the Dockerfile as *text*. It never builds it.

## The provenance problem, and how this avoids it

To build the image you need a real `wenlan-server`, and PR CI has no validated release archive. Minting a receipt in CI would weaken exactly what a receipt proves, so this doesn't.

Instead the verifier accepts a second provenance source: **the sha256 digest GitHub reports for an already-published release asset**. It's immutable, already public, and is not a receipt — so nothing in CI can produce release provenance.

- Exactly one source must be supplied. Both, or neither, is an error.
- The evidence JSON records which was used (`"provenance": "published-release-asset"` vs `"closed-receipt"`).
- **The release lane is untouched** and still binds bytes to the closed receipt. `release-workflow-contract.test.py` now pins this: it fails if the `docker` job ever drops `--receipt` or reaches for `--published-digest`.

amd64 only — arm64 under QEMU costs far more than the coverage adds, and both arches carry identical `DT_NEEDED` sets (verified during the v0.15.4 recovery).

## Verified locally

Against the real published v0.15.4 asset, with Docker:

```
{"architecture": "amd64", "archive_sha256": "dd251f85…", "provenance": "published-release-asset",
 "server_sha256": "ae526457…", "status": "passed"}
```

That covers build, image inspect, byte-identity of the copied binary, and the full semantic smoke — `/api/health`, `/api/memory/store`, `/api/memory/search` returning the sentinel, `/api/status`. `server_sha256` matches the receipt-based run exactly: same bytes, two independent provenance sources.

Negative cases all rejected:

| Input | Result |
|---|---|
| wrong digest | `Linux archive bytes differ from the closed receipt` |
| both sources | `pass exactly one of --receipt or --published-digest/--published-size` |
| neither source | same |

Contract suites pass: `release-workflow-contract.test.py`, `verify-release-runtime-image.test.py`, `validate-versions.test.sh`.

This PR touches the filtered paths, so the new job runs on it — the PR is its own proof.

**Known wart:** the digest-mismatch message says "closed receipt" on both paths. The literal is required by contract; left alone rather than churn the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)