### PR TITLE
fix(kg): ambient enrichment dual-writes canonical edges; migration 111 repairs parity

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -707,9 +707,10 @@ pub const EMBEDDING_DIM: usize = 768;
 
 /// Current DB schema version (highest `PRAGMA user_version` applied by `migrate()`).
 /// Bump this whenever a new migration lands. Used as an eval cache invalidation key.
-/// Migration 110 adds M5's policy-independent judge-eligibility registry and
-/// generation fence. It follows the inert M6 substrate at 109.
-pub const SCHEMA_VERSION: u32 = 110;
+/// Migration 111 repairs the edges-parity damage the ambient entity-enrichment
+/// lane did while it wrote `relations` without their `edges` twin. It follows
+/// M5's judge-eligibility registry and generation fence at 110.
+pub const SCHEMA_VERSION: u32 = 111;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8513,6 +8514,17 @@ impl MemoryDB {
             if version < 110 {
                 self.migrate_110_judge_eligibility(version).await?;
             }
+
+            // Migration 111 (KG close plan G1): repair the parity damage the
+            // ambient entity-enrichment lane did while it wrote `relations`
+            // without their `edges` twin — re-run the relations backfill,
+            // retire the orphan edges its hard DELETE left active, retire every
+            // pre-repair parity watermark, and reset the grounding cursor once
+            // so relations it skipped get rescanned. See
+            // migrate_111_ambient_edge_parity_repair.
+            if version < 111 {
+                self.migrate_111_ambient_edge_parity_repair(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -12366,6 +12378,287 @@ impl MemoryDB {
             .await
             .map_err(|error| WenlanError::VectorDb(format!("m110 bump: {error}")))?;
         log::info!("[migration] Migration 110 applied: M5 judge eligibility safety fence");
+        Ok(())
+    }
+
+    /// Migration 111: repair the edges-parity damage the ambient
+    /// entity-enrichment lane caused, and un-blind the grounding sweep to it.
+    ///
+    /// `commit_entity_enrichment_at_version` wrote `relations` rows through a
+    /// raw INSERT with no `edges` twin, and hard-DELETEd competing relation rows
+    /// without retracting theirs. Both halves are fixed at the writer; this is
+    /// the one-time repair of what already shipped, in four steps:
+    ///
+    ///   1. Mint the edges `relations` implies but `edges` does not hold
+    ///      ACTIVE. "Hole" is defined the way the parity oracle defines it —
+    ///      `reconcile_edges_parity` compares against `WHERE valid_until IS
+    ///      NULL`, so a retracted edge is as absent to the sweep as a missing
+    ///      one, and both must be holes here or the migration reports clean
+    ///      while the sweep reports drift forever. The two shapes take
+    ///      different repairs. NEVER WRITTEN goes through
+    ///      [`Self::backfill_edges_from_relations`], the same helper migration
+    ///      81 used, whose inserts are `ON CONFLICT(edge_id) DO NOTHING` over a
+    ///      content-addressed id, so re-running it only fills genuine holes.
+    ///      WRITTEN THEN RETRACTED cannot be healed that way — `DO NOTHING`
+    ///      never un-retracts — so those go through the LIVE writer
+    ///      `dual_write_edge_with_payload`, whose conflict rule clears
+    ///      `valid_until` and re-derives fence-safe lineage from the CURRENT
+    ///      endpoint spaces. That shape is reachable whenever a canonical
+    ///      delete retracted the pair and the OLD ambient lane then
+    ///      re-extracted the same triple, raw-INSERTing the relation with no
+    ///      edge write.
+    ///   2. Retract every ACTIVE `relates` edge with no `relations` row behind
+    ///      it. `relations` is the sole producer of `relates`, and the canonical
+    ///      delete path (`supersede_relation`) already retracts its edge, so an
+    ///      orphan active edge is exactly the damage step 1 cannot undo — and
+    ///      the parity sweep counts it as drift forever. Soft-invalidated the
+    ///      same way `supersede_relation` does; never hard-deleted.
+    ///   3. Bump the dual-write epoch IF steps 1 or 2 found damage, retiring
+    ///      every parity watermark taken while coverage was lapsed so no reader
+    ///      can flip until a fresh reconcile re-proves parity. A database that
+    ///      was whole (a fresh install; a store the ambient lane never touched)
+    ///      never lapsed, so it keeps its epoch and any clean watermark.
+    ///   4. Drop the durable `edge_grounding_cursor` IF step 1 changed anything. The
+    ///      sweep permanently advances past a relation with no edge row, so
+    ///      everything step 1 backfilled sits behind the watermark and would
+    ///      never be scanned. Tying the reset to a migration number (not to
+    ///      boot) makes it fire at most once — a startup reset would re-spend
+    ///      the whole entailment backlog on every daemon launch.
+    ///
+    /// Fence-safe: the backfill only ever emits `assertion` when both endpoint
+    /// spaces are present and equal (stamping that same space), and `legacy`
+    /// otherwise — and `legacy` is exempt from `edges_space_fence`.
+    async fn migrate_111_ambient_edge_parity_repair(
+        &self,
+        prior_version: i64,
+    ) -> Result<(), WenlanError> {
+        // A data repair that retracts existing rows, like migration 107 — take
+        // the §6.9 restore point first.
+        self.backup_before_migration(111, prior_version).await?;
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m111 begin: {e}")))?;
+
+        let result: Result<(usize, usize, usize, Vec<CommunityGenerationUpdate>), WenlanError> =
+            async {
+                // What `relations` implies -- each id carried with the
+                // classification a canonical write would give it -- and what
+                // `edges` actually holds. Everything is read BEFORE any write so
+                // "did this database lapse?" is answered by the damage found,
+                // not by the fact a migration ran. The endpoint-space join and
+                // the three-way classification are the SAME ones
+                // `backfill_edges_from_relations` and `create_relation_with_span`
+                // apply, so an edge healed here is indistinguishable from a
+                // canonically-written one.
+                let mut expected: HashMap<String, (String, String, String, &str, String, bool)> =
+                    HashMap::new();
+                let mut rows = conn
+                    .query(
+                        "SELECT r.from_entity, r.to_entity, r.relation_type, \
+                                fe.space, te.space \
+                         FROM relations r \
+                         LEFT JOIN entities fe ON fe.id = r.from_entity \
+                         LEFT JOIN entities te ON te.id = r.to_entity",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m111 select relations: {e}")))?;
+                while let Some(row) = rows
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m111 relations row: {e}")))?
+                {
+                    let from: String = row.get(0).unwrap_or_default();
+                    let to: String = row.get(1).unwrap_or_default();
+                    let relation_type: String = row.get(2).unwrap_or_default();
+                    let from_space: Option<String> = row.get(3).unwrap_or(None);
+                    let to_space: Option<String> = row.get(4).unwrap_or(None);
+                    let (lineage, space, cross_space_downgrade) = match (&from_space, &to_space) {
+                        (Some(fs), Some(ts)) if fs == ts => ("assertion", fs.clone(), false),
+                        _ => (
+                            "legacy",
+                            from_space
+                                .clone()
+                                .or(to_space)
+                                .unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
+                            true,
+                        ),
+                    };
+                    let edge_id = crate::provenance::compute_edge_id(
+                        "relates",
+                        "entity",
+                        &from,
+                        "entity",
+                        &to,
+                        &relation_type,
+                    );
+                    expected.insert(
+                        edge_id,
+                        (
+                            from,
+                            to,
+                            relation_type,
+                            lineage,
+                            space,
+                            cross_space_downgrade,
+                        ),
+                    );
+                }
+                drop(rows);
+
+                let mut active: HashSet<String> = HashSet::new();
+                let mut retracted: HashSet<String> = HashSet::new();
+                let mut orphans: Vec<String> = Vec::new();
+                let mut edge_rows = conn
+                    .query(
+                        "SELECT edge_id, valid_until FROM edges WHERE edge_type = 'relates'",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m111 select edges: {e}")))?;
+                while let Some(row) = edge_rows
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m111 edges row: {e}")))?
+                {
+                    let edge_id: String = row.get(0).unwrap_or_default();
+                    if row.get::<Option<i64>>(1).unwrap_or(None).is_none() {
+                        if !expected.contains_key(&edge_id) {
+                            orphans.push(edge_id.clone());
+                        }
+                        active.insert(edge_id);
+                    } else {
+                        retracted.insert(edge_id);
+                    }
+                }
+                drop(edge_rows);
+
+                // Step 1a: relations whose edge was never written at all.
+                let absent = expected
+                    .keys()
+                    .filter(|id| !active.contains(*id) && !retracted.contains(*id))
+                    .count();
+                if absent > 0 {
+                    let counts = Self::backfill_edges_from_relations(&conn).await?;
+                    log::info!(
+                        "[migration] m111 relations backfill: {absent} absent edge(s) over \
+                         classifiable={}, unknown={}",
+                        counts.classifiable,
+                        counts.unknown_inserted
+                    );
+                }
+
+                // Step 1b: relations whose edge exists but is retracted. The
+                // backfill above could not touch these (`DO NOTHING`); the live
+                // writer's conflict rule un-retracts them.
+                let mut graph_changes = Vec::new();
+                let mut healed = 0usize;
+                for (edge_id, (from, to, relation_type, lineage, space, downgrade)) in &expected {
+                    if !retracted.contains(edge_id) {
+                        continue;
+                    }
+                    let (_, changes) = Self::dual_write_edge_with_payload(
+                        &conn,
+                        "relates",
+                        "entity",
+                        from,
+                        "entity",
+                        to,
+                        relation_type,
+                        lineage,
+                        space,
+                        *downgrade,
+                        None,
+                        None,
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("m111 reactivate retracted edge: {e}"))
+                    })?;
+                    graph_changes.extend(changes);
+                    healed += 1;
+                }
+
+                // Step 2: retract the edges its hard DELETE stranded.
+                for edge_id in &orphans {
+                    if let Some(change) = Self::dual_write_invalidate_edge(&conn, edge_id, None)
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("m111 retract orphan: {e}")))?
+                    {
+                        graph_changes.push(change);
+                    }
+                }
+                let generation_updates =
+                    Self::bump_community_graph_generations(&conn, graph_changes)
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("m111 repair generation: {e}"))
+                        })?;
+
+                // Step 3: coverage lapsed on this database -- retire its watermarks.
+                let minted = absent + healed;
+                if minted > 0 || !orphans.is_empty() {
+                    let affected = conn
+                        .execute(
+                            "UPDATE edges_migration_state SET epoch = epoch + 1 WHERE id = 1",
+                            (),
+                        )
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("m111 epoch bump: {e}")))?;
+                    // Same rule `bump_dual_write_epoch` enforces: a zero-row
+                    // UPDATE means the state row is gone, so nothing was
+                    // retired and a stale watermark would keep looking current.
+                    // (That method takes the connection lock itself, so it
+                    // cannot be called from inside this transaction.)
+                    if affected == 0 {
+                        return Err(WenlanError::VectorDb(
+                            "m111 epoch bump: no edges_migration_state row to bump".to_string(),
+                        ));
+                    }
+                }
+
+                // Step 4: edges minted by either half of step 1 sit behind the
+                // sweep's watermark -- it advanced past their relations while
+                // no ACTIVE edge backed them.
+                if minted > 0 {
+                    conn.execute(
+                        "DELETE FROM app_metadata WHERE key = ?1",
+                        libsql::params![crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY],
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("m111 grounding cursor reset: {e}"))
+                    })?;
+                }
+
+                Ok((absent, healed, orphans.len(), generation_updates))
+            }
+            .await;
+
+        let (backfilled, healed, orphans_retracted, generation_updates) = match result {
+            Ok(value) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m111 commit: {e}")))?;
+                value
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+        self.record_community_dirty_nodes(generation_updates);
+
+        conn.execute("PRAGMA user_version = 111", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m111 bump: {e}")))?;
+        log::info!(
+            "[migration] Migration 111 applied: ambient edges-parity repair \
+             ({backfilled} absent relates edges backfilled, \
+             {healed} retracted relates edges reactivated, \
+             {orphans_retracted} orphan relates edges retracted)"
+        );
         Ok(())
     }
 
@@ -31841,11 +32134,16 @@ impl MemoryDB {
     /// transaction. The LLM parse is intentionally complete before this method
     /// runs; no KG row becomes visible unless the source is still current and
     /// non-pending when the receipt is written.
+    /// `content` is the exact memory text `kg_results` was extracted from --
+    /// threaded through (never re-fetched) so each relation's `span` quote is
+    /// located against the string the model actually saw, matching
+    /// `create_relation_with_span`'s contract.
     async fn commit_entity_enrichment_at_version(
         &self,
         source_id: &str,
         expected_version: i64,
         kg_results: &[crate::extract::KgExtractionResult],
+        content: &str,
     ) -> Result<bool, WenlanError> {
         // Avoid CPU-heavy embedding/minhash preparation when inference already
         // returned after the source became stale. The transaction below still
@@ -31935,6 +32233,7 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("entity enrichment begin: {e}")))?;
 
         let mut created_entities: Vec<(String, String)> = Vec::new();
+        let mut generation_updates: Vec<CommunityGenerationUpdate> = Vec::new();
         let result: Result<bool, WenlanError> = async {
             let mut current_rows = conn
                 .query(
@@ -31976,6 +32275,38 @@ impl MemoryDB {
                     "entity enrichment replace source observations: {e}"
                 ))
             })?;
+
+            // File newly-derived entities with the source memory's Space, the
+            // same rule the canonical extraction lane applies (`commit_kg` ->
+            // `post_write::create_entity`, whose `WriteSpaceTarget` comes from
+            // `get_memory_space`). This lane used to hardcode `space = NULL`,
+            // which made every relation it wrote classify `legacy` (both
+            // endpoints unresolved) instead of `assertion` like its canonical
+            // sibling. `memories.space` is NOT NULL since migration 91 and
+            // carries the reserved sentinel for an unfiled memory, so fold the
+            // sentinel back to NULL exactly as `get_memory_space` does.
+            let entity_space: Option<String> = {
+                let mut rows = conn
+                    .query(
+                        "SELECT space FROM memories WHERE source_id = ?1 AND source = 'memory' LIMIT 1",
+                        libsql::params![source_id],
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("entity enrichment source space: {e}"))
+                    })?;
+                let space = match rows.next().await.map_err(|e| {
+                    WenlanError::VectorDb(format!("entity enrichment source space row: {e}"))
+                })? {
+                    Some(row) => row
+                        .get::<Option<String>>(0)
+                        .unwrap_or(None)
+                        .filter(|s| s != UNFILED_SPACE_ID),
+                    None => None,
+                };
+                drop(rows);
+                space
+            };
 
             let mut entity_ids: HashMap<String, String> = HashMap::new();
             let mut first_entity_id: Option<String> = None;
@@ -32087,14 +32418,18 @@ impl MemoryDB {
                             "INSERT INTO entities
                                  (id, name, entity_type, space, source_agent, confidence,
                                   confirmed, created_at, updated_at, embedding)
-                             VALUES (?1, ?2, ?3, NULL, 'post_ingest', NULL,
+                             VALUES (?1, ?2, ?3, ?6, 'post_ingest', NULL,
                                      0, ?4, ?4, vector32(?5))",
                             libsql::params![
                                 id.as_str(),
                                 name.as_str(),
                                 entity_type.as_str(),
                                 now,
-                                embedding.as_str()
+                                embedding.as_str(),
+                                entity_space
+                                    .as_deref()
+                                    .map(|s| libsql::Value::Text(s.to_string()))
+                                    .unwrap_or(libsql::Value::Null)
                             ],
                         )
                         .await
@@ -32273,6 +32608,129 @@ impl MemoryDB {
                     .map_err(|e| {
                         WenlanError::VectorDb(format!("entity enrichment relation insert: {e}"))
                     })?;
+
+                    // Dual-write the canonical `relates` edge in the SAME
+                    // transaction as the legacy `relations` row (M2 "one edge
+                    // store"). Classification mirrors
+                    // `create_relation_with_span` and
+                    // `backfill_edges_from_relations` exactly, so a live write,
+                    // a backfilled row, and this lane converge on one edge_id
+                    // AND one lineage.
+                    let mut endpoint_rows = conn
+                        .query(
+                            "SELECT fe.space, te.space FROM entities fe, entities te \
+                             WHERE fe.id = ?1 AND te.id = ?2",
+                            libsql::params![from_id.as_str(), to_id.as_str()],
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!(
+                                "entity enrichment relation endpoint spaces: {e}"
+                            ))
+                        })?;
+                    let (from_space, to_space): (Option<String>, Option<String>) =
+                        match endpoint_rows.next().await.map_err(|e| {
+                            WenlanError::VectorDb(format!(
+                                "entity enrichment relation endpoint row: {e}"
+                            ))
+                        })? {
+                            Some(row) => (row.get(0).unwrap_or(None), row.get(1).unwrap_or(None)),
+                            None => (None, None),
+                        };
+                    drop(endpoint_rows);
+                    let (lineage, edge_space, cross_space_downgrade) =
+                        match (&from_space, &to_space) {
+                            (Some(fs), Some(ts)) if fs == ts => ("assertion", fs.clone(), false),
+                            _ => (
+                                "legacy",
+                                from_space
+                                    .clone()
+                                    .or_else(|| to_space.clone())
+                                    .unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
+                                true,
+                            ),
+                        };
+                    // M3g Stage A span capture: the quote is located in the
+                    // exact content the extractor read, never re-fetched.
+                    // `model_version` stays NULL -- this lane's `extract_fn` is
+                    // opaque about which provider ran, unlike `commit_kg`.
+                    let span_json = relation.span.as_deref().map(|quote| {
+                        let offsets = crate::extract::locate_span_chars(content, quote);
+                        serde_json::json!({
+                            "quote": quote,
+                            "char_start": offsets.map(|(start, _)| start),
+                            "char_end": offsets.map(|(_, end)| end),
+                        })
+                    });
+                    let payload = serde_json::json!({
+                        "source_memory_id": source_id,
+                        "span": span_json,
+                        "model_version": serde_json::Value::Null,
+                        "prompt_version":
+                            crate::extract::EXTRACT_KNOWLEDGE_GRAPH_PROMPT_VERSION,
+                    })
+                    .to_string();
+                    let (_, graph_changes) = Self::dual_write_edge_with_payload(
+                        &conn,
+                        "relates",
+                        "entity",
+                        from_id,
+                        "entity",
+                        to_id,
+                        canonical.as_str(),
+                        lineage,
+                        &edge_space,
+                        cross_space_downgrade,
+                        None,
+                        Some(payload.as_str()),
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!(
+                            "entity enrichment relation dual-write: {e}"
+                        ))
+                    })?;
+                    generation_updates.extend(
+                        Self::bump_community_graph_generations(&conn, graph_changes)
+                            .await
+                            .map_err(|e| {
+                                WenlanError::VectorDb(format!(
+                                    "entity enrichment relation generation: {e}"
+                                ))
+                            })?,
+                    );
+
+                    // Retire the competing relations' edges BEFORE dropping the
+                    // rows, the same soft-supersession `supersede_relation`
+                    // applies on the canonical delete path. Without this the
+                    // hard DELETE below left an orphan ACTIVE edge, which the
+                    // parity sweep counts as drift forever.
+                    let mut losing_rows = conn
+                        .query(
+                            "SELECT relation_type FROM relations \
+                             WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type <> ?3",
+                            libsql::params![
+                                from_id.as_str(),
+                                to_id.as_str(),
+                                canonical.as_str()
+                            ],
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!(
+                                "entity enrichment relation supersede scan: {e}"
+                            ))
+                        })?;
+                    let mut losing_types: Vec<String> = Vec::new();
+                    while let Some(row) = losing_rows.next().await.map_err(|e| {
+                        WenlanError::VectorDb(format!(
+                            "entity enrichment relation supersede row: {e}"
+                        ))
+                    })? {
+                        losing_types.push(row.get::<String>(0).unwrap_or_default());
+                    }
+                    drop(losing_rows);
+
                     conn.execute(
                         "DELETE FROM relations
                          WHERE from_entity = ?1 AND to_entity = ?2
@@ -32285,6 +32743,38 @@ impl MemoryDB {
                             "entity enrichment relation supersede: {e}"
                         ))
                     })?;
+
+                    let mut retired_changes = Vec::new();
+                    for losing_type in losing_types {
+                        let edge_id = crate::provenance::compute_edge_id(
+                            "relates",
+                            "entity",
+                            from_id,
+                            "entity",
+                            to_id,
+                            &losing_type,
+                        );
+                        if let Some(change) =
+                            Self::dual_write_invalidate_edge(&conn, &edge_id, None)
+                                .await
+                                .map_err(|e| {
+                                    WenlanError::VectorDb(format!(
+                                        "entity enrichment relation retract: {e}"
+                                    ))
+                                })?
+                        {
+                            retired_changes.push(change);
+                        }
+                    }
+                    generation_updates.extend(
+                        Self::bump_community_graph_generations(&conn, retired_changes)
+                            .await
+                            .map_err(|e| {
+                                WenlanError::VectorDb(format!(
+                                    "entity enrichment relation retract generation: {e}"
+                                ))
+                            })?,
+                    );
                 }
             }
 
@@ -32339,6 +32829,7 @@ impl MemoryDB {
                 conn.execute("COMMIT", ())
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("entity enrichment commit: {e}")))?;
+                self.record_community_dirty_nodes(generation_updates);
                 drop(conn);
                 if minhash_enabled {
                     for (entity_id, name) in created_entities {
@@ -32692,10 +33183,15 @@ impl MemoryDB {
             }
         }
 
-        match extract_fn(content).await {
+        match extract_fn(content.clone()).await {
             Ok(kg_results) => {
                 if !self
-                    .commit_entity_enrichment_at_version(&source_id, expected_version, &kg_results)
+                    .commit_entity_enrichment_at_version(
+                        &source_id,
+                        expected_version,
+                        &kg_results,
+                        &content,
+                    )
                     .await?
                 {
                     log::info!("[entity_enrichment_slice] dropped stale result for {source_id}");

--- a/crates/wenlan-core/src/db/claim_derivation_test.rs
+++ b/crates/wenlan-core/src/db/claim_derivation_test.rs
@@ -192,7 +192,7 @@ async fn migration_110_from_104_installs_eligibility_before_the_105_drift_scan()
         let mut rows = conn.query("PRAGMA user_version", ()).await.unwrap();
         rows.next().await.unwrap().unwrap().get(0).unwrap()
     };
-    assert_eq!(user_version, 110);
+    assert_eq!(user_version, i64::from(crate::db::SCHEMA_VERSION));
     assert_eq!(eligibility_schema_fingerprint(&conn).await, fresh);
 }
 
@@ -229,7 +229,7 @@ async fn migration_110_from_109_converges_with_the_fresh_schema() {
         let mut rows = conn.query("PRAGMA user_version", ()).await.unwrap();
         rows.next().await.unwrap().unwrap().get(0).unwrap()
     };
-    assert_eq!(user_version, 110);
+    assert_eq!(user_version, i64::from(crate::db::SCHEMA_VERSION));
     let upgraded = eligibility_schema_fingerprint(&conn).await;
     assert_eq!(upgraded, fresh, "fresh and 109 -> 110 must converge");
     assert!(conn

--- a/crates/wenlan-core/src/db/m6_followup_schema_test.rs
+++ b/crates/wenlan-core/src/db/m6_followup_schema_test.rs
@@ -56,7 +56,6 @@ async fn user_version(db: &MemoryDB) -> i64 {
 #[tokio::test]
 async fn migrated_database_carries_all_fourteen_followup_tables_and_counter() {
     let (db, _temp) = test_db().await;
-    assert_eq!(SCHEMA_VERSION, 110);
     assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
     for table in FOLLOWUP_TABLES {
         assert!(

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -1307,15 +1307,40 @@ async fn migration_95_repairs_stamped_schema_and_bootstraps_existing_grounded_sp
              'm95-bootstrap-root', 1, 'm95-bootstrap-digest', 'generated',
              'm95-bootstrap-group', 'active', 1
          );
-         INSERT INTO edges (
+         INSERT INTO relations (
+             id, from_entity, to_entity, relation_type, source_agent, created_at
+         ) VALUES (
+             'm95-bootstrap-relation', 'm95-bootstrap-left', 'm95-bootstrap-right',
+             'related_to', 'test', 1
+         );",
+    )
+    .await
+    .unwrap();
+    // Content-addressed, and backed by the `relations` row above: `relations` is
+    // the sole producer of `relates`, so an edge with no relation behind it is
+    // parity drift that migration 111's repair retracts.
+    conn.execute(
+        "INSERT INTO edges (
              edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
              lineage, grounded, root_id, space, created_at
          ) VALUES (
-             'm95-bootstrap-edge', 'm95-bootstrap-left', 'entity',
+             ?1, 'm95-bootstrap-left', 'entity',
              'm95-bootstrap-right', 'entity', 'relates', 'assertion', 1,
              'm95-bootstrap-root', 'm95-bootstrap-space', 1
-         );
-         DROP TABLE community_members;
+         )",
+        libsql::params![crate::provenance::compute_edge_id(
+            "relates",
+            "entity",
+            "m95-bootstrap-left",
+            "entity",
+            "m95-bootstrap-right",
+            "related_to",
+        )],
+    )
+    .await
+    .unwrap();
+    conn.execute_batch(
+        "DROP TABLE community_members;
          DROP TABLE grouping_leases;
          DROP TABLE space_graph_state;
          DROP TABLE communities;
@@ -23660,6 +23685,7 @@ async fn test_upsert_memory_in_place_invalidates_entity_projection() {
             "mem_uip_entity",
             1,
             &extracted_entity("In-place Old Entity", "concept"),
+            "In-place Old Entity",
         )
         .await
         .unwrap());
@@ -24405,6 +24431,7 @@ async fn same_source_upsert_uses_old_version_plus_one() {
             "mem_replaced_generation",
             1,
             &extracted_entity("Original Replacement Entity", "concept"),
+            "Original Replacement Entity",
         )
         .await
         .unwrap());
@@ -24612,6 +24639,7 @@ async fn update_memory_invalidates_source_owned_kg_and_requeues_entity_enrichmen
                 "Old Beta",
                 "Old Alpha collaborates with Old Beta",
             ),
+            "Old Alpha collaborates with Old Beta",
         )
         .await
         .unwrap());
@@ -29491,27 +29519,23 @@ async fn entity_slice_auto_links_without_inference() {
     assert_eq!(linked.input_version, Some(1));
 }
 
-// I3 CHARACTERIZATION (pre-existing M2 parity gap, NOT introduced by M3g).
+// KG close plan G1 (was the I3 characterization of the M2 parity gap).
 //
 // The ambient Entity-enrichment lane the scheduler drives —
 // `run_entity_enrichment_slice_with_auto_link` ->
-// `commit_entity_enrichment_at_version` — writes `relations` through a raw
-// INSERT that neither consumes `relation.span` nor dual-writes to the unified
-// `edges` table. Contrast `create_relation_with_span`, which DOES dual-write a
-// payload-bearing `relates` edge. This lane is byte-identical on origin/main's
-// merge-base (M2 shipped it); the M3g Stage-A diff touches none of it.
+// `commit_entity_enrichment_at_version` — used to write `relations` through a
+// raw INSERT that neither consumed `relation.span` nor dual-wrote to the
+// unified `edges` table, so the canonical store was bypassed by the path that
+// runs most. It now dual-writes the SAME content-addressed `relates` edge
+// `create_relation_with_span` does, carrying the span payload, and files its
+// new entities with the source memory's Space so the edge classifies
+// `assertion` rather than `legacy` (both endpoints previously unresolved).
 //
-// Why this is SAFE for M3g and reported (not silently fixed) here: a relation
-// with no `edges` row is invisible to the grounding sweep — the sweep looks up
-// `edges` by edge_id and skips a missing row, so it can never false-ground a
-// relation this lane produced. The gap is a COVERAGE limitation on the unified
-// edges store, not an M3g correctness bug, and predates this branch.
-//
-// This test LOCKS IN the current (gap) behavior. When the M2 lane is routed
-// through the payload-bearing writer upstream, this test turns RED — the signal
-// to flip the assertion to expect a `relates` edge carrying the span payload.
+// This test is the inverted characterization: it asserts the dual-write, the
+// lineage, and the payload. Turning it red again means the lane fell back off
+// the canonical writer.
 #[tokio::test]
-async fn ambient_entity_sweep_writes_relation_without_edges_dual_write_pre_existing_m2_gap() {
+async fn ambient_entity_sweep_dual_writes_canonical_relates_edge() {
     let (db, _dir) = test_db().await;
     db.upsert_documents(vec![make_memory_doc(
         "mem_i3_entity_sweep",
@@ -29570,18 +29594,550 @@ async fn ambient_entity_sweep_writes_relation_without_edges_dual_write_pre_exist
     };
     assert_eq!(relation_count, 1, "the ambient sweep wrote the relation");
 
-    let relates_edges: i64 = {
+    let (lineage, space, payload_text, valid_until): (String, String, String, Option<i64>) = {
         let mut rows = conn
-            .query("SELECT COUNT(*) FROM edges WHERE edge_type = 'relates'", ())
+            .query(
+                "SELECT e.lineage, e.space, e.payload, e.valid_until FROM edges e \
+                 JOIN entities fe ON e.src_id = fe.id \
+                 JOIN entities te ON e.dst_id = te.id \
+                 WHERE e.edge_type = 'relates' AND fe.name = 'Alice' AND te.name = 'ProjectX'",
+                (),
+            )
+            .await
+            .unwrap();
+        let row = rows
+            .next()
+            .await
+            .unwrap()
+            .expect("the ambient sweep must dual-write the canonical relates edge");
+        (
+            row.get(0).unwrap(),
+            row.get(1).unwrap(),
+            row.get::<Option<String>>(2)
+                .unwrap()
+                .expect("span payload must be captured"),
+            row.get::<Option<i64>>(3).unwrap(),
+        )
+    };
+    assert_eq!(
+        lineage, "assertion",
+        "both endpoints inherit the source memory's Space, so the edge is first-class"
+    );
+    assert_eq!(space, "work");
+    assert!(valid_until.is_none(), "a fresh edge is active");
+
+    let payload: serde_json::Value = serde_json::from_str(&payload_text).unwrap();
+    assert_eq!(
+        payload["source_memory_id"],
+        serde_json::json!("mem_i3_entity_sweep")
+    );
+    assert_eq!(
+        payload["span"]["quote"],
+        serde_json::json!("Alice works on ProjectX")
+    );
+    assert_eq!(payload["span"]["char_start"], serde_json::json!(0));
+}
+
+/// KG close plan G1: the ambient lane's dedup DELETE hard-removes every
+/// competing `relations` row between the same endpoints. It used to leave their
+/// dual-written edges ACTIVE, which the parity sweep counts as drift forever.
+/// The loser's edge must now be soft-invalidated the same way
+/// `supersede_relation` does on the canonical delete path.
+#[tokio::test]
+async fn ambient_dedup_delete_retracts_the_losing_edge() {
+    let (db, _dir) = test_db().await;
+    let content = "Alice works on ProjectX.";
+    db.upsert_documents(vec![make_memory_doc(
+        "mem_g1_dedup",
+        content,
+        "fact",
+        "work",
+        "folder",
+    )])
+    .await
+    .unwrap();
+
+    let graph = |relation_type: &str| {
+        vec![crate::extract::KgExtractionResult {
+            index: 0,
+            entities: vec![
+                crate::extract::ExtractedEntity {
+                    name: "Alice".to_string(),
+                    entity_type: "person".to_string(),
+                },
+                crate::extract::ExtractedEntity {
+                    name: "ProjectX".to_string(),
+                    entity_type: "project".to_string(),
+                },
+            ],
+            observations: Vec::new(),
+            relations: vec![crate::extract::ExtractedRelation {
+                from: "Alice".to_string(),
+                to: "ProjectX".to_string(),
+                relation_type: relation_type.to_string(),
+                confidence: Some(0.9),
+                explanation: None,
+                span: None,
+            }],
+        }]
+    };
+
+    assert!(db
+        .commit_entity_enrichment_at_version("mem_g1_dedup", 1, &graph("works_on"), content)
+        .await
+        .unwrap());
+    // A second extraction of the same memory proposes a different type between
+    // the same endpoints: the new row wins, the old row is DELETEd.
+    assert!(db
+        .commit_entity_enrichment_at_version("mem_g1_dedup", 1, &graph("related_to"), content)
+        .await
+        .unwrap());
+
+    let conn = db.conn.lock().await;
+    let surviving_types: Vec<String> = {
+        let mut rows = conn
+            .query("SELECT relation_type FROM relations", ())
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            out.push(row.get::<String>(0).unwrap());
+        }
+        out
+    };
+    assert_eq!(
+        surviving_types,
+        vec!["related_to".to_string()],
+        "the dedup DELETE removed the losing relation row"
+    );
+
+    let mut active = 0i64;
+    let mut retracted = 0i64;
+    {
+        let mut rows = conn
+            .query(
+                "SELECT valid_until FROM edges WHERE edge_type = 'relates'",
+                (),
+            )
+            .await
+            .unwrap();
+        while let Some(row) = rows.next().await.unwrap() {
+            if row.get::<Option<i64>>(0).unwrap().is_some() {
+                retracted += 1;
+            } else {
+                active += 1;
+            }
+        }
+    }
+    assert_eq!(
+        active, 1,
+        "exactly the surviving relation keeps an active edge — no orphan"
+    );
+    assert_eq!(
+        retracted, 1,
+        "the deleted relation's edge is soft-invalidated, not left active or hard-deleted"
+    );
+}
+
+/// KG close plan G1 steps 2-4: migration 111 repairs what the ambient lane
+/// already wrote — backfills the missing edges, retracts the orphans its hard
+/// DELETE left behind, retires the pre-repair parity epoch, and resets the
+/// grounding cursor EXACTLY ONCE (a per-boot reset would re-spend the whole
+/// entailment backlog on every launch).
+#[tokio::test]
+async fn migration_111_repairs_ambient_parity_and_resets_the_grounding_cursor_once() {
+    let (db, _dir) = test_db().await;
+    db.create_space("work", None, false).await.unwrap();
+    let alice = db
+        .store_entity("Alice", "person", Some("work"), Some("post_ingest"), None)
+        .await
+        .unwrap();
+    let project = db
+        .store_entity(
+            "ProjectX",
+            "project",
+            Some("work"),
+            Some("post_ingest"),
+            None,
+        )
+        .await
+        .unwrap();
+    let orphan_src = db
+        .store_entity(
+            "Orphan Src",
+            "concept",
+            Some("work"),
+            Some("post_ingest"),
+            None,
+        )
+        .await
+        .unwrap();
+    let orphan_dst = db
+        .store_entity(
+            "Orphan Dst",
+            "concept",
+            Some("work"),
+            Some("post_ingest"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // (a) The shape the old ambient INSERT left: a relation with no edge twin.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO relations
+                 (id, from_entity, to_entity, relation_type, source_agent,
+                  confidence, explanation, source_memory_id, created_at)
+             VALUES ('rel_g1_bare', ?1, ?2, 'works_on', 'post_ingest', NULL, NULL, NULL, 1)",
+            libsql::params![alice.as_str(), project.as_str()],
+        )
+        .await
+        .unwrap();
+    }
+
+    // (b) The shape the old ambient DELETE left: an active edge with no
+    //     relation behind it. Built by dual-writing properly, then removing the
+    //     legacy row the way that lane did.
+    db.create_relation_with_span(
+        &orphan_src,
+        &orphan_dst,
+        "related_to",
+        Some("post_ingest"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let orphan_edge_id = crate::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &orphan_src,
+        "entity",
+        &orphan_dst,
+        "related_to",
+    );
+    let bare_edge_id = crate::provenance::compute_edge_id(
+        "relates", "entity", &alice, "entity", &project, "works_on",
+    );
+
+    let epoch_before: i64;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "DELETE FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
+            libsql::params![orphan_src.as_str(), orphan_dst.as_str()],
+        )
+        .await
+        .unwrap();
+        let mut rows = conn
+            .query("SELECT epoch FROM edges_migration_state WHERE id = 1", ())
+            .await
+            .unwrap();
+        epoch_before = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    }
+
+    db.set_app_metadata(
+        crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY,
+        r#"{"cursor":9999,"stuck_rowid":null,"failures":0,"entailment_version":"v1|m"}"#,
+    )
+    .await
+    .unwrap();
+
+    // Wind back to the pre-repair boundary and run the chain.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute("PRAGMA user_version = 110", ()).await.unwrap();
+    }
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("migration 111 must apply");
+
+    let conn = db.conn.lock().await;
+    let bare_state: Option<(String, Option<i64>)> = {
+        let mut rows = conn
+            .query(
+                "SELECT lineage, valid_until FROM edges WHERE edge_id = ?1",
+                libsql::params![bare_edge_id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next()
+            .await
+            .unwrap()
+            .map(|row| (row.get(0).unwrap(), row.get::<Option<i64>>(1).unwrap()))
+    };
+    let (bare_lineage, bare_valid_until) =
+        bare_state.expect("the backfill must mint the missing edge");
+    assert_eq!(
+        bare_lineage, "assertion",
+        "both endpoints are in one Space, so the backfilled edge is first-class"
+    );
+    assert!(bare_valid_until.is_none(), "the backfilled edge is active");
+
+    let orphan_valid_until: Option<i64> = {
+        let mut rows = conn
+            .query(
+                "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                libsql::params![orphan_edge_id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    assert!(
+        orphan_valid_until.is_some(),
+        "an active edge with no relation behind it is retracted, not left as drift"
+    );
+
+    let epoch_after: i64 = {
+        let mut rows = conn
+            .query("SELECT epoch FROM edges_migration_state WHERE id = 1", ())
             .await
             .unwrap();
         rows.next().await.unwrap().unwrap().get(0).unwrap()
     };
     assert_eq!(
-        relates_edges, 0,
-        "PRE-EXISTING M2 GAP: the ambient Entity sweep writes a relation with no \
-         edges dual-write. When the lane is routed through the payload-bearing \
-         writer upstream, flip this to expect the relates edge + span payload."
+        epoch_after,
+        epoch_before + 1,
+        "the repair retires every parity watermark taken while coverage was lapsed"
+    );
+    drop(conn);
+
+    assert!(
+        db.get_app_metadata(crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY)
+            .await
+            .unwrap()
+            .is_none(),
+        "the grounding cursor is reset so backfilled relations get rescanned"
+    );
+
+    // Idempotence: the reset is tied to the migration number, not to boot. A
+    // cursor written after the repair survives every later startup.
+    db.set_app_metadata(
+        crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY,
+        r#"{"cursor":7,"stuck_rowid":null,"failures":0,"entailment_version":"v1|m"}"#,
+    )
+    .await
+    .unwrap();
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("a second startup is a no-op");
+    let cursor_after = db
+        .get_app_metadata(crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY)
+        .await
+        .unwrap();
+    assert!(
+        cursor_after.is_some_and(|value| value.contains("\"cursor\":7")),
+        "the reset must not re-fire on every startup"
+    );
+    let conn = db.conn.lock().await;
+    let epoch_final: i64 = {
+        let mut rows = conn
+            .query("SELECT epoch FROM edges_migration_state WHERE id = 1", ())
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    assert_eq!(epoch_final, epoch_after, "and neither does the epoch bump");
+}
+
+/// The third damage shape: the relation is live but its edge is RETRACTED.
+/// Reachable because a canonical delete retracts the edge and drops the legacy
+/// row, and the OLD ambient lane then re-extracted the same triple and
+/// raw-INSERTed the relation with no edge write. `reconcile_edges_parity`
+/// compares against ACTIVE edges only, so this counts as drift to the sweep
+/// forever — and `insert_backfilled_edge` is `ON CONFLICT DO NOTHING`, so a
+/// backfill can never heal it. The repair must route these through the live
+/// writer instead. The settling assertion is the oracle itself: drift 0.
+#[tokio::test]
+async fn migration_111_reactivates_a_retracted_edge_and_settles_parity_at_zero() {
+    let (db, _dir) = test_db().await;
+    db.create_space("work", None, false).await.unwrap();
+    let src = db
+        .store_entity("Retracted Src", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+    let dst = db
+        .store_entity("Retracted Dst", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+
+    // Canonical write, then the canonical delete — which retracts the edge and
+    // hard-deletes the legacy row.
+    let relation_id = db
+        .create_relation_with_span(
+            &src,
+            &dst,
+            "related_to",
+            Some("test"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    db.supersede_relation(&relation_id, "some-other-relation")
+        .await
+        .unwrap()
+        .expect("the canonical delete must find the relation");
+
+    let edge_id =
+        crate::provenance::compute_edge_id("relates", "entity", &src, "entity", &dst, "related_to");
+    {
+        let conn = db.conn.lock().await;
+        let valid_until: Option<i64> = {
+            let mut rows = conn
+                .query(
+                    "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id.as_str()],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert!(
+            valid_until.is_some(),
+            "fixture precondition: the canonical delete retracted the edge"
+        );
+
+        // Now the old ambient lane re-extracts the same triple: a bare relation
+        // INSERT with no edge write.
+        conn.execute(
+            "INSERT INTO relations
+                 (id, from_entity, to_entity, relation_type, source_agent,
+                  confidence, explanation, source_memory_id, created_at)
+             VALUES ('rel_g1_retracted', ?1, ?2, 'related_to', 'post_ingest', NULL, NULL, NULL, 1)",
+            libsql::params![src.as_str(), dst.as_str()],
+        )
+        .await
+        .unwrap();
+        conn.execute("PRAGMA user_version = 110", ()).await.unwrap();
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("migration 111 must apply");
+
+    {
+        let conn = db.conn.lock().await;
+        let (lineage, valid_until): (String, Option<i64>) = {
+            let mut rows = conn
+                .query(
+                    "SELECT lineage, valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id.as_str()],
+                )
+                .await
+                .unwrap();
+            let row = rows.next().await.unwrap().unwrap();
+            (row.get(0).unwrap(), row.get::<Option<i64>>(1).unwrap())
+        };
+        assert!(
+            valid_until.is_none(),
+            "a live relation's retracted edge must be reactivated, not left as drift"
+        );
+        assert_eq!(
+            lineage, "assertion",
+            "reactivation re-derives lineage from the CURRENT endpoint spaces"
+        );
+    }
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "the repair must settle the parity oracle at zero, not merely look clean \
+         to its own detector (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
+/// The damage gate is the detector, not the version number: an undamaged
+/// database that crosses 110 -> 111 must keep its epoch and its grounding
+/// cursor, or every healthy install pays a full entailment rescan and loses a
+/// clean parity watermark for a repair that had nothing to repair.
+#[tokio::test]
+async fn migration_111_is_a_no_op_on_an_undamaged_database() {
+    let (db, _dir) = test_db().await;
+    db.create_space("work", None, false).await.unwrap();
+    let src = db
+        .store_entity("Healthy Src", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+    let dst = db
+        .store_entity("Healthy Dst", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+    // Canonically written and left alone: relation live, edge active.
+    db.create_relation_with_span(
+        &src,
+        &dst,
+        "related_to",
+        Some("test"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    db.set_app_metadata(
+        crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY,
+        r#"{"cursor":42,"stuck_rowid":null,"failures":0,"entailment_version":"v1|m"}"#,
+    )
+    .await
+    .unwrap();
+
+    let epoch_before: i64;
+    {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT epoch FROM edges_migration_state WHERE id = 1", ())
+            .await
+            .unwrap();
+        epoch_before = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        drop(rows);
+        conn.execute("PRAGMA user_version = 110", ()).await.unwrap();
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("migration 111 must apply");
+
+    let conn = db.conn.lock().await;
+    let epoch_after: i64 = {
+        let mut rows = conn
+            .query("SELECT epoch FROM edges_migration_state WHERE id = 1", ())
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    assert_eq!(
+        epoch_after, epoch_before,
+        "a database that never lapsed keeps its epoch, so a clean watermark stays current"
+    );
+    drop(conn);
+
+    let cursor = db
+        .get_app_metadata(crate::edge_grounding::EDGE_GROUNDING_CURSOR_KEY)
+        .await
+        .unwrap();
+    assert!(
+        cursor.is_some_and(|value| value.contains("\"cursor\":42")),
+        "and keeps its grounding cursor, so it does not re-spend the entailment backlog"
     );
 }
 
@@ -29697,6 +30253,7 @@ async fn entity_reenrichment_replaces_only_source_owned_observations() {
                 "concept",
                 "old source-owned observation",
             ),
+            "old source-owned observation",
         )
         .await
         .unwrap());
@@ -29737,6 +30294,7 @@ async fn entity_reenrichment_replaces_only_source_owned_observations() {
                 "concept",
                 "new source-owned observation",
             ),
+            "new source-owned observation",
         )
         .await
         .unwrap());
@@ -29804,6 +30362,7 @@ async fn forget_removes_only_source_owned_observations() {
                 "concept",
                 "source-owned observation to forget",
             ),
+            "source-owned observation to forget",
         )
         .await
         .unwrap());


### PR DESCRIPTION
## What

Makes the always-on ambient entity-extraction path a first-class writer of the canonical `edges` store, and ships a damage-gated data repair (migration 111) for the drift it has been manufacturing.

## The defect (three heads, one path)

`commit_entity_enrichment_at_version` — the enrichment lane that runs constantly — was:
1. inserting `relations` rows with **no** canonical `edges` row (the grounding promoter permanently skips such relations),
2. hard-deleting competing relations **without superseding** their dual-written edges (permanent, self-renewing edges-parity drift → `reader_uses_edges` can never flip → legacy-store retirement blocked),
3. filing extracted entities with `space=NULL`, so even backfilled edges classified `lineage='legacy'` — invisible to downstream grounded readers.

A pre-existing characterization test documented exactly this gap and flipped RED on the first writer change — the repo's own hand confirming the defect.

## The fix

**Writer** (same transaction, no new mechanism): dual-write via `dual_write_edge_with_payload` with classification character-identical to `create_relation_with_span`; supersede losers via the same soft-supersession `supersede_relation` uses; resolve the memory's Space in-txn (identical to `get_memory_space`, unfiled-sentinel fold included) so edges classify `assertion`; community generation bump + dirty-node recording matching the canonical lane.

**Migration 111** (backup first; damage-gated): backfills never-written edges; **reactivates** written-then-retracted edges through the live writer's conflict rule; retracts orphaned active edges; bumps the dual-write epoch (fail-loud) and resets the edge-grounding cursor **only when damage was found** — a healthy database is proven untouched by a dedicated test.

## Independent review

Fresh-eyes review against a targeted checklist (migration safety incl. crash-mid-repair, space-fence interaction, edge-id identity across all three writers, locking, SQL safety, test honesty). One confirmed defect: the damage detector counted retracted edges as "present" while the parity sweep counts only active ones — leaving "relation live / edge retracted" drift undetected, unrepaired, and unhealable by any path on the branch. Fixed: the detector now splits active/retracted with the same lineage classification as the backfill, and heals retracted-but-expected edges by reactivation. Pinned by a mutation-controlled settling test (short-circuiting the heal loop makes it fail) that builds the damage through real code paths and asserts `reconcile_edges_parity` drift lands at **zero**. Three minor findings (fail-loud epoch bump, a tautological version assert, missing healthy-no-op coverage) also fixed.

## Receipts

- Focused suites in this worktree: 21 / 572+3 ign / 557+7 ign / 424+1 ign — all green
- New tests: ambient dual-write (+ lineage/space/span-payload pins), loser retraction, migration repair, retracted-edge settling (mutation-controlled), healthy-DB no-op
- clippy clean, fmt clean, `cargo check` clean across wenlan-server / wenlan-mcp / wenlan CLI
- Session-lead re-runs: `migration_111` 3 passed, `ambient_` 15 passed

## Known follow-ups (out of scope, tracked in docs/plans/2026-08-04-kg-revamp-close-plan.md)

- Same missing-dual-write class on the **entity shadow-page** parity axis (M3 store, different watermark)
- `model_version` in the ambient span payload (nothing reads it today)
- The live oracle: after this lands, `WENLAN_ENABLE_EDGES_RECONCILE=1` on a real store → `edges_parity_watermark` should read drift 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
