### PR TITLE
test(truth): stamp origin_class in grounding bench raw seed

### DIFF
--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -44032,8 +44032,8 @@ async fn edge_grounding_scale_and_latency_bench() {
             conn.execute(
                 "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
                     last_modified, chunk_type, source_agent, space, confidence, confirmed, \
-                    memory_type, pending_revision) \
-                 VALUES (?1, ?2, 'memory', ?1, 't', 0, 1712707200, 'text', 'folder', 'space_a', 1.0, 1, 'fact', 0)",
+                    memory_type, pending_revision, origin_class) \
+                 VALUES (?1, ?2, 'memory', ?1, 't', 0, 1712707200, 'text', 'folder', 'space_a', 1.0, 1, 'fact', 0, 'document_ingest')",
                 libsql::params![format!("mem_{i}"), format!("Folder document {i}.")],
             )
             .await


### PR DESCRIPTION
Post-G2 the grounding sweep's candidate gate reads `memories.origin_class` and fails closed on NULL, so `edge_grounding_scale_and_latency_bench`'s raw-SQL folder-document seed produced zero candidates (0 full ticks — the bench fails on main today). Stamp `'document_ingest'` to mirror `upsert_documents`.

This is the exact fixture the G3 receipts (PR #476 §3) were measured with: 30 full ticks, promoted 750/779, mutex p95 48.3ms. The edit missed the G2 PR (#475); this ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91