### PR TITLE
fix(truth): fence M5 claim edges out of the edges parity sweep

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -17709,9 +17709,13 @@ impl MemoryDB {
 
     /// Stage-(d) reconciliation sweep (spec v3 §7 M2 row). Recomputes the
     /// content-addressed `edge_id` set the five legacy stores imply and
-    /// diffs it against the live *active* edge set, asserting
-    /// `edges ≡ relations ∪ page_sources ∪ page_evidence ∪ pages.citations ∪
-    /// page_links`. Stamps `edges_parity_watermark` with the drift and the
+    /// diffs it against the live *active* edges in the legacy-derivable
+    /// universe, asserting `edges − claim-lineage ≡ relations ∪ page_sources ∪
+    /// page_evidence ∪ pages.citations ∪ page_links`. M5 claim edges
+    /// (claim_revision/root endpoints: `supports`, `attests`) are outside the
+    /// diff — no legacy store implies them, and the schema CHECK bars
+    /// `lineage='legacy'` from those endpoint kinds. Stamps
+    /// `edges_parity_watermark` with the drift and the
     /// current epoch; `reader_uses_edges` gates every cutover on that stamp.
     ///
     /// This RE-DERIVES the expected set independently -- it does NOT call the
@@ -17960,12 +17964,22 @@ impl MemoryDB {
         // actual: the live active edges, id -> stored structural columns. Reads
         // the SAME columns `detect_communities` (and every reader) consume, so a
         // corrupted endpoint is visible here even when the id set matches.
+        //
+        // Scoped to the legacy-derivable universe: M5 claim edges (`supports`
+        // from a claim_revision, `attests` from a root) have no legacy-store
+        // counterpart to diff against — the schema CHECK guarantees
+        // `lineage='legacy'` never touches a claim_revision/root endpoint, so
+        // the endpoint-kind fence excludes exactly the edges the five stores
+        // can never imply. Without it every M5 edge counts as "extra" and the
+        // watermark can never come clean on a post-M5 database.
         let mut actual: HashMap<String, (String, String, String, String, String)> = HashMap::new();
         {
             let mut rows = conn
                 .query(
                     "SELECT edge_id, edge_type, src_kind, src_id, dst_kind, dst_id \
-                     FROM edges WHERE valid_until IS NULL",
+                     FROM edges WHERE valid_until IS NULL \
+                       AND src_kind NOT IN ('claim_revision', 'root') \
+                       AND dst_kind NOT IN ('claim_revision', 'root')",
                     (),
                 )
                 .await

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -43019,6 +43019,83 @@ async fn reader_flips_only_after_clean_parity_and_reverts() {
     }
 }
 
+/// M5 claim edges (`supports` from a claim_revision, `attests` from a root)
+/// have no legacy-store counterpart. The sweep must fence them out of the
+/// actual set — otherwise every claim edge counts as "extra" and a post-M5
+/// database can never stamp a clean watermark (observed live 2026-08-04:
+/// 2,540 supports edges reported as drift on an otherwise-clean corpus).
+#[tokio::test]
+async fn reconcile_ignores_claim_lineage_edges() {
+    let (db, _dir) = test_db().await;
+    // Legacy world: one relation, dual-written.
+    let e1 = db
+        .create_entity("Alice", "person", Some("space_a"))
+        .await
+        .unwrap();
+    let e2 = db
+        .create_entity("Bob", "person", Some("space_a"))
+        .await
+        .unwrap();
+    db.create_relation(&e1, &e2, "knows", None, None, None, None)
+        .await
+        .unwrap();
+
+    // M5 world on the same database: a claim revision supported by an
+    // evidence memory, attested by a human root (the claim_edge_lifecycle
+    // seed shape).
+    db.insert_page(
+        "pg1",
+        "pg1",
+        None,
+        "",
+        None,
+        Some("space_a"),
+        &[],
+        "2026-07-27T00:00:00Z",
+    )
+    .await
+    .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute_batch(
+            "INSERT INTO memories (id, content, source, source_id, title, chunk_index,
+                                   last_modified, chunk_type, space)
+             VALUES ('m1', 'evidence', 'memory', 'mem1', 'title', 0, 0, 'text', 'space_a');
+
+             INSERT INTO claims (claim_id, page_id, created_at) VALUES ('c1', 'pg1', 0);
+             INSERT INTO claim_revisions (claim_revision_id, claim_id, predecessor_revision_id,
+                                          canonical_text, canonical_text_digest, claim_kind,
+                                          extractor_version, created_at)
+             VALUES ('cr1', 'c1', '', 'a sentence', 'digest', 'observation', 1, 0);
+
+             INSERT INTO provenance_roots (root_id, identity_version, identity_digest,
+                                           root_kind, independence_group_id, created_at)
+             VALUES ('r1', 1, 'r1', 'human_capture', 'g', 0);
+
+             INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+                                lineage, grounded, root_id, space, created_at)
+             VALUES ('s1', 'cr1', 'claim_revision', 'mem1', 'memory', 'supports',
+                     'evidence', 1, 'r1', 'space_a', 0);
+             INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+                                lineage, grounded, root_id, space, created_at)
+             VALUES ('a1', 'r1', 'root', 'cr1', 'claim_revision', 'attests',
+                     'assertion', 0, 'r1', 'space_a', 0);",
+        )
+        .await
+        .unwrap();
+    }
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "claim-lineage edges must not count as drift: {report:?}"
+    );
+    assert_eq!(
+        report.extra_count, 0,
+        "supports/attests edges are outside the legacy-derivable universe"
+    );
+}
+
 #[tokio::test]
 async fn epoch_bump_retires_watermark_and_reblocks_reader() {
     let (db, _dir) = test_db().await;


### PR DESCRIPTION
## What

`reconcile_edges_parity` diffs ALL active rows in `edges` against the five legacy stores (`relations`, `page_sources`, `page_evidence`, `pages.citations`, `page_links`). M5 introduced claim-lineage edges (`supports`: claim_revision→memory, `attests`: root→claim_revision) into the same table. The sweep predates M5, so every claim edge counts as an "extra" — on the live DB that is 2,540 permanent phantom drift, and the `communities` reader-cutover gate (`drift == 0`) can never open post-M5.

Fix: fence claim-lineage edges out of the actual-set query by endpoint kind:

```sql
AND src_kind NOT IN ('claim_revision', 'root')
AND dst_kind NOT IN ('claim_revision', 'root')
```

Endpoint kind is the correct predicate: the schema CHECK already bars `lineage='legacy'` edges from claim_revision/root endpoint kinds, so the fence excludes exactly the M5 edges and nothing legacy-derived.

## Invariant after this change

`edges − claim-lineage ≡ relations ∪ page_sources ∪ page_evidence ∪ pages.citations ∪ page_links`

## Test

New regression test `reconcile_ignores_claim_lineage_edges`: seeds a legacy relation plus a full M5 world (memory, claim, claim_revision, provenance_root, one `supports` + one `attests` edge — the `claim_edge_lifecycle_test.rs` seed shape) and asserts `drift_count == 0` and `extra_count == 0`.

## Live verification

On a scratch copy of the live DB (post data-repair of 32 historical rows, done separately as an operational fix), the real `reconcile_edges_parity` run with this fix reports drift=0, expected=actual=2,387. Entity-page parity stays drift=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
