### PR TITLE
fix(kg): ambient entity sweep dual-writes entity shadow pages; migration 113 repairs parity

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -710,7 +710,7 @@ pub const EMBEDDING_DIM: usize = 768;
 /// Migration 111 repairs the edges-parity damage the ambient entity-enrichment
 /// lane did while it wrote `relations` without their `edges` twin. It follows
 /// M5's judge-eligibility registry and generation fence at 110.
-pub const SCHEMA_VERSION: u32 = 112;
+pub const SCHEMA_VERSION: u32 = 113;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8533,6 +8533,17 @@ impl MemoryDB {
             if version < 112 {
                 self.migrate_112_origin_class(version).await?;
             }
+
+            // Migration 113 (KG close plan G5): repair the entity/page parity
+            // damage the ambient entity-enrichment lane did while it inserted
+            // `entities` rows without their `kind='entity'` shadow-page twin
+            // (the same skew class migration 111 repaired for `edges`; #473
+            // fixed the edge half of this path but missed the entity half).
+            // Backfills a shadow page + `entity_page_map` row for every entity
+            // that has none. See migrate_113_entity_shadow_page_repair.
+            if version < 113 {
+                self.migrate_113_entity_shadow_page_repair(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -12845,6 +12856,79 @@ impl MemoryDB {
             "[migration] Migration 112 applied: memories.origin_class \
              ({classified} rows classified document_ingest, {defaulted} generated)"
         );
+        Ok(())
+    }
+
+    // Migration 113 (KG close plan G5): backfill the `kind='entity'` shadow
+    // pages the ambient entity-enrichment lane failed to dual-write. #473
+    // taught `commit_entity_enrichment_at_version` to dual-write canonical
+    // `edges` but not entity shadow pages, so every entity it created since
+    // migration 92 violates the M3 PR-1 dual-write invariant and shows up as
+    // `missing` drift in `entity_page_parity_watermark` — permanently holding
+    // the `reader_uses_entity_pages` cutover gate closed. The companion code
+    // fix makes that path dual-write; this migration repairs the rows already
+    // written. Uses the SAME helpers as the live dual-write
+    // (`insert_entity_shadow_page` + `update_entity_shadow_page`, the
+    // migration-92 pattern), so a repaired entity is byte-identical in shape
+    // to a correctly created one, aliases folded in. Idempotent: scoped to
+    // entities with no `entity_page_map` row at all.
+    async fn migrate_113_entity_shadow_page_repair(
+        &self,
+        prior_version: i64,
+    ) -> Result<(), WenlanError> {
+        self.backup_before_migration(113, prior_version).await?;
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m113 begin: {e}")))?;
+
+        let result: Result<u64, WenlanError> = async {
+            let mut rows = conn
+                .query(
+                    "SELECT id FROM entities \
+                     WHERE id NOT IN (SELECT entity_id FROM entity_page_map)",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m113 scan: {e}")))?;
+            let mut unmapped: Vec<String> = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m113 scan row: {e}")))?
+            {
+                if let Ok(id) = row.get::<String>(0) {
+                    unmapped.push(id);
+                }
+            }
+
+            let now_iso = chrono::Utc::now().to_rfc3339();
+            for entity_id in &unmapped {
+                let page_id = crate::pages::new_page_id();
+                Self::insert_entity_shadow_page(&conn, entity_id, &page_id, &now_iso).await?;
+                Self::update_entity_shadow_page(&conn, entity_id, &now_iso).await?;
+            }
+            Ok(unmapped.len() as u64)
+        }
+        .await;
+
+        let repaired = match result {
+            Ok(value) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m113 commit: {e}")))?;
+                value
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+
+        conn.execute("PRAGMA user_version = 113", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m113 bump: {e}")))?;
+        log::info!("[migration] Migration 113 applied: {repaired} entity shadow pages backfilled");
         Ok(())
     }
 
@@ -32451,6 +32535,7 @@ impl MemoryDB {
         }
 
         let now = chrono::Utc::now().timestamp();
+        let now_iso = chrono::Utc::now().to_rfc3339();
         let conn = self.conn.lock().await;
         conn.execute("BEGIN", ())
             .await
@@ -32660,6 +32745,13 @@ impl MemoryDB {
                         .map_err(|e| {
                             WenlanError::VectorDb(format!("entity enrichment entity insert: {e}"))
                         })?;
+                        // M3 PR-1 dual-write invariant: every `entities` INSERT
+                        // creates its `kind='entity'` shadow page in the same
+                        // transaction (mirrors `store_entity`). This path missed
+                        // it when #473 added canonical-edge dual-writes here;
+                        // caught live by `reconcile_entity_page_parity`.
+                        let page_id = crate::pages::new_page_id();
+                        Self::insert_entity_shadow_page(&conn, &id, &page_id, &now_iso).await?;
                         created_entities.push((id.clone(), name.clone()));
                         id
                     }
@@ -32675,6 +32767,10 @@ impl MemoryDB {
                 .map_err(|e| {
                     WenlanError::VectorDb(format!("entity enrichment alias insert: {e}"))
                 })?;
+                // `aliases` is a shadow-mirrored column, so a (possibly new)
+                // alias on a resolved entity must re-sync the shadow too --
+                // same rule as `add_entity_alias`. No-op when nothing changed.
+                Self::update_entity_shadow_page(&conn, &entity_id, &now_iso).await?;
 
                 if first_entity_id.is_none() {
                     first_entity_id = Some(entity_id.clone());

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -29638,6 +29638,119 @@ async fn ambient_entity_sweep_dual_writes_canonical_relates_edge() {
     assert_eq!(payload["span"]["char_start"], serde_json::json!(0));
 }
 
+/// KG close plan G5: #473 taught the ambient entity sweep to dual-write
+/// canonical `edges` but left its `entities` INSERT without the
+/// `kind='entity'` shadow-page twin `store_entity` writes (M3 PR-1
+/// invariant), so every sweep-created entity held the
+/// `reader_uses_entity_pages` cutover gate closed as `missing` parity drift
+/// (observed live 2026-08-04, drift=2). The sweep must now shadow-write in
+/// the same transaction, and the parity sweep must come back clean.
+#[tokio::test]
+async fn ambient_entity_sweep_dual_writes_shadow_pages() {
+    let (db, _dir) = test_db().await;
+    db.upsert_documents(vec![make_memory_doc(
+        "mem_g5_shadow",
+        "Alice works on ProjectX.",
+        "fact",
+        "work",
+        "folder",
+    )])
+    .await
+    .unwrap();
+
+    let kg = vec![crate::extract::KgExtractionResult {
+        index: 0,
+        entities: vec![
+            crate::extract::ExtractedEntity {
+                name: "Alice".to_string(),
+                entity_type: "person".to_string(),
+            },
+            crate::extract::ExtractedEntity {
+                name: "ProjectX".to_string(),
+                entity_type: "project".to_string(),
+            },
+        ],
+        observations: Vec::new(),
+        relations: Vec::new(),
+    }];
+
+    let selected =
+        db.run_entity_enrichment_slice_with_auto_link(0.05, move |_content: String| async move {
+            Ok(kg)
+        })
+        .await
+        .unwrap();
+    assert_eq!(selected, 1, "the sweep processed the seeded memory");
+
+    {
+        let conn = db.conn.lock().await;
+        let unmapped: i64 = {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM entities \
+                     WHERE id NOT IN (SELECT entity_id FROM entity_page_map)",
+                    (),
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            unmapped, 0,
+            "every sweep-created entity must have a shadow page mapped"
+        );
+    }
+
+    let report = db.reconcile_entity_page_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "sweep-created entities must reconcile clean (report={report:?})"
+    );
+}
+
+/// KG close plan G5: migration 113 repairs the entities #473's sweep already
+/// wrote without shadow pages. Simulate the damage (a mapped-page-less
+/// entity, the live drift shape), run the migration, and the parity sweep
+/// must come back clean — the repaired shadow byte-identical in shape to a
+/// live dual-written one, aliases folded in.
+#[tokio::test]
+async fn migration_113_backfills_missing_entity_shadow_pages() {
+    let (db, _dir) = test_db().await;
+    let eid = db
+        .store_entity("Orphan", "concept", Some("work"), None, None)
+        .await
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "DELETE FROM pages WHERE id = \
+             (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
+            libsql::params![eid.clone()],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "DELETE FROM entity_page_map WHERE entity_id = ?1",
+            libsql::params![eid.clone()],
+        )
+        .await
+        .unwrap();
+    }
+    assert_eq!(
+        db.reconcile_entity_page_parity().await.unwrap().drift_count,
+        1,
+        "the simulated damage must register as drift"
+    );
+
+    db.migrate_113_entity_shadow_page_repair(112).await.unwrap();
+
+    let report = db.reconcile_entity_page_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "migration 113 must repair the missing shadow (report={report:?})"
+    );
+}
+
 /// KG close plan G1: the ambient lane's dedup DELETE hard-removes every
 /// competing `relations` row between the same endpoints. It used to leave their
 /// dual-written edges ACTIVE, which the parity sweep counts as drift forever.


### PR DESCRIPTION
## What

PR #473 taught the ambient entity sweep (`commit_entity_enrichment_at_version`) to dual-write canonical `edges`, but left its `entities` INSERT without the `kind='entity'` shadow-page twin that `store_entity` writes (the M3 PR-1 dual-write invariant). Every entity the sweep creates registers as `missing` drift in `entity_page_parity_watermark`, permanently holding the `reader_uses_entity_pages` cutover gate closed.

Observed live 2026-08-04: the parity sweep stamped drift=2 at 19:37 UTC — two `source_agent='post_ingest'` entities created at 18:17 by the ambient Entity lane, zero `entity_page_map` rows. The gate had been clean (drift 0) at 17:46.

## Fix

- New entities in the sweep path get `insert_entity_shadow_page` in the same transaction, matching `store_entity`.
- After the alias upsert, `update_entity_shadow_page` re-syncs the shadow (aliases are a shadow-mirrored column — a new alias resolving onto an existing entity previously also drifted, as `corrupt`).
- **Migration 113** backfills a shadow page for every entity with no `entity_page_map` row, using the same helpers as the live dual-write (the migration-92 pattern), so repaired shadows are byte-identical in shape and aliases fold in. Idempotent; takes the standard pre-migration backup.

## Tests

- `ambient_entity_sweep_dual_writes_shadow_pages` — drives the scheduler's Entity lane end-to-end and asserts zero unmapped entities and a clean `reconcile_entity_page_parity` report.
- `migration_113_backfills_missing_entity_shadow_pages` — simulates the live damage shape (entity with no map row), asserts drift 1, runs the migration, asserts drift 0.

Also green: the `reconcile` (51), `shadow` (82), and `enrichment` (64) test families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
