### PR TITLE
fix(kg): G6 Stage 0 — close three dual-write gaps that re-drift edges parity

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -491,6 +491,7 @@ impl MemoryDB {
             drop(rows);
 
             let mut folded = 0usize;
+            let mut graph_changes: Vec<CommunityGraphChange> = Vec::new();
             for (id, from, to, conf, expl, smid) in &ids {
                 // Does a canonical edge already exist for this pair?
                 let mut ex = conn
@@ -553,8 +554,75 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
                 }
+                // Dual-write (G6 Stage 0): `relation_type` is a structural
+                // field of the content-addressed edge id, so a fold retires
+                // the old-type edge and asserts the canonical-type one —
+                // otherwise every folded row becomes permanent parity drift
+                // (one "extra" plus one "missing"). Endpoint-space
+                // classification mirrors `create_relation_with_span`.
+                let old_edge_id = crate::provenance::compute_edge_id(
+                    "relates", "entity", from, "entity", to, old_type,
+                );
+                let new_edge_id = crate::provenance::compute_edge_id(
+                    "relates", "entity", from, "entity", to, canonical,
+                );
+                let mut space_rows = conn
+                    .query(
+                        "SELECT fe.space, te.space FROM entities fe, entities te WHERE fe.id = ?1 AND te.id = ?2",
+                        libsql::params![from.clone(), to.clone()],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                let (from_space, to_space): (Option<String>, Option<String>) = match space_rows
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+                {
+                    Some(row) => (row.get(0).unwrap_or(None), row.get(1).unwrap_or(None)),
+                    None => (None, None),
+                };
+                drop(space_rows);
+                let (lineage, space, cross_space_downgrade) = match (&from_space, &to_space) {
+                    (Some(fs), Some(ts)) if fs == ts => ("assertion", fs.clone(), false),
+                    _ => (
+                        "legacy",
+                        from_space
+                            .or(to_space)
+                            .unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
+                        true,
+                    ),
+                };
+                let (_, mint_changes) = Self::dual_write_edge_with_payload(
+                    &conn,
+                    "relates",
+                    "entity",
+                    from,
+                    "entity",
+                    to,
+                    canonical,
+                    lineage,
+                    &space,
+                    cross_space_downgrade,
+                    None,
+                    None,
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("fold mint edge: {e}")))?;
+                graph_changes.extend(mint_changes);
+                // Retire AFTER the mint: `superseded_by` is an FK into
+                // `edges`, so the canonical successor must exist first.
+                if let Some(change) =
+                    Self::dual_write_invalidate_edge(&conn, &old_edge_id, Some(&new_edge_id))
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("fold retire edge: {e}")))?
+                {
+                    graph_changes.push(change);
+                }
                 folded += 1;
             }
+            Self::bump_community_graph_generations(&conn, graph_changes)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("fold graph bump: {e}")))?;
 
             if !pre_image.is_empty() {
                 let pre_json =
@@ -45114,6 +45182,25 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("delete_page begin: {e}")))?;
         let result = async {
+            // Dual-write (G6 Stage 0): the FK CASCADE below drops this page's
+            // page_sources/page_evidence/page_links rows, and inbound
+            // page_links lose their target (NULL targets derive no edge), so
+            // every canonical edge touching this page retires in the same
+            // transaction — else each becomes permanent "extra" parity drift.
+            // A direct bulk retire is equivalent to per-edge invalidation
+            // here: page edges are never grounded `relates` assertions, so no
+            // community-graph change is possible (mirrors
+            // `replace_page_links`).
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "UPDATE edges SET valid_until = ?2, superseded_by = NULL \
+                 WHERE valid_until IS NULL \
+                   AND ((src_kind = 'page' AND src_id = ?1) \
+                     OR (dst_kind = 'page' AND dst_id = ?1))",
+                libsql::params![id, now],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("delete_page retire edges: {e}")))?;
             conn.execute(
                 "UPDATE page_links SET target_page_id = NULL WHERE target_page_id = ?1",
                 libsql::params![id],
@@ -46295,6 +46382,54 @@ impl MemoryDB {
         let result: Result<(), WenlanError> = async {
             let before = Self::page_memory_provenance_state(&conn, page_id).await?;
 
+            // Dual-write (G6 Stage 0): snapshot the sids the prune below
+            // removes so their canonical `cites` edges retire in the same
+            // transaction. The provenance bump at the end NULLs
+            // `pages.citations` whenever the set changes, so a pruned row has
+            // no surviving legacy backing — leaving its edge active is
+            // permanent "extra" parity drift (the 2026-07-23 live damage
+            // class).
+            let removed: Vec<String> = {
+                let (sql, bind): (String, Vec<libsql::Value>) = if memory_source_ids.is_empty() {
+                    (
+                        "SELECT memory_source_id FROM page_sources WHERE page_id = ?1".to_string(),
+                        vec![libsql::Value::Text(page_id.to_string())],
+                    )
+                } else {
+                    let placeholders: String = (0..memory_source_ids.len())
+                        .map(|i| format!("?{}", i + 2))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    let mut bind: Vec<libsql::Value> =
+                        Vec::with_capacity(1 + memory_source_ids.len());
+                    bind.push(libsql::Value::Text(page_id.to_string()));
+                    for sid in memory_source_ids {
+                        bind.push(libsql::Value::Text((*sid).to_string()));
+                    }
+                    (
+                        format!(
+                            "SELECT memory_source_id FROM page_sources WHERE page_id = ?1 AND memory_source_id NOT IN ({placeholders})"
+                        ),
+                        bind,
+                    )
+                };
+                let mut rows = conn
+                    .query(&sql, libsql::params_from_iter(bind))
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_page_sources removed scan: {e}"))
+                    })?;
+                let mut removed = Vec::new();
+                while let Some(row) = rows
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+                {
+                    removed.push(row.get::<String>(0).unwrap_or_default());
+                }
+                removed
+            };
+
             if memory_source_ids.is_empty() {
             if let Err(e) = conn
                 .execute(
@@ -46387,6 +46522,21 @@ impl MemoryDB {
                 )));
             }
         }
+
+            // Retire the pruned rows' canonical edges (kept sids are
+            // re-asserted just below via `insert_resolved_page_evidence`'s
+            // dual-write, which reactivates on the same content-addressed
+            // edge id if one was ever retired).
+            for sid in &removed {
+                let edge_id = crate::provenance::compute_edge_id(
+                    "cites", "page", page_id, "memory", sid, sid,
+                );
+                Self::dual_write_invalidate_edge(&conn, &edge_id, None)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_page_sources retire edge: {e}"))
+                    })?;
+            }
 
             if let Err(e) = Self::insert_resolved_page_evidence(
                 &conn,

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -47194,3 +47194,235 @@ async fn refcount_retracts_only_after_last_backing_store_drops_citation() {
         "no legacy store backs mem_oi anymore -- the edge must retract"
     );
 }
+
+// ---- G6 Stage 0: dual-write gap regression tests (parity oracle) ----
+
+/// `fold_relation_type` mutates `relation_type` — a structural field of the
+/// content-addressed edge id — so it must retire the old-type edge and assert
+/// the canonical-type one, in both the simple-rename and the collision-merge
+/// branch. The oracle is the ambient parity sweep itself: drift 0 after a fold.
+#[tokio::test]
+async fn fold_relation_type_dual_writes_edges() {
+    let (db, _dir) = test_db().await;
+    db.create_space("work", None, false).await.unwrap();
+    let a = db
+        .store_entity("Fold A", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+    let b = db
+        .store_entity("Fold B", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+    let c = db
+        .store_entity("Fold C", "concept", Some("work"), Some("test"), None)
+        .await
+        .unwrap();
+
+    // Simple rename: a->c carries only the old type (both are vocabulary canonicals).
+    db.create_relation(&a, &c, "works_on", Some("test"), None, None, None)
+        .await
+        .unwrap();
+    // Collision merge: a->b carries BOTH the old and the canonical type.
+    db.create_relation(&a, &b, "works_on", Some("test"), None, None, None)
+        .await
+        .unwrap();
+    db.create_relation(&a, &b, "leads", Some("test"), None, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: canonical writes leave parity clean"
+    );
+
+    let folded = db.fold_relation_type("works_on", "leads").await.unwrap();
+    assert_eq!(folded, 2);
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a vocabulary fold must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+
+    // Belt-and-braces: the old-type edges are retired, superseded by canonical.
+    let conn = db.conn.lock().await;
+    for to in [&b, &c] {
+        let old_edge_id =
+            crate::provenance::compute_edge_id("relates", "entity", &a, "entity", to, "works_on");
+        let new_edge_id =
+            crate::provenance::compute_edge_id("relates", "entity", &a, "entity", to, "leads");
+        let mut rows = conn
+            .query(
+                "SELECT valid_until, superseded_by FROM edges WHERE edge_id = ?1",
+                libsql::params![old_edge_id.as_str()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().expect("old-type edge exists");
+        assert!(
+            row.get::<Option<i64>>(0).unwrap().is_some(),
+            "old-type edge is retired"
+        );
+        assert_eq!(
+            row.get::<Option<String>>(1).unwrap().as_deref(),
+            Some(new_edge_id.as_str()),
+            "old-type edge points at its canonical successor"
+        );
+    }
+}
+
+/// `replace_page_sources` prunes `page_sources` + memory-kind `page_evidence`
+/// rows and NULLs `pages.citations` — every legacy backing of a pruned sid's
+/// cites edge — so it must retire those edges in the same transaction. This is
+/// the same damage class as the 2026-07-23 live stale-edge incident.
+#[tokio::test]
+async fn replace_page_sources_retires_pruned_cites_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_prune",
+        "Prune Target",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    for sid in ["mem_g6_keep", "mem_g6_drop"] {
+        let doc = make_memory_doc(sid, "Some content.", "knowledge", "work", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.link_page_source("page_g6_prune", sid, "distill")
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: linked sources leave parity clean"
+    );
+
+    // Prune one sid, keep the other.
+    db.replace_page_sources("page_g6_prune", &["mem_g6_keep"], "reconcile")
+        .await
+        .unwrap();
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a source prune must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+    {
+        let conn = db.conn.lock().await;
+        for (sid, retired) in [("mem_g6_drop", true), ("mem_g6_keep", false)] {
+            let edge_id = crate::provenance::compute_edge_id(
+                "cites",
+                "page",
+                "page_g6_prune",
+                "memory",
+                sid,
+                sid,
+            );
+            let mut rows = conn
+                .query(
+                    "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id.as_str()],
+                )
+                .await
+                .unwrap();
+            let row = rows.next().await.unwrap().expect("edge exists");
+            assert_eq!(
+                row.get::<Option<i64>>(0).unwrap().is_some(),
+                retired,
+                "{sid}: retired={retired}"
+            );
+        }
+    }
+
+    // Empty keep-set: the remaining source is pruned too.
+    db.replace_page_sources("page_g6_prune", &[], "clear")
+        .await
+        .unwrap();
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "an empty-set replace must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
+/// `delete_page` FK-CASCADEs away this page's rows in all three link stores
+/// and NULLs inbound `page_links` targets, so every canonical edge touching
+/// the page — outbound cites AND inbound links — must retire with it.
+#[tokio::test]
+async fn delete_page_retires_all_page_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_del",
+        "Delete Target",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    db.insert_page(
+        "page_g6_linker",
+        "Inbound Linker",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    let doc = make_memory_doc("mem_g6_del", "Some content.", "knowledge", "work", "agent");
+    db.upsert_documents(vec![doc]).await.unwrap();
+    db.link_page_source("page_g6_del", "mem_g6_del", "distill")
+        .await
+        .unwrap();
+    db.replace_page_links(
+        "page_g6_linker",
+        &[crate::synthesis::wikilinks::Wikilink {
+            label: "Delete Target".to_string(),
+            target_page_id: Some("page_g6_del".to_string()),
+        }],
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: cites + inbound links leave parity clean"
+    );
+
+    db.delete_page("page_g6_del").await.unwrap();
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a page delete must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM edges WHERE valid_until IS NULL \
+             AND ((src_kind = 'page' AND src_id = 'page_g6_del') \
+               OR (dst_kind = 'page' AND dst_id = 'page_g6_del'))",
+            (),
+        )
+        .await
+        .unwrap();
+    let active: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(active, 0, "no active edge may still touch the deleted page");
+}

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -1,0 +1,112 @@
+# G6 retirement program — retire the six legacy KG stores
+
+Status: authored 2026-08-04, after G5 completed (all three flips live, both parity
+watermarks drift 0, T1 ceremony committed at generation 1). This is the execution
+plan for the close plan's G6: *"delete the five old link-bookkeeping tables and the
+old entity table so there is exactly one source of truth."*
+
+Scope basis: a full non-test reference map of `crates/wenlan-core/src` +
+`crates/wenlan-server/src` (2026-08-04). Counts below are distinct functions, not
+lines.
+
+## The load-bearing finding
+
+The G5 reader-cutover flips gate exactly **two** consumers: `detect_communities`
+(`reader_uses_edges`, consumer `communities`) and the scoped-entity reads in
+`db/scoped_entities.rs` (`reader_uses_entity_pages`, consumer `scoped_entities`).
+**Every other reader in the product reads the legacy tables directly and ungated** —
+`handle_get_entity_detail`, `handle_list_recent_relations`, `handle_get_page_sources`,
+`handle_get_page`, `handle_search_pages`, the lint/kg-quality/repair tooling, and the
+retrieval helpers. Dropping any table today breaks them regardless of cutover state.
+G6 is therefore a reader-migration program with a drop at the end, not a drop with
+prep.
+
+## Stage 0 — close the dual-write gaps (do this FIRST, keeps parity honest)
+
+Writers that mutate legacy stores without the canonical `edges` dual-write.
+Each is the same training-serving-skew class as #473/#479, and each re-drifts
+parity the moment it runs. All sites below were verified at the code level on
+2026-08-04 (the original scope-sweep list contained one false positive).
+
+**Part 1 (this PR): the three primary-path gaps.**
+
+| Function | Gap | Fix |
+|---|---|---|
+| `fold_relation_type` (db.rs ~435) | UPDATE `relation_type` + collision DELETE, no edge retire/mint. `relation_type` is a structural field of the derived edge id — one vocabulary heal re-drifts parity (extra + missing per folded row). | Per folded row: mint the canonical-type edge (endpoint-space classification mirrors `create_relation_with_span`), then retire the old-type edge superseded-by the new one (mint first — `superseded_by` is an FK into `edges`). Community-graph generations bumped for any grounded assertions touched. |
+| `replace_page_sources` (db.rs ~46282) | Prunes `page_sources` + memory-kind `page_evidence` rows and NULLs `pages.citations`, no edge invalidation. **Likely root cause of the 2026-07-23 live damage** (3 stale active edges the 32-row repair retired). | Snapshot the pruned sids before the DELETEs, retire each one's cites edge in the same transaction. Kept sids re-assert through `insert_resolved_page_evidence`'s dual-write. |
+| `delete_page` (db.rs ~45109) | FK CASCADE drops the page's rows in all three link stores and NULLs inbound `page_links` targets (NULL targets derive no edge), no edge retirement. | Bulk-retire every active edge touching the page (`src_kind='page' AND src_id` OR `dst_kind='page' AND dst_id`) in the delete transaction — page edges are never grounded `relates` assertions, so the direct UPDATE is equivalent to per-edge invalidation (mirrors `replace_page_links`). |
+
+`link_page_source` (flagged by the sweep) is a **false positive**: it calls
+`insert_resolved_page_evidence`, which dual-writes the same content-addressed
+edge id the page_sources row derives to.
+
+**Part 2 (follow-up PR): secondary writers, verified 2026-08-04.**
+
+| Function | Gap | Status |
+|---|---|---|
+| `rebind_source_id_inner` (db.rs ~27860, incl. `rebind_source_page_in_transaction`) | Renames `page_sources.memory_source_id`, `page_evidence.locator`, and optionally the source page id — identity fields of the content-addressed edge id — with no edge rewrite. Every touching edge strands (extra) and its successor shows as missing. | CONFIRMED, unfixed. Fix must recompute edge ids while preserving grounding/payload/provenance, and chase `superseded_by` FKs. |
+| `replace_source_page_inner` (db.rs ~43093) | DELETEs ALL `page_sources` + `page_evidence` rows (external kinds included) then reinserts the new set; removed rows' edges never retired. | CONFIRMED, unfixed. Same fix shape as `replace_page_sources`, plus external-kind retire. |
+| `accept_page_merge` (db.rs ~44859) | Repoints inbound `page_links.target_page_id` loser→winner with a raw UPDATE; the loser-dst links edges stay active (extra), winner-dst edges show missing. (The loser's own source rows stay in place, so its cites edges remain consistently implied — archived pages are not filtered by the parity derivation.) | CONFIRMED (links repoint only), unfixed. Retire+mint per repointed row using `replace_page_links`'s space/lineage derivation. |
+| `resolve_orphan_page_links` (db.rs ~45684) | Sets `target_page_id` on a previously-orphan row (which derives no edge) without minting the now-implied links edge. | CONFIRMED, unfixed. Mint with `replace_page_links`'s derivation. |
+| `try_update_page_content` (db.rs ~43975) | Rewrites `pages.citations` wholesale without reconciling edges. Narrow: drifts only when a locator backed ONLY by citations (not by `page_sources`/`page_evidence`) drops out of the new value. | CONFIRMED (narrow), unfixed. Reconcile like `set_page_citations` does. |
+
+Exit: all fixes merged with regression tests (parity clean after driving each
+path); ambient watermarks stay drift 0 across a soak.
+
+## Stage 1 — migrate readers onto canonical stores, cheapest first
+
+Order by measured entanglement:
+
+1. **`page_links`** (~9 fns) — one dual-write-aware writer choke point
+   (`replace_page_links`), small reader fan-out (`get_page_outbound_links`,
+   `get_page_inbound_links`, orphan-label lint), no shared-struct entanglement.
+2. **`relations`** (~20 fns) — clear writer choke points, but readers include
+   product routes (`get_entity_detail`, `list_recent_relations`), k-hop expansion,
+   and lint/repair tooling. Entangled with `entities` via shared CRUD
+   (`merge_entities`, `commit_entity_enrichment_at_version`,
+   `delete_by_source_id_in_transaction`) — those functions change once, in this
+   stage, for both stores' read sides.
+3. **`page_sources` + `page_evidence`** (~30 fns, co-written pair) —
+   `insert_resolved_page_evidence` is the evidence choke point; `page_sources` has
+   no single choke point and needs one first.
+4. **`pages.citations`** (4 writer fns, 10+ readers) — hardest: a column in every
+   `Page` row mapper (db.rs + db/scoped_pages.rs). Retiring it is a struct/mapping
+   reshape, its own PR.
+5. **`entities` + `entity_aliases` + `observations`** (~25+ fns) — largest surface;
+   readers move to the `kind='entity'` shadow pages. Depends on stage 1.2's shared-
+   CRUD rework.
+
+Each store's migration is one PR: readers redirected to `edges`/shadow pages,
+behavior-equivalence tests, and the store's parity derivation dropped from
+`reconcile_edges_parity` in the SAME PR that removes its last legacy reader.
+
+Exit per store: zero non-test readers of the legacy store outside migrations and
+the parity sweep; ambient drift stays 0.
+
+## Stage 2 — writers go canonical-only, sweeps retire
+
+Only after Stage 1 empties the reader side: flip writers from dual-write to
+canonical-only, retire `reconcile_edges_parity` / `reconcile_entity_page_parity`
+and their watermarks/flags/plist entries, drop the `backfill_edges_from_*`
+machinery. The cutover-lever tables (`edges_reader_cutover`,
+`entity_reader_cutover`) retire with them.
+
+## Stage 3 — the retirement migration (the point of no return)
+
+One migration drops `relations`, `page_sources`, `page_evidence`, `page_links`,
+the `pages.citations` column, `entities`, `entity_aliases`, `observations`, and
+`entity_page_map`. Contract per the close plan:
+
+- Pre-migration SQLite online backup (the standard `backup_before_migration`), plus
+  an **operator-verified restore drill receipt** (drill already rehearsed 2026-08-04,
+  receipts doc §7 — re-verify against the pre-retirement backup specifically).
+- A **declared downgrade barrier**: daemon versions before this migration cannot
+  open the database afterward; `wenlan doctor` must say so plainly.
+- Export/import is NOT the safety net (debt register).
+- User confirms the point of no return before the migration ships in a release.
+
+## Rollback story per stage
+
+- Stage 0/1: normal PR reverts; legacy stores still authoritative-adjacent.
+- Stage 2: revert restores dual-write; canonical stores never stopped being written.
+- Stage 3: restore-from-backup only. That is the whole reason it goes last.


### PR DESCRIPTION
## What

G6 Stage 0 part 1: three writers mutated legacy KG stores without the canonical `edges` dual-write, so each one re-drifts the parity watermarks the G5 reader-cutover gates depend on — the same training-serving-skew class as #473/#479.

| Writer | Gap | Fix |
|---|---|---|
| `fold_relation_type` | Folds `relation_type` (a structural field of the content-addressed edge id) with no edge retire/mint — one vocabulary heal re-drifts parity per folded row. | Mint the canonical-type edge (endpoint-space classification mirrors `create_relation_with_span`), then retire the old-type edge superseded-by the new one. Mint happens first because `superseded_by` is an FK into `edges`. |
| `replace_page_sources` | Prunes `page_sources` + memory-kind `page_evidence` and NULLs `pages.citations` with no edge invalidation — the likely root cause of the 2026-07-23 live stale-edge damage. | Snapshot the pruned sids before the DELETEs and retire each one's cites edge in the same transaction. Kept sids re-assert via `insert_resolved_page_evidence`'s dual-write. |
| `delete_page` | FK CASCADE drops the page's rows in all three link stores and NULLs inbound `page_links` targets, stranding every edge that touches the page. | Bulk-retire all active edges with this page as src or dst inside the delete transaction (page edges are never grounded `relates` assertions, so no community-graph change is possible — mirrors `replace_page_links`). |

`link_page_source`, flagged by the original scope sweep, is a false positive: it dual-writes transitively via `insert_resolved_page_evidence` (same content-addressed edge id).

Also updates `docs/plans/2026-08-04-g6-retirement-program.md` with the verified Stage 0 map, including five confirmed secondary-writer gaps queued for part 2 (`rebind_source_id_inner`, `replace_source_page_inner`, `accept_page_merge`'s links repoint, `resolve_orphan_page_links`, `try_update_page_content`'s citations rewrite).

## Test

Three new regression tests drive each real path and use the ambient parity sweep itself as the oracle (`reconcile_edges_parity().drift_count == 0`), plus direct edge-state assertions:

- `fold_relation_type_dual_writes_edges` — simple rename + collision merge, old-type edges retired superseded-by canonical
- `replace_page_sources_retires_pruned_cites_edges` — partial prune + empty-set replace
- `delete_page_retires_all_page_edges` — outbound cites + inbound links both retired

`fold_relation`, `replace_page_sources`, `delete_page`, `reconcile` (51), `vocab`, `page_links`, `heal` families all green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
