### PR TITLE
fix(kg): G6 Stage 0 part 2 — five secondary writers re-drifting edges parity

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -14163,6 +14163,206 @@ impl MemoryDB {
         Ok((affected > 0).then_some(graph_change).flatten())
     }
 
+    /// Re-address every canonical edge touching a renamed identity (G6
+    /// Stage 0, for `rebind_source_id_inner`). Edge ids are
+    /// content-addressed over (edge_type, src, dst, discriminator), so an
+    /// identity rename maps each old edge to a new edge_id
+    /// deterministically; grounding, payload, and provenance columns ride
+    /// along untouched. `superseded_by` self-references are detached and
+    /// re-attached around the primary-key rewrite (the FK is enforced
+    /// immediately), and a collision with an existing row at the target
+    /// identity resolves by retiring the old row into the existing one
+    /// (reactivating it when the old row was active, so the renamed legacy
+    /// rows keep implying an active edge).
+    async fn rebind_edges_identity(
+        conn: &libsql::Connection,
+        kind: &str,
+        old_id: &str,
+        new_id: &str,
+    ) -> Result<(), libsql::Error> {
+        if old_id == new_id {
+            return Ok(());
+        }
+        // `cites` edges: the discriminator mirrors the destination locator in
+        // every derivation (page_sources, page_evidence, pages.citations), so
+        // the new edge_id is derivable from the stored row alone.
+        // `relates`/`mentions` never touch memory/page identities; `links` is
+        // re-asserted below; M5 claim edges live outside the legacy-derivable
+        // universe (same endpoint fence as the parity sweep).
+        let mut rows = conn
+            .query(
+                "SELECT edge_id, src_kind, src_id, dst_kind, dst_id, valid_until \
+                 FROM edges WHERE edge_type = 'cites' \
+                   AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))",
+                libsql::params![kind, old_id],
+            )
+            .await?;
+        #[allow(clippy::type_complexity)]
+        let mut touched: Vec<(String, String, String, String, String, Option<i64>)> = Vec::new();
+        while let Some(row) = rows.next().await? {
+            touched.push((
+                row.get(0).unwrap_or_default(),
+                row.get(1).unwrap_or_default(),
+                row.get(2).unwrap_or_default(),
+                row.get(3).unwrap_or_default(),
+                row.get(4).unwrap_or_default(),
+                row.get::<Option<i64>>(5).unwrap_or(None),
+            ));
+        }
+        drop(rows);
+        let now = chrono::Utc::now().timestamp();
+        for (edge_id, src_kind, src_id, dst_kind, dst_id, valid_until) in &touched {
+            let new_src = if src_kind == kind && src_id == old_id {
+                new_id
+            } else {
+                src_id.as_str()
+            };
+            let new_dst = if dst_kind == kind && dst_id == old_id {
+                new_id
+            } else {
+                dst_id.as_str()
+            };
+            let new_edge_id = crate::provenance::compute_edge_id(
+                "cites", src_kind, new_src, dst_kind, new_dst, new_dst,
+            );
+            if new_edge_id == *edge_id {
+                continue;
+            }
+            let mut exist_rows = conn
+                .query(
+                    "SELECT 1 FROM edges WHERE edge_id = ?1",
+                    libsql::params![new_edge_id.as_str()],
+                )
+                .await?;
+            let exists = exist_rows.next().await?.is_some();
+            drop(exist_rows);
+            if exists {
+                conn.execute(
+                    "UPDATE edges SET superseded_by = ?1 WHERE superseded_by = ?2",
+                    libsql::params![new_edge_id.as_str(), edge_id.as_str()],
+                )
+                .await?;
+                if valid_until.is_none() {
+                    conn.execute(
+                        "UPDATE edges SET valid_until = NULL, superseded_by = NULL \
+                         WHERE edge_id = ?1",
+                        libsql::params![new_edge_id.as_str()],
+                    )
+                    .await?;
+                }
+                conn.execute(
+                    "UPDATE edges SET valid_until = COALESCE(valid_until, ?1), superseded_by = ?2 \
+                     WHERE edge_id = ?3",
+                    libsql::params![now, new_edge_id.as_str(), edge_id.as_str()],
+                )
+                .await?;
+            } else {
+                let mut ref_rows = conn
+                    .query(
+                        "SELECT edge_id FROM edges WHERE superseded_by = ?1",
+                        libsql::params![edge_id.as_str()],
+                    )
+                    .await?;
+                let mut successors: Vec<String> = Vec::new();
+                while let Some(row) = ref_rows.next().await? {
+                    successors.push(row.get(0).unwrap_or_default());
+                }
+                drop(ref_rows);
+                if !successors.is_empty() {
+                    conn.execute(
+                        "UPDATE edges SET superseded_by = NULL WHERE superseded_by = ?1",
+                        libsql::params![edge_id.as_str()],
+                    )
+                    .await?;
+                }
+                conn.execute(
+                    "UPDATE edges SET edge_id = ?1, src_id = ?2, dst_id = ?3 \
+                     WHERE edge_id = ?4",
+                    libsql::params![new_edge_id.as_str(), new_src, new_dst, edge_id.as_str()],
+                )
+                .await?;
+                for successor in &successors {
+                    conn.execute(
+                        "UPDATE edges SET superseded_by = ?1 WHERE edge_id = ?2",
+                        libsql::params![new_edge_id.as_str(), successor.as_str()],
+                    )
+                    .await?;
+                }
+            }
+        }
+        // `links` edges: the discriminator is the page_links label_key, which
+        // is not stored on the edge row — retire every links edge touching
+        // the old identity and re-assert from the current (already renamed)
+        // page_links rows via the standard dual-write. Links edges are never
+        // grounded `relates` assertions, so the direct retire is safe.
+        if kind == "page" {
+            conn.execute(
+                "UPDATE edges SET valid_until = ?2, superseded_by = NULL \
+                 WHERE edge_type = 'links' AND valid_until IS NULL \
+                   AND (src_id = ?1 OR dst_id = ?1)",
+                libsql::params![old_id, now],
+            )
+            .await?;
+            let mut link_rows = conn
+                .query(
+                    "SELECT pl.source_page_id, pl.target_page_id, pl.label_key, \
+                            sp.space, tp.space \
+                     FROM page_links pl \
+                     INNER JOIN pages sp ON sp.id = pl.source_page_id \
+                     INNER JOIN pages tp ON tp.id = pl.target_page_id \
+                     WHERE pl.target_page_id IS NOT NULL \
+                       AND (pl.source_page_id = ?1 OR pl.target_page_id = ?1)",
+                    libsql::params![new_id],
+                )
+                .await?;
+            #[allow(clippy::type_complexity)]
+            let mut reassert: Vec<(
+                String,
+                String,
+                String,
+                Option<String>,
+                Option<String>,
+            )> = Vec::new();
+            while let Some(row) = link_rows.next().await? {
+                reassert.push((
+                    row.get(0).unwrap_or_default(),
+                    row.get(1).unwrap_or_default(),
+                    row.get(2).unwrap_or_default(),
+                    row.get::<Option<String>>(3).unwrap_or(None),
+                    row.get::<Option<String>>(4).unwrap_or(None),
+                ));
+            }
+            drop(link_rows);
+            for (src_page, dst_page, label_key, src_space, dst_space) in &reassert {
+                let Some(space) = src_space.as_deref() else {
+                    continue;
+                };
+                let cross_space_downgrade =
+                    Self::resolved_space_downgrades(dst_space.as_deref(), space);
+                let lineage = if cross_space_downgrade {
+                    "legacy"
+                } else {
+                    "synthesis"
+                };
+                Self::dual_write_edge(
+                    conn,
+                    "links",
+                    "page",
+                    src_page,
+                    "page",
+                    dst_page,
+                    label_key,
+                    lineage,
+                    space,
+                    cross_space_downgrade,
+                    None,
+                )
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
     async fn bump_community_graph_generations(
         conn: &libsql::Connection,
         changes: Vec<CommunityGraphChange>,
@@ -28020,6 +28220,33 @@ impl MemoryDB {
             if let Some((old_page_id, new_page_id)) = source_page_ids {
                 Self::rebind_source_page_in_transaction(&conn, old_page_id, new_page_id).await?;
             }
+            // Dual-write (G6 Stage 0): the renames above move the legacy
+            // stores onto the new identity, but edge ids are
+            // content-addressed — every canonical edge touching the old
+            // identity must be re-addressed in the same transaction, or it
+            // strands as "extra" parity drift while the renamed rows imply
+            // "missing" successors.
+            Self::rebind_edges_identity(&conn, "memory", old_source_id, new_source_id)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("rebind_source_id edges: {e}")))?;
+            if let Some((old_page_id, new_page_id)) = source_page_ids {
+                Self::rebind_edges_identity(&conn, "page", old_page_id, new_page_id)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("rebind_source_id page edges: {e}"))
+                    })?;
+            }
+            // Edge payloads carry span-capture provenance keyed on the source
+            // memory id; keep it pointing at the live identity so grounding
+            // promotion can still relocate the quote.
+            conn.execute(
+                "UPDATE edges SET payload = json_set(payload, '$.source_memory_id', ?1) \
+                 WHERE payload IS NOT NULL AND json_valid(payload) \
+                   AND json_extract(payload, '$.source_memory_id') = ?2",
+                libsql::params![new_source_id, old_source_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("rebind_source_id edge payload: {e}")))?;
             Ok::<(), WenlanError>(())
         }
         .await;
@@ -43222,6 +43449,60 @@ impl MemoryDB {
             if affected == 0 {
                 return Ok(false);
             }
+            // Dual-write (G6 Stage 0): snapshot every (kind, locator) the two
+            // DELETEs below un-imply so their canonical cites edges retire in
+            // this transaction (the pages UPDATE above already NULLed
+            // `citations`, so a removed row keeps no legacy backing). Kept
+            // memory sids re-assert through `insert_resolved_page_evidence`'s
+            // dual-write.
+            let mut removed: std::collections::BTreeSet<(String, String)> = Default::default();
+            let mut sid_rows = conn
+                .query(
+                    "SELECT memory_source_id FROM page_sources WHERE page_id=?1",
+                    libsql::params![id],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("replace_source_page removed scan: {e}"))
+                })?;
+            while let Some(row) = sid_rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                removed.insert((
+                    "memory".to_string(),
+                    row.get::<String>(0).unwrap_or_default(),
+                ));
+            }
+            drop(sid_rows);
+            let mut ev_rows = conn
+                .query(
+                    "SELECT source_kind, locator FROM page_evidence \
+                     WHERE page_id=?1 AND locator IS NOT NULL",
+                    libsql::params![id],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("replace_source_page removed evidence: {e}"))
+                })?;
+            while let Some(row) = ev_rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                let kind: String = row.get(0).unwrap_or_default();
+                let dst = if kind == "memory" {
+                    "memory"
+                } else {
+                    "external"
+                };
+                removed.insert((dst.to_string(), row.get::<String>(1).unwrap_or_default()));
+            }
+            drop(ev_rows);
+            for sid in source_memory_ids {
+                removed.remove(&("memory".to_string(), (*sid).to_string()));
+            }
             conn.execute(
                 "DELETE FROM page_sources WHERE page_id=?1",
                 libsql::params![id],
@@ -43251,6 +43532,16 @@ impl MemoryDB {
                 .map_err(|e| {
                     WenlanError::VectorDb(format!("replace_source_page evidence insert: {e}"))
                 })?;
+            for (dst_kind, locator) in &removed {
+                let edge_id = crate::provenance::compute_edge_id(
+                    "cites", "page", id, dst_kind, locator, locator,
+                );
+                Self::dual_write_invalidate_edge(&conn, &edge_id, None)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_source_page retire edge: {e}"))
+                    })?;
+            }
             // Same transaction as the version bump above: a re-enriched source
             // page is a new version like any other, and leaves the same durable
             // row behind.
@@ -44081,6 +44372,19 @@ impl MemoryDB {
         // deliberately doesn't clear staleness on apply (the refinery's
         // ownership gate stages a revision card on the next sweep instead,
         // per `post_write::update_page`).
+        //
+        // Dual-write (G6 Stage 0): the UPDATE below rewrites `pages.citations`
+        // wholesale, so a locator whose only legacy backing was the OLD
+        // citations value would strand its cites edge as permanent "extra"
+        // parity drift. Reconcile edges against the old-vs-new citation sets
+        // BEFORE the column changes (same helper as `set_page_citations`);
+        // rolled back together with the UPDATE if a CAS guard fails below.
+        if let Err(e) = Self::dual_write_page_citations(&conn, id, citations_bind).await {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(WenlanError::VectorDb(format!(
+                "update_page_content citations: {e}"
+            )));
+        }
         let affected = if let Some(cl) = changelog {
             // Changelog-aware variant: write changelog atomically with content.
             let mut sql = if require_stale {
@@ -44978,6 +45282,78 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("accept_page_merge evidence copy: {e}")))?;
 
+            // Dual-write (G6 Stage 0): the INSERT..SELECT above copies the
+            // absorbed page's evidence rows onto the survivor, making the
+            // survivor's cites edges for them implied. Memory-kind rows are
+            // minted through `insert_resolved_page_evidence` below; external
+            // rows mint here (NULL locators derive no edge — skip, matching
+            // the backfill). Derivation mirrors `link_page_evidence`.
+            let mut space_rows = conn
+                .query(
+                    "SELECT space FROM pages WHERE id = ?1",
+                    libsql::params![survivor_id],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("accept_page_merge survivor space: {e}"))
+                })?;
+            let survivor_space: Option<String> = match space_rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                Some(row) => row.get(0).unwrap_or(None),
+                None => None,
+            };
+            drop(space_rows);
+            if let Some(space) = &survivor_space {
+                let mut ext_rows = conn
+                    .query(
+                        "SELECT source_kind, locator FROM page_evidence \
+                         WHERE page_id = ?1 AND source_kind != 'memory' AND locator IS NOT NULL",
+                        libsql::params![absorbed_id],
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("accept_page_merge ext evidence: {e}"))
+                    })?;
+                let mut ext: Vec<(String, String)> = Vec::new();
+                while let Some(row) = ext_rows
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+                {
+                    ext.push((
+                        row.get::<String>(0).unwrap_or_default(),
+                        row.get::<String>(1).unwrap_or_default(),
+                    ));
+                }
+                drop(ext_rows);
+                for (source_kind, locator) in &ext {
+                    let lineage = match source_kind.as_str() {
+                        "external_url" | "external_file" => "evidence",
+                        _ => "legacy",
+                    };
+                    Self::dual_write_edge(
+                        &conn,
+                        "cites",
+                        "page",
+                        survivor_id,
+                        "external",
+                        locator,
+                        locator,
+                        lineage,
+                        space,
+                        false,
+                        None,
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("accept_page_merge ext edge: {e}"))
+                    })?;
+                }
+            }
+
             let source_refs: Vec<&str> = union.iter().map(String::as_str).collect();
             Self::insert_resolved_page_evidence(
                 &conn,
@@ -45008,6 +45384,37 @@ impl MemoryDB {
             }
 
             let absorbed_title_key = absorbed.title.to_lowercase();
+            // Dual-write (G6 Stage 0): the repoint below moves inbound and
+            // label-matching page_links rows onto the survivor, so each
+            // affected row's old links edge (if it had a target) retires and
+            // the survivor-target edge mints — else the old edges are
+            // permanent "extra" drift and the new implications "missing".
+            // Mint precedes retire because `superseded_by` is an FK into
+            // `edges`. Space/lineage derivation mirrors `replace_page_links`.
+            let mut link_rows = conn
+                .query(
+                    "SELECT pl.source_page_id, pl.label_key, pl.target_page_id, p.space \
+                     FROM page_links pl INNER JOIN pages p ON p.id = pl.source_page_id \
+                     WHERE pl.target_page_id = ?1 OR pl.label_key = ?2",
+                    libsql::params![absorbed_id, absorbed_title_key.as_str()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("accept_page_merge link scan: {e}")))?;
+            #[allow(clippy::type_complexity)]
+            let mut repointed: Vec<(String, String, Option<String>, Option<String>)> = Vec::new();
+            while let Some(row) = link_rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                repointed.push((
+                    row.get::<String>(0).unwrap_or_default(),
+                    row.get::<String>(1).unwrap_or_default(),
+                    row.get::<Option<String>>(2).unwrap_or(None),
+                    row.get::<Option<String>>(3).unwrap_or(None),
+                ));
+            }
+            drop(link_rows);
             conn.execute(
                 "UPDATE page_links SET target_page_id = ?1 \
                  WHERE target_page_id = ?2 OR label_key = ?3",
@@ -45015,6 +45422,51 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("accept_page_merge links: {e}")))?;
+            for (src_page, label_key, old_target, src_space) in &repointed {
+                if old_target.as_deref() == Some(survivor_id) {
+                    continue; // already pointed at the survivor: nothing moved
+                }
+                let new_edge_id = if let Some(space) = src_space.as_deref() {
+                    let cross_space_downgrade =
+                        Self::resolved_space_downgrades(survivor_space.as_deref(), space);
+                    let lineage = if cross_space_downgrade {
+                        "legacy"
+                    } else {
+                        "synthesis"
+                    };
+                    Some(
+                        Self::dual_write_edge(
+                            &conn,
+                            "links",
+                            "page",
+                            src_page,
+                            "page",
+                            survivor_id,
+                            label_key,
+                            lineage,
+                            space,
+                            cross_space_downgrade,
+                            None,
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("accept_page_merge link mint: {e}"))
+                        })?,
+                    )
+                } else {
+                    None
+                };
+                if let Some(old) = old_target.as_deref() {
+                    let old_edge_id = crate::provenance::compute_edge_id(
+                        "links", "page", src_page, "page", old, label_key,
+                    );
+                    Self::dual_write_invalidate_edge(&conn, &old_edge_id, new_edge_id.as_deref())
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("accept_page_merge link retire: {e}"))
+                        })?;
+                }
+            }
 
             let resolved = conn
                 .execute(
@@ -45723,17 +46175,91 @@ impl MemoryDB {
                 continue;
             };
             let conn = self.conn.lock().await;
-            let changed = conn
-                .execute(
-                    "UPDATE page_links SET target_page_id = ?1
-                     WHERE source_page_id = ?2 AND label_key = ?3
-                       AND target_page_id IS NULL",
-                    libsql::params![target, source_page_id, label_key.as_str()],
-                )
+            conn.execute("BEGIN", ())
                 .await
-                .map_err(|e| WenlanError::VectorDb(format!("resolve_orphan_links update: {e}")))?;
-            if changed > 0 {
-                resolved_labels.insert(label_key);
+                .map_err(|e| WenlanError::VectorDb(format!("resolve_orphan_links begin: {e}")))?;
+            let row_result: Result<u64, WenlanError> = async {
+                let changed = conn
+                    .execute(
+                        "UPDATE page_links SET target_page_id = ?1
+                         WHERE source_page_id = ?2 AND label_key = ?3
+                           AND target_page_id IS NULL",
+                        libsql::params![target.clone(), source_page_id.clone(), label_key.as_str()],
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("resolve_orphan_links update: {e}"))
+                    })?;
+                // Dual-write (G6 Stage 0): an orphan row derives no edge, so
+                // resolving its target makes the canonical `links` edge
+                // implied — mint it in the same transaction or the row is
+                // permanent "missing" parity drift. Space/lineage derivation
+                // mirrors `replace_page_links`.
+                if changed > 0 {
+                    if let Some(space) = scope.as_deref() {
+                        let mut dst_rows = conn
+                            .query(
+                                "SELECT space FROM pages WHERE id = ?1",
+                                libsql::params![target.clone()],
+                            )
+                            .await
+                            .map_err(|e| {
+                                WenlanError::VectorDb(format!(
+                                    "resolve_orphan_links dst space: {e}"
+                                ))
+                            })?;
+                        let dst_space: Option<String> =
+                            match dst_rows.next().await.map_err(|e| {
+                                WenlanError::VectorDb(format!(
+                                    "resolve_orphan_links dst space: {e}"
+                                ))
+                            })? {
+                                Some(row) => row.get(0).unwrap_or(None),
+                                None => None,
+                            };
+                        drop(dst_rows);
+                        let cross_space_downgrade =
+                            Self::resolved_space_downgrades(dst_space.as_deref(), space);
+                        let lineage = if cross_space_downgrade {
+                            "legacy"
+                        } else {
+                            "synthesis"
+                        };
+                        Self::dual_write_edge(
+                            &conn,
+                            "links",
+                            "page",
+                            &source_page_id,
+                            "page",
+                            &target,
+                            &label_key,
+                            lineage,
+                            space,
+                            cross_space_downgrade,
+                            None,
+                        )
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("resolve_orphan_links edge mint: {e}"))
+                        })?;
+                    }
+                }
+                Ok(changed)
+            }
+            .await;
+            match row_result {
+                Ok(changed) => {
+                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                        WenlanError::VectorDb(format!("resolve_orphan_links commit: {e}"))
+                    })?;
+                    if changed > 0 {
+                        resolved_labels.insert(label_key);
+                    }
+                }
+                Err(error) => {
+                    let _ = conn.execute("ROLLBACK", ()).await;
+                    return Err(error);
+                }
             }
         }
         Ok(resolved_labels.len())
@@ -46818,18 +47344,45 @@ impl MemoryDB {
         expected_version: i64,
     ) -> Result<bool, WenlanError> {
         let conn = self.conn.lock().await;
-        let affected = conn
-            .execute(
-                "UPDATE pages SET citations = ?1, changelog = ?2
-                 WHERE id = ?3 AND version = ?4 AND status = 'active'
-                   AND citations IS NULL",
-                libsql::params![citations_json, changelog_json, page_id, expected_version],
-            )
-            .await
-            .map_err(|e| {
-                WenlanError::VectorDb(format!("set_page_citations_with_changelog_at_version: {e}"))
-            })?;
-        Ok(affected > 0)
+        conn.execute("BEGIN", ()).await.map_err(|e| {
+            WenlanError::VectorDb(format!(
+                "set_page_citations_with_changelog_at_version begin: {e}"
+            ))
+        })?;
+        let exec = async {
+            let affected = conn
+                .execute(
+                    "UPDATE pages SET citations = ?1, changelog = ?2
+                     WHERE id = ?3 AND version = ?4 AND status = 'active'
+                       AND citations IS NULL",
+                    libsql::params![citations_json, changelog_json, page_id, expected_version],
+                )
+                .await?;
+            // Dual-write (G6 Stage 0): the guard above means the OLD value was
+            // NULL, so the helper only asserts the new citation set's edges
+            // (idempotent for locators already backed by page_evidence).
+            if affected > 0 {
+                Self::dual_write_page_citations(&conn, page_id, citations_json).await?;
+            }
+            Ok::<u64, libsql::Error>(affected)
+        }
+        .await;
+        match exec {
+            Ok(affected) => {
+                conn.execute("COMMIT", ()).await.map_err(|e| {
+                    WenlanError::VectorDb(format!(
+                        "set_page_citations_with_changelog_at_version commit: {e}"
+                    ))
+                })?;
+                Ok(affected > 0)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(WenlanError::VectorDb(format!(
+                    "set_page_citations_with_changelog_at_version: {e}"
+                )))
+            }
+        }
     }
 
     /// Test-only: overwrite a page's `citations` column directly, bypassing the

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -44666,6 +44666,71 @@ impl MemoryDB {
             )));
         }
 
+        // Dual-write (G6 Stage 0): snapshot the memory locators the two
+        // prunes below remove (page_sources sids UNION memory-kind
+        // page_evidence locators — both derive the same content-addressed
+        // cites edge) so their canonical edges retire in this transaction.
+        // Unlike `replace_page_sources`, this path SETS `pages.citations` to
+        // an explicit new value (reconciled above), so a pruned locator can
+        // still be citation-backed — the D7 refcount check at the retire
+        // site keeps those edges active.
+        let removed_locators: Vec<String> = {
+            let (sql, bind): (String, Vec<libsql::Value>) = if source_memory_ids.is_empty() {
+                (
+                    "SELECT memory_source_id FROM page_sources WHERE page_id = ?1
+                     UNION
+                     SELECT locator FROM page_evidence
+                     WHERE page_id = ?1 AND source_kind = 'memory'"
+                        .to_string(),
+                    vec![libsql::Value::Text(id.to_string())],
+                )
+            } else {
+                let placeholders: String = (0..source_memory_ids.len())
+                    .map(|i| format!("?{}", i + 2))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let mut bind: Vec<libsql::Value> = Vec::with_capacity(1 + source_memory_ids.len());
+                bind.push(libsql::Value::Text(id.to_string()));
+                for sid in source_memory_ids {
+                    bind.push(libsql::Value::Text((*sid).to_string()));
+                }
+                (
+                    format!(
+                        "SELECT memory_source_id FROM page_sources
+                         WHERE page_id = ?1 AND memory_source_id NOT IN ({placeholders})
+                         UNION
+                         SELECT locator FROM page_evidence
+                         WHERE page_id = ?1 AND source_kind = 'memory'
+                           AND locator NOT IN ({placeholders})"
+                    ),
+                    bind,
+                )
+            };
+            let mut rows = match conn.query(&sql, libsql::params_from_iter(bind)).await {
+                Ok(rows) => rows,
+                Err(e) => {
+                    let _ = conn.execute("ROLLBACK", ()).await;
+                    return Err(WenlanError::VectorDb(format!(
+                        "update_page_content removed scan: {e}"
+                    )));
+                }
+            };
+            let mut removed = Vec::new();
+            loop {
+                match rows.next().await {
+                    Ok(Some(row)) => removed.push(row.get::<String>(0).unwrap_or_default()),
+                    Ok(None) => break,
+                    Err(e) => {
+                        let _ = conn.execute("ROLLBACK", ()).await;
+                        return Err(WenlanError::VectorDb(format!(
+                            "update_page_content removed row: {e}"
+                        )));
+                    }
+                }
+            }
+            removed
+        };
+
         // Reconcile join table: DELETE rows whose memory_source_id is no
         // longer in the list, then INSERT OR IGNORE the survivors. Preserves
         // existing `link_reason` on rows that survive — only brand-new rows
@@ -44763,6 +44828,31 @@ impl MemoryDB {
                 )));
             }
         }
+        // Retire the pruned locators' canonical edges — except those the new
+        // `pages.citations` value (written above) still backs (D7 refcount).
+        // Kept sids are re-asserted just below via
+        // `insert_resolved_page_evidence`'s dual-write.
+        for locator in &removed_locators {
+            match Self::cites_backed_by_page_citations(&conn, id, locator).await {
+                Ok(true) => continue,
+                Ok(false) => {}
+                Err(e) => {
+                    let _ = conn.execute("ROLLBACK", ()).await;
+                    return Err(WenlanError::VectorDb(format!(
+                        "update_page_content citations check: {e}"
+                    )));
+                }
+            }
+            let edge_id =
+                crate::provenance::compute_edge_id("cites", "page", id, "memory", locator, locator);
+            if let Err(e) = Self::dual_write_invalidate_edge(&conn, &edge_id, None).await {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(WenlanError::VectorDb(format!(
+                    "update_page_content retire edge: {e}"
+                )));
+            }
+        }
+
         if let Err(e) =
             Self::insert_resolved_page_evidence(&conn, id, source_memory_ids, now_ts, link_reason)
                 .await

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -47354,6 +47354,110 @@ async fn replace_page_sources_retires_pruned_cites_edges() {
     );
 }
 
+/// `try_update_page_content` reimplements `replace_page_sources`'s
+/// prune-then-reinsert on `page_sources` + memory-kind `page_evidence`, so a
+/// sid dropped from the new source list must have its cites edge retired in
+/// the same transaction — except when the new `pages.citations` value still
+/// backs the locator (D7 refcount). Same damage class as the 2026-07-23 live
+/// stale-edge incident, on the higher-traffic write path (manual edits,
+/// refinery rewrites, page growth).
+#[tokio::test]
+async fn update_page_content_retires_pruned_cites_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_upc",
+        "Update Target",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    for sid in ["mem_g6_upc_keep", "mem_g6_upc_drop", "mem_g6_upc_cited"] {
+        let doc = make_memory_doc(sid, "Some content.", "knowledge", "work", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+        db.link_page_source("page_g6_upc", sid, "distill")
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: linked sources leave parity clean"
+    );
+
+    // Drop two sids, keep one; the new citations value still backs one of
+    // the dropped locators, so its edge must survive (D7 refcount).
+    let citations = r#"[{"occurrence":1,"marker":1,"source_kind":"memory","locator":"mem_g6_upc_cited","score":1.0,"status":"verified","scope":"sentence"}]"#;
+    let landed = db
+        .try_update_page_content_with_changelog(
+            "page_g6_upc",
+            "new content",
+            &["mem_g6_upc_keep"],
+            "reconcile",
+            false,
+            "[]",
+            Some(citations),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(landed, "non-CAS content update must land");
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a content update must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+    {
+        let conn = db.conn.lock().await;
+        for (sid, retired) in [
+            ("mem_g6_upc_drop", true),
+            ("mem_g6_upc_keep", false),
+            ("mem_g6_upc_cited", false),
+        ] {
+            let edge_id = crate::provenance::compute_edge_id(
+                "cites",
+                "page",
+                "page_g6_upc",
+                "memory",
+                sid,
+                sid,
+            );
+            let mut rows = conn
+                .query(
+                    "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id.as_str()],
+                )
+                .await
+                .unwrap();
+            let row = rows.next().await.unwrap().expect("edge exists");
+            assert_eq!(
+                row.get::<Option<i64>>(0).unwrap().is_some(),
+                retired,
+                "{sid}: retired={retired}"
+            );
+        }
+    }
+
+    // Empty source list + NULL citations: every remaining backing drops, so
+    // every cites edge must retire.
+    db.update_page_content("page_g6_upc", "cleared", &[], "clear")
+        .await
+        .unwrap();
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "an empty-set update must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
 /// `delete_page` FK-CASCADEs away this page's rows in all three link stores
 /// and NULLs inbound `page_links` targets, so every canonical edge touching
 /// the page — outbound cites AND inbound links — must retire with it.

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -47426,3 +47426,392 @@ async fn delete_page_retires_all_page_edges() {
     let active: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
     assert_eq!(active, 0, "no active edge may still touch the deleted page");
 }
+
+// ---- G6 Stage 0 part 2: secondary-writer dual-write gaps (parity oracle) ----
+
+/// A resolved orphan link makes the canonical `links` edge implied — the
+/// resolver must mint it or the row is permanent "missing" drift.
+#[tokio::test]
+async fn resolve_orphan_page_links_mints_links_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_orphan_src",
+        "Orphan Src",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    db.replace_page_links(
+        "page_g6_orphan_src",
+        &[crate::synthesis::wikilinks::Wikilink {
+            label: "Late Target".to_string(),
+            target_page_id: None,
+        }],
+    )
+    .await
+    .unwrap();
+    db.insert_page(
+        "page_g6_late_target",
+        "Late Target",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: an orphan link derives no edge"
+    );
+
+    assert_eq!(db.resolve_orphan_page_links().await.unwrap(), 1);
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "orphan resolution must mint the implied links edge (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
+/// A page merge repoints inbound links rows and copies the absorbed page's
+/// evidence onto the survivor — both moves change which edges the stores
+/// imply, so both must reconcile in the merge transaction.
+#[tokio::test]
+async fn accept_page_merge_reconciles_links_and_evidence_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    for (id, title) in [
+        ("page_g6_survivor", "Merge Survivor"),
+        ("page_g6_absorbed", "Merge Absorbed"),
+        ("page_g6_linker", "Merge Linker"),
+    ] {
+        db.insert_page(id, title, None, "content", None, None, &[], &now)
+            .await
+            .unwrap();
+    }
+    let doc = make_memory_doc(
+        "mem_g6_merge",
+        "Some content.",
+        "knowledge",
+        "work",
+        "agent",
+    );
+    db.upsert_documents(vec![doc]).await.unwrap();
+    db.link_page_source("page_g6_absorbed", "mem_g6_merge", "distill")
+        .await
+        .unwrap();
+    db.link_page_evidence(
+        "page_g6_absorbed",
+        "external_url",
+        Some("https://example.com/doc"),
+        None,
+        "cite",
+    )
+    .await
+    .unwrap();
+    db.replace_page_links(
+        "page_g6_linker",
+        &[crate::synthesis::wikilinks::Wikilink {
+            label: "Merge Absorbed".to_string(),
+            target_page_id: Some("page_g6_absorbed".to_string()),
+        }],
+    )
+    .await
+    .unwrap();
+    db.insert_refinement_proposal(
+        "proposal_g6_merge",
+        "page_merge",
+        &[
+            "page_g6_survivor".to_string(),
+            "page_g6_absorbed".to_string(),
+        ],
+        None,
+        1.0,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: canonical writes leave parity clean"
+    );
+
+    db.accept_page_merge("proposal_g6_merge", "page_g6_survivor", "page_g6_absorbed")
+        .await
+        .unwrap();
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a page merge must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+    // The linker's edge now points at the survivor; the absorbed-target edge
+    // is retired.
+    let conn = db.conn.lock().await;
+    let old_edge_id = crate::provenance::compute_edge_id(
+        "links",
+        "page",
+        "page_g6_linker",
+        "page",
+        "page_g6_absorbed",
+        "merge absorbed",
+    );
+    let mut rows = conn
+        .query(
+            "SELECT valid_until FROM edges WHERE edge_id = ?1",
+            libsql::params![old_edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("old links edge exists");
+    assert!(
+        row.get::<Option<i64>>(0).unwrap().is_some(),
+        "absorbed-target links edge is retired"
+    );
+}
+
+/// A source-page replace deletes and rebuilds the page's entire evidence set;
+/// rows that do not survive must retire their edges in the same transaction.
+#[tokio::test]
+async fn replace_source_page_retires_removed_source_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page_with_kind(
+        "page_g6_source",
+        "Source page",
+        None,
+        "Original body",
+        None,
+        None,
+        &[],
+        &now,
+        "source",
+        "confirmed",
+        None,
+        Some("[]"),
+    )
+    .await
+    .unwrap();
+    for sid in ["mem_g6_src_old", "mem_g6_src_new"] {
+        let doc = make_memory_doc(sid, "Some content.", "knowledge", "work", "agent");
+        db.upsert_documents(vec![doc]).await.unwrap();
+    }
+    db.link_page_source("page_g6_source", "mem_g6_src_old", "distill")
+        .await
+        .unwrap();
+    db.link_page_evidence(
+        "page_g6_source",
+        "external_url",
+        Some("https://example.com/replaced"),
+        None,
+        "cite",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: canonical writes leave parity clean"
+    );
+
+    assert!(db
+        .replace_source_page(
+            "page_g6_source",
+            "Source page",
+            None,
+            "Replaced body",
+            &["mem_g6_src_new"],
+            "source_refresh",
+        )
+        .await
+        .unwrap());
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a source-page replace must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
+/// A source-id rebind renames identity fields the edge ids are
+/// content-addressed over; every touching edge must be re-addressed.
+#[tokio::test]
+async fn rebind_source_id_readdresses_cites_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_rebind",
+        "Rebind Page",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    let doc = make_memory_doc(
+        "mem_g6_rebind_old",
+        "Some content.",
+        "knowledge",
+        "work",
+        "agent",
+    );
+    db.upsert_documents(vec![doc]).await.unwrap();
+    db.link_page_source("page_g6_rebind", "mem_g6_rebind_old", "distill")
+        .await
+        .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: canonical writes leave parity clean"
+    );
+
+    db.rebind_source_id("memory", "mem_g6_rebind_old", "mem_g6_rebind_new")
+        .await
+        .unwrap();
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a source-id rebind must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+    // No ACTIVE edge still references the old identity. A retired edge
+    // keeping the old id is correct history (superseded-by chain below).
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM edges \
+             WHERE valid_until IS NULL \
+               AND (src_id = 'mem_g6_rebind_old' OR dst_id = 'mem_g6_rebind_old')",
+            (),
+        )
+        .await
+        .unwrap();
+    let stale: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(
+        stale, 0,
+        "no active edge may still reference the old identity"
+    );
+    drop(rows);
+    let new_edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "page_g6_rebind",
+        "memory",
+        "mem_g6_rebind_new",
+        "mem_g6_rebind_new",
+    );
+    let mut rows = conn
+        .query(
+            "SELECT valid_until FROM edges WHERE edge_id = ?1",
+            libsql::params![new_edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    let row = rows
+        .next()
+        .await
+        .unwrap()
+        .expect("re-addressed edge exists");
+    assert!(
+        row.get::<Option<i64>>(0).unwrap().is_none(),
+        "re-addressed edge is active"
+    );
+    drop(rows);
+    // Any retired old-identity edge must chain to the new edge.
+    let old_edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "page_g6_rebind",
+        "memory",
+        "mem_g6_rebind_old",
+        "mem_g6_rebind_old",
+    );
+    let mut rows = conn
+        .query(
+            "SELECT superseded_by FROM edges WHERE edge_id = ?1",
+            libsql::params![old_edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    if let Some(row) = rows.next().await.unwrap() {
+        assert_eq!(
+            row.get::<Option<String>>(0).unwrap().as_deref(),
+            Some(new_edge_id.as_str()),
+            "retired old-identity edge chains superseded_by to the new edge"
+        );
+    }
+}
+
+/// A content update rewrites `pages.citations` wholesale; a locator whose only
+/// backing was the old citations value must lose its edge with it.
+#[tokio::test]
+async fn page_content_update_reconciles_citation_only_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_cit",
+        "Citation Page",
+        None,
+        "body",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    let doc = make_memory_doc("mem_g6_cit", "Some content.", "knowledge", "work", "agent");
+    db.upsert_documents(vec![doc]).await.unwrap();
+    // Citations-only backing: no page_sources / page_evidence row for it.
+    let citations = serde_json::json!([
+        {"occurrence": 1, "marker": 1, "source_kind": "memory", "locator": "mem_g6_cit",
+         "score": 0.9, "status": "verified", "scope": "sentence"}
+    ]);
+    db.set_page_citations("page_g6_cit", Some(&citations.to_string()))
+        .await
+        .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: set_page_citations minted the citation edge"
+    );
+
+    // The rewrite drops the citation — its edge must retire with it.
+    db.try_update_page_content_with_changelog(
+        "page_g6_cit",
+        "new body",
+        &[],
+        "fs_edit",
+        false,
+        "rewrite",
+        Some("[]"),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a citations rewrite must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}

--- a/crates/wenlan-core/src/db/repair_deterministic.rs
+++ b/crates/wenlan-core/src/db/repair_deterministic.rs
@@ -79,6 +79,9 @@ where
                 };
             let parity_before = crate::repair::parity_input_generation_on_connection(&conn).await?;
             let non_target_before = crate::repair::effect_guard_receipt(conn.total_changes());
+            // Canonical-edge dual-writes made alongside a legacy-store repair
+            // (G6 Stage 0); measured per-arm and allowed by the effect guard.
+            let mut edge_dual_write_changes: u64 = 0;
             let affected = match (manifest.target(), manifest.writer(), manifest.mutation()) {
                 (
                     RepairTarget::Memory { source_id, .. },
@@ -222,17 +225,102 @@ where
                         return Err(WenlanError::Conflict("repair_target_stale".to_string()));
                     }
                     drop(target_rows);
-                    conn.execute(
-                        "UPDATE page_links SET target_page_id=?1
-                         WHERE source_page_id=?2 AND label_key=?3 AND target_page_id IS NULL",
-                        libsql::params![
-                            after_target_page_id.clone(),
-                            source_page_id.clone(),
-                            label_key.clone()
-                        ],
-                    )
-                    .await
-                    .map_err(|error| WenlanError::VectorDb(format!("repair bind page link: {error}")))?
+                    let changed = conn
+                        .execute(
+                            "UPDATE page_links SET target_page_id=?1
+                             WHERE source_page_id=?2 AND label_key=?3 AND target_page_id IS NULL",
+                            libsql::params![
+                                after_target_page_id.clone(),
+                                source_page_id.clone(),
+                                label_key.clone()
+                            ],
+                        )
+                        .await
+                        .map_err(|error| {
+                            WenlanError::VectorDb(format!("repair bind page link: {error}"))
+                        })?;
+                    // Dual-write (G6 Stage 0): an orphan row derives no edge,
+                    // so binding its target makes the canonical `links` edge
+                    // implied — mint it in the same transaction, mirroring
+                    // `resolve_orphan_page_links`.
+                    let changes_before_mint = conn.total_changes();
+                    if changed > 0 {
+                        let mut src_rows = conn
+                            .query(
+                                "SELECT space FROM pages WHERE id = ?1",
+                                libsql::params![source_page_id.clone()],
+                            )
+                            .await
+                            .map_err(|error| {
+                                WenlanError::VectorDb(format!("repair bind link src space: {error}"))
+                            })?;
+                        let src_space: Option<String> =
+                            match src_rows.next().await.map_err(|error| {
+                                WenlanError::VectorDb(format!("repair bind link src row: {error}"))
+                            })? {
+                                Some(row) => row.get(0).unwrap_or(None),
+                                None => None,
+                            };
+                        drop(src_rows);
+                        if let Some(src_space) = src_space.as_deref() {
+                            let mut dst_rows = conn
+                                .query(
+                                    "SELECT space FROM pages WHERE id = ?1",
+                                    libsql::params![after_target_page_id.clone()],
+                                )
+                                .await
+                                .map_err(|error| {
+                                    WenlanError::VectorDb(format!(
+                                        "repair bind link dst space: {error}"
+                                    ))
+                                })?;
+                            let dst_space: Option<String> =
+                                match dst_rows.next().await.map_err(|error| {
+                                    WenlanError::VectorDb(format!(
+                                        "repair bind link dst row: {error}"
+                                    ))
+                                })? {
+                                    Some(row) => row.get(0).unwrap_or(None),
+                                    None => None,
+                                };
+                            drop(dst_rows);
+                            let cross_space_downgrade = MemoryDB::resolved_space_downgrades(
+                                dst_space.as_deref(),
+                                src_space,
+                            );
+                            let lineage = if cross_space_downgrade {
+                                "legacy"
+                            } else {
+                                "synthesis"
+                            };
+                            MemoryDB::dual_write_edge(
+                                &conn,
+                                "links",
+                                "page",
+                                source_page_id,
+                                "page",
+                                after_target_page_id,
+                                label_key,
+                                lineage,
+                                src_space,
+                                cross_space_downgrade,
+                                None,
+                            )
+                            .await
+                            .map_err(|error| {
+                                WenlanError::VectorDb(format!(
+                                    "repair bind link edge mint: {error}"
+                                ))
+                            })?;
+                        }
+                    }
+                    edge_dual_write_changes = conn
+                        .total_changes()
+                        .checked_sub(changes_before_mint)
+                        .ok_or_else(|| {
+                            WenlanError::VectorDb("repair_effect_counter_underflow".to_string())
+                        })?;
+                    changed
                 }
                 (
                     RepairTarget::Page { page_id, scope },
@@ -353,6 +441,7 @@ where
                 };
             let allowed_changes = affected
                 .checked_add(allowed_derived_changes)
+                .and_then(|changes| changes.checked_add(edge_dual_write_changes))
                 .ok_or_else(|| WenlanError::VectorDb("repair_effect_counter_overflow".to_string()))?;
             let parity_bump = crate::repair::parity_input_generation_on_connection(&conn)
                 .await?

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -343,6 +343,14 @@ crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::approved_
 crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::approved_general_only_deterministic_manifest_applies_and_verifies_exact_field|TestDbSession::query|1
 crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::approved_general_only_deterministic_manifest_applies_and_verifies_exact_field|test_primary_session|1
 crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::approved_general_only_deterministic_manifest_applies_and_verifies_exact_field|test_primary_session|2
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|TestDbRow::get|1
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|TestDbRow::get|2
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|TestDbRows::next|1
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|TestDbRows::next|2
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|TestDbSession::query|1
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|TestDbSession::query|2
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|test_primary_session|1
+crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::bind_page_link_repair_mints_the_links_edge|test_primary_session|2
 crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::current_schema_diagnostic_distinguishes_old_and_future_versions|TestDbSession::execute|1
 crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::current_schema_diagnostic_distinguishes_old_and_future_versions|test_primary_session|1
 crates/wenlan-core/src/repair_plan_tests.rs|crate::repair_plan::tests::deep_only_deterministic_finding_is_visible_but_not_general_only_ready|TestDbSession::execute_batch|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,9 +3229,10 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        989,
+        997,
         "PR-D integration must expose the frozen 968 support calls, the 6 PR-D test identities, \
-         the 5 M5 derivation-marker fixture calls, and the 10 M6 shadow-promoter fixture calls"
+         the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, and \
+         the 8 G6 BindPageLink repair-test calls"
     );
 }
 

--- a/crates/wenlan-core/src/repair_plan_tests.rs
+++ b/crates/wenlan-core/src/repair_plan_tests.rs
@@ -2622,6 +2622,153 @@ async fn deterministic_db_writers_apply_exactly_and_orphan_binding_fails_when_am
     assert_eq!(target, None);
 }
 
+/// The repair tool's orphan-bind (`RepairWriter::BindPageLink`) is a second
+/// writer of `page_links.target_page_id` beside `resolve_orphan_page_links`;
+/// a successful bind must mint the now-implied canonical `links` edge, or the
+/// row is permanent "missing" parity drift (G6 Stage 0).
+#[tokio::test]
+async fn bind_page_link_repair_mints_the_links_edge() {
+    use crate::lint::{
+        context::{CancellationToken, LintClock},
+        runner::LintRunner,
+    };
+    use wenlan_types::{
+        lint::LintQuery,
+        repair::{ApplyRepairRequest, RepairWriter},
+    };
+
+    let (db, _dir) = crate::db::tests::test_db().await;
+    let page_root = tempfile::tempdir().unwrap();
+    let now = "2026-07-15T00:00:00Z";
+    db.insert_page(
+        "source_link",
+        "Source Link",
+        None,
+        "see [[Unique Link Target]]",
+        None,
+        Some("work"),
+        &[],
+        now,
+    )
+    .await
+    .unwrap();
+    db.insert_page(
+        "target_link_a",
+        "Unique Link Target",
+        None,
+        "target",
+        None,
+        Some("work"),
+        &[],
+        now,
+    )
+    .await
+    .unwrap();
+    let runner = || LintRunner::new(LintClock::fixed(), CancellationToken::new());
+    let general = runner()
+        .run(
+            &db,
+            &LintQuery::new(Some(LintProfile::General), None),
+            Some(page_root.path()),
+            true,
+        )
+        .await
+        .unwrap();
+    let deep = runner()
+        .run(
+            &db,
+            &LintQuery::new(Some(LintProfile::Deep), None),
+            Some(page_root.path()),
+            true,
+        )
+        .await
+        .unwrap();
+    let repair_root = tempfile::tempdir().unwrap();
+    let store = crate::repair::RepairArtifactStore::new(repair_root.path().to_path_buf());
+    let plan = prepare_repair_plan(
+        &db,
+        &store,
+        RepairPlanRequest::try_new(RepairLintScope::global(), general, Some(deep)).unwrap(),
+        Some(page_root.path()),
+        1_721_000_000,
+    )
+    .await
+    .unwrap();
+    let manifest = plan
+        .entries()
+        .iter()
+        .find_map(|entry| match entry.resolution() {
+            RepairResolution::Ready { manifest }
+                if manifest.writer() == RepairWriter::BindPageLink =>
+            {
+                Some(manifest.as_ref().clone())
+            }
+            _ => None,
+        })
+        .expect("bind manifest ready");
+    let request = ApplyRepairRequest::try_new(
+        manifest.manifest_id().to_string(),
+        manifest.manifest_digest().clone(),
+        format!(
+            "apply repair {} {}",
+            manifest.manifest_id(),
+            manifest.manifest_digest().as_str()
+        ),
+    )
+    .unwrap();
+    crate::repair::apply_repair(&db, &store, request, 1_721_000_001)
+        .await
+        .unwrap();
+
+    let target = db
+        .test_primary_session()
+        .await
+        .query(
+            "SELECT target_page_id FROM page_links WHERE source_page_id='source_link'",
+            (),
+        )
+        .await
+        .unwrap()
+        .next()
+        .await
+        .unwrap()
+        .unwrap()
+        .get::<Option<String>>(0)
+        .unwrap();
+    assert_eq!(target.as_deref(), Some("target_link_a"), "row bound");
+
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a repair-tool orphan bind must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+    let edge_id = crate::provenance::compute_edge_id(
+        "links",
+        "page",
+        "source_link",
+        "page",
+        "target_link_a",
+        "unique link target",
+    );
+    let valid_until = db
+        .test_primary_session()
+        .await
+        .query(
+            "SELECT valid_until FROM edges WHERE edge_id = ?1",
+            libsql::params![edge_id.as_str()],
+        )
+        .await
+        .unwrap()
+        .next()
+        .await
+        .unwrap()
+        .expect("minted links edge exists")
+        .get::<Option<i64>>(0)
+        .unwrap();
+    assert!(valid_until.is_none(), "minted links edge is active");
+}
+
 #[tokio::test]
 async fn page_projection_manifest_repairs_only_the_named_page_projection() {
     use crate::db::repair_verification::{

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -40,15 +40,20 @@ parity the moment it runs. All sites below were verified at the code level on
 `insert_resolved_page_evidence`, which dual-writes the same content-addressed
 edge id the page_sources row derives to.
 
-**Part 2 (follow-up PR): secondary writers, verified 2026-08-04.**
+**Part 2 (second PR): secondary writers, verified and fixed 2026-08-05.**
 
 | Function | Gap | Status |
 |---|---|---|
-| `rebind_source_id_inner` (db.rs ~27860, incl. `rebind_source_page_in_transaction`) | Renames `page_sources.memory_source_id`, `page_evidence.locator`, and optionally the source page id — identity fields of the content-addressed edge id — with no edge rewrite. Every touching edge strands (extra) and its successor shows as missing. | CONFIRMED, unfixed. Fix must recompute edge ids while preserving grounding/payload/provenance, and chase `superseded_by` FKs. |
-| `replace_source_page_inner` (db.rs ~43093) | DELETEs ALL `page_sources` + `page_evidence` rows (external kinds included) then reinserts the new set; removed rows' edges never retired. | CONFIRMED, unfixed. Same fix shape as `replace_page_sources`, plus external-kind retire. |
-| `accept_page_merge` (db.rs ~44859) | Repoints inbound `page_links.target_page_id` loser→winner with a raw UPDATE; the loser-dst links edges stay active (extra), winner-dst edges show missing. (The loser's own source rows stay in place, so its cites edges remain consistently implied — archived pages are not filtered by the parity derivation.) | CONFIRMED (links repoint only), unfixed. Retire+mint per repointed row using `replace_page_links`'s space/lineage derivation. |
-| `resolve_orphan_page_links` (db.rs ~45684) | Sets `target_page_id` on a previously-orphan row (which derives no edge) without minting the now-implied links edge. | CONFIRMED, unfixed. Mint with `replace_page_links`'s derivation. |
-| `try_update_page_content` (db.rs ~43975) | Rewrites `pages.citations` wholesale without reconciling edges. Narrow: drifts only when a locator backed ONLY by citations (not by `page_sources`/`page_evidence`) drops out of the new value. | CONFIRMED (narrow), unfixed. Reconcile like `set_page_citations` does. |
+| `rebind_source_id_inner` (db.rs ~27860, incl. `rebind_source_page_in_transaction`) | Renames `page_sources.memory_source_id`, `page_evidence.locator`, and optionally the source page id — identity fields of the content-addressed edge id. The M2 PR-1 block already retired+minted memory-locator cites edges for pages listed in `page_sources`/`page_evidence`, but the page-id rename half had no edge rewrite, and citations-only cites edges were missed. | FIXED. New `rebind_edges_identity` helper re-addresses cites edges (disc = dst locator, derivable from the row) with FK-safe `superseded_by` detach/re-attach, collision-aware (an already-minted successor absorbs the old edge as retired history); links edges retire + re-assert from `page_links`. Payload `source_memory_id` provenance re-stamped. |
+| `replace_source_page_inner` (db.rs ~43093) | DELETEs ALL `page_sources` + `page_evidence` rows (external kinds included) then reinserts the new set; removed rows' edges never retired. | FIXED. Removed-locator snapshot before the DELETEs; each dropped locator's cites edge retired in-transaction (external kinds included). |
+| `accept_page_merge` (db.rs ~44859) | Repoints inbound `page_links.target_page_id` loser→winner with a raw UPDATE; the loser-dst links edges stay active (extra), winner-dst edges show missing. Also copies the absorbed page's external evidence rows without minting their edges. | FIXED. Per repointed row: mint the winner-dst links edge (replace_page_links derivation), retire the loser-dst edge superseded-by it. Copied external evidence rows mint their cites edges. |
+| `resolve_orphan_page_links` (db.rs ~45684) | Sets `target_page_id` on a previously-orphan row (which derives no edge) without minting the now-implied links edge. | FIXED. Mints with `replace_page_links`'s derivation in the same per-row transaction. |
+| `try_update_page_content` (db.rs ~43975) | Rewrites `pages.citations` wholesale without reconciling edges. Narrow: drifts only when a locator backed ONLY by citations (not by `page_sources`/`page_evidence`) drops out of the new value. | FIXED. Calls the shared `dual_write_page_citations` reconciler inside the CAS transaction (`set_page_citations_with_changelog_at_version` rewired onto the same helper). |
+
+Known limitation (M5 follow-up, outside Stage 0 scope): M5 claim `supports`
+edges are fenced out of the parity universe, and a source-id rebind retracts
+them (`retract_support_for_rebound_source`, M5 row 13) rather than re-address
+them — pages citing the renamed document re-derive support. No parity impact.
 
 Exit: all fixes merged with regression tests (parity clean after driving each
 path); ambient watermarks stay drift 0 across a soak.

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -49,6 +49,13 @@ edge id the page_sources row derives to.
 | `accept_page_merge` (db.rs ~44859) | Repoints inbound `page_links.target_page_id` loser→winner with a raw UPDATE; the loser-dst links edges stay active (extra), winner-dst edges show missing. Also copies the absorbed page's external evidence rows without minting their edges. | FIXED. Per repointed row: mint the winner-dst links edge (replace_page_links derivation), retire the loser-dst edge superseded-by it. Copied external evidence rows mint their cites edges. |
 | `resolve_orphan_page_links` (db.rs ~45684) | Sets `target_page_id` on a previously-orphan row (which derives no edge) without minting the now-implied links edge. | FIXED. Mints with `replace_page_links`'s derivation in the same per-row transaction. |
 | `try_update_page_content` (db.rs ~43975) | Rewrites `pages.citations` wholesale without reconciling edges. Narrow: drifts only when a locator backed ONLY by citations (not by `page_sources`/`page_evidence`) drops out of the new value. | FIXED. Calls the shared `dual_write_page_citations` reconciler inside the CAS transaction (`set_page_citations_with_changelog_at_version` rewired onto the same helper). |
+| `apply_deterministic_repair_cas`, `RepairWriter::BindPageLink` arm (db/repair_deterministic.rs) | The repair tool's own orphan-bind — a second writer of `page_links.target_page_id` beside `resolve_orphan_page_links` — set the target with a raw UPDATE and no edge mint. Found by the Stage 1.1 scout (`docs/superpowers/g6-stage1-page-links-scout.md`). | FIXED. The arm mints the links edge in-transaction (same derivation as `resolve_orphan_page_links`); the mint's row changes are measured and allowed by the repair effect guard. |
+
+Residual (not Stage 0 scope, tracked): the generic repair **rollback** artifact
+restores legacy-store rows byte-wise (`rollback-v1.json` row restore) without
+edge reconciliation — rolling back a bind would re-orphan the row while its
+minted edge stays active. Operator-driven and rare; the parity sweep catches it.
+Fold into Stage 2 when repair writers go canonical-only.
 
 Known limitation (M5 follow-up, outside Stage 0 scope): M5 claim `supports`
 edges are fenced out of the parity universe, and a source-id rebind retracts
@@ -65,6 +72,15 @@ Order by measured entanglement:
 1. **`page_links`** (~9 fns) — one dual-write-aware writer choke point
    (`replace_page_links`), small reader fan-out (`get_page_outbound_links`,
    `get_page_inbound_links`, orphan-label lint), no shared-struct entanglement.
+   **Scout correction (2026-08-05, `docs/superpowers/g6-stage1-page-links-scout.md`):
+   this store cannot fully migrate onto `edges` as wired.** The `label` display
+   text is not stored on edge rows (label_key is only a hash input), and orphan
+   rows (`target_page_id IS NULL`) derive no edge at all — so the two product-route
+   readers behind `GET /api/pages/{id}/links` and all orphan-feed readers stay on
+   `page_links`. Only `load_link_counts` migrates cleanly today. Decision needed
+   before this store reaches Stage 3: carry the label in a `links` edge payload
+   (schema change), or keep `page_links` alive as a label+orphan side-table and
+   shrink the Stage 3 drop list accordingly.
 2. **`relations`** (~20 fns) — clear writer choke points, but readers include
    product routes (`get_entity_detail`, `list_recent_relations`), k-hop expansion,
    and lint/repair tooling. Entangled with `entities` via shared CRUD

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -68,6 +68,17 @@ path); ambient watermarks stay drift 0 across a soak.
 
 ## Stage 1 — migrate readers onto canonical stores, cheapest first
 
+**Decision (user, 2026-08-05): one source of truth.** The semantic-payload
+schema change is authorized — `relates` edges carry `relation_type` (+
+`confidence`/`explanation`/`source_agent`), `links` edges carry the display
+`label`, with a backfill migration from the legacy rows. No legacy store
+survives Stage 3 as a permanent side-table. The same principle extends to
+`cites` edges where Stage 1.3 found unrecoverable columns (`link_reason`,
+`linked_at`, the 4-way `source_kind`): carry them in edge payload/columns
+rather than keeping `page_sources`/`page_evidence` alive. The payload PR
+lands FIRST (before any reader migration), since every blocked reader in the
+scout reports migrates only once the semantic fields exist on the edge.
+
 Order by measured entanglement:
 
 1. **`page_links`** (~9 fns) — one dual-write-aware writer choke point

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -50,6 +50,7 @@ edge id the page_sources row derives to.
 | `resolve_orphan_page_links` (db.rs ~45684) | Sets `target_page_id` on a previously-orphan row (which derives no edge) without minting the now-implied links edge. | FIXED. Mints with `replace_page_links`'s derivation in the same per-row transaction. |
 | `try_update_page_content` (db.rs ~43975) | Rewrites `pages.citations` wholesale without reconciling edges. Narrow: drifts only when a locator backed ONLY by citations (not by `page_sources`/`page_evidence`) drops out of the new value. | FIXED. Calls the shared `dual_write_page_citations` reconciler inside the CAS transaction (`set_page_citations_with_changelog_at_version` rewired onto the same helper). |
 | `apply_deterministic_repair_cas`, `RepairWriter::BindPageLink` arm (db/repair_deterministic.rs) | The repair tool's own orphan-bind — a second writer of `page_links.target_page_id` beside `resolve_orphan_page_links` — set the target with a raw UPDATE and no edge mint. Found by the Stage 1.1 scout (`docs/superpowers/g6-stage1-page-links-scout.md`). | FIXED. The arm mints the links edge in-transaction (same derivation as `resolve_orphan_page_links`); the mint's row changes are measured and allowed by the repair effect guard. |
+| `try_update_page_content` — `page_sources`/`page_evidence` half (db.rs ~44266) | Beyond the citations rewrite (row above), the same function does its OWN prune-then-reinsert of `page_sources` + memory-kind `page_evidence` against the `source_memory_ids` argument — a second instance of the `replace_page_sources` bug, with no removed-sid snapshot and no edge retirement. High traffic: manual edits, refinery rewrites, and page growth all route through it. Found by the Stage 1.3 scout (`docs/superpowers/g6-stage1-page-sources-evidence-scout.md`). | FIXED. Snapshot of the pruned locators (page_sources ∪ memory-kind page_evidence) before the DELETEs; each retired in-transaction UNLESS the new `pages.citations` value still backs it (D7 refcount via `cites_backed_by_page_citations` — this path, unlike `replace_page_sources`, sets citations to an explicit new value). Kept sids re-assert through `insert_resolved_page_evidence`. |
 
 Residual (not Stage 0 scope, tracked): the generic repair **rollback** artifact
 restores legacy-store rows byte-wise (`rollback-v1.json` row restore) without
@@ -87,6 +88,16 @@ Order by measured entanglement:
    (`merge_entities`, `commit_entity_enrichment_at_version`,
    `delete_by_source_id_in_transaction`) — those functions change once, in this
    stage, for both stores' read sides.
+   **Scout correction (2026-08-05, `docs/superpowers/g6-stage1-relations-scout.md`):
+   blocked harder than page_links.** `relation_type` is a hash-input-only
+   discriminator — never stored on the edge row or payload — so every reader
+   that returns or filters on it (both product routes, most lint/repair tooling;
+   9 of 13 readers) cannot migrate as wired. Only topology-only readers (k-hop
+   ×2, aggregate count, scope subquery) migrate cleanly. All relations writers
+   already dual-write (no Stage 0 gap). Same decision as page_links, but
+   sharper: the semantic-payload schema change (relation_type + confidence /
+   explanation / source_agent on `relates` edges, label on `links` edges, plus
+   backfill migration) is realistically the only path to Stage 3 for this store.
 3. **`page_sources` + `page_evidence`** (~30 fns, co-written pair) —
    `insert_resolved_page_evidence` is the evidence choke point; `page_sources` has
    no single choke point and needs one first.


### PR DESCRIPTION
## Summary

G6 Stage 0, part 2 (follow-up to #481): closes the remaining dual-write gaps where secondary writers mutate the legacy link stores without the canonical `edges` dual-write, re-drifting parity. Plan: `docs/plans/2026-08-04-g6-retirement-program.md`, Part 2 table (statuses updated in this PR). Five gaps came from the plan's verified sweep; two more were found by the Stage 1 scouts while this PR was open and are fixed here too.

- **`rebind_source_id_inner`** — new `rebind_edges_identity` helper re-addresses cites edges across an identity rename (the discriminator equals the destination locator in every derivation, so the new edge id is derivable from the stored row), with FK-safe `superseded_by` detach/re-attach and a collision branch that absorbs an already-minted successor as retired history; links edges retire + re-assert from `page_links`; payload `source_memory_id` provenance re-stamped.
- **`replace_source_page_inner`** — snapshots removed locators (external kinds included) before the wholesale DELETE and retires each dropped cites edge in-transaction.
- **`accept_page_merge`** — the links repoint now mints the winner-dst edge and retires the loser-dst edge superseded-by it; copied external evidence rows mint their cites edges.
- **`resolve_orphan_page_links`** — mints the now-implied links edge in the same per-row transaction as the target resolve.
- **`try_update_page_content` / `set_page_citations_with_changelog_at_version`** — both rewired onto the shared `dual_write_page_citations` reconciler inside the CAS transaction.
- **`apply_deterministic_repair_cas` `BindPageLink` arm** (Stage 1.1 scout finding) — the repair tool's own orphan-bind now mints the links edge in-transaction; the mint's row changes are measured and allowed by the repair effect guard.
- **`try_update_page_content` source/evidence half** (Stage 1.3 scout finding) — the same function's own prune-then-reinsert of `page_sources` + memory-kind `page_evidence` (a second instance of the `replace_page_sources` bug class) now snapshots the pruned locators and retires their edges in-transaction, except locators the new `pages.citations` value still backs (D7 refcount).

Known limitation noted in the plan doc: M5 claim `supports` edges are retracted (not re-addressed) on a source-id rebind, per M5 row 13 — no parity impact (they are fenced out of the parity universe).

## Test plan

- [x] 7 new parity-oracle regression tests — each drives the real path and asserts `reconcile_edges_parity()` drift 0 plus the specific edge end-state (re-addressed edge active, retired edge chains `superseded_by`, dropped locator retired, orphan resolve mints, citation-only locator loses its edge, repair bind mints, content-update prune retires with citation-backed survivor)
- [x] Families green: rebind (10), reconcile (53), page_merge (6), replace_source_page (6), orphan (63), citations (39), page_links (12), repair (229), update_page_content (4), page_growth (8), drift_guard r4 (35)
- [x] `cargo clippy -p wenlan-core --all-targets` clean; `cargo fmt --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
