### PR TITLE
fix(kg): carry the label on rebind re-mints; survive the m81 pre-semantic_type crash window

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -9118,6 +9118,14 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("m81 DDL: {e}")))?;
 
+            // A crash between m81's COMMIT and its `user_version = 81` stamp
+            // on a pre-G6 binary leaves `edges` already created WITHOUT
+            // `semantic_type` at user_version 80 — the CREATE IF NOT EXISTS
+            // above cannot widen it, and the backfill INSERTs below name the
+            // column. Probe-add it so the rerun succeeds (same guard as
+            // migrations 98/111/115).
+            Self::ensure_edges_semantic_type_column(&conn).await?;
+
             let relations = Self::backfill_edges_from_relations(&conn).await?;
             let page_sources = Self::backfill_edges_from_page_sources(&conn).await?;
             let page_evidence = Self::backfill_edges_from_page_evidence(&conn).await?;
@@ -14273,6 +14281,12 @@ impl MemoryDB {
     /// Returns `libsql::Error` so callers whose existing transaction block
     /// is already typed that way (the common case in this file) can
     /// `.await?` it directly.
+    ///
+    /// Test-only seeding wrapper: since G6 Stage 1 every production mint
+    /// supplies its semantic fields through `dual_write_edge_with_payload`;
+    /// kept for the parity-fixture tests that assert the payload-less path
+    /// still converges.
+    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     async fn dual_write_edge(
         conn: &libsql::Connection,
@@ -14785,7 +14799,7 @@ impl MemoryDB {
             let mut link_rows = conn
                 .query(
                     "SELECT pl.source_page_id, pl.target_page_id, pl.label_key, \
-                            sp.space, tp.space \
+                            pl.label, sp.space, tp.space \
                      FROM page_links pl \
                      INNER JOIN pages sp ON sp.id = pl.source_page_id \
                      INNER JOIN pages tp ON tp.id = pl.target_page_id \
@@ -14799,6 +14813,7 @@ impl MemoryDB {
                 String,
                 String,
                 String,
+                String,
                 Option<String>,
                 Option<String>,
             )> = Vec::new();
@@ -14807,12 +14822,13 @@ impl MemoryDB {
                     row.get(0).unwrap_or_default(),
                     row.get(1).unwrap_or_default(),
                     row.get(2).unwrap_or_default(),
-                    row.get::<Option<String>>(3).unwrap_or(None),
+                    row.get(3).unwrap_or_default(),
                     row.get::<Option<String>>(4).unwrap_or(None),
+                    row.get::<Option<String>>(5).unwrap_or(None),
                 ));
             }
             drop(link_rows);
-            for (src_page, dst_page, label_key, src_space, dst_space) in &reassert {
+            for (src_page, dst_page, label_key, label, src_space, dst_space) in &reassert {
                 let Some(space) = src_space.as_deref() else {
                     continue;
                 };
@@ -14823,7 +14839,12 @@ impl MemoryDB {
                 } else {
                     "synthesis"
                 };
-                Self::dual_write_edge(
+                // G6 Stage 1: the re-asserted edge must carry the display
+                // label like every other links mint — a rebind without it
+                // leaves an active label-less edge the parity oracle flags
+                // as semantic drift.
+                let semantic_patch = serde_json::json!({ "label": label }).to_string();
+                Self::dual_write_edge_with_payload(
                     conn,
                     "links",
                     "page",
@@ -14835,6 +14856,9 @@ impl MemoryDB {
                     space,
                     cross_space_downgrade,
                     None,
+                    None,
+                    None,
+                    Some(&semantic_patch),
                 )
                 .await?;
             }

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -48392,6 +48392,150 @@ async fn rebind_source_id_readdresses_cites_edges() {
     }
 }
 
+/// A page-identity rebind re-asserts every touching `links` edge from the
+/// renamed `page_links` rows; the re-mint must carry the display label like
+/// any other links mint, or the parity oracle's semantic-drift check flags
+/// the edge as corrupt (G6 Stage 1 post-merge review finding #1).
+#[tokio::test]
+async fn rebind_source_page_reasserts_links_edges_with_label() {
+    let (db, _dir) = test_db().await;
+    db.upsert_documents(vec![make_memory_doc(
+        "mem-g6-links-rebind-old",
+        "Body",
+        "fact",
+        "work",
+        "folder",
+    )])
+    .await
+    .unwrap();
+    let chunk_id = db
+        .get_memories_by_source_id("memory", "mem-g6-links-rebind-old")
+        .await
+        .unwrap()[0]
+        .id
+        .clone();
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_links_target",
+        "G6 Links Target",
+        None,
+        "Target body",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    db.insert_page_with_kind(
+        "page_g6_links_src_old",
+        "G6 Links Source",
+        None,
+        "See [[G6 Links Target]].",
+        None,
+        None,
+        &[chunk_id.as_str()],
+        &now,
+        "source",
+        "unconfirmed",
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: canonical writes leave parity clean"
+    );
+
+    db.rebind_source_id_with_source_page(
+        "memory",
+        "mem-g6-links-rebind-old",
+        "mem-g6-links-rebind-new",
+        "page_g6_links_src_old",
+        "page_g6_links_src_new",
+    )
+    .await
+    .unwrap();
+
+    {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT json_extract(payload, '$.label') FROM edges \
+                 WHERE edge_type = 'links' AND valid_until IS NULL \
+                   AND src_id = 'page_g6_links_src_new' \
+                   AND dst_id = 'page_g6_links_target'",
+                (),
+            )
+            .await
+            .unwrap();
+        let row = rows
+            .next()
+            .await
+            .unwrap()
+            .expect("re-asserted links edge exists");
+        assert_eq!(
+            row.get::<Option<String>>(0).unwrap_or(None).as_deref(),
+            Some("G6 Links Target"),
+            "the rebind re-mint carries the display label"
+        );
+    }
+    let report = db.reconcile_edges_parity().await.unwrap();
+    assert_eq!(
+        report.drift_count, 0,
+        "a page rebind must not re-drift edges parity (missing={}, extra={}, corrupt={})",
+        report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
+/// A crash between m81's COMMIT and its `user_version = 81` stamp on a
+/// pre-G6 binary leaves an `edges` table WITHOUT `semantic_type` at
+/// user_version 80. The m81 rerun's CREATE IF NOT EXISTS cannot widen it,
+/// and its backfill INSERTs name the column — the rerun must probe-add it
+/// instead of failing startup (G6 Stage 1 post-merge review finding #2).
+#[tokio::test]
+async fn migration_81_rerun_recovers_pre_semantic_type_edges_table() {
+    let (db, _dir) = test_db().await;
+    // A live relation guarantees the rerun actually executes a backfill
+    // INSERT that names `semantic_type` (an empty store would pass
+    // vacuously and m98's guard would mask the defect).
+    let e1 = db.create_entity("G6RerunA", "person", None).await.unwrap();
+    let e2 = db.create_entity("G6RerunB", "person", None).await.unwrap();
+    db.create_relation(&e1, &e2, "knows", Some("claude"), None, None, None)
+        .await
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute("ALTER TABLE edges DROP COLUMN semantic_type", ())
+            .await
+            .expect("drop semantic_type to emulate the pre-G6 partial state");
+        conn.execute("PRAGMA user_version = 80", ()).await.unwrap();
+    }
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("m81 rerun must widen the pre-existing edges table, not fail its backfill INSERTs");
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM pragma_table_info('edges') WHERE name = 'semantic_type'",
+            (),
+        )
+        .await
+        .unwrap();
+    let present: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(present, 1, "semantic_type restored by the m81 rerun guard");
+    drop(rows);
+    let mut vrows = conn.query("PRAGMA user_version", ()).await.unwrap();
+    let uv: i64 = vrows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(
+        uv as u32,
+        crate::db::SCHEMA_VERSION,
+        "chain completes back to the current schema version"
+    );
+}
+
 /// A content update rewrites `pages.citations` wholesale; a locator whose only
 /// backing was the old citations value must lose its edge with it.
 #[tokio::test]


### PR DESCRIPTION
Two post-merge review findings against #486 (G6 Stage 1 payload PR), both independently confirmed at the code level and RED-verified with paired regression tests.

## Finding 1 — rebind mints label-less links edges
`rebind_edges_identity` re-asserted a page's links edges through the payload-less `dual_write_edge`; its SELECT never fetched `pl.label`. Any page-identity rebind therefore minted active links edges with no `payload.label`, which `reconcile_edges_parity`'s new semantic-drift check classifies as corrupt. The re-assert now selects the label and passes the same `{"label": ...}` semantic patch as every other links mint.

Regression test `rebind_source_page_reasserts_links_edges_with_label`: RED run (fix reverted) fails with `left: None / right: Some("G6 Links Target")`; green with the fix, parity drift 0 after rebind.

## Finding 2 — m81 rerun bricks on the pre-semantic_type crash window
m81 stamps `user_version = 81` in a separate statement after COMMIT. A crash from a pre-G6 binary in that window leaves an `edges` table WITHOUT `semantic_type` at user_version 80; the rerun's `CREATE TABLE IF NOT EXISTS` cannot widen it and the backfill INSERTs name the column — a repeatable startup failure. m81 now probe-adds the column right after its DDL batch (same `ensure_edges_semantic_type_column` guard as m98/m111/m115).

Regression test `migration_81_rerun_recovers_pre_semantic_type_edges_table` (seeds a live relation so the backfill INSERT actually executes): RED run fails with `table edges has no column named semantic_type`; green with the fix, chain completes to the current schema version.

## Consequence cleanup
Fix 1 removed the last production caller of `dual_write_edge`; it is now `#[cfg(test)]` (test-only seeding wrapper) rather than deleted, so its parity-fixture test callers stay as-is and the production build carries no dead code.

## Receipts
- RED controls: both tests proved failing against the unfixed code, files restored byte-identical, re-verified green
- fmt clean; clippy `-D warnings` clean on lib and tests
- Full suites: wenlan-core 4058 passed / 0 failed, wenlan-server 619 / 0, wenlan CLI 106 / 0

Review: Codex gpt-5.6-sol (independent post-merge review of #486). RED controls + gates: Sonnet executor lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91