### PR TITLE
feat(kg): G6 Stage 1.1 — resolved page-link readers cut over to canonical links edges

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -46847,68 +46847,6 @@ impl MemoryDB {
         }
     }
 
-    /// Outbound links from a page. Used by `/api/pages/{id}/links` and the
-    /// `/pages` preview's link-count line.
-    pub async fn get_page_outbound_links(
-        &self,
-        source_page_id: &str,
-    ) -> Result<Vec<crate::synthesis::wikilinks::Wikilink>, WenlanError> {
-        let conn = self.conn.lock().await;
-        let mut rows = conn
-            .query(
-                "SELECT target_page_id, label FROM page_links \
-                 WHERE source_page_id = ?1 ORDER BY label_key",
-                libsql::params![source_page_id],
-            )
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("get_page_outbound_links: {e}")))?;
-        let mut out = Vec::new();
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
-        {
-            out.push(crate::synthesis::wikilinks::Wikilink {
-                target_page_id: row.get::<Option<String>>(0).unwrap_or(None),
-                label: row.get::<String>(1).unwrap_or_default(),
-            });
-        }
-        Ok(out)
-    }
-
-    /// Inbound links to a page — every active source whose body contains a
-    /// `[[Title]]` reference that resolves here. Used by the page's "linked
-    /// from" view. Tie-break on source_page_id keeps order stable across
-    /// same-second timestamps.
-    pub async fn get_page_inbound_links(
-        &self,
-        target_page_id: &str,
-    ) -> Result<Vec<(String, String)>, WenlanError> {
-        let conn = self.conn.lock().await;
-        let mut rows = conn
-            .query(
-                "SELECT pl.source_page_id, pl.label FROM page_links pl \
-                 INNER JOIN pages p ON p.id = pl.source_page_id \
-                 WHERE pl.target_page_id = ?1 AND p.status = 'active' \
-                 ORDER BY p.last_modified DESC, pl.source_page_id ASC",
-                libsql::params![target_page_id],
-            )
-            .await
-            .map_err(|e| WenlanError::VectorDb(format!("get_page_inbound_links: {e}")))?;
-        let mut out = Vec::new();
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| WenlanError::VectorDb(e.to_string()))?
-        {
-            out.push((
-                row.get::<String>(0).unwrap_or_default(),
-                row.get::<String>(1).unwrap_or_default(),
-            ));
-        }
-        Ok(out)
-    }
-
     /// Group every still-orphan label by count, restricted to active source
     /// pages (archived pages keep their `page_links` rows via cascade-on-
     /// delete-only, but they shouldn't inflate the emergence signal once

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -8598,14 +8598,14 @@ async fn rebind_source_id_moves_the_machine_source_page_identity() {
         1
     );
     let outbound = db
-        .get_page_outbound_links("source_page_rebind_new")
+        .get_page_outbound_links_scoped("source_page_rebind_new", &ReadScope::Global)
         .await
         .unwrap();
     assert!(outbound
         .iter()
         .any(|link| { link.target_page_id.as_deref() == Some("page_rebind_link_target") }));
     let inbound = db
-        .get_page_inbound_links("source_page_rebind_new")
+        .get_page_inbound_links_scoped("source_page_rebind_new", &ReadScope::Global)
         .await
         .unwrap();
     assert!(inbound
@@ -19594,7 +19594,10 @@ async fn page_links_resolve_against_existing_titles() {
     .await
     .unwrap();
 
-    let out = db.get_page_outbound_links("page_src").await.unwrap();
+    let out = db
+        .get_page_outbound_links_scoped("page_src", &ReadScope::Global)
+        .await
+        .unwrap();
     // Three labels, sorted alphabetically.
     assert_eq!(out.len(), 3);
     let by_label: std::collections::HashMap<_, _> = out
@@ -19631,7 +19634,10 @@ async fn wikilink_resolution_uses_the_source_page_scope() {
     )
     .await;
 
-    let links = db.get_page_outbound_links("source-work").await.unwrap();
+    let links = db
+        .get_page_outbound_links_scoped("source-work", &ReadScope::Global)
+        .await
+        .unwrap();
     assert_eq!(links.len(), 1);
     assert_eq!(
         links[0].target_page_id.as_deref(),
@@ -19655,7 +19661,7 @@ async fn wikilink_same_scope_duplicate_titles_remain_unresolved() {
     .await;
 
     let links = db
-        .get_page_outbound_links("source-ambiguous")
+        .get_page_outbound_links_scoped("source-ambiguous", &ReadScope::Global)
         .await
         .unwrap();
     assert_eq!(links.len(), 1);
@@ -19695,11 +19701,11 @@ async fn orphan_wikilink_repair_is_scoped_per_source_page() {
 
     assert_eq!(db.resolve_orphan_page_links().await.unwrap(), 1);
     let work_links = db
-        .get_page_outbound_links("orphan-source-work")
+        .get_page_outbound_links_scoped("orphan-source-work", &ReadScope::Global)
         .await
         .unwrap();
     let personal_links = db
-        .get_page_outbound_links("orphan-source-personal")
+        .get_page_outbound_links_scoped("orphan-source-personal", &ReadScope::Global)
         .await
         .unwrap();
     assert_eq!(work_links[0].target_page_id.as_deref(), Some("future-work"));
@@ -19740,7 +19746,7 @@ async fn orphan_resolver_preserves_explicit_cross_scope_targets() {
 
     db.resolve_orphan_page_links().await.unwrap();
     let links = db
-        .get_page_outbound_links("explicit-source-personal")
+        .get_page_outbound_links_scoped("explicit-source-personal", &ReadScope::Global)
         .await
         .unwrap();
     assert_eq!(
@@ -19796,7 +19802,10 @@ async fn page_links_inbound_excludes_archived() {
     .unwrap();
     db.archive_page("page_archived_src").await.unwrap();
 
-    let inbound = db.get_page_inbound_links("page_target_in").await.unwrap();
+    let inbound = db
+        .get_page_inbound_links_scoped("page_target_in", &ReadScope::Global)
+        .await
+        .unwrap();
     let src_ids: Vec<&str> = inbound.iter().map(|(s, _)| s.as_str()).collect();
     assert!(src_ids.contains(&"page_active_src"));
     // Archived source must not surface even though the row exists in
@@ -19822,7 +19831,10 @@ async fn page_links_update_overwrites_old_links() {
     .await
     .unwrap();
 
-    let v1 = db.get_page_outbound_links("page_evolving").await.unwrap();
+    let v1 = db
+        .get_page_outbound_links_scoped("page_evolving", &ReadScope::Global)
+        .await
+        .unwrap();
     assert_eq!(v1.len(), 2);
 
     // Rewrite — Alpha drops, Gamma appears, Beta stays.
@@ -19835,7 +19847,10 @@ async fn page_links_update_overwrites_old_links() {
     .await
     .unwrap();
 
-    let v2 = db.get_page_outbound_links("page_evolving").await.unwrap();
+    let v2 = db
+        .get_page_outbound_links_scoped("page_evolving", &ReadScope::Global)
+        .await
+        .unwrap();
     let labels: std::collections::HashSet<&str> = v2.iter().map(|l| l.label.as_str()).collect();
     assert!(labels.contains("Gamma"));
     assert!(labels.contains("Beta"));
@@ -19902,7 +19917,10 @@ async fn page_links_resolve_orphans_after_target_appears() {
 
     // Confirm both source pages now point at the new target.
     for src in ["page_a", "page_b"] {
-        let out = db.get_page_outbound_links(src).await.unwrap();
+        let out = db
+            .get_page_outbound_links_scoped(src, &ReadScope::Global)
+            .await
+            .unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].target_page_id.as_deref(), Some("page_z"));
     }
@@ -19930,13 +19948,19 @@ async fn page_links_cascade_on_source_delete() {
     .unwrap();
 
     assert_eq!(
-        db.get_page_inbound_links("page_tgt").await.unwrap().len(),
+        db.get_page_inbound_links_scoped("page_tgt", &ReadScope::Global)
+            .await
+            .unwrap()
+            .len(),
         1
     );
     db.delete_page("page_src_d").await.unwrap();
     // FK cascade wipes outbound rows when the source row is deleted.
     assert_eq!(
-        db.get_page_inbound_links("page_tgt").await.unwrap().len(),
+        db.get_page_inbound_links_scoped("page_tgt", &ReadScope::Global)
+            .await
+            .unwrap()
+            .len(),
         0
     );
 }
@@ -19970,7 +19994,7 @@ async fn page_links_target_delete_becomes_orphan_and_reresolves() {
     .await
     .unwrap();
     assert_eq!(
-        db.get_page_outbound_links("page_source_keep")
+        db.get_page_outbound_links_scoped("page_source_keep", &ReadScope::Global)
             .await
             .unwrap()[0]
             .target_page_id
@@ -19980,7 +20004,7 @@ async fn page_links_target_delete_becomes_orphan_and_reresolves() {
 
     db.delete_page("page_target_old").await.unwrap();
     let target_after_delete = db
-        .get_page_outbound_links("page_source_keep")
+        .get_page_outbound_links_scoped("page_source_keep", &ReadScope::Global)
         .await
         .unwrap()[0]
         .target_page_id
@@ -20000,7 +20024,7 @@ async fn page_links_target_delete_becomes_orphan_and_reresolves() {
     .unwrap();
     let resolved = db.resolve_orphan_page_links().await.unwrap();
     let target_after_repair = db
-        .get_page_outbound_links("page_source_keep")
+        .get_page_outbound_links_scoped("page_source_keep", &ReadScope::Global)
         .await
         .unwrap()[0]
         .target_page_id

--- a/crates/wenlan-core/src/db/scoped_pages.rs
+++ b/crates/wenlan-core/src/db/scoped_pages.rs
@@ -51,6 +51,10 @@ fn page_not_found() -> WenlanError {
     WenlanError::NotFound("page not found".to_string())
 }
 
+fn page_link_label_key(label: &str) -> String {
+    label.to_lowercase()
+}
+
 /// One unresolved wikilink, still attached to the page whose body it came from.
 ///
 /// This is the row `list_orphan_link_labels_scoped` throws away:
@@ -786,39 +790,90 @@ impl MemoryDB {
         scope: &ReadScope,
     ) -> Result<Vec<crate::synthesis::wikilinks::Wikilink>, WenlanError> {
         let (scope_sql, scope_value) = page_scope_clause(scope, "c.workspace", 2);
-        let sql = format!(
-            "SELECT c.id, pl.target_page_id, pl.label FROM pages c \
-             LEFT JOIN page_links pl ON pl.source_page_id = c.id \
-             WHERE c.id = ?1{scope_sql} ORDER BY pl.label_key"
-        );
-        let mut params = vec![libsql::Value::Text(source_page_id.to_string())];
-        if let Some(value) = scope_value {
-            params.push(value);
-        }
         let conn = self.conn.lock().await;
-        let mut rows = conn.query(&sql, params).await.map_err(|error| {
+        let existence_sql = format!("SELECT c.id FROM pages c WHERE c.id = ?1{scope_sql}");
+        let mut existence_params = vec![libsql::Value::Text(source_page_id.to_string())];
+        if let Some(value) = scope_value.clone() {
+            existence_params.push(value);
+        }
+        let mut rows = conn
+            .query(&existence_sql, existence_params)
+            .await
+            .map_err(|error| {
+                WenlanError::VectorDb(format!("get_page_outbound_links_scoped: {error}"))
+            })?;
+        let found = rows
+            .next()
+            .await
+            .map_err(|error| WenlanError::VectorDb(error.to_string()))?
+            .is_some();
+        drop(rows);
+        if !found {
+            return Err(page_not_found());
+        }
+
+        let edge_sql = format!(
+            "SELECT e.dst_id, json_extract(e.payload, '$.label') \
+             FROM edges e INNER JOIN pages c ON c.id = e.src_id \
+             WHERE c.id = ?1 AND e.edge_type = 'links' \
+               AND e.src_kind = 'page' AND e.dst_kind = 'page' \
+               AND e.valid_until IS NULL{scope_sql}"
+        );
+        let mut edge_params = vec![libsql::Value::Text(source_page_id.to_string())];
+        if let Some(value) = scope_value {
+            edge_params.push(value);
+        }
+        let mut rows = conn.query(&edge_sql, edge_params).await.map_err(|error| {
             WenlanError::VectorDb(format!("get_page_outbound_links_scoped: {error}"))
         })?;
-        let mut found = false;
         let mut links = Vec::new();
         while let Some(row) = rows
             .next()
             .await
             .map_err(|error| WenlanError::VectorDb(error.to_string()))?
         {
-            found = true;
-            let Some(label) = row.get::<Option<String>>(2).unwrap_or(None) else {
+            let label = row
+                .get::<Option<String>>(1)
+                .unwrap_or(None)
+                .unwrap_or_default();
+            links.push((
+                page_link_label_key(&label),
+                crate::synthesis::wikilinks::Wikilink {
+                    target_page_id: row.get::<String>(0).ok(),
+                    label,
+                },
+            ));
+        }
+        drop(rows);
+
+        let mut rows = conn
+            .query(
+                "SELECT target_page_id, label FROM page_links \
+                 WHERE source_page_id = ?1 AND target_page_id IS NULL",
+                libsql::params![source_page_id],
+            )
+            .await
+            .map_err(|error| {
+                WenlanError::VectorDb(format!("get_page_outbound_links_scoped: {error}"))
+            })?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| WenlanError::VectorDb(error.to_string()))?
+        {
+            let Some(label) = row.get::<Option<String>>(1).unwrap_or(None) else {
                 continue;
             };
-            links.push(crate::synthesis::wikilinks::Wikilink {
-                target_page_id: row.get::<Option<String>>(1).unwrap_or(None),
-                label,
-            });
+            links.push((
+                page_link_label_key(&label),
+                crate::synthesis::wikilinks::Wikilink {
+                    target_page_id: row.get::<Option<String>>(0).unwrap_or(None),
+                    label,
+                },
+            ));
         }
-        if !found {
-            return Err(page_not_found());
-        }
-        Ok(links)
+        links.sort_by(|left, right| left.0.cmp(&right.0));
+        Ok(links.into_iter().map(|(_, link)| link).collect())
     }
 
     pub async fn get_page_inbound_links_scoped(
@@ -831,9 +886,12 @@ impl MemoryDB {
         let (target_scope_sql, target_scope_value) =
             page_scope_clause(scope, "target.workspace", 3);
         let sql = format!(
-            "SELECT target.id, source.id, pl.label FROM pages target \
-             LEFT JOIN page_links pl ON pl.target_page_id = target.id \
-             LEFT JOIN pages source ON source.id = pl.source_page_id \
+            "SELECT target.id, source.id, json_extract(e.payload, '$.label') \
+             FROM pages target \
+             LEFT JOIN edges e ON e.dst_id = target.id \
+               AND e.edge_type = 'links' AND e.src_kind = 'page' \
+               AND e.dst_kind = 'page' AND e.valid_until IS NULL \
+             LEFT JOIN pages source ON source.id = e.src_id \
                AND source.status = 'active'{source_scope_sql} \
              WHERE target.id = ?1{target_scope_sql} \
              ORDER BY source.last_modified DESC, source.id ASC"

--- a/crates/wenlan-core/src/db/scoped_pages_test.rs
+++ b/crates/wenlan-core/src/db/scoped_pages_test.rs
@@ -513,18 +513,36 @@ async fn page_links_scoped_gate_parent_and_filter_source_pages() {
         .await
         .unwrap();
     }
-    let conn = db.conn.lock().await;
-    conn.execute(
-        "INSERT INTO page_links (source_page_id, target_page_id, label, label_key)
-         VALUES ('work-source', 'work-target', 'Work target', 'work target'),
-                ('personal-source', 'work-target', 'Work target', 'work target'),
-                ('work-source', NULL, 'Work orphan', 'work orphan'),
-                ('personal-source', NULL, 'Personal orphan', 'personal orphan')",
-        (),
+    db.replace_page_links(
+        "work-source",
+        &[
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("work-target".to_string()),
+                label: "Work target".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: None,
+                label: "Work orphan".to_string(),
+            },
+        ],
     )
     .await
     .unwrap();
-    drop(conn);
+    db.replace_page_links(
+        "personal-source",
+        &[
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("work-target".to_string()),
+                label: "Work target".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: None,
+                label: "Personal orphan".to_string(),
+            },
+        ],
+    )
+    .await
+    .unwrap();
 
     let scope = ReadScope::Space("work".to_string());
     let outbound = db
@@ -550,6 +568,205 @@ async fn page_links_scoped_gate_parent_and_filter_source_pages() {
         db.get_page_sources_scoped("personal-parent", &scope).await,
         Err(crate::WenlanError::NotFound(message)) if message == "page not found"
     ));
+}
+
+#[tokio::test]
+async fn page_links_scoped_outbound_merges_edges_and_orphans_by_label_key() {
+    let (db, _tmp) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    for (id, title) in [
+        ("outbound-source", "Outbound source"),
+        ("outbound-alpha", "Alpha"),
+        ("outbound-zulu", "Zulu"),
+    ] {
+        db.insert_page_with_kind(
+            id,
+            title,
+            None,
+            "outbound label ordering",
+            None,
+            Some("work"),
+            &[],
+            &now,
+            "authored",
+            "confirmed",
+            Some("work"),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    db.replace_page_links(
+        "outbound-source",
+        &[
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("outbound-zulu".to_string()),
+                label: "zUlU".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("outbound-alpha".to_string()),
+                label: "ALPHA".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: None,
+                label: "Bravo".to_string(),
+            },
+        ],
+    )
+    .await
+    .unwrap();
+
+    let links = db
+        .get_page_outbound_links_scoped("outbound-source", &ReadScope::Global)
+        .await
+        .unwrap();
+    assert_eq!(
+        links,
+        vec![
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("outbound-alpha".to_string()),
+                label: "ALPHA".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: None,
+                label: "Bravo".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("outbound-zulu".to_string()),
+                label: "zUlU".to_string(),
+            },
+        ]
+    );
+}
+
+#[tokio::test]
+async fn page_links_scoped_inbound_reads_edges_orders_and_filters_sources() {
+    let (db, _tmp) = test_db().await;
+    for (id, workspace, modified) in [
+        ("inbound-target", "work", "2026-08-04T00:00:00Z"),
+        ("inbound-new", "work", "2026-08-04T03:00:00Z"),
+        ("inbound-old", "work", "2026-08-04T02:00:00Z"),
+        ("inbound-other-space", "personal", "2026-08-04T01:00:00Z"),
+    ] {
+        db.insert_page_with_kind(
+            id,
+            id,
+            None,
+            "inbound edge ordering",
+            None,
+            Some(workspace),
+            &[],
+            modified,
+            "authored",
+            "confirmed",
+            Some(workspace),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    for (source, label) in [
+        ("inbound-new", "New label"),
+        ("inbound-old", "Old label"),
+        ("inbound-other-space", "Other label"),
+    ] {
+        db.replace_page_links(
+            source,
+            &[crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("inbound-target".to_string()),
+                label: label.to_string(),
+            }],
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(
+        db.get_page_inbound_links_scoped("inbound-target", &ReadScope::Global)
+            .await
+            .unwrap(),
+        vec![
+            ("inbound-new".to_string(), "New label".to_string()),
+            ("inbound-old".to_string(), "Old label".to_string()),
+            ("inbound-other-space".to_string(), "Other label".to_string()),
+        ]
+    );
+    assert_eq!(
+        db.get_page_inbound_links_scoped("inbound-target", &ReadScope::Space("work".to_string()),)
+            .await
+            .unwrap(),
+        vec![
+            ("inbound-new".to_string(), "New label".to_string()),
+            ("inbound-old".to_string(), "Old label".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn page_links_scoped_outbound_reads_edges_not_resolved_page_links() {
+    let (db, _tmp) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    for id in [
+        "reader-swap-source",
+        "reader-swap-legacy-target",
+        "reader-swap-edge-target",
+    ] {
+        db.insert_page_with_kind(
+            id,
+            id,
+            None,
+            "reader swap control",
+            None,
+            Some("work"),
+            &[],
+            &now,
+            "authored",
+            "confirmed",
+            Some("work"),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO page_links (source_page_id, target_page_id, label_key, label)
+         VALUES ('reader-swap-source', 'reader-swap-legacy-target',
+                 'legacy-only', 'Legacy only')",
+        (),
+    )
+    .await
+    .unwrap();
+    let edge_id = crate::provenance::compute_edge_id(
+        "links",
+        "page",
+        "reader-swap-source",
+        "page",
+        "reader-swap-edge-target",
+        "edge-only",
+    );
+    conn.execute(
+        "INSERT INTO edges (
+             edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+             lineage, grounded, space, payload, created_at
+         ) VALUES (?1, 'reader-swap-source', 'page', 'reader-swap-edge-target',
+                   'page', 'links', 'synthesis', 0, 'work', ?2, 0)",
+        libsql::params![edge_id, r#"{"label":"Edge only"}"#],
+    )
+    .await
+    .unwrap();
+    drop(conn);
+
+    assert_eq!(
+        db.get_page_outbound_links_scoped("reader-swap-source", &ReadScope::Global)
+            .await
+            .unwrap(),
+        vec![crate::synthesis::wikilinks::Wikilink {
+            target_page_id: Some("reader-swap-edge-target".to_string()),
+            label: "Edge only".to_string(),
+        }]
+    );
 }
 
 #[tokio::test]

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -46,7 +46,6 @@ crates/wenlan-core/src/lint/pages/link_checks_test.rs|crate::lint::pages::link_c
 crates/wenlan-core/src/lint/pages/link_checks_test.rs|crate::lint::pages::link_checks::tests::link_row_count|TestDbRow::get|1
 crates/wenlan-core/src/lint/pages/link_checks_test.rs|crate::lint::pages::link_checks::tests::link_row_count|TestDbRows::next|1
 crates/wenlan-core/src/lint/pages/link_checks_test.rs|crate::lint::pages::link_checks::tests::link_row_count|TestDbSession::query|1
-crates/wenlan-core/src/lint/pages/link_checks_test/artifacts.rs|crate::lint::pages::link_checks::tests::artifacts::optional_artifacts_are_neutral_but_deterministic_broken_targets_warn|TestDbSession::execute|1
 crates/wenlan-core/src/lint/pages/link_checks_test/artifacts.rs|crate::lint::pages::link_checks::tests::artifacts::optional_artifacts_are_neutral_but_deterministic_broken_targets_warn|test_secondary_session|1
 crates/wenlan-core/src/lint/pages/link_checks_test/orphans.rs|crate::lint::pages::link_checks::tests::orphans::ambiguous_unbound_occurrence_remains_a_finding|test_secondary_session|1
 crates/wenlan-core/src/lint/pages/link_checks_test/orphans.rs|crate::lint::pages::link_checks::tests::orphans::coverage_counts_occurrences_while_metric_counts_distinct_labels|test_secondary_session|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,8 +3229,8 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        997,
-        "PR-D integration must expose the frozen 968 support calls, the 6 PR-D test identities, \
+        996,
+        "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
          the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, and \
          the 8 G6 BindPageLink repair-test calls"
     );

--- a/crates/wenlan-core/src/lint/pages/diagnostic_scale_test.rs
+++ b/crates/wenlan-core/src/lint/pages/diagnostic_scale_test.rs
@@ -114,6 +114,33 @@ async fn generate_fixture(root: &Path) {
                label TEXT NOT NULL,
                PRIMARY KEY (source_page_id, label_key)
              );
+             CREATE TABLE edges (
+               edge_id TEXT PRIMARY KEY,
+               src_id TEXT NOT NULL,
+               src_kind TEXT NOT NULL CHECK(src_kind IN ('page','memory','entity','external')),
+               dst_id TEXT NOT NULL,
+               dst_kind TEXT NOT NULL CHECK(dst_kind IN ('page','memory','entity','external')),
+               edge_type TEXT NOT NULL CHECK(edge_type IN ('mentions','relates','cites','supports','links')),
+               lineage TEXT NOT NULL CHECK(lineage IN ('assertion','evidence','synthesis','legacy')),
+               grounded INTEGER NOT NULL CHECK(grounded IN (0,1)),
+               root_id TEXT REFERENCES provenance_roots(root_id),
+               space TEXT NOT NULL,
+               weight REAL,
+               payload TEXT,
+               provenance TEXT,
+               operation_id TEXT,
+               created_at INTEGER NOT NULL,
+               superseded_by TEXT REFERENCES edges(edge_id),
+               valid_until INTEGER,
+               semantic_type TEXT
+             );
+             CREATE INDEX idx_edges_src ON edges(src_kind, src_id);
+             CREATE INDEX idx_edges_dst ON edges(dst_kind, dst_id);
+             CREATE INDEX idx_edges_root ON edges(root_id) WHERE root_id IS NOT NULL;
+             CREATE INDEX idx_edges_operation ON edges(operation_id) WHERE operation_id IS NOT NULL;
+             CREATE INDEX idx_edges_superseded ON edges(superseded_by) WHERE superseded_by IS NOT NULL;
+             CREATE INDEX idx_edges_active_grounded_space_type
+               ON edges(space, edge_type) WHERE valid_until IS NULL AND grounded = 1;
              CREATE INDEX idx_page_links_target ON page_links(target_page_id)
                WHERE target_page_id IS NOT NULL;
              CREATE INDEX idx_page_links_orphan ON page_links(label_key)

--- a/crates/wenlan-core/src/lint/pages/link_checks/artifacts.rs
+++ b/crates/wenlan-core/src/lint/pages/link_checks/artifacts.rs
@@ -86,13 +86,14 @@ async fn load_link_counts(context: &LintContext<'_, '_>) -> Result<LinkCounts, (
         .query(
             "SELECT \
                (SELECT COUNT(*) FROM pages WHERE status = 'archived'), \
-               COUNT(*), \
+               COUNT(*) + (SELECT COUNT(*) FROM page_links WHERE target_page_id IS NULL), \
                COALESCE(SUM(CASE WHEN target.status = 'active' THEN 1 ELSE 0 END), 0), \
-               COALESCE(SUM(CASE WHEN pl.target_page_id IS NOT NULL \
-                                  AND (target.id IS NULL OR target.status != 'active') \
+               COALESCE(SUM(CASE WHEN target.id IS NULL OR target.status != 'active' \
                                  THEN 1 ELSE 0 END), 0) \
-             FROM page_links pl \
-             LEFT JOIN pages target ON target.id = pl.target_page_id",
+             FROM edges e \
+             LEFT JOIN pages target ON target.id = e.dst_id \
+             WHERE e.edge_type = 'links' AND e.src_kind = 'page' \
+               AND e.dst_kind = 'page' AND e.valid_until IS NULL",
             libsql::params::Params::None,
         )
         .await

--- a/crates/wenlan-core/src/lint/pages/link_checks_test/artifacts.rs
+++ b/crates/wenlan-core/src/lint/pages/link_checks_test/artifacts.rs
@@ -7,13 +7,27 @@ async fn optional_artifacts_are_neutral_but_deterministic_broken_targets_warn() 
     insert_page(&conn, "page-active", None, "active").await;
     insert_page(&conn, "page-target", None, "active").await;
     insert_page(&conn, "page-archived-target", None, "archived").await;
-    conn.execute(
-        "INSERT INTO page_links (source_page_id, target_page_id, label_key, label) \
-         VALUES ('page-active', 'page-target', 'resolved', 'resolved'), \
-                ('page-active', 'page-missing', 'missing', 'missing'), \
-                ('page-active', 'page-archived-target', 'archived', 'archived'), \
-                ('page-active', NULL, 'unresolved', 'unresolved')",
-        (),
+    drop(conn);
+    db.replace_page_links(
+        "page-active",
+        &[
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("page-target".to_string()),
+                label: "resolved".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("page-missing".to_string()),
+                label: "missing".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: Some("page-archived-target".to_string()),
+                label: "archived".to_string(),
+            },
+            crate::synthesis::wikilinks::Wikilink {
+                target_page_id: None,
+                label: "unresolved".to_string(),
+            },
+        ],
     )
     .await
     .unwrap();

--- a/crates/wenlan-core/src/sources/page_watcher.rs
+++ b/crates/wenlan-core/src/sources/page_watcher.rs
@@ -611,7 +611,10 @@ mod tests {
 
         // The block-free body means no `mem_*` rows reach the wikilink graph
         // via replace_page_links.
-        let links = db.get_page_outbound_links("page_edit").await.unwrap();
+        let links = db
+            .get_page_outbound_links_scoped("page_edit", &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
         assert!(
             !links.iter().any(|l| l.label.starts_with("mem_")),
             "no mem_* link rows should persist; got {:?}",
@@ -760,7 +763,10 @@ mod tests {
             .await
             .unwrap();
 
-        let links = db.get_page_outbound_links("page_links").await.unwrap();
+        let links = db
+            .get_page_outbound_links_scoped("page_links", &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
         let mem_links: Vec<_> = links
             .iter()
             .filter(|l| l.label.starts_with("mem_"))
@@ -822,7 +828,10 @@ mod tests {
             .join("mem_two.md")
             .exists());
         // No mem_* page_links.
-        let links = db.get_page_outbound_links("page_rt").await.unwrap();
+        let links = db
+            .get_page_outbound_links_scoped("page_rt", &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
         assert!(links.iter().all(|l| !l.label.starts_with("mem_")));
     }
 }

--- a/crates/wenlan-core/src/synthesis/refinement_queue.rs
+++ b/crates/wenlan-core/src/synthesis/refinement_queue.rs
@@ -1361,7 +1361,10 @@ mod tests {
             survivor_sources
         );
 
-        let survivor_links = db.get_page_inbound_links("page_survivor").await.unwrap();
+        let survivor_links = db
+            .get_page_inbound_links_scoped("page_survivor", &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
         assert!(
             survivor_links
                 .iter()
@@ -1370,7 +1373,10 @@ mod tests {
             "wikilinks to the absorbed title must point at the survivor now, got {:?}",
             survivor_links
         );
-        let absorbed_links = db.get_page_inbound_links("page_absorbed").await.unwrap();
+        let absorbed_links = db
+            .get_page_inbound_links_scoped("page_absorbed", &crate::read_scope::ReadScope::Global)
+            .await
+            .unwrap();
         assert!(
             !absorbed_links
                 .iter()

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -93,6 +93,11 @@ Order by measured entanglement:
    before this store reaches Stage 3: carry the label in a `links` edge payload
    (schema change), or keep `page_links` alive as a label+orphan side-table and
    shrink the Stage 3 drop list accordingly.
+   **Status (2026-08-04):** PR #486 closed the label gap. The product-route
+   readers and `load_link_counts` now read resolved links from `edges`, while
+   orphan readers stay on `page_links`. The decision is recorded: at Stage 3,
+   `page_links` narrows to an orphan-only store rather than being dropped
+   entirely.
 2. **`relations`** (~20 fns) — clear writer choke points, but readers include
    product routes (`get_entity_detail`, `list_recent_relations`), k-hop expansion,
    and lint/repair tooling. Entangled with `entities` via shared CRUD


### PR DESCRIPTION
G6 Stage 1.1 (program: `docs/plans/2026-08-04-g6-retirement-program.md`): resolved page-link readers cut over from `page_links` to the canonical `links` edges, now that #486/#487 carry the display label in edge payload.

## What moved
- `get_page_outbound_links_scoped` / inbound (product route `GET /api/pages/{id}/links`): resolved links read active `links` edges (`valid_until IS NULL`), labels from payload `$.label`; orphan rows (`target_page_id IS NULL`) deliberately stay on `page_links` (the store narrows to orphan-only at Stage 3).
- `load_link_counts` (lint): outbound = active links edges + orphan `page_links` rows — preserves the legacy metric exactly (it counted resolved + orphans).
- Two dead unscoped readers removed from `db.rs` (zero remaining callers, verified tree-wide).

## Behavior notes
- Sort key is `label.to_lowercase()` — one definition across writer (`page_links.label_key`), edge-id derivation, and reader ordering.
- A corrupted active edge with no payload `$.label` is shown with an empty label in BOTH directions (kept, not hidden); detecting that corruption is the parity sweep's job.
- The readers have no `page_links` fallback: `reconcile_edges_parity` is now load-bearing for a product route. Live receipt (2026-08-05 ambient sweep, post-m115, post-M5-fence): drift 0, 121/121 links matched, 88 orphans correctly skipped.

## Tests
- Two behavior tests (outbound merge/order, inbound order/filter) + one divergence test (`page_links_scoped_outbound_reads_edges_not_resolved_page_links`) that seeds the two stores in disagreement and asserts the reader believes only `edges` — fails against the legacy query on both fields.
- Full suites on the integrated branch: core 4061 passed / 0 failed / 33 ignored, server 619 passed / 0 failed / 3 ignored (42 test binaries), CLI 106 passed / 0 failed / 1 ignored; fmt + clippy clean.

## Review
One independent Opus review (fix-first: 6 findings, all fixed — orphan-count semantics, archived-target branch coverage, dead fixture rows, sort-key unification, label-less symmetry, divergence test) + closure pass (clean; one dead-code nit noted for a future touch).

Post-merge runtime check at daemon upgrade: diff `GET /api/pages/{id}/links` on a vault page carrying resolved + orphan links; watch lint latency (`load_link_counts` now scans `edges` unindexed — follow-up: partial index on `edge_type WHERE valid_until IS NULL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
