### PR TITLE
feat(kg): G6 Stage 1.2 — relations readers cut over to canonical relates edges

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -596,7 +596,7 @@ impl MemoryDB {
                 // the edge (G6 Stage 1) — the merge branch just rewrote them.
                 let mut sem_rows = conn
                     .query(
-                        "SELECT confidence, explanation, source_agent FROM relations \
+                        "SELECT confidence, explanation, source_agent, created_at FROM relations \
                          WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
                         libsql::params![from.clone(), to.clone(), canonical.to_string()],
                     )
@@ -611,8 +611,14 @@ impl MemoryDB {
                         row.get::<Option<f64>>(0).unwrap_or(None),
                         row.get::<Option<String>>(1).unwrap_or(None).as_deref(),
                         row.get::<Option<String>>(2).unwrap_or(None).as_deref(),
+                        row.get::<i64>(3).unwrap_or_else(|_| chrono::Utc::now().timestamp()),
                     ),
-                    None => Self::relates_semantic_patch(None, None, None),
+                    None => Self::relates_semantic_patch(
+                        None,
+                        None,
+                        None,
+                        chrono::Utc::now().timestamp(),
+                    ),
                 };
                 drop(sem_rows);
                 let (_, mint_changes) = Self::dual_write_edge_with_payload(
@@ -804,7 +810,11 @@ pub const EMBEDDING_DIM: usize = 768;
 /// lane did while it wrote `relations` without their `edges` twin. It follows
 /// M5's judge-eligibility registry and generation fence at 110. Migration 115
 /// adds `edges.semantic_type` + the payload semantic keys (G6 Stage 1).
-pub const SCHEMA_VERSION: u32 = 115;
+/// Migration 116 backfills `payload.asserted_at` (+ fill-if-absent
+/// `source_memory_id`) on active relates edges (G6 Stage 1.2), so the
+/// migrated `relations` readers order/filter on the relation's true
+/// creation time instead of the edge's dual-write timestamp.
+pub const SCHEMA_VERSION: u32 = 116;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8657,6 +8667,17 @@ impl MemoryDB {
             if version < 115 {
                 self.migrate_115_edge_semantic_payload(version).await?;
             }
+
+            // Migration 116 (KG close plan G6, Stage 1.2): backfill
+            // `payload.asserted_at` (always) and fill-if-absent
+            // `source_memory_id` on every active relates edge from its
+            // live `relations` twin, so the migrated readers can order
+            // and filter on the relation's true creation time instead of
+            // the edge's (possibly migration-day) `created_at`. See
+            // migrate_116_relates_asserted_at.
+            if version < 116 {
+                self.migrate_116_relates_asserted_at(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -13321,7 +13342,7 @@ impl MemoryDB {
                 let mut rows = conn
                     .query(
                         "SELECT from_entity, to_entity, relation_type, \
-                                confidence, explanation, source_agent \
+                                confidence, explanation, source_agent, created_at \
                          FROM relations",
                         (),
                     )
@@ -13338,6 +13359,7 @@ impl MemoryDB {
                     let confidence: Option<f64> = row.get(3).unwrap_or(None);
                     let explanation: Option<String> = row.get(4).unwrap_or(None);
                     let source_agent: Option<String> = row.get(5).unwrap_or(None);
+                    let created_at: i64 = row.get(6).unwrap_or_default();
                     let edge_id = crate::provenance::compute_edge_id(
                         "relates",
                         "entity",
@@ -13346,13 +13368,15 @@ impl MemoryDB {
                         &to_entity,
                         &relation_type,
                     );
-                    // An empty patch is no patch (mirrors
-                    // `relates_semantic_patch`): only semantic_type is set,
-                    // and a NULL payload stays NULL instead of becoming "{}".
+                    // Migration 116 (G6 Stage 1.2) always overwrites
+                    // `asserted_at` afterward from the same live relations
+                    // row, so this call's contribution to that key is
+                    // redundant-but-harmless on a fresh full-chain upgrade.
                     let patch = Self::relates_semantic_patch(
                         confidence,
                         explanation.as_deref(),
                         source_agent.as_deref(),
+                        created_at,
                     );
                     pending.push((edge_id, relation_type, patch));
                 }
@@ -13434,6 +13458,92 @@ impl MemoryDB {
             "[migration] Migration 115 applied: semantic payload backfilled \
              ({relates_updated} relates, {cites_updated} cites, {links_updated} links updates)"
         );
+        Ok(())
+    }
+
+    /// Backfill `payload.asserted_at` (always) and fill-if-absent
+    /// `payload.source_memory_id` on every active `relates` edge, joined
+    /// structurally to its live `relations` twin on `(src_id, dst_id,
+    /// semantic_type)` = `(from_entity, to_entity, relation_type)` --
+    /// UNIQUE in `relations` (the upsert conflict target), so the join
+    /// cannot multiply rows. Edges with no matching live `relations` row
+    /// (retired legacy row, cross-store residue) are left untouched -- the
+    /// COALESCE fallback in the migrated readers covers them. Idempotent:
+    /// a rerun recomputes the same `asserted_at` from the same live row,
+    /// and `source_memory_id` is only ever filled once it is present.
+    async fn migrate_116_relates_asserted_at(&self, prior_version: i64) -> Result<(), WenlanError> {
+        self.backup_before_migration(116, prior_version).await?;
+        let conn = self.conn.lock().await;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m116 begin: {e}")))?;
+
+        let result: Result<u64, WenlanError> = async {
+            #[allow(clippy::type_complexity)]
+            let mut pending: Vec<(String, i64, Option<String>)> = Vec::new();
+            let mut rows = conn
+                .query(
+                    "SELECT e.edge_id, r.created_at, r.source_memory_id \
+                     FROM edges e \
+                     JOIN relations r \
+                       ON r.from_entity = e.src_id AND r.to_entity = e.dst_id \
+                      AND r.relation_type = e.semantic_type \
+                     WHERE e.edge_type = 'relates' AND e.valid_until IS NULL",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m116 scan: {e}")))?;
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m116 row: {e}")))?
+            {
+                let edge_id: String = row.get(0).unwrap_or_default();
+                let created_at: i64 = row.get(1).unwrap_or_default();
+                let source_memory_id: Option<String> = row.get(2).unwrap_or(None);
+                pending.push((edge_id, created_at, source_memory_id));
+            }
+            drop(rows);
+
+            let mut updated = 0u64;
+            for (edge_id, created_at, source_memory_id) in pending {
+                updated += conn
+                    .execute(
+                        "UPDATE edges SET payload = CASE \
+                             WHEN json_extract(payload, '$.source_memory_id') IS NULL \
+                                  AND ?3 IS NOT NULL \
+                             THEN json_set(json_set(COALESCE(payload, '{}'), \
+                                      '$.asserted_at', ?2), '$.source_memory_id', ?3) \
+                             ELSE json_set(COALESCE(payload, '{}'), '$.asserted_at', ?2) \
+                         END \
+                         WHERE edge_id = ?1 AND valid_until IS NULL",
+                        libsql::params![edge_id, created_at, source_memory_id],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m116 update: {e}")))?;
+            }
+            Ok(updated)
+        }
+        .await;
+
+        let updated = match result {
+            Ok(count) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m116 commit: {e}")))?;
+                count
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+
+        conn.execute("PRAGMA user_version = 116", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m116 bump: {e}")))?;
+        log::info!("[migration] Migration 116 applied: {updated} relates edges backfilled");
         Ok(())
     }
 
@@ -14358,13 +14468,15 @@ impl MemoryDB {
     /// the relation's display/audit fields, mirrored from its `relations`
     /// row. Only known values are included — `json_patch` treats a JSON
     /// null as "remove the key", so an absent value must be absent from
-    /// the patch, not null. Returns `None` when every field is absent: an
-    /// empty patch is no patch, and must not materialize a `"{}"` payload
-    /// on an edge whose payload would otherwise stay NULL.
+    /// the patch, not null. `asserted_at` (G6 Stage 1.2) mirrors the
+    /// STORED relations row's `created_at` and is always included, so the
+    /// patch is never empty — every call now carries at least this key,
+    /// unlike the pre-Stage-1.2 all-`None` case that returned `None`.
     fn relates_semantic_patch(
         confidence: Option<f64>,
         explanation: Option<&str>,
         source_agent: Option<&str>,
+        asserted_at: i64,
     ) -> Option<String> {
         let mut patch = serde_json::Map::new();
         if let Some(v) = confidence {
@@ -14376,11 +14488,8 @@ impl MemoryDB {
         if let Some(v) = source_agent {
             patch.insert("source_agent".into(), serde_json::json!(v));
         }
-        if patch.is_empty() {
-            None
-        } else {
-            Some(serde_json::Value::Object(patch).to_string())
-        }
+        patch.insert("asserted_at".into(), serde_json::json!(asserted_at));
+        Some(serde_json::Value::Object(patch).to_string())
     }
 
     /// Build the semantic-patch JSON for a `cites` edge (G6 Stage 1): the
@@ -14409,20 +14518,26 @@ impl MemoryDB {
     /// Like [`dual_write_edge`], plus an optional JSON `payload` written
     /// once at INSERT time (M3g Stage A span capture, §2.3/§6.6) and the
     /// G6 semantic fields. The `ON CONFLICT` clause below never assigns
-    /// `payload` from ?12, so a later reactivation/re-write of the same
-    /// content-addressed `edge_id` cannot clobber the PROVENANCE keys
-    /// (`span`, `model_version`, `prompt_version`, `source_memory_id`) --
+    /// `payload` from ?12 wholesale, so a later reactivation/re-write of
+    /// the same content-addressed `edge_id` cannot clobber the
+    /// PROVENANCE keys (`span`, `model_version`, `prompt_version`) --
     /// those stay write-once-at-birth by construction. The SEMANTIC keys
     /// (`label`, `link_reason`, `linked_at`, `source_kind`, `title`,
-    /// `confidence`, `explanation`, `source_agent`), passed as the
-    /// separate `semantic_patch` JSON object, are `json_patch`-MERGED on
-    /// both insert and conflict -- a re-assertion of the same fact
-    /// refreshes them (G6 Stage 1 "one source of truth", spec
-    /// docs/plans/2026-08-05-g6-edge-semantic-payload-spec.md), which is
-    /// what keeps e.g. a relation's confidence current on the edge.
-    /// `semantic_type` (the relates `relation_type`; NULL for cites, and
-    /// reserved for links) is a real column, COALESCE-kept on conflict so
-    /// a caller that does not know it cannot NULL it out.
+    /// `confidence`, `explanation`, `source_agent`, `asserted_at`),
+    /// passed as the separate `semantic_patch` JSON object, are
+    /// `json_patch`-MERGED on both insert and conflict -- a re-assertion
+    /// of the same fact refreshes them (G6 Stage 1 "one source of truth",
+    /// spec docs/plans/2026-08-05-g6-edge-semantic-payload-spec.md),
+    /// which is what keeps e.g. a relation's confidence current on the
+    /// edge. `source_memory_id` (G6 Stage 1.2) is the one exception to
+    /// write-once: it is FILL-IF-ABSENT on conflict -- when the stored
+    /// payload lacks it and `?12` carries one, that single key (only that
+    /// key, never the rest of `?12`'s provenance) is copied in, mirroring
+    /// the legacy `relations` upsert's `COALESCE(source_memory_id,
+    /// EXCLUDED.source_memory_id)`. `semantic_type` (the relates
+    /// `relation_type`; NULL for cites, and reserved for links) is a real
+    /// column, COALESCE-kept on conflict so a caller that does not know
+    /// it cannot NULL it out.
     #[allow(clippy::too_many_arguments)]
     async fn dual_write_edge_with_payload(
         conn: &libsql::Connection,
@@ -14551,8 +14666,15 @@ impl MemoryDB {
                  superseded_by = NULL,
                  space = excluded.space,
                  semantic_type = COALESCE(?13, edges.semantic_type),
-                 payload = CASE WHEN ?14 IS NULL THEN edges.payload
-                                ELSE json_patch(COALESCE(edges.payload, '{}'), ?14) END,
+                 payload = CASE
+                     WHEN json_extract(edges.payload, '$.source_memory_id') IS NULL
+                          AND json_extract(?12, '$.source_memory_id') IS NOT NULL
+                     THEN json_set(
+                              json_patch(COALESCE(edges.payload, '{}'), COALESCE(?14, '{}')),
+                              '$.source_memory_id', json_extract(?12, '$.source_memory_id'))
+                     WHEN ?14 IS NOT NULL THEN json_patch(COALESCE(edges.payload, '{}'), ?14)
+                     ELSE edges.payload
+                 END,
                  lineage = CASE
                      WHEN edges.valid_until IS NOT NULL THEN excluded.lineage
                      WHEN ?11 = 1 THEN 'legacy'
@@ -14569,7 +14691,9 @@ impl MemoryDB {
                 OR (excluded.lineage = 'synthesis' AND edges.lineage NOT IN ('evidence', 'synthesis'))
                 OR (excluded.lineage = 'assertion' AND edges.lineage != 'assertion')
                 OR ?13 IS NOT NULL
-                OR ?14 IS NOT NULL",
+                OR ?14 IS NOT NULL
+                OR (json_extract(edges.payload, '$.source_memory_id') IS NULL
+                    AND json_extract(?12, '$.source_memory_id') IS NOT NULL)",
             libsql::params![
                 edge_id.clone(),
                 src_id.to_string(),
@@ -15114,6 +15238,13 @@ impl MemoryDB {
     /// write is parity-invisible to the M2 oracle (§1). No LLM/embedding call
     /// happens here (§6.3): entailment ran outside, and each survivor's root was
     /// minted before this call. Returns the number of edges ACTUALLY flipped.
+    // 2026-08-05, G6 Stage 1.2 deliberate carryover: the `EXISTS (SELECT 1
+    // FROM relations WHERE id = ?4 ...)` guard below stays on `relations`.
+    // The M5 grounding validator deliberately checks the legacy row as an
+    // INDEPENDENT witness of the promoted fact -- collapsing it onto the
+    // same `edges` row the UPDATE targets would remove that independence.
+    // Redesign belongs to Stage 2, not a reader swap (see
+    // docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md).
     pub async fn promote_edges_grounded(
         &self,
         survivors: &[crate::edge_grounding::EdgePromotion],
@@ -26123,16 +26254,18 @@ impl MemoryDB {
                 ),
             };
             let sql = format!(
-                "SELECT r.from_entity, r.to_entity FROM relations r
-                 JOIN entities ef ON ef.id = r.from_entity
-                 JOIN entities et ON et.id = r.to_entity
-                 WHERE r.from_entity IN ({ph}) {endpoint_scope}
+                "SELECT r.src_id, r.dst_id FROM edges r
+                 JOIN entities ef ON ef.id = r.src_id
+                 JOIN entities et ON et.id = r.dst_id
+                 WHERE r.edge_type='relates' AND r.valid_until IS NULL
+                   AND r.src_id IN ({ph}) {endpoint_scope}
                  UNION
-                 SELECT r.from_entity, r.to_entity FROM relations r
-                 JOIN entities ef ON ef.id = r.from_entity
-                 JOIN entities et ON et.id = r.to_entity
-                 WHERE r.to_entity IN ({ph}) {endpoint_scope}
-                 ORDER BY from_entity, to_entity",
+                 SELECT r.src_id, r.dst_id FROM edges r
+                 JOIN entities ef ON ef.id = r.src_id
+                 JOIN entities et ON et.id = r.dst_id
+                 WHERE r.edge_type='relates' AND r.valid_until IS NULL
+                   AND r.dst_id IN ({ph}) {endpoint_scope}
+                 ORDER BY src_id, dst_id",
                 ph = ph
             );
             let mut params: Vec<libsql::Value> = frontier
@@ -26657,15 +26790,17 @@ impl MemoryDB {
                 ),
             };
             let sql = format!(
-                "SELECT r.to_entity FROM relations r
-                 JOIN entities ef ON ef.id = r.from_entity
-                 JOIN entities et ON et.id = r.to_entity
-                 WHERE r.from_entity IN ({ph}) {endpoint_scope}
+                "SELECT r.dst_id FROM edges r
+                 JOIN entities ef ON ef.id = r.src_id
+                 JOIN entities et ON et.id = r.dst_id
+                 WHERE r.edge_type='relates' AND r.valid_until IS NULL
+                   AND r.src_id IN ({ph}) {endpoint_scope}
                  UNION
-                 SELECT r.from_entity FROM relations r
-                 JOIN entities ef ON ef.id = r.from_entity
-                 JOIN entities et ON et.id = r.to_entity
-                 WHERE r.to_entity IN ({ph}) {endpoint_scope}",
+                 SELECT r.src_id FROM edges r
+                 JOIN entities ef ON ef.id = r.src_id
+                 JOIN entities et ON et.id = r.dst_id
+                 WHERE r.edge_type='relates' AND r.valid_until IS NULL
+                   AND r.dst_id IN ({ph}) {endpoint_scope}",
                 ph = ph
             );
 
@@ -32315,7 +32450,7 @@ impl MemoryDB {
                 // just moved the row under this (from, to, type) triple.
                 let mut sem_rows = conn
                     .query(
-                        "SELECT confidence, explanation, source_agent FROM relations \
+                        "SELECT confidence, explanation, source_agent, created_at FROM relations \
                          WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
                         libsql::params![
                             plan.src_id.clone(),
@@ -32334,8 +32469,14 @@ impl MemoryDB {
                         row.get::<Option<f64>>(0).unwrap_or(None),
                         row.get::<Option<String>>(1).unwrap_or(None).as_deref(),
                         row.get::<Option<String>>(2).unwrap_or(None).as_deref(),
+                        row.get::<i64>(3).unwrap_or_else(|_| chrono::Utc::now().timestamp()),
                     ),
-                    None => Self::relates_semantic_patch(None, None, None),
+                    None => Self::relates_semantic_patch(
+                        None,
+                        None,
+                        None,
+                        chrono::Utc::now().timestamp(),
+                    ),
                 };
                 drop(sem_rows);
                 let (new_edge_id, reactivation_changes) = Self::dual_write_edge_with_payload(
@@ -32786,13 +32927,16 @@ impl MemoryDB {
             // Check if this was an insert (the id we generated exists) vs an update.
             let mut rows = conn
                 .query(
-                    "SELECT id, confidence, explanation, source_agent FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
+                    "SELECT id, confidence, explanation, source_agent, created_at FROM relations WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
                     libsql::params![from_entity.to_string(), to_entity.to_string(), canonical.clone()],
                 )
                 .await?;
             // The edge's semantic patch mirrors the STORED row, not this
             // call's arguments — the upsert above keeps the higher
             // confidence, so a weaker re-assert must not regress the edge.
+            // `created_at` likewise mirrors the STORED row (immutable under
+            // the upsert), never `now` — that is `asserted_at`'s whole point
+            // (G6 Stage 1.2 trap 1: edges.created_at is not a substitute).
             let (existing_id, semantic_patch) = match rows.next().await? {
                 Some(row) => (
                     row.get::<String>(0).unwrap_or(id.clone()),
@@ -32800,11 +32944,12 @@ impl MemoryDB {
                         row.get::<Option<f64>>(1).unwrap_or(None),
                         row.get::<Option<String>>(2).unwrap_or(None).as_deref(),
                         row.get::<Option<String>>(3).unwrap_or(None).as_deref(),
+                        row.get::<i64>(4).unwrap_or(now),
                     ),
                 ),
                 None => (
                     id.clone(),
-                    Self::relates_semantic_patch(confidence, explanation, source_agent),
+                    Self::relates_semantic_patch(confidence, explanation, source_agent, now),
                 ),
             };
             drop(rows);
@@ -33080,17 +33225,21 @@ impl MemoryDB {
         // Fetch relations (both directions) with entity names
         let mut rel_rows = conn
             .query(
-                "SELECT r.id, r.relation_type, r.source_agent, r.created_at,
-                        'outgoing' as direction, r.to_entity as entity_id,
+                "SELECT r.edge_id, r.semantic_type, json_extract(r.payload, '$.source_agent'),
+                        COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at),
+                        'outgoing' as direction, r.dst_id as entity_id,
                         e.name as entity_name, e.entity_type as entity_type
-                 FROM relations r JOIN entities e ON e.id = r.to_entity
-                 WHERE r.from_entity = ?1
+                 FROM edges r JOIN entities e ON e.id = r.dst_id
+                 WHERE r.edge_type = 'relates' AND r.valid_until IS NULL
+                       AND r.src_id = ?1 AND r.semantic_type IS NOT NULL
                  UNION ALL
-                 SELECT r.id, r.relation_type, r.source_agent, r.created_at,
-                        'incoming' as direction, r.from_entity as entity_id,
+                 SELECT r.edge_id, r.semantic_type, json_extract(r.payload, '$.source_agent'),
+                        COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at),
+                        'incoming' as direction, r.src_id as entity_id,
                         e.name as entity_name, e.entity_type as entity_type
-                 FROM relations r JOIN entities e ON e.id = r.from_entity
-                 WHERE r.to_entity = ?1
+                 FROM edges r JOIN entities e ON e.id = r.src_id
+                 WHERE r.edge_type = 'relates' AND r.valid_until IS NULL
+                       AND r.dst_id = ?1 AND r.semantic_type IS NOT NULL
                  ORDER BY 4 DESC",
                 libsql::params![entity_id],
             )
@@ -33991,7 +34140,7 @@ impl MemoryDB {
                     // re-extraction must not regress the edge).
                     let mut sem_rows = conn
                         .query(
-                            "SELECT confidence, explanation, source_agent FROM relations \
+                            "SELECT confidence, explanation, source_agent, created_at FROM relations \
                              WHERE from_entity = ?1 AND to_entity = ?2 AND relation_type = ?3",
                             libsql::params![
                                 from_id.as_str(),
@@ -34014,11 +34163,13 @@ impl MemoryDB {
                             row.get::<Option<f64>>(0).unwrap_or(None),
                             row.get::<Option<String>>(1).unwrap_or(None).as_deref(),
                             row.get::<Option<String>>(2).unwrap_or(None).as_deref(),
+                            row.get::<i64>(3).unwrap_or(now),
                         ),
                         None => Self::relates_semantic_patch(
                             relation.confidence,
                             relation.explanation.as_deref(),
                             Some("post_ingest"),
+                            now,
                         ),
                     };
                     drop(sem_rows);
@@ -36862,16 +37013,18 @@ impl MemoryDB {
         since_ms: Option<i64>,
     ) -> Result<Vec<wenlan_types::RecentRelation>, WenlanError> {
         let conn = self.conn.lock().await;
-        let sql = "SELECT r.id, r.from_entity, r.relation_type, r.to_entity, \
+        let sql = "SELECT r.edge_id, r.src_id, r.semantic_type, r.dst_id, \
                    e1.name AS from_entity_name, e2.name AS to_entity_name, \
-                   r.created_at \
-                   FROM relations r \
-                   JOIN entities e1 ON r.from_entity = e1.id \
-                   JOIN entities e2 ON r.to_entity = e2.id \
-                   WHERE (?1 IS NULL OR r.created_at >= ?1) \
+                   COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) AS asserted_ts \
+                   FROM edges r \
+                   JOIN entities e1 ON r.src_id = e1.id \
+                   JOIN entities e2 ON r.dst_id = e2.id \
+                   WHERE r.edge_type = 'relates' AND r.valid_until IS NULL \
+                   AND r.semantic_type IS NOT NULL \
+                   AND (?1 IS NULL OR COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) >= ?1) \
                    AND e1.name IS NOT NULL AND e1.name != '' \
                    AND e2.name IS NOT NULL AND e2.name != '' \
-                   ORDER BY r.created_at DESC LIMIT ?2";
+                   ORDER BY asserted_ts DESC LIMIT ?2";
         let mut rows = conn
             .query(sql, libsql::params![since_ms, limit as i64])
             .await

--- a/crates/wenlan-core/src/db/kg_quality_diagnostics.rs
+++ b/crates/wenlan-core/src/db/kg_quality_diagnostics.rs
@@ -10,6 +10,11 @@ pub(crate) struct ContradictionObservationCount {
 }
 
 impl MemoryDB {
+    // 2026-08-05, G6 Stage 1.2 deliberate carryover: stays on `relations`.
+    // `payload.source_memory_id` now converges via migration 116 + the
+    // writer's fill-if-absent semantics, but historical completeness isn't
+    // proven yet -- this reader migrates with the final relations-exit PR
+    // (see docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md).
     pub(crate) async fn count_stale_relation_sources(&self) -> Result<usize, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn

--- a/crates/wenlan-core/src/db/kg_quality_vocabulary.rs
+++ b/crates/wenlan-core/src/db/kg_quality_vocabulary.rs
@@ -4,6 +4,14 @@ use super::MemoryDB;
 use crate::error::WenlanError;
 
 impl MemoryDB {
+    // 2026-08-05, G6 Stage 1.2 deliberate carryover: stays on `relations`,
+    // not `edges`. This is writer coupling, not drift detection -- the
+    // healer's writer, `fold_relation_type` (db.rs), enumerates
+    // `SELECT ... FROM relations WHERE relation_type = ?1` to do the actual
+    // fold. If discovery read `edges` here while repair enumerates
+    // `relations`, the healer would discover a type it then folds zero rows
+    // for. Migrate this reader only alongside `fold_relation_type` itself
+    // (see docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md).
     pub(crate) async fn distinct_relation_types_for_vocabulary_heal(
         &self,
     ) -> Result<Vec<String>, WenlanError> {

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -10879,6 +10879,103 @@ async fn test_get_entity_detail() {
     assert_eq!(origin_detail.relations[0].entity_name, "Alice");
 }
 
+/// G6 Stage 1.2 (relations-readers migration,
+/// docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md):
+/// get_entity_detail now reads active `relates` edges instead of
+/// `relations` rows. The relation `id` is therefore the edge's
+/// content-addressed `edge_id`, not the legacy `relations` row's uuid (no
+/// route dereferences it back into `relations`, so this wire-visible id
+/// swap is safe), and `created_at` is sourced via `asserted_at`, which
+/// mirrors the relations row's own `created_at`.
+#[tokio::test]
+async fn get_entity_detail_reads_relates_edge_fields() {
+    let (db, _dir) = test_db().await;
+    let alice_id = db
+        .store_entity(
+            "Alice G6",
+            "person",
+            Some("work"),
+            Some("claude"),
+            Some(0.9),
+        )
+        .await
+        .unwrap();
+    let wenlan_id = db
+        .store_entity("Wenlan G6", "project", Some("work"), None, None)
+        .await
+        .unwrap();
+    db.create_relation(
+        &alice_id,
+        &wenlan_id,
+        "works_on",
+        Some("claude"),
+        Some(0.9),
+        Some("seen"),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let relation_type = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT relation_type FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
+                libsql::params![alice_id.as_str(), wenlan_id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next()
+            .await
+            .unwrap()
+            .expect("relation row")
+            .get::<String>(0)
+            .unwrap()
+    };
+    let expected_edge_id = crate::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &alice_id,
+        "entity",
+        &wenlan_id,
+        &relation_type,
+    );
+
+    let detail = db.get_entity_detail(&alice_id).await.unwrap();
+    assert_eq!(detail.relations.len(), 1);
+    let relation = &detail.relations[0];
+    assert_eq!(
+        relation.id, expected_edge_id,
+        "relation id must be the active edge's edge_id, not the relations row uuid"
+    );
+    assert_eq!(relation.relation_type, relation_type);
+    assert_eq!(relation.source_agent.as_deref(), Some("claude"));
+    assert_eq!(relation.direction, "outgoing");
+    assert_eq!(relation.entity_id, wenlan_id);
+    assert_eq!(relation.entity_name, "Wenlan G6");
+
+    let stored_created_at: i64 = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT created_at FROM relations WHERE from_entity = ?1 AND to_entity = ?2",
+                libsql::params![alice_id.as_str(), wenlan_id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next()
+            .await
+            .unwrap()
+            .expect("relation row")
+            .get(0)
+            .unwrap()
+    };
+    assert_eq!(
+        relation.created_at, stored_created_at,
+        "created_at must mirror the relations row's created_at via asserted_at"
+    );
+}
+
 #[tokio::test]
 async fn test_update_observation() {
     let (db, _dir) = test_db().await;
@@ -29804,7 +29901,9 @@ async fn migration_114_resyncs_stale_entity_shadow_pages() {
 async fn migration_115_backfills_edge_semantic_payload() {
     let (db, _dir) = test_db().await;
 
-    // relates — live path (dual-writes the edge with payload=NULL today).
+    // relates — live path (post-#486, dual-writes the edge with a
+    // `relates_semantic_patch` payload -- `asserted_at` always, plus
+    // `source_memory_id` when supplied -- never payload=NULL).
     let from = db
         .store_entity("Alice", "person", Some("work"), None, None)
         .await
@@ -30061,6 +30160,405 @@ async fn migration_115_backfills_edge_semantic_payload() {
             "pass {pass}: links display label"
         );
     }
+}
+
+/// G6 Stage 1.2 (docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md):
+/// migration 116 backfills `payload.asserted_at` (always) and fills
+/// `payload.source_memory_id` only when absent, from the live `relations`
+/// twin. A pre-Stage-1.2 edge is simulated by clearing both keys after the
+/// write (the writer now stamps them at insert time, so a fresh write is
+/// never actually missing them). The loop runs the migration twice: the
+/// second pass must converge on the identical end-state.
+#[tokio::test]
+async fn migration_116_backfills_asserted_at_and_fills_source_memory_id() {
+    let (db, _dir) = test_db().await;
+    let from = db
+        .create_entity("G6 Backfill A", "person", Some("space_a"))
+        .await
+        .unwrap();
+    let to = db
+        .create_entity("G6 Backfill B", "project", Some("space_a"))
+        .await
+        .unwrap();
+    db.create_relation(
+        &from,
+        &to,
+        "relates_to",
+        Some("agent"),
+        Some(0.5),
+        None,
+        Some("mem_backfill"),
+    )
+    .await
+    .unwrap();
+
+    let forced_created_at = 1_000_000_000i64;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE relations SET created_at = ?1 WHERE from_entity = ?2 AND to_entity = ?3",
+            libsql::params![forced_created_at, from.as_str(), to.as_str()],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "UPDATE edges SET payload = json_remove(payload, '$.asserted_at', '$.source_memory_id') \
+             WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?2",
+            libsql::params![from.as_str(), to.as_str()],
+        )
+        .await
+        .unwrap();
+    }
+
+    for pass in 1..=2 {
+        db.migrate_116_relates_asserted_at(115).await.unwrap();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT json_extract(payload, '$.asserted_at'), \
+                        json_extract(payload, '$.source_memory_id') \
+                 FROM edges WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?2",
+                libsql::params![from.as_str(), to.as_str()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().expect("relates edge active");
+        assert_eq!(
+            row.get::<Option<i64>>(0).unwrap(),
+            Some(forced_created_at),
+            "pass {pass}: asserted_at must mirror the relations row's created_at"
+        );
+        assert_eq!(
+            row.get::<Option<String>>(1).unwrap().as_deref(),
+            Some("mem_backfill"),
+            "pass {pass}: source_memory_id must fill in when absent"
+        );
+    }
+}
+
+/// G6 Stage 1.2: the payload backfill migration 116 is non-structural (it
+/// only touches `edges.payload`), so it must never introduce parity drift.
+#[tokio::test]
+async fn migration_116_keeps_relates_edge_parity_clean() {
+    let (db, _dir) = test_db().await;
+    let from = db
+        .create_entity("G6 Parity A", "person", Some("space_a"))
+        .await
+        .unwrap();
+    let to = db
+        .create_entity("G6 Parity B", "project", Some("space_a"))
+        .await
+        .unwrap();
+    db.create_relation(
+        &from,
+        &to,
+        "relates_to",
+        Some("agent"),
+        Some(0.7),
+        None,
+        Some("mem_parity"),
+    )
+    .await
+    .unwrap();
+
+    db.migrate_116_relates_asserted_at(115).await.unwrap();
+
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "the payload backfill must not disturb edges parity"
+    );
+}
+
+/// G6 Stage 1.2 divergence test (Sol review S3): no other test can tell
+/// whether a migrated reader actually reads `edges` versus `relations`, since
+/// every OTHER fixture keeps both stores in parity via the dual-write. Here
+/// they're deliberately split: one relates fact exists ONLY in `edges`, and
+/// TWO exist ONLY in `relations` (asymmetric counts so a reader that quietly
+/// fell back to `relations` would report a different number, not the same
+/// one by coincidence). Covers readers #1 (`expand_anchor_entities_khop`),
+/// #2 (`expand_entities_khop_scoped`), #3 (`aggregate_counts`), #5
+/// (`get_entity_detail`), #7 (`list_recent_relations`), #9
+/// (`relation_vocabulary`), and #11 (`relation_integrity`) — each must see
+/// the edge-only fact and stay blind to the relations-only orphans. Readers
+/// #4 (`entity_scope_clause`) and #13 (`load_relations`, both in
+/// `lint/semantic_candidates.rs`) are NOT exercised by this test.
+#[tokio::test]
+async fn migrated_readers_diverge_from_relations_and_follow_edges() {
+    let (db, _dir) = test_db().await;
+    let edge_src = db
+        .create_entity("G6 Divergence EdgeSrc", "thing", None)
+        .await
+        .unwrap();
+    let edge_dst = db
+        .create_entity("G6 Divergence EdgeDst", "thing", None)
+        .await
+        .unwrap();
+    let rel_src = db
+        .create_entity("G6 Divergence RelSrc", "thing", None)
+        .await
+        .unwrap();
+    let rel_dst = db
+        .create_entity("G6 Divergence RelDst", "thing", None)
+        .await
+        .unwrap();
+
+    {
+        let conn = db.conn.lock().await;
+        // Edge-only fact: no `relations` twin.
+        conn.execute(
+            "INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type)
+             VALUES ('edge-only-1',?1,'entity',?2,'entity','relates','legacy',0,?3,1,'edge_only_type')",
+            libsql::params![edge_src.clone(), edge_dst.clone(), UNFILED_SPACE_ID],
+        )
+        .await
+        .unwrap();
+        // Two relations-only orphans (asymmetric count vs the one edge-only
+        // fact above): no `edges` twin for either.
+        conn.execute(
+            "INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at)
+             VALUES ('rel-only-1',?1,?2,'rel_only_type_a',1)",
+            libsql::params![rel_src.clone(), rel_dst.clone()],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at)
+             VALUES ('rel-only-2',?1,?2,'rel_only_type_b',1)",
+            libsql::params![rel_src.clone(), rel_dst.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    // Reader #5: get_entity_detail.
+    let edge_detail = db.get_entity_detail(&edge_src).await.unwrap();
+    assert!(
+        edge_detail
+            .relations
+            .iter()
+            .any(|r| r.entity_id == edge_dst),
+        "must see the edge-only relation"
+    );
+    let rel_detail = db.get_entity_detail(&rel_src).await.unwrap();
+    assert!(
+        rel_detail.relations.is_empty(),
+        "must not see the relations-only orphans"
+    );
+
+    // Reader #7: list_recent_relations.
+    let recent = db.list_recent_relations(50, None).await.unwrap();
+    assert!(
+        recent
+            .iter()
+            .any(|r| r.from_entity_id == edge_src && r.to_entity_id == edge_dst),
+        "must see the edge-only relation"
+    );
+    assert!(
+        !recent
+            .iter()
+            .any(|r| r.from_entity_id == rel_src && r.to_entity_id == rel_dst),
+        "must not see the relations-only orphans"
+    );
+
+    // Readers #1/#2: k-hop expansion.
+    let expanded = temp_env::async_with_vars([("WENLAN_GRAPH_KHOP_DEPTH", Some("1"))], async {
+        db.expand_anchor_entities_khop(std::slice::from_ref(&edge_src), &ReadScope::Global)
+            .await
+            .unwrap()
+    })
+    .await;
+    assert!(
+        expanded.contains(&edge_dst),
+        "khop must reach the edge-only neighbor"
+    );
+    let not_expanded = temp_env::async_with_vars([("WENLAN_GRAPH_KHOP_DEPTH", Some("1"))], async {
+        db.expand_anchor_entities_khop(std::slice::from_ref(&rel_src), &ReadScope::Global)
+            .await
+            .unwrap()
+    })
+    .await;
+    assert!(
+        !not_expanded.contains(&rel_dst),
+        "khop must not reach a relations-only orphan"
+    );
+
+    // Reader #2: expand_entities_khop_scoped (explicit-param sibling of #1).
+    let expanded_scoped = db
+        .expand_entities_khop_scoped(std::slice::from_ref(&edge_src), 1, 64, &ReadScope::Global)
+        .await
+        .unwrap();
+    assert!(
+        expanded_scoped.contains(&edge_dst),
+        "scoped khop must reach the edge-only neighbor"
+    );
+    let not_expanded_scoped = db
+        .expand_entities_khop_scoped(std::slice::from_ref(&rel_src), 1, 64, &ReadScope::Global)
+        .await
+        .unwrap();
+    assert!(
+        !not_expanded_scoped.contains(&rel_dst),
+        "scoped khop must not reach a relations-only orphan"
+    );
+
+    // Readers #3, #9, #11: Deep profile is a registered superset of General
+    // (see deep_profile_is_a_registered_superset_without_duplicate_general_checks),
+    // so one report covers relation_integrity + aggregate_counts (General/kg)
+    // and relation_vocabulary (Deep).
+    let report = crate::lint::runner::LintRunner::new(
+        crate::lint::context::LintClock::fixed(),
+        crate::lint::context::CancellationToken::new(),
+    )
+    .run(
+        &db,
+        &wenlan_types::lint::LintQuery {
+            profile: Some(wenlan_types::lint::LintProfile::Deep),
+            space: None,
+        },
+        None,
+        false,
+    )
+    .await
+    .unwrap();
+    let find_check = |id: &str| {
+        report
+            .checks()
+            .iter()
+            .find(|check| check.check_id() == id)
+            .unwrap_or_else(|| panic!("missing check {id}"))
+    };
+    assert_eq!(
+        find_check("relations.integrity").coverage().denominator(),
+        1,
+        "relation_integrity population must come from edges (1), not relations (2)"
+    );
+    assert_eq!(
+        find_check("relations.vocabulary_integrity")
+            .coverage()
+            .denominator(),
+        1,
+        "relation_vocabulary population must come from edges (1), not relations (2)"
+    );
+    let kg_relations_count = find_check("kg.aggregate_inventory")
+        .metrics()
+        .iter()
+        .find_map(|metric| {
+            (metric.code() == wenlan_types::lint::LintMetricCode::KgRelations).then(|| match metric
+                .value()
+            {
+                wenlan_types::lint::LintMetricValue::Count { value } => *value,
+                _ => 0,
+            })
+        })
+        .unwrap();
+    assert_eq!(
+        kg_relations_count, 1,
+        "aggregate_counts must count edges (1), not relations (2)"
+    );
+}
+
+/// G6 Stage 1.2 Trap 1 (recency scramble): `edges.created_at` is
+/// migration-day for m81-backfilled edges, not a substitute for
+/// `relations.created_at`. `list_recent_relations` must order and filter
+/// on `asserted_at` (COALESCE'd to `edges.created_at` only when absent),
+/// never on the edge's own dual-write timestamp.
+#[tokio::test]
+async fn list_recent_relations_orders_by_asserted_at_not_edge_created_at() {
+    let (db, _dir) = test_db().await;
+    let hub = db
+        .create_entity("G6 Recency Hub", "person", Some("space_a"))
+        .await
+        .unwrap();
+    let e_a = db
+        .create_entity("G6 Recency A", "project", Some("space_a"))
+        .await
+        .unwrap();
+    let e_b = db
+        .create_entity("G6 Recency B", "project", Some("space_a"))
+        .await
+        .unwrap();
+    let e_c = db
+        .create_entity("G6 Recency C", "project", Some("space_a"))
+        .await
+        .unwrap();
+    let e_d = db
+        .create_entity("G6 Recency D", "project", Some("space_a"))
+        .await
+        .unwrap();
+
+    // "type_a".."type_d" all fold to the same normalized relation_type
+    // (create_relation resolves unknown types against the shared
+    // vocabulary), so ordering is asserted on the target entity name
+    // instead -- the (from, to) pair is already unique per target below.
+    db.create_relation(&hub, &e_a, "type_a", None, None, None, None)
+        .await
+        .unwrap();
+    db.create_relation(&hub, &e_b, "type_b", None, None, None, None)
+        .await
+        .unwrap();
+    db.create_relation(&hub, &e_c, "type_c", None, None, None, None)
+        .await
+        .unwrap();
+    db.create_relation(&hub, &e_d, "type_d", None, None, None, None)
+        .await
+        .unwrap();
+
+    // Force distinct relations.created_at (the truth) mirrored onto
+    // edges.payload.asserted_at. e_d additionally gets a much newer
+    // edges.created_at (an m81-style backfill mismatch) to prove ordering
+    // and since_ms filtering key off asserted_at, not edges.created_at.
+    {
+        let conn = db.conn.lock().await;
+        for (target, created_at) in [
+            (&e_a, 1_000i64),
+            (&e_b, 2_000i64),
+            (&e_c, 3_000i64),
+            (&e_d, 500i64),
+        ] {
+            conn.execute(
+                "UPDATE relations SET created_at = ?1 \
+                 WHERE from_entity = ?2 AND to_entity = ?3",
+                libsql::params![created_at, hub.as_str(), target.as_str()],
+            )
+            .await
+            .unwrap();
+            conn.execute(
+                "UPDATE edges SET payload = json_set(COALESCE(payload, '{}'), '$.asserted_at', ?1) \
+                 WHERE edge_type = 'relates' AND src_id = ?2 AND dst_id = ?3",
+                libsql::params![created_at, hub.as_str(), target.as_str()],
+            )
+            .await
+            .unwrap();
+        }
+        conn.execute(
+            "UPDATE edges SET created_at = 9999999 \
+             WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?2",
+            libsql::params![hub.as_str(), e_d.as_str()],
+        )
+        .await
+        .unwrap();
+    }
+
+    let all = db.list_recent_relations(10, None).await.unwrap();
+    let names: Vec<&str> = all.iter().map(|r| r.to_entity_name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "G6 Recency C",
+            "G6 Recency B",
+            "G6 Recency A",
+            "G6 Recency D"
+        ],
+        "order must follow asserted_at DESC, not edges.created_at"
+    );
+
+    let since = db.list_recent_relations(10, Some(1_500)).await.unwrap();
+    let since_names: Vec<&str> = since.iter().map(|r| r.to_entity_name.as_str()).collect();
+    assert_eq!(
+        since_names,
+        vec!["G6 Recency C", "G6 Recency B"],
+        "since_ms must filter on asserted_at, not edges.created_at"
+    );
 }
 
 /// G6 Stage 1 writer teeth: the live producers must carry semantic fields at
@@ -47157,6 +47655,35 @@ async fn source_backed_relation_retry_preserves_original_relation_and_edge_prove
     assert_eq!(
         relation_source, edge_source,
         "relation and extraction edge provenance must agree after retry"
+    );
+
+    // G6 Stage 1.2: asserted_at must still mirror the ORIGINAL stored row's
+    // created_at (immutable under the upsert), never `now` at the retry;
+    // confidence keeps the higher (0.9) value the retry supplied.
+    let original_created_at: i64 = {
+        let mut rows = conn
+            .query(
+                "SELECT created_at FROM relations WHERE id = ?1",
+                libsql::params![retry_id.clone()],
+            )
+            .await
+            .unwrap();
+        rows.next()
+            .await
+            .unwrap()
+            .expect("relation row")
+            .get(0)
+            .unwrap()
+    };
+    assert_eq!(
+        payload["asserted_at"],
+        serde_json::json!(original_created_at),
+        "asserted_at must mirror the ORIGINAL stored relation's created_at across the re-assert"
+    );
+    assert_eq!(
+        payload["confidence"],
+        serde_json::json!(0.9),
+        "confidence must reflect the STORED (higher) value after the re-assert"
     );
 }
 

--- a/crates/wenlan-core/src/db/scoped_entities.rs
+++ b/crates/wenlan-core/src/db/scoped_entities.rs
@@ -212,17 +212,23 @@ impl MemoryDB {
             ReadScope::Global => unreachable!(),
         };
         let relation_sql = format!(
-            "SELECT r.id, r.relation_type, r.source_agent, r.created_at, \
-                    'outgoing' AS direction, r.to_entity AS entity_id, \
+            "SELECT r.edge_id, r.semantic_type, json_extract(r.payload, '$.source_agent'), \
+                    COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at), \
+                    'outgoing' AS direction, r.dst_id AS entity_id, \
                     e.name AS entity_name, e.entity_type AS entity_type \
-             FROM relations r JOIN entities e ON e.id = r.to_entity \
-             WHERE r.from_entity = ?1 {endpoint_filter} \
+             FROM edges r JOIN entities e ON e.id = r.dst_id \
+             WHERE r.edge_type = 'relates' AND r.valid_until IS NULL \
+               AND r.semantic_type IS NOT NULL \
+               AND r.src_id = ?1 {endpoint_filter} \
              UNION ALL \
-             SELECT r.id, r.relation_type, r.source_agent, r.created_at, \
-                    'incoming' AS direction, r.from_entity AS entity_id, \
+             SELECT r.edge_id, r.semantic_type, json_extract(r.payload, '$.source_agent'), \
+                    COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at), \
+                    'incoming' AS direction, r.src_id AS entity_id, \
                     e.name AS entity_name, e.entity_type AS entity_type \
-             FROM relations r JOIN entities e ON e.id = r.from_entity \
-             WHERE r.to_entity = ?1 {endpoint_filter} \
+             FROM edges r JOIN entities e ON e.id = r.src_id \
+             WHERE r.edge_type = 'relates' AND r.valid_until IS NULL \
+               AND r.semantic_type IS NOT NULL \
+               AND r.dst_id = ?1 {endpoint_filter} \
              ORDER BY 4 DESC"
         );
         let mut relation_values = vec![libsql::Value::Text(entity_id.to_string())];
@@ -323,16 +329,19 @@ impl MemoryDB {
             ReadScope::Global => unreachable!(),
         };
         let sql = format!(
-            "SELECT r.id, r.from_entity, r.relation_type, r.to_entity, \
-                    e1.name, e2.name, r.created_at \
-             FROM relations r \
-             JOIN entities e1 ON r.from_entity = e1.id \
-             JOIN entities e2 ON r.to_entity = e2.id \
-             WHERE (?1 IS NULL OR r.created_at >= ?1) \
+            "SELECT r.edge_id, r.src_id, r.semantic_type, r.dst_id, \
+                    e1.name, e2.name, \
+                    COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) AS asserted_ts \
+             FROM edges r \
+             JOIN entities e1 ON r.src_id = e1.id \
+             JOIN entities e2 ON r.dst_id = e2.id \
+             WHERE r.edge_type = 'relates' AND r.valid_until IS NULL \
+               AND r.semantic_type IS NOT NULL \
+               AND (?1 IS NULL OR COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) >= ?1) \
                AND e1.name IS NOT NULL AND e1.name != '' \
                AND e2.name IS NOT NULL AND e2.name != '' \
                {scope_filter} \
-             ORDER BY r.created_at DESC LIMIT ?2"
+             ORDER BY asserted_ts DESC LIMIT ?2"
         );
         let mut values = vec![
             since_ms

--- a/crates/wenlan-core/src/db/scoped_entities_test.rs
+++ b/crates/wenlan-core/src/db/scoped_entities_test.rs
@@ -377,14 +377,30 @@ async fn get_entity_detail_scoped_requires_matching_relation_endpoints() {
         )
         .await
         .unwrap();
-    let visible = db
-        .create_relation(&work, &work_peer, "related_to", None, None, None, None)
+    db.create_relation(&work, &work_peer, "related_to", None, None, None, None)
         .await
         .unwrap();
-    let hidden = db
-        .create_relation(&work, &personal, "related_to", None, None, None, None)
+    db.create_relation(&work, &personal, "related_to", None, None, None, None)
         .await
         .unwrap();
+    // G6 Stage 1.2 Trap 2: the reader's relation `id` is now the active
+    // edge's edge_id, not create_relation's relations-row uuid return value.
+    let visible = crate::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &work,
+        "entity",
+        &work_peer,
+        "related_to",
+    );
+    let hidden = crate::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &work,
+        "entity",
+        &personal,
+        "related_to",
+    );
 
     let detail = db
         .get_entity_detail_scoped(&work, &ReadScope::Space("work".to_string()))
@@ -426,14 +442,30 @@ async fn list_recent_relations_scoped_requires_both_endpoints() {
         )
         .await
         .unwrap();
-    let visible = db
-        .create_relation(&work, &work_peer, "related_to", None, None, None, None)
+    db.create_relation(&work, &work_peer, "related_to", None, None, None, None)
         .await
         .unwrap();
-    let hidden = db
-        .create_relation(&work, &personal, "related_to", None, None, None, None)
+    db.create_relation(&work, &personal, "related_to", None, None, None, None)
         .await
         .unwrap();
+    // G6 Stage 1.2 Trap 2: the reader's relation `id` is now the active
+    // edge's edge_id, not create_relation's relations-row uuid return value.
+    let visible = crate::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &work,
+        "entity",
+        &work_peer,
+        "related_to",
+    );
+    let hidden = crate::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &work,
+        "entity",
+        &personal,
+        "related_to",
+    );
 
     let selected = db
         .list_recent_relations_scoped(20, None, &ReadScope::Space("work".to_string()))
@@ -740,6 +772,79 @@ async fn list_recent_relations_scoped_hybrid_matches_legacy() {
         format!("{legacy:?}"),
         format!("{hybrid:?}"),
         "hybrid list_recent_relations_scoped must be byte-identical to legacy"
+    );
+}
+
+/// G6 Stage 1.2 (relations-readers migration,
+/// docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md): the scoped
+/// variants must read the same `relates` edge fields as their unscoped
+/// counterparts -- edge_id as `id`, entity names via the join -- and the
+/// scope filter must still exclude a relation from a different space.
+#[tokio::test]
+async fn get_entity_detail_scoped_and_list_recent_relations_scoped_read_edges() {
+    let (db, _tmp) = test_db().await;
+    let scope = ReadScope::Space("g6_scoped_space_a".to_string());
+    let alice = db
+        .create_entity("G6 Scoped Alice", "person", Some("g6_scoped_space_a"))
+        .await
+        .unwrap();
+    let wenlan = db
+        .create_entity("G6 Scoped Wenlan", "project", Some("g6_scoped_space_a"))
+        .await
+        .unwrap();
+    db.create_relation(
+        &alice,
+        &wenlan,
+        "works_on",
+        Some("claude"),
+        Some(0.9),
+        Some("seen"),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let expected_edge_id = crate::provenance::compute_edge_id(
+        "relates", "entity", &alice, "entity", &wenlan, "works_on",
+    );
+
+    let detail = db.get_entity_detail_scoped(&alice, &scope).await.unwrap();
+    assert_eq!(detail.relations.len(), 1);
+    assert_eq!(
+        detail.relations[0].id, expected_edge_id,
+        "scoped detail relation id must be the active edge's edge_id"
+    );
+    assert_eq!(detail.relations[0].entity_name, "G6 Scoped Wenlan");
+
+    let recent = db
+        .list_recent_relations_scoped(10, None, &scope)
+        .await
+        .unwrap();
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].id, expected_edge_id);
+    assert_eq!(recent[0].from_entity_name, "G6 Scoped Alice");
+    assert_eq!(recent[0].to_entity_name, "G6 Scoped Wenlan");
+
+    // A relation in a different space must not leak into this scope.
+    let outside_a = db
+        .create_entity("G6 Scoped Outside A", "person", Some("g6_scoped_space_b"))
+        .await
+        .unwrap();
+    let outside_b = db
+        .create_entity("G6 Scoped Outside B", "project", Some("g6_scoped_space_b"))
+        .await
+        .unwrap();
+    db.create_relation(&outside_a, &outside_b, "knows", None, None, None, None)
+        .await
+        .unwrap();
+    let recent_after = db
+        .list_recent_relations_scoped(10, None, &scope)
+        .await
+        .unwrap();
+    assert_eq!(
+        recent_after.len(),
+        1,
+        "a relation in a different space must not leak into this scope"
     );
 }
 

--- a/crates/wenlan-core/src/lint/deep.rs
+++ b/crates/wenlan-core/src/lint/deep.rs
@@ -245,11 +245,11 @@ async fn relation_vocabulary(context: &LintContext<'_, '_>) -> Result<RowCheck, 
         context,
         &format!(
             "SELECT CASE WHEN v.canonical IS NULL THEN 1 ELSE 0 END
-               FROM relations r
-               LEFT JOIN entities f ON f.id=r.from_entity
-               LEFT JOIN relation_type_vocabulary v ON v.canonical=r.relation_type
+               FROM (SELECT * FROM edges WHERE edge_type='relates' AND valid_until IS NULL) r
+               LEFT JOIN entities f ON f.id=r.src_id
+               LEFT JOIN relation_type_vocabulary v ON v.canonical=r.semantic_type
               WHERE 1=1{scope}
-              ORDER BY r.id"
+              ORDER BY r.edge_id"
         ),
         params,
     )

--- a/crates/wenlan-core/src/lint/deep_test.rs
+++ b/crates/wenlan-core/src/lint/deep_test.rs
@@ -48,6 +48,12 @@ async fn deep_profile_detects_structural_and_advisory_counterexamples() {
              INSERT INTO relations
                  (id,from_entity,to_entity,relation_type,created_at)
              VALUES ('rel_a','entity_a','entity_a','legacy_custom_type',0);
+             -- G6 Stage 1.2: relation_vocabulary (reader #9) reads `edges`,
+             -- not `relations` -- mirror the dual-write here.
+             INSERT INTO edges
+                 (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type)
+             VALUES ('edge-rel_a','entity_a','entity','entity_a','entity','relates','legacy',0,
+                     '00000000-0000-4000-8000-000000000001',0,'legacy_custom_type');
              INSERT INTO memories
                  (id,content,source,source_id,title,chunk_index,last_modified,chunk_type,
                   memory_type,entity_id,pending_revision,is_recap,supersede_mode,structured_fields)

--- a/crates/wenlan-core/src/lint/kg/query.rs
+++ b/crates/wenlan-core/src/lint/kg/query.rs
@@ -85,12 +85,12 @@ async fn relation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, (
     row_check(
         context,
         &format!(
-            "SELECT CASE WHEN f.id IS NULL OR t.id IS NULL OR TRIM(r.relation_type)=''
+            "SELECT CASE WHEN f.id IS NULL OR t.id IS NULL OR TRIM(r.semantic_type)=''
                   THEN 1 ELSE 0 END
-               FROM relations r
-               LEFT JOIN entities f ON f.id=r.from_entity
-               LEFT JOIN entities t ON t.id=r.to_entity
-               {clause} ORDER BY r.id"
+               FROM (SELECT * FROM edges WHERE edge_type='relates' AND valid_until IS NULL) r
+               LEFT JOIN entities f ON f.id=r.src_id
+               LEFT JOIN entities t ON t.id=r.dst_id
+               {clause} ORDER BY r.edge_id"
         ),
         params,
     )

--- a/crates/wenlan-core/src/lint/kg/query/aggregate.rs
+++ b/crates/wenlan-core/src/lint/kg/query/aggregate.rs
@@ -54,7 +54,8 @@ pub(super) async fn entity_partitions(
 pub(super) async fn aggregate_counts(context: &LintContext<'_, '_>) -> Result<AggregateCounts, ()> {
     let values = scalar_row(
         context,
-        "SELECT (SELECT COUNT(*) FROM entities), (SELECT COUNT(*) FROM relations),
+        "SELECT (SELECT COUNT(*) FROM entities),
+                (SELECT COUNT(*) FROM edges WHERE edge_type='relates' AND valid_until IS NULL),
                 (SELECT COUNT(*) FROM observations), (SELECT COUNT(*) FROM memory_entities)",
         libsql::params::Params::None,
         4,

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -226,7 +226,13 @@ async fn seed_corrupt_graph(db: &crate::db::MemoryDB) {
         "INSERT INTO entities (id,name,entity_type,space,confidence,confirmed,created_at,updated_at) VALUES ('entity-ok','Secret Entity','concept',NULL,0.8,0,1,1),('entity-bad',' ','', 'missing-space',1.5,2,1,1);
          INSERT INTO observations (id,entity_id,content,confidence,confirmed,created_at) VALUES ('obs-orphan','missing-id','secret observation',0.5,0,1),('obs-invalid','entity-ok',' ',2.0,2,1);
          INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at) VALUES ('relation-from','missing-id','entity-ok','secret_relation',1),('relation-to','entity-ok','missing-id','secret_relation',1);
-         INSERT INTO memory_entities (memory_id,entity_id) VALUES ('missing-id','entity-ok'),('memory-ok','missing-id'),('entity-ok','entity-ok');"
+         INSERT INTO memory_entities (memory_id,entity_id) VALUES ('missing-id','entity-ok'),('memory-ok','missing-id'),('entity-ok','entity-ok');
+         -- G6 Stage 1.2: relation_integrity (reader #11) reads `edges`, not
+         -- `relations` -- mirror the dangling-endpoint rows here the same way
+         -- create_relation's dual-write would.
+         INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type) VALUES
+             ('edge-relation-from','missing-id','entity','entity-ok','entity','relates','legacy',0,'00000000-0000-4000-8000-000000000001',1,'secret_relation'),
+             ('edge-relation-to','entity-ok','entity','missing-id','entity','relates','legacy',0,'00000000-0000-4000-8000-000000000001',1,'secret_relation');"
     ).await.unwrap();
 }
 
@@ -241,7 +247,11 @@ async fn seed_valid_scoped_graph(db: &crate::db::MemoryDB) {
         "INSERT INTO entities (id,name,entity_type,space,confirmed,created_at,updated_at) VALUES ('ent-a','Alpha','concept','alpha',0,1,1),('ent-b','Beta','concept','beta',0,1,1);
          INSERT INTO observations (id,entity_id,content,confirmed,created_at) VALUES ('obs-a','ent-a','a',0,1),('obs-b','ent-b','b',0,1);
          INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at) VALUES ('rel-a','ent-a','ent-b','related',1);
-         INSERT INTO memory_entities (memory_id,entity_id) VALUES ('mem-alpha','ent-a'),('mem-beta','ent-b'),('mem-none','ent-a');"
+         INSERT INTO memory_entities (memory_id,entity_id) VALUES ('mem-alpha','ent-a'),('mem-beta','ent-b'),('mem-none','ent-a');
+         -- G6 Stage 1.2: relation_integrity + aggregate_counts (readers #11, #3)
+         -- read `edges`, not `relations` -- mirror the dual-write here.
+         INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type) VALUES
+             ('edge-rel-a','ent-a','entity','ent-b','entity','relates','legacy',0,'alpha',1,'related');"
     ).await.unwrap();
 }
 

--- a/crates/wenlan-core/src/lint/semantic_candidates.rs
+++ b/crates/wenlan-core/src/lint/semantic_candidates.rs
@@ -777,9 +777,10 @@ fn entity_scope_clause(scope: &ScopeFilter) -> (String, libsql::params::Params) 
                         WHERE {memory_filter} AND m.space=?1
                     )
                     OR e.id IN (
-                        SELECT r.to_entity FROM relations r
-                        JOIN entities source ON source.id=r.from_entity
-                        WHERE source.space=?1
+                        SELECT r.dst_id FROM edges r
+                        JOIN entities source ON source.id=r.src_id
+                        WHERE r.edge_type='relates' AND r.valid_until IS NULL
+                          AND source.space=?1
                     ))"
             ),
             libsql::params::Params::Positional(vec![libsql::Value::Text(value.clone())]),
@@ -793,9 +794,10 @@ fn entity_scope_clause(scope: &ScopeFilter) -> (String, libsql::params::Params) 
                         WHERE {memory_filter} AND m.space IS NULL
                     )
                     OR e.id IN (
-                        SELECT r.to_entity FROM relations r
-                        JOIN entities source ON source.id=r.from_entity
-                        WHERE source.space IS NULL
+                        SELECT r.dst_id FROM edges r
+                        JOIN entities source ON source.id=r.src_id
+                        WHERE r.edge_type='relates' AND r.valid_until IS NULL
+                          AND source.space IS NULL
                     ))"
             ),
             libsql::params::Params::None,
@@ -829,7 +831,7 @@ async fn load_memory_entity_links(
 async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<Relation>, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "source.space");
     let mut rows = context.snapshot().query(
-        &format!("SELECT r.from_entity,r.to_entity,r.relation_type FROM relations r JOIN entities source ON source.id=r.from_entity WHERE 1=1{scope} ORDER BY r.from_entity,r.to_entity,r.id"),
+        &format!("SELECT r.src_id,r.dst_id,r.semantic_type FROM edges r JOIN entities source ON source.id=r.src_id WHERE r.edge_type='relates' AND r.valid_until IS NULL AND r.semantic_type IS NOT NULL{scope} ORDER BY r.src_id,r.dst_id,r.edge_id"),
         params,
     ).await.map_err(|_| ())?;
     let mut output = Vec::new();

--- a/crates/wenlan-core/src/lint/semantic_test.rs
+++ b/crates/wenlan-core/src/lint/semantic_test.rs
@@ -306,7 +306,12 @@ async fn scoped_candidates_hydrate_cross_space_existing_link_endpoints() {
              INSERT INTO memory_entities (memory_id,entity_id)
              VALUES ('mem-work','entity-personal');
              INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at)
-             VALUES ('relation-cross','entity-work','entity-personal','related',1);",
+             VALUES ('relation-cross','entity-work','entity-personal','related',1);
+             -- G6 Stage 1.2: entity_scope_clause/load_relations (reader #4)
+             -- read `edges`, not `relations` -- mirror the dual-write here.
+             INSERT INTO edges
+                 (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type)
+             VALUES ('edge-relation-cross','entity-work','entity','entity-personal','entity','relates','legacy',0,'work',1,'related');",
         )
         .await
         .unwrap();
@@ -419,6 +424,14 @@ async fn suspicious_existing_page_and_entity_links_are_distinct_candidates() {
          INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at)
          VALUES ('relation-same','entity-work','entity-work-peer','related',1),
                 ('relation-cross','entity-work','entity-personal','related',1);
+         -- G6 Stage 1.2: entity_scope_clause/load_relations (reader #4) read
+         -- `edges`, not `relations` -- mirror the dual-write here. Both rows
+         -- matter: the test asserts the same-space relation is NOT flagged
+         -- while the cross-space one is.
+         INSERT INTO edges
+             (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type)
+         VALUES ('edge-relation-same','entity-work','entity','entity-work-peer','entity','relates','assertion',0,'work',1,'related'),
+                ('edge-relation-cross','entity-work','entity','entity-personal','entity','relates','legacy',0,'work',1,'related');
          INSERT INTO pages
              (id,title,content,source_memory_ids,version,status,created_at,last_compiled,
               last_modified,workspace,creation_kind,review_status)

--- a/crates/wenlan-core/src/repair_plan/semantic.rs
+++ b/crates/wenlan-core/src/repair_plan/semantic.rs
@@ -192,10 +192,17 @@ async fn load_record_inventory(
     )
     .await?;
 
+    // G6 Stage 1.2 reader #12: read `edges`, matching #13's
+    // (`lint::semantic_candidates::load_relations`) query shape -- the two
+    // readers mint the same `relation-entity:{id}:{type}:{endpoint}` keys, so
+    // reading different stores here would leave an edge-only relation with no
+    // inventory record, permanently Blocking its repair.
     let mut rows = snapshot
         .query(
-            "SELECT from_entity,to_entity,relation_type
-             FROM relations ORDER BY from_entity,to_entity,relation_type,id",
+            "SELECT src_id,dst_id,semantic_type
+             FROM edges WHERE edge_type='relates' AND valid_until IS NULL
+                   AND semantic_type IS NOT NULL
+             ORDER BY src_id,dst_id,edge_id",
             libsql::params::Params::None,
         )
         .await

--- a/crates/wenlan-server/tests/route_convergence.rs
+++ b/crates/wenlan-server/tests/route_convergence.rs
@@ -196,7 +196,7 @@ async fn create_relation_missing_entities_returns_422() {
 /// M3g fence: `span`/`model_version`/`prompt_version` are daemon-internal (KG
 /// extraction) only. An agent hitting `/api/memory/relations` directly must
 /// never be able to set them -- the handler strips all three before the
-/// core call, so a request that supplies them still writes `payload=NULL`.
+/// core call.
 #[tokio::test]
 async fn create_relation_strips_agent_supplied_span_capture_fields() {
     let (app, dir) = test_app().await;
@@ -255,9 +255,22 @@ async fn create_relation_strips_agent_supplied_span_capture_fields() {
         .expect("relates edge row")
         .get(0)
         .unwrap();
+    // G6 Stage 1.2: every relates mint now stamps `asserted_at` (mirrors the
+    // stored relations row's created_at), so the payload is no longer empty.
+    // The provenance-stripping contract this test guards is that agent-
+    // supplied span/model_version/prompt_version never land in it.
+    let payload_json: serde_json::Value =
+        serde_json::from_str(payload.as_deref().expect("payload must carry asserted_at"))
+            .expect("payload must be valid JSON");
     assert!(
-        payload.is_none(),
-        "agent-supplied span/model_version/prompt_version must be stripped, got payload: {payload:?}"
+        payload_json.get("span").is_none()
+            && payload_json.get("model_version").is_none()
+            && payload_json.get("prompt_version").is_none(),
+        "agent-supplied span/model_version/prompt_version must be stripped, got payload: {payload_json}"
+    );
+    assert!(
+        payload_json.get("asserted_at").is_some(),
+        "payload must still carry asserted_at, got: {payload_json}"
     );
 }
 

--- a/crates/wenlan-server/tests/space_scoping/knowledge_cases.rs
+++ b/crates/wenlan-server/tests/space_scoping/knowledge_cases.rs
@@ -186,16 +186,35 @@ pub async fn detail_and_relation_endpoints_are_scoped() {
     let work = seed_entity(&fixture, "Work anchor", Some("work")).await;
     let work_peer = seed_entity(&fixture, "Work peer", Some("work")).await;
     let personal = seed_entity(&fixture, "Personal peer", Some("personal")).await;
-    let work_relation = fixture
+    fixture
         .db
         .create_relation(&work, &work_peer, "related_to", None, None, None, None)
         .await
         .unwrap();
-    let mixed_relation = fixture
+    fixture
         .db
         .create_relation(&work, &personal, "related_to", None, None, None, None)
         .await
         .unwrap();
+    // G6 Stage 1.2 wire-visible id swap (spec Trap 2): the wire `id` is now
+    // the active edge's content-addressed edge_id, not the `relations` row
+    // uuid `create_relation` returns.
+    let work_relation = wenlan_core::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &work,
+        "entity",
+        &work_peer,
+        "related_to",
+    );
+    let mixed_relation = wenlan_core::provenance::compute_edge_id(
+        "relates",
+        "entity",
+        &work,
+        "entity",
+        &personal,
+        "related_to",
+    );
 
     let (status, detail) = json_body(
         fixture

--- a/docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md
+++ b/docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md
@@ -1,0 +1,154 @@
+# G6 Stage 1.2 — migrate `relations` readers onto `edges`
+
+Parent program: `docs/plans/2026-08-04-g6-retirement-program.md` (Stage 1, store 2).
+Scout report: `docs/superpowers/g6-stage1-relations-scout.md` (gitignored working doc;
+its findings are restated here so this spec is self-contained).
+Prerequisite: the semantic-payload PR (#486) + review fixes (#487) — `relates` edges
+now carry `semantic_type = relation_type` and payload keys `confidence`, `explanation`,
+`source_agent` (semantic, refresh-on-reassert) and `span`, `model_version`,
+`prompt_version`, `source_memory_id` (provenance, write-once). Migration 115 backfilled
+both groups from live legacy rows. Verified on the live DB: 0 of 304 active relates
+edges missing `semantic_type`.
+
+## Contract (from the program doc)
+
+- Readers hard-cut to `edges` — no `reader_uses_edges` gate for these consumers; the
+  cutover-lever tables retire wholesale in Stage 2.
+- Writers keep dual-writing (Stage 2 flips them). The parity sweep derivation for
+  `relations` **stays** in `reconcile_edges_parity` — this PR does NOT remove the
+  store's last legacy reader (two deliberate carryovers below).
+- One PR: reader redirects + migration 116 + behavior-equivalence tests.
+
+## The two traps this spec exists to encode
+
+**Trap 1 — `created_at` recency scramble.** `list_recent_relations(_scoped)` orders and
+filters on `relations.created_at`; `get_entity_detail(_scoped)` orders its relations
+list the same way. Edges backfilled by migration 81 carry migration-day
+`edges.created_at`, so ordering by the edge column would scramble the recency feed and
+misdate every pre-m81 relation. Additionally the relations upsert
+(`ON CONFLICT(from_entity,to_entity,relation_type)`) keeps the ORIGINAL `created_at`
+on re-assert, while a re-asserted edge may be a fresh row. `edges.created_at` is
+therefore NOT a substitute for `relations.created_at`.
+
+Fix: a new **semantic payload key `asserted_at`** (integer, epoch seconds, mirrors the
+stored `relations.created_at`). Migrated readers order/filter on
+`COALESCE(json_extract(e.payload,'$.asserted_at'), e.created_at)`.
+
+**Trap 2 — wire-visible `id` swap.** `RelationWithEntity.id` and `RecentRelation.id`
+currently carry the `relations` row UUID. After migration they carry the
+content-addressed `edge_id`. Verified safe: no route dereferences a relation id back
+into a lookup or delete (`/api/memory/relations` is POST-create only; relation ids are
+display-only on the wire). The change is shape-compatible (still a TEXT id). Flag it
+in the PR description as a wire-visible value change; do not add a compatibility shim.
+
+## Migration 116
+
+Idempotent, follows the m115 pattern. Two backfills over ACTIVE relates edges
+(`edge_type='relates' AND valid_until IS NULL`), joining structurally to the live
+legacy row — the join key `(src_id, dst_id, semantic_type)` = `(from_entity,
+to_entity, relation_type)` is UNIQUE in `relations` (the upsert conflict target), so
+no re-derivation of edge ids is needed:
+
+1. **`asserted_at`** — always set:
+   `payload = json_set(COALESCE(payload,'{}'), '$.asserted_at', r.created_at)`.
+2. **`source_memory_id`** — fill-if-absent only: set from `r.source_memory_id` when
+   the payload key is currently missing/null AND the legacy row has a value. This
+   converges edges born before #486 whose legacy row gained `source_memory_id` later
+   (the legacy upsert COALESCEs it in). Never overwrite an existing payload value.
+
+Edges with no matching live relations row (retired legacy row, cross-store residue)
+are left untouched — the COALESCE fallback in readers covers them.
+
+## Writer-side changes (dual-write stays; patches gain one key)
+
+- `relates_semantic_patch(...)` gains an `asserted_at: i64` parameter, emitted into
+  the semantic patch. Every caller threads the STORED relations row's `created_at`
+  (the same SELECT-after-write mirror that already sources `confidence`/
+  `explanation`/`source_agent` — extend that SELECT with `created_at`). Refresh-on-
+  reassert is harmless: the stored `created_at` is immutable under the upsert.
+- `source_memory_id` moves from strict write-once-at-birth to **fill-if-absent**,
+  mirroring the legacy COALESCE semantics: on re-assert, the patch may supply it and
+  the merge must set it ONLY when the stored payload lacks it. (It is still written
+  at most once.) Update the payload-contract doc comment on
+  `dual_write_edge_with_payload` accordingly, and list `asserted_at` among the
+  semantic keys.
+
+## Reader migration table
+
+All migrated readers filter `edge_type='relates' AND valid_until IS NULL`, use
+`src_id`/`dst_id` (kind `entity`) as endpoints, `semantic_type` as `relation_type`,
+and `COALESCE(json_extract(payload,'$.asserted_at'), created_at)` wherever legacy
+read `relations.created_at`.
+
+| # | Reader | Location | Notes |
+|---|---|---|---|
+| 1 | `expand_anchor_entities_khop` | db.rs ~25500 | topology-only; clean swap |
+| 2 | `expand_entities_khop_scoped` | db.rs ~26056 | topology-only; clean swap |
+| 3 | `aggregate_counts` | lint/kg/query/aggregate.rs:54 | count active relates edges |
+| 4 | `entity_scope_clause` subquery | lint/semantic_candidates.rs:767 | swap subquery source |
+| 5 | `get_entity_detail` | db.rs ~33020 | UNION ALL both directions over edges; `id`=edge_id, `relation_type`=semantic_type, `source_agent`=payload `$.source_agent`, `created_at`=COALESCE(asserted_at, created_at); ORDER BY that value DESC |
+| 6 | `get_entity_detail_scoped` | db/scoped_entities.rs:84 | same as #5 + scope filter; keep the entity-page name-hydration overlay logic byte-equivalent (it overlays names on the selected rows; only the selection source changes) |
+| 7 | `list_recent_relations` | db.rs ~36859 | recency feed over edges; keep the non-empty-name JOIN filters against `entities`; `since_ms` filter and ORDER BY on the COALESCE expression |
+| 8 | `list_recent_relations_scoped` | db/scoped_entities.rs:291 | Global still delegates to #7; scope filter on the joined `entities` rows as today; hydration overlay preserved unchanged |
+| 9 | `relation_vocabulary` | lint/deep.rs:242 | distinct `semantic_type` over active relates |
+| 10 | `distinct_relation_types_for_vocabulary_heal` | db/kg_quality_vocabulary.rs:7 | same; heal writers still write `relations` (dual-write keeps types equal under parity) |
+| 11 | `relation_integrity` | lint/kg/query.rs:83 | dangling-endpoint check: src_id/dst_id existence in `entities` |
+
+**Conditional (investigate before migrating — bounded discretion):**
+
+| # | Reader | Location | Condition |
+|---|---|---|---|
+| 12 | `load_record_inventory` | repair_plan/semantic.rs:164 | Migrate ONLY if the captured record identity is never dereferenced back into `relations` by the repair apply/CAS path (`apply_deterministic_repair_cas` and friends). If the apply path verifies or mutates relations rows BY THE CAPTURED ID, keep this reader on `relations` and say so in the PR description. |
+| 13 | `load_relations` | lint/semantic_candidates.rs:829 | Same condition — trace where its ids flow. |
+
+**Deliberate carryovers (stay on `relations`, dated notes in code):**
+
+- `count_stale_relation_sources` — payload `source_memory_id` converges via m116 +
+  fill-if-absent, but historical completeness isn't proven yet; migrates with the
+  final relations-exit PR.
+- `promote_edges_grounded` legacy-existence validation (db.rs ~14614) — the M5
+  grounding validator deliberately checks the legacy row as an independent witness;
+  redesign belongs to Stage 2, not a reader swap.
+
+These two (plus the conditional outcomes) mean the Stage 1 exit criterion for
+`relations` ("zero non-test readers outside migrations and the parity sweep") is NOT
+met by this PR; the program doc's per-store status line should record what remains.
+
+## Tests (RED-control discipline: prove each new test fails on the unfixed code)
+
+1. **m116 backfill** — seed relations via `create_relation` pre-m116 (or simulate a
+   pre-asserted_at edge by clearing the key), run migrations, assert `asserted_at`
+   equals the relations row's `created_at` and fill-if-absent `source_memory_id`
+   converged. Include an idempotency rerun (m55/m81-rerun test idiom in
+   db/main_tests.rs).
+2. **Recency-order equivalence** — seed ≥3 relations with distinct forced
+   `created_at` values (UPDATE relations + re-run m116 or patch payloads), plus one
+   edge simulating m81 backfill (edges.created_at newer than asserted_at); assert
+   `list_recent_relations` order matches `relations.created_at` DESC, not
+   edges.created_at; assert `since_ms` filters on the same value.
+3. **`get_entity_detail` equivalence** — field-by-field against a seeded fixture:
+   directions, names, relation_type, source_agent, created_at values, order. Assert
+   `id` is now the active edge's `edge_id`.
+4. **Scoped variants** — same assertions under a Space scope; hydration overlay
+   still applies when the entity-pages gate is on (existing scoped tests are the
+   template).
+5. **Writer mirror** — after `create_relation` then a weaker re-assert, the edge
+   payload's `asserted_at` still equals the ORIGINAL row `created_at` and
+   `confidence` kept the higher value (extends the existing stored-row-mirror test).
+6. **Parity stays 0** — existing parity fixture tests keep passing (the relations
+   derivation is untouched).
+
+## Gates
+
+`cargo fmt --check`; `cargo clippy -p wenlan-core -- -D warnings` (and `--tests`);
+focused test modules first, then the full `-p wenlan-core` suite (background it —
+~22 min, exceeds the 10-min foreground cap); `-p wenlan-server` suite (route contract
+tests cover `/api/knowledge/recent-relations` and entity detail).
+
+## Out of scope
+
+Writers stay dual-write; parity derivation stays; `relation_id` uses inside grounding
+promotion (db.rs ~14966) untouched; no schema DDL beyond payload backfill; entities
+readers (Stage 1.5) untouched. Coordination: Stage 1.1 (page_links readers) is in
+flight on branch `g6/stage1-readers` touching db/scoped_pages.rs + db.rs ~46850 —
+disjoint from this PR's regions; rebase whichever lands second.


### PR DESCRIPTION
G6 Stage 1.2 (program: `docs/plans/2026-08-04-g6-retirement-program.md`; spec: `docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md`, in this PR): `relations` readers cut over to canonical `relates` edges.

## Migration 116
Two payload backfills over active relates edges, joined structurally on `(src_id, dst_id, semantic_type)` = the relations UNIQUE conflict target: `asserted_at` (always, from `relations.created_at`) and `source_memory_id` (fill-if-absent only). Idempotent; unmatched edges untouched.

## Writers (dual-write stays)
Every relates mint's semantic patch now carries `asserted_at` mirrored from the STORED row's `created_at` (immutable under the legacy upsert, so re-asserts can't scramble recency). `source_memory_id` moves to fill-if-absent on conflict, mirroring the legacy `COALESCE`.

## Readers migrated (12)
Both k-hop expanders, `aggregate_counts`, `entity_scope_clause`, `get_entity_detail(_scoped)`, `list_recent_relations(_scoped)`, `relation_vocabulary`, `relation_integrity`, `load_record_inventory`, `load_relations`. Ordering/filtering uses `COALESCE(json_extract(payload,'$.asserted_at'), created_at)` wherever legacy used `relations.created_at` (m81-backfilled edges carry migration-day `created_at` — the recency trap). All queries NULL-guard `semantic_type` (nullable on edges, NOT NULL on legacy).

## Deliberate carryovers (stay on `relations`, dated comments)
- `distinct_relation_types_for_vocabulary_heal` — writer coupling: the healer's writer `fold_relation_type` enumerates `relations`; discovery must read the store its repair enumerates. Migrates only alongside the writer.
- `count_stale_relation_sources` — payload `source_memory_id` completeness not yet proven historically.
- `promote_edges_grounded` legacy-existence validation — the M5 grounding validator's independent witness; redesign belongs to Stage 2.

Parity derivation for `relations` stays in `reconcile_edges_parity` (this PR does not remove the store's last reader).

## Wire-visible changes (flagged)
- `RelationWithEntity.id` and `RecentRelation.id` now carry the content-addressed `edge_id` (was the relations row UUID). Display-only in-repo — no route dereferences a relation id (only POST-create + list routes exist).
- `POST /api/memory/relations` still returns the relations UUID: the same relation has two id spaces on the wire until Stage 2. Known and accepted for the transition.
- New permanently-red lint shape possible under store drift: an edge with non-canonical `semantic_type` whose relations row is already canonical — parity's job to surface.

## Tests
Migration-116 backfill + parity-clean + idempotency; recency-ordering (RED via prove-then-revert mutation: order flips to migration-day timestamps without the COALESCE); entity-detail edge fields (`id == compute_edge_id`); scoped variants; asserted_at/confidence upsert mirror; and a divergence test (`migrated_readers_diverge_from_relations_and_follow_edges`) with asymmetric seeding — readers report the edge count (1), not the relations count (2), pinning the store choice for 7 readers as standing regression assertions.
Full suites on the integrated branch: core 4064 passed / 0 failed / 33 ignored, server 618 passed / 0 failed / 3 ignored (43 test binaries), CLI 106 passed / 0 failed / 1 ignored; fmt + clippy clean. The server run surfaced two stale test contracts (route_convergence payload-strip assertion, space-scoping wire-id assertion) — both updated to the post-1.2 contract and closure-reviewed.

## Review
One independent Opus review (fix-first: unmigrated reader #12 breaking its pairing with #13, NULL `semantic_type` hard-erroring the recency endpoints, no store-pinning test — all fixed) + closure pass (clean; 2 residuals fixed: NULL guards on the two new repair/lint reads, scoped-khop pin + honest docstring).

Post-merge runtime checks at daemon upgrade: `reconcile_edges_parity` relates drift on the live DB under m116; recency feed order vs `relations.created_at` on a DB with genuine m81-backfilled edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
