### PR TITLE
feat(kg): G6 Stage 1.3 — page_sources/page_evidence readers cut over to canonical cites edges

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -19928,6 +19928,10 @@ impl MemoryDB {
     /// retracts one of ITS OWN dropped citations, so a still-active
     /// `page_sources`/`page_evidence` row keeps the shared edge alive (D7
     /// refcount, spec v3 M3).
+    ///
+    /// G6 Stage 1.3 carryover (2026-08-05): writer-side D7 refcount machinery,
+    /// not a reader migration target -- it must keep reading the legacy tables
+    /// directly since it is what decides whether they still justify the edge.
     async fn cites_backed_outside_page_citations(
         conn: &libsql::Connection,
         page_id: &str,
@@ -28064,6 +28068,28 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("delete Page evidence: {e}")))?;
+            // G6 Stage 1.3: the readers above (`get_page_sources`,
+            // `get_page_evidence`) now derive from active `cites` edges, not
+            // these legacy tables. Retiring only the page_sources/page_evidence
+            // rows without also retiring their edge twin left a stale edge
+            // readable after its provenance rows were pruned. Mirror the
+            // same locator set (logical source id + physical memory rows).
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "UPDATE edges
+                 SET valid_until = ?3, superseded_by = NULL
+                 WHERE edge_type = 'cites' AND src_kind = 'page' AND dst_kind = 'memory'
+                   AND valid_until IS NULL
+                   AND (
+                       dst_id = ?2
+                       OR dst_id IN (
+                           SELECT id FROM memories WHERE source = ?1 AND source_id = ?2
+                       )
+                   )",
+                libsql::params![source, source_id, now],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("delete Page cites edges: {e}")))?;
         }
 
         let mut deleted_locators = physical_row_ids;
@@ -28314,6 +28340,9 @@ impl MemoryDB {
 
         let mut affected_pages: HashMap<String, i64> = HashMap::new();
         for (source, source_id) in unique_sources {
+            // G6 Stage 1.3: the `page_sources` EXISTS clause reads `edges`
+            // (`cites`, `dst_kind='memory'`) instead. The `pages.source_memory_ids`
+            // legacy JSON mirror stays untouched -- out of scope (Stage 1.4).
             let mut rows = conn
                 .query(
                     "SELECT DISTINCT p.id
@@ -28324,11 +28353,12 @@ impl MemoryDB {
                            )
                        AND (
                            EXISTS (
-                               SELECT 1 FROM page_sources ps
-                               WHERE ps.page_id = p.id
+                               SELECT 1 FROM edges ps
+                               WHERE ps.edge_type = 'cites' AND ps.valid_until IS NULL
+                                 AND ps.dst_kind = 'memory' AND ps.src_id = p.id
                                  AND (
-                                     ps.memory_source_id = ?2
-                                     OR ps.memory_source_id IN (
+                                     ps.dst_id = ?2
+                                     OR ps.dst_id IN (
                                          SELECT m.id FROM memories m
                                          WHERE m.source = ?1 AND m.source_id = ?2
                                      )
@@ -39832,6 +39862,11 @@ impl MemoryDB {
         space_filter: Option<&str>,
     ) -> Result<Vec<ClusterMemRow>, WenlanError> {
         let conn = self.conn.lock().await;
+        // S3 (2026-08-05 G6 Stage 1.3 review): distill-eligibility predicate
+        // stays on page_evidence pending a focused migration -- widening it
+        // to the edges/cites union (which includes D7 survivors backed only
+        // by pages.citations) changes the eligibility pool and deserves its
+        // own test attention. Folds into Stage 2.
         let mut sql = String::from(
             "SELECT m.source_id, m.content, m.entity_id, m.space, m.embedding, e.name, m.source_agent, m.content_hash \
              FROM memories m \
@@ -40105,6 +40140,11 @@ impl MemoryDB {
         limit: usize,
     ) -> Result<Vec<RawDistillationSeed>, WenlanError> {
         let conn = self.conn.lock().await;
+        // S3 (2026-08-05 G6 Stage 1.3 review): distill-eligibility predicate
+        // stays on page_evidence pending a focused migration -- widening it
+        // to the edges/cites union (which includes D7 survivors backed only
+        // by pages.citations) changes the eligibility pool and deserves its
+        // own test attention. Folds into Stage 2.
         let mut sql = String::from(
             "SELECT m.id, m.source_id, m.content, m.entity_id, m.space, m.embedding, \
                     e.name, m.source_agent, m.content_hash, \
@@ -40163,6 +40203,11 @@ impl MemoryDB {
         // Fetch the raw fixed-K ANN window first, then evaluate staging
         // eligibility. Predicates after vector_top_k cannot increase work or
         // silently trigger a brute-force fallback.
+        // S3 (2026-08-05 G6 Stage 1.3 review): distill-eligibility predicate
+        // stays on page_evidence pending a focused migration -- widening it
+        // to the edges/cites union (which includes D7 survivors backed only
+        // by pages.citations) changes the eligibility pool and deserves its
+        // own test attention. Folds into Stage 2.
         let mut rows = conn
             .query(
                 "SELECT m.source_id, m.content, m.entity_id, m.space, m.embedding, \
@@ -41831,13 +41876,20 @@ impl MemoryDB {
 
                 let mut affected_pages = HashSet::new();
                 for chunk_id in &chunk_ids {
+                    // G6 Stage 1.3: the `page_sources` EXISTS clause reads
+                    // `edges` (`cites`, `dst_kind='memory'`) instead -- same
+                    // reader #6 twin as `mark_pages_depending_on_memory_sources_except`.
+                    // The `pages.source_memory_ids` legacy JSON mirror stays
+                    // untouched -- out of scope (Stage 1.4).
                     let mut page_rows = conn
                         .query(
                             "SELECT DISTINCT p.id
                          FROM pages p
                          WHERE EXISTS (
-                                   SELECT 1 FROM page_sources ps
-                                   WHERE ps.page_id = p.id AND ps.memory_source_id = ?1
+                                   SELECT 1 FROM edges ps
+                                   WHERE ps.edge_type = 'cites' AND ps.valid_until IS NULL
+                                     AND ps.dst_kind = 'memory' AND ps.src_id = p.id
+                                     AND ps.dst_id = ?1
                                )
                             OR EXISTS (
                                    SELECT 1
@@ -47738,6 +47790,10 @@ impl MemoryDB {
     /// rather than accumulate forever (e.g. the reserved Overview page's
     /// maintenance refresh, spec §5.3) call this before `refresh_page` so the
     /// evidence `refresh_page` reads back is already bounded.
+    // G6 Stage 1.3 carryover (2026-08-05): writer-internal before/after
+    // provenance snapshot (undo-ledger bookkeeping), not a reader migration
+    // target -- it must read the legacy tables directly since it exists to
+    // detect their own change.
     async fn page_memory_provenance_state(
         conn: &libsql::Connection,
         page_id: &str,
@@ -48033,7 +48089,25 @@ impl MemoryDB {
         }
     }
 
-    /// Get all source memories linked to a page, ordered by linked_at ascending.
+    /// Get all sources linked to a page, ordered by linked_at ascending.
+    ///
+    /// G6 Stage 1.3: reads `edges` (`cites`) instead of `page_sources`, spanning
+    /// all `dst_kind`s (no `dst_kind` filter). Ruling (2026-08-05, closure
+    /// review): the original migration filtered `dst_kind='memory'` on the
+    /// premise that legacy `page_sources` was memory-only, but `insert_page`'s
+    /// dual-write (`db.rs`, `INSERT OR IGNORE INTO page_sources`) has never
+    /// applied a kind check -- every source id in `source_memory_ids`, memory
+    /// or external, lands there. Filtering `get_page_sources` to `dst_kind=
+    /// 'memory'` silently narrowed it below what `page_sources` actually
+    /// returned, a real regression (`refresh_page`, distill.rs, depends on the
+    /// full set to build its numbered-citation block). Note this unfiltered
+    /// read is not exactly `page_sources`' old result set either -- it's the
+    /// wider S1 union (see the spec's "Equivalence rationale"), so it also
+    /// admits locators backed only by `page_evidence` or `pages.citations`
+    /// (e.g. a D7 survivor). `linked_at` is COALESCE-total over the
+    /// payload-mirrored legacy value and `edges.created_at` (the ordering
+    /// trap: an m81-era edge's `created_at` is migration day, not the
+    /// original link time) — same discipline as Stage 1.2's `asserted_at`.
     pub async fn get_page_sources(
         &self,
         page_id: &str,
@@ -48041,7 +48115,13 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT page_id, memory_source_id, linked_at, link_reason FROM page_sources WHERE page_id = ?1 ORDER BY linked_at ASC",
+                "SELECT src_id, dst_id,
+                        COALESCE(json_extract(payload,'$.linked_at'), created_at),
+                        json_extract(payload,'$.link_reason')
+                 FROM edges
+                 WHERE edge_type = 'cites' AND valid_until IS NULL
+                       AND src_id = ?1
+                 ORDER BY COALESCE(json_extract(payload,'$.linked_at'), created_at) ASC, dst_id ASC",
                 libsql::params![page_id],
             )
             .await
@@ -48069,6 +48149,10 @@ impl MemoryDB {
     /// Count at most `cap + 1` Page-source links without materializing the
     /// complete source set. Automatic callers use the sentinel row to reject
     /// oversized prompts before loading source contents.
+    ///
+    /// G6 Stage 1.3: counts `edges` (`cites`) instead of `page_sources`,
+    /// spanning all `dst_kind`s (no `dst_kind` filter) -- see the
+    /// `get_page_sources` doc comment for the ruling.
     pub async fn count_page_sources_up_to(
         &self,
         page_id: &str,
@@ -48079,7 +48163,10 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT COUNT(*) FROM (
-                     SELECT 1 FROM page_sources WHERE page_id = ?1 LIMIT ?2
+                     SELECT 1 FROM edges
+                     WHERE edge_type = 'cites' AND valid_until IS NULL
+                           AND src_id = ?1
+                     LIMIT ?2
                  )",
                 libsql::params![page_id, sentinel_limit],
             )
@@ -48095,6 +48182,15 @@ impl MemoryDB {
     }
 
     /// Typed evidence read path (P2). Successor to `get_page_sources`.
+    ///
+    /// G6 Stage 1.3: reads `edges` (`cites`) instead of `page_evidence`, spanning
+    /// all `dst_kind`s (no `dst_kind` filter, matching the legacy table's shape).
+    /// `source_kind` and `linked_at` are COALESCE-total per the NULL-payload
+    /// discipline: `source_kind` falls back on the NOT NULL `dst_kind` column
+    /// (`memory` -> `memory`, else `external`) for the rare pre-#486 edge whose
+    /// legacy row vanished before m115's payload backfill; `linked_at` falls
+    /// back on `edges.created_at` for the same ordering-trap reason as
+    /// `get_page_sources`.
     pub async fn get_page_evidence(
         &self,
         page_id: &str,
@@ -48102,8 +48198,16 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT page_id, source_kind, locator, title, linked_at, link_reason
-             FROM page_evidence WHERE page_id = ?1 ORDER BY linked_at ASC",
+                "SELECT src_id,
+                        COALESCE(json_extract(payload,'$.source_kind'),
+                                 CASE dst_kind WHEN 'memory' THEN 'memory' ELSE 'external' END),
+                        dst_id,
+                        json_extract(payload,'$.title'),
+                        COALESCE(json_extract(payload,'$.linked_at'), created_at),
+                        json_extract(payload,'$.link_reason')
+                 FROM edges
+                 WHERE edge_type = 'cites' AND valid_until IS NULL AND src_id = ?1
+                 ORDER BY COALESCE(json_extract(payload,'$.linked_at'), created_at) ASC, dst_id ASC",
                 libsql::params![page_id],
             )
             .await
@@ -48594,6 +48698,9 @@ impl MemoryDB {
     }
 
     /// Reverse lookup: find all active pages that reference a given memory source_id.
+    ///
+    /// G6 Stage 1.3: joins `edges` (`cites`, `dst_kind='memory'`) instead of
+    /// `page_sources`.
     pub async fn get_pages_for_memory(
         &self,
         memory_source_id: &str,
@@ -48607,8 +48714,9 @@ impl MemoryDB {
                         COALESCE(c.changelog, '[]'), COALESCE(c.creation_kind, 'distilled'), COALESCE(c.review_status, 'confirmed'),
                         c.workspace, c.citations, COALESCE(c.kind, 'concept')
                  FROM pages c
-                 INNER JOIN page_sources cs ON c.id = cs.page_id
-                 WHERE cs.memory_source_id = ?1 AND c.status = 'active'
+                 INNER JOIN edges cs ON cs.src_id = c.id AND cs.edge_type = 'cites'
+                        AND cs.valid_until IS NULL AND cs.dst_kind = 'memory'
+                 WHERE cs.dst_id = ?1 AND c.status = 'active'
                    AND COALESCE(c.kind, 'concept') != 'entity'",
                 libsql::params![memory_source_id],
             )
@@ -48631,6 +48739,10 @@ impl MemoryDB {
     /// invalidate so a `page_sources`/`page_evidence` row pruned for a
     /// since-deleted memory does not retract an edge `pages.citations` still
     /// independently cites (D7 refcount, spec v3 M3).
+    ///
+    /// G6 Stage 1.3 carryover (2026-08-05): writer-side D7 refcount machinery
+    /// (its caller is the `page_sources`/`page_evidence` orphan-cleanup path),
+    /// not a reader migration target.
     async fn cites_backed_by_page_citations(
         conn: &libsql::Connection,
         page_id: &str,

--- a/crates/wenlan-core/src/db/claim_derivation.rs
+++ b/crates/wenlan-core/src/db/claim_derivation.rs
@@ -1829,6 +1829,10 @@ impl MemoryDB {
         }
         drop(lease);
 
+        // G6 Stage 1.3 carryover (2026-08-05): already edges-aware by design --
+        // the UNION already covers both a legacy-only `page_evidence` row and
+        // an edges-only row, so migrating the `page_evidence` arm would only
+        // drop coverage during the transition. Leave as is.
         let mut rows = conn
             .query(
                 "WITH linked(source_id) AS (

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -22738,6 +22738,84 @@ async fn test_link_concept_source_idempotent() {
     assert_eq!(sources[0].memory_source_id, "src1");
 }
 
+/// G6 Stage 1.3 test 1 (equivalence per product reader): `get_page_sources`,
+/// `get_page_sources_scoped`, and `get_page_evidence` now read `edges`
+/// instead of `page_sources`/`page_evidence`. Seeds via the real writers
+/// (`link_page_source`, which also dual-writes through
+/// `insert_resolved_page_evidence`), then forces one edge's `created_at` to
+/// diverge from its payload `$.linked_at` (the ordering trap: an m81-era
+/// edge's `created_at` is migration day, not the original link time) --
+/// order and the projected `linked_at` must follow the payload, not
+/// `edges.created_at`.
+#[tokio::test]
+async fn get_page_sources_and_evidence_follow_payload_linked_at_not_edge_created_at() {
+    let (db, _dir) = test_db().await;
+    seed_memory_with_source_id_and_space(&db, "mem_g13_a", "content a", "space_a").await;
+    seed_memory_with_source_id_and_space(&db, "mem_g13_b", "content b", "space_a").await;
+    {
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_g13", "space_a").await;
+    }
+    db.link_page_source("page_g13", "mem_g13_a", "reason a")
+        .await
+        .unwrap();
+    db.link_page_source("page_g13", "mem_g13_b", "reason b")
+        .await
+        .unwrap();
+
+    // b's payload linked_at (500) stays earlier than a's (1000) even though
+    // b's edge row is forced to look newer (9999999) -- proves the reader
+    // orders and projects off the payload, not edges.created_at.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE edges SET payload = json_set(payload, '$.linked_at', 1000) \
+             WHERE edge_type = 'cites' AND src_id = 'page_g13' AND dst_id = 'mem_g13_a'",
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "UPDATE edges SET payload = json_set(payload, '$.linked_at', 500), created_at = 9999999 \
+             WHERE edge_type = 'cites' AND src_id = 'page_g13' AND dst_id = 'mem_g13_b'",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    let sources = db.get_page_sources("page_g13").await.unwrap();
+    assert_eq!(sources.len(), 2);
+    assert_eq!(
+        sources[0].memory_source_id, "mem_g13_b",
+        "must order by payload linked_at (500), not edges.created_at (9999999)"
+    );
+    assert_eq!(sources[0].linked_at, 500);
+    assert_eq!(sources[0].link_reason.as_deref(), Some("reason b"));
+    assert_eq!(sources[1].memory_source_id, "mem_g13_a");
+    assert_eq!(sources[1].linked_at, 1000);
+    assert_eq!(sources[1].link_reason.as_deref(), Some("reason a"));
+
+    let scoped = db
+        .get_page_sources_scoped("page_g13", &ReadScope::Global)
+        .await
+        .unwrap();
+    assert_eq!(scoped.len(), 2);
+    assert_eq!(scoped[0].memory_source_id, "mem_g13_b");
+    assert_eq!(scoped[0].linked_at, 500);
+    assert_eq!(scoped[1].memory_source_id, "mem_g13_a");
+    assert_eq!(scoped[1].linked_at, 1000);
+
+    let evidence = db.get_page_evidence("page_g13").await.unwrap();
+    assert_eq!(evidence.len(), 2);
+    assert_eq!(evidence[0].locator.as_deref(), Some("mem_g13_b"));
+    assert_eq!(evidence[0].linked_at, 500);
+    assert_eq!(evidence[0].source_kind, "memory");
+    assert_eq!(evidence[0].link_reason.as_deref(), Some("reason b"));
+    assert_eq!(evidence[1].locator.as_deref(), Some("mem_g13_a"));
+    assert_eq!(evidence[1].linked_at, 1000);
+}
+
 #[tokio::test]
 async fn page_source_revision_advances_only_when_the_source_set_changes() {
     let (db, _dir) = test_db().await;
@@ -23050,6 +23128,29 @@ async fn test_get_concept_sources_ordered() {
         )
         .await
         .unwrap();
+        // G6 Stage 1.3: `get_page_sources` reads `edges`, ordering by
+        // `COALESCE(json_extract(payload,'$.linked_at'), created_at)` -- mirror
+        // the dual-write here (payload carries the controlled linked_at so
+        // ordering stays deterministic), same pattern as the retro-scan fixture.
+        for (memory_source_id, linked_at, link_reason) in
+            [("src_b", 200i64, "later"), ("src_a", 100i64, "earlier")]
+        {
+            conn.execute(
+                "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, \
+                                     lineage, grounded, space, created_at, payload) \
+                 VALUES (?1, 'c_ord', 'page', ?2, 'memory', 'cites', 'legacy', 0, ?5, ?3, ?4)",
+                libsql::params![
+                    format!("concept-sources-ordered-{memory_source_id}"),
+                    memory_source_id,
+                    linked_at,
+                    serde_json::json!({"linked_at": linked_at, "link_reason": link_reason})
+                        .to_string(),
+                    crate::db::UNFILED_SPACE_ID,
+                ],
+            )
+            .await
+            .unwrap();
+        }
     }
 
     let sources = db.get_page_sources("c_ord").await.unwrap();
@@ -46767,6 +46868,352 @@ async fn link_page_source_dual_writes_cites_edge_via_page_evidence_chokepoint() 
     assert_eq!(space, "space_a");
 }
 
+/// G6 Stage 1.3 test 2 (kind fallback): an active cites edge whose payload
+/// is absent (a simulated pre-#486 remnant -- m115 backfilled the payload
+/// from every edge's live legacy twin, so this models an edge that predates
+/// that migration and has since lost its legacy row). `get_page_evidence`
+/// must apply the NULL-payload discipline and return it with the
+/// dst_kind-derived kind and the created_at-derived linked_at, not error or
+/// drop the row.
+#[tokio::test]
+async fn get_page_evidence_falls_back_when_payload_is_absent() {
+    let (db, _dir) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_g13_kf", "space_a").await;
+        conn.execute(
+            "INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at) \
+             VALUES ('g13-kindfallback','page_g13_kf','page','mem_g13_kf_orphan','memory','cites','legacy',0,'space_a',42)",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    let evidence = db.get_page_evidence("page_g13_kf").await.unwrap();
+    assert_eq!(evidence.len(), 1);
+    assert_eq!(
+        evidence[0].source_kind, "memory",
+        "must fall back to the dst_kind-derived kind, not error or drop the row"
+    );
+    assert_eq!(
+        evidence[0].linked_at, 42,
+        "must fall back to edges.created_at when payload is absent"
+    );
+    assert_eq!(evidence[0].locator.as_deref(), Some("mem_g13_kf_orphan"));
+    assert_eq!(evidence[0].title, None);
+    assert_eq!(evidence[0].link_reason, None);
+}
+
+/// G6 Stage 1.3 test 3 (divergence, the 1.2 pattern): no other test can tell
+/// whether a migrated reader actually reads `edges` versus quietly falling
+/// back to `page_sources`/`page_evidence`, since every OTHER fixture keeps
+/// the stores in parity via the dual-write. Here they're deliberately
+/// split: one cites fact exists ONLY in `edges`, and TWO exist ONLY in
+/// `page_sources`/`page_evidence` (asymmetric counts so a reader that
+/// quietly fell back to the legacy tables would report a different number,
+/// not the same one by coincidence). Covers readers #1 (`get_page_sources`),
+/// #4 (`get_page_evidence`), #5 (`get_pages_for_memory`), #6
+/// (`mark_pages_depending_on_memory_sources_except`, exercised via its
+/// public caller `update_memory`), and the two migrated EXISTS lints
+/// (#9 `pages.source_page_integrity`, #10 `memories.derived.page_links`) --
+/// each must see the edge-only fact and stay blind to the legacy-only
+/// orphans. Reader #6 runs last since its caller mutates the memory rows.
+/// Exception (S2, 2026-08-05 review): `pages.source_page_integrity`'s
+/// single EXISTS deliberately reads `page_evidence OR edges` (no dst_kind
+/// filter; a NULL-locator authored row is provenance with no edge twin), so
+/// it is NOT blind to the legacy-only page's real `page_evidence` rows --
+/// see the assertion below. Closure review (2026-08-05): a THIRD page,
+/// `g13_div_page_sources_only`, seeds a `page_sources` row alone (no
+/// page_evidence, no edge, `source_memory_ids='[]'`) to keep this check's
+/// negative-direction proof alive -- the migrated reader has no provenance
+/// it can see for that page, so it stays flagged.
+#[tokio::test]
+async fn migrated_readers_diverge_from_legacy_and_follow_edges() {
+    let (db, _dir) = test_db().await;
+    seed_memory_with_source_id_and_space(&db, "g13_div_mem_edge", "edge-only content", "space_a")
+        .await;
+    seed_memory_with_source_id_and_space(
+        &db,
+        "g13_div_mem_legacy_1",
+        "legacy content 1",
+        "space_a",
+    )
+    .await;
+    seed_memory_with_source_id_and_space(
+        &db,
+        "g13_div_mem_legacy_2",
+        "legacy content 2",
+        "space_a",
+    )
+    .await;
+    {
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "g13_div_page_edge", "space_a").await;
+        insert_raw_page_for_m81_test(&conn, "g13_div_page_legacy", "space_a").await;
+        insert_raw_page_for_m81_test(&conn, "g13_div_page_sources_only", "space_a").await;
+        conn.execute(
+            "UPDATE pages SET creation_kind = 'source' \
+             WHERE id IN ('g13_div_page_edge', 'g13_div_page_legacy', 'g13_div_page_sources_only')",
+            (),
+        )
+        .await
+        .unwrap();
+
+        // Edge-only fact: no page_sources/page_evidence twin.
+        conn.execute(
+            "INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,payload) \
+             VALUES ('g13-div-edge-only','g13_div_page_edge','page','g13_div_mem_edge','memory','cites','evidence',0,'space_a',100, \
+                     '{\"source_kind\":\"memory\",\"linked_at\":100,\"link_reason\":\"edge_only\"}')",
+            (),
+        )
+        .await
+        .unwrap();
+
+        // Two legacy-only facts (asymmetric count vs the one edge-only fact
+        // above): no edges twin for either.
+        seed_page_source(&conn, "g13_div_page_legacy", "g13_div_mem_legacy_1").await;
+        seed_page_source(&conn, "g13_div_page_legacy", "g13_div_mem_legacy_2").await;
+        seed_page_evidence(
+            &conn,
+            "g13_div_page_legacy",
+            "memory",
+            Some("g13_div_mem_legacy_1"),
+        )
+        .await;
+        seed_page_evidence(
+            &conn,
+            "g13_div_page_legacy",
+            "memory",
+            Some("g13_div_mem_legacy_2"),
+        )
+        .await;
+
+        // Negative-direction proof (closure review): a page_sources row with
+        // NO page_evidence row and NO edge -- the migrated
+        // `pages.source_page_integrity` check has nothing to see for this
+        // page and must still flag it.
+        seed_page_source(
+            &conn,
+            "g13_div_page_sources_only",
+            "g13_div_mem_sources_only",
+        )
+        .await;
+    }
+
+    // Reader #1: get_page_sources.
+    let edge_sources = db.get_page_sources("g13_div_page_edge").await.unwrap();
+    assert_eq!(edge_sources.len(), 1, "must see the edge-only fact");
+    assert_eq!(edge_sources[0].memory_source_id, "g13_div_mem_edge");
+    let legacy_sources = db.get_page_sources("g13_div_page_legacy").await.unwrap();
+    assert!(
+        legacy_sources.is_empty(),
+        "must not see the legacy-only orphans"
+    );
+
+    // Reader #4: get_page_evidence.
+    let edge_evidence = db.get_page_evidence("g13_div_page_edge").await.unwrap();
+    assert_eq!(edge_evidence.len(), 1, "must see the edge-only fact");
+    let legacy_evidence = db.get_page_evidence("g13_div_page_legacy").await.unwrap();
+    assert!(
+        legacy_evidence.is_empty(),
+        "must not see the legacy-only orphans"
+    );
+
+    // Reader #5: get_pages_for_memory.
+    let pages_for_edge_mem = db.get_pages_for_memory("g13_div_mem_edge").await.unwrap();
+    assert!(
+        pages_for_edge_mem
+            .iter()
+            .any(|p| p.id == "g13_div_page_edge"),
+        "must see the edge-only fact"
+    );
+    let pages_for_legacy_mem = db
+        .get_pages_for_memory("g13_div_mem_legacy_1")
+        .await
+        .unwrap();
+    assert!(
+        !pages_for_legacy_mem
+            .iter()
+            .any(|p| p.id == "g13_div_page_legacy"),
+        "must not see the legacy-only orphans"
+    );
+
+    // Readers #9/#10: the two migrated EXISTS lints, via the public
+    // LintRunner (must run before reader #6 below deletes the memory rows).
+    let report = crate::lint::runner::LintRunner::new(
+        crate::lint::context::LintClock::fixed(),
+        crate::lint::context::CancellationToken::new(),
+    )
+    .run(
+        &db,
+        &wenlan_types::lint::LintQuery {
+            profile: Some(wenlan_types::lint::LintProfile::General),
+            space: None,
+        },
+        None,
+        false,
+    )
+    .await
+    .unwrap();
+    let find_check = |id: &str| {
+        report
+            .checks()
+            .iter()
+            .find(|check| check.check_id() == id)
+            .unwrap_or_else(|| panic!("missing check {id}"))
+    };
+    let affected_of = |check: &wenlan_types::lint::LintCheckResult| {
+        check
+            .metrics()
+            .iter()
+            .find_map(|metric| {
+                (metric.code() == wenlan_types::lint::LintMetricCode::AffectedRecords).then(|| {
+                    match metric.value() {
+                        wenlan_types::lint::LintMetricValue::Count { value } => *value,
+                        _ => 0,
+                    }
+                })
+            })
+            .unwrap()
+    };
+    // S2 (2026-08-05 review): this check's single EXISTS reads
+    // `page_evidence OR edges` (no dst_kind filter), not edges-only, so the
+    // legacy-only page's real `page_evidence` rows (seeded above) make it
+    // PASS this check too. Closure review (2026-08-05): the third page
+    // (`g13_div_page_sources_only`) seeds ONLY a `page_sources` row -- no
+    // page_evidence, no edge -- so it has no provenance the migrated reader
+    // can see and stays flagged. Net: 1 affected (the sources-only page),
+    // not the edge-only or legacy-only page.
+    assert_eq!(
+        affected_of(find_check("pages.source_page_integrity")),
+        1,
+        "source_page_integrity must flag only the sources-only page -- the \
+         edge-only page has an edge and the legacy-only page has real \
+         page_evidence rows, both real provenance under the migrated \
+         page_evidence-OR-edges check, but a page_sources row alone (no \
+         page_evidence, no edge) is invisible to it"
+    );
+    assert_eq!(
+        affected_of(find_check("memories.derived.page_links")),
+        2,
+        "page_links must flag both legacy-only memories as missing page linkage \
+         (2), not the edge-only memory -- population must come from edges"
+    );
+
+    // Reader #6: mark_pages_depending_on_memory_sources_except, exercised via
+    // its public caller update_memory (content update, not deletion --
+    // delete_by_source_id also runs a separate, out-of-scope orphan-cleanup
+    // subsystem that reads the legacy tables directly to remove them, which
+    // would confound this reader-migration-only assertion).
+    db.update_memory("g13_div_mem_edge", "edge-only content, edited")
+        .await
+        .unwrap();
+    let edge_page_stale = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT stale_reason FROM pages WHERE id = 'g13_div_page_edge'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next()
+            .await
+            .unwrap()
+            .unwrap()
+            .get::<Option<String>>(0)
+            .unwrap()
+    };
+    assert_eq!(
+        edge_page_stale.as_deref(),
+        Some("source_updated"),
+        "must mark the edge-only page stale when its cited memory is updated"
+    );
+
+    db.update_memory("g13_div_mem_legacy_1", "legacy content 1, edited")
+        .await
+        .unwrap();
+    let legacy_page_stale = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT stale_reason FROM pages WHERE id = 'g13_div_page_legacy'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next()
+            .await
+            .unwrap()
+            .unwrap()
+            .get::<Option<String>>(0)
+            .unwrap()
+    };
+    assert_eq!(
+        legacy_page_stale, None,
+        "must not mark the legacy-only page stale -- it isn't backed by edges"
+    );
+}
+
+/// G6 Stage 1.3 test 4 (parity stays 0): the reader migration touches no
+/// writer and no parity derivation, so a page linked through both real
+/// writers must still reconcile clean.
+#[tokio::test]
+async fn stage_1_3_reader_migration_keeps_cites_edge_parity_clean() {
+    let (db, _dir) = test_db().await;
+    seed_memory_with_source_id_and_space(&db, "g13_parity_mem", "content", "space_a").await;
+    {
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "g13_parity_page", "space_a").await;
+    }
+    db.link_page_source("g13_parity_page", "g13_parity_mem", "test")
+        .await
+        .unwrap();
+    db.link_page_evidence(
+        "g13_parity_page",
+        "authored",
+        None,
+        Some("Editor note"),
+        "test",
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "the Stage 1.3 reader migration must not disturb edges parity"
+    );
+
+    // S2 (2026-08-05 review): pin the drop explicitly. `page_evidence` now
+    // has 2 rows (the memory-kind row from link_page_source, plus the
+    // authored/NULL-locator row above), but a NULL-locator row mints no
+    // edge (link_page_evidence's documented skip), so the edge-backed
+    // reader #4 (`get_page_evidence`) must return only 1.
+    let evidence_row_count = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM page_evidence WHERE page_id = 'g13_parity_page'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+    };
+    assert_eq!(evidence_row_count, 2, "legacy page_evidence has both rows");
+    let evidence = db.get_page_evidence("g13_parity_page").await.unwrap();
+    assert_eq!(
+        evidence.len(),
+        1,
+        "get_page_evidence must drop the NULL-locator authored row -- it has \
+         no edge twin, so the edge-backed reader reports fewer rows than the \
+         legacy table by design"
+    );
+    assert_eq!(evidence[0].source_kind, "memory");
+}
+
 #[tokio::test]
 async fn replace_page_links_dual_writes_and_invalidates_removed_links() {
     let (db, _dir) = test_db().await;
@@ -48145,6 +48592,146 @@ async fn cleanup_orphaned_page_sources_preserves_edge_backed_by_page_citations()
         None,
         "pages.citations still backs mem_gone -- the shared edge must stay active"
     );
+}
+
+/// G6 Stage 1.3 S1: pins the D7 survivor as IN SCOPE by design, not an
+/// accident. Post-1.3, "page sources" means "active `cites` edges", which
+/// includes an edge kept alive only by `pages.citations` backing after its
+/// `page_sources` row was pruned (D7 refcount, `cites_backed_by_page_citations`
+/// at db.rs). The reader migration widens what `get_page_sources` reports
+/// versus the pre-migration legacy table -- this is deliberate and
+/// time-boxed: Stage 2 retires `pages.citations`' edge-backing role.
+#[tokio::test]
+async fn get_page_sources_returns_d7_survivor_backed_only_by_citations() {
+    let (db, _dir) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_d7", "space_a").await;
+        seed_page_source(&conn, "page_d7", "mem_d7_gone").await;
+        let citations = serde_json::json!([
+            {"occurrence": 1, "marker": 1, "source_kind": "memory", "locator": "mem_d7_gone",
+             "score": 0.9, "status": "verified", "scope": "sentence"}
+        ]);
+        conn.execute(
+            "UPDATE pages SET citations = ?1 WHERE id = 'page_d7'",
+            libsql::params![citations.to_string()],
+        )
+        .await
+        .unwrap();
+        conn.execute("BEGIN", ()).await.unwrap();
+        MemoryDB::dual_write_edge(
+            &conn,
+            "cites",
+            "page",
+            "page_d7",
+            "memory",
+            "mem_d7_gone",
+            "mem_d7_gone",
+            "legacy",
+            "space_a",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+        conn.execute("COMMIT", ()).await.unwrap();
+    }
+
+    // mem_d7_gone was never a real memory, so its page_sources row is an
+    // orphan -- pruned by the cleanup sweep, but the edge survives because
+    // pages.citations still backs it.
+    let removed = db.cleanup_orphaned_page_sources().await.unwrap();
+    assert_eq!(removed, 1);
+
+    let sources = db.get_page_sources("page_d7").await.unwrap();
+    assert_eq!(
+        sources.len(),
+        1,
+        "get_page_sources must still report the D7 survivor: the legacy row is \
+         gone but the edge stays active, and reading edges means reading the \
+         edge, not the legacy row"
+    );
+    assert_eq!(sources[0].memory_source_id, "mem_d7_gone");
+}
+
+/// G6 Stage 1.3 pin (closure ruling, 2026-08-05): `get_page_sources` is an
+/// ENUMERATION reader and must return every `dst_kind`, not just `memory` --
+/// the `dst_kind='memory'` filter this reader carried before the ruling
+/// narrowed it below what legacy `page_sources` actually returned (that
+/// table's dual-write, `insert_page`'s `INSERT OR IGNORE INTO page_sources`,
+/// has no kind check -- see the spec's "Reader migration table" note). Seeds
+/// one memory-kind and one external-kind cites edge on the same page and
+/// asserts both come back, ordering discipline intact.
+#[tokio::test]
+async fn get_page_sources_returns_external_kind_locators_alongside_memory() {
+    let (db, _dir) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        insert_raw_page_for_m81_test(&conn, "page_ext_pin", "space_a").await;
+        conn.execute("BEGIN", ()).await.unwrap();
+        MemoryDB::dual_write_edge(
+            &conn,
+            "cites",
+            "page",
+            "page_ext_pin",
+            "memory",
+            "mem_ext_pin",
+            "mem_ext_pin",
+            "legacy",
+            "space_a",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+        MemoryDB::dual_write_edge(
+            &conn,
+            "cites",
+            "page",
+            "page_ext_pin",
+            "external",
+            "https://example.test/g6-ext-pin",
+            "https://example.test/g6-ext-pin",
+            "legacy",
+            "space_a",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+        conn.execute("COMMIT", ()).await.unwrap();
+        // `dual_write_edge` (the test helper above) writes a NULL payload, and
+        // `json_set(NULL, ...)` is a SQLite no-op -- seed a valid JSON object
+        // first so the linked_at write actually lands.
+        conn.execute(
+            "UPDATE edges SET payload = json_set(COALESCE(payload, '{}'), '$.linked_at', 100) \
+             WHERE edge_type = 'cites' AND src_id = 'page_ext_pin' AND dst_kind = 'memory'",
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "UPDATE edges SET payload = json_set(COALESCE(payload, '{}'), '$.linked_at', 200) \
+             WHERE edge_type = 'cites' AND src_id = 'page_ext_pin' AND dst_kind = 'external'",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    let sources = db.get_page_sources("page_ext_pin").await.unwrap();
+    assert_eq!(
+        sources.len(),
+        2,
+        "an external-kind cites edge must not be filtered out of page-source enumeration"
+    );
+    assert_eq!(sources[0].memory_source_id, "mem_ext_pin");
+    assert_eq!(sources[0].linked_at, 100);
+    assert_eq!(
+        sources[1].memory_source_id,
+        "https://example.test/g6-ext-pin"
+    );
+    assert_eq!(sources[1].linked_at, 200);
 }
 
 #[tokio::test]

--- a/crates/wenlan-core/src/db/maintenance_duplicate_reads.rs
+++ b/crates/wenlan-core/src/db/maintenance_duplicate_reads.rs
@@ -174,6 +174,8 @@ impl NearDuplicateSliceReader<'_> {
         Ok(pair_rows)
     }
 
+    /// G6 Stage 1.3: reads `edges` (`cites`, `dst_kind='memory'`) instead of
+    /// `page_sources`. Orders by id, not `linked_at` -- no ordering-trap concern.
     pub(crate) async fn load_bounded_page_source_ids(
         &self,
         page_id: &str,
@@ -182,8 +184,10 @@ impl NearDuplicateSliceReader<'_> {
         let mut source_rows = self
             .conn
             .query(
-                "SELECT memory_source_id FROM page_sources \
-                 WHERE page_id = ?1 ORDER BY memory_source_id LIMIT ?2",
+                "SELECT dst_id FROM edges \
+                 WHERE edge_type = 'cites' AND valid_until IS NULL AND dst_kind = 'memory' \
+                       AND src_kind = 'page' AND src_id = ?1 \
+                 ORDER BY dst_id LIMIT ?2",
                 libsql::params![page_id, source_read_limit as i64],
             )
             .await

--- a/crates/wenlan-core/src/db/maintenance_duplicate_reads_test.rs
+++ b/crates/wenlan-core/src/db/maintenance_duplicate_reads_test.rs
@@ -52,6 +52,28 @@ async fn near_duplicate_reader_preserves_pair_order_cursor_and_raw_sources() {
     )
     .await
     .unwrap();
+    // G6 Stage 1.3: `load_bounded_page_source_ids` migrated onto `edges` --
+    // mirror the dual-write here so this raw-SQL fixture still drives the
+    // reader it's meant to test (`lineage='legacy'` exempts the cross-space
+    // fence trigger), same pattern as the retro-scan fixture.
+    for (linked_at, source_id) in [
+        (3, "normalized-b-3"),
+        (1, "normalized-b-1"),
+        (2, "normalized-b-2"),
+    ] {
+        conn.execute(
+            "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, \
+                                 lineage, grounded, space, created_at) \
+             VALUES (?1, 'b', 'page', ?2, 'memory', 'cites', 'legacy', 0, 'work', ?3)",
+            libsql::params![
+                format!("dup-reads-b-{source_id}"),
+                source_id,
+                linked_at as i64
+            ],
+        )
+        .await
+        .unwrap();
+    }
     conn.execute("UPDATE pages SET status = 'archived' WHERE id = 'c'", ())
         .await
         .unwrap();

--- a/crates/wenlan-core/src/db/maintenance_retro_scan.rs
+++ b/crates/wenlan-core/src/db/maintenance_retro_scan.rs
@@ -74,10 +74,15 @@ impl MemoryDB {
 
         // The caller-provided cap is sufficient for its stub decision; no
         // exact count or full source-list materialization is needed.
+        //
+        // G6 Stage 1.3: reads `edges` (`cites`, `dst_kind='memory'`) instead of
+        // `page_sources`.
         let mut source_rows = conn
             .query(
-                "SELECT memory_source_id FROM page_sources \
-                 WHERE page_id = ?1 ORDER BY memory_source_id LIMIT ?2",
+                "SELECT dst_id FROM edges \
+                 WHERE edge_type = 'cites' AND valid_until IS NULL AND dst_kind = 'memory' \
+                       AND src_kind = 'page' AND src_id = ?1 \
+                 ORDER BY dst_id LIMIT ?2",
                 libsql::params![page_id.as_str(), source_read_limit as i64],
             )
             .await

--- a/crates/wenlan-core/src/db/maintenance_retro_scan_test.rs
+++ b/crates/wenlan-core/src/db/maintenance_retro_scan_test.rs
@@ -41,6 +41,23 @@ async fn insert_normalized_sources(db: &MemoryDB, page_id: &str, source_ids: &[&
         )
         .await
         .unwrap();
+        // G6 Stage 1.3: the retro-scan reader migrated onto `edges` --
+        // mirror the dual-write here so this raw-SQL fixture still drives
+        // the reader it's meant to test (`lineage='legacy'` exempts the
+        // cross-space fence trigger).
+        conn.execute(
+            "INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, \
+                                 lineage, grounded, space, created_at) \
+             VALUES (?1, ?2, 'page', ?3, 'memory', 'cites', 'legacy', 0, 'default', ?4)",
+            libsql::params![
+                format!("retro-scan-{page_id}-{source_id}"),
+                page_id,
+                *source_id,
+                linked_at as i64,
+            ],
+        )
+        .await
+        .unwrap();
     }
 }
 

--- a/crates/wenlan-core/src/db/scoped_pages.rs
+++ b/crates/wenlan-core/src/db/scoped_pages.rs
@@ -740,6 +740,12 @@ impl MemoryDB {
         }
     }
 
+    /// G6 Stage 1.3: the joined side reads `edges` (`cites`) instead of
+    /// `page_sources`, spanning all `dst_kind`s (no `dst_kind` filter) -- see
+    /// the unscoped `get_page_sources` doc comment for the ruling. `linked_at`
+    /// is COALESCE-total over the payload-mirrored legacy value and
+    /// `edges.created_at` (ordering trap, same discipline as the unscoped
+    /// reader).
     pub async fn get_page_sources_scoped(
         &self,
         page_id: &str,
@@ -747,9 +753,13 @@ impl MemoryDB {
     ) -> Result<Vec<wenlan_types::PageSource>, WenlanError> {
         let (scope_sql, scope_value) = page_scope_clause(scope, "c.workspace", 2);
         let sql = format!(
-            "SELECT c.id, ps.page_id, ps.memory_source_id, ps.linked_at, ps.link_reason \
-             FROM pages c LEFT JOIN page_sources ps ON ps.page_id = c.id \
-             WHERE c.id = ?1{scope_sql} ORDER BY ps.linked_at ASC"
+            "SELECT c.id, ps.src_id, ps.dst_id, \
+                    COALESCE(json_extract(ps.payload,'$.linked_at'), ps.created_at), \
+                    json_extract(ps.payload,'$.link_reason') \
+             FROM pages c LEFT JOIN edges ps ON ps.src_id = c.id AND ps.edge_type = 'cites' \
+                    AND ps.valid_until IS NULL \
+             WHERE c.id = ?1{scope_sql} \
+             ORDER BY COALESCE(json_extract(ps.payload,'$.linked_at'), ps.created_at) ASC, ps.dst_id ASC"
         );
         let mut params = vec![libsql::Value::Text(page_id.to_string())];
         if let Some(value) = scope_value {

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -37,8 +37,8 @@ crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_check
 crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::insert_page_with_scope|TestDbSession::execute|1
 crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::same_effective_scope_active_duplicate_titles_warn|test_secondary_session|1
 crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::selected_duplicate_scope_filters_registered_and_uncategorized|test_secondary_session|1
-crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::source_page_integrity_accepts_any_canonical_or_legacy_provenance_representation|TestDbSession::execute_batch|1
-crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::source_page_integrity_accepts_any_canonical_or_legacy_provenance_representation|test_secondary_session|1
+crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::source_page_integrity_accepts_json_mirror_cites_edge_or_evidence_row_provenance|TestDbSession::execute_batch|1
+crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::source_page_integrity_accepts_json_mirror_cites_edge_or_evidence_row_provenance|test_secondary_session|1
 crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::source_page_integrity_runs_without_page_projection_or_page_root|TestDbSession::execute_batch|1
 crates/wenlan-core/src/lint/pages/db_checks_test.rs|crate::lint::pages::db_checks::tests::source_page_integrity_runs_without_page_projection_or_page_root|test_secondary_session|1
 crates/wenlan-core/src/lint/pages/integration_test_support.rs|crate::lint::pages::integration_tests::support::semantic_fingerprint|open_isolated_lint_snapshot_for_test|1

--- a/crates/wenlan-core/src/lint/deep.rs
+++ b/crates/wenlan-core/src/lint/deep.rs
@@ -131,6 +131,19 @@ async fn memory_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()
     .await
 }
 
+// G6 Stage 1.3 reader #12 disposition: MIGRATE. The `page_evidence` EXISTS
+// below is one of five independent per-channel well-formedness checks (fact,
+// graph, page, summary, episode) over the canonical retrieval substrate, not a
+// cross-store consistency check between two legacy tables -- so it migrates to
+// `edges` like the rest of the table, unlike the provenance-consistency lints
+// in `lint/pages/provenance_checks/source.rs`, which stay legacy carryovers.
+// S1 (2026-08-05): this widens what counts as "page channel present" to
+// include a D7 survivor -- a `cites` edge kept alive only by `pages.citations`
+// backing after its `page_sources`/`page_evidence` row was pruned (see
+// `cites_backed_by_page_citations`). That's by design: post-1.3, "page
+// channel present" MEANS "an active `cites` edge exists", and edges ≡
+// page_sources ∪ page_evidence(non-NULL locator) ∪ pages.citations by parity
+// construction. Stage 2 retires `pages.citations`' edge-backing role.
 async fn retrieval_substrate(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "m.space", false);
     rows(
@@ -152,8 +165,9 @@ async fn retrieval_substrate(context: &LintContext<'_, '_>) -> Result<RowCheck, 
                     NOT EXISTS(SELECT 1 FROM child_vectors c
                                 WHERE c.parent_kind='memory' AND c.parent_id=h.source_id)
                 AND NOT EXISTS(SELECT 1 FROM memory_entities me WHERE me.memory_id=h.source_id)
-                AND NOT EXISTS(SELECT 1 FROM page_evidence pe
-                                WHERE pe.source_kind='memory' AND pe.locator=h.source_id)
+                AND NOT EXISTS(SELECT 1 FROM edges pe
+                                WHERE pe.edge_type='cites' AND pe.valid_until IS NULL
+                                  AND pe.dst_kind='memory' AND pe.dst_id=h.source_id)
                 AND NOT EXISTS(SELECT 1 FROM summary_node_sources s
                                 WHERE s.memory_source_id=h.source_id)
                 AND NOT EXISTS(SELECT 1 FROM memories ep

--- a/crates/wenlan-core/src/lint/memories/query.rs
+++ b/crates/wenlan-core/src/lint/memories/query.rs
@@ -48,9 +48,10 @@ pub(super) async fn load_records(context: &LintContext<'_, '_>) -> Result<Vec<Me
              EXISTS(SELECT 1 FROM child_vectors c
                      WHERE c.parent_kind='memory' AND c.parent_id=m.source_id
                        AND c.embedding IS NOT NULL) AS fact,
-             EXISTS(SELECT 1 FROM page_sources p WHERE p.memory_source_id=m.source_id)
-               OR EXISTS(SELECT 1 FROM page_evidence pe
-                          WHERE pe.source_kind='memory' AND pe.locator=m.source_id) AS page_link,
+             -- G6 Stage 1.3: collapses the page_sources/page_evidence OR-of-two
+             -- EXISTS into one EXISTS over `edges` (`cites`, `dst_kind='memory'`).
+             EXISTS(SELECT 1 FROM edges p WHERE p.edge_type='cites' AND p.valid_until IS NULL
+                     AND p.dst_kind='memory' AND p.dst_id=m.source_id) AS page_link,
              EXISTS(SELECT 1 FROM summary_node_sources s
                      WHERE s.memory_source_id=m.source_id) AS summary,
              MAX(CASE WHEN m.chunk_index=0 THEN m.source_text END) AS episode_source_text,

--- a/crates/wenlan-core/src/lint/pages/db_checks.rs
+++ b/crates/wenlan-core/src/lint/pages/db_checks.rs
@@ -105,10 +105,21 @@ async fn load_and_assess_source_integrity(context: &LintContext<'_, '_>) -> Resu
             libsql::params::Params::None,
         ),
     };
+    // G6 Stage 1.3: page provenance reads `edges` (`cites`).
+    // S2 (2026-08-05 review): the evidence EXISTS reads `page_evidence` OR
+    // `edges` -- a NULL-locator `authored` row IS provenance (it has no
+    // edge twin; `insert_resolved_page_evidence` only dual-writes when a
+    // real locator resolves), and this check is well-formedness over
+    // provenance rows, not a reader of the canonical `edges` store alone.
+    // Closure review (2026-08-05): the former page_sources-analog EXISTS
+    // (edges restricted to dst_kind='memory') is a strict subset of this
+    // evidence arm's edges half (no dst_kind filter) -- any edge satisfying
+    // it also satisfies the OR here, so it never changed `valid`. Deleted.
     let sql = format!(
         "SELECT p.source_memory_ids,
-                EXISTS(SELECT 1 FROM page_sources ps WHERE ps.page_id=p.id),
                 EXISTS(SELECT 1 FROM page_evidence pe WHERE pe.page_id=p.id)
+                OR EXISTS(SELECT 1 FROM edges pe WHERE pe.edge_type='cites' AND pe.valid_until IS NULL
+                       AND pe.src_id=p.id)
            FROM pages p
           WHERE p.status='active' AND p.creation_kind='source'{scope_clause}
           ORDER BY p.id"
@@ -124,9 +135,8 @@ async fn load_and_assess_source_integrity(context: &LintContext<'_, '_>) -> Resu
         let source_ids = row.get::<String>(0).map_err(|_| ())?;
         let parsed_nonempty =
             serde_json::from_str::<Vec<String>>(&source_ids).is_ok_and(|ids| !ids.is_empty());
-        let has_page_source = row.get::<i64>(1).map_err(|_| ())? != 0;
-        let has_page_evidence = row.get::<i64>(2).map_err(|_| ())? != 0;
-        let valid = parsed_nonempty || has_page_source || has_page_evidence;
+        let has_page_evidence = row.get::<i64>(1).map_err(|_| ())? != 0;
+        let valid = parsed_nonempty || has_page_evidence;
         assessment.push(if valid { Level::Pass } else { Level::Error });
         affected = affected.saturating_add(u64::from(!valid));
     }

--- a/crates/wenlan-core/src/lint/pages/db_checks_test.rs
+++ b/crates/wenlan-core/src/lint/pages/db_checks_test.rs
@@ -250,7 +250,23 @@ async fn insert_page_with_scope(
 }
 
 #[tokio::test]
-async fn source_page_integrity_accepts_any_canonical_or_legacy_provenance_representation() {
+async fn source_page_integrity_accepts_json_mirror_cites_edge_or_evidence_row_provenance() {
+    // S2/S5/S6 (2026-08-05 review): three pages, three DISTINCT provenance
+    // shapes, each proving one branch of the check without redundancy. Post
+    // closure-review deletion of the redundant page_sources-analog EXISTS,
+    // the check is a single `page_evidence OR edges` test (no dst_kind
+    // filter on the edges half), so all three pages route through it:
+    //   - source_json: valid via the JSON `source_memory_ids` mirror alone
+    //     (checked before the EXISTS, no DB row needed).
+    //   - source_join: valid via a `cites` edge alone -- a legacy
+    //     page_sources row with NO edge twin would NOT satisfy the EXISTS;
+    //     the edge is the load-bearing seed here, not the legacy row.
+    //   - source_evidence: valid via a legacy `page_evidence` row alone --
+    //     S2's OR reads a NULL-locator authored row as provenance with no
+    //     edge twin, so no edge seed is needed here. An earlier fixture
+    //     revision added a synthetic edge for this page too; it was dead
+    //     weight (the legacy row alone already satisfies the OR) and has
+    //     been dropped.
     let (db, _tmp) = test_db().await;
     let conn = db.test_secondary_session().unwrap();
     conn.execute_batch(
@@ -273,7 +289,9 @@ async fn source_page_integrity_accepts_any_canonical_or_legacy_provenance_repres
          INSERT INTO page_sources(page_id,memory_source_id,linked_at,link_reason)
          VALUES ('source_join','mem-join',1,'legacy');
          INSERT INTO page_evidence(page_id,source_kind,locator,linked_at,link_reason)
-         VALUES ('source_evidence','external_url',NULL,1,'canonical');",
+         VALUES ('source_evidence','external_url',NULL,1,'canonical');
+         INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at)
+         VALUES ('source_join-edge','source_join','page','mem-join','memory','cites','legacy',0,'default',1);",
     )
     .await
     .unwrap();

--- a/crates/wenlan-core/src/lint/pages/provenance_checks/source.rs
+++ b/crates/wenlan-core/src/lint/pages/provenance_checks/source.rs
@@ -34,6 +34,12 @@ struct SourceBuilder {
     evidence_kinds: Vec<String>,
 }
 
+// G6 Stage 1.3 carryover (2026-08-05): this module validates `page_sources`
+// and `page_evidence` AGAINST EACH OTHER (cross-store consistency), which is
+// definitionally inexpressible over a single canonical `edges` store -- there
+// is no second legacy copy left to disagree with once migrated. Stays on the
+// legacy tables through Stage 1 and Stage 2; retires with the stores at
+// Stage 3, same as `load_sources`/`source_ctes` below.
 pub(super) async fn load_and_assess_sources(
     context: &LintContext<'_, '_>,
 ) -> Result<Assessment, ()> {

--- a/crates/wenlan-core/src/lint/semantic_candidates.rs
+++ b/crates/wenlan-core/src/lint/semantic_candidates.rs
@@ -872,10 +872,14 @@ async fn load_pages(context: &LintContext<'_, '_>) -> Result<Vec<Page>, ()> {
     Ok(output)
 }
 
+// G6 Stage 1.3: reads `edges` (`cites`) instead of `page_evidence`. `source_kind`
+// is COALESCE-total over the payload-mirrored value and the NOT NULL `dst_kind`
+// column (NULL-payload discipline); the old `locator IS NOT NULL` filter is
+// redundant now that `dst_id` is a NOT NULL edge column.
 async fn load_page_evidence(context: &LintContext<'_, '_>) -> Result<Vec<PageEvidence>, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "p.workspace");
     let mut rows = context.snapshot().query(
-        &format!("SELECT pe.page_id,pe.source_kind,pe.locator FROM page_evidence pe JOIN pages p ON p.id=pe.page_id WHERE pe.locator IS NOT NULL{scope} ORDER BY pe.page_id,pe.source_kind,pe.locator"),
+        &format!("SELECT pe.src_id, COALESCE(json_extract(pe.payload,'$.source_kind'), CASE pe.dst_kind WHEN 'memory' THEN 'memory' ELSE 'external' END) AS resolved_kind, pe.dst_id FROM edges pe JOIN pages p ON p.id=pe.src_id WHERE pe.edge_type='cites' AND pe.valid_until IS NULL{scope} ORDER BY pe.src_id,resolved_kind,pe.dst_id"),
         params,
     ).await.map_err(|_| ())?;
     let mut output = Vec::new();

--- a/crates/wenlan-core/src/lint/semantic_test.rs
+++ b/crates/wenlan-core/src/lint/semantic_test.rs
@@ -441,7 +441,14 @@ async fn suspicious_existing_page_and_entity_links_are_distinct_candidates() {
                  'now','now','now','work','research','confirmed');
          INSERT INTO page_evidence (page_id,source_kind,locator,linked_at,link_reason)
          VALUES ('page-unrelated','memory','mem-source',0,'test'),
-                ('page-external','external_url','https://example.test/source',0,'test');",
+                ('page-external','external_url','https://example.test/source',0,'test');
+         -- G6 Stage 1.3: PageEvidenceLinks/PageProvenanceAdequacy candidate
+         -- generation reads `edges`, not `page_evidence` -- mirror the
+         -- dual-write here too (dst_kind drives the memory/external split).
+         INSERT INTO edges
+             (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at)
+         VALUES ('edge-evidence-unrelated','page-unrelated','page','mem-source','memory','cites','legacy',0,'work',0),
+                ('edge-evidence-external','page-external','page','https://example.test/source','external','cites','legacy',0,'work',0);",
         )
         .await
         .unwrap();
@@ -470,9 +477,17 @@ async fn suspicious_existing_page_and_entity_links_are_distinct_candidates() {
 #[tokio::test]
 async fn candidate_generator_failure_is_incomplete() {
     let (db, _dir) = test_db().await;
+    // G6 Stage 1.3: `load_page_evidence`/`load_relations` moved onto `edges`,
+    // so dropping `page_evidence` no longer breaks the up-front candidate
+    // load batch (`candidates::load` in semantic_candidates.rs). `pages` and
+    // most other loader tables have FK dependents SQLite refuses to drop
+    // (`PRAGMA foreign_keys=ON`); `memory_entities` is still read directly by
+    // `load_memory_entity_links` in that same `?`-chained batch and has no
+    // incoming FK references, so dropping it reproduces the same "one query
+    // fails, every check reports FailedToRun" cascade this test exercises.
     db.test_primary_session()
         .await
-        .execute_batch("DROP TABLE page_evidence;")
+        .execute_batch("DROP TABLE memory_entities;")
         .await
         .unwrap();
 
@@ -480,6 +495,21 @@ async fn candidate_generator_failure_is_incomplete() {
     assert_reason(
         &report,
         LintSemanticCheckId::MemoryEntityLinks,
+        LintOutcome::FailedToRun,
+        LintReasonCode::SemanticCandidateGenerationFailure,
+    );
+    // `MemoryClassification`'s own loader (`load_memories`) runs and succeeds
+    // BEFORE `load_memory_entity_links` in the `?`-chain (semantic_candidates.rs
+    // `load()`), so this check's inputs are intact. It still comes back
+    // FailedToRun: a single loader failure aborts `load()` as a whole, and
+    // `run()`'s fallback (`failed_generation`) blanket-marks every
+    // `LintSemanticCheckId`, not just the one whose loader threw. Asserting on
+    // `MemoryEntityLinks` alone (the check that OWNS the dropped table) cannot
+    // tell cascade propagation apart from a plain local failure; a check with
+    // healthy inputs still going down is the property this test exists to pin.
+    assert_reason(
+        &report,
+        LintSemanticCheckId::MemoryClassification,
         LintOutcome::FailedToRun,
         LintReasonCode::SemanticCandidateGenerationFailure,
     );

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -117,9 +117,55 @@ Order by measured entanglement:
 3. **`page_sources` + `page_evidence`** (~30 fns, co-written pair) —
    `insert_resolved_page_evidence` is the evidence choke point; `page_sources` has
    no single choke point and needs one first.
+   **Status (2026-08-05):** Stage 1.3 migrated all readers in the spec table
+   (11 mandatory plus one conditional, `retrieval_substrate` in `lint/deep.rs`,
+   a per-channel well-formedness check rather than a cross-store consistency
+   check) onto `edges` (`cites` edge type). No id-swap trap here (unlike
+   Stage 1.2): `memory_source_id`/`locator` are real `dst_id` columns, not
+   hash-input discriminators, so both stores migrate cleanly with no schema
+   change.
+
+   Review round (S1-S7) surfaced four readers beyond the spec table and one
+   equivalence-rationale correction:
+   - **Equivalence (S1):** parity drift 0 proves a THREE-store union, not
+     two — `edges ≡ page_sources ∪ page_evidence(non-NULL locator) ∪
+     pages.citations`. A `cites` edge can stay active backed only by
+     `pages.citations` after its `page_sources`/`page_evidence` row is
+     pruned (the D7 refcount survivor). The migrated readers adopt this
+     union knowingly, pinned by
+     `get_page_sources_returns_d7_survivor_backed_only_by_citations`.
+   - **`delete_non_head_memory_chunks` (db.rs)** — the same page-invalidation
+     shape as reader #6, migrated to `edges` (S3a).
+   - **The evidence half of `lint/pages/db_checks.rs`'s
+     `pages.source_page_integrity` check** — reverted to `page_evidence OR
+     edges` (S2): a NULL-locator `authored` row is real provenance with no
+     edge twin, so an edges-only read undercounted it. The page_sources half
+     of the same check stays edges-only.
+   - **Three distill-eligibility predicates** (`query_distillation_staging_pool`,
+     `query_distillation_seed_slice`, `query_distillation_ann_neighbors`, all
+     db.rs) — CARRYOVER, dated in place (S3b): widening them to the
+     edges/cites union changes the eligibility pool and needs its own test
+     attention; folds into Stage 2.
+
+   Four locations stay on legacy by design and are dated in place: the two
+   provenance cross-store lints in `lint/pages/provenance_checks/source.rs`
+   (compare the legacy tables against each other, not against edges — an
+   edges-only read would make the check trivially pass), the D7 refcount
+   helpers `cites_backed_by_page_citations` / `cites_backed_outside_page_citations`
+   (writer-side machinery gating whether `pages.citations` still backs a
+   locator before retiring its edge), and `page_memory_provenance_state`
+   (writer-internal before/after snapshot). `page_sources`/`page_evidence`
+   themselves stay live as the dual-write target; only the reader side moved.
 4. **`pages.citations`** (4 writer fns, 10+ readers) — hardest: a column in every
    `Page` row mapper (db.rs + db/scoped_pages.rs). Retiring it is a struct/mapping
    reshape, its own PR.
+   **Stage 1.4 (pages.citations) — reclassified 2026-08-05:** `pages.citations`
+   is a derived render cache, not a truth store. Per-occurrence annotation
+   state (occurrence/marker/score/status/scope) is render-layer by design;
+   `citations IS NULL` drives the citation-backfill sweep with no edges
+   analog; the column passes the delete-and-rebuild test. Stage 2 retires its
+   edge-backing role (D7 refcount simplification); the column survives Stage 3
+   the way the FTS index does. No reader cutover.
 5. **`entities` + `entity_aliases` + `observations`** (~25+ fns) — largest surface;
    readers move to the `kind='entity'` shadow pages. Depends on stage 1.2's shared-
    CRUD rework.

--- a/docs/plans/2026-08-05-g6-stage13-page-sources-evidence-readers-spec.md
+++ b/docs/plans/2026-08-05-g6-stage13-page-sources-evidence-readers-spec.md
@@ -1,0 +1,168 @@
+# G6 Stage 1.3 — migrate `page_sources` + `page_evidence` readers onto `edges`
+
+Parent program: `docs/plans/2026-08-04-g6-retirement-program.md` (Stage 1, store 3).
+Scout: `docs/superpowers/g6-stage1-page-sources-evidence-scout.md` (gitignored working
+doc; findings restated here). Prerequisites: #486/#487 (cites edges carry payload keys
+`source_kind` (always), `linked_at`, `link_reason`, `title` via `cites_semantic_patch`,
+refresh-on-reassert; m115 backfilled them from live legacy rows) and the Stage 1.2 PR
+(NULL-guard discipline, divergence-test pattern). The Stage-0-class writer gap the
+scout found (`try_update_page_content`) was fixed in PR #482 — writers are complete;
+`dual_write_edge` is `#[cfg(test)]`, so no production mint can bypass the payload path
+(compile-time guarantee, no writer changes in this PR).
+
+## Structural differences from Stage 1.2 (why this store is easier)
+
+- The identifying value (`page_sources.memory_source_id` == `page_evidence.locator`)
+  is a REAL edge column (`dst_id`) at every dual-write site, not a hash-input-only
+  discriminator. No semantic_type analog needed.
+- No wire type exposes a legacy row id (`PageSource` = page_id, memory_source_id,
+  linked_at, link_reason; `PageEvidence` adds source_kind, locator, title). NO trap-2
+  id swap in this PR.
+- The 4-way `source_kind` (`memory`/`external_url`/`external_file`/`authored`)
+  collapses to 2-way `dst_kind` on the edge row but survives in payload
+  `$.source_kind` — and `cites_semantic_patch` writes it UNCONDITIONALLY, so only
+  pre-#486 edges whose legacy row vanished before m115 can lack it.
+
+## Equivalence rationale (S1, 2026-08-05 review finding)
+
+Parity drift 0 is often read as "edges ≡ `page_sources` ∪ `page_evidence`" (a
+two-store union). That's the wrong equivalence, and reading the migrated
+readers against it makes the D7 survivor look like a bug. The parity-honest
+equivalence is a THREE-store union:
+
+```
+edges (cites) ≡ page_sources
+              ∪ page_evidence (non-NULL locator)
+              ∪ pages.citations
+```
+
+`pages.citations` independently derives `cites` edges (`backfill_edges_from_page_citations`,
+db.rs:20358), same as `page_sources` (`backfill_edges_from_page_sources`, db.rs:20161)
+and `page_evidence` (`backfill_edges_from_page_evidence`, db.rs:20214) — three
+derivation sites feeding the same content-addressed edge_id space, all folded
+into the SAME parity sweep. A `cites` edge for `(page, locator)` can therefore
+stay active with NEITHER `page_sources` NOR `page_evidence` backing it, as
+long as `pages.citations` still does (the D7 refcount: `cites_backed_by_page_citations`,
+checked before an orphan-cleanup invalidate). The migrated readers know this
+and adopt it: post-1.3, "page sources"/"page evidence" MEANS "active `cites`
+edges", which is a WIDER population than "rows in the legacy table" whenever
+a D7 survivor exists. This is deliberate and time-boxed — Stage 2 retires
+`pages.citations`' edge-backing role, at which point the union narrows back
+to two stores. See `get_page_sources_returns_d7_survivor_backed_only_by_citations`
+(db/main_tests.rs) for the pinned reader-side behavior.
+
+## The ordering trap (same class as 1.2's trap 1)
+
+Legacy readers order by `linked_at ASC` and the numbered-source lists downstream
+(citation backfill, post-ingest) depend on that stable order. `edges.created_at` on
+m81-era edges is migration-day, NOT the legacy `linked_at`. Every migrated reader that
+ordered by `linked_at` uses:
+
+```sql
+COALESCE(json_extract(e.payload,'$.linked_at'), e.created_at)
+```
+
+and projects that same expression wherever the wire field `linked_at: i64`
+(non-optional) is populated — never a bare payload extract, which can be NULL.
+
+## NULL-payload discipline (1.2 review finding S2/R1, applied at design time)
+
+Any projection of a payload key into a non-optional field must be COALESCE-total:
+
+- `linked_at` → the COALESCE above (always non-NULL: created_at is NOT NULL).
+- `source_kind` → `COALESCE(json_extract(e.payload,'$.source_kind'), CASE e.dst_kind
+  WHEN 'memory' THEN 'memory' ELSE 'external' END)` — dst_kind is a NOT NULL real
+  column, so the fallback is total and lossless for memory rows, coarse-but-honest
+  for degraded external rows.
+- `link_reason`, `title` → already Option on the wire; plain extract is fine.
+
+## Reader migration table
+
+All migrated queries filter `edge_type='cites' AND valid_until IS NULL`, with
+`src_kind='page'` where the query is page-anchored. **Ruling (2026-08-05, closure
+review, corrects the original premise below):** `page_sources` was never
+memory-only at the data level -- `insert_page`'s dual-write does `INSERT OR IGNORE
+INTO page_sources` for every id in `source_memory_ids` with no kind check, memory
+or external alike, and mints the typed `cites` edge twin regardless (`dst_kind`
+resolved per source). Filtering the enumeration readers (`get_page_sources`,
+`get_page_sources_scoped`, `count_page_sources_up_to`) to `dst_kind='memory'`
+narrowed their output below what legacy `page_sources` actually returned -- a real
+regression a production caller (`refresh_page`, distill.rs) depended on. Those
+three readers carry NO `dst_kind` filter, same as `page_evidence`'s span-all-kinds
+readers; the S1 union semantics ("page sources = active cites edges") has no kind
+carve-out either. `dst_kind='memory'` stays correct only where a reader is keyed
+BY a known memory id (`get_pages_for_memory`, `mark_pages_depending_on_memory_
+sources_except`, `load_bounded_page_source_ids`, retro-scan, and the deletion-path
+edge retirement added alongside this ruling) -- there `dst_id` IS the memory id
+being matched, not an enumeration-scope filter.
+
+| # | Reader | Location | Notes |
+|---|---|---|---|
+| 1 | `get_page_sources` | db.rs ~48099 | product route via `handle_get_page_sources`; SELECT src_id, dst_id, COALESCE-linked_at, `$.link_reason`; ORDER BY the COALESCE ASC; no dst_kind filter (ruling above) |
+| 2 | `get_page_sources_scoped` | db/scoped_pages.rs:739 | same + scope handling exactly as the existing scoped variant; no dst_kind filter (ruling above) |
+| 3 | `count_page_sources_up_to` | db.rs ~48134 | clean COUNT-with-LIMIT swap; no dst_kind filter (ruling above) |
+| 4 | `get_page_evidence` | db.rs ~48160 | all kinds; COALESCE source_kind + linked_at per discipline; `$.title`, `$.link_reason` optional |
+| 5 | `get_pages_for_memory` | db.rs ~47650 | `SELECT src_id ... WHERE dst_kind='memory' AND dst_id=?` then JOIN pages — clean |
+| 6 | `mark_pages_depending_on_memory_sources_except` | db.rs ~27613 | EXISTS swap — clean |
+| 7 | `load_bounded_page_source_ids` | db/maintenance_duplicate_reads.rs:177 | clean |
+| 8 | retro-scan bounded source count | db/maintenance_retro_scan.rs:79 | clean |
+| 9 | db_checks page-has-sources / page-has-evidence | lint/pages/db_checks.rs:110-111 | EXISTS swaps — clean |
+| 10 | memories-lint reverse lookup | lint/memories/query.rs:51-52 | EXISTS swap — clean |
+| 11 | semantic-candidates evidence loader | lint/semantic_candidates.rs:876 | needs page_id, source_kind, locator → src_id, COALESCE source_kind, dst_id |
+
+**Conditional (investigate first, bounded discretion — same protocol as 1.2's #12/#13):**
+
+| # | Reader | Location | Condition |
+|---|---|---|---|
+| 12 | orphan-evidence check | lint/deep.rs:155 | Scout time-boxed it; read it fully. If it is a well-formedness check over the canonical store, migrate with the discipline above. If it cross-checks the legacy stores against each other or another store, it is a carryover — dated comment. Report which and why. |
+
+**Deliberate carryovers (stay on legacy, dated comments):**
+
+- The provenance-consistency lints in `lint/pages/provenance_checks/source.rs` (:37,
+  :78, :193-236) — they validate the two legacy tables AGAINST EACH OTHER (cross-store
+  consistency), which is definitionally inexpressible over a single canonical store.
+  They retire with the stores at Stage 3.
+- `page_memory_provenance_state` (db.rs ~46822) — writer-internal undo-ledger
+  bookkeeping, not a reader migration target.
+- The D7 refcount helpers (`cites_backed_outside_page_citations`,
+  `cites_backed_by_page_citations`) — writer-side machinery, untouched.
+- The claim-derivation UNION bridge (db/claim_derivation.rs:1832-1845) — already
+  edges-aware by design; leave as is.
+
+Parity derivation for this pair STAYS in `reconcile_edges_parity` (the carryover lints
+are still legacy readers). Program-doc status note in the same PR.
+
+## No migration needed
+
+No new schema, no new migration: m115 already backfilled the cites payload keys. (If
+implementation uncovers active cites edges whose payload lacks `linked_at` on rows the
+COALESCE ordering would visibly mis-order — i.e. legacy row still live with a
+different linked_at — bounce it back; do not invent an m117 unilaterally.)
+
+## Tests (RED-control discipline as in 1.2)
+
+1. **Equivalence per product reader** — seeded fixture via the real writers
+   (`link_page_source`, `link_page_evidence`); field-by-field including order for
+   `get_page_sources(_scoped)` and `get_page_evidence`; assert `linked_at` on the wire
+   equals the legacy value (payload-backed), not edge insert time (seed one edge whose
+   `created_at` is forced to differ from payload `$.linked_at`).
+2. **Kind fallback** — an active cites edge with NO payload (simulated pre-#486
+   remnant): `get_page_evidence` returns it with the dst_kind-derived kind and
+   created_at-derived linked_at rather than erroring or dropping it.
+3. **Divergence test** (the 1.2 pattern, asymmetric seeding): one cites fact only in
+   `edges`, two only in `page_sources`/`page_evidence`; assert readers #1, #4, #5, #6
+   and the two EXISTS lints see the edge-only fact and stay blind to the legacy-only
+   orphans. RED-control via a prove-then-revert mutation of one reader.
+4. **Parity stays 0** — existing parity fixtures unchanged.
+
+## Gates
+
+Same as 1.2: fmt, clippy (both variants), focused modules (page/source/evidence
+filters, the lint modules touched, the divergence test), full suites at integration
+time (queued by the session lead, not the executor).
+
+## Out of scope
+
+`pages.citations` readers (Stage 1.4 — `row_to_page` reshape, its own PR); entities
+(Stage 1.5); writer changes (none needed); dropping any parity derivation; the
+provenance-consistency lints' eventual retirement design.


### PR DESCRIPTION
## G6 Stage 1.3 — page_sources + page_evidence readers cut over to canonical cites edges

Third reader cutover of the G6 retirement program (`docs/plans/2026-08-04-g6-retirement-program.md`, Stage 1 store 3; spec `docs/plans/2026-08-05-g6-stage13-page-sources-evidence-readers-spec.md`, included in this PR). All 11 mandatory readers plus the conditional `retrieval_substrate` lint move from `page_sources`/`page_evidence` onto active `cites` edges. No schema change, no new migration — m115 already backfilled the payload keys.

### Design decision recorded in this PR (S1, union semantics)

`reconcile_edges_parity` derives expected cites edges from **three** stores: `page_sources` ∪ `page_evidence` (non-NULL locator) ∪ `pages.citations`. Drift 0 therefore licenses union semantics, not two-store equivalence: post-1.3, "page sources/evidence" MEANS "active cites edges", which by design includes a D7 survivor — an edge kept alive only by `pages.citations` backing after its legacy row was pruned. This is deliberate and time-boxed: Stage 2 retires `pages.citations`' edge-backing role. Documented in the spec ("Equivalence rationale"), inline at the readers, and pinned by test `get_page_sources_returns_d7_survivor_backed_only_by_citations`.

### What moved

- Product readers: `get_page_sources`(+scoped), `count_page_sources_up_to`, `get_page_evidence`, `get_pages_for_memory`, `mark_pages_depending_on_memory_sources_except`, `delete_non_head_memory_chunks` (merge-chunk-cleanup twin), `load_bounded_page_source_ids`, retro-scan bounded-source count.
- Lints: `pages.source_page_integrity` (page_sources half; the evidence half reads `page_evidence OR edges` because NULL-locator authored evidence has no edge twin — dated rationale in place), `memories.derived.page_links`, `semantic_candidates`, `retrieval_substrate` (per-channel well-formedness ⇒ migrates).
- Ordering discipline: `COALESCE(json_extract(payload,'$.linked_at'), created_at)` everywhere (m81-era edges carry migration-day `created_at`), with `dst_id ASC` tiebreak for deterministic order.

### Deliberate carryovers (dated in place)

Provenance cross-store lints (`lint/pages/provenance_checks/source.rs` — compare the legacy tables against each other), the D7 refcount helpers, `page_memory_provenance_state` (writer-internal), and the three distillation-eligibility predicates (eligibility-pool widening deserves its own test attention; folds into Stage 2). Parity derivation for this pair stays in `reconcile_edges_parity` until the last legacy reader retires.

### Production fixes surfaced by the full-suite gate

- **Memory deletion now retires cites edges.** `delete_by_source_id_in_transaction` deleted the legacy `page_sources`/`page_evidence` rows but left the canonical edge twin active — under edges-backed readers a deleted memory kept appearing as a page source. Deletion now invalidates the matching cites edges alongside the legacy DELETEs.
- **Enumeration readers carry no `dst_kind` filter.** The spec's original "page_sources is memory-only" premise was wrong — the `insert_page` dual-write inserts every `source_memory_ids` item with no kind check — so a `dst_kind='memory'` filter on `get_page_sources`(+scoped)/`count_page_sources_up_to` silently dropped external-file/URL citations from page refresh. The filter stays only on readers keyed by a known memory id. Pinned by the (unchanged) distill regression test plus a direct external-locator test.

### Also in this PR

- Stage 1.4 reclassification note in the program doc: `pages.citations` is a derived render cache, not a truth store — Stage 2 retires its edge-backing role; the column survives Stage 3 like the FTS index. No reader cutover.
- Retro-scan test fixture now seeds edge twins (pre-existing gap from the Phase 1 migration of that reader).

### Tests

New: D7-survivor pinning test; payload-fallback test; divergence test with asymmetric seeding (edge-only fact seen, legacy-only orphans invisible) with RED control via prove-then-revert; parity-stays-0 test extended with the NULL-locator 2-vs-1 drop assertion.

Suites (full capture): core 4073 passed / 0 failed / 33 ignored; server 619 / 0 / 3 over 43 binaries; CLI 106 / 0 / 1. fmt clean; clippy both variants clean. (The last two review items — a test assertion and a doc comment — landed after the chain; covered by a focused `lint::semantic` 20/20 + fmt + clippy.)

Reviewed by the Opus investigator lane (full review + bounded closure pass); findings S1–S7 dispositioned as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
