### PR TITLE
feat(kg): G6 Stage 1.5a — clean entity readers cut over to kind='entity' shadow pages

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -101,6 +101,8 @@ mod claim_identity_test;
 #[cfg(test)]
 mod edges_rebuild_test;
 #[cfg(test)]
+mod entity_clean_readers_test;
+#[cfg(test)]
 mod entity_page_adapter_test;
 #[cfg(test)]
 mod eval_lifecycle_integrity_test;
@@ -10089,6 +10091,23 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// G6 Stage 1.5a test helper: backfills the `kind='entity'` shadow page
+    /// for a raw-SQL-seeded `entities` row (test fixtures that `INSERT INTO
+    /// entities` directly, bypassing `store_entity`, would otherwise be
+    /// invisible to every reader migrated in this stage). Call right after
+    /// the raw insert. Not for production use -- normal writes stay on
+    /// `store_entity`, which does this in the same transaction.
+    #[cfg(test)]
+    pub(crate) async fn test_seed_entity_shadow_page(
+        &self,
+        entity_id: &str,
+    ) -> Result<(), WenlanError> {
+        let now_iso = chrono::Utc::now().to_rfc3339();
+        let page_id = crate::pages::new_page_id();
+        let conn = self.conn.lock().await;
+        Self::insert_entity_shadow_page(&conn, entity_id, &page_id, &now_iso).await
+    }
+
     // Migration 92 (M3 PR-1, stage f): dual-write entities as `kind='entity'`
     // page shadows. Adds `pages.entity_type`/`pages.confidence`/
     // `pages.entity_confirmed` (mirroring the matching `entities` columns),
@@ -15055,13 +15074,22 @@ impl MemoryDB {
     /// selective `idx_memories_source_id` join. The scale bench (`db::tests`) pins
     /// this via `EXPLAIN QUERY PLAN` over THIS exact string, so stripping the `+`
     /// reddens by cause, not only by the p95 timing symptom.
+    /// G6 Stage 1.5a: `fe`/`te` hydrate only `name` (via the `kind='entity'`
+    /// shadow page, joined through `entity_page_map`), which does not touch
+    /// the `+m.source` memories access-path fix pinned by the `EXPLAIN QUERY
+    /// PLAN` scale-bench assertion above (`db/main_tests.rs`,
+    /// `edge_grounding_candidates` scale bench) — that assertion only checks
+    /// the `memories` LEFT JOIN's index selection, which this join is
+    /// independent of.
     const EDGE_GROUNDING_CANDIDATE_SCAN_SQL: &'static str =
         "SELECT r.rowid, r.from_entity, r.to_entity, r.relation_type,
-                        r.source_memory_id, fe.name, te.name,
+                        r.source_memory_id, pfe.title, pte.title,
                         m.content, m.origin_class, m.source_id, m.url, r.id
                  FROM relations r
-                 JOIN entities fe ON fe.id = r.from_entity
-                 JOIN entities te ON te.id = r.to_entity
+                 JOIN entity_page_map epmfe ON epmfe.entity_id = r.from_entity
+                 JOIN pages pfe ON pfe.id = epmfe.page_id AND pfe.kind = 'entity' AND pfe.status = 'active'
+                 JOIN entity_page_map epmte ON epmte.entity_id = r.to_entity
+                 JOIN pages pte ON pte.id = epmte.page_id AND pte.kind = 'entity' AND pte.status = 'active'
                  LEFT JOIN memories m
                         ON m.source_id = r.source_memory_id
                        AND +m.source = 'memory'
@@ -19605,6 +19633,15 @@ impl MemoryDB {
     /// consumer that flips onto this gate MUST strictly exclude
     /// cross-space legacy rows from its OWN flipped read (read-side
     /// exclusion only, never a row mutation).
+    ///
+    /// 2026-08-05, G6 Stage 1.5a: the 18 readers migrated in that stage
+    /// bypass this gate entirely -- by G6 program design, Stage 1 is an
+    /// unconditional hard cutover to the canonical shadow-page store, the
+    /// same contract 1.1-1.3 used for `edges` while the `reader_uses_edges`
+    /// gate + cutover lever still existed. This gate's only remaining
+    /// consumers are the `scoped_entities` vanguard hybrid reads
+    /// (`db/scoped_entities.rs`); this gate and `entity_reader_cutover`
+    /// retire together in Stage 2 when the writers cut over.
     async fn reader_uses_entity_pages(
         conn: &libsql::Connection,
         consumer: &str,
@@ -24713,8 +24750,15 @@ impl MemoryDB {
             .collect();
         if !entity_ids.is_empty() {
             let placeholders: Vec<String> = entity_ids.iter().map(|_| "?".to_string()).collect();
+            // G6 Stage 1.5a review fix #6: name-only, space-free hydration by
+            // id set -- CLEAN under the spec's own rule, moved onto the
+            // `kind='entity'` shadow page via `entity_page_map`, same join
+            // shape as `EDGE_GROUNDING_CANDIDATE_SCAN_SQL` above.
             let sql = format!(
-                "SELECT id, name FROM entities WHERE id IN ({})",
+                "SELECT epm.entity_id, p.title FROM entity_page_map epm
+                 JOIN pages p ON p.id = epm.page_id
+                 WHERE p.kind = 'entity' AND p.status = 'active'
+                   AND epm.entity_id IN ({})",
                 placeholders.join(",")
             );
             let params: Vec<libsql::Value> = entity_ids
@@ -26185,6 +26229,10 @@ impl MemoryDB {
     ///
     /// Returns the deduped, sorted expanded id set (always a superset of the
     /// non-empty seeds). Empty seeds -> empty (caller keeps the anchor set).
+    /// G6 Stage 1.5a: the endpoint scope-filter joins the `kind='entity'`
+    /// shadow page (via `entity_page_map`) instead of `entities` directly —
+    /// safe under the space-sentinel fold, same argument as
+    /// `filter_entity_ids_scoped`.
     async fn expand_anchor_entities_khop(
         &self,
         anchor_entity_ids: &[String],
@@ -26249,24 +26297,28 @@ impl MemoryDB {
             let (endpoint_scope, scope_value) = match scope {
                 ReadScope::Global => (String::new(), None),
                 ReadScope::Space(space) => (
-                    format!("AND ef.space = ?{scope_parameter} AND et.space = ?{scope_parameter}"),
+                    format!("AND pf.space = ?{scope_parameter} AND pt.space = ?{scope_parameter}"),
                     Some(libsql::Value::Text(space.clone())),
                 ),
                 ReadScope::Uncategorized => (
-                    "AND ef.space IS NULL AND et.space IS NULL".to_string(),
-                    None,
+                    format!("AND pf.space = ?{scope_parameter} AND pt.space = ?{scope_parameter}"),
+                    Some(libsql::Value::Text(crate::db::UNFILED_SPACE_ID.to_string())),
                 ),
             };
             let sql = format!(
                 "SELECT r.src_id, r.dst_id FROM edges r
-                 JOIN entities ef ON ef.id = r.src_id
-                 JOIN entities et ON et.id = r.dst_id
+                 JOIN entity_page_map epmf ON epmf.entity_id = r.src_id
+                 JOIN pages pf ON pf.id = epmf.page_id AND pf.kind = 'entity' AND pf.status = 'active'
+                 JOIN entity_page_map epmt ON epmt.entity_id = r.dst_id
+                 JOIN pages pt ON pt.id = epmt.page_id AND pt.kind = 'entity' AND pt.status = 'active'
                  WHERE r.edge_type='relates' AND r.valid_until IS NULL
                    AND r.src_id IN ({ph}) {endpoint_scope}
                  UNION
                  SELECT r.src_id, r.dst_id FROM edges r
-                 JOIN entities ef ON ef.id = r.src_id
-                 JOIN entities et ON et.id = r.dst_id
+                 JOIN entity_page_map epmf ON epmf.entity_id = r.src_id
+                 JOIN pages pf ON pf.id = epmf.page_id AND pf.kind = 'entity' AND pf.status = 'active'
+                 JOIN entity_page_map epmt ON epmt.entity_id = r.dst_id
+                 JOIN pages pt ON pt.id = epmt.page_id AND pt.kind = 'entity' AND pt.status = 'active'
                  WHERE r.edge_type='relates' AND r.valid_until IS NULL
                    AND r.dst_id IN ({ph}) {endpoint_scope}
                  ORDER BY src_id, dst_id",
@@ -26743,6 +26795,8 @@ impl MemoryDB {
             .await
     }
 
+    /// G6 Stage 1.5a: same shadow-page endpoint join as
+    /// `expand_anchor_entities_khop`.
     async fn expand_entities_khop_scoped(
         &self,
         seed_ids: &[String],
@@ -26785,24 +26839,28 @@ impl MemoryDB {
             let (endpoint_scope, scope_value) = match scope {
                 ReadScope::Global => (String::new(), None),
                 ReadScope::Space(space) => (
-                    format!("AND ef.space = ?{scope_parameter} AND et.space = ?{scope_parameter}"),
+                    format!("AND pf.space = ?{scope_parameter} AND pt.space = ?{scope_parameter}"),
                     Some(libsql::Value::Text(space.clone())),
                 ),
                 ReadScope::Uncategorized => (
-                    "AND ef.space IS NULL AND et.space IS NULL".to_string(),
-                    None,
+                    format!("AND pf.space = ?{scope_parameter} AND pt.space = ?{scope_parameter}"),
+                    Some(libsql::Value::Text(crate::db::UNFILED_SPACE_ID.to_string())),
                 ),
             };
             let sql = format!(
                 "SELECT r.dst_id FROM edges r
-                 JOIN entities ef ON ef.id = r.src_id
-                 JOIN entities et ON et.id = r.dst_id
+                 JOIN entity_page_map epmf ON epmf.entity_id = r.src_id
+                 JOIN pages pf ON pf.id = epmf.page_id AND pf.kind = 'entity' AND pf.status = 'active'
+                 JOIN entity_page_map epmt ON epmt.entity_id = r.dst_id
+                 JOIN pages pt ON pt.id = epmt.page_id AND pt.kind = 'entity' AND pt.status = 'active'
                  WHERE r.edge_type='relates' AND r.valid_until IS NULL
                    AND r.src_id IN ({ph}) {endpoint_scope}
                  UNION
                  SELECT r.src_id FROM edges r
-                 JOIN entities ef ON ef.id = r.src_id
-                 JOIN entities et ON et.id = r.dst_id
+                 JOIN entity_page_map epmf ON epmf.entity_id = r.src_id
+                 JOIN pages pf ON pf.id = epmf.page_id AND pf.kind = 'entity' AND pf.status = 'active'
+                 JOIN entity_page_map epmt ON epmt.entity_id = r.dst_id
+                 JOIN pages pt ON pt.id = epmt.page_id AND pt.kind = 'entity' AND pt.status = 'active'
                  WHERE r.edge_type='relates' AND r.valid_until IS NULL
                    AND r.dst_id IN ({ph}) {endpoint_scope}",
                 ph = ph
@@ -31494,6 +31552,13 @@ impl MemoryDB {
     // ===== Knowledge Graph Methods =====
 
     /// Create a new entity in the knowledge graph (simplified — no embedding, no source_agent/confidence).
+    /// Test-only: has zero production callers (the canonical write path is
+    /// `resolve_or_create_entity` -> `store_entity`, which dual-writes the
+    /// `kind='entity'` shadow page in the same transaction). Gated to keep it
+    /// from becoming a silent shadow-invariant violation if a future caller
+    /// picks it up; it now writes its own shadow page so test fixtures built
+    /// on it stay invariant-complete (G6 Stage 1.5a).
+    #[cfg(test)]
     pub async fn create_entity(
         &self,
         name: &str,
@@ -31502,21 +31567,46 @@ impl MemoryDB {
     ) -> Result<String, WenlanError> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now().timestamp();
+        let now_iso = chrono::Utc::now().to_rfc3339();
 
         let conn = self.conn.lock().await;
-        conn.execute(
-            "INSERT INTO entities (id, name, entity_type, space, confirmed, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, 0, ?5, ?5)",
-            libsql::params![
-                id.clone(),
-                name.to_string(),
-                entity_type.to_string(),
-                space.map(|d| d.to_string()),
-                now
-            ],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("create_entity: {}", e)))?;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_entity begin: {}", e)))?;
+
+        let result: Result<(), WenlanError> = async {
+            conn.execute(
+                "INSERT INTO entities (id, name, entity_type, space, confirmed, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, 0, ?5, ?5)",
+                libsql::params![
+                    id.clone(),
+                    name.to_string(),
+                    entity_type.to_string(),
+                    space.map(|d| d.to_string()),
+                    now
+                ],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("create_entity: {}", e)))?;
+
+            let page_id = crate::pages::new_page_id();
+            Self::insert_entity_shadow_page(&conn, &id, &page_id, &now_iso).await?;
+
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("create_entity commit: {}", e)))?;
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        }
 
         Ok(id)
     }
@@ -31785,6 +31875,10 @@ impl MemoryDB {
     /// the T16 MinHash cascade to apply the same-type guard on band candidates
     /// without loading the full `EntityDetail` (observations etc.). Returns
     /// `None` if the id does not exist.
+    /// G6 Stage 1.5a: reads the `kind='entity'` shadow page (title=name,
+    /// entity_type) via `entity_page_map` instead of `entities` directly —
+    /// both fields are mirrored 1:1 by `insert_entity_shadow_page`/
+    /// `update_entity_shadow_page`, and this reader never touches `space`.
     pub async fn get_entity_name_type(
         &self,
         entity_id: &str,
@@ -31792,7 +31886,9 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT name, entity_type FROM entities WHERE id = ?1",
+                "SELECT p.title, p.entity_type FROM entity_page_map epm
+                 JOIN pages p ON p.id = epm.page_id
+                 WHERE epm.entity_id = ?1 AND p.kind = 'entity' AND p.status = 'active'",
                 libsql::params![entity_id.to_string()],
             )
             .await
@@ -33122,6 +33218,16 @@ impl MemoryDB {
         Ok(result)
     }
 
+    // G6 Stage 1.5a carryover (2026-08-05): NOT migrated. This guards relation
+    // writes (`post_write/entity_graph.rs`, both endpoints of a new relation)
+    // reading the exact store `store_entity`/`merge_entities` write -- the
+    // spec's WRITER-COUPLED shared-CRUD core, whose discovery reads flip with
+    // their writers in Stage 2, not ahead of them. The reason is Stage-2
+    // writer-BATCH alignment (this check and its writer move as one unit so
+    // the migration doesn't split a single logical write path across two
+    // stores mid-flight), not connection-level coupling -- the shared-mutex
+    // `conn` below can never observe another writer's uncommitted rows
+    // regardless of which store it queries, so that argument never held.
     pub async fn entity_exists(&self, entity_id: &str) -> Result<bool, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
@@ -33417,13 +33523,25 @@ impl MemoryDB {
     }
 
     /// Resolve entity by name: exact match → LIKE substring → vector search → None.
+    /// G6 Stage 1.5a: steps A/B migrated onto the `kind='entity'` shadow
+    /// page's `title` (mirrors `entities.name`), joined via `entity_page_map`.
+    /// Step C (vector similarity) is unchanged — it stays legacy, BLOCKED for
+    /// 1.5b per spec.
     pub async fn resolve_entity_by_name(&self, name: &str) -> Result<Option<String>, WenlanError> {
         {
             let conn = self.conn.lock().await;
-            // Step A: exact case-insensitive match
+            // Step A: exact case-insensitive match. G6 Stage 1.5a review fix
+            // #5: an ambiguous name (two active entity pages with the same
+            // title) has equal title match quality by construction, so the
+            // ORDER BY below is purely for a stable winner across access
+            // paths -- not a relevance ranking.
             let mut rows = conn
                 .query(
-                    "SELECT id FROM entities WHERE LOWER(name) = LOWER(?1) LIMIT 1",
+                    "SELECT epm.entity_id FROM entity_page_map epm
+                     JOIN pages p ON p.id = epm.page_id
+                     WHERE p.kind = 'entity' AND p.status = 'active'
+                       AND LOWER(p.title) = LOWER(?1)
+                     ORDER BY p.title ASC, epm.entity_id ASC LIMIT 1",
                     libsql::params![name],
                 )
                 .await
@@ -33432,10 +33550,16 @@ impl MemoryDB {
                 let id: String = row.get(0).unwrap();
                 return Ok(Some(id));
             }
-            // Step B: fuzzy LIKE substring match
+            // Step B: fuzzy LIKE substring match. Same determinism fix as
+            // step A -- the ORDER BY gives a stable winner among equally
+            // matching titles, not a relevance ranking.
             let mut rows = conn
                 .query(
-                    "SELECT id FROM entities WHERE name LIKE '%' || ?1 || '%' LIMIT 1",
+                    "SELECT epm.entity_id FROM entity_page_map epm
+                     JOIN pages p ON p.id = epm.page_id
+                     WHERE p.kind = 'entity' AND p.status = 'active'
+                       AND p.title LIKE '%' || ?1 || '%'
+                     ORDER BY p.title ASC, epm.entity_id ASC LIMIT 1",
                     libsql::params![name],
                 )
                 .await
@@ -37002,10 +37126,17 @@ impl MemoryDB {
     }
 
     /// Count rows in the `entities` table (knowledge-graph nodes).
+    /// G6 Stage 1.5a: counts via `entity_page_map` (1:1 with `entities` by
+    /// the shadow-page invariant) instead of `entities` directly.
     pub async fn count_entities(&self) -> Result<i64, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
-            .query("SELECT COUNT(*) FROM entities", ())
+            .query(
+                "SELECT COUNT(*) FROM entity_page_map epm
+                 JOIN pages p ON p.id = epm.page_id
+                 WHERE p.kind = 'entity' AND p.status = 'active'",
+                (),
+            )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("count_entities query: {}", e)))?;
         let row = rows
@@ -39867,10 +39998,14 @@ impl MemoryDB {
         // to the edges/cites union (which includes D7 survivors backed only
         // by pages.citations) changes the eligibility pool and deserves its
         // own test attention. Folds into Stage 2.
+        // G6 Stage 1.5a: `e.name` hydration moved onto the `kind='entity'`
+        // shadow page (via `entity_page_map`) -- name-only projection, no
+        // space touch, LEFT JOIN semantics preserved.
         let mut sql = String::from(
-            "SELECT m.source_id, m.content, m.entity_id, m.space, m.embedding, e.name, m.source_agent, m.content_hash \
+            "SELECT m.source_id, m.content, m.entity_id, m.space, m.embedding, p.title, m.source_agent, m.content_hash \
              FROM memories m \
-             LEFT JOIN entities e ON m.entity_id = e.id \
+             LEFT JOIN entity_page_map epm ON epm.entity_id = m.entity_id \
+             LEFT JOIN pages p ON p.id = epm.page_id AND p.kind = 'entity' AND p.status = 'active' \
              WHERE m.source = 'memory' AND m.chunk_index = 0 \
                AND (m.pinned = 0 OR m.pinned IS NULL) \
                AND m.supersede_mode NOT IN ('archive', 'evicted') \
@@ -40145,9 +40280,12 @@ impl MemoryDB {
         // to the edges/cites union (which includes D7 survivors backed only
         // by pages.citations) changes the eligibility pool and deserves its
         // own test attention. Folds into Stage 2.
+        // G6 Stage 1.5a: `e.name` hydration moved onto the `kind='entity'`
+        // shadow page (via `entity_page_map`) -- same pattern as
+        // `query_distillation_staging_pool` above.
         let mut sql = String::from(
             "SELECT m.id, m.source_id, m.content, m.entity_id, m.space, m.embedding, \
-                    e.name, m.source_agent, m.content_hash, \
+                    p.title, m.source_agent, m.content_hash, \
                     CASE WHEN m.source = 'memory' AND m.chunk_index = 0 \
                            AND (m.pinned = 0 OR m.pinned IS NULL) \
                            AND m.supersede_mode NOT IN ('archive', 'evicted') \
@@ -40160,7 +40298,8 @@ impl MemoryDB {
                            ) \
                          THEN 1 ELSE 0 END AS eligible \
              FROM memories m \
-             LEFT JOIN entities e ON m.entity_id = e.id \
+             LEFT JOIN entity_page_map epm ON epm.entity_id = m.entity_id \
+             LEFT JOIN pages p ON p.id = epm.page_id AND p.kind = 'entity' AND p.status = 'active' \
              WHERE 1 = 1",
         );
         let mut bind = Vec::<libsql::Value>::new();
@@ -40208,10 +40347,13 @@ impl MemoryDB {
         // to the edges/cites union (which includes D7 survivors backed only
         // by pages.citations) changes the eligibility pool and deserves its
         // own test attention. Folds into Stage 2.
+        // G6 Stage 1.5a: `e.name` hydration moved onto the `kind='entity'`
+        // shadow page (via `entity_page_map`) -- same pattern as the two
+        // sibling distillation queries above.
         let mut rows = conn
             .query(
                 "SELECT m.source_id, m.content, m.entity_id, m.space, m.embedding, \
-                        e.name, m.source_agent, m.content_hash, \
+                        p.title, m.source_agent, m.content_hash, \
                         CASE WHEN m.source = 'memory' AND m.chunk_index = 0 \
                                AND (m.pinned = 0 OR m.pinned IS NULL) \
                                AND m.supersede_mode NOT IN ('archive', 'evicted') \
@@ -40226,7 +40368,8 @@ impl MemoryDB {
                              THEN 1 ELSE 0 END AS eligible \
                  FROM vector_top_k('memories_vec_idx', vector32(?1), ?2) AS vt \
                  JOIN memories m ON m.rowid = vt.id \
-                 LEFT JOIN entities e ON m.entity_id = e.id",
+                 LEFT JOIN entity_page_map epm ON epm.entity_id = m.entity_id \
+                 LEFT JOIN pages p ON p.id = epm.page_id AND p.kind = 'entity' AND p.status = 'active'",
                 libsql::params![vec_str, limit as i64],
             )
             .await

--- a/crates/wenlan-core/src/db/entity_clean_readers_test.rs
+++ b/crates/wenlan-core/src/db/entity_clean_readers_test.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// G6 Stage 1.5a: RED-control tests for the CLEAN entity readers migrated
+// onto `kind='entity'` shadow pages (see
+// docs/plans/2026-08-05-g6-stage15a-entity-clean-readers-spec.md, "Tests"
+// section, items 1-3). Item 4 (parity watermark unchanged, still drift 0) is
+// covered by the pre-existing, untouched
+// `db::tests::reconcile_clean_dual_write_reports_zero_drift_and_stamps_watermark`
+// fixture -- no new test needed there.
+
+use super::MemoryDB;
+use crate::read_scope::ReadScope;
+
+async fn insert_edge(db: &MemoryDB, src: &str, dst: &str) {
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type)
+         VALUES (?1,?2,'entity',?3,'entity','relates','legacy',0,'00000000-0000-4000-8000-000000000001',1,'related')",
+        libsql::params![format!("edge-{src}-{dst}"), src, dst],
+    )
+    .await
+    .unwrap();
+}
+
+/// Test category 1 (spec "Tests" item 1): equivalence per migrated
+/// product-adjacent reader -- khop, name_type, counts -- seeded via the real
+/// writer (`store_entity`), field-by-field against what was written.
+#[tokio::test]
+async fn migrated_readers_return_fields_that_match_what_store_entity_wrote() {
+    let (db, _tmp) = crate::db::tests::test_db().await;
+
+    let anchor = db
+        .store_entity("Anchor Corp", "organization", None, None, Some(0.62))
+        .await
+        .unwrap();
+    let neighbor = db
+        .store_entity("Neighbor LLC", "organization", None, None, Some(0.81))
+        .await
+        .unwrap();
+    insert_edge(&db, &anchor, &neighbor).await;
+
+    // count_entities: plain COUNT via the shadow page, must equal the
+    // number of real writes.
+    assert_eq!(db.count_entities().await.unwrap(), 2);
+
+    // get_entity_name_type: name/type hydration must equal the exact
+    // strings passed to store_entity, not a derived or truncated form.
+    let (anchor_name, anchor_type) = db.get_entity_name_type(&anchor).await.unwrap().unwrap();
+    assert_eq!(anchor_name, "Anchor Corp");
+    assert_eq!(anchor_type, "organization");
+    let (neighbor_name, neighbor_type) = db.get_entity_name_type(&neighbor).await.unwrap().unwrap();
+    assert_eq!(neighbor_name, "Neighbor LLC");
+    assert_eq!(neighbor_type, "organization");
+
+    // khop: one-hop expansion from the anchor must reach the neighbor via
+    // the shadow-page-joined edge traversal.
+    let expanded = db
+        .expand_entities_khop_scoped(std::slice::from_ref(&anchor), 1, 50, &ReadScope::Global)
+        .await
+        .unwrap();
+    assert!(
+        expanded.contains(&neighbor),
+        "khop expansion from {anchor} must reach {neighbor} via the relates edge, got {expanded:?}"
+    );
+}
+
+/// Test category 2 (spec "Tests" item 2): divergence under asymmetric
+/// seeding. One entity exists only as a shadow page (writer-seeded, then its
+/// `entities` row deleted via raw SQL) -- migrated readers must still see
+/// it, because they never touch `entities`. Two entities exist only as raw
+/// `entities` rows with no shadow page (seeded via raw SQL, bypassing the
+/// mirror invariant on purpose) -- migrated readers must NOT see them.
+///
+/// RED-control: manually reverting `count_entities`'s SQL to the legacy
+/// `SELECT COUNT(*) FROM entities` and re-running this test locally makes it
+/// fail (returns 2, asserted 1) -- confirming the assertion below actually
+/// exercises the migration rather than passing vacuously. Not committed as
+/// code; verified by hand per the 1.2/1.3 RED-control precedent.
+#[tokio::test]
+async fn migrated_readers_see_shadow_only_entities_not_raw_only_entities() {
+    let (db, _tmp) = crate::db::tests::test_db().await;
+
+    // Shadow-only: written for real, then the legacy row is deleted,
+    // leaving only entity_page_map + the pages row behind.
+    let shadow_only = db
+        .store_entity("Shadow Only", "concept", None, None, Some(0.5))
+        .await
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute("PRAGMA foreign_keys = OFF", ()).await.unwrap();
+        conn.execute(
+            "DELETE FROM entities WHERE id = ?1",
+            libsql::params![shadow_only.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    // Raw-only: inserted directly into `entities`, bypassing store_entity
+    // (and therefore `insert_entity_shadow_page`) entirely.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute_batch(
+            "INSERT INTO entities (id,name,entity_type,confirmed,created_at,updated_at) VALUES
+                 ('raw-only-1','Raw Only One','concept',0,1,1),
+                 ('raw-only-2','Raw Only Two','concept',0,1,1);",
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(
+        db.count_entities().await.unwrap(),
+        1,
+        "count_entities must see the shadow-only entity and neither raw-only entity"
+    );
+    assert_eq!(
+        db.get_entity_name_type(&shadow_only).await.unwrap(),
+        Some(("Shadow Only".to_string(), "concept".to_string())),
+        "get_entity_name_type must resolve the shadow-only entity via entity_page_map"
+    );
+    assert_eq!(
+        db.get_entity_name_type("raw-only-1").await.unwrap(),
+        None,
+        "get_entity_name_type must not see a raw entities row with no shadow page"
+    );
+    assert_eq!(
+        db.get_entity_name_type("raw-only-2").await.unwrap(),
+        None,
+        "get_entity_name_type must not see a raw entities row with no shadow page"
+    );
+}
+
+/// Test category 3 (spec "Tests" item 3): the mirror invariant itself --
+/// `pages.title`/`entity_type`/`confidence` must track updates made through
+/// the writer-coupled mutators (`store_entity` at creation,
+/// `merge_entities`'s type-promotion at update), not just the initial
+/// insert. This is the invariant every reader migrated in this stage now
+/// load-bears.
+#[tokio::test]
+async fn shadow_page_title_type_and_confidence_track_store_entity_updates() {
+    let (db, _tmp) = crate::db::tests::test_db().await;
+
+    // "entity" is merge_entities's generic-type marker (its `is_generic`
+    // predicate matches only "entity"/"unknown"/""), so this canonical is
+    // eligible for the alias's concrete type to be promoted onto it.
+    let canonical = db
+        .store_entity("Origin Corp", "entity", None, None, Some(0.4))
+        .await
+        .unwrap();
+    let alias = db
+        .store_entity("Origin Corp Inc", "database", None, None, Some(0.9))
+        .await
+        .unwrap();
+
+    async fn read_shadow(db: &MemoryDB, entity_id: &str) -> (String, String, Option<f64>) {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT p.title, p.entity_type, p.confidence FROM entity_page_map epm
+                 JOIN pages p ON p.id = epm.page_id
+                 WHERE epm.entity_id = ?1 AND p.kind = 'entity' AND p.status = 'active'",
+                libsql::params![entity_id.to_string()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        let title: String = row.get(0).unwrap();
+        let entity_type: String = row.get(1).unwrap();
+        let confidence: Option<f64> = row.get(2).ok();
+        (title, entity_type, confidence)
+    }
+
+    // Baseline: the initial insert already mirrors title/type/confidence.
+    let (title, entity_type, confidence) = read_shadow(&db, &canonical).await;
+    assert_eq!(title, "Origin Corp");
+    assert_eq!(entity_type, "entity");
+    assert!((confidence.unwrap() - 0.4).abs() < 1e-6);
+
+    // Update: merge_entities promotes the canonical's generic type to the
+    // alias's concrete type and re-syncs the shadow page.
+    db.merge_entities(&canonical, &alias).await.unwrap();
+
+    let (title, entity_type, confidence) = read_shadow(&db, &canonical).await;
+    assert_eq!(title, "Origin Corp", "title must be unchanged by the merge");
+    assert_eq!(
+        entity_type, "database",
+        "entity_type must round-trip the merge's generic->concrete promotion"
+    );
+    assert!(
+        (confidence.unwrap() - 0.4).abs() < 1e-6,
+        "confidence must still track the entities row after the re-sync"
+    );
+}

--- a/crates/wenlan-core/src/db/eval_lifecycle_integrity.rs
+++ b/crates/wenlan-core/src/db/eval_lifecycle_integrity.rs
@@ -81,9 +81,16 @@ impl MemoryDB {
             }
         };
 
+        // G6 Stage 1.5a: counts via `entity_page_map` (1:1 with `entities` by
+        // the shadow-page invariant) instead of `entities` directly.
         let entity_count = {
             let mut rows = conn
-                .query("SELECT COUNT(*) FROM entities", libsql::params![])
+                .query(
+                    "SELECT COUNT(*) FROM entity_page_map epm
+                     JOIN pages p ON p.id = epm.page_id
+                     WHERE p.kind = 'entity' AND p.status = 'active'",
+                    libsql::params![],
+                )
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("count entities: {e}")))?;
             if let Ok(Some(row)) = rows.next().await {

--- a/crates/wenlan-core/src/db/eval_lifecycle_integrity_test.rs
+++ b/crates/wenlan-core/src/db/eval_lifecycle_integrity_test.rs
@@ -135,6 +135,9 @@ async fn lifecycle_state_counts_preserve_all_four_legacy_queries() {
         .await
         .unwrap();
     }
+    // G6 Stage 1.5a: entity_count now reads the `kind='entity'` shadow page.
+    db.test_seed_entity_shadow_page("entity-1").await.unwrap();
+    db.test_seed_entity_shadow_page("entity-2").await.unwrap();
 
     for fixture in [
         MemoryFixture {

--- a/crates/wenlan-core/src/db/kg_quality_diagnostics.rs
+++ b/crates/wenlan-core/src/db/kg_quality_diagnostics.rs
@@ -41,12 +41,17 @@ impl MemoryDB {
     pub(crate) async fn list_contradiction_observation_counts(
         &self,
     ) -> Result<Vec<ContradictionObservationCount>, WenlanError> {
+        // G6 Stage 1.5a: entity-name hydration moved onto the `kind='entity'`
+        // shadow page via `entity_page_map`; the observations content read
+        // itself is unchanged (out of scope -- see spec target #17).
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT e.name, COUNT(o.id) as obs_count
-                 FROM entities e JOIN observations o ON o.entity_id = e.id
-                 GROUP BY e.id, e.name HAVING obs_count >= 10
+                "SELECT p.title, COUNT(o.id) as obs_count
+                 FROM entity_page_map epm
+                 JOIN pages p ON p.id = epm.page_id AND p.kind = 'entity' AND p.status = 'active'
+                 JOIN observations o ON o.entity_id = epm.entity_id
+                 GROUP BY epm.entity_id, p.title HAVING obs_count >= 10
                  ORDER BY obs_count DESC LIMIT 20",
                 (),
             )

--- a/crates/wenlan-core/src/db/kg_quality_diagnostics_test.rs
+++ b/crates/wenlan-core/src/db/kg_quality_diagnostics_test.rs
@@ -3,14 +3,19 @@
 use super::MemoryDB;
 
 async fn insert_entity(db: &MemoryDB, id: &str, name: &str) {
-    let conn = db.conn.lock().await;
-    conn.execute(
-        "INSERT INTO entities (id, name, entity_type, created_at, updated_at)
-         VALUES (?1, ?2, 'test', 1, 1)",
-        libsql::params![id, name],
-    )
-    .await
-    .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO entities (id, name, entity_type, created_at, updated_at)
+             VALUES (?1, ?2, 'test', 1, 1)",
+            libsql::params![id, name],
+        )
+        .await
+        .unwrap();
+    }
+    // G6 Stage 1.5a: list_contradiction_observation_counts now reads the
+    // `kind='entity'` shadow page.
+    db.test_seed_entity_shadow_page(id).await.unwrap();
 }
 
 async fn insert_memory_source(db: &MemoryDB, id: &str, source_id: &str) {

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -41295,14 +41295,32 @@ async fn migration_90_creates_entity_page_map_table() {
 #[tokio::test]
 async fn migration_90_entity_page_map_enforces_unique_entity_and_page() {
     let (db, _dir) = test_db().await;
-    let e1 = db.create_entity("Alice", "person", None).await.unwrap();
-    let e2 = db.create_entity("Bob", "person", None).await.unwrap();
     let conn = db.conn.lock().await;
+    // Raw-seeded, not `db.create_entity` -- since the G6 Stage 1.5a landmine
+    // fix, that helper also mints a shadow page + its own entity_page_map
+    // row, which would collide with the manual insert below before this
+    // test ever reaches the constraint it's checking. These three
+    // migration_90 tests exercise entity_page_map's own schema (UNIQUE +
+    // cascades) in isolation from the shadow-page mirror.
+    conn.execute(
+        "INSERT INTO entities (id, name, entity_type, created_at, updated_at) \
+         VALUES ('e1', 'Alice', 'person', 0, 0)",
+        (),
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO entities (id, name, entity_type, created_at, updated_at) \
+         VALUES ('e2', 'Bob', 'person', 0, 0)",
+        (),
+    )
+    .await
+    .unwrap();
     insert_test_page(&conn, "page_1").await;
     insert_test_page(&conn, "page_2").await;
     conn.execute(
-        "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES (?1, 'page_1', '2024-01-01T00:00:00Z')",
-        libsql::params![e1.clone()],
+        "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES ('e1', 'page_1', '2024-01-01T00:00:00Z')",
+        (),
     )
     .await
     .unwrap();
@@ -41310,8 +41328,8 @@ async fn migration_90_entity_page_map_enforces_unique_entity_and_page() {
     // Same entity_id, different page_id -> UNIQUE(entity_id) violation.
     let dup_entity = conn
         .execute(
-            "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES (?1, 'page_2', '2024-01-01T00:00:00Z')",
-            libsql::params![e1],
+            "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES ('e1', 'page_2', '2024-01-01T00:00:00Z')",
+            (),
         )
         .await;
     assert!(dup_entity.is_err(), "duplicate entity_id must be rejected");
@@ -41319,8 +41337,8 @@ async fn migration_90_entity_page_map_enforces_unique_entity_and_page() {
     // Different entity_id, same page_id -> UNIQUE(page_id) violation.
     let dup_page = conn
         .execute(
-            "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES (?1, 'page_1', '2024-01-01T00:00:00Z')",
-            libsql::params![e2],
+            "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES ('e2', 'page_1', '2024-01-01T00:00:00Z')",
+            (),
         )
         .await;
     assert!(dup_page.is_err(), "duplicate page_id must be rejected");
@@ -41329,26 +41347,34 @@ async fn migration_90_entity_page_map_enforces_unique_entity_and_page() {
 #[tokio::test]
 async fn migration_90_entity_page_map_cascades_on_entity_delete() {
     let (db, _dir) = test_db().await;
-    let e1 = db.create_entity("Alice", "person", None).await.unwrap();
     {
         let conn = db.conn.lock().await;
+        // Raw-seeded -- see the unique-constraint test above for why
+        // `db.create_entity` can't be used here.
+        conn.execute(
+            "INSERT INTO entities (id, name, entity_type, created_at, updated_at) \
+             VALUES ('e1', 'Alice', 'person', 0, 0)",
+            (),
+        )
+        .await
+        .unwrap();
         insert_test_page(&conn, "page_1").await;
         conn.execute(
-            "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES (?1, 'page_1', '2024-01-01T00:00:00Z')",
-            libsql::params![e1.clone()],
+            "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES ('e1', 'page_1', '2024-01-01T00:00:00Z')",
+            (),
         )
         .await
         .unwrap();
     }
 
-    db.delete_entity(&e1).await.unwrap();
+    db.delete_entity("e1").await.unwrap();
 
     let conn = db.conn.lock().await;
     let remaining: i64 = {
         let mut rows = conn
             .query(
                 "SELECT COUNT(*) FROM entity_page_map WHERE entity_id = ?1",
-                libsql::params![e1],
+                libsql::params!["e1"],
             )
             .await
             .unwrap();
@@ -41360,12 +41386,20 @@ async fn migration_90_entity_page_map_cascades_on_entity_delete() {
 #[tokio::test]
 async fn migration_90_entity_page_map_cascades_on_page_delete() {
     let (db, _dir) = test_db().await;
-    let e1 = db.create_entity("Alice", "person", None).await.unwrap();
     let conn = db.conn.lock().await;
+    // Raw-seeded -- see the unique-constraint test above for why
+    // `db.create_entity` can't be used here.
+    conn.execute(
+        "INSERT INTO entities (id, name, entity_type, created_at, updated_at) \
+         VALUES ('e1', 'Alice', 'person', 0, 0)",
+        (),
+    )
+    .await
+    .unwrap();
     insert_test_page(&conn, "page_1").await;
     conn.execute(
-        "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES (?1, 'page_1', '2024-01-01T00:00:00Z')",
-        libsql::params![e1.clone()],
+        "INSERT INTO entity_page_map (entity_id, page_id, created_at) VALUES ('e1', 'page_1', '2024-01-01T00:00:00Z')",
+        (),
     )
     .await
     .unwrap();
@@ -41378,7 +41412,7 @@ async fn migration_90_entity_page_map_cascades_on_page_delete() {
         let mut rows = conn
             .query(
                 "SELECT COUNT(*) FROM entity_page_map WHERE entity_id = ?1",
-                libsql::params![e1],
+                libsql::params!["e1"],
             )
             .await
             .unwrap();

--- a/crates/wenlan-core/src/db/repair_deterministic.rs
+++ b/crates/wenlan-core/src/db/repair_deterministic.rs
@@ -172,12 +172,21 @@ where
                     },
                 ) if memory_id == mutation_memory_id && entity_id == mutation_entity_id => conn
                     .execute(
+                        // G6 Stage 1.5a review fix: the planner
+                        // (`resolve_memory_entity_links`, repair_plan/deterministic.rs)
+                        // already reads the `kind='entity'` shadow page for this same
+                        // existence decision -- the applier's guard must read the same
+                        // store, or a raw-seeded `entities` row with no shadow page
+                        // would plan-delete but fail to apply.
                         "DELETE FROM memory_entities
                          WHERE memory_id=?1 AND entity_id=?2
                            AND (NOT EXISTS(
                                 SELECT 1 FROM memories m WHERE m.source_id=memory_entities.memory_id)
                              OR NOT EXISTS(
-                                SELECT 1 FROM entities e WHERE e.id=memory_entities.entity_id))",
+                                SELECT 1 FROM entity_page_map epm
+                                JOIN pages p ON p.id = epm.page_id
+                                WHERE epm.entity_id = memory_entities.entity_id
+                                  AND p.kind = 'entity' AND p.status = 'active'))",
                         libsql::params![memory_id.clone(), entity_id.clone()],
                     )
                     .await

--- a/crates/wenlan-core/src/db/scoped_entities.rs
+++ b/crates/wenlan-core/src/db/scoped_entities.rs
@@ -572,6 +572,15 @@ impl MemoryDB {
         Ok(proposals)
     }
 
+    /// G6 Stage 1.5a: scope-filters via the `kind='entity'` shadow page's
+    /// `space` column (through `entity_page_map`) instead of `entities.space`
+    /// directly. Safe under the space-sentinel fold: `ReadScope::Uncategorized`
+    /// matches `pages.space = UNFILED_SPACE_ID` (the NULL fold target), and
+    /// `ReadScope::Space(name)` only ever carries a name resolved through
+    /// `resolve_read_scope`/`db.get_space` against a REGISTERED space —
+    /// `create_space`/`update_space` reject `UNFILED_SPACE_ID` as a
+    /// user-supplied name (db.rs `UNFILED_SPACE_ID` doc comment), so the two
+    /// branches can never collide.
     pub(super) async fn filter_entity_ids_scoped(
         &self,
         entity_ids: &[String],
@@ -587,13 +596,20 @@ impl MemoryDB {
         let scope_index = entity_ids.len() + 1;
         let (scope_sql, scope_value) = match scope {
             ReadScope::Space(space) => (
-                format!("AND space = ?{scope_index}"),
+                format!("AND p.space = ?{scope_index}"),
                 Some(libsql::Value::Text(space.clone())),
             ),
-            ReadScope::Uncategorized => ("AND space IS NULL".to_string(), None),
+            ReadScope::Uncategorized => (
+                format!("AND p.space = ?{scope_index}"),
+                Some(libsql::Value::Text(crate::db::UNFILED_SPACE_ID.to_string())),
+            ),
             ReadScope::Global => unreachable!(),
         };
-        let sql = format!("SELECT id FROM entities WHERE id IN ({placeholders}) {scope_sql}");
+        let sql = format!(
+            "SELECT epm.entity_id FROM entity_page_map epm
+             JOIN pages p ON p.id = epm.page_id
+             WHERE epm.entity_id IN ({placeholders}) AND p.kind = 'entity' AND p.status = 'active' {scope_sql}"
+        );
         let mut params: Vec<libsql::Value> = entity_ids
             .iter()
             .map(|id| libsql::Value::Text(id.clone()))

--- a/crates/wenlan-core/src/db/space_context.rs
+++ b/crates/wenlan-core/src/db/space_context.rs
@@ -9,13 +9,19 @@ use wenlan_types::{Space, WriteSpaceSource, WriteSpaceTarget};
 const LEGACY_DEFAULT_WATERMARK: &str = "legacy_default_imported";
 
 impl MemoryDB {
+    // G6 Stage 1.5a: `ent_count` reads the `kind='entity'` shadow page's
+    // `space` (via `entity_page_map`) instead of `entities.space` directly.
+    // Safe: `s.name` here is always a registered space's name (the outer
+    // `WHERE s.id != UNFILED_SPACE_ID` excludes the one spaces row whose
+    // name IS the sentinel), so it can never equal `UNFILED_SPACE_ID` and
+    // spuriously match NULL-folded entities.
     async fn get_space_by_id(&self, id: &str) -> Result<Option<Space>, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
                 "SELECT s.id, s.name, s.description, s.suggested, s.created_at, s.updated_at,
                         (SELECT COUNT(DISTINCT c.source_id) FROM memories c WHERE c.space = s.name AND c.source = 'memory' AND c.pending_revision = 0 AND COALESCE(c.is_recap, 0) = 0 AND c.source_id NOT IN (SELECT supersedes FROM memories WHERE supersedes IS NOT NULL AND pending_revision = 0 AND source = 'memory' GROUP BY supersedes)) as mem_count,
-                        (SELECT COUNT(*) FROM entities e WHERE e.space = s.name) as ent_count,
+                        (SELECT COUNT(*) FROM entity_page_map epm JOIN pages p ON p.id = epm.page_id WHERE p.kind = 'entity' AND p.status = 'active' AND p.space = s.name) as ent_count,
                         s.sort_order, s.starred, s.is_default
                  FROM spaces s
                  WHERE s.id = ?1 AND s.id != ?2",

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -299,6 +299,15 @@ crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::de
 crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::orphan_revision_is_one_exact_repair_for_both_checks|test_primary_session|1
 crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::page_projection_reserved_target_is_blocked|TestDbSession::execute|1
 crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::page_projection_reserved_target_is_blocked|test_primary_session|1
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbRow::get|1
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbRow::get|2
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbRows::next|1
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbRows::next|2
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbSession::execute_batch|1
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbSession::query|1
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|TestDbSession::query|2
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|test_primary_session|1
+crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard|test_primary_session|2
 crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::registered_scope_does_not_resolve_global_tag_findings|TestDbSession::execute_batch|1
 crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::registered_scope_does_not_resolve_global_tag_findings|test_primary_session|1
 crates/wenlan-core/src/repair_plan/deterministic_tests.rs|crate::repair_plan::deterministic::tests::source_page_archive_accepts_rust_whitespace_persisted_below_ingress|TestDbSession::execute|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,10 +3229,11 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        996,
+        1005,
         "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
-         the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, and \
-         the 8 G6 BindPageLink repair-test calls"
+         the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, \
+         the 8 G6 BindPageLink repair-test calls, and the 9 G6 Stage 1.5a \
+         raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard calls"
     );
 }
 

--- a/crates/wenlan-core/src/lint/deep.rs
+++ b/crates/wenlan-core/src/lint/deep.rs
@@ -86,6 +86,12 @@ pub(super) async fn run(
     ]
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The scope clause below
+// filters on `e.space` directly (nullable legacy `entities.space`); the
+// shadow-page mirror folds NULL to the `UNFILED_SPACE_ID` sentinel, so a
+// migrated read would silently change which rows a space-scoped query
+// matches. Stays on `entities` until the space-sentinel audit (spec's 1.5b
+// decision record).
 async fn alias_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "e.space", true);
     rows(
@@ -209,6 +215,13 @@ async fn structured_conflicts(context: &LintContext<'_, '_>) -> Result<RowCheck,
     .await
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated (entity-existence side
+// -- observation content itself is out of scope for this stage regardless,
+// see the spec's 1.5b observations ruling). The scope clause below filters
+// on `e.space` directly; the shadow-page mirror folds NULL to the
+// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
+// which rows a space-scoped query matches. Stays on `entities` until the
+// space-sentinel audit.
 async fn observation_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "e.space", true);
     rows(
@@ -253,6 +266,12 @@ async fn page_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> 
     .await
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The scope clause below
+// filters on `f.space` directly (nullable legacy `entities.space` via the
+// src-entity alias); the shadow-page mirror folds NULL to the
+// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
+// which rows a space-scoped query matches. Stays on `entities` until the
+// space-sentinel audit.
 async fn relation_vocabulary(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "f.space", true);
     rows(

--- a/crates/wenlan-core/src/lint/kg/query.rs
+++ b/crates/wenlan-core/src/lint/kg/query.rs
@@ -45,6 +45,14 @@ pub(super) async fn load(context: &LintContext<'_, '_>, hub_cap: u64) -> Result<
     })
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The `e.space IS NOT
+// NULL AND NOT EXISTS(spaces…)` body below is not merely imprecise under the
+// shadow-page mirror -- it goes VACUOUSLY TRUE for every row. The mirror
+// folds NULL `entities.space` to the `UNFILED_SPACE_ID` sentinel on the page
+// row, so a shadow-page read would always see space as non-NULL, and the
+// sentinel never matches a real `spaces.name` row; every entity would flag
+// as a false integrity violation, not just a subtly different one. Stays on
+// `entities` until the space-sentinel audit (spec's 1.5b decision record).
 async fn entity_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (clause, params) = scope_clause(context.scope().filter(), "e", false);
     row_check(
@@ -63,6 +71,13 @@ async fn entity_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()>
     .await
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated (entity-existence side
+// -- observation content itself is out of scope for this stage regardless,
+// see the spec's 1.5b observations ruling). `scope_clause` below filters on
+// `e.space`/`e.id` directly against `entities`; the shadow-page mirror folds
+// NULL `entities.space` to the `UNFILED_SPACE_ID` sentinel, so a migrated
+// read would silently change which rows a space-scoped query matches. Stays
+// on `entities` until the space-sentinel audit.
 async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (clause, params) = scope_clause(context.scope().filter(), "e", true);
     row_check(
@@ -80,6 +95,12 @@ async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck
     .await
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. `scope_clause` below
+// filters on `f.space`/`f.id` (the src-entity alias) directly against
+// `entities`; the shadow-page mirror folds NULL `entities.space` to the
+// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
+// which rows a space-scoped query matches. Stays on `entities` until the
+// space-sentinel audit.
 async fn relation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (clause, params) = scope_clause(context.scope().filter(), "f", true);
     row_check(
@@ -97,17 +118,24 @@ async fn relation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, (
     .await
 }
 
+// G6 Stage 1.5a: the entity-existence side (`e.id IS NULL`) moved onto the
+// `kind='entity'` shadow page via `entity_page_map` -- safe because the
+// scope clause here filters on the memories-derived alias `m`, never on
+// `entities`/the entity side's space at all.
 async fn link_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
     let (clause, params) = scope_clause(context.scope().filter(), "m", true);
     row_check(
         context,
         &format!(
-            "SELECT CASE WHEN m.source_id IS NULL OR e.id IS NULL THEN 1 ELSE 0 END
+            "SELECT CASE WHEN m.source_id IS NULL OR e.entity_id IS NULL THEN 1 ELSE 0 END
                FROM memory_entities me
                LEFT JOIN (SELECT source_id, MAX(id) AS id, MAX(space) AS space FROM memories
                            GROUP BY source_id) m
                  ON m.source_id=me.memory_id
-               LEFT JOIN entities e ON e.id=me.entity_id
+               LEFT JOIN (SELECT epm.entity_id FROM entity_page_map epm
+                          JOIN pages p ON p.id = epm.page_id
+                          WHERE p.kind = 'entity' AND p.status = 'active') e
+                 ON e.entity_id=me.entity_id
                {clause} ORDER BY me.memory_id, me.entity_id"
         ),
         params,

--- a/crates/wenlan-core/src/lint/kg/query/aggregate.rs
+++ b/crates/wenlan-core/src/lint/kg/query/aggregate.rs
@@ -27,6 +27,17 @@ impl AggregateCounts {
     }
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. This is a space-count
+// partition, not a well-formedness check -- `KgEntitiesScoped` vs
+// `KgEntitiesUncategorized` IS the NULL-vs-non-NULL `entities.space` split.
+// The shadow-page mirror folds NULL to the `UNFILED_SPACE_ID` sentinel, so a
+// migrated read would see `pages.space` as never NULL and
+// `KgEntitiesUncategorized` would always report 0. Known transitional skew:
+// the `KgEntities` metric emitted here is legacy-derived (`COUNT(*) FROM
+// entities`), while `aggregate_counts` below emits the same metric code
+// shadow-derived (`entity_page_map` JOIN `pages`) -- the two only diverge if
+// the mirror invariant breaks. This function retires with the `entities`
+// store, not before.
 pub(super) async fn entity_partitions(
     context: &LintContext<'_, '_>,
 ) -> Result<Vec<LintMetric>, ()> {
@@ -51,10 +62,13 @@ pub(super) async fn entity_partitions(
     ])
 }
 
+// G6 Stage 1.5a: the `entities` count moved onto `entity_page_map` (1:1 with
+// `entities` by the shadow-page invariant); no space touch here.
 pub(super) async fn aggregate_counts(context: &LintContext<'_, '_>) -> Result<AggregateCounts, ()> {
     let values = scalar_row(
         context,
-        "SELECT (SELECT COUNT(*) FROM entities),
+        "SELECT (SELECT COUNT(*) FROM entity_page_map epm JOIN pages p ON p.id = epm.page_id
+                  WHERE p.kind = 'entity' AND p.status = 'active'),
                 (SELECT COUNT(*) FROM edges WHERE edge_type='relates' AND valid_until IS NULL),
                 (SELECT COUNT(*) FROM observations), (SELECT COUNT(*) FROM memory_entities)",
         libsql::params::Params::None,
@@ -74,12 +88,16 @@ pub(super) async fn advisory_metrics(
     hub_cap: u64,
 ) -> Result<Vec<LintMetric>, ()> {
     let cap = i64::try_from(hub_cap).map_err(|_| ())?;
+    // G6 Stage 1.5a: `e.id`/`e.name`/`e.entity_type` moved onto the
+    // `kind='entity'` shadow page via `entity_page_map`; no space touch.
     let values = scalar_row(
         context,
         "WITH degree AS (
-             SELECT e.id, LOWER(TRIM(e.name)) AS normalized_name,
-                    LOWER(TRIM(e.entity_type)) AS entity_type, COUNT(me.memory_id) AS links
-               FROM entities e LEFT JOIN memory_entities me ON me.entity_id=e.id GROUP BY e.id
+             SELECT e.entity_id AS id, LOWER(TRIM(p.title)) AS normalized_name,
+                    LOWER(TRIM(p.entity_type)) AS entity_type, COUNT(me.memory_id) AS links
+               FROM entity_page_map e
+               JOIN pages p ON p.id = e.page_id AND p.kind = 'entity' AND p.status = 'active'
+               LEFT JOIN memory_entities me ON me.entity_id=e.entity_id GROUP BY e.entity_id
          ), duplicate AS (
              SELECT COALESCE(SUM(amount-1),0) AS extras FROM (
                  SELECT COUNT(*) AS amount FROM degree GROUP BY normalized_name HAVING amount>1

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -65,6 +65,9 @@ async fn imported_document_entity_links_have_a_valid_memory_owner() {
         )
         .await
         .unwrap();
+    // G6 Stage 1.5a: link_integrity's entity-existence side now reads the
+    // `kind='entity'` shadow page.
+    db.test_seed_entity_shadow_page("entity-doc").await.unwrap();
 
     let report = run(&db, None, test_config(true)).await;
     assert_eq!(check(&report, LINKS).outcome(), LintOutcome::Pass);
@@ -253,12 +256,19 @@ async fn seed_valid_scoped_graph(db: &crate::db::MemoryDB) {
          INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type) VALUES
              ('edge-rel-a','ent-a','entity','ent-b','entity','relates','legacy',0,'alpha',1,'related');"
     ).await.unwrap();
+    // G6 Stage 1.5a: aggregate_counts + link_integrity now read the
+    // `kind='entity'` shadow page.
+    db.test_seed_entity_shadow_page("ent-a").await.unwrap();
+    db.test_seed_entity_shadow_page("ent-b").await.unwrap();
 }
 
 async fn seed_advisory_graph(db: &crate::db::MemoryDB) {
     let conn = db.test_primary_session().await;
     conn.execute_batch("INSERT INTO entities (id,name,entity_type,confirmed,created_at,updated_at) VALUES ('hub','Shared','person',0,1,1),('dupe',' shared ','concept',0,1,1);").await.unwrap();
     drop(conn);
+    // G6 Stage 1.5a: advisory_metrics now reads the `kind='entity'` shadow page.
+    db.test_seed_entity_shadow_page("hub").await.unwrap();
+    db.test_seed_entity_shadow_page("dupe").await.unwrap();
     for index in 0..21 {
         let id = format!("mem-{index:02}");
         insert_memory(db, &id, None).await;

--- a/crates/wenlan-core/src/lint/semantic_candidates.rs
+++ b/crates/wenlan-core/src/lint/semantic_candidates.rs
@@ -828,6 +828,12 @@ async fn load_memory_entity_links(
     Ok(output)
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. `scope_clause` below
+// filters on `source.space` (the src-entity alias) directly against
+// `entities`; the shadow-page mirror folds NULL `entities.space` to the
+// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
+// which rows a space-scoped query matches. Stays on `entities` until the
+// space-sentinel audit.
 async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<Relation>, ()> {
     let (scope, params) = scope_clause(context.scope().filter(), "source.space");
     let mut rows = context.snapshot().query(

--- a/crates/wenlan-core/src/repair.rs
+++ b/crates/wenlan-core/src/repair.rs
@@ -4706,6 +4706,12 @@ fn decode_entity_extraction_space(encoded: &str) -> Result<Option<String>, Wenla
         .map_err(|_| WenlanError::Validation("repair_target_schema_mismatch".to_string()))
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The `(?2 IS NULL AND
+// space IS NULL) OR space=?2` guard below distinguishes a literal NULL
+// `entities.space` from a registered space; the shadow-page mirror folds
+// NULL to the `UNFILED_SPACE_ID` sentinel, so a migrated read would silently
+// change which rows validate. Stays on `entities` until the space-sentinel
+// audit.
 async fn validate_selected_entities_on_snapshot(
     snapshot: &LintReadSnapshot<'_>,
     entity_ids: &[String],
@@ -4735,6 +4741,16 @@ async fn validate_selected_entities_on_snapshot(
     Ok(())
 }
 
+// G6 Stage 1.5a carryover (2026-08-05): NOT migrated, for two independent
+// reasons. (1) Same space-sentinel trap as the snapshot variant above -- the
+// `(?2 IS NULL AND space IS NULL) OR space=?2` guard distinguishes a literal
+// NULL `entities.space` from a registered space, which the shadow-page
+// mirror's NULL-to-sentinel fold would silently change. (2) This variant
+// runs on the shared-mutex connection inside the entity-extraction repair's
+// own `BEGIN IMMEDIATE` (`db/repair_memory_cas.rs`), re-verifying entities
+// that repair batch itself just wrote -- Stage-2 writer-batch alignment, NOT
+// connection-level coupling (the shared-mutex conn can never see uncommitted
+// foreign state from another writer). Flips with `store_entity` in Stage 2.
 pub(crate) async fn validate_selected_entities_on_connection(
     connection: &libsql::Connection,
     entity_ids: &[String],

--- a/crates/wenlan-core/src/repair/entity_extraction_tests.rs
+++ b/crates/wenlan-core/src/repair/entity_extraction_tests.rs
@@ -52,6 +52,17 @@ async fn entity_extraction_fixture() -> EntityExtractionFixture {
         )
         .await
         .unwrap();
+    // G6 Stage 1.5a review fix round fallout: `entities` is raw-SQL-seeded
+    // above (bypassing `store_entity`), so without a shadow page these three
+    // entities are invisible to the readers this stage migrated
+    // (`link_integrity`, `entity_integrity`, ...) -- `mem-entity`/
+    // `ent-existing`'s link would read as broken before this repair ever
+    // runs, corrupting the before/after lint comparison in
+    // `record_repair_verification`. Backfill the invariant the same way a
+    // real write would.
+    for entity_id in ["ent-existing", "ent-new", "ent-extra"] {
+        db.test_seed_entity_shadow_page(entity_id).await.unwrap();
+    }
 
     let occurrence = RepairDigest::parse(OCCURRENCE).unwrap();
     let review_id = format!("lint_review_{OCCURRENCE}");

--- a/crates/wenlan-core/src/repair_plan/deterministic.rs
+++ b/crates/wenlan-core/src/repair_plan/deterministic.rs
@@ -1004,16 +1004,23 @@ async fn resolve_memory_entity_links(
     snapshot: &LintReadSnapshot<'_>,
     scope: &RepairLintScope,
 ) -> Result<Vec<DeterministicResolution>, WenlanError> {
+    // G6 Stage 1.5a: entity-existence side moved onto the `kind='entity'`
+    // shadow page via `entity_page_map` -- safe because `scoped_memory_entity_clause`
+    // filters only on the memories-derived alias `m`, never on `entities`/the
+    // entity side's space.
     let (scope_clause, params) = scoped_memory_entity_clause(scope);
     let sql = format!(
-        "SELECT me.memory_id,me.entity_id,m.source_id,m.space,e.id
+        "SELECT me.memory_id,me.entity_id,m.source_id,m.space,e.entity_id
            FROM memory_entities me
            LEFT JOIN (
                 SELECT source_id,MAX(space) AS space
                   FROM memories GROUP BY source_id
            ) m ON m.source_id=me.memory_id
-           LEFT JOIN entities e ON e.id=me.entity_id
-          WHERE (m.source_id IS NULL OR e.id IS NULL){scope_clause}
+           LEFT JOIN (SELECT epm.entity_id FROM entity_page_map epm
+                      JOIN pages p ON p.id = epm.page_id
+                      WHERE p.kind = 'entity' AND p.status = 'active') e
+             ON e.entity_id=me.entity_id
+          WHERE (m.source_id IS NULL OR e.entity_id IS NULL){scope_clause}
           ORDER BY me.memory_id,me.entity_id"
     );
     let mut rows = snapshot.query(&sql, params).await.map_err(|error| {

--- a/crates/wenlan-core/src/repair_plan/deterministic_tests.rs
+++ b/crates/wenlan-core/src/repair_plan/deterministic_tests.rs
@@ -929,6 +929,93 @@ async fn imported_document_owner_with_missing_entity_prepares_and_applies_in_sco
     assert_eq!(owner_count, 1);
 }
 
+/// G6 Stage 1.5a review fix #3: the applier's `DeleteMemoryEntityLink` guard
+/// (`db/repair_deterministic.rs`) used to re-check legacy `entities`
+/// existence while the planner (`resolve_memory_entity_links`, above) already
+/// reads the `kind='entity'` shadow page. Under the old guard, a raw-seeded
+/// `entities` row with no shadow page still exists in `entities`, so the
+/// planner would propose a delete (no shadow page => looks orphaned) but the
+/// applier's WHERE clause would match zero rows (the legacy row is still
+/// there) and `apply_deterministic_repair_cas` would surface
+/// `repair_target_stale` instead of applying. This test seeds exactly that
+/// scenario -- a valid, present memory owner (so the memory-side branch is
+/// false) paired with a raw-seeded, shadow-page-less entity (so only the
+/// entity-side branch can trigger the delete) -- to isolate and pin the
+/// entity-side branch alone.
+///
+/// RED control (manual, not committed as code): temporarily reverting the
+/// guard's entity-side clause in `db/repair_deterministic.rs` back to
+/// `NOT EXISTS(SELECT 1 FROM entities e WHERE e.id=memory_entities.entity_id)`
+/// makes the `apply_repair` call below fail with `repair_target_stale`;
+/// restoring the shadow-page clause makes it pass again.
+#[tokio::test]
+async fn raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard() {
+    let (db, _dir) = test_db().await;
+    db.test_primary_session()
+        .await
+        .execute_batch(
+            "INSERT INTO memories
+                 (id,content,source,source_id,title,chunk_index,last_modified,chunk_type)
+             VALUES
+                 ('row_raw','Raw Entity Owner','local_files','/tmp/raw_entity.md','doc',0,1,'text');
+             PRAGMA foreign_keys=OFF;
+             INSERT INTO entities(id,name,entity_type,confirmed,created_at,updated_at)
+             VALUES ('entity_raw_no_shadow','Raw','concept',0,1,1);
+             INSERT INTO memory_entities(memory_id,entity_id)
+             VALUES ('/tmp/raw_entity.md','entity_raw_no_shadow');
+             PRAGMA foreign_keys=ON;",
+        )
+        .await
+        .unwrap();
+    let repair_root = tempfile::tempdir().unwrap();
+    let store = RepairArtifactStore::new(repair_root.path().to_path_buf());
+    let manifest = prepared_manifest(&db, &store, RepairWriter::DeleteMemoryEntityLink).await;
+    assert!(matches!(
+        manifest.target(),
+        RepairTarget::MemoryEntityLink {
+            memory_id,
+            entity_id,
+            scope: RepairScope::Uncategorized,
+        } if memory_id == "/tmp/raw_entity.md" && entity_id == "entity_raw_no_shadow"
+    ));
+
+    let receipt =
+        crate::repair::apply_repair(&db, &store, exact_apply_request(&manifest), 1_721_000_002)
+            .await
+            .expect("planner and applier must read the same shadow-page existence store");
+    assert_eq!(receipt.writer(), RepairWriter::DeleteMemoryEntityLink);
+    let conn = db.test_primary_session().await;
+    let link_count = conn
+        .query(
+            "SELECT COUNT(*) FROM memory_entities
+             WHERE memory_id='/tmp/raw_entity.md' AND entity_id='entity_raw_no_shadow'",
+            (),
+        )
+        .await
+        .unwrap()
+        .next()
+        .await
+        .unwrap()
+        .unwrap()
+        .get::<i64>(0)
+        .unwrap();
+    let entity_row_count = conn
+        .query(
+            "SELECT COUNT(*) FROM entities WHERE id='entity_raw_no_shadow'",
+            (),
+        )
+        .await
+        .unwrap()
+        .next()
+        .await
+        .unwrap()
+        .unwrap()
+        .get::<i64>(0)
+        .unwrap();
+    assert_eq!(link_count, 0);
+    assert_eq!(entity_row_count, 1);
+}
+
 #[tokio::test]
 async fn orphan_revision_cas_rejects_scope_state_and_noop_then_changes_only_pending_revision() {
     let (db, _dir) = test_db().await;

--- a/crates/wenlan-core/src/repair_plan/semantic.rs
+++ b/crates/wenlan-core/src/repair_plan/semantic.rs
@@ -175,9 +175,15 @@ async fn load_record_inventory(
         &mut inventory,
     )
     .await?;
+    // G6 Stage 1.5a: id-only enumeration moved onto `entity_page_map` (1:1
+    // with `entities` by the shadow-page invariant); no space touch, order
+    // is by the entity id itself (not a name), so it is unaffected by the
+    // mirror-invariant name equivalence.
     load_simple_records(
         snapshot,
-        "SELECT id FROM entities ORDER BY id",
+        "SELECT epm.entity_id AS id FROM entity_page_map epm
+         JOIN pages p ON p.id = epm.page_id
+         WHERE p.kind = 'entity' AND p.status = 'active' ORDER BY epm.entity_id",
         "entity",
         RepairAffectedRecordKind::Entity,
         &mut inventory,

--- a/crates/wenlan-core/tests/m4_community_gates.rs
+++ b/crates/wenlan-core/tests/m4_community_gates.rs
@@ -2515,11 +2515,11 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
     let observer = observer_db.connect().expect("connect correction observer");
 
     let left = db
-        .create_entity("Correction Left", "concept", Some(SPACE))
+        .store_entity("Correction Left", "concept", Some(SPACE), None, None)
         .await
         .expect("create left entity");
     let right = db
-        .create_entity("Correction Right", "concept", Some(SPACE))
+        .store_entity("Correction Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create right entity");
     let relation_id = db
@@ -2577,15 +2577,15 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
     );
 
     let canonical = db
-        .create_entity("Canonical Entity", "concept", Some(SPACE))
+        .store_entity("Canonical Entity", "concept", Some(SPACE), None, None)
         .await
         .expect("create canonical entity");
     let alias = db
-        .create_entity("Alias Entity", "concept", Some(SPACE))
+        .store_entity("Alias Entity", "concept", Some(SPACE), None, None)
         .await
         .expect("create alias entity");
     let neighbor = db
-        .create_entity("Merge Neighbor", "concept", Some(SPACE))
+        .store_entity("Merge Neighbor", "concept", Some(SPACE), None, None)
         .await
         .expect("create merge neighbor");
     let merge_relation = db
@@ -2675,11 +2675,11 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
     );
 
     let restart_left = db
-        .create_entity("Restart Left", "concept", Some(SPACE))
+        .store_entity("Restart Left", "concept", Some(SPACE), None, None)
         .await
         .expect("create restart left");
     let restart_right = db
-        .create_entity("Restart Right", "concept", Some(SPACE))
+        .store_entity("Restart Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create restart right");
     let restart_relation = db
@@ -2792,11 +2792,11 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
         .await
         .expect("seed deletion-cascade source");
     let delete_left = reopened
-        .create_entity("Delete Cascade Left", "concept", Some(SPACE))
+        .store_entity("Delete Cascade Left", "concept", Some(SPACE), None, None)
         .await
         .expect("create delete-cascade left");
     let delete_right = reopened
-        .create_entity("Delete Cascade Right", "concept", Some(SPACE))
+        .store_entity("Delete Cascade Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create delete-cascade right");
     let delete_relation = reopened
@@ -2882,11 +2882,11 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
         .await
         .expect("seed refresh-cascade source");
     let refresh_left = reopened
-        .create_entity("Refresh Cascade Left", "concept", Some(SPACE))
+        .store_entity("Refresh Cascade Left", "concept", Some(SPACE), None, None)
         .await
         .expect("create refresh-cascade left");
     let refresh_right = reopened
-        .create_entity("Refresh Cascade Right", "concept", Some(SPACE))
+        .store_entity("Refresh Cascade Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create refresh-cascade right");
     let refresh_relation = reopened

--- a/crates/wenlan-server/tests/refinery_routes.rs
+++ b/crates/wenlan-server/tests/refinery_routes.rs
@@ -428,11 +428,11 @@ async fn accept_entity_merge_flow() {
     let (app, _tmp, db) = test_app().await;
 
     let new_id = db
-        .create_entity("Acme Corporation", "organization", None)
+        .store_entity("Acme Corporation", "organization", None, None, None)
         .await
         .unwrap();
     let existing_id = db
-        .create_entity("Acme Corp", "organization", None)
+        .store_entity("Acme Corp", "organization", None, None, None)
         .await
         .unwrap();
     db.insert_refinement_proposal(
@@ -716,11 +716,11 @@ async fn accept_returns_422_for_already_resolved() {
 async fn accept_logs_apply_and_resolve_activity_with_agent() {
     let (app, _tmp, db) = test_app().await;
     let new_id = db
-        .create_entity("Acme Corporation", "organization", None)
+        .store_entity("Acme Corporation", "organization", None, None, None)
         .await
         .unwrap();
     let existing_id = db
-        .create_entity("Acme Corp", "organization", None)
+        .store_entity("Acme Corp", "organization", None, None, None)
         .await
         .unwrap();
     db.insert_refinement_proposal(

--- a/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
+++ b/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
@@ -865,6 +865,15 @@ edges a name scan cannot attribute.
   them from `--json` rather than trusting them later.
 - **Not a safety property.** Internal-only means no *current* caller crosses the
   crate boundary, which one `pub` re-export changes.
+- **Not associated-const aware (known gap, 2026-08-05).** The scan
+  (`m5-reader-sweep.py` `sweep()`, ~line 465) walks each function's
+  brace-matched body only, so a SQL literal defined in an associated const at
+  impl level -- outside any function body -- is invisible to the predicate.
+  `db.rs::EDGE_GROUNDING_CANDIDATE_SCAN_SQL` is such a const: it now contains
+  `JOIN pages` plus title projections, making its consumer
+  `db.rs::edge_grounding_candidates` a genuine depth-0 page-bearing reader
+  that this inventory is missing. Not fixed here -- the predicate would need
+  to also walk associated-const initializers.
 
 Every row is `marker_shape = none`. There is no caller to gesture.
 
@@ -889,6 +898,7 @@ carrying the authority of agreement.
 | `core/db.rs::find_matching_page_scoped` | `pub` | no | no | — | — |
 | `core/db.rs::find_stale_archived_pages` | `pub` | no | **yes** | `server/cmd_backfill.rs::run` | — |
 | `core/db.rs::find_unique_active_page_id_by_title_scoped` | `pub` | no | no | — | — |
+| `core/db.rs::get_entity_name_type` | `pub` | no | **yes** | `server/page_map_routes.rs::compute_ref_state` | — |
 | `core/db.rs::get_page_by_entity` | `pub` | no | no | — | — |
 | `core/db.rs::get_page_inner` | `private` | no | no | — | — |
 | `core/db.rs::get_pages_for_memory` | `pub` | no | no | — | — |
@@ -908,12 +918,18 @@ carrying the authority of agreement.
 | `core/db.rs::migrate_89_page_kind_fold` | `private` | no | no | — | — |
 | `core/db.rs::oldest_active_page` | `pub` | no | no | — | — |
 | `core/db.rs::page_merge_row` | `private` | no | no | — | — |
+| `core/db.rs::query_distillation_ann_neighbors` | `private` | no | no | — | — |
+| `core/db.rs::query_distillation_seed_slice` | `private` | no | no | — | — |
+| `core/db.rs::query_distillation_staging_pool` | `private` | no | no | — | — |
 | `core/db.rs::rebind_source_page_in_transaction` | `private` | no | no | — | — |
 | `core/db.rs::reconcile_entity_page_parity` | `pub` | no | **yes** | `server/scheduler/ambient.rs::run_ambient_job` | — |
+| `core/db.rs::resolve_entity_by_name` | `pub` | no | **yes** | `server/memory_routes.rs::handle_store_memory` | — |
 | `core/db.rs::run_migrations` | `pub` | no | no | — | — |
+| `core/db.rs::search_memory_with_cue` | `private` | no | no | — | — |
 | `core/db/claim_derivation.rs::derive_leased_page_claims` | `pub(super)` | no | no | — | — |
 | `core/db/claim_derivation.rs::evaluate_support_on` | `private` | no | no | — | — |
 | `core/db/claim_derivation.rs::load_linked_memory_chunks` | `private` | no | no | — | — |
+| `core/db/kg_quality_diagnostics.rs::list_contradiction_observation_counts` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_duplicate_reads.rs::embedding_near_duplicate_pairs` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_duplicate_reads.rs::scan_near_duplicate_slice` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_retro_scan.rs::scan_automatic_retro_stub_slice` | `pub(crate)` | no | no | — | — |
@@ -929,6 +945,7 @@ carrying the authority of agreement.
 | `core/db/truth_exposure.rs::page_truth_states` | `pub` | no | no | — | — |
 | `core/lint/deep.rs::page_body_result` | `private` | no | no | — | — |
 | `core/lint/deep.rs::page_duplicates` | `private` | no | no | — | — |
+| `core/lint/kg/query/aggregate.rs::advisory_metrics` | `pub(super)` | no | no | — | — |
 | `core/lint/pages/db_checks.rs::load_rows` | `private` | no | no | — | — |
 | `core/lint/pages/link_checks/orphans.rs::load` | `pub(super)` | yes | no | — | — |
 | `core/lint/semantic_candidates.rs::load_pages` | `private` | yes | no | — | — |
@@ -955,6 +972,9 @@ carrying the authority of agreement.
 | `core/db.rs::accept_page_merge` | `pub` | no | no | — | `core/db.rs::page_merge_row` |
 | `core/db.rs::augment_with_graph_gated` | `private` | no | no | — | `core/db/scoped_entities.rs::search_entities_by_vector_scoped` |
 | `core/db.rs::find_best_overlapping_page` | `pub` | no | no | — | `core/db.rs::load_page_source_index` |
+| `core/db.rs::find_cross_space_distillation_cluster_slice` | `pub` | no | no | — | `core/db.rs::query_distillation_ann_neighbors`, `core/db.rs::query_distillation_seed_slice` |
+| `core/db.rs::find_cross_space_distillation_clusters` | `pub` | no | no | — | `core/db.rs::query_distillation_staging_pool` |
+| `core/db.rs::find_distillation_clusters_scoped` | `pub` | no | no | — | `core/db.rs::query_distillation_staging_pool` |
 | `core/db.rs::get_page` | `pub` | no | **yes** | `server/page_map_routes.rs::ensure_page_is_active`, `server/page_map_routes.rs::visible_page`, `server/page_routes.rs::handle_create_page`, `server/page_routes.rs::handle_refresh_page`, `server/page_routes.rs::handle_update_page` | `core/db.rs::get_page_inner` |
 | `core/db.rs::get_page_browse` | `pub` | no | no | — | `core/db.rs::get_page_inner` |
 | `core/db.rs::insert_document_source_page_at_hash` | `pub(crate)` | no | no | — | `core/db.rs::insert_page_with_kind_inner` |
@@ -963,11 +983,16 @@ carrying the authority of agreement.
 | `core/db.rs::list_pages` | `pub` | no | **yes** | `server/main/startup.rs::prepare_startup_state` | `core/db.rs::list_pages_inner` |
 | `core/db.rs::list_pages_browse` | `pub` | no | no | — | `core/db.rs::list_pages_inner` |
 | `core/db.rs::list_stale_pages` | `pub` | no | no | — | `core/db.rs::list_stale_pages_scoped` |
+| `core/db.rs::minhash_resolve_candidate` | `pub` | no | no | — | `core/db.rs::get_entity_name_type` |
 | `core/db.rs::new` | `pub` | yes | no | — | `core/db.rs::run_migrations` |
 | `core/db.rs::new_with_shared_embedder` | `pub` | no | no | — | `core/db.rs::run_migrations` |
 | `core/db.rs::rebind_source_id_inner` | `private` | no | no | — | `core/db.rs::rebind_source_page_in_transaction` |
 | `core/db.rs::replace_source_page_inner` | `private` | no | no | — | `core/db.rs::append_page_history` |
 | `core/db.rs::resolve_orphan_page_links` | `pub` | no | **yes** | `server/routes.rs::handle_distill` | `core/db.rs::find_unique_active_page_id_by_title_scoped` |
+| `core/db.rs::search_memory` | `pub` | no | **yes** | `server/brief_routes.rs::handle_read_brief`, `server/memory_routes.rs::handle_search_memory`, `server/routes.rs::handle_search` | `core/db.rs::search_memory_with_cue` |
+| `core/db.rs::search_memory_cross_rerank_cued` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
+| `core/db.rs::search_memory_expanded` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
+| `core/db.rs::search_memory_temporal` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
 | `core/db.rs::try_update_page_content` | `private` | no | no | — | `core/db.rs::append_page_history` |
 | `core/db/claim_derivation.rs::evaluate_page_support` | `pub` | no | no | — | `core/db/claim_derivation.rs::evaluate_support_on` |
 | `core/db/claim_derivation.rs::finalize_page_support` | `pub` | no | no | — | `core/db/claim_derivation.rs::evaluate_support_on` |
@@ -978,7 +1003,9 @@ carrying the authority of agreement.
 | `core/db/scoped_pages.rs::list_recent_pages_with_badges_scoped` | `pub` | no | **yes** | `server/routes.rs::handle_recent_pages` | `core/db.rs::list_recent_pages_with_badges` |
 | `core/db/truth_exposure.rs::page_visibility` | `pub` | no | no | — | `core/db/truth_exposure.rs::page_truth_states` |
 | `core/export/knowledge.rs::plan_truth_cutover` | `pub` | no | **yes** | `server/cmd_cutover.rs::run` | `core/db/truth_exposure.rs::page_truth_states` |
+| `core/kg_quality.rs::scan_contradictions` | `pub` | no | no | — | `core/db/kg_quality_diagnostics.rs::list_contradiction_observation_counts` |
 | `core/lint/deep.rs::run` | `pub(super)` | yes | no | — | `core/lint/deep.rs::page_body_result`, `core/lint/deep.rs::page_duplicates` |
+| `core/lint/kg/query.rs::load` | `pub(super)` | yes | no | — | `core/lint/kg/query/aggregate.rs::advisory_metrics` |
 | `core/lint/pages/db_checks.rs::run` | `pub(crate)` | yes | no | — | `core/lint/pages/db_checks.rs::load_rows` |
 | `core/m6/signals.rs::community_overview` | `pub` | no | no | — | `core/m6/independence.rs::distinct_group_count`, `core/m6/signals.rs::scoped_root_ids` |
 | `core/m6/signals.rs::evidence_cluster` | `pub` | no | no | — | `core/m6/independence.rs::distinct_group_count`, `core/m6/signals.rs::scoped_group_ids`, `core/m6/signals.rs::scoped_root_ids` |
@@ -1003,6 +1030,7 @@ carrying the authority of agreement.
 | `core/synthesis/detect.rs::detect_page_candidates` | `pub` | no | no | — | `core/db.rs::find_matching_page_scoped` |
 | `core/synthesis/distill.rs::build_existing_titles_hint` | `pub(crate)` | no | no | — | `core/db.rs::list_active_page_titles_scoped`, `core/db.rs::list_relevant_active_page_titles` |
 | `core/synthesis/distill.rs::distill_one_cluster_with_tuning` | `private` | no | no | — | `core/db.rs::find_matching_page_scoped` |
+| `core/synthesis/distill.rs::resolve_distill_target` | `pub` | no | **yes** | `server/routes.rs::handle_distill` | `core/db.rs::resolve_entity_by_name` |
 | `core/synthesis/overview.rs::ensure_overview_page` | `private` | no | no | — | `core/db.rs::find_active_page_id_by_title` |
 | `core/synthesis/wikilinks.rs::resolve_against_pages` | `pub` | no | no | — | `core/db.rs::find_unique_active_page_id_by_title_scoped` |
 | `core/truth_adapter.rs::verdicts` | `private` | no | no | — | `core/db/truth_exposure.rs::page_truth_states` |
@@ -1011,6 +1039,8 @@ carrying the authority of agreement.
 | `server/entity_graph_routes.rs::handle_list_entities` | `pub` | no | no | — | `core/db/scoped_entities.rs::list_entities_scoped` |
 | `server/entity_graph_routes.rs::handle_search_entities` | `pub` | no | no | — | `core/db/scoped_entities.rs::search_entities_by_vector_scoped` |
 | `server/knowledge_routes.rs::handle_list_recent_relations` | `pub` | no | no | — | `core/db/scoped_entities.rs::list_recent_relations_scoped` |
+| `server/memory_routes.rs::handle_store_memory` | `pub` | no | no | — | `core/db.rs::resolve_entity_by_name` |
+| `server/page_map_routes.rs::compute_ref_state` | `private` | no | no | `server/page_map_routes.rs::wire_node` | `core/db.rs::get_entity_name_type` |
 | `server/routes.rs::handle_distill` | `pub` | no | no | — | `core/db.rs::list_stale_pages_scoped`, `core/db.rs::load_page_source_index` |
 | `server/routes.rs::handle_recent_page_changes` | `pub` | no | no | — | `core/db/scoped_pages.rs::list_recent_changes_scoped` |
 | `server/routes.rs::handle_recent_retrievals` | `pub` | no | no | — | `core/db.rs::list_recent_retrievals_scoped` |
@@ -1023,6 +1053,8 @@ carrying the authority of agreement.
 | `core/citations.rs::run_citation_backfill_with_page_limit` | `private` | no | no | — | `core/db.rs::get_page` |
 | `core/db.rs::augment_with_graph` | `pub` | no | no | — | `core/db.rs::augment_with_graph_gated` |
 | `core/db.rs::augment_with_graph_seeded_scoped` | `private` | no | no | — | `core/db.rs::augment_with_graph_gated` |
+| `core/db.rs::commit_entity_enrichment_at_version` | `private` | no | no | — | `core/db.rs::minhash_resolve_candidate` |
+| `core/db.rs::find_distillation_clusters` | `pub` | no | no | — | `core/db.rs::find_distillation_clusters_scoped` |
 | `core/db.rs::find_page_by_source_memory` | `pub` | no | no | — | `core/db.rs::get_page` |
 | `core/db.rs::first_active_page` | `pub` | no | no | — | `core/db.rs::list_pages` |
 | `core/db.rs::insert_page` | `pub(crate)` | yes | no | — | `core/db.rs::insert_page_with_kind` |
@@ -1032,7 +1064,11 @@ carrying the authority of agreement.
 | `core/db.rs::refresh_page_wikilinks` | `pub` | no | no | — | `core/db.rs::get_page`, `core/synthesis/wikilinks.rs::resolve_against_pages` |
 | `core/db.rs::replace_source_page` | `pub(crate)` | no | no | — | `core/db.rs::replace_source_page_inner` |
 | `core/db.rs::replace_source_page_at_document_hash` | `pub(crate)` | no | no | — | `core/db.rs::replace_source_page_inner` |
-| `core/db.rs::search_memory_with_cue` | `private` | no | no | — | `core/db.rs::augment_with_graph_gated` |
+| `core/db.rs::resolve_or_create_entity` | `pub` | no | no | — | `core/db.rs::minhash_resolve_candidate` |
+| `core/db.rs::search_corrections_by_topic_scoped` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/db.rs::search_memory_cross_rerank` | `pub` | no | **yes** | `server/memory_routes.rs::handle_search_memory` | `core/db.rs::search_memory_cross_rerank_cued` |
+| `core/db.rs::search_memory_decomposed` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/db.rs::search_memory_prf` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/db.rs::try_accept_page_revision` | `pub(crate)` | no | no | — | `core/db.rs::try_update_page_content` |
 | `core/db.rs::try_update_page_content_if_stale` | `pub` | no | no | — | `core/db.rs::try_update_page_content` |
 | `core/db.rs::try_update_page_content_with_changelog` | `pub` | no | no | — | `core/db.rs::try_update_page_content` |
@@ -1047,32 +1083,59 @@ carrying the authority of agreement.
 | `core/db/scoped_pages.rs::get_page_scoped_inner` | `private` | no | no | — | `core/db.rs::get_page`, `core/db.rs::get_page_browse` |
 | `core/db/scoped_pages.rs::list_pages_scoped_inner` | `private` | no | no | — | `core/db.rs::list_pages`, `core/db.rs::list_pages_browse` |
 | `core/document_enrichment.rs::write_document_source_page` | `private` | no | no | — | `core/db.rs::get_page` |
-| `core/eval/answer_quality.rs::run_e2e_answer_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
+| `core/eval/answer_quality.rs::build_structured_context` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/answer_quality.rs::generate_e2e_answers_for_question` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/answer_quality.rs::run_e2e_answer_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
 | `core/eval/answer_quality.rs::run_e2e_context_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
 | `core/eval/answer_quality.rs::run_e2e_context_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/answer_quality.rs::run_e2e_locomo_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
+| `core/eval/answer_quality.rs::run_e2e_locomo_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
 | `core/eval/answer_quality.rs::run_fullpipeline_lme` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/context_path.rs::run_context_path_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/context_path.rs::run_context_path_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/longmemeval.rs::run_longmemeval_rerank_pool_probe` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
+| `core/eval/context_path.rs::run_context_path_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/context_path.rs::run_context_path_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/lifecycle.rs::measure_phase` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/lifecycle.rs::run_lifecycle_fixture` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/lifecycle.rs::run_lifecycle_phases` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/locomo.rs::run_locomo_eval_core` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/locomo.rs::run_locomo_eval_cross_rerank_temporal_collect` | `pub` | no | no | — | `core/db.rs::search_memory_cross_rerank_cued` |
+| `core/eval/locomo.rs::run_locomo_eval_expanded_intent_collect` | `pub` | no | no | — | `core/db.rs::search_memory_expanded` |
+| `core/eval/locomo.rs::run_locomo_eval_from_db` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/locomo.rs::run_locomo_eval_from_db_collect_core` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/locomo.rs::run_locomo_eval_graph_stream_collect` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/locomo.rs::run_locomo_eval_with_gate` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_decompose_ce_probe_from_db` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_decompose_recall_probe_from_db` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_core` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_from_db` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect_core` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_graph_stream_collect` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_temporal` | `pub` | no | no | — | `core/db.rs::search_memory_temporal` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_temporal_collect` | `pub` | no | no | — | `core/db.rs::search_memory_temporal` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_with_gate` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_headroom_probe_from_db` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_headroom_probe_per_question` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/longmemeval.rs::run_longmemeval_rerank_pool_probe` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory_cross_rerank_cued` |
 | `core/eval/pipeline.rs::run_locomo_pipeline_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
 | `core/eval/pipeline.rs::run_longmemeval_pipeline_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_memory_layer_comparison` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_multi_turn_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_native_memory_augmentation` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_pipeline_token_eval_simulated` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_quality_at_scale_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_quality_cost_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval.rs::run_scaling_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/retrieval_drift.rs::capture_rankings` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
+| `core/eval/pipeline.rs::run_strategy_search` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_memory_layer_comparison` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_multi_turn_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_native_memory_augmentation` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_pipeline_token_eval_simulated` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_quality_at_scale_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_quality_cost_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_scaling_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval_drift.rs::capture_rankings` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/runner.rs::run_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/shared.rs::open_or_seed_scenario_db` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
 | `core/export/knowledge.rs::enforce_projection_directory_invariant#1` | `pub` | yes | no | — | `core/db/truth_exposure.rs::page_visibility` |
 | `core/export/knowledge.rs::run_truth_cutover` | `pub` | no | **yes** | `server/cmd_cutover.rs::run` | `core/export/knowledge.rs::plan_truth_cutover` |
+| `core/kg_quality.rs::run_rethink` | `pub` | no | no | — | `core/kg_quality.rs::scan_contradictions` |
+| `core/kg_quality.rs::verify_page` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/lint/semantic.rs::run_agent_submit` | `private` | no | no | — | `core/truth_adapter.rs::verdicts` |
 | `core/m6/oracle.rs::recompute_full` | `pub` | no | no | — | `core/m6/signals.rs::community_overview`, `core/m6/signals.rs::evidence_cluster`, `core/m6/signals.rs::orphan_wikilink`, `core/m6/signals.rs::space_overview` |
 | `core/m6/shadow.rs::admitted_proposals` | `private` | no | no | — | `core/m6/signals.rs::community_overview`, `core/m6/signals.rs::evidence_cluster`, `core/m6/signals.rs::orphan_wikilink`, `core/m6/signals.rs::space_overview` |
 | `core/maintenance.rs::list_distilled_stub_pages` | `private` | no | no | — | `core/db.rs::list_pages` |
-| `core/maintenance.rs::run_maintenance_tick` | `pub` | no | no | — | `core/db.rs::list_stale_pages` |
+| `core/maintenance.rs::run_maintenance_tick` | `pub` | no | no | — | `core/db.rs::find_cross_space_distillation_clusters`, `core/db.rs::list_stale_pages` |
 | `core/maintenance/duplicates.rs::detect_all_near_duplicate_pages` | `pub(super)` | no | no | — | `core/maintenance/duplicates.rs::detect_near_duplicate_pages_inner` |
 | `core/maintenance/duplicates.rs::detect_near_duplicate_pages` | `pub(super)` | no | no | — | `core/maintenance/duplicates.rs::detect_near_duplicate_pages_inner` |
 | `core/maintenance/duplicates.rs::list_page_source_sets` | `private` | no | no | — | `core/db.rs::list_pages` |
@@ -1098,7 +1161,8 @@ carrying the authority of agreement.
 | `core/sources/page_watcher.rs::sync_one_file` | `private` | no | no | — | `core/db.rs::get_page` |
 | `core/synthesis/distill.rs::build_page_compile_user_prompt` | `pub(crate)` | no | no | — | `core/synthesis/distill.rs::build_existing_titles_hint` |
 | `core/synthesis/distill.rs::distill_one_cluster` | `pub` | no | no | — | `core/synthesis/distill.rs::distill_one_cluster_with_tuning` |
-| `core/synthesis/distill.rs::distill_pages_scoped_gated` | `pub(crate)` | no | no | — | `core/synthesis/distill.rs::distill_one_cluster_with_tuning` |
+| `core/synthesis/distill.rs::distill_pages_scoped_gated` | `pub(crate)` | no | no | — | `core/db.rs::find_distillation_clusters_scoped`, `core/synthesis/distill.rs::distill_one_cluster_with_tuning` |
+| `core/synthesis/distill.rs::formation_sweep` | `pub` | no | **yes** | `server/routes.rs::handle_distill` | `core/db.rs::find_distillation_clusters_scoped` |
 | `core/synthesis/distill.rs::refresh_page_with_prompt` | `pub(crate)` | no | no | — | `core/db.rs::get_page` |
 | `core/synthesis/overview.rs::refresh_overview_page` | `pub` | no | no | — | `core/synthesis/overview.rs::ensure_overview_page` |
 | `core/synthesis/overview.rs::top_page_source_ids` | `private` | no | no | — | `core/db.rs::list_pages` |
@@ -1106,16 +1170,20 @@ carrying the authority of agreement.
 | `core/truth_adapter.rs::filter_page_refs` | `pub` | no | **yes** | `server/brief_routes.rs::handle_read_brief`, `server/memory_routes.rs::handle_search_memory`, `server/page_routes.rs::handle_get_page_links`, `server/page_routes.rs::handle_get_page_revisions`, `server/page_routes.rs::handle_get_page_sources`, `server/page_routes.rs::handle_list_orphan_links`, `server/routes.rs::handle_distill`, `server/routes.rs::handle_recent_page_changes`, `server/routes.rs::handle_recent_pages`, `server/routes.rs::handle_recent_retrievals`, `server/routes.rs::handle_search` | `core/db/truth_exposure.rs::page_visibility` |
 | `core/truth_adapter.rs::filter_pages` | `pub` | no | **yes** | `server/page_routes.rs::handle_list_pages`, `server/page_routes.rs::handle_search_pages`, `server/routes.rs::handle_distill` | `core/truth_adapter.rs::verdicts` |
 | `core/truth_adapter.rs::page_write_permit` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_page`, `server/page_routes.rs::handle_export_pages` | `core/db/truth_exposure.rs::page_visibility` |
+| `server/brief_routes.rs::handle_read_brief` | `pub` | no | **yes** | `server/routes.rs::handle_context` | `core/db.rs::search_memory` |
 | `server/cmd_cutover.rs::run` | `pub` | yes | no | — | `core/export/knowledge.rs::plan_truth_cutover` |
 | `server/main/runtime.rs::register_optional_runtime_workers` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db/claim_derivation.rs::reconcile_supported_pages` |
 | `server/main/startup.rs::prepare_startup_state` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db.rs::list_pages` |
+| `server/memory_routes.rs::handle_search_memory` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `server/page_map_routes.rs::ensure_page_is_active` | `private` | no | no | `server/page_map_routes.rs::handle_create_map_edge`, `server/page_map_routes.rs::handle_create_map_node`, `server/page_map_routes.rs::handle_delete_map_edge`, `server/page_map_routes.rs::handle_delete_map_node`, `server/page_map_routes.rs::handle_improve_page_map`, `server/page_map_routes.rs::handle_patch_map_edge`, `server/page_map_routes.rs::handle_patch_map_node`, `server/page_map_routes.rs::handle_put_page_map_layout`, `server/page_map_routes.rs::handle_reset_page_map` | `core/db.rs::get_page` |
 | `server/page_map_routes.rs::visible_page` | `private` | no | no | `server/page_map_routes.rs::compute_ref_state`, `server/page_map_routes.rs::ensure_page_exists` | `core/db.rs::get_page` |
+| `server/page_map_routes.rs::wire_node` | `private` | no | no | `server/page_map_routes.rs::build_map_response`, `server/page_map_routes.rs::handle_create_map_node`, `server/page_map_routes.rs::handle_delete_map_node`, `server/page_map_routes.rs::handle_patch_map_node` | `server/page_map_routes.rs::compute_ref_state` |
 | `server/page_routes.rs::handle_create_page` | `pub` | no | no | — | `core/db.rs::get_page` |
 | `server/page_routes.rs::handle_refresh_page` | `pub` | no | no | — | `core/db.rs::get_page` |
 | `server/page_routes.rs::handle_update_page` | `pub` | no | no | — | `core/db.rs::get_page` |
 | `server/repair_routes.rs::handle_prepare` | `private` | no | no | — | `core/repair.rs::prepare_memory_reclassification_with_pages` |
 | `server/routes.rs::handle_recent_pages` | `pub` | no | no | — | `core/db/scoped_pages.rs::list_recent_pages_with_badges_scoped` |
+| `server/routes.rs::handle_search` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `server/scheduler.rs::fire_maintenance_stage_safe` | `private` | no | no | `server/scheduler.rs::spawn_scheduler` | `core/maintenance.rs::run_maintenance_stage_slice` |
 | `server/scheduler/ambient.rs::run_ambient_job_safe` | `pub(super)` | no | no | `server/scheduler.rs::spawn_scheduler` | `server/scheduler/ambient.rs::run_ambient_job` |
 
@@ -1126,25 +1194,36 @@ carrying the authority of agreement.
 | `core/citations.rs::run_citation_backfill_slice` | `pub` | no | **yes** | `server/scheduler/ambient.rs::run_ambient_job` | `core/citations.rs::run_citation_backfill_with_page_limit` |
 | `core/citations.rs::run_citation_backfill_tick` | `pub` | no | no | — | `core/citations.rs::run_citation_backfill_with_page_limit` |
 | `core/db.rs::augment_with_graph_seeded` | `pub` | no | no | — | `core/db.rs::augment_with_graph_seeded_scoped` |
-| `core/db.rs::search_memory` | `pub` | no | **yes** | `server/brief_routes.rs::handle_read_brief`, `server/memory_routes.rs::handle_search_memory`, `server/routes.rs::handle_search` | `core/db.rs::search_memory_with_cue` |
-| `core/db.rs::search_memory_cross_rerank_cued` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
-| `core/db.rs::search_memory_expanded` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
-| `core/db.rs::search_memory_temporal` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
+| `core/db.rs::run_entity_enrichment_slice_inner` | `private` | no | no | — | `core/db.rs::commit_entity_enrichment_at_version` |
+| `core/db.rs::search_corrections_by_topic` | `pub` | no | no | — | `core/db.rs::search_corrections_by_topic_scoped` |
 | `core/db/repair_verification.rs::record_repair_verification_atomic` | `pub(crate)` | no | no | — | `core/repair.rs::projection_page_row_on_connection` |
 | `core/db/scoped_pages.rs::get_page_scoped` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_page` | `core/db/scoped_pages.rs::get_page_scoped_inner` |
 | `core/db/scoped_pages.rs::get_page_scoped_browse` | `pub` | no | **yes** | `server/page_routes.rs::handle_get_page`, `server/page_routes.rs::handle_get_page_revisions` | `core/db/scoped_pages.rs::get_page_scoped_inner` |
 | `core/db/scoped_pages.rs::list_pages_scoped` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_pages` | `core/db/scoped_pages.rs::list_pages_scoped_inner` |
 | `core/db/scoped_pages.rs::list_pages_scoped_browse` | `pub` | no | **yes** | `server/page_routes.rs::handle_list_pages` | `core/db/scoped_pages.rs::list_pages_scoped_inner` |
 | `core/document_enrichment.rs::run_document_enrichment_with_request_budget` | `private` | no | no | — | `core/document_enrichment.rs::write_document_source_page` |
-| `core/eval/answer_quality.rs::run_fullpipeline_lme_batch` | `pub` | no | no | — | `core/eval/shared.rs::open_or_seed_scenario_db` |
-| `core/eval/answer_quality.rs::run_fullpipeline_locomo_batch` | `pub` | no | no | — | `core/eval/shared.rs::open_or_seed_scenario_db` |
-| `core/eval/lifecycle.rs::run_lifecycle_phases` | `private` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
+| `core/eval/answer_quality.rs::run_fullpipeline_lme_batch` | `pub` | no | no | — | `core/eval/answer_quality.rs::build_structured_context`, `core/eval/shared.rs::open_or_seed_scenario_db` |
+| `core/eval/answer_quality.rs::run_fullpipeline_locomo_batch` | `pub` | no | no | — | `core/eval/answer_quality.rs::build_structured_context`, `core/eval/shared.rs::open_or_seed_scenario_db` |
+| `core/eval/lifecycle.rs::run_lifecycle_locomo` | `pub` | no | no | — | `core/eval/lifecycle.rs::run_lifecycle_phases` |
+| `core/eval/lifecycle.rs::run_lifecycle_longmemeval` | `pub` | no | no | — | `core/eval/lifecycle.rs::run_lifecycle_phases` |
+| `core/eval/locomo.rs::run_locomo_eval` | `pub` | no | no | — | `core/eval/locomo.rs::run_locomo_eval_core` |
+| `core/eval/locomo.rs::run_locomo_eval_cross_rerank` | `pub` | no | no | — | `core/eval/locomo.rs::run_locomo_eval_core` |
+| `core/eval/locomo.rs::run_locomo_eval_cross_rerank_from_db` | `pub` | no | no | — | `core/db.rs::search_memory_cross_rerank` |
+| `core/eval/locomo.rs::run_locomo_eval_cross_rerank_from_db_collect` | `pub` | no | no | — | `core/eval/locomo.rs::run_locomo_eval_from_db_collect_core` |
+| `core/eval/locomo.rs::run_locomo_eval_from_db_collect` | `pub` | no | no | — | `core/eval/locomo.rs::run_locomo_eval_from_db_collect_core` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_core` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_cross_rerank` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_core` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_cross_rerank_from_db` | `pub` | no | no | — | `core/db.rs::search_memory_cross_rerank` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_cross_rerank_from_db_collect` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect_core` |
+| `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect_core` |
+| `core/eval/pipeline.rs::evaluate_condition` | `private` | no | no | — | `core/eval/pipeline.rs::run_strategy_search` |
 | `core/eval/retrieval.rs::run_native_memory_comparison` | `pub` | no | no | — | `core/eval/retrieval.rs::run_native_memory_augmentation` |
 | `core/eval/shared.rs::enrich_db_for_eval_local` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
 | `core/eval/shared.rs::enrich_post_ingest_batched` | `pub(crate)` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
-| `core/eval/shared.rs::run_concept_distillation_batch_api` | `pub` | no | no | — | `core/db.rs::max_page_overlap` |
+| `core/eval/shared.rs::run_concept_distillation_batch_api` | `pub` | no | no | — | `core/db.rs::find_distillation_clusters`, `core/db.rs::max_page_overlap` |
 | `core/export/knowledge.rs::write_page_gated#1` | `pub` | yes | no | — | `core/truth_adapter.rs::page_write_permit` |
 | `core/export/knowledge.rs::write_page_gated#2` | `pub` | yes | no | — | `core/truth_adapter.rs::page_write_permit` |
+| `core/importer.rs::resolve_entity_bulk` | `pub(crate)` | no | no | — | `core/db.rs::resolve_or_create_entity` |
 | `core/ingest.rs::run_canonical_enrichment` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
 | `core/lint/semantic.rs::run` | `pub(super)` | yes | no | — | `core/lint/semantic.rs::run_agent_submit` |
 | `core/m6/shadow.rs::prepare` | `private` | yes | no | — | `core/m6/shadow.rs::admitted_proposals` |
@@ -1153,6 +1232,7 @@ carrying the authority of agreement.
 | `core/maintenance/duplicates.rs::source_overlap_pairs` | `private` | no | no | — | `core/maintenance/duplicates.rs::list_page_source_sets` |
 | `core/maintenance/page_merge_order.rs::order_survivor` | `pub(super)` | no | no | — | `core/maintenance/page_merge_order.rs::load_candidate` |
 | `core/post_ingest.rs::write_grown_page` | `private` | no | no | — | `core/db.rs::find_page_by_source_memory` |
+| `core/post_write/entity_graph.rs::create_entity` | `pub` | yes | no | — | `core/db.rs::resolve_or_create_entity` |
 | `core/post_write/page_dispatch.rs::create_page_with_tuning` | `pub` | no | **yes** | `server/page_routes.rs::handle_create_page` | `core/post_write/page_dispatch.rs::page_write` |
 | `core/post_write/page_dispatch.rs::update_page` | `pub` | no | **yes** | `server/page_routes.rs::handle_refresh_page` | `core/post_write/page_dispatch.rs::page_write` |
 | `core/post_write/page_dispatch.rs::update_page_at_source_revision` | `pub(crate)` | no | no | — | `core/post_write/page_dispatch.rs::page_write` |
@@ -1171,18 +1251,16 @@ carrying the authority of agreement.
 | `core/synthesis/refinement_queue.rs::apply_cross_space_discovery` | `private` | no | no | — | `core/post_write/page_dispatch.rs::page_write` |
 | `core/synthesis/refinement_queue.rs::apply_refinement` | `pub` | no | no | — | `core/synthesis/refinement_queue.rs::apply_refinement_with_decision` |
 | `core/truth_adapter.rs::filter_page` | `pub` | no | **yes** | `server/page_map_routes.rs::visible_page`, `server/page_routes.rs::handle_get_page`, `server/page_routes.rs::handle_get_page_revisions` | `core/truth_adapter.rs::filter_pages` |
-| `server/brief_routes.rs::handle_read_brief` | `pub` | no | **yes** | `server/routes.rs::handle_context` | `core/truth_adapter.rs::filter_page_refs` |
 | `server/main.rs::run_daemon` | `private` | no | no | `server/main.rs::main` | `server/main/runtime.rs::register_optional_runtime_workers`, `server/main/startup.rs::prepare_startup_state` |
-| `server/memory_routes.rs::handle_search_memory` | `pub` | no | no | — | `core/truth_adapter.rs::filter_page_refs` |
-| `server/page_map_routes.rs::compute_ref_state` | `private` | no | no | `server/page_map_routes.rs::wire_node` | `server/page_map_routes.rs::visible_page` |
+| `server/page_map_routes.rs::build_map_response` | `private` | no | no | `server/page_map_routes.rs::handle_get_page_map`, `server/page_map_routes.rs::handle_improve_page_map`, `server/page_map_routes.rs::handle_put_page_map_layout` | `server/page_map_routes.rs::wire_node` |
 | `server/page_map_routes.rs::ensure_page_exists` | `private` | no | no | `server/page_map_routes.rs::handle_get_page_map` | `server/page_map_routes.rs::visible_page` |
 | `server/page_map_routes.rs::handle_create_map_edge` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
-| `server/page_map_routes.rs::handle_create_map_node` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
+| `server/page_map_routes.rs::handle_create_map_node` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active`, `server/page_map_routes.rs::wire_node` |
 | `server/page_map_routes.rs::handle_delete_map_edge` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
-| `server/page_map_routes.rs::handle_delete_map_node` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
+| `server/page_map_routes.rs::handle_delete_map_node` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active`, `server/page_map_routes.rs::wire_node` |
 | `server/page_map_routes.rs::handle_improve_page_map` | `pub` | no | no | — | `core/page_map_improve.rs::improve_page_map`, `server/page_map_routes.rs::ensure_page_is_active` |
 | `server/page_map_routes.rs::handle_patch_map_edge` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
-| `server/page_map_routes.rs::handle_patch_map_node` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
+| `server/page_map_routes.rs::handle_patch_map_node` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active`, `server/page_map_routes.rs::wire_node` |
 | `server/page_map_routes.rs::handle_put_page_map_layout` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
 | `server/page_map_routes.rs::handle_reset_page_map` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |
 | `server/page_routes.rs::handle_export_page` | `pub` | no | no | — | `core/truth_adapter.rs::page_write_permit` |
@@ -1196,7 +1274,7 @@ carrying the authority of agreement.
 | `server/page_routes.rs::handle_search_pages` | `pub` | no | no | — | `core/truth_adapter.rs::filter_pages` |
 | `server/refinery_routes.rs::handle_accept_refinement` | `pub` | no | no | — | `core/synthesis/refinement_queue.rs::apply_refinement_with_decision` |
 | `server/repair_routes.rs::handle_apply` | `private` | no | no | — | `core/repair.rs::apply_repair_with_pages` |
-| `server/routes.rs::handle_search` | `pub` | no | no | — | `core/truth_adapter.rs::filter_page_refs` |
+| `server/routes.rs::handle_context` | `pub` | no | no | — | `server/brief_routes.rs::handle_read_brief` |
 | `server/scheduler.rs::fire_steep_phase` | `private` | no | no | `server/scheduler.rs::fire_steep_phase_safe` | `core/refinery/mod.rs::run_periodic_steep_phase_with_api` |
 | `server/scheduler.rs::spawn_scheduler` | `pub` | no | **yes** | `server/main.rs::run_daemon` | `server/scheduler.rs::fire_maintenance_stage_safe`, `server/scheduler/ambient.rs::run_ambient_job_safe` |
 | `server/source_routes.rs::sync_directory_source` | `pub(crate)` | no | no | `server/scheduler.rs::sync_directory_sources`, `server/source_routes.rs::handle_sync_source` | `core/db.rs::rebind_source_id_with_source_page` |

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -169,6 +169,18 @@ Order by measured entanglement:
 5. **`entities` + `entity_aliases` + `observations`** (~25+ fns) — largest surface;
    readers move to the `kind='entity'` shadow pages. Depends on stage 1.2's shared-
    CRUD rework.
+   **Stage 1.5a — status (2026-08-05):** migrated the 18 CLEAN readers in the
+   spec table (`docs/plans/2026-08-05-g6-stage15a-entity-clean-readers-spec.md`)
+   onto `entity_page_map` JOIN `pages` (`kind='entity'`, `status='active'`); the
+   `create_entity` shadow-page landmine fixed alongside. 10 readers stay CARRYOVER
+   (space-sensitive under the NULL->`UNFILED_SPACE_ID` fold, or writer-coupled —
+   dated in place, see the spec's carryover list). Hard-cut, no `reader_uses_entity_pages`
+   gate on the migrated readers: this is the program's Stage 1 contract, the same
+   unconditional cutover 1.1-1.3 used for `edges` while that gate + cutover-lever
+   still existed; the gate and `entity_reader_cutover` retire together with the
+   writers in Stage 2. Empirically backed on the live DB (swept 2026-08-05 07:30,
+   post-migrations 113/114): `entity_page_parity_watermark` drift 0, 907/907
+   expected-vs-actual shadow pages, 0 `entities` rows without a live shadow page.
 
 Each store's migration is one PR: readers redirected to `edges`/shadow pages,
 behavior-equivalence tests, and the store's parity derivation dropped from

--- a/docs/plans/2026-08-05-g6-stage15a-entity-clean-readers-spec.md
+++ b/docs/plans/2026-08-05-g6-stage15a-entity-clean-readers-spec.md
@@ -1,0 +1,138 @@
+# G6 Stage 1.5a — migrate the CLEAN entity readers onto shadow pages
+
+Parent program: `docs/plans/2026-08-04-g6-retirement-program.md` (Stage 1, store 5).
+Grounding: the 2026-08-05 entity-reader inventory (scout, delivered in-session; key
+facts restated here — the implementer verifies every site at the code level before
+editing, and bounces back any site whose read contradicts this spec rather than
+improvising). Prerequisites: Stages 1.1–1.3 merged. NO schema change in this PR —
+every reader migrated here needs only fields the shadow pages already mirror
+(title=name, entity_type, confidence, entity_confirmed, embedding, space,
+workspace, aliases via `entity_page_map`).
+
+## What this PR is NOT (deferred to 1.5b, decisions recorded below)
+
+- NO migration of readers needing `source_agent`, `created_at`/`updated_at`,
+  `community_id`, `embedding_updated_at`, or `observations` content — those wait
+  for the 1.5b scalar mirror extension (m117) and the observations ruling.
+- NO change to the `reader_uses_entity_pages` gated hybrid paths in
+  `db/scoped_entities.rs` — they keep their residual direct reads until 1.5b.
+- NO touch of the WRITER-COUPLED shared-CRUD core (`store_entity`,
+  `merge_entities`, `commit_entity_enrichment_at_version`, `add_entity_alias`,
+  `refresh_entity_embedding`, `confirm_entity`, `add_observation`,
+  `create_relation_with_span`, `delete_entity`, `fold_entity_type`,
+  `resolve_entity_by_alias`, dedup-candidate + repair-apply EXISTS guards) —
+  writers and their coupled discovery reads flip together in Stage 2.
+
+## The space-sentinel trap (this stage's Trap 1)
+
+`insert_entity_shadow_page`/`update_entity_shadow_page` fold NULL
+`entities.space` to the `UNFILED_SPACE_ID` sentinel on the page row, so
+`pages.space` ≠ `entities.space` semantically. Any migrated reader that filters
+or projects space MUST either (a) prove its consumers treat NULL and the
+sentinel identically, or (b) keep reading `entities.space` with a dated comment
+(making it a 1.5b carryover, not a clean migration). `load_entities`
+(lint/semantic_candidates.rs:748) is known to distinguish via `scope_matches` —
+it is NOT in this PR's migration set despite otherwise-clean fields. The
+implementer verifies the space handling of every reader below before migrating
+it; any that turns out space-sensitive gets the (b) treatment and a report line.
+
+## Migration targets (verify each; migrate those that hold)
+
+All from the inventory's CLEAN set, excluding space-sensitive and
+writer-coupled entries. Target store: `pages` joined via `entity_page_map`
+(`kind='entity'`, `status='active'`), fields per the mirror. Keep result
+shapes and ordering byte-compatible; where legacy ordered by `entities.name`,
+order by `pages.title` (same value by mirror invariant).
+
+1. `expand_anchor_entities_khop` (db.rs:26188) — id/space existence checks
+2. `expand_entities_khop_scoped` (db.rs:26746) — same
+3. `filter_entity_ids_scoped` (db/scoped_entities.rs:575)
+4. `get_entity_name_type` (db.rs:31766) — name/entity_type projection
+5. `count_entities` (db.rs:36983)
+6. `get_space_by_id` entity count (db/space_context.rs:12)
+7. distillation query trio's `e.name` join (db.rs:39837/40110/40164)
+8. `entity_integrity` (lint/kg/query.rs:48) — name/entity_type/confirmed/confidence/space
+9. `relation_integrity` / `link_integrity` entity-existence sides (lint/kg/query.rs:83/100)
+10. aggregate readers (lint/kg/query/aggregate.rs:30/54/72)
+11. `alias_integrity` entity-existence side (lint/deep.rs:89)
+12. `relation_vocabulary` entity side (lint/deep.rs)
+13. `load_relations` entity join (lint/semantic_candidates.rs:831)
+14. `load_record_inventory` entity side (repair_plan/semantic.rs:164)
+15. `resolve_memory_entity_links` (repair_plan/deterministic.rs:1003)
+16. `validate_selected_entities_on_{snapshot,connection}` (repair.rs:4709/4738)
+17. `list_contradiction_observation_counts` entity-name side only (db/kg_quality_diagnostics.rs:41)
+18. `observation_integrity` / `observation_duplicates` entity-existence sides only
+    (lint/kg/query.rs:66, lint/deep.rs:205) — the observations reads stay
+19. `entity_exists` (db.rs:33103) — verify no writer coupling bites; it guards
+    relation writes, reading the store `store_entity` writes; if the coupling
+    argument holds (write path must see its own uncommitted row), carryover with
+    a dated comment instead
+20. `EDGE_GROUNDING_CANDIDATE_SCAN_SQL` name hydration (db.rs:14993)
+21. `eval_lifecycle_integrity` count (db/eval_lifecycle_integrity.rs:49)
+22. `resolve_entity_by_name`'s own SQL (db.rs:33398) — id-by-name; its
+    fallthrough to `search_entities_by_vector` stays legacy (BLOCKED, 1.5b)
+23. `search_memory_with_cue`'s post-search `entity_name` hydration
+    (db.rs:24754) — name-only, space-free `SELECT id, name FROM entities
+    WHERE id IN (…)` over the result set's entity ids; missing from the
+    original scout inventory, added by review during the fix round
+    (2026-08-05)
+
+Lint/repair readers here follow the 1.2/1.3 precedent: a well-formedness check
+over the canonical store migrates; a cross-store consistency check does not.
+`assert_entities_have_shadow_pages` and `reconcile_entity_page_parity` are
+cross-store by definition — untouched.
+
+## The `create_entity` landmine (fix in this PR)
+
+`create_entity` (db.rs:31475) is a live `pub async fn` with zero production
+callers that does NOT write a shadow page — any future caller silently violates
+the shadow invariant. Fix: `#[cfg(test)]`-gate it AND make it call
+`insert_entity_shadow_page` inside its transaction, so even test fixtures
+produce invariant-complete state (several 1.5a tests will rely on that).
+
+## Tests (RED-control discipline as 1.2/1.3)
+
+1. Equivalence per migrated product-adjacent reader (khop pair, name_type,
+   counts) — seeded via real writers (`store_entity`), field-by-field.
+2. Divergence test, asymmetric seeding: one entity present only as a shadow
+   page + map row (seeded by writer then legacy row deleted via raw SQL), two
+   present only as raw `entities` rows without shadow pages (raw SQL, bypassing
+   the invariant on purpose); assert migrated readers see 1, not 2. RED via
+   prove-then-revert mutation of one reader.
+3. Mirror-invariant leans: a test asserting `pages.title/entity_type/confidence`
+   round-trip `store_entity` updates (pins the mirror this PR now load-bears).
+4. Parity: `entity_page_parity_watermark` fixtures unchanged, still drift 0.
+
+## Gates
+
+fmt, clippy both variants, focused modules; full suites queued by the session
+lead at integration time. Program-doc status note for 1.5a in the same PR.
+
+## 1.5b decisions recorded (design ruled in-session 2026-08-05, execution later)
+
+- **Scalar mirror extension (m117):** `source_agent`, `created_at`,
+  `updated_at`, `community_id`, `embedding_updated_at` become entity-page
+  columns per the M3 precedent (entity_type/confidence/entity_confirmed are
+  already real `pages` columns), with a backfill migration and writer
+  thread-through. Unblocks `list_entities(_scoped)`, `get_entity_detail`
+  entity-half, `search_entities_by_vector(_scoped)`, `search_entities_by_name`,
+  `load_summary_buckets` legacy branch, `summary_eligible_predicate` legacy
+  branch, embedding-refresh sweep.
+- **Space sentinel:** target state is "space is never NULL" — the retirement
+  migration folds NULL→sentinel in `entities` before the drop, and consumers
+  that distinguish must be reworked or the distinction declared dead by then.
+  1.5b carries the audit of `scope_matches` consumers.
+- **Observations (FLAGGED for user veto, same class as the 1.4
+  reclassification):** `observations` is NOT a duplicated legacy store — it is
+  the only store of observation content, with no canonical twin and no
+  dual-write. Ruling: reclassify out of the Stage 3 drop list; it survives as
+  the single source of truth for observation content, re-anchored if needed
+  (entity ids stay meaningful post-drop — they are the edges src/dst identity
+  space). The alternative (a JSON observations column on shadow pages) puts an
+  unbounded per-entity collection into a row column and couples every
+  observation write to a page-row rewrite; rejected. Stage 3's drop list
+  shrinks accordingly: `entities`, `entity_aliases`, `entity_page_map` drop;
+  `observations` stays.
+- **`list_recent_relations` structural join:** the entity join is structurally
+  legacy even when gated (gate only overlays title hydration) — rework rides
+  1.5b with the scalar extension.

--- a/scripts/m5-reader-sweep.py
+++ b/scripts/m5-reader-sweep.py
@@ -60,6 +60,14 @@ remain in --json only. Caller identities are the uniquely enclosing
 brace-matched function. A relevant name-resolvable call with no unique owner
 fails closed. The exact generated list retains duplicate multiplicity.
 
+KNOWN LIMITATION (2026-08-05): the SQLBLK scan in sweep() (~line 465) walks
+each function's brace-matched body only, so a SQL literal defined in an
+associated const at impl level -- outside any function body -- is invisible
+to the predicate. `db.rs::EDGE_GROUNDING_CANDIDATE_SCAN_SQL` is such a const;
+its consumer `db.rs::edge_grounding_candidates` is a genuine depth-0
+page-bearing reader missing from the inventory as a result. Not fixed here --
+the predicate would need to also walk associated-const initializers.
+
 Usage:
   python3 scripts/m5-reader-sweep.py [--json]
   python3 scripts/m5-reader-sweep.py --self-test


### PR DESCRIPTION
## G6 Stage 1.5a — clean entity readers cut over to kind='entity' shadow pages

Fourth reader cutover of the G6 retirement program (`docs/plans/2026-08-04-g6-retirement-program.md`, Stage 1 store 5; spec `docs/plans/2026-08-05-g6-stage15a-entity-clean-readers-spec.md`, included in this PR). 18 readers whose field needs are already mirrored (title=name, entity_type, confidence, entity_confirmed, embedding, space, workspace, aliases) move from `entities` onto the `kind='entity'` shadow pages via `entity_page_map`. No schema change.

### Scope discipline

- **Migrated (18):** khop expansion pair, `filter_entity_ids_scoped`, `get_entity_name_type`, `count_entities`, `get_space_by_id` entity count, the distillation staging trio's name join, `link_integrity` entity side, the aggregate lint readers, `load_record_inventory`, `resolve_memory_entity_links`, `list_contradiction_observation_counts` name side, edge-grounding name hydration, `eval_lifecycle_integrity` count, `resolve_entity_by_name` (SQL steps; the vector fallthrough stays legacy).
- **Carryovers (10, dated):** space-sensitive readers (the shadow mirror folds NULL `entities.space` to the UNFILED sentinel, so `pages.space` ≠ `entities.space` semantically) and writer-coupled reads that flip with the writers in Stage 2.
- **Not touched:** the `reader_uses_entity_pages` gated hybrids, the shared-CRUD writer core, and everything needing unmirrored scalars (`source_agent`, timestamps, `community_id`, `embedding_updated_at`) or `observations` content — that is Stage 1.5b (scalar mirror extension m117), decisions recorded in the spec.

### `create_entity` landmine fix

`create_entity` was a live `pub` constructor with zero production callers that skipped the shadow-page mint — any future caller would silently break the mirror invariant the migrated readers now load-bear. It is `#[cfg(test)]`-gated and now writes its shadow page inside its own transaction; integration tests that used it switched to `store_entity`.

### Design ruling: hard-cut, gate bypassed by program contract

The migrated readers bypass `reader_uses_entity_pages` (the fail-closed cutover gate) deliberately: Stage 1 of the G6 program is an unconditional reader cutover, exactly as the edges stages (1.1–1.3) bypassed the edges cutover lever. The gate and the `entity_reader_cutover` table retire in Stage 2 with the writers. Empirical backing on the live DB: `entity_page_parity_watermark` drift 0 at 907/907, and 0 entities without an active shadow page. Dated notes at the gate site and in the program doc.

### Review-driven fixes

- **Planner/applier store split closed**: the repair planner (migrated) and the applier's guarded DELETE (was legacy) now read the same shadow-page store for the same decision, with an isolating RED-controlled test.
- **Determinism**: `resolve_entity_by_name` gained a stable `ORDER BY` (ambiguous-name winner no longer flips with the access path).
- **Inventory gap**: `search_memory_with_cue`'s entity-name hydration was missing from the scout inventory; found by review, migrated as target #23.
- **m5 reader-inventory census regenerated** (all drift traced to this branch's migrations — chiefly the #23 hydration making `search_memory_with_cue` a depth-0 page-bearing reader). The chase surfaced a pre-existing sweep-script blind spot (SQL in associated consts is invisible; `edge_grounding_candidates` is a known-missing depth-0 row) — recorded in the script header and inventory doc, not fixed here.
- The ignored edge-grounding EXPLAIN-plan bench was run manually over the new 4-way join: green.

### Tests

New `db/entity_clean_readers_test.rs`: field-by-field equivalence seeded via real writers; asymmetric divergence (shadow-only entity seen, raw-only entities invisible) with a hand-run RED control (reverting `count_entities` to legacy failed the test, restored, green); mirror-invariant round-trip through `store_entity` + `merge_entities` type promotion. Fixture fallout in raw-SQL-seeding test modules handled via a `test_seed_entity_shadow_page` helper. Entity-page parity fixture untouched and green.

Suites (full capture): core 4077 passed / 0 failed / 33 ignored; m4_community_gates 20 passed / 0 failed / 6 ignored; server 619 passed / 0 failed / 3 ignored over 43 binaries; CLI 106 passed / 0 failed / 1 ignored over 11 binaries. fmt clean; clippy clean on core (lib+tests) and server.

Reviewed by the Opus investigator lane (fresh full review of the integrated diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
