### PR TITLE
feat(kg): G6 Stage 1.5b — scalar mirror extension + entity reader completion

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -168,25 +168,12 @@ mod space_rename_test;
 #[path = "db/test_support_test.rs"]
 pub(crate) mod test_support;
 
-fn push_read_scope_filter(
-    scope: &ReadScope,
-    column: &str,
-    conditions: &mut Vec<String>,
-    values: &mut Vec<libsql::Value>,
-) {
-    match scope {
-        ReadScope::Global => {}
-        ReadScope::Space(space) => {
-            conditions.push(format!("{column} = ?"));
-            values.push(libsql::Value::Text(space.clone()));
-        }
-        ReadScope::Uncategorized => conditions.push(format!("{column} IS NULL")),
-    }
-}
-
-/// Same as `push_read_scope_filter`, but for columns migrated by the space-sentinel
-/// fold (`memories.space`, `chunks.space`, `pages.workspace`): unfiled rows are
-/// stored as `UNFILED_SPACE_ID`, not SQL NULL, so `Uncategorized` must match either.
+/// Builds the `ReadScope::Uncategorized` filter for a space column folded by
+/// the space-sentinel migration (`memories.space`, `chunks.space`,
+/// `pages.workspace`, and as of G6 Stage 1.5b Part 2, `entities.space`):
+/// unfiled rows are stored as `UNFILED_SPACE_ID`, not SQL NULL, so
+/// `Uncategorized` must match either. The plain, NULL-only sibling this
+/// mirrored was retired once entities.space (its last caller) folded too.
 fn push_read_scope_filter_folded(
     scope: &ReadScope,
     column: &str,
@@ -815,8 +802,13 @@ pub const EMBEDDING_DIM: usize = 768;
 /// Migration 116 backfills `payload.asserted_at` (+ fill-if-absent
 /// `source_memory_id`) on active relates edges (G6 Stage 1.2), so the
 /// migrated `relations` readers order/filter on the relation's true
-/// creation time instead of the edge's dual-write timestamp.
-pub const SCHEMA_VERSION: u32 = 116;
+/// creation time instead of the edge's dual-write timestamp. Migration 117
+/// extends the entity-page scalar mirror with `source_agent`/
+/// `entity_created_at`/`entity_updated_at`/`community_id`/
+/// `embedding_updated_at` (G6 Stage 1.5b Part 1). Migration 118 folds NULL
+/// `entities.space` -> `UNFILED_SPACE_ID` and stamps NOT NULL DEFAULT (G6
+/// Stage 1.5b Part 2).
+pub const SCHEMA_VERSION: u32 = 118;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8680,6 +8672,25 @@ impl MemoryDB {
             if version < 116 {
                 self.migrate_116_relates_asserted_at(version).await?;
             }
+
+            // Migration 117 (G6 Stage 1.5b Part 1): extends the M3 entity-page
+            // scalar mirror with `source_agent`/`entity_created_at`/
+            // `entity_updated_at`/`community_id`/`embedding_updated_at`,
+            // backfilled from `entities` via `entity_page_map`. See
+            // migrate_117_entity_page_scalar_mirror.
+            if version < 117 {
+                self.migrate_117_entity_page_scalar_mirror(version).await?;
+            }
+
+            // Migration 118 (G6 Stage 1.5b Part 2, ruled 2026-08-05: its own
+            // number after m117 so a failed scalar backfill and a failed
+            // fold stay distinguishable): folds NULL `entities.space` ->
+            // `UNFILED_SPACE_ID` and stamps NOT NULL DEFAULT, mirroring
+            // migration 91's `memories.space` fold. See
+            // migrate_118_entity_space_fold.
+            if version < 118 {
+                self.migrate_118_entity_space_fold(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -10080,6 +10091,11 @@ impl MemoryDB {
                 aliases = (SELECT json_group_array(alias_name)
                            FROM (SELECT alias_name FROM entity_aliases
                                  WHERE canonical_entity_id = ?1 ORDER BY alias_name)),
+                source_agent = (SELECT source_agent FROM entities WHERE id = ?1),
+                entity_created_at = (SELECT created_at FROM entities WHERE id = ?1),
+                entity_updated_at = (SELECT updated_at FROM entities WHERE id = ?1),
+                community_id = (SELECT community_id FROM entities WHERE id = ?1),
+                embedding_updated_at = (SELECT embedding_updated_at FROM entities WHERE id = ?1),
                 last_modified = ?3
              WHERE kind = 'entity'
                AND id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
@@ -10105,7 +10121,12 @@ impl MemoryDB {
         let now_iso = chrono::Utc::now().to_rfc3339();
         let page_id = crate::pages::new_page_id();
         let conn = self.conn.lock().await;
-        Self::insert_entity_shadow_page(&conn, entity_id, &page_id, &now_iso).await
+        Self::insert_entity_shadow_page(&conn, entity_id, &page_id, &now_iso).await?;
+        // G6 Stage 1.5b Part 1: same live-only re-sync as `create_entity`/
+        // `store_entity` -- backfills source_agent/entity_created_at/
+        // entity_updated_at/community_id/embedding_updated_at, which
+        // `insert_entity_shadow_page` deliberately leaves untouched.
+        Self::update_entity_shadow_page(&conn, entity_id, &now_iso).await
     }
 
     // Migration 92 (M3 PR-1, stage f): dual-write entities as `kind='entity'`
@@ -13563,6 +13584,360 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("m116 bump: {e}")))?;
         log::info!("[migration] Migration 116 applied: {updated} relates edges backfilled");
+        Ok(())
+    }
+
+    // Migration 117 (G6 Stage 1.5b Part 1): extends the M3 entity-page
+    // scalar mirror (`entity_type`/`confidence`/`entity_confirmed`, added by
+    // migration 92) with `source_agent`/`entity_created_at`/
+    // `entity_updated_at`/`community_id`/`embedding_updated_at`, backfilled
+    // from `entities` via `entity_page_map`. The entity timestamps get the
+    // `entity_` prefix so they don't capture `pages`' own `created_at`/
+    // `updated_at`. These 5 columns are intentionally NOT added to
+    // `insert_entity_shadow_page` (migration 92's own backfill invokes it,
+    // chronologically before this migration ever runs) -- only to
+    // `update_entity_shadow_page`, mirroring the existing `aliases`
+    // exclusion (migration 93).
+    async fn migrate_117_entity_page_scalar_mirror(
+        &self,
+        prior_version: i64,
+    ) -> Result<(), WenlanError> {
+        self.backup_before_migration(117, prior_version).await?;
+        let conn = self.conn.lock().await;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m117 begin: {e}")))?;
+
+        let result: Result<u64, WenlanError> = async {
+            for (col, ddl) in [
+                (
+                    "source_agent",
+                    "ALTER TABLE pages ADD COLUMN source_agent TEXT",
+                ),
+                (
+                    "entity_created_at",
+                    "ALTER TABLE pages ADD COLUMN entity_created_at INTEGER",
+                ),
+                (
+                    "entity_updated_at",
+                    "ALTER TABLE pages ADD COLUMN entity_updated_at INTEGER",
+                ),
+                (
+                    "community_id",
+                    "ALTER TABLE pages ADD COLUMN community_id TEXT",
+                ),
+                (
+                    "embedding_updated_at",
+                    "ALTER TABLE pages ADD COLUMN embedding_updated_at INTEGER",
+                ),
+            ] {
+                let has_col: bool = {
+                    let mut rows = conn
+                        .query(
+                            "SELECT COUNT(*) FROM pragma_table_info('pages') WHERE name = ?1",
+                            libsql::params![col],
+                        )
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("m117 col check {col}: {e}")))?;
+                    match rows.next().await {
+                        Ok(Some(row)) => row.get::<i64>(0).unwrap_or(0) > 0,
+                        _ => false,
+                    }
+                };
+                if !has_col {
+                    conn.execute(ddl, ())
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("m117 add {col}: {e}")))?;
+                }
+            }
+
+            let updated = conn
+                .execute(
+                    "UPDATE pages SET
+                        source_agent = (SELECT source_agent FROM entities
+                                        WHERE id = (SELECT entity_id FROM entity_page_map
+                                                    WHERE page_id = pages.id)),
+                        entity_created_at = (SELECT created_at FROM entities
+                                             WHERE id = (SELECT entity_id FROM entity_page_map
+                                                         WHERE page_id = pages.id)),
+                        entity_updated_at = (SELECT updated_at FROM entities
+                                             WHERE id = (SELECT entity_id FROM entity_page_map
+                                                         WHERE page_id = pages.id)),
+                        community_id = (SELECT community_id FROM entities
+                                        WHERE id = (SELECT entity_id FROM entity_page_map
+                                                    WHERE page_id = pages.id)),
+                        embedding_updated_at = (SELECT embedding_updated_at FROM entities
+                                                WHERE id = (SELECT entity_id FROM entity_page_map
+                                                            WHERE page_id = pages.id))
+                     WHERE kind = 'entity'
+                       AND EXISTS (SELECT 1 FROM entity_page_map WHERE page_id = pages.id)",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m117 backfill: {e}")))?;
+            Ok(updated)
+        }
+        .await;
+
+        let updated = match result {
+            Ok(count) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m117 commit: {e}")))?;
+                count
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+
+        conn.execute("PRAGMA user_version = 117", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m117 bump: {e}")))?;
+        log::info!("[migration] Migration 117 applied: {updated} entity shadow pages backfilled");
+        Ok(())
+    }
+
+    /// Extracted so it is directly testable, mirroring
+    /// `assert_memories_space_backfilled` -- the writable_schema NOT NULL
+    /// patch validates nothing on its own, so this EXISTS check is the only
+    /// thing standing between a surviving NULL and a column that lies about
+    /// itself. EXISTS (not COUNT) per the known libSQL vector-index COUNT
+    /// bug note -- `entities` carries an F32_BLOB embedding column too.
+    async fn assert_entities_space_backfilled(
+        conn: &libsql::Connection,
+    ) -> Result<(), WenlanError> {
+        let unresolved: bool = {
+            let mut rows = conn
+                .query(
+                    "SELECT EXISTS(SELECT 1 FROM entities WHERE space IS NULL)",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 assert query: {e}")))?;
+            match rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 assert row: {e}")))?
+            {
+                Some(row) => {
+                    row.get::<i64>(0)
+                        .map_err(|e| WenlanError::VectorDb(format!("m118 assert col: {e}")))?
+                        != 0
+                }
+                None => false,
+            }
+        };
+        if unresolved {
+            return Err(WenlanError::VectorDb(
+                "m118: an entities row still has NULL space after backfill -- refusing to \
+                 stamp NOT NULL over a lie"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    // Migration 118 (G6 Stage 1.5b Part 2, ruled 2026-08-05: its own number
+    // after m117 so a failed scalar backfill and a failed fold stay
+    // distinguishable): folds NULL `entities.space` -> `UNFILED_SPACE_ID`,
+    // then stamps NOT NULL DEFAULT `UNFILED_SPACE_ID` via the migration-67/80/91
+    // writable_schema pattern -- mirrors migration 91's `memories.space` fold
+    // exactly (same table-size class, same batch/assert/patch shape). The
+    // shadow-page mirror needs no re-sync here: `update_entity_shadow_page`
+    // already COALESCEs a NULL `entities.space` to the sentinel at write
+    // time (M3 PR-1 stage e), so every existing shadow page already reads
+    // the sentinel regardless of whether the source row was NULL or folded.
+    async fn migrate_118_entity_space_fold(&self, prior_version: i64) -> Result<(), WenlanError> {
+        self.backup_before_migration(118, prior_version).await?;
+
+        // Same table-size class as migration 91's `memories.space` fold;
+        // same lock-duration budget.
+        const BATCH_SIZE: i64 = 10_000;
+
+        let null_count: i64 = {
+            let conn = self.conn.lock().await;
+            let mut rows = conn
+                .query("SELECT COUNT(*) FROM entities WHERE space IS NULL", ())
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 audit count: {e}")))?;
+            match rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 audit row: {e}")))?
+            {
+                Some(row) => row
+                    .get::<i64>(0)
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 audit col: {e}")))?,
+                None => 0,
+            }
+        };
+        log::info!(
+            "[migration] Migration 118 pre-fold audit: {null_count} entities row(s) with NULL space"
+        );
+
+        // Backfill in rowid-range batches, one commit per batch -- mirrors
+        // migration 91 steps 3-4. The cursor starts at i64::MIN so a row at
+        // a non-positive rowid is folded too; a resumed run re-touches
+        // already-folded rows as a cheap no-op.
+        let mut cursor: i64 = i64::MIN;
+        loop {
+            let conn = self.conn.lock().await;
+            conn.execute("BEGIN", ())
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 begin batch: {e}")))?;
+            let result: Result<Option<i64>, WenlanError> = async {
+                let hi: Option<i64> =
+                    {
+                        let mut rows = conn
+                            .query(
+                                "SELECT MAX(rowid) FROM \
+                             (SELECT rowid FROM entities WHERE rowid > ?1 ORDER BY rowid LIMIT ?2)",
+                                libsql::params![cursor, BATCH_SIZE],
+                            )
+                            .await
+                            .map_err(|e| WenlanError::VectorDb(format!("m118 batch bound: {e}")))?;
+                        match rows.next().await.map_err(|e| {
+                            WenlanError::VectorDb(format!("m118 batch bound row: {e}"))
+                        })? {
+                            Some(row) => row.get::<Option<i64>>(0).map_err(|e| {
+                                WenlanError::VectorDb(format!("m118 batch bound col: {e}"))
+                            })?,
+                            None => None,
+                        }
+                    };
+                let Some(hi) = hi else {
+                    return Ok(None);
+                };
+                conn.execute(
+                    "UPDATE entities SET space = ?3 \
+                     WHERE space IS NULL AND rowid > ?1 AND rowid <= ?2",
+                    libsql::params![cursor, hi, UNFILED_SPACE_ID],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 backfill space: {e}")))?;
+                Ok(Some(hi))
+            }
+            .await;
+            match result {
+                Ok(Some(hi)) => {
+                    conn.execute("COMMIT", ())
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("m118 commit batch: {e}")))?;
+                    cursor = hi;
+                }
+                Ok(None) => {
+                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                        WenlanError::VectorDb(format!("m118 commit final batch: {e}"))
+                    })?;
+                    break;
+                }
+                Err(e) => {
+                    let _ = conn.execute("ROLLBACK", ()).await;
+                    return Err(e);
+                }
+            }
+        }
+
+        // Assert every row resolved, then rebuild `idx_entities_space`
+        // without its now-vacuous `WHERE space IS NOT NULL` partial
+        // predicate (mirrors migration 91's `idx_memories_space` rebuild).
+        {
+            let conn = self.conn.lock().await;
+            conn.execute("BEGIN", ())
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 begin assert: {e}")))?;
+            let result: Result<(), WenlanError> = async {
+                Self::assert_entities_space_backfilled(&conn).await?;
+                conn.execute("DROP INDEX IF EXISTS idx_entities_space", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 drop idx: {e}")))?;
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_entities_space ON entities(space)",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m118 create idx: {e}")))?;
+                Ok(())
+            }
+            .await;
+            match result {
+                Ok(()) => {
+                    conn.execute("COMMIT", ())
+                        .await
+                        .map_err(|e| WenlanError::VectorDb(format!("m118 commit assert: {e}")))?;
+                }
+                Err(e) => {
+                    let _ = conn.execute("ROLLBACK", ()).await;
+                    return Err(e);
+                }
+            }
+        }
+
+        // Stamp NOT NULL via the migration-67/80/91 writable_schema pattern
+        // rather than rebuilding `entities` (a full rebuild would need to
+        // rewire the vector-index-bearing statements for no benefit over
+        // the text patch). Bare autocommit statements, matching migration
+        // 91. The DEFAULT is the reserved sentinel id, so a bare INSERT
+        // that omits space lands the sentinel, never NULL.
+        let conn = self.conn.lock().await;
+        let current_sql: Option<String> =
+            {
+                let mut rows = conn
+                    .query(
+                        "SELECT sql FROM sqlite_master WHERE type='table' AND name='entities'",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 read entities sql: {e}")))?;
+                match rows
+                    .next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 entities sql row: {e}")))?
+                {
+                    Some(row) => Some(row.get::<String>(0).map_err(|e| {
+                        WenlanError::VectorDb(format!("m118 entities sql col: {e}"))
+                    })?),
+                    None => None,
+                }
+            };
+        if let Some(sql) = current_sql {
+            let patched = sql.replacen(
+                "space TEXT,",
+                &format!("space TEXT NOT NULL DEFAULT '{UNFILED_SPACE_ID}',"),
+                1,
+            );
+            if patched != sql {
+                conn.execute("PRAGMA writable_schema=ON", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 writable on: {e}")))?;
+                // Always turn writable_schema back OFF, even if the patch fails:
+                // the shared process-lifetime connection must never be left in
+                // the schema-writable state (a later write could corrupt the
+                // schema). Capture the patch result, RESET unconditionally, then
+                // propagate the patch error.
+                let patch = conn
+                    .execute(
+                        "UPDATE sqlite_master SET sql=?1 WHERE type='table' AND name='entities'",
+                        libsql::params![patched],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 patch schema: {e}")));
+                conn.execute("PRAGMA writable_schema=RESET", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m118 writable reset: {e}")))?;
+                patch?;
+            }
+        }
+
+        conn.execute("PRAGMA user_version = 118", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m118 bump: {e}")))?;
+        log::info!(
+            "[migration] Migration 118 applied: entities.space unfiled fold + NOT NULL (G6 Stage 1.5b Part 2)"
+        );
         Ok(())
     }
 
@@ -19274,10 +19649,14 @@ impl MemoryDB {
         // `insert_entity_shadow_page`/`update_entity_shadow_page` write:
         // name, entity_type, confidence, confirmed (-> `entity_confirmed`),
         // embedding, space semantics (both `space` and `workspace` carry the
-        // same unfiled-sentinel fold), and the `entity_aliases` projection
+        // same unfiled-sentinel fold), the `entity_aliases` projection
         // (recomputed here the same way `update_entity_shadow_page` does, so
         // a shadow whose aliases were never re-synced after an alias change
-        // is flagged corrupt). Embedding compares raw blob bytes -- NULL vs
+        // is flagged corrupt), and the G6 Stage 1.5b Part 1 scalar mirror
+        // (`source_agent`, `entity_created_at`/`entity_updated_at`,
+        // `community_id` -- compared via the entities-side integer's string
+        // form since `pages.community_id` is TEXT -- and
+        // `embedding_updated_at`). Embedding compares raw blob bytes -- NULL vs
         // NULL (never embedded on either side) is equal via the `Option`
         // fold to an empty Vec; a genuine F32_BLOB(768) is never empty, so no
         // false match against an unset embedding. An undecodable mirrored
@@ -19299,7 +19678,11 @@ impl MemoryDB {
                                 SELECT alias_name FROM entity_aliases
                                 WHERE canonical_entity_id = e.id ORDER BY alias_name
                              )) AS expected_aliases,
-                            e.confirmed, e.embedding, p.entity_confirmed, p.embedding
+                            e.confirmed, e.embedding, p.entity_confirmed, p.embedding,
+                            e.source_agent, e.created_at, e.updated_at, e.community_id,
+                            e.embedding_updated_at,
+                            p.source_agent, p.entity_created_at, p.entity_updated_at,
+                            p.community_id, p.embedding_updated_at
                      FROM entities e
                      LEFT JOIN entity_page_map m ON m.entity_id = e.id
                      LEFT JOIN pages p ON p.id = m.page_id
@@ -19329,6 +19712,21 @@ impl MemoryDB {
                     let expected_aliases: Option<String> = row.get(11)?;
                     let confirmed: Option<i64> = row.get(12)?;
                     let embedding: Vec<u8> = row.get::<Option<Vec<u8>>>(13)?.unwrap_or_default();
+                    let source_agent: Option<String> = row.get(16)?;
+                    let created_at: Option<i64> = row.get(17)?;
+                    let updated_at: Option<i64> = row.get(18)?;
+                    // community_id is INTEGER on entities, TEXT on pages (SQLite
+                    // TEXT-affinity coercion at mirror time) -- compare via the
+                    // integer's string form, matching what actually lands there.
+                    // TEXT was the deliberate choice, not a shortcut: every
+                    // existing consumer of entities.community_id already reads
+                    // it as a string (CAST(e.community_id AS TEXT) into the
+                    // durable-community Option<String> fields, and the m4
+                    // `communities` table keys are TEXT), so an INTEGER mirror
+                    // would introduce casts rather than remove them.
+                    let community_id: Option<String> =
+                        row.get::<Option<i64>>(19)?.map(|v| v.to_string());
+                    let embedding_updated_at: Option<i64> = row.get(20)?;
                     Ok((
                         name,
                         entity_type,
@@ -19337,6 +19735,11 @@ impl MemoryDB {
                         expected_aliases,
                         confirmed,
                         embedding,
+                        source_agent,
+                        created_at,
+                        updated_at,
+                        community_id,
+                        embedding_updated_at,
                     ))
                 })();
                 let Ok((
@@ -19347,6 +19750,11 @@ impl MemoryDB {
                     expected_aliases,
                     confirmed,
                     embedding,
+                    source_agent,
+                    created_at,
+                    updated_at,
+                    community_id,
+                    embedding_updated_at,
                 )) = entity_side
                 else {
                     corrupt_count += 1;
@@ -19386,6 +19794,11 @@ impl MemoryDB {
                     let page_confirmed: Option<i64> = row.get(14)?;
                     let page_embedding: Vec<u8> =
                         row.get::<Option<Vec<u8>>>(15)?.unwrap_or_default();
+                    let page_source_agent: Option<String> = row.get(21)?;
+                    let page_entity_created_at: Option<i64> = row.get(22)?;
+                    let page_entity_updated_at: Option<i64> = row.get(23)?;
+                    let page_community_id: Option<String> = row.get(24)?;
+                    let page_embedding_updated_at: Option<i64> = row.get(25)?;
                     Ok((
                         page_entity_type,
                         page_confidence,
@@ -19394,6 +19807,11 @@ impl MemoryDB {
                         page_aliases,
                         page_confirmed,
                         page_embedding,
+                        page_source_agent,
+                        page_entity_created_at,
+                        page_entity_updated_at,
+                        page_community_id,
+                        page_embedding_updated_at,
                     ))
                 })();
                 let Ok((
@@ -19404,6 +19822,11 @@ impl MemoryDB {
                     page_aliases,
                     page_confirmed,
                     page_embedding,
+                    page_source_agent,
+                    page_entity_created_at,
+                    page_entity_updated_at,
+                    page_community_id,
+                    page_embedding_updated_at,
                 )) = page_side
                 else {
                     corrupt_count += 1;
@@ -19420,7 +19843,12 @@ impl MemoryDB {
                     && page_workspace.as_deref() == Some(expected_space.as_str())
                     && page_aliases == expected_aliases
                     && page_confirmed == confirmed
-                    && page_embedding == embedding;
+                    && page_embedding == embedding
+                    && page_source_agent == source_agent
+                    && page_entity_created_at == created_at
+                    && page_entity_updated_at == updated_at
+                    && page_community_id == community_id
+                    && page_embedding_updated_at == embedding_updated_at;
                 if !matches {
                     corrupt_count += 1;
                     if corrupt_sample.len() < EntityPageParityReport::SAMPLE_CAP {
@@ -19557,6 +19985,13 @@ impl MemoryDB {
     /// literal `"communities"` key, named as a const per the stage-c
     /// contract so every `scoped_entities.rs` call site shares one source
     /// of truth.
+    ///
+    /// G6 Stage 1.5b Part 3 (spec item 9): the last `scoped_entities.rs`
+    /// call site (`list_recent_relations_scoped`) collapsed onto an
+    /// unconditional hard cutover, so this const has no reader left. Left
+    /// dead-but-present per the spec -- the gate and `entity_reader_cutover`
+    /// retire together in Stage 2 with the writers.
+    #[allow(dead_code)]
     pub(crate) const SCOPED_ENTITIES_CONSUMER: &str = "scoped_entities";
 
     /// Flip an entity-reader consumer's cutover ON or OFF (M3 PR-2 stage b;
@@ -19642,6 +20077,12 @@ impl MemoryDB {
     /// consumers are the `scoped_entities` vanguard hybrid reads
     /// (`db/scoped_entities.rs`); this gate and `entity_reader_cutover`
     /// retire together in Stage 2 when the writers cut over.
+    ///
+    /// 2026-08-05, G6 Stage 1.5b Part 3 (spec item 9): those vanguard hybrid
+    /// reads have now all collapsed onto an unconditional hard cutover
+    /// (same as the 1.5a readers), so this predicate has no caller left.
+    /// Left dead-but-present per the spec rather than deleted here.
+    #[allow(dead_code)]
     async fn reader_uses_entity_pages(
         conn: &libsql::Connection,
         consumer: &str,
@@ -20510,15 +20951,29 @@ impl MemoryDB {
             }
         }
 
+        // G6 Stage 1.5b Part 2: `fe.space`/`te.space` are `entities.space`,
+        // folded by the space-sentinel migration. A missing entity row still
+        // reads as SQL NULL (LEFT JOIN no-match), but an unfiled entity that
+        // DOES exist now carries `UNFILED_SPACE_ID` rather than NULL -- so
+        // both are treated as "no space" here, same as bare NULL was before
+        // the fold, to keep the null_space tally's meaning ("originally
+        // unfiled") identical pre/post fold.
         let relations = tally(
             conn,
-            "SELECT \
-                SUM(CASE WHEN fe.space IS NOT NULL AND fe.space = te.space THEN 1 ELSE 0 END), \
-                SUM(CASE WHEN fe.space IS NOT NULL AND te.space IS NOT NULL AND fe.space != te.space THEN 1 ELSE 0 END), \
-                SUM(CASE WHEN fe.space IS NULL OR te.space IS NULL THEN 1 ELSE 0 END) \
-             FROM relations r \
-             LEFT JOIN entities fe ON fe.id = r.from_entity \
-             LEFT JOIN entities te ON te.id = r.to_entity",
+            &format!(
+                "SELECT \
+                    SUM(CASE WHEN fe.space IS NOT NULL AND fe.space != '{unfiled}' \
+                             AND fe.space = te.space THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN fe.space IS NOT NULL AND fe.space != '{unfiled}' \
+                             AND te.space IS NOT NULL AND te.space != '{unfiled}' \
+                             AND fe.space != te.space THEN 1 ELSE 0 END), \
+                    SUM(CASE WHEN fe.space IS NULL OR fe.space = '{unfiled}' \
+                             OR te.space IS NULL OR te.space = '{unfiled}' THEN 1 ELSE 0 END) \
+                 FROM relations r \
+                 LEFT JOIN entities fe ON fe.id = r.from_entity \
+                 LEFT JOIN entities te ON te.id = r.to_entity",
+                unfiled = UNFILED_SPACE_ID
+            ),
         )
         .await?;
 
@@ -21542,9 +21997,10 @@ impl MemoryDB {
                 })?;
                 // Fold the mapped entity shadows' space columns to the sentinel
                 // (M3 PR-1 dual-write parity). MUST run BEFORE the entities.space
-                // clear below so the join still sees the deleted space. entities
-                // themselves stay NULL (entities never fold -- only the NOT NULL
-                // pages shadow columns fold, matching insert_entity_shadow_page).
+                // fold below so the join still sees the deleted space. As of
+                // G6 Stage 1.5b Part 2, entities.space folds the same way the
+                // pages shadow columns already did -- `SET space = NULL` here
+                // would recreate exactly the NULL the fold migration removes.
                 tx.execute(
                     "UPDATE pages SET space = ?2, workspace = ?2 \
                      WHERE kind = 'entity' \
@@ -21558,8 +22014,8 @@ impl MemoryDB {
                     WenlanError::VectorDb(format!("delete_space unassign shadow fold: {}", e))
                 })?;
                 tx.execute(
-                    "UPDATE entities SET space = NULL WHERE space = ?1",
-                    libsql::params![name],
+                    "UPDATE entities SET space = ?2 WHERE space = ?1",
+                    libsql::params![name, UNFILED_SPACE_ID],
                 )
                 .await
                 .map_err(|e| {
@@ -27318,7 +27774,13 @@ impl MemoryDB {
                         id: row.get::<String>(0).unwrap_or_default(),
                         name: row.get::<String>(1).unwrap_or_default(),
                         entity_type: row.get::<String>(2).unwrap_or_default(),
-                        space: row.get::<Option<String>>(3).unwrap_or(None),
+                        // G6 Stage 1.5b Part 2: `entities.space` is folded
+                        // (never NULL; unfiled rows carry
+                        // `UNFILED_SPACE_ID`), but the wire contract keeps
+                        // `null` for "unfiled" -- normalize here.
+                        space: crate::space_context::normalize_unfiled_space(
+                            row.get::<Option<String>>(3).unwrap_or(None),
+                        ),
                         source_agent: row.get::<Option<String>>(4).unwrap_or(None),
                         confidence: row.get::<Option<f64>>(5).unwrap_or(None).map(|v| v as f32),
                         confirmed: row.get::<i64>(6).unwrap_or(0) != 0,
@@ -27358,7 +27820,13 @@ impl MemoryDB {
                             id: row.get::<String>(0).unwrap_or_default(),
                             name: row.get::<String>(1).unwrap_or_default(),
                             entity_type: row.get::<String>(2).unwrap_or_default(),
-                            space: row.get::<Option<String>>(3).unwrap_or(None),
+                            // G6 Stage 1.5b Part 2: `entities.space` is
+                            // folded (never NULL; unfiled rows carry
+                            // `UNFILED_SPACE_ID`), but the wire contract
+                            // keeps `null` for "unfiled" -- normalize here.
+                            space: crate::space_context::normalize_unfiled_space(
+                                row.get::<Option<String>>(3).unwrap_or(None),
+                            ),
                             source_agent: row.get::<Option<String>>(4).unwrap_or(None),
                             confidence: row.get::<Option<f64>>(5).unwrap_or(None).map(|v| v as f32),
                             confirmed: row.get::<i64>(6).unwrap_or(0) != 0,
@@ -27374,6 +27842,73 @@ impl MemoryDB {
                 }
                 Err(e) => {
                     log::warn!("[memory_db] entity brute-force search also failed: {}", e);
+                }
+            }
+        }
+
+        // G6 Stage 1.5b Part 3: ranking stays on `entities.embedding`'s
+        // DiskANN index by design (M3 PR-2 stage f review: the design
+        // deliberately does not swap ranking infrastructure), but the
+        // display fields overlay from the `kind='entity'` shadow page,
+        // unconditionally -- same program contract as 1.5a, mirroring
+        // `search_entities_by_vector_scoped`'s hydration overlay.
+        if !results.is_empty() {
+            struct Mirror {
+                title: String,
+                entity_type: String,
+                confidence: Option<f64>,
+                confirmed: i64,
+            }
+            let entity_ids: Vec<String> = results
+                .iter()
+                .map(|result| result.entity.id.clone())
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
+            let placeholders = (1..=entity_ids.len())
+                .map(|index| format!("?{index}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            let hydrate_sql = format!(
+                "SELECT m.entity_id, p.title, p.entity_type, p.confidence, p.entity_confirmed \
+                 FROM entity_page_map m \
+                 JOIN pages p ON p.id = m.page_id AND p.kind = 'entity' AND p.status = 'active' \
+                 WHERE m.entity_id IN ({placeholders})"
+            );
+            let hydrate_params: Vec<libsql::Value> = entity_ids
+                .iter()
+                .map(|id| libsql::Value::Text(id.clone()))
+                .collect();
+            let mut hydrate_rows = conn
+                .query(&hydrate_sql, hydrate_params)
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("search_entities_by_vector hydrate: {e}"))
+                })?;
+            let mut mirrors: HashMap<String, Mirror> = HashMap::new();
+            while let Some(row) = hydrate_rows.next().await.map_err(|e| {
+                WenlanError::VectorDb(format!("search_entities_by_vector hydrate next: {e}"))
+            })? {
+                let entity_id: String = row.get(0).unwrap_or_default();
+                mirrors.insert(
+                    entity_id,
+                    Mirror {
+                        title: row.get(1).unwrap_or_default(),
+                        entity_type: row.get(2).unwrap_or_default(),
+                        confidence: row.get::<Option<f64>>(3).unwrap_or(None),
+                        confirmed: row.get::<i64>(4).unwrap_or(0),
+                    },
+                );
+            }
+            // A hydration miss (id with no live shadow row -- unreachable
+            // under a clean dual-write) keeps the legacy-sourced fields
+            // already in `results` rather than dropping or erroring the row.
+            for result in &mut results {
+                if let Some(mirror) = mirrors.get(&result.entity.id) {
+                    result.entity.name = mirror.title.clone();
+                    result.entity.entity_type = mirror.entity_type.clone();
+                    result.entity.confidence = mirror.confidence.map(|value| value as f32);
+                    result.entity.confirmed = mirror.confirmed != 0;
                 }
             }
         }
@@ -27550,8 +28085,11 @@ impl MemoryDB {
     /// Load eligible memories for the T18 summary-rollup build. The consumer
     /// reads durable `community_members` only when its per-space parity proof is
     /// clean and current; otherwise it falls back to label-prop
-    /// `entities.community_id`. Returns opaque string ids so the existing
-    /// integer labels and durable ids share one internal shape.
+    /// `community_id`, read off the entity's `kind='entity'` shadow page
+    /// (G6 Stage 1.5b Part 3 -- mirrored 1:1 off `entities.community_id` by
+    /// `insert_entity_shadow_page`/`update_entity_shadow_page`, unconditional
+    /// hard cutover). Returns opaque string ids so the existing integer labels
+    /// and durable ids share one internal shape.
     pub async fn load_summary_buckets(
         &self,
     ) -> Result<Vec<(String, Vec<crate::refinery::summary::SummaryMember>)>, WenlanError> {
@@ -27576,10 +28114,12 @@ impl MemoryDB {
             )
         } else {
             (
-                "JOIN entities e ON m.entity_id = e.id",
-                "CAST(e.community_id AS TEXT)",
-                "AND e.community_id IS NOT NULL",
-                "e.community_id",
+                "JOIN entity_page_map epm ON epm.entity_id = m.entity_id
+                 JOIN pages p ON p.id = epm.page_id
+                  AND p.kind = 'entity' AND p.status = 'active'",
+                "CAST(p.community_id AS TEXT)",
+                "AND p.community_id IS NOT NULL",
+                "p.community_id",
             )
         };
         let sql = format!(
@@ -31582,7 +32122,9 @@ impl MemoryDB {
                     id.clone(),
                     name.to_string(),
                     entity_type.to_string(),
-                    space.map(|d| d.to_string()),
+                    // G6 Stage 1.5b Part 2: entities.space is folded (never
+                    // NULL) -- fold at write time, else NULLs recur post-migration.
+                    space.map(|d| d.to_string()).unwrap_or_else(|| UNFILED_SPACE_ID.to_string()),
                     now
                 ],
             )
@@ -31591,6 +32133,14 @@ impl MemoryDB {
 
             let page_id = crate::pages::new_page_id();
             Self::insert_entity_shadow_page(&conn, &id, &page_id, &now_iso).await?;
+            // G6 Stage 1.5b Part 1: `insert_entity_shadow_page` stays
+            // migration-92-safe (it also backfills historical entities
+            // mid-migration-sequence, before migration 117 adds these
+            // columns), so it never touches source_agent/entity_created_at/
+            // entity_updated_at/community_id/embedding_updated_at. This
+            // live-only path re-syncs them immediately after, same
+            // transaction, mirroring `store_entity`.
+            Self::update_entity_shadow_page(&conn, &id, &now_iso).await?;
 
             Ok(())
         }
@@ -31645,9 +32195,11 @@ impl MemoryDB {
                     id.clone(),
                     name.to_string(),
                     entity_type.to_string(),
+                    // G6 Stage 1.5b Part 2: entities.space is folded (never
+                    // NULL) -- fold at write time, else NULLs recur post-migration.
                     space
                         .map(|s| libsql::Value::Text(s.to_string()))
-                        .unwrap_or(libsql::Value::Null),
+                        .unwrap_or_else(|| libsql::Value::Text(UNFILED_SPACE_ID.to_string())),
                     source_agent
                         .map(|s| libsql::Value::Text(s.to_string()))
                         .unwrap_or(libsql::Value::Null),
@@ -32176,12 +32728,18 @@ impl MemoryDB {
     }
 
     /// Search entities by exact name (case-insensitive).
+    /// G6 Stage 1.5b Part 3: reads the `kind='entity'` shadow page via
+    /// `entity_page_map`, unconditional hard cutover (same program contract
+    /// as 1.5a and `list_entities` above).
     pub async fn search_entities_by_name(&self, name: &str) -> Result<Vec<Entity>, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT id, name, entity_type, space, source_agent, confidence, confirmed, created_at, updated_at
-                 FROM entities WHERE LOWER(name) = LOWER(?1)",
+                "SELECT epm.entity_id, p.title, p.entity_type, p.space, p.source_agent, \
+                        p.confidence, p.entity_confirmed, p.entity_created_at, p.entity_updated_at \
+                 FROM entity_page_map epm \
+                 JOIN pages p ON p.id = epm.page_id \
+                 WHERE p.kind = 'entity' AND p.status = 'active' AND LOWER(p.title) = LOWER(?1)",
                 libsql::params![name.to_string()],
             )
             .await
@@ -32197,7 +32755,12 @@ impl MemoryDB {
                 id: row.get::<String>(0).unwrap_or_default(),
                 name: row.get::<String>(1).unwrap_or_default(),
                 entity_type: row.get::<String>(2).unwrap_or_default(),
-                space: row.get::<Option<String>>(3).unwrap_or(None),
+                // G6 Stage 1.5b Part 2: `entities.space` is folded (never
+                // NULL; unfiled rows carry `UNFILED_SPACE_ID`), but the wire
+                // contract keeps `null` for "unfiled" -- normalize here.
+                space: crate::space_context::normalize_unfiled_space(
+                    row.get::<Option<String>>(3).unwrap_or(None),
+                ),
                 source_agent: row.get::<Option<String>>(4).unwrap_or(None),
                 confidence: row.get::<Option<f64>>(5).unwrap_or(None).map(|v| v as f32),
                 confirmed: row.get::<i64>(6).unwrap_or(0) != 0,
@@ -32256,7 +32819,12 @@ impl MemoryDB {
         }
     }
 
-    /// Add an observation to an entity.
+    /// Add an observation to an entity. Also re-syncs the entity's
+    /// `kind='entity'` shadow page (G6 review fix: `updated_at` is a
+    /// shadow-mirrored column and `list_entities(_scoped)` orders by it, so a
+    /// best-effort/unmirrored write here would permanently drift the exact
+    /// watermark Stage 2 uses as its proof surface) -- same
+    /// transaction-then-`update_entity_shadow_page` pattern as `store_entity`.
     pub async fn add_observation(
         &self,
         entity_id: &str,
@@ -32266,30 +32834,53 @@ impl MemoryDB {
     ) -> Result<String, WenlanError> {
         let id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now().timestamp();
+        let now_iso = chrono::Utc::now().to_rfc3339();
 
         let conn = self.conn.lock().await;
-        conn.execute(
-            "INSERT INTO observations (id, entity_id, content, source_agent, confidence, confirmed, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)",
-            libsql::params![
-                id.clone(),
-                entity_id.to_string(),
-                content.to_string(),
-                source_agent.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
-                confidence.map(|v| libsql::Value::Real(v as f64)).unwrap_or(libsql::Value::Null),
-                now
-            ],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("add_observation: {}", e)))?;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("add_observation begin: {}", e)))?;
 
-        // Update entity's updated_at
-        conn.execute(
-            "UPDATE entities SET updated_at = ?1 WHERE id = ?2",
-            libsql::params![now, entity_id.to_string()],
-        )
-        .await
-        .ok(); // Best effort
+        let result: Result<(), WenlanError> = async {
+            conn.execute(
+                "INSERT INTO observations (id, entity_id, content, source_agent, confidence, confirmed, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0, ?6)",
+                libsql::params![
+                    id.clone(),
+                    entity_id.to_string(),
+                    content.to_string(),
+                    source_agent.map(|s| libsql::Value::Text(s.to_string())).unwrap_or(libsql::Value::Null),
+                    confidence.map(|v| libsql::Value::Real(v as f64)).unwrap_or(libsql::Value::Null),
+                    now
+                ],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("add_observation: {}", e)))?;
+
+            conn.execute(
+                "UPDATE entities SET updated_at = ?1 WHERE id = ?2",
+                libsql::params![now, entity_id.to_string()],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("add_observation timestamp: {}", e)))?;
+
+            Self::update_entity_shadow_page(&conn, entity_id, &now_iso).await?;
+
+            Ok(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("add_observation commit: {}", e)))?;
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        }
 
         Ok(id)
     }
@@ -33244,6 +33835,13 @@ impl MemoryDB {
             .is_some())
     }
 
+    /// G6 Stage 1.5b Part 3: reads the `kind='entity'` shadow page via
+    /// `entity_page_map`, unconditional hard cutover (same program contract
+    /// as 1.5a). Every selected field is mirrored 1:1 onto `pages` by
+    /// `insert_entity_shadow_page`/`update_entity_shadow_page` (Part 1
+    /// extended the mirror to `source_agent`/`entity_created_at`/
+    /// `entity_updated_at`; Part 2's space fold made `space` safe to trust
+    /// off the mirror too), so this never touches `entities` directly.
     pub async fn list_entities(
         &self,
         entity_type: Option<&str>,
@@ -33252,25 +33850,34 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
 
         let mut sql = String::from(
-            "SELECT id, name, entity_type, space, source_agent, confidence, confirmed, created_at, updated_at
-             FROM entities WHERE 1=1"
+            "SELECT epm.entity_id, p.title, p.entity_type, p.space, p.source_agent, \
+                    p.confidence, p.entity_confirmed, p.entity_created_at, p.entity_updated_at \
+             FROM entity_page_map epm \
+             JOIN pages p ON p.id = epm.page_id \
+             WHERE p.kind = 'entity' AND p.status = 'active'",
         );
         let mut params: Vec<libsql::Value> = Vec::new();
 
         if let Some(et) = entity_type {
             params.push(et.into());
-            sql.push_str(&format!(" AND entity_type = ?{}", params.len()));
+            sql.push_str(&format!(" AND p.entity_type = ?{}", params.len()));
         }
         if let Some(d) = space {
             if d == "uncategorized" {
-                sql.push_str(" AND space IS NULL");
+                // G6 Stage 1.5b Part 2: `entities.space` is folded (never
+                // NULL; unfiled rows carry `UNFILED_SPACE_ID`), so
+                // "uncategorized" must match either.
+                sql.push_str(&format!(
+                    " AND (p.space IS NULL OR p.space = '{}')",
+                    UNFILED_SPACE_ID
+                ));
             } else {
                 params.push(d.into());
-                sql.push_str(&format!(" AND space = ?{}", params.len()));
+                sql.push_str(&format!(" AND p.space = ?{}", params.len()));
             }
         }
 
-        sql.push_str(" ORDER BY updated_at DESC");
+        sql.push_str(" ORDER BY p.entity_updated_at DESC");
 
         let mut rows = conn
             .query(&sql, libsql::params_from_iter(params))
@@ -33287,7 +33894,12 @@ impl MemoryDB {
                 id: row.get::<String>(0).unwrap_or_default(),
                 name: row.get::<String>(1).unwrap_or_default(),
                 entity_type: row.get::<String>(2).unwrap_or_default(),
-                space: row.get::<Option<String>>(3).unwrap_or(None),
+                // G6 Stage 1.5b Part 2: `entities.space` is folded (never
+                // NULL; unfiled rows carry `UNFILED_SPACE_ID`), but the wire
+                // contract keeps `null` for "unfiled" -- normalize here.
+                space: crate::space_context::normalize_unfiled_space(
+                    row.get::<Option<String>>(3).unwrap_or(None),
+                ),
                 source_agent: row.get::<Option<String>>(4).unwrap_or(None),
                 confidence: row.get::<Option<f64>>(5).unwrap_or(None).map(|v| v as f32),
                 confirmed: row.get::<i64>(6).unwrap_or(0) != 0,
@@ -33298,14 +33910,23 @@ impl MemoryDB {
         Ok(entities)
     }
 
+    /// G6 Stage 1.5b Part 3: the entity-half reads the `kind='entity'`
+    /// shadow page via `entity_page_map`, unconditional hard cutover (same
+    /// program contract as 1.5a and `list_entities` above). The
+    /// observations query and the relations query's own `entities` JOIN
+    /// (which hydrates the OTHER side of each relation) stay on their own
+    /// stores -- out of scope per spec.
     pub async fn get_entity_detail(&self, entity_id: &str) -> Result<EntityDetail, WenlanError> {
         let conn = self.conn.lock().await;
 
         // Fetch entity
         let mut rows = conn
             .query(
-                "SELECT id, name, entity_type, space, source_agent, confidence, confirmed, created_at, updated_at
-                 FROM entities WHERE id = ?1",
+                "SELECT epm.entity_id, p.title, p.entity_type, p.space, p.source_agent, \
+                        p.confidence, p.entity_confirmed, p.entity_created_at, p.entity_updated_at \
+                 FROM entity_page_map epm \
+                 JOIN pages p ON p.id = epm.page_id \
+                 WHERE epm.entity_id = ?1 AND p.kind = 'entity' AND p.status = 'active'",
                 libsql::params![entity_id],
             )
             .await
@@ -33320,7 +33941,12 @@ impl MemoryDB {
                 id: row.get::<String>(0).unwrap_or_default(),
                 name: row.get::<String>(1).unwrap_or_default(),
                 entity_type: row.get::<String>(2).unwrap_or_default(),
-                space: row.get::<Option<String>>(3).unwrap_or(None),
+                // G6 Stage 1.5b Part 2: `entities.space` is folded (never
+                // NULL; unfiled rows carry `UNFILED_SPACE_ID`), but the wire
+                // contract keeps `null` for "unfiled" -- normalize here.
+                space: crate::space_context::normalize_unfiled_space(
+                    row.get::<Option<String>>(3).unwrap_or(None),
+                ),
                 source_agent: row.get::<Option<String>>(4).unwrap_or(None),
                 confidence: row.get::<Option<f64>>(5).unwrap_or(None).map(|v| v as f32),
                 confirmed: row.get::<i64>(6).unwrap_or(0) != 0,
@@ -33890,9 +34516,10 @@ impl MemoryDB {
             // `get_memory_space`). This lane used to hardcode `space = NULL`,
             // which made every relation it wrote classify `legacy` (both
             // endpoints unresolved) instead of `assertion` like its canonical
-            // sibling. `memories.space` is NOT NULL since migration 91 and
-            // carries the reserved sentinel for an unfiled memory, so fold the
-            // sentinel back to NULL exactly as `get_memory_space` does.
+            // sibling. `memories.space` is NOT NULL since migration 91 and, as
+            // of G6 Stage 1.5b Part 2, `entities.space` is folded the same
+            // way -- carry the source memory's space straight through instead
+            // of folding the sentinel back to NULL.
             let entity_space: Option<String> = {
                 let mut rows = conn
                     .query(
@@ -33906,10 +34533,7 @@ impl MemoryDB {
                 let space = match rows.next().await.map_err(|e| {
                     WenlanError::VectorDb(format!("entity enrichment source space row: {e}"))
                 })? {
-                    Some(row) => row
-                        .get::<Option<String>>(0)
-                        .unwrap_or(None)
-                        .filter(|s| s != UNFILED_SPACE_ID),
+                    Some(row) => row.get::<Option<String>>(0).unwrap_or(None),
                     None => None,
                 };
                 drop(rows);
@@ -34034,10 +34658,13 @@ impl MemoryDB {
                                 entity_type.as_str(),
                                 now,
                                 embedding.as_str(),
+                                // G6 Stage 1.5b Part 2: entities.space is
+                                // folded (never NULL) -- fold at write time,
+                                // else NULLs recur post-migration.
                                 entity_space
                                     .as_deref()
                                     .map(|s| libsql::Value::Text(s.to_string()))
-                                    .unwrap_or(libsql::Value::Null)
+                                    .unwrap_or_else(|| libsql::Value::Text(UNFILED_SPACE_ID.to_string()))
                             ],
                         )
                         .await
@@ -34051,6 +34678,11 @@ impl MemoryDB {
                         // caught live by `reconcile_entity_page_parity`.
                         let page_id = crate::pages::new_page_id();
                         Self::insert_entity_shadow_page(&conn, &id, &page_id, &now_iso).await?;
+                        // G6 Stage 1.5b Part 1: same live-only re-sync as
+                        // `create_entity`/`store_entity` -- `insert_entity_shadow_page`
+                        // stays migration-92-safe and never touches the Part 1
+                        // mirror columns, so backfill them here.
+                        Self::update_entity_shadow_page(&conn, &id, &now_iso).await?;
                         created_entities.push((id.clone(), name.clone()));
                         id
                     }
@@ -34116,6 +34748,13 @@ impl MemoryDB {
                             "entity enrichment observation timestamp: {e}"
                         ))
                     })?;
+                    // `updated_at` is a shadow-mirrored column; the resolved-
+                    // existing-entity path's shadow sync above (this loop's
+                    // earlier `update_entity_shadow_page` call, per entity) ran
+                    // before this observation bumped `updated_at`, so it must
+                    // re-sync again here or the shadow strands at the pre-
+                    // observation timestamp (G6 review fix).
+                    Self::update_entity_shadow_page(&conn, entity_id, &now_iso).await?;
                 }
 
                 for relation in &kg.relations {
@@ -35460,22 +36099,32 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(e.to_string()))?
         {
-            // Endpoint-space predicate reused verbatim from
-            // `audit_legacy_cross_space_links`'s `relations` tally
-            // (NULL-safe: an indeterminate-space endpoint is `null_space`,
-            // not `cross_space`, so it is not excluded here either).
-            "SELECT e.src_id, e.dst_id FROM edges e \
-             LEFT JOIN entities se ON se.id = e.src_id \
-             LEFT JOIN entities de ON de.id = e.dst_id \
-             WHERE e.edge_type = 'relates' AND e.valid_until IS NULL \
-             AND NOT (e.lineage = 'legacy' \
-                      AND se.space IS NOT NULL AND de.space IS NOT NULL \
-                      AND se.space != de.space)"
+            // Endpoint-space predicate mirrors `audit_legacy_cross_space_links`'s
+            // `relations` tally: an indeterminate-space endpoint is
+            // `null_space`, not `cross_space`, so it is not excluded here
+            // either. G6 Stage 1.5b Part 2: `se.space`/`de.space` are
+            // `entities.space`, folded by the space-sentinel migration -- an
+            // unfiled endpoint now carries `UNFILED_SPACE_ID` rather than
+            // NULL when the entity row exists, so the sentinel is excluded
+            // from the "has a real space" check alongside NULL (missing
+            // entity row), keeping the admitted edge set identical pre/post
+            // fold.
+            format!(
+                "SELECT e.src_id, e.dst_id FROM edges e \
+                 LEFT JOIN entities se ON se.id = e.src_id \
+                 LEFT JOIN entities de ON de.id = e.dst_id \
+                 WHERE e.edge_type = 'relates' AND e.valid_until IS NULL \
+                 AND NOT (e.lineage = 'legacy' \
+                          AND se.space IS NOT NULL AND se.space != '{unfiled}' \
+                          AND de.space IS NOT NULL AND de.space != '{unfiled}' \
+                          AND se.space != de.space)",
+                unfiled = UNFILED_SPACE_ID
+            )
         } else {
-            "SELECT from_entity, to_entity FROM relations"
+            "SELECT from_entity, to_entity FROM relations".to_string()
         };
         let mut edge_rows = conn
-            .query(adjacency_sql, ())
+            .query(&adjacency_sql, ())
             .await
             .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
 
@@ -35561,6 +36210,9 @@ impl MemoryDB {
         conn.execute("BEGIN", ())
             .await
             .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+        // G6 Stage 1.5b Part 1: community_id is a shared-CRUD write to entities,
+        // so mirror it onto the shadow page in the same transaction.
+        let now_iso = chrono::Utc::now().to_rfc3339();
         let update_result: Result<(), WenlanError> = async {
             for (i, entity_id) in entity_ids.iter().enumerate() {
                 let community_id = label_to_community[&labels[i]];
@@ -35570,6 +36222,7 @@ impl MemoryDB {
                 )
                 .await
                 .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+                Self::update_entity_shadow_page(&conn, entity_id, &now_iso).await?;
             }
             Ok(())
         }
@@ -37168,6 +37821,12 @@ impl MemoryDB {
     ///
     /// `since_ms` filters by `created_at` (unix seconds). Rows where either
     /// entity name is missing are excluded so the UI always shows readable text.
+    /// G6 Stage 1.5b Part 3: joins the `kind='entity'` shadow page via
+    /// `entity_page_map` for each endpoint's display name, unconditional
+    /// hard cutover (same program contract as `list_entities`). Structural
+    /// rework, not a hydration overlay -- unlike `list_recent_relations_scoped`
+    /// pre-migration, this fn never had a GATED legacy base query to preserve,
+    /// only the one unconditional shape.
     pub async fn list_recent_relations(
         &self,
         limit: usize,
@@ -37175,17 +37834,19 @@ impl MemoryDB {
     ) -> Result<Vec<wenlan_types::RecentRelation>, WenlanError> {
         let conn = self.conn.lock().await;
         let sql = "SELECT r.edge_id, r.src_id, r.semantic_type, r.dst_id, \
-                   e1.name AS from_entity_name, e2.name AS to_entity_name, \
+                   p1.title AS from_entity_name, p2.title AS to_entity_name, \
                    COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) AS asserted_ts \
                    FROM edges r \
-                   JOIN entities e1 ON r.src_id = e1.id \
-                   JOIN entities e2 ON r.dst_id = e2.id \
+                   JOIN entity_page_map epm1 ON r.src_id = epm1.entity_id \
+                   JOIN pages p1 ON p1.id = epm1.page_id AND p1.kind = 'entity' AND p1.status = 'active' \
+                   JOIN entity_page_map epm2 ON r.dst_id = epm2.entity_id \
+                   JOIN pages p2 ON p2.id = epm2.page_id AND p2.kind = 'entity' AND p2.status = 'active' \
                    WHERE r.edge_type = 'relates' AND r.valid_until IS NULL \
                    AND r.semantic_type IS NOT NULL \
                    AND (?1 IS NULL OR COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) >= ?1) \
-                   AND e1.name IS NOT NULL AND e1.name != '' \
-                   AND e2.name IS NOT NULL AND e2.name != '' \
-                   ORDER BY asserted_ts DESC LIMIT ?2";
+                   AND p1.title IS NOT NULL AND p1.title != '' \
+                   AND p2.title IS NOT NULL AND p2.title != '' \
+                   ORDER BY asserted_ts DESC, r.edge_id DESC LIMIT ?2";
         let mut rows = conn
             .query(sql, libsql::params![since_ms, limit as i64])
             .await

--- a/crates/wenlan-core/src/db/kg_quality_embedding_refresh.rs
+++ b/crates/wenlan-core/src/db/kg_quality_embedding_refresh.rs
@@ -10,17 +10,24 @@ pub(crate) struct StaleEntityEmbeddingCandidate {
 }
 
 impl MemoryDB {
+    /// G6 Stage 1.5b Part 3: reads the entity's `kind='entity'` shadow page
+    /// via `entity_page_map`, unconditional hard cutover (same program
+    /// contract as `MemoryDB::list_entities`). `embedding_updated_at` is
+    /// mirrored 1:1 onto `pages` by
+    /// `insert_entity_shadow_page`/`update_entity_shadow_page`.
     pub(crate) async fn stale_entity_embedding_candidates_for_refresh(
         &self,
     ) -> Result<Vec<StaleEntityEmbeddingCandidate>, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT e.id, e.name
-                 FROM entities e
-                 LEFT JOIN observations o ON o.entity_id = e.id
-                    AND o.created_at > COALESCE(e.embedding_updated_at, 0)
-                 GROUP BY e.id, e.name
+                "SELECT epm.entity_id, p.title
+                 FROM entity_page_map epm
+                 JOIN pages p ON p.id = epm.page_id
+                    AND p.kind = 'entity' AND p.status = 'active'
+                 LEFT JOIN observations o ON o.entity_id = epm.entity_id
+                    AND o.created_at > COALESCE(p.embedding_updated_at, 0)
+                 GROUP BY epm.entity_id, p.title
                  HAVING COUNT(o.id) >= 5",
                 (),
             )

--- a/crates/wenlan-core/src/db/kg_quality_embedding_refresh_test.rs
+++ b/crates/wenlan-core/src/db/kg_quality_embedding_refresh_test.rs
@@ -3,15 +3,20 @@
 use super::MemoryDB;
 
 async fn insert_entity(db: &MemoryDB, id: &str, name: &str, embedding_updated_at: Option<i64>) {
-    let conn = db.conn.lock().await;
-    conn.execute(
-        "INSERT INTO entities (
-             id, name, entity_type, created_at, updated_at, embedding_updated_at
-         ) VALUES (?1, ?2, 'test', 1, 1, ?3)",
-        libsql::params![id, name, embedding_updated_at],
-    )
-    .await
-    .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO entities (
+                 id, name, entity_type, created_at, updated_at, embedding_updated_at
+             ) VALUES (?1, ?2, 'test', 1, 1, ?3)",
+            libsql::params![id, name, embedding_updated_at],
+        )
+        .await
+        .unwrap();
+    }
+    // G6 Stage 1.5b Part 3: `stale_entity_embedding_candidates_for_refresh`
+    // now reads the shadow page, so the raw `entities` insert above needs one.
+    db.test_seed_entity_shadow_page(id).await.unwrap();
 }
 
 async fn insert_observations(db: &MemoryDB, entity_id: &str, observations: &[(i64, &str)]) {

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -2283,6 +2283,14 @@ async fn empty_grounded_space_holds_and_keeps_all_community_consumers_on_legacy(
             .unwrap();
         }
     }
+    // G6 Stage 1.5b Part 3: the legacy branches of `load_summary_buckets` and
+    // `summary_eligible_predicate` now read `community_id` off the entity's
+    // shadow page, so the raw-SQL `entities` inserts above need one each.
+    for suffix in ["a", "b", "c"] {
+        db.test_seed_entity_shadow_page(&format!("m96-held-entity-{suffix}"))
+            .await
+            .unwrap();
+    }
 
     let outcome = db
         .run_next_community_grouping_cycle()
@@ -2524,6 +2532,15 @@ async fn community_reader_reconciliation_flips_equivalent_consumers_and_is_rever
         )
         .await
         .unwrap();
+    }
+    // G6 Stage 1.5b Part 3: `load_summary_buckets`/`summary_eligible_predicate`'s
+    // legacy branches now read `community_id` off the entity's shadow page,
+    // so the raw-SQL `entities` inserts above need one each (exercised below
+    // once the BUCKETS consumer is flipped back off durable).
+    for suffix in ["a", "b", "c"] {
+        db.test_seed_entity_shadow_page(&format!("m96-parity-entity-{suffix}"))
+            .await
+            .unwrap();
     }
 
     for consumer in [
@@ -2803,6 +2820,14 @@ async fn community_reader_parity_is_a_true_global_differential() {
             .await
             .unwrap();
         }
+    }
+    // G6 Stage 1.5b Part 3: `load_summary_buckets`'s legacy branch now reads
+    // `community_id` off the entity's shadow page, so the raw-SQL `entities`
+    // inserts above need one each.
+    for suffix in ["a", "b", "c"] {
+        db.test_seed_entity_shadow_page(&format!("m96-global-entity-{suffix}"))
+            .await
+            .unwrap();
     }
 
     let legacy_buckets = db.load_summary_buckets().await.unwrap();
@@ -11569,7 +11594,9 @@ async fn test_store_entity_null_domain() {
         .await
         .unwrap();
 
-    // Verify space is NULL, not empty string
+    // G6 Stage 1.5b Part 2: space is folded (never NULL) at write time --
+    // an unfiled entity carries UNFILED_SPACE_ID, not NULL. source_agent has
+    // no such fold and stays NULL when absent, as this section's name says.
     let conn = db.conn.lock().await;
     let mut rows = conn
         .query(
@@ -11581,8 +11608,8 @@ async fn test_store_entity_null_domain() {
     let row = rows.next().await.unwrap().unwrap();
     let space_val = row.get_value(0).unwrap();
     assert!(
-        matches!(space_val, libsql::Value::Null),
-        "space should be NULL, got {:?}",
+        matches!(space_val, libsql::Value::Text(ref s) if s == UNFILED_SPACE_ID),
+        "space should be the unfiled sentinel, got {:?}",
         space_val
     );
     let agent_val = row.get_value(1).unwrap();
@@ -16131,6 +16158,16 @@ async fn load_summary_buckets_excludes_pending_and_hide_superseded_memories() {
         )
         .await
         .unwrap();
+        // G6 Stage 1.5b Part 3: `load_summary_buckets`'s legacy branch now
+        // reads `community_id` off the entity's shadow page, so the raw
+        // `entities` update above must land on the mirror too.
+        conn.execute(
+            "UPDATE pages SET community_id = 7 \
+             WHERE id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
+            libsql::params![entity_id.clone()],
+        )
+        .await
+        .unwrap();
     }
 
     let mut active = make_memory_doc(
@@ -16824,11 +16861,11 @@ async fn delete_space_unassign_folds_memories_to_sentinel_not_null() {
 }
 
 #[tokio::test]
-async fn delete_space_unassign_folds_entity_shadow_space_to_sentinel() {
-    // rework2 ITEM 2 (M3 PR-1): unassign clears entities.space to NULL
-    // (entities never fold), but the mapped kind='entity' shadow's NOT NULL
-    // space/workspace must fold to the sentinel -- not keep the deleted
-    // space name -- matching insert_entity_shadow_page's fold rule.
+async fn delete_space_unassign_folds_entity_and_shadow_space_to_sentinel() {
+    // rework2 ITEM 2 (M3 PR-1) originally left entities.space NULL on
+    // unassign while only the kind='entity' shadow's NOT NULL space/workspace
+    // folded to the sentinel. As of G6 Stage 1.5b Part 2, entities.space
+    // folds the same way -- both must carry the sentinel, never NULL.
     let (db, _dir) = test_db().await;
     db.create_space("old", None, false).await.unwrap();
     let id = db
@@ -16845,10 +16882,10 @@ async fn delete_space_unassign_folds_entity_shadow_space_to_sentinel() {
     db.delete_space("old", "unassign").await.unwrap();
 
     let conn = db.conn.lock().await;
-    let entity_space_null: i64 = {
+    let entity_space: String = {
         let mut rows = conn
             .query(
-                "SELECT space IS NULL FROM entities WHERE id = ?1",
+                "SELECT space FROM entities WHERE id = ?1",
                 libsql::params![id.clone()],
             )
             .await
@@ -16856,8 +16893,8 @@ async fn delete_space_unassign_folds_entity_shadow_space_to_sentinel() {
         rows.next().await.unwrap().unwrap().get(0).unwrap()
     };
     assert_eq!(
-        entity_space_null, 1,
-        "entities.space must be NULL after unassign (entities never fold)"
+        entity_space, UNFILED_SPACE_ID,
+        "entities.space must fold to the sentinel after unassign, never NULL"
     );
 
     let (space, workspace): (String, String) = {
@@ -16885,6 +16922,53 @@ async fn delete_space_unassign_folds_entity_shadow_space_to_sentinel() {
         workspace, UNFILED_SPACE_ID,
         "shadow workspace must fold to the sentinel"
     );
+}
+
+/// G6 Stage 1.5b Part 2 writer-side fold invariant: `store_entity` and
+/// `create_entity` must fold `space: None` to `UNFILED_SPACE_ID` at write
+/// time, not pass NULL through -- else NULLs recur even after the fold
+/// migration backfills existing rows.
+#[tokio::test]
+async fn store_entity_folds_none_space_to_sentinel_never_null() {
+    let (db, _dir) = test_db().await;
+    let store_id = db
+        .store_entity("Ada Lovelace", "person", None, Some("test"), None)
+        .await
+        .unwrap();
+    let create_id = db
+        .create_entity("Grace Hopper", "person", None)
+        .await
+        .unwrap();
+
+    let conn = db.conn.lock().await;
+    let null_count: i64 = {
+        let mut rows = conn
+            .query("SELECT COUNT(*) FROM entities WHERE space IS NULL", ())
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    assert_eq!(
+        null_count, 0,
+        "no entities.space row may be NULL after a None-space write"
+    );
+
+    for id in [store_id, create_id] {
+        let space: String = {
+            let mut rows = conn
+                .query(
+                    "SELECT space FROM entities WHERE id = ?1",
+                    libsql::params![id],
+                )
+                .await
+                .unwrap();
+            rows.next().await.unwrap().unwrap().get(0).unwrap()
+        };
+        assert_eq!(
+            space, UNFILED_SPACE_ID,
+            "an unfiled entity must carry the sentinel, never NULL"
+        );
+    }
 }
 
 #[tokio::test]
@@ -30395,6 +30479,392 @@ async fn migration_116_keeps_relates_edge_parity_clean() {
     );
 }
 
+/// G6 Stage 1.5b Part 1: migration 117 backfills the entity-page scalar
+/// mirror (`source_agent`/`entity_created_at`/`entity_updated_at`/
+/// `community_id`/`embedding_updated_at`) from `entities` via
+/// `entity_page_map`, row-for-row.
+#[tokio::test]
+async fn migration_117_backfills_entity_page_scalar_mirror() {
+    let (db, _dir) = test_db().await;
+    let id = db
+        .store_entity(
+            "G6 Scalar Mirror",
+            "person",
+            Some("space_a"),
+            Some("test-agent"),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let forced_created_at = 1_000_000_001i64;
+    let forced_updated_at = 1_000_000_002i64;
+    let forced_community_id = 7i64;
+    let forced_embedding_updated_at = 1_000_000_003i64;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE entities SET created_at = ?1, updated_at = ?2, community_id = ?3,
+                embedding_updated_at = ?4
+             WHERE id = ?5",
+            libsql::params![
+                forced_created_at,
+                forced_updated_at,
+                forced_community_id,
+                forced_embedding_updated_at,
+                id.as_str()
+            ],
+        )
+        .await
+        .unwrap();
+        // Simulate a shadow page that predates migration 117: null out the
+        // new mirror columns even though the entity row already carries them.
+        conn.execute(
+            "UPDATE pages SET source_agent = NULL, entity_created_at = NULL,
+                entity_updated_at = NULL, community_id = NULL, embedding_updated_at = NULL
+             WHERE kind = 'entity'
+               AND id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
+            libsql::params![id.as_str()],
+        )
+        .await
+        .unwrap();
+    }
+
+    for pass in 1..=2 {
+        db.migrate_117_entity_page_scalar_mirror(116).await.unwrap();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT p.source_agent, p.entity_created_at, p.entity_updated_at,
+                        p.community_id, p.embedding_updated_at
+                 FROM pages p
+                 JOIN entity_page_map m ON m.page_id = p.id
+                 WHERE m.entity_id = ?1",
+                libsql::params![id.as_str()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().expect("shadow page row");
+        assert_eq!(
+            row.get::<Option<String>>(0).unwrap().as_deref(),
+            Some("test-agent"),
+            "pass {pass}: source_agent must mirror entities.source_agent"
+        );
+        assert_eq!(
+            row.get::<Option<i64>>(1).unwrap(),
+            Some(forced_created_at),
+            "pass {pass}: entity_created_at must mirror entities.created_at"
+        );
+        assert_eq!(
+            row.get::<Option<i64>>(2).unwrap(),
+            Some(forced_updated_at),
+            "pass {pass}: entity_updated_at must mirror entities.updated_at"
+        );
+        assert_eq!(
+            row.get::<Option<String>>(3).unwrap().as_deref(),
+            Some(forced_community_id.to_string()).as_deref(),
+            "pass {pass}: community_id must mirror entities.community_id (as text)"
+        );
+        assert_eq!(
+            row.get::<Option<i64>>(4).unwrap(),
+            Some(forced_embedding_updated_at),
+            "pass {pass}: embedding_updated_at must mirror entities.embedding_updated_at"
+        );
+    }
+}
+
+/// G6 Stage 1.5b Part 1: every shared-CRUD writer that touches one of the
+/// 5 new mirrored scalars re-syncs the shadow page via the existing
+/// `update_entity_shadow_page` call already on its path -- this pins that
+/// the mirror actually lands for `store_entity`, `confirm_entity`,
+/// `refresh_entity_embedding`, and `merge_entities`, not just that the
+/// function compiles.
+#[tokio::test]
+async fn entity_writers_thread_through_scalar_mirror_to_shadow_page() {
+    async fn shadow_scalars(
+        db: &MemoryDB,
+        entity_id: &str,
+    ) -> (Option<String>, Option<i64>, Option<i64>, Vec<u8>) {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT p.source_agent, p.entity_updated_at, p.embedding_updated_at, p.embedding
+                 FROM pages p
+                 JOIN entity_page_map m ON m.page_id = p.id
+                 WHERE m.entity_id = ?1",
+                libsql::params![entity_id],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().expect("shadow page row");
+        (
+            row.get(0).unwrap(),
+            row.get(1).unwrap(),
+            row.get(2).unwrap(),
+            row.get::<Option<Vec<u8>>>(3).unwrap().unwrap_or_default(),
+        )
+    }
+
+    let (db, _dir) = test_db().await;
+
+    // store_entity: source_agent lands on the shadow at write time.
+    let id = db
+        .store_entity(
+            "G6 Thread Through",
+            "person",
+            Some("space_a"),
+            Some("agent-x"),
+            None,
+        )
+        .await
+        .unwrap();
+    let (source_agent, _, _, _) = shadow_scalars(&db, &id).await;
+    assert_eq!(
+        source_agent.as_deref(),
+        Some("agent-x"),
+        "store_entity must thread source_agent onto the shadow page"
+    );
+
+    // confirm_entity: re-syncs the mirror without corrupting it.
+    db.confirm_entity(&id, true).await.unwrap();
+    let entity_updated_at: Option<i64> = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT updated_at FROM entities WHERE id = ?1",
+                libsql::params![id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    let (_, page_entity_updated_at, _, _) = shadow_scalars(&db, &id).await;
+    assert_eq!(
+        page_entity_updated_at, entity_updated_at,
+        "confirm_entity must re-sync entity_updated_at onto the shadow page"
+    );
+
+    // refresh_entity_embedding: embedding_updated_at + embedding both land.
+    db.refresh_entity_embedding(&id, "G6 Thread Through refreshed")
+        .await
+        .unwrap();
+    let embedding_updated_at: Option<i64> = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT embedding_updated_at FROM entities WHERE id = ?1",
+                libsql::params![id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    let (_, _, page_embedding_updated_at, page_embedding) = shadow_scalars(&db, &id).await;
+    assert_eq!(
+        page_embedding_updated_at, embedding_updated_at,
+        "refresh_entity_embedding must re-sync embedding_updated_at onto the shadow page"
+    );
+    assert!(
+        !page_embedding.is_empty(),
+        "refresh_entity_embedding must re-sync the embedding bytes onto the shadow page"
+    );
+
+    // merge_entities: the canonical's shadow still mirrors the canonical
+    // entity row (source_agent survives the merge transaction).
+    let alias_id = db
+        .store_entity(
+            "G6 Thread Through Alias",
+            "person",
+            Some("space_a"),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    db.merge_entities(&id, &alias_id).await.unwrap();
+    let (source_agent_after_merge, _, _, _) = shadow_scalars(&db, &id).await;
+    assert_eq!(
+        source_agent_after_merge.as_deref(),
+        Some("agent-x"),
+        "merge_entities must leave the canonical's mirrored source_agent intact"
+    );
+
+    // add_observation: re-syncs entity_updated_at onto the shadow page (G6
+    // review fix -- the write used to be a bare best-effort `.ok()` UPDATE on
+    // `entities` with no shadow sync at all).
+    db.add_observation(&id, "G6 Thread Through observation", None, None)
+        .await
+        .unwrap();
+    let entity_updated_at_after_observation: Option<i64> = {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT updated_at FROM entities WHERE id = ?1",
+                libsql::params![id.as_str()],
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    let (_, page_entity_updated_at_after_observation, _, _) = shadow_scalars(&db, &id).await;
+    assert_eq!(
+        page_entity_updated_at_after_observation, entity_updated_at_after_observation,
+        "add_observation must re-sync entity_updated_at onto the shadow page"
+    );
+}
+
+// -- G6 Stage 1.5b Part 2: migration 118 entity space fold --
+
+/// Mirrors `relax_memories_space_to_nullable` for `entities`.
+async fn relax_entities_space_to_nullable(conn: &libsql::Connection) {
+    let sql: String = {
+        let mut rows = conn
+            .query(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='entities'",
+                (),
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get(0).unwrap()
+    };
+    let patched = sql.replacen(
+        &format!("space TEXT NOT NULL DEFAULT '{UNFILED_SPACE_ID}',"),
+        "space TEXT,",
+        1,
+    );
+    assert_ne!(
+        patched, sql,
+        "expected entities.space to already be NOT NULL before relaxing"
+    );
+    conn.execute("PRAGMA writable_schema=ON", ()).await.unwrap();
+    conn.execute(
+        "UPDATE sqlite_master SET sql=?1 WHERE type='table' AND name='entities'",
+        libsql::params![patched],
+    )
+    .await
+    .unwrap();
+    conn.execute("PRAGMA writable_schema=RESET", ())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn migration_118_backfills_null_space_to_unfiled() {
+    let (db, _dir) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        relax_entities_space_to_nullable(&conn).await;
+        insert_raw_entity_for_m92_test(
+            &conn,
+            "ent_null_space",
+            "G6 Null Space",
+            "person",
+            None,
+            None,
+            0,
+        )
+        .await;
+        conn.execute("PRAGMA user_version = 117", ()).await.unwrap();
+    }
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .unwrap();
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query("SELECT space FROM entities WHERE id = 'ent_null_space'", ())
+        .await
+        .unwrap();
+    let space: String = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(space, UNFILED_SPACE_ID);
+}
+
+#[tokio::test]
+async fn migration_118_not_null_constraint_rejects_null_space_insert() {
+    let (db, _dir) = test_db().await;
+    let conn = db.conn.lock().await;
+    let result = conn
+        .execute(
+            "INSERT INTO entities (id, name, entity_type, space, confidence, confirmed, created_at, updated_at) \
+             VALUES ('ent_reject', 'G6 Reject', 'person', NULL, NULL, 0, unixepoch(), unixepoch())",
+            (),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "inserting a NULL space must be rejected once migration 118 has run"
+    );
+}
+
+#[tokio::test]
+async fn migration_118_raw_insert_omitting_space_lands_unfiled() {
+    // Proves the DEFAULT half of the fix, mirroring
+    // `migration_91_raw_insert_omitting_space_lands_unfiled`: a raw INSERT
+    // that omits `space` entirely must land the sentinel rather than
+    // tripping the NOT NULL constraint -- the companion
+    // `migration_118_not_null_constraint_rejects_null_space_insert` proves
+    // an EXPLICIT NULL bind is still rejected, since a column DEFAULT only
+    // fires when the column is omitted.
+    let (db, _dir) = test_db().await;
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO entities (id, name, entity_type, confidence, confirmed, created_at, updated_at) \
+         VALUES ('ent_omitted', 'G6 Omitted', 'person', NULL, 0, unixepoch(), unixepoch())",
+        (),
+    )
+    .await
+    .expect("omitting space must fall back to the column DEFAULT, not error");
+
+    let mut rows = conn
+        .query("SELECT space FROM entities WHERE id = 'ent_omitted'", ())
+        .await
+        .unwrap();
+    let space: String = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(space, UNFILED_SPACE_ID);
+}
+
+#[tokio::test]
+async fn migration_118_rebuilds_index_without_partial_predicate() {
+    let (db, _dir) = test_db().await;
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_entities_space'",
+            (),
+        )
+        .await
+        .unwrap();
+    let sql: String = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert!(
+        !sql.contains("WHERE"),
+        "idx_entities_space must drop its now-vacuous partial predicate: {sql}"
+    );
+}
+
+#[tokio::test]
+async fn migration_118_assertion_detects_unresolved_space() {
+    let (db, _dir) = test_db().await;
+    let conn = db.conn.lock().await;
+    relax_entities_space_to_nullable(&conn).await;
+    insert_raw_entity_for_m92_test(
+        &conn,
+        "ent_unresolved",
+        "G6 Unresolved",
+        "person",
+        None,
+        None,
+        0,
+    )
+    .await;
+
+    let result = MemoryDB::assert_entities_space_backfilled(&conn).await;
+    let err = result.expect_err("assertion must detect the NULL survivor");
+    assert!(
+        err.to_string().contains("m118"),
+        "error should identify migration 118: {err}"
+    );
+}
+
 /// G6 Stage 1.2 divergence test (Sol review S3): no other test can tell
 /// whether a migrated reader actually reads `edges` versus `relations`, since
 /// every OTHER fixture keeps both stores in parity via the dual-write. Here
@@ -41683,7 +42153,7 @@ async fn migration_92_backfills_preexisting_entities_into_shadow_pages() {
             "e_pre2",
             "Pre-existing Bob",
             "person",
-            None,
+            Some(UNFILED_SPACE_ID),
             None,
             0,
         )
@@ -41750,9 +42220,26 @@ async fn migration_92_backfill_report_records_created_count() {
     let (db, _dir) = test_db().await;
     {
         let conn = db.conn.lock().await;
-        insert_raw_entity_for_m92_test(&conn, "e_r1", "Report Alice", "person", None, None, 0)
-            .await;
-        insert_raw_entity_for_m92_test(&conn, "e_r2", "Report Bob", "person", None, None, 0).await;
+        insert_raw_entity_for_m92_test(
+            &conn,
+            "e_r1",
+            "Report Alice",
+            "person",
+            Some(UNFILED_SPACE_ID),
+            None,
+            0,
+        )
+        .await;
+        insert_raw_entity_for_m92_test(
+            &conn,
+            "e_r2",
+            "Report Bob",
+            "person",
+            Some(UNFILED_SPACE_ID),
+            None,
+            0,
+        )
+        .await;
     }
     rerun_migration_92(&db).await;
 
@@ -41773,7 +42260,16 @@ async fn migration_92_backfill_report_records_created_count() {
 async fn migration_92_assertion_detects_entity_missing_shadow_page() {
     let (db, _dir) = test_db().await;
     let conn = db.conn.lock().await;
-    insert_raw_entity_for_m92_test(&conn, "e_orphan", "Orphan Dave", "person", None, None, 0).await;
+    insert_raw_entity_for_m92_test(
+        &conn,
+        "e_orphan",
+        "Orphan Dave",
+        "person",
+        Some(UNFILED_SPACE_ID),
+        None,
+        0,
+    )
+    .await;
 
     let result = MemoryDB::assert_entities_have_shadow_pages(&conn).await;
     let err = result.expect_err("assertion must detect the entity with no shadow page");
@@ -41797,9 +42293,26 @@ async fn migration_92_resume_reads_stored_cursor_and_skips_below_range() {
     let (db, _dir) = test_db().await;
     let (r_below, r_tail) = {
         let conn = db.conn.lock().await;
-        insert_raw_entity_for_m92_test(&conn, "e_below", "Below Cursor", "person", None, None, 0)
-            .await;
-        insert_raw_entity_for_m92_test(&conn, "e_tail", "Tail", "person", None, None, 0).await;
+        insert_raw_entity_for_m92_test(
+            &conn,
+            "e_below",
+            "Below Cursor",
+            "person",
+            Some(UNFILED_SPACE_ID),
+            None,
+            0,
+        )
+        .await;
+        insert_raw_entity_for_m92_test(
+            &conn,
+            "e_tail",
+            "Tail",
+            "person",
+            Some(UNFILED_SPACE_ID),
+            None,
+            0,
+        )
+        .await;
         // Both entities must be unmapped so the backfill has real work and
         // the completeness assertion has teeth: clear any shadow pages the
         // initial test_db migration minted, plus the map.
@@ -44953,6 +45466,179 @@ async fn detect_communities_flipped_excludes_cross_space_legacy_edge() {
     );
 }
 
+/// G6 Stage 1.5b Part 2 pin test: the community adjacency builder's
+/// cross-space exclusion (D6) treats an indeterminate-space endpoint
+/// identically whether `entities.space` is literal SQL NULL (pre-fold) or
+/// the `UNFILED_SPACE_ID` sentinel (post-fold) -- the space-sentinel fold
+/// changes the spelling of "unfiled," never the semantics, so the admitted
+/// edge set must be IDENTICAL before and after. No fold migration exists
+/// yet at this stage of the PR, so the fold is simulated in place: the same
+/// fixture is run once with the endpoint's space left NULL, then again
+/// after flipping that one row's stored space to the sentinel (exactly
+/// what the fold migration will do), and both runs must agree.
+#[tokio::test]
+async fn detect_communities_flipped_admits_sentinel_endpoint_like_null() {
+    let (db, _dir) = test_db().await;
+    let a = db
+        .create_entity("A", "person", Some("space_a"))
+        .await
+        .unwrap();
+    let b = db.create_entity("B", "person", None).await.unwrap();
+
+    // `lineage='legacy'` edge (the fence exempts it at write time) --
+    // mirrors what a real cross-space backfill/dual-write produces.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO relations (id, from_entity, to_entity, relation_type, created_at) \
+             VALUES ('rel_indeterminate', ?1, ?2, 'knows', 0)",
+            libsql::params![a.clone(), b.clone()],
+        )
+        .await
+        .unwrap();
+        MemoryDB::insert_backfilled_edge(
+            &conn, "relates", "entity", &a, "entity", &b, "knows", "legacy", "space_a", "test",
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn community_map(db: &MemoryDB) -> std::collections::BTreeMap<String, i64> {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query("SELECT id, community_id FROM entities ORDER BY id", ())
+            .await
+            .unwrap();
+        let mut m = std::collections::BTreeMap::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            m.insert(
+                row.get::<String>(0).unwrap(),
+                row.get::<i64>(1).unwrap_or(-1),
+            );
+        }
+        m
+    }
+
+    // Flip: prove parity, enable the edges-backed consumer.
+    assert_eq!(db.reconcile_edges_parity().await.unwrap().drift_count, 0);
+    db.set_reader_cutover("communities", true).await.unwrap();
+    {
+        let conn = db.conn.lock().await;
+        assert!(MemoryDB::reader_uses_edges(&conn, "communities")
+            .await
+            .unwrap());
+    }
+
+    // Pre-fold: B's space is literal NULL. Indeterminate -> admitted -> A
+    // and B merge into one community.
+    db.detect_communities().await.unwrap();
+    let null_map = community_map(&db).await;
+    assert_eq!(
+        null_map[&a], null_map[&b],
+        "a NULL-space endpoint is indeterminate, not cross-space -- must merge"
+    );
+
+    // Simulate the fold in place: B's space becomes the sentinel, same as
+    // the fold migration will write.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE entities SET space = ?1 WHERE id = ?2",
+            libsql::params![UNFILED_SPACE_ID, b.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    // Post-fold: B's space is the sentinel. Must still be indeterminate,
+    // not cross-space -- admission must be IDENTICAL to the NULL case.
+    db.detect_communities().await.unwrap();
+    let sentinel_map = community_map(&db).await;
+    assert_eq!(
+        sentinel_map[&a], sentinel_map[&b],
+        "a sentinel-space endpoint is indeterminate, not cross-space -- must merge, same as NULL"
+    );
+}
+
+/// G6 Stage 1.5b Part 1: `detect_communities`'s legacy label-propagation
+/// write is a shared-CRUD write to `entities.community_id` -- it must
+/// thread through to the shadow page like every other writer on this list,
+/// or `reconcile_entity_page_parity` would flag every community-assigned
+/// entity as drift after the next detection run.
+#[tokio::test]
+async fn detect_communities_threads_community_id_through_to_shadow_page() {
+    let (db, _dir) = test_db().await;
+    let a = db
+        .create_entity("G6 Community Thread A", "person", Some("space_a"))
+        .await
+        .unwrap();
+    let b = db
+        .create_entity("G6 Community Thread B", "person", Some("space_a"))
+        .await
+        .unwrap();
+    db.create_relation(&a, &b, "knows", None, None, None, None)
+        .await
+        .unwrap();
+
+    db.detect_communities().await.unwrap();
+
+    let conn = db.conn.lock().await;
+    for id in [&a, &b] {
+        let mut rows = conn
+            .query(
+                "SELECT e.community_id, p.community_id
+                 FROM entities e
+                 JOIN entity_page_map m ON m.entity_id = e.id
+                 JOIN pages p ON p.id = m.page_id
+                 WHERE e.id = ?1",
+                libsql::params![id.as_str()],
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().expect("shadow page row");
+        let entity_community_id: i64 = row.get(0).unwrap();
+        let page_community_id: Option<String> = row.get(1).unwrap();
+        assert_eq!(
+            page_community_id.as_deref(),
+            Some(entity_community_id.to_string()).as_deref(),
+            "the shadow page's community_id must mirror entities.community_id after detect_communities"
+        );
+    }
+}
+
+/// G6 Stage 1.5b Part 2 pin test: `get_entity_detail` is the read path
+/// `handle_create_entity` (and every other entity route) relies on to
+/// produce the wire response -- it must fold `UNFILED_SPACE_ID` back to
+/// `null` for an entity whose `entities.space` carries the sentinel, same
+/// as it already does for a literal NULL. No fold migration exists yet at
+/// this stage of the PR, so the fold is simulated in place via a direct
+/// SQL UPDATE (exactly what the fold migration will write).
+#[tokio::test]
+async fn get_entity_detail_normalizes_sentinel_space_to_none() {
+    let (db, _dir) = test_db().await;
+    let id = db.create_entity("Sentinel Co", "org", None).await.unwrap();
+    assert_eq!(
+        db.get_entity_detail(&id).await.unwrap().entity.space,
+        None,
+        "a NULL-space entity must read back as None (baseline, pre-fold)"
+    );
+
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE entities SET space = ?1 WHERE id = ?2",
+            libsql::params![UNFILED_SPACE_ID, id.clone()],
+        )
+        .await
+        .unwrap();
+    }
+    assert_eq!(
+        db.get_entity_detail(&id).await.unwrap().entity.space,
+        None,
+        "a sentinel-space entity must ALSO read back as None -- the wire contract stays null"
+    );
+}
+
 /// §6.9 restore drill: an online backup is a sound, INDEPENDENT restore
 /// point. Seed (including an EMBEDDED row so the DiskANN vector index carries
 /// real content -- the shadow tables a naive `VACUUM INTO` would reorder),
@@ -45838,70 +46524,42 @@ async fn bench_reconcile_entity_page_parity_at_scale() {
         assert!(proven_epoch.is_some(), "watermark must be stamped");
     }
 
-    // ---- flipped-read benchmark at scale: cutover OFF (legacy) vs ON
-    // (hybrid), on the SAME seeded DB, under the clean watermark just
-    // proven above ----
+    // ---- read benchmark at scale: list_entities_scoped/get_entity_
+    // detail_scoped timing under the clean watermark just proven above.
+    // G6 review fix: this used to flip `set_entity_reader_cutover` OFF
+    // then ON and assert both arms byte-identical -- vacuous once Part 3
+    // collapsed the gate (no scoped reader consults it anymore, so OFF
+    // and ON run the identical unconditional-canonical code path and the
+    // comparison could never fail). Single un-gated pass keeps the
+    // timing data for the PR body.
     let scope = ReadScope::Space(SPACE.to_string());
     let detail_ids = sample_ids(&entity_ids, DETAIL_SAMPLE);
 
-    db.set_entity_reader_cutover(MemoryDB::SCOPED_ENTITIES_CONSUMER, false)
-        .await
-        .unwrap();
-    let t_list_off = Instant::now();
-    let list_off = db.list_entities_scoped(None, &scope).await.unwrap();
-    let list_off_secs = t_list_off.elapsed().as_secs_f64();
-    let t_detail_off = Instant::now();
-    let mut detail_off = Vec::with_capacity(detail_ids.len());
+    let t_list = Instant::now();
+    let list = db.list_entities_scoped(None, &scope).await.unwrap();
+    let list_secs = t_list.elapsed().as_secs_f64();
+    let t_detail = Instant::now();
+    let mut detail = Vec::with_capacity(detail_ids.len());
     for id in &detail_ids {
-        detail_off.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
+        detail.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
     }
-    let detail_off_secs = t_detail_off.elapsed().as_secs_f64();
-    eprintln!(
-        "[bench §6.5 entity] OFF leg done: list={list_off_secs:.3}s detail={detail_off_secs:.3}s"
-    );
-
-    db.set_entity_reader_cutover(MemoryDB::SCOPED_ENTITIES_CONSUMER, true)
-        .await
-        .unwrap();
-    {
-        let conn = db.conn.lock().await;
-        assert!(
-            MemoryDB::reader_uses_entity_pages(&conn, MemoryDB::SCOPED_ENTITIES_CONSUMER)
-                .await
-                .unwrap(),
-            "sanity: a clean, current watermark must open the gate at scale"
-        );
-    }
-    let t_list_on = Instant::now();
-    let list_on = db.list_entities_scoped(None, &scope).await.unwrap();
-    let list_on_secs = t_list_on.elapsed().as_secs_f64();
-    let t_detail_on = Instant::now();
-    let mut detail_on = Vec::with_capacity(detail_ids.len());
-    for id in &detail_ids {
-        detail_on.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
-    }
-    let detail_on_secs = t_detail_on.elapsed().as_secs_f64();
+    let detail_secs = t_detail.elapsed().as_secs_f64();
 
     assert_eq!(
-        list_off.len(),
+        list.len(),
         ENTITIES,
         "sanity: full listing covers every seeded entity"
     );
     assert_eq!(
-        format!("{list_off:?}"),
-        format!("{list_on:?}"),
-        "flipped list_entities_scoped must be byte-identical to legacy at scale"
-    );
-    assert_eq!(
-        format!("{detail_off:?}"),
-        format!("{detail_on:?}"),
-        "flipped get_entity_detail_scoped must be byte-identical to legacy at scale"
+        detail.len(),
+        DETAIL_SAMPLE,
+        "sanity: every sampled detail id resolved"
     );
     eprintln!(
-        "[bench §6.5 entity] list_entities_scoped (full listing, n={ENTITIES}): off={list_off_secs:.3}s on={list_on_secs:.3}s"
+        "[bench §6.5 entity] list_entities_scoped (full listing, n={ENTITIES}): {list_secs:.3}s"
     );
     eprintln!(
-        "[bench §6.5 entity] get_entity_detail_scoped (n={DETAIL_SAMPLE}): off={detail_off_secs:.3}s on={detail_on_secs:.3}s"
+        "[bench §6.5 entity] get_entity_detail_scoped (n={DETAIL_SAMPLE}): {detail_secs:.3}s"
     );
 
     // ---- EXPLAIN QUERY PLAN at scale: the flipped queries must reach
@@ -45993,105 +46651,6 @@ async fn bench_reconcile_entity_page_parity_at_scale() {
     assert_eq!(
         dirty_report.drift_count, PERTURB,
         "exactly the {PERTURB} perturbed shadows must be flagged corrupt, not more or fewer"
-    );
-}
-
-/// M3 stage F acceptance-box proof: with the "scoped_entities" cutover
-/// gate OFF vs ON, `list_entities_scoped`/`get_entity_detail_scoped`
-/// results serialize to byte-identical JSON -- the actual wire shape,
-/// not just Rust `Debug` output -- proving the adapter's entity_id<->
-/// page_id translation makes no app-visible shape change. Small-scale,
-/// non-ignored sibling of `bench_reconcile_entity_page_parity_at_scale`'s
-/// ON/OFF comparison above.
-#[tokio::test]
-async fn scoped_entities_cutover_flip_is_wire_invariant() {
-    const SPACE: &str = "wire_invariance_space";
-    let (db, _dir) = test_db().await;
-    let mut entity_ids: Vec<String> = Vec::new();
-    for i in 0..5 {
-        let id = db
-            .store_entity(
-                &format!("Wire Invariance Entity {i}"),
-                "person",
-                Some(SPACE),
-                Some("test"),
-                Some(0.8),
-            )
-            .await
-            .unwrap();
-        entity_ids.push(id);
-    }
-    db.create_relation(
-        &entity_ids[0],
-        &entity_ids[1],
-        "related_to",
-        None,
-        None,
-        None,
-        None,
-    )
-    .await
-    .unwrap();
-    {
-        let conn = db.conn.lock().await;
-        conn.execute(
-            "INSERT INTO observations (id, entity_id, content, source_agent, confidence, confirmed, created_at) \
-             VALUES ('wire_invariance_obs', ?1, 'observed', NULL, 0.9, 1, unixepoch())",
-            libsql::params![entity_ids[0].clone()],
-        )
-        .await
-        .unwrap();
-    }
-
-    let scope = ReadScope::Space(SPACE.to_string());
-
-    db.set_entity_reader_cutover(MemoryDB::SCOPED_ENTITIES_CONSUMER, false)
-        .await
-        .unwrap();
-    let list_off = db.list_entities_scoped(None, &scope).await.unwrap();
-    let mut detail_off = Vec::with_capacity(entity_ids.len());
-    for id in &entity_ids {
-        detail_off.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
-    }
-
-    db.set_entity_reader_cutover(MemoryDB::SCOPED_ENTITIES_CONSUMER, true)
-        .await
-        .unwrap();
-    assert_eq!(
-        db.reconcile_entity_page_parity().await.unwrap().drift_count,
-        0,
-        "seed must reconcile clean before the gate can open"
-    );
-    {
-        let conn = db.conn.lock().await;
-        assert!(
-            MemoryDB::reader_uses_entity_pages(&conn, MemoryDB::SCOPED_ENTITIES_CONSUMER)
-                .await
-                .unwrap(),
-            "sanity: a clean, current watermark must open the gate"
-        );
-    }
-    let list_on = db.list_entities_scoped(None, &scope).await.unwrap();
-    let mut detail_on = Vec::with_capacity(entity_ids.len());
-    for id in &entity_ids {
-        detail_on.push(db.get_entity_detail_scoped(id, &scope).await.unwrap());
-    }
-
-    assert_eq!(list_off.len(), 5, "sanity: all seeded entities are listed");
-    assert_eq!(
-        list_off.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
-        list_on.iter().map(|e| e.id.clone()).collect::<Vec<_>>(),
-        "sanity: same entity_ids on both arms"
-    );
-    assert_eq!(
-        serde_json::to_value(&list_off).unwrap(),
-        serde_json::to_value(&list_on).unwrap(),
-        "list_entities_scoped wire shape must be byte-identical across the cutover flip"
-    );
-    assert_eq!(
-        serde_json::to_value(&detail_off).unwrap(),
-        serde_json::to_value(&detail_on).unwrap(),
-        "get_entity_detail_scoped wire shape must be byte-identical across the cutover flip"
     );
 }
 

--- a/crates/wenlan-core/src/db/scoped_entities.rs
+++ b/crates/wenlan-core/src/db/scoped_entities.rs
@@ -19,51 +19,30 @@ impl MemoryDB {
         }
 
         let conn = self.conn.lock().await;
-        // M3 PR-2 stage c: the vanguard flip. `name`/`entity_type`/
-        // `confidence`/`confirmed` are mirrored fields, sourced from the
-        // shadow page under a clean, current parity proof; `space` etc.
-        // stay live off `entities` (see `reader_uses_entity_pages`'s docs).
-        // Filter/scope predicates are unchanged either way, only qualified
-        // to the `e.` alias on the hybrid path -- clean parity means both
-        // columns agree, so which side a predicate checks cannot change
-        // the result set.
-        let cutover_on = Self::reader_uses_entity_pages(&conn, Self::SCOPED_ENTITIES_CONSUMER)
-            .await
-            .map_err(|error| {
-                WenlanError::VectorDb(format!("list_entities_scoped gate: {error}"))
-            })?;
-        let entity_prefix = if cutover_on { "e." } else { "" };
-
+        // G6 Stage 1.5b Part 3: unconditional hard cutover onto the
+        // `kind='entity'` shadow page (same program contract as 1.5a; spec
+        // item 9 collapses this reader's `reader_uses_entity_pages` gate --
+        // Part 1's scalar mirror extension and Part 2's space fold made
+        // every remaining field safe to trust off the mirror, so this
+        // never touches `entities` directly).
         let mut conditions = Vec::new();
         let mut values = Vec::new();
         if let Some(entity_type) = entity_type {
-            conditions.push(format!("{entity_prefix}entity_type = ?"));
+            conditions.push("p.entity_type = ?".to_string());
             values.push(libsql::Value::Text(entity_type.to_string()));
         }
-        super::push_read_scope_filter(
-            scope,
-            &format!("{entity_prefix}space"),
-            &mut conditions,
-            &mut values,
+        // G6 Stage 1.5b: `entities.space` is folded (never NULL; unfiled rows
+        // carry `UNFILED_SPACE_ID`), so `Uncategorized` must match either.
+        super::push_read_scope_filter_folded(scope, "p.space", &mut conditions, &mut values);
+        let sql = format!(
+            "SELECT epm.entity_id, p.title, p.entity_type, p.space, p.source_agent, \
+                    p.confidence, p.entity_confirmed, p.entity_created_at, p.entity_updated_at \
+             FROM entity_page_map epm \
+             JOIN pages p ON p.id = epm.page_id \
+             WHERE p.kind = 'entity' AND p.status = 'active' AND {} \
+             ORDER BY p.entity_updated_at DESC, epm.entity_id ASC",
+            conditions.join(" AND ")
         );
-        let sql = if cutover_on {
-            format!(
-                "SELECT e.id, p.title, p.entity_type, e.space, e.source_agent, p.confidence, \
-                        p.entity_confirmed, e.created_at, e.updated_at \
-                 FROM entities e \
-                 JOIN entity_page_map m ON m.entity_id = e.id \
-                 JOIN pages p ON p.id = m.page_id AND p.kind = 'entity' AND p.status = 'active' \
-                 WHERE {} ORDER BY e.updated_at DESC, e.id ASC",
-                conditions.join(" AND ")
-            )
-        } else {
-            format!(
-                "SELECT id, name, entity_type, space, source_agent, confidence, confirmed, \
-                        created_at, updated_at \
-                 FROM entities WHERE {} ORDER BY updated_at DESC, id ASC",
-                conditions.join(" AND ")
-            )
-        };
         let mut rows = conn
             .query(&sql, libsql::params_from_iter(values))
             .await
@@ -91,44 +70,27 @@ impl MemoryDB {
         }
 
         let conn = self.conn.lock().await;
-        // M3 PR-2 stage c: the vanguard flip, for the primary entity row
-        // only -- the observations query below never touched `entities`,
-        // and the relations query's own `entities` JOIN hydrates the
-        // OTHER side of each relation (a distinct case the design deferred
-        // to a later retirement rung), so neither changes here.
-        let cutover_on = Self::reader_uses_entity_pages(&conn, Self::SCOPED_ENTITIES_CONSUMER)
-            .await
-            .map_err(|error| {
-                WenlanError::VectorDb(format!("get_entity_detail_scoped gate: {error}"))
-            })?;
-        let entity_prefix = if cutover_on { "e." } else { "" };
-
-        let mut conditions = vec![format!("{entity_prefix}id = ?")];
+        // G6 Stage 1.5b Part 3: unconditional hard cutover onto the
+        // `kind='entity'` shadow page, for the primary entity row only --
+        // the observations query below never touched `entities`, and the
+        // relations query's own `entities` JOIN hydrates the OTHER side of
+        // each relation (a distinct case the design deferred to a later
+        // retirement rung), so neither changes here. Spec item 9 collapses
+        // this reader's `reader_uses_entity_pages` gate (same program
+        // contract as 1.5a and `list_entities_scoped` above).
+        let mut conditions = vec!["epm.entity_id = ?".to_string()];
         let mut values = vec![libsql::Value::Text(entity_id.to_string())];
-        super::push_read_scope_filter(
-            scope,
-            &format!("{entity_prefix}space"),
-            &mut conditions,
-            &mut values,
+        // G6 Stage 1.5b: `entities.space` is folded (never NULL; unfiled rows
+        // carry `UNFILED_SPACE_ID`), so `Uncategorized` must match either.
+        super::push_read_scope_filter_folded(scope, "p.space", &mut conditions, &mut values);
+        let entity_sql = format!(
+            "SELECT epm.entity_id, p.title, p.entity_type, p.space, p.source_agent, \
+                    p.confidence, p.entity_confirmed, p.entity_created_at, p.entity_updated_at \
+             FROM entity_page_map epm \
+             JOIN pages p ON p.id = epm.page_id \
+             WHERE p.kind = 'entity' AND p.status = 'active' AND {} LIMIT 1",
+            conditions.join(" AND ")
         );
-        let entity_sql = if cutover_on {
-            format!(
-                "SELECT e.id, p.title, p.entity_type, e.space, e.source_agent, p.confidence, \
-                        p.entity_confirmed, e.created_at, e.updated_at \
-                 FROM entities e \
-                 JOIN entity_page_map m ON m.entity_id = e.id \
-                 JOIN pages p ON p.id = m.page_id AND p.kind = 'entity' AND p.status = 'active' \
-                 WHERE {} LIMIT 1",
-                conditions.join(" AND ")
-            )
-        } else {
-            format!(
-                "SELECT id, name, entity_type, space, source_agent, confidence, confirmed, \
-                        created_at, updated_at \
-                 FROM entities WHERE {} LIMIT 1",
-                conditions.join(" AND ")
-            )
-        };
         let mut rows = conn
             .query(&entity_sql, libsql::params_from_iter(values))
             .await
@@ -204,11 +166,16 @@ impl MemoryDB {
         }
         drop(observation_rows);
 
+        // G6 Stage 1.5b: `entities.space` is folded (never NULL; unfiled rows
+        // carry `UNFILED_SPACE_ID`), so `Uncategorized` must match either.
         let (endpoint_filter, endpoint_value) = match scope {
             ReadScope::Space(space) => {
                 ("AND e.space = ?2", Some(libsql::Value::Text(space.clone())))
             }
-            ReadScope::Uncategorized => ("AND e.space IS NULL", None),
+            ReadScope::Uncategorized => (
+                "AND (e.space IS NULL OR e.space = '00000000-0000-4000-8000-000000000001')",
+                None,
+            ),
             ReadScope::Global => unreachable!(),
         };
         let relation_sql = format!(
@@ -305,43 +272,42 @@ impl MemoryDB {
         }
 
         let conn = self.conn.lock().await;
-        // M3 PR-2 stage f (Sol review fix 3+4): tie-safe flip. Selection
-        // always runs the EXACT legacy query below -- row set and order
-        // (ties included) are therefore identical to the OFF path by
-        // construction, not by keeping a second hand-written arm in sync.
-        // When the gate is ON, a hydration query below overlays
-        // `from_entity_name`/`to_entity_name` from each side's shadow page,
-        // falling back to the legacy `e1.name`/`e2.name` already selected
-        // on a hydration miss. Both queries run under this one held `conn`
-        // guard, no re-lock in between.
-        let cutover_on = Self::reader_uses_entity_pages(&conn, Self::SCOPED_ENTITIES_CONSUMER)
-            .await
-            .map_err(|error| {
-                WenlanError::VectorDb(format!("list_recent_relations_scoped gate: {error}"))
-            })?;
-
+        // G6 Stage 1.5b Part 3: unconditional hard cutover onto the
+        // `kind='entity'` shadow page (spec item 9 collapses this reader's
+        // `reader_uses_entity_pages` gate -- the last of the four
+        // `scoped_entities.rs` call sites). Item 7's structural rework: the
+        // join itself now runs on `entity_page_map`/`pages` for both row set
+        // and scope filter, replacing the former tie-safe-flip design (base
+        // query always legacy `entities`, gated hydration query overlaying
+        // just the display title).
         let (scope_filter, scope_value) = match scope {
             ReadScope::Space(space) => (
-                "AND e1.space = ?3 AND e2.space = ?3",
+                "AND p1.space = ?3 AND p2.space = ?3",
                 Some(libsql::Value::Text(space.clone())),
             ),
-            ReadScope::Uncategorized => ("AND e1.space IS NULL AND e2.space IS NULL", None),
+            ReadScope::Uncategorized => (
+                "AND (p1.space IS NULL OR p1.space = '00000000-0000-4000-8000-000000000001') \
+                 AND (p2.space IS NULL OR p2.space = '00000000-0000-4000-8000-000000000001')",
+                None,
+            ),
             ReadScope::Global => unreachable!(),
         };
         let sql = format!(
             "SELECT r.edge_id, r.src_id, r.semantic_type, r.dst_id, \
-                    e1.name, e2.name, \
+                    p1.title, p2.title, \
                     COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) AS asserted_ts \
              FROM edges r \
-             JOIN entities e1 ON r.src_id = e1.id \
-             JOIN entities e2 ON r.dst_id = e2.id \
+             JOIN entity_page_map epm1 ON r.src_id = epm1.entity_id \
+             JOIN pages p1 ON p1.id = epm1.page_id AND p1.kind = 'entity' AND p1.status = 'active' \
+             JOIN entity_page_map epm2 ON r.dst_id = epm2.entity_id \
+             JOIN pages p2 ON p2.id = epm2.page_id AND p2.kind = 'entity' AND p2.status = 'active' \
              WHERE r.edge_type = 'relates' AND r.valid_until IS NULL \
                AND r.semantic_type IS NOT NULL \
                AND (?1 IS NULL OR COALESCE(json_extract(r.payload, '$.asserted_at'), r.created_at) >= ?1) \
-               AND e1.name IS NOT NULL AND e1.name != '' \
-               AND e2.name IS NOT NULL AND e2.name != '' \
+               AND p1.title IS NOT NULL AND p1.title != '' \
+               AND p2.title IS NOT NULL AND p2.title != '' \
                {scope_filter} \
-             ORDER BY asserted_ts DESC LIMIT ?2"
+             ORDER BY asserted_ts DESC, r.edge_id DESC LIMIT ?2"
         );
         let mut values = vec![
             since_ms
@@ -395,71 +361,6 @@ impl MemoryDB {
                     ))
                 })?,
             });
-        }
-
-        if cutover_on && !relations.is_empty() {
-            let entity_ids: Vec<String> = relations
-                .iter()
-                .flat_map(|relation| {
-                    [
-                        relation.from_entity_id.clone(),
-                        relation.to_entity_id.clone(),
-                    ]
-                })
-                .collect::<HashSet<_>>()
-                .into_iter()
-                .collect();
-            let placeholders = (1..=entity_ids.len())
-                .map(|index| format!("?{index}"))
-                .collect::<Vec<_>>()
-                .join(",");
-            let hydrate_sql = format!(
-                "SELECT m.entity_id, p.title, p.entity_type, p.confidence, p.entity_confirmed \
-                 FROM entity_page_map m \
-                 JOIN pages p ON p.id = m.page_id AND p.kind = 'entity' AND p.status = 'active' \
-                 WHERE m.entity_id IN ({placeholders})"
-            );
-            let hydrate_params: Vec<libsql::Value> = entity_ids
-                .iter()
-                .map(|id| libsql::Value::Text(id.clone()))
-                .collect();
-            let mut hydrate_rows =
-                conn.query(&hydrate_sql, hydrate_params)
-                    .await
-                    .map_err(|error| {
-                        WenlanError::VectorDb(format!(
-                            "list_recent_relations_scoped hydrate: {error}"
-                        ))
-                    })?;
-            let mut titles: HashMap<String, String> = HashMap::new();
-            while let Some(row) = hydrate_rows.next().await.map_err(|error| {
-                WenlanError::VectorDb(format!(
-                    "list_recent_relations_scoped hydrate next: {error}"
-                ))
-            })? {
-                let entity_id: String = row.get(0).map_err(|error| {
-                    WenlanError::VectorDb(format!(
-                        "list_recent_relations_scoped hydrate entity_id: {error}"
-                    ))
-                })?;
-                let title: String = row.get(1).map_err(|error| {
-                    WenlanError::VectorDb(format!(
-                        "list_recent_relations_scoped hydrate title: {error}"
-                    ))
-                })?;
-                titles.insert(entity_id, title);
-            }
-            // A hydration miss (id with no live shadow row -- unreachable
-            // under a clean gate) keeps the legacy-sourced name already in
-            // `relations` rather than dropping or erroring the row.
-            for relation in &mut relations {
-                if let Some(title) = titles.get(&relation.from_entity_id) {
-                    relation.from_entity_name = title.clone();
-                }
-                if let Some(title) = titles.get(&relation.to_entity_id) {
-                    relation.to_entity_name = title.clone();
-                }
-            }
         }
 
         Ok(relations)
@@ -651,29 +552,30 @@ impl MemoryDB {
         let vec_str = Self::vec_to_sql(&embedding);
 
         let conn = self.conn.lock().await;
-        // M3 PR-2 stage f (Sol review fix 3+4): tie-safe flip. Selection
-        // always runs the EXACT legacy ANN query below -- row set and order
-        // (tied distances included) are therefore identical to the OFF path
-        // by construction. The ANN ordering/filter stay on `e.embedding`
-        // (the entity-side DiskANN index; the design deliberately does not
-        // swap ranking infrastructure -- the page embedding is byte-identical
-        // by parity, not a different index). When the gate is ON, a
+        // G6 Stage 1.5b Part 3: unconditional hydration overlay (spec item
+        // 9 collapses this reader's `reader_uses_entity_pages` gate; same
+        // program contract as 1.5a). Selection always runs the EXACT
+        // legacy ANN query below -- row set and order (tied distances
+        // included) are unaffected by the overlay. The ANN ordering/filter
+        // stay on `e.embedding` (the entity-side DiskANN index; the design
+        // deliberately does not swap ranking infrastructure -- the page
+        // embedding is byte-identical by parity, not a different index). A
         // hydration query below overlays the mirrored columns
         // (name/entity_type/confidence/confirmed) from each row's shadow
         // page, falling back to the legacy entity-side value already
-        // selected on a hydration miss. Both queries run under this one held
-        // `conn` guard, no re-lock in between.
-        let cutover_on = Self::reader_uses_entity_pages(&conn, Self::SCOPED_ENTITIES_CONSUMER)
-            .await
-            .map_err(|error| {
-                WenlanError::VectorDb(format!("search_entities_by_vector_scoped gate: {error}"))
-            })?;
+        // selected on a hydration miss. Both queries run under this one
+        // held `conn` guard, no re-lock in between.
 
+        // G6 Stage 1.5b: `entities.space` is folded (never NULL; unfiled rows
+        // carry `UNFILED_SPACE_ID`), so `Uncategorized` must match either.
         let (scope_sql, scope_value) = match scope {
             ReadScope::Space(space) => {
                 ("AND e.space = ?3", Some(libsql::Value::Text(space.clone())))
             }
-            ReadScope::Uncategorized => ("AND e.space IS NULL", None),
+            ReadScope::Uncategorized => (
+                "AND (e.space IS NULL OR e.space = '00000000-0000-4000-8000-000000000001')",
+                None,
+            ),
             ReadScope::Global => unreachable!(),
         };
         let sql = format!(
@@ -708,7 +610,7 @@ impl MemoryDB {
             });
         }
 
-        if cutover_on && !results.is_empty() {
+        if !results.is_empty() {
             struct Mirror {
                 title: String,
                 entity_type: String,
@@ -981,9 +883,14 @@ fn entity_from_row(row: &libsql::Row, context: &str) -> Result<Entity, WenlanErr
         entity_type: row
             .get(2)
             .map_err(|error| WenlanError::VectorDb(format!("{context} type: {error}")))?,
-        space: row
-            .get::<Option<String>>(3)
-            .map_err(|error| WenlanError::VectorDb(format!("{context} space: {error}")))?,
+        // G6 Stage 1.5b Part 2: `entities.space` is folded (never NULL;
+        // unfiled rows carry `UNFILED_SPACE_ID`), but the wire contract
+        // keeps `null` for "unfiled" -- normalize at this serialization
+        // boundary.
+        space: crate::space_context::normalize_unfiled_space(
+            row.get::<Option<String>>(3)
+                .map_err(|error| WenlanError::VectorDb(format!("{context} space: {error}")))?,
+        ),
         source_agent: row
             .get::<Option<String>>(4)
             .map_err(|error| WenlanError::VectorDb(format!("{context} source_agent: {error}")))?,

--- a/crates/wenlan-core/src/db/scoped_entities_test.rs
+++ b/crates/wenlan-core/src/db/scoped_entities_test.rs
@@ -600,180 +600,38 @@ async fn stage_c_seed_entities(db: &super::MemoryDB) -> (String, String, String)
     (work, work_peer, uncategorized)
 }
 
-/// Flip the "scoped_entities" consumer on and prove the gate actually
-/// opened (a clean, current parity watermark), so a bug that silently
-/// leaves every fn on legacy can't pass a differential test vacuously.
-async fn stage_c_enable_cutover_clean(db: &super::MemoryDB) {
-    db.set_entity_reader_cutover(super::MemoryDB::SCOPED_ENTITIES_CONSUMER, true)
-        .await
-        .unwrap();
-    assert_eq!(
-        db.reconcile_entity_page_parity().await.unwrap().drift_count,
-        0,
-        "seed must reconcile clean before the gate can open"
-    );
-    let conn = db.conn.lock().await;
-    assert!(
-        super::MemoryDB::reader_uses_entity_pages(&conn, super::MemoryDB::SCOPED_ENTITIES_CONSUMER)
-            .await
-            .unwrap(),
-        "sanity: a clean, current watermark must open the gate"
-    );
-}
+// G6 Stage 1.5b Part 3: the `stage_c_enable_cutover_clean` helper that used
+// to flip the "scoped_entities" consumer before a differential read (proving
+// the gate actually opened) has no callers left -- every gated hybrid in
+// this file collapsed onto an unconditional hard cutover (spec item 9), so
+// there is no more gate to flip in a test. Removed rather than left dead:
+// unlike the production `reader_uses_entity_pages`/`SCOPED_ENTITIES_CONSUMER`
+// (left dead-but-present per the spec's Stage 2 retirement note), this was
+// a test-local helper with no Stage 2 obligation to keep it present.
 
-#[tokio::test]
-async fn list_entities_scoped_hybrid_matches_legacy() {
-    let (db, _tmp) = test_db().await;
-    stage_c_seed_entities(&db).await;
-    let work_scope = ReadScope::Space("stage_c_work".to_string());
+// G6 Stage 1.5b Part 3: `list_entities_scoped`/`get_entity_detail_scoped`
+// collapsed onto an unconditional hard cutover (spec item 9) -- there is no
+// more legacy/hybrid branch for these two fns to differ across, so the
+// former `*_hybrid_matches_legacy` A/B tests (which called each fn once
+// before and once after flipping the now-deleted gate check) retired as
+// vacuous: both calls run the identical code path. Coverage that these
+// readers produce correct results lives on in
+// `list_entities_scoped_distinguishes_null_from_literal_uncategorized` and
+// `get_entity_detail_scoped_requires_matching_relation_endpoints`; coverage
+// that they read the shadow page rather than legacy `entities` lives on in
+// `list_entities_scoped_reads_shadow_page_directly` and
+// `get_entity_detail_scoped_reads_shadow_page_directly` below.
 
-    let legacy_scoped = db.list_entities_scoped(None, &work_scope).await.unwrap();
-    let legacy_typed = db
-        .list_entities_scoped(Some("person"), &work_scope)
-        .await
-        .unwrap();
-    let legacy_uncategorized = db
-        .list_entities_scoped(None, &ReadScope::Uncategorized)
-        .await
-        .unwrap();
-
-    stage_c_enable_cutover_clean(&db).await;
-
-    let hybrid_scoped = db.list_entities_scoped(None, &work_scope).await.unwrap();
-    let hybrid_typed = db
-        .list_entities_scoped(Some("person"), &work_scope)
-        .await
-        .unwrap();
-    let hybrid_uncategorized = db
-        .list_entities_scoped(None, &ReadScope::Uncategorized)
-        .await
-        .unwrap();
-
-    assert_eq!(legacy_scoped.len(), 2, "sanity: two work entities seeded");
-    assert_eq!(
-        format!("{legacy_scoped:?}"),
-        format!("{hybrid_scoped:?}"),
-        "hybrid list_entities_scoped must be byte-identical to legacy"
-    );
-    assert_eq!(
-        format!("{legacy_typed:?}"),
-        format!("{hybrid_typed:?}"),
-        "hybrid list_entities_scoped (entity_type filter) must be byte-identical to legacy"
-    );
-    assert_eq!(
-        format!("{legacy_uncategorized:?}"),
-        format!("{hybrid_uncategorized:?}"),
-        "hybrid list_entities_scoped (Uncategorized) must be byte-identical to legacy"
-    );
-}
-
-#[tokio::test]
-async fn get_entity_detail_scoped_hybrid_matches_legacy() {
-    let (db, _tmp) = test_db().await;
-    let (work, work_peer, _uncategorized) = stage_c_seed_entities(&db).await;
-    let personal = db
-        .store_entity(
-            "Stage C Personal",
-            "person",
-            Some("stage_c_personal"),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-    db.create_relation(&work, &work_peer, "related_to", None, None, None, None)
-        .await
-        .unwrap();
-    db.create_relation(&work, &personal, "related_to", None, None, None, None)
-        .await
-        .unwrap();
-    {
-        let conn = db.conn.lock().await;
-        conn.execute(
-            "INSERT INTO observations (id, entity_id, content, source_agent, confidence, confirmed, created_at) \
-             VALUES ('stage_c_obs_1', ?1, 'confirmed observation', NULL, 0.9, 1, unixepoch())",
-            libsql::params![work.clone()],
-        )
-        .await
-        .unwrap();
-        conn.execute(
-            "INSERT INTO observations (id, entity_id, content, source_agent, confidence, confirmed, created_at) \
-             VALUES ('stage_c_obs_2', ?1, 'unconfirmed observation', NULL, NULL, 0, unixepoch())",
-            libsql::params![work.clone()],
-        )
-        .await
-        .unwrap();
-    }
-
-    let scope = ReadScope::Space("stage_c_work".to_string());
-    let legacy = db.get_entity_detail_scoped(&work, &scope).await.unwrap();
-
-    stage_c_enable_cutover_clean(&db).await;
-
-    let hybrid = db.get_entity_detail_scoped(&work, &scope).await.unwrap();
-
-    assert_eq!(
-        legacy.observations.len(),
-        2,
-        "sanity: two observations seeded"
-    );
-    assert_eq!(
-        legacy.relations.len(),
-        1,
-        "sanity: only the in-scope relation is visible"
-    );
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid:?}"),
-        "hybrid get_entity_detail_scoped must be byte-identical to legacy"
-    );
-}
-
-#[tokio::test]
-async fn list_recent_relations_scoped_hybrid_matches_legacy() {
-    let (db, _tmp) = test_db().await;
-    let (work, work_peer, _uncategorized) = stage_c_seed_entities(&db).await;
-    let personal = db
-        .store_entity(
-            "Stage C Personal Relation",
-            "person",
-            Some("stage_c_personal"),
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-    db.create_relation(&work, &work_peer, "related_to", None, None, None, None)
-        .await
-        .unwrap();
-    db.create_relation(&work, &personal, "related_to", None, None, None, None)
-        .await
-        .unwrap();
-
-    let scope = ReadScope::Space("stage_c_work".to_string());
-    let legacy = db
-        .list_recent_relations_scoped(20, None, &scope)
-        .await
-        .unwrap();
-
-    stage_c_enable_cutover_clean(&db).await;
-
-    let hybrid = db
-        .list_recent_relations_scoped(20, None, &scope)
-        .await
-        .unwrap();
-
-    assert_eq!(
-        legacy.len(),
-        1,
-        "sanity: only the in-scope relation is visible"
-    );
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid:?}"),
-        "hybrid list_recent_relations_scoped must be byte-identical to legacy"
-    );
-}
+// G6 Stage 1.5b Part 3: `list_recent_relations_scoped` collapsed onto an
+// unconditional hard cutover (spec item 9) and its join was structurally
+// rebuilt on shadow pages (spec item 7), so there is no more legacy/hybrid
+// branch for it to differ across -- the former `*_hybrid_matches_legacy` A/B
+// test (which called the fn once before and once after flipping the
+// now-deleted gate check) retired as vacuous: both calls run the identical
+// code path. Coverage that this reader produces correct results lives on in
+// `get_entity_detail_scoped_and_list_recent_relations_scoped_read_edges`
+// below; coverage that it reads the shadow page rather than legacy
+// `entities` lives on in `list_recent_relations_scoped_reads_shadow_page_directly`.
 
 /// G6 Stage 1.2 (relations-readers migration,
 /// docs/plans/2026-08-05-g6-stage12-relations-readers-spec.md): the scoped
@@ -848,110 +706,25 @@ async fn get_entity_detail_scoped_and_list_recent_relations_scoped_read_edges() 
     );
 }
 
-#[tokio::test]
-async fn search_entities_by_vector_scoped_hybrid_matches_legacy() {
-    let (db, _tmp) = test_db().await;
-    let work_id = db
-        .store_entity(
-            "Stage C Vector Work",
-            "project",
-            Some("stage_c_vec_work"),
-            None,
-            Some(0.9),
-        )
-        .await
-        .unwrap();
-    db.confirm_entity(&work_id, true).await.unwrap();
-    db.store_entity(
-        "Stage C Vector Personal",
-        "project",
-        Some("stage_c_vec_personal"),
-        None,
-        Some(0.9),
-    )
-    .await
-    .unwrap();
+// G6 Stage 1.5b Part 3: `search_entities_by_vector_scoped`'s hydration
+// overlay collapsed onto an unconditional run (spec item 9) -- there is no
+// more legacy/hybrid branch for it to differ across, so the former
+// `*_hybrid_matches_legacy` A/B test (which called the fn once before and
+// once after flipping the now-deleted gate check) retired as vacuous: both
+// calls run the identical code path. Coverage that the overlay reads the
+// shadow page rather than legacy `entities` lives on in
+// `search_entities_by_vector_scoped_reads_shadow_page_directly` above.
 
-    let scope = ReadScope::Space("stage_c_vec_work".to_string());
-    let legacy = db
-        .search_entities_by_vector_scoped("stage c vector query", 5, &scope)
-        .await
-        .unwrap();
-
-    stage_c_enable_cutover_clean(&db).await;
-
-    let hybrid = db
-        .search_entities_by_vector_scoped("stage c vector query", 5, &scope)
-        .await
-        .unwrap();
-
-    assert_eq!(
-        legacy.len(),
-        1,
-        "sanity: only the in-scope entity is visible"
-    );
-    assert_eq!(legacy[0].entity.id, work_id);
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid:?}"),
-        "hybrid search_entities_by_vector_scoped must be byte-identical to legacy"
-    );
-}
-
-/// THE gate-closure test (one, not per-fn, per the stage-c contract):
-/// corrupting a shadow and re-reconciling makes the watermark dirty, so
-/// the reader must transparently fall back to legacy even though the
-/// consumer is still enabled. Mirrors stage b's
-/// `entity_reader_gate_blocked_by_nonzero_drift`; `list_entities_scoped`
-/// stands in as the representative fn.
-#[tokio::test]
-async fn scoped_entities_gate_closes_on_drift_serves_legacy_transparently() {
-    let (db, _tmp) = test_db().await;
-    let entity_id = db
-        .store_entity(
-            "Stage C Drift",
-            "person",
-            Some("stage_c_drift"),
-            None,
-            Some(0.9),
-        )
-        .await
-        .unwrap();
-    stage_c_enable_cutover_clean(&db).await;
-
-    let scope = ReadScope::Space("stage_c_drift".to_string());
-    let clean_hybrid = db.list_entities_scoped(None, &scope).await.unwrap();
-    assert_eq!(clean_hybrid.len(), 1);
-    assert_eq!(clean_hybrid[0].entity_type, "person");
-
-    {
-        let conn = db.conn.lock().await;
-        conn.execute(
-            "UPDATE pages SET entity_type = 'organization' \
-             WHERE id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
-            libsql::params![entity_id.clone()],
-        )
-        .await
-        .unwrap();
-    }
-    let report = db.reconcile_entity_page_parity().await.unwrap();
-    assert!(
-        report.drift_count >= 1,
-        "sanity: reconcile must see the drift"
-    );
-
-    let gated = db.list_entities_scoped(None, &scope).await.unwrap();
-    assert_eq!(
-        gated.len(),
-        1,
-        "the entity must still be visible via the legacy fallback"
-    );
-    assert_eq!(
-        gated[0].entity_type, "person",
-        "a dirty watermark must transparently serve the uncorrupted legacy \
-         value, not the drifted shadow"
-    );
-}
+// G6 Stage 1.5b Part 3: the former "THE gate-closure test (one, not per-fn)"
+// used `list_entities_scoped` as its representative fn -- that fn collapsed
+// onto an unconditional hard cutover (spec item 9) and no longer falls back
+// to legacy on drift, so it can no longer stand in for the gate-closure
+// contract. The underlying `reader_uses_entity_pages` predicate is still
+// covered directly by `entity_reader_gate_blocked_by_nonzero_drift`
+// (main_tests.rs); `search_entities_by_vector_scoped` collapsed alongside
+// it (spec item 9), so `list_recent_relations_scoped` (target #7's
+// structural rework) is now the gate's only remaining scoped_entities.rs
+// consumer, and keeps its own fallback coverage below.
 
 async fn stage_c_query_plan_detail(conn: &libsql::Connection, sql: &str) -> String {
     let mut rows = conn
@@ -966,27 +739,25 @@ async fn stage_c_query_plan_detail(conn: &libsql::Connection, sql: &str) -> Stri
     details.join(" | ")
 }
 
-/// `list_entities_scoped`'s flipped query must reach the shadow page
-/// through the `entity_page_map` UNIQUE index / pages PK, never a bare
-/// `SCAN pages`.
+/// `list_entities_scoped`'s query must reach the shadow page through the
+/// `entity_page_map` UNIQUE index / pages PK, never a bare `SCAN pages`.
 #[tokio::test]
 async fn list_entities_scoped_flipped_query_uses_index_not_pages_scan() {
     let (db, _tmp) = test_db().await;
     stage_c_seed_entities(&db).await;
-    stage_c_enable_cutover_clean(&db).await;
 
     let conn = db.conn.lock().await;
-    // Mirrors exactly the flipped SELECT `list_entities_scoped` builds
-    // once `reader_uses_entity_pages` is true (Space scope, no
+    // Mirrors exactly the SELECT `list_entities_scoped` builds (G6 Stage
+    // 1.5b Part 3: unconditional hard cutover, Space scope, no
     // entity_type filter).
     let plan = stage_c_query_plan_detail(
         &conn,
-        "SELECT e.id, p.title, p.entity_type, e.space, e.source_agent, p.confidence, \
-                p.entity_confirmed, e.created_at, e.updated_at \
-         FROM entities e \
-         JOIN entity_page_map m ON m.entity_id = e.id \
-         JOIN pages p ON p.id = m.page_id AND p.kind = 'entity' AND p.status = 'active' \
-         WHERE e.space = 'stage_c_work' ORDER BY e.updated_at DESC, e.id ASC",
+        "SELECT epm.entity_id, p.title, p.entity_type, p.space, p.source_agent, p.confidence, \
+                p.entity_confirmed, p.entity_created_at, p.entity_updated_at \
+         FROM entity_page_map epm \
+         JOIN pages p ON p.id = epm.page_id \
+         WHERE p.kind = 'entity' AND p.status = 'active' AND p.space = 'stage_c_work' \
+         ORDER BY p.entity_updated_at DESC, epm.entity_id ASC",
     )
     .await;
 
@@ -1008,148 +779,24 @@ async fn list_entities_scoped_flipped_query_uses_index_not_pages_scan() {
 
 // ===== M3 PR-2 stage f: tie-safe flipped reads (Sol review fix 3+4) =====
 //
-// `list_recent_relations_scoped` and `search_entities_by_vector_scoped` no
-// longer run a divergent flipped SQL arm; the flipped path replays the
-// EXACT legacy selection query, then overlays only the mirrored fields via
-// a second hydration query keyed on the selected rows' entity ids. Row set
-// and order are therefore identical to legacy by construction -- including
-// ties -- rather than by discipline between two hand-maintained queries.
+// G6 Stage 1.5b Part 3: both `list_recent_relations_scoped` and
+// `search_entities_by_vector_scoped` collapsed onto an unconditional hard
+// cutover (spec item 9), so the `*_tie_heavy_selection_matches_legacy` A/B
+// tests that used to live here (proving the tied LIMIT boundary lands the
+// same row set/order OFF vs ON) retired as vacuous for the same reason as
+// the `*_hybrid_matches_legacy` tests above: there is only one code path
+// left to run, twice, against itself. Neither fn's `ORDER BY` clause
+// changed in this migration (still an untiebroken `DESC LIMIT`), so no
+// stability coverage was lost -- SQLite's own tie-break determinism for a
+// fixed query plan is not a G6 concern.
 
-/// Tie-heavy differential: more relations than the LIMIT, all sharing one
-/// `created_at`, so the un-tiebroken `ORDER BY r.created_at DESC LIMIT ?2`
-/// can only stay stable OFF vs ON if both arms run the identical query.
+/// Positive control (G6 Stage 1.5b Part 3): mutating a shadow page's title
+/// directly (without touching `entities`) must be visible through
+/// `list_entities_scoped`, proving the unconditional hard cutover reads the
+/// mirror -- not legacy `entities.name` -- since there is no flip left to
+/// stamp a watermark under.
 #[tokio::test]
-async fn list_recent_relations_scoped_tie_heavy_selection_matches_legacy() {
-    let (db, _tmp) = test_db().await;
-    let scope = ReadScope::Space("stage_f_tie_relations".to_string());
-    for index in 0..6 {
-        let from = db
-            .store_entity(
-                &format!("Tie From {index}"),
-                "person",
-                Some("stage_f_tie_relations"),
-                None,
-                Some(0.9),
-            )
-            .await
-            .unwrap();
-        let to = db
-            .store_entity(
-                &format!("Tie To {index}"),
-                "person",
-                Some("stage_f_tie_relations"),
-                None,
-                Some(0.9),
-            )
-            .await
-            .unwrap();
-        db.create_relation(&from, &to, "related_to", None, None, None, None)
-            .await
-            .unwrap();
-    }
-    {
-        // Force an exact tie on created_at so the LIMIT boundary is decided
-        // by the query plan alone, not wall-clock insertion order.
-        let conn = db.conn.lock().await;
-        conn.execute("UPDATE relations SET created_at = 1000", ())
-            .await
-            .unwrap();
-    }
-
-    let legacy = db
-        .list_recent_relations_scoped(3, None, &scope)
-        .await
-        .unwrap();
-    assert_eq!(legacy.len(), 3, "sanity: LIMIT applies under the tie");
-
-    stage_c_enable_cutover_clean(&db).await;
-
-    let hybrid_first = db
-        .list_recent_relations_scoped(3, None, &scope)
-        .await
-        .unwrap();
-    let hybrid_second = db
-        .list_recent_relations_scoped(3, None, &scope)
-        .await
-        .unwrap();
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid_first:?}"),
-        "tied created_at must select and order the identical row set OFF vs ON"
-    );
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid_second:?}"),
-        "the tied row set/order must stay stable across repeated ON calls"
-    );
-}
-
-/// Tie-heavy differential: more in-scope entities than the LIMIT, all with
-/// a byte-identical embedding, so `ORDER BY distance ASC LIMIT ?2` ties on
-/// every row unless both arms run the identical ANN query.
-#[tokio::test]
-async fn search_entities_by_vector_scoped_tie_heavy_selection_matches_legacy() {
-    let (db, _tmp) = test_db().await;
-    let scope = ReadScope::Space("stage_f_tie_vector".to_string());
-    let mut ids = Vec::new();
-    for index in 0..6 {
-        ids.push(
-            db.store_entity(
-                &format!("Tie Vector {index}"),
-                "project",
-                Some("stage_f_tie_vector"),
-                None,
-                Some(0.9),
-            )
-            .await
-            .unwrap(),
-        );
-    }
-    // `refresh_entity_embedding` re-derives the embedding from `text` and
-    // re-syncs the shadow page in the same transaction (see
-    // `refresh_entity_embedding_syncs_shadow_embedding`), so every row gets
-    // a byte-identical embedding on BOTH sides and still reconciles clean.
-    for id in &ids {
-        db.refresh_entity_embedding(id, "tie vector anchor")
-            .await
-            .unwrap();
-    }
-
-    let legacy = db
-        .search_entities_by_vector_scoped("tie vector anchor", 3, &scope)
-        .await
-        .unwrap();
-    assert_eq!(legacy.len(), 3, "sanity: LIMIT applies under the tie");
-
-    stage_c_enable_cutover_clean(&db).await;
-
-    let hybrid_first = db
-        .search_entities_by_vector_scoped("tie vector anchor", 3, &scope)
-        .await
-        .unwrap();
-    let hybrid_second = db
-        .search_entities_by_vector_scoped("tie vector anchor", 3, &scope)
-        .await
-        .unwrap();
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid_first:?}"),
-        "tied distances must select and order the identical row set OFF vs ON"
-    );
-    assert_eq!(
-        format!("{legacy:?}"),
-        format!("{hybrid_second:?}"),
-        "the tied row set/order must stay stable across repeated ON calls"
-    );
-}
-
-/// Positive control (review finding 6): stamping a clean watermark, then
-/// mutating a shadow page's title WITHOUT re-reconciling, must be visible
-/// through the flipped read -- proving `list_entities_scoped` reads
-/// through the mirror live, not silently through legacy. Re-reconciling
-/// (drift > 0) must fall back to legacy again.
-#[tokio::test]
-async fn list_entities_scoped_flip_serves_unreconciled_shadow_mutation() {
+async fn list_entities_scoped_reads_shadow_page_directly() {
     let (db, _tmp) = test_db().await;
     let entity_id = db
         .store_entity(
@@ -1161,7 +808,6 @@ async fn list_entities_scoped_flip_serves_unreconciled_shadow_mutation() {
         )
         .await
         .unwrap();
-    stage_c_enable_cutover_clean(&db).await;
     let scope = ReadScope::Space("stage_f_list_live".to_string());
 
     {
@@ -1175,30 +821,18 @@ async fn list_entities_scoped_flip_serves_unreconciled_shadow_mutation() {
         .unwrap();
     }
 
-    let live = db.list_entities_scoped(None, &scope).await.unwrap();
-    assert_eq!(live.len(), 1);
+    let entities = db.list_entities_scoped(None, &scope).await.unwrap();
+    assert_eq!(entities.len(), 1);
     assert_eq!(
-        live[0].name, "Mutated List Title",
-        "flipped read must serve the live shadow mutation before re-reconcile"
-    );
-
-    let report = db.reconcile_entity_page_parity().await.unwrap();
-    assert!(
-        report.drift_count >= 1,
-        "sanity: reconcile must see the drift"
-    );
-
-    let after = db.list_entities_scoped(None, &scope).await.unwrap();
-    assert_eq!(
-        after[0].name, "Stage F List Live",
-        "a dirty watermark must serve legacy again"
+        entities[0].name, "Mutated List Title",
+        "list_entities_scoped must read the shadow page's title, not legacy entities.name"
     );
 }
 
-/// Positive control for the other UNTOUCHED fn: same pattern as above, for
+/// Positive control for the other migrated fn: same pattern as above, for
 /// `get_entity_detail_scoped`'s primary entity row.
 #[tokio::test]
-async fn get_entity_detail_scoped_flip_serves_unreconciled_shadow_mutation() {
+async fn get_entity_detail_scoped_reads_shadow_page_directly() {
     let (db, _tmp) = test_db().await;
     let entity_id = db
         .store_entity(
@@ -1210,7 +844,6 @@ async fn get_entity_detail_scoped_flip_serves_unreconciled_shadow_mutation() {
         )
         .await
         .unwrap();
-    stage_c_enable_cutover_clean(&db).await;
     let scope = ReadScope::Space("stage_f_detail_live".to_string());
 
     {
@@ -1224,36 +857,26 @@ async fn get_entity_detail_scoped_flip_serves_unreconciled_shadow_mutation() {
         .unwrap();
     }
 
-    let live = db
+    let detail = db
         .get_entity_detail_scoped(&entity_id, &scope)
         .await
         .unwrap();
     assert_eq!(
-        live.entity.name, "Mutated Detail Title",
-        "flipped read must serve the live shadow mutation before re-reconcile"
-    );
-
-    let report = db.reconcile_entity_page_parity().await.unwrap();
-    assert!(
-        report.drift_count >= 1,
-        "sanity: reconcile must see the drift"
-    );
-
-    let after = db
-        .get_entity_detail_scoped(&entity_id, &scope)
-        .await
-        .unwrap();
-    assert_eq!(
-        after.entity.name, "Stage F Detail Live",
-        "a dirty watermark must serve legacy again"
+        detail.entity.name, "Mutated Detail Title",
+        "get_entity_detail_scoped must read the shadow page's title, not legacy entities.name"
     );
 }
 
-/// Positive control for the RESTRUCTURED relations fn: proves the
-/// hydration overlay reads live shadow state (before re-reconcile), not a
-/// cached value, and falls back to legacy once the watermark goes dirty.
+/// Positive control (G6 Stage 1.5b Part 3): mutating a shadow page's title
+/// directly (without touching `entities`) must be visible through
+/// `list_recent_relations_scoped`, proving the rebuilt join (spec item 7)
+/// reads the mirror -- not legacy `entities.name` -- since there is no flip
+/// left to stamp a watermark under. The former second half of this test
+/// (re-reconcile, then assert a dirty watermark falls back to the legacy
+/// name) no longer holds: the join has no legacy branch left to fall back
+/// to, so that assertion would now be simply wrong, not merely untested.
 #[tokio::test]
-async fn list_recent_relations_scoped_flip_serves_unreconciled_shadow_mutation() {
+async fn list_recent_relations_scoped_reads_shadow_page_directly() {
     let (db, _tmp) = test_db().await;
     let from = db
         .store_entity(
@@ -1278,7 +901,6 @@ async fn list_recent_relations_scoped_flip_serves_unreconciled_shadow_mutation()
     db.create_relation(&from, &to, "related_to", None, None, None, None)
         .await
         .unwrap();
-    stage_c_enable_cutover_clean(&db).await;
     let scope = ReadScope::Space("stage_f_relation_live".to_string());
 
     {
@@ -1299,32 +921,17 @@ async fn list_recent_relations_scoped_flip_serves_unreconciled_shadow_mutation()
     assert_eq!(live.len(), 1);
     assert_eq!(
         live[0].from_entity_name, "Mutated From Title",
-        "the hydration overlay must serve the live shadow mutation before re-reconcile"
+        "list_recent_relations_scoped must read the shadow page's title, not legacy entities.name"
     );
     assert_eq!(live[0].to_entity_name, "Stage F Relation To");
-
-    let report = db.reconcile_entity_page_parity().await.unwrap();
-    assert!(
-        report.drift_count >= 1,
-        "sanity: reconcile must see the drift"
-    );
-
-    let after = db
-        .list_recent_relations_scoped(20, None, &scope)
-        .await
-        .unwrap();
-    assert_eq!(
-        after[0].from_entity_name, "Stage F Relation From",
-        "a dirty watermark must fall back to legacy for the overlay too"
-    );
 }
 
-/// Positive control for the RESTRUCTURED vector fn: proves the hydration
-/// overlay reads live shadow state for every mirrored field
-/// (name/entity_type/confidence/confirmed) before re-reconcile, and falls
-/// back to legacy once the watermark goes dirty.
+/// Positive control: proves the hydration overlay reads live shadow state
+/// for every mirrored field (name/entity_type/confidence/confirmed)
+/// unconditionally (G6 Stage 1.5b Part 3 collapsed the gate this overlay
+/// used to sit behind -- spec item 9).
 #[tokio::test]
-async fn search_entities_by_vector_scoped_flip_serves_unreconciled_shadow_mutation() {
+async fn search_entities_by_vector_scoped_reads_shadow_page_directly() {
     let (db, _tmp) = test_db().await;
     let entity_id = db
         .store_entity(
@@ -1336,7 +943,6 @@ async fn search_entities_by_vector_scoped_flip_serves_unreconciled_shadow_mutati
         )
         .await
         .unwrap();
-    stage_c_enable_cutover_clean(&db).await;
     let scope = ReadScope::Space("stage_f_vector_live".to_string());
 
     {
@@ -1351,28 +957,13 @@ async fn search_entities_by_vector_scoped_flip_serves_unreconciled_shadow_mutati
         .unwrap();
     }
 
-    let live = db
+    let results = db
         .search_entities_by_vector_scoped("stage f vector live query", 5, &scope)
         .await
         .unwrap();
-    assert_eq!(live.len(), 1);
-    assert_eq!(live[0].entity.name, "Mutated Vector Title");
-    assert_eq!(live[0].entity.entity_type, "organization");
-    assert_eq!(live[0].entity.confidence, Some(0.75));
-    assert!(live[0].entity.confirmed);
-
-    let report = db.reconcile_entity_page_parity().await.unwrap();
-    assert!(
-        report.drift_count >= 1,
-        "sanity: reconcile must see the drift"
-    );
-
-    let after = db
-        .search_entities_by_vector_scoped("stage f vector live query", 5, &scope)
-        .await
-        .unwrap();
-    assert_eq!(after[0].entity.name, "Stage F Vector Live");
-    assert_eq!(after[0].entity.entity_type, "project");
-    assert_eq!(after[0].entity.confidence, Some(0.5));
-    assert!(!after[0].entity.confirmed);
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].entity.name, "Mutated Vector Title");
+    assert_eq!(results[0].entity.entity_type, "organization");
+    assert_eq!(results[0].entity.confidence, Some(0.75));
+    assert!(results[0].entity.confirmed);
 }

--- a/crates/wenlan-core/src/derived_artifact_state.rs
+++ b/crates/wenlan-core/src/derived_artifact_state.rs
@@ -7,22 +7,34 @@ pub(crate) fn summary_eligible_predicate(alias: &str) -> String {
     let durable_gate = crate::db::community_reader_durable_gate_sql(
         crate::db::COMMUNITY_SUMMARY_ELIGIBILITY_CONSUMER,
     );
+    // G6 Stage 1.5b Part 3: reads `community_id` off the entity's `kind='entity'`
+    // shadow page via `entity_page_map`/`pages` rather than `entities` directly
+    // (unconditional hard cutover, same program contract as `load_summary_buckets`
+    // above) -- the column is mirrored 1:1 off `entities.community_id` by
+    // `insert_entity_shadow_page`/`update_entity_shadow_page`.
     let legacy = format!(
         "{alias}.entity_id IN (
-             SELECT owner.id FROM entities owner
+             SELECT owner_epm.entity_id
+               FROM entity_page_map owner_epm
+               JOIN pages owner_p
+                 ON owner_p.id=owner_epm.page_id
+                AND owner_p.kind='entity' AND owner_p.status='active'
              JOIN (
-                 SELECT peer_entity.community_id
+                 SELECT peer_p.community_id
                    FROM memories peer
-                   JOIN entities peer_entity ON peer.entity_id=peer_entity.id
+                   JOIN entity_page_map peer_epm ON peer.entity_id=peer_epm.entity_id
+                   JOIN pages peer_p
+                     ON peer_p.id=peer_epm.page_id
+                    AND peer_p.kind='entity' AND peer_p.status='active'
                   WHERE peer.source='memory' AND peer.chunk_index=0
                     AND peer.is_recap=0 AND peer.supersede_mode<>'archive'
                     AND peer.source_id NOT LIKE 'merged_%'
                     AND peer.source_id NOT LIKE 'recap_%'
                     AND peer.embedding IS NOT NULL
-                    AND peer_entity.community_id IS NOT NULL
-                  GROUP BY peer_entity.community_id
+                    AND peer_p.community_id IS NOT NULL
+                  GROUP BY peer_p.community_id
                  HAVING COUNT(*) >= {minimum}
-             ) eligible ON eligible.community_id=owner.community_id
+             ) eligible ON eligible.community_id=owner_p.community_id
          )"
     );
     let durable = format!(
@@ -189,6 +201,15 @@ mod tests {
         )
         .await
         .unwrap();
+        drop(conn);
+        // G6 Stage 1.5b Part 3: `summary_eligible_predicate`'s legacy branch now
+        // reads `community_id` off the entity's shadow page, so the raw-SQL
+        // `entities` inserts above need a shadow page each (test helper for
+        // exactly this).
+        for entity_id in ["large-a", "large-b", "large-c", "small-a", "small-b"] {
+            db.test_seed_entity_shadow_page(entity_id).await.unwrap();
+        }
+        let conn = db.test_primary_session().await;
         let vector = format!(
             "[{}]",
             std::iter::repeat_n("0", 768).collect::<Vec<_>>().join(",")

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -521,6 +521,7 @@ crates/wenlan-core/src/lint/runtime_test.rs|crate::lint::runtime::tests::missing
 crates/wenlan-core/src/lint/runtime_test.rs|crate::lint::runtime::tests::missing_memories_is_schema_finding_with_only_dependent_status_incomplete|test_primary_session|1
 crates/wenlan-core/src/lint/runtime_test.rs|crate::lint::runtime::tests::schema_and_index_fixtures_fail_loud_without_status_rescue|TestDbSession::execute_batch|1
 crates/wenlan-core/src/lint/runtime_test.rs|crate::lint::runtime::tests::schema_and_index_fixtures_fail_loud_without_status_rescue|test_primary_session|1
+crates/wenlan-core/src/lint/semantic_candidates.rs|crate::lint::semantic::candidates::scope_matches_tests::uncategorized_scope_selects_the_unfiled_sentinel_entity|open_isolated_lint_snapshot_for_test|1
 crates/wenlan-core/src/lint/semantic_test.rs|crate::lint::semantic::tests::approved_link_repair_removes_candidate_on_rerun|TestDbSession::execute|1
 crates/wenlan-core/src/lint/semantic_test.rs|crate::lint::semantic::tests::approved_link_repair_removes_candidate_on_rerun|TestDbSession::execute_batch|1
 crates/wenlan-core/src/lint/semantic_test.rs|crate::lint::semantic::tests::approved_link_repair_removes_candidate_on_rerun|test_primary_session|1
@@ -597,6 +598,7 @@ crates/wenlan-core/src/derived_artifact_state.rs|crate::derived_artifact_state::
 crates/wenlan-core/src/derived_artifact_state.rs|crate::derived_artifact_state::tests::summary_eligibility_requires_a_qualifying_community_and_candidate|TestDbSession::execute_batch|1
 crates/wenlan-core/src/derived_artifact_state.rs|crate::derived_artifact_state::tests::summary_eligibility_requires_a_qualifying_community_and_candidate|TestDbSession::query|1
 crates/wenlan-core/src/derived_artifact_state.rs|crate::derived_artifact_state::tests::summary_eligibility_requires_a_qualifying_community_and_candidate|test_primary_session|1
+crates/wenlan-core/src/derived_artifact_state.rs|crate::derived_artifact_state::tests::summary_eligibility_requires_a_qualifying_community_and_candidate|test_primary_session|2
 crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::assert_corrupt_prepared_generation_is_replaced|TestDbSession::execute|1
 crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::assert_corrupt_prepared_generation_is_replaced|TestDbSession::execute|2
 crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::assert_corrupt_prepared_generation_is_replaced|TestDbSession::execute|3

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,11 +3229,15 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        1005,
+        1007,
         "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
          the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, \
-         the 8 G6 BindPageLink repair-test calls, and the 9 G6 Stage 1.5a \
-         raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard calls"
+         the 8 G6 BindPageLink repair-test calls, the 9 G6 Stage 1.5a \
+         raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard calls, \
+         the 1 G6 Stage 1.5b uncategorized_scope_selects_the_unfiled_sentinel_entity call, and \
+         the 1 G6 Stage 1.5b Part 3 second test_primary_session re-acquire in \
+         summary_eligibility_requires_a_qualifying_community_and_candidate (drop/reseed/reacquire \
+         around test_seed_entity_shadow_page's internal conn lock)"
     );
 }
 

--- a/crates/wenlan-core/src/lint/deep.rs
+++ b/crates/wenlan-core/src/lint/deep.rs
@@ -86,14 +86,16 @@ pub(super) async fn run(
     ]
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The scope clause below
-// filters on `e.space` directly (nullable legacy `entities.space`); the
-// shadow-page mirror folds NULL to the `UNFILED_SPACE_ID` sentinel, so a
-// migrated read would silently change which rows a space-scoped query
-// matches. Stays on `entities` until the space-sentinel audit (spec's 1.5b
-// decision record).
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `e.space` now uses `scope_clause_folded`,
+// sentinel-aware. The `entity_aliases`/`entities` join itself is a separate,
+// still-legacy concern. 1.5b Part 3 (item 8) disposition: not a
+// reader-migration target -- this audits the legacy `entities` store's own
+// data quality, and reading the shadow-page mirror instead would validate
+// the mirror rather than the store it exists to check. Stays on `entities`
+// until Stage 2 retires the store itself.
 async fn alias_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (scope, params) = scope_clause(context.scope().filter(), "e.space", true);
+    let (scope, params) = scope_clause_folded(context.scope().filter(), "e.space", true);
     rows(
         context,
         &format!(
@@ -215,15 +217,17 @@ async fn structured_conflicts(context: &LintContext<'_, '_>) -> Result<RowCheck,
     .await
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated (entity-existence side
-// -- observation content itself is out of scope for this stage regardless,
-// see the spec's 1.5b observations ruling). The scope clause below filters
-// on `e.space` directly; the shadow-page mirror folds NULL to the
-// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
-// which rows a space-scoped query matches. Stays on `entities` until the
-// space-sentinel audit.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `e.space` now uses `scope_clause_folded`,
+// sentinel-aware (entity-existence side only -- observation content itself
+// is out of scope for this stage regardless, see the spec's 1.5b
+// observations ruling). 1.5b Part 3 (item 8) disposition: not a
+// reader-migration target -- this audits the legacy `entities` store's own
+// data quality, and reading the shadow-page mirror instead would validate
+// the mirror rather than the store it exists to check. Stays on `entities`
+// until Stage 2 retires the store itself.
 async fn observation_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (scope, params) = scope_clause(context.scope().filter(), "e.space", true);
+    let (scope, params) = scope_clause_folded(context.scope().filter(), "e.space", true);
     rows(
         context,
         &format!(
@@ -266,14 +270,16 @@ async fn page_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> 
     .await
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The scope clause below
-// filters on `f.space` directly (nullable legacy `entities.space` via the
-// src-entity alias); the shadow-page mirror folds NULL to the
-// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
-// which rows a space-scoped query matches. Stays on `entities` until the
-// space-sentinel audit.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `f.space` (the src-entity alias) now uses
+// `scope_clause_folded`, sentinel-aware. The `entities` join itself is a
+// separate, still-legacy concern. 1.5b Part 3 (item 8) disposition: not a
+// reader-migration target -- this audits the legacy `entities` store's own
+// data quality, and reading the shadow-page mirror instead would validate
+// the mirror rather than the store it exists to check. Stays on `entities`
+// until Stage 2 retires the store itself.
 async fn relation_vocabulary(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (scope, params) = scope_clause(context.scope().filter(), "f.space", true);
+    let (scope, params) = scope_clause_folded(context.scope().filter(), "f.space", true);
     rows(
         context,
         &format!(
@@ -603,6 +609,38 @@ fn scope_clause(
         ScopeFilter::Uncategorized => (
             format!(
                 " AND {column} IS NULL{}",
+                if exclude_missing_owner {
+                    format!(
+                        " AND {} IS NOT NULL",
+                        column.trim_end_matches(".space").to_owned() + ".id"
+                    )
+                } else {
+                    String::new()
+                }
+            ),
+            libsql::params::Params::None,
+        ),
+    }
+}
+
+/// Same as `scope_clause`, but for an `entities.space` column folded by the
+/// 1.5b space-sentinel migration: an unfiled row stores `UNFILED_SPACE_ID`,
+/// not SQL NULL, so `Uncategorized` must match either.
+fn scope_clause_folded(
+    scope: &ScopeFilter,
+    column: &str,
+    exclude_missing_owner: bool,
+) -> (String, libsql::params::Params) {
+    match scope {
+        ScopeFilter::Global => (String::new(), libsql::params::Params::None),
+        ScopeFilter::Registered(value) => (
+            format!(" AND {column}=?1"),
+            libsql::params::Params::Positional(vec![libsql::Value::Text(value.clone())]),
+        ),
+        ScopeFilter::Uncategorized => (
+            format!(
+                " AND ({column} IS NULL OR {column} = '{}'){}",
+                crate::db::UNFILED_SPACE_ID,
                 if exclude_missing_owner {
                     format!(
                         " AND {} IS NOT NULL",

--- a/crates/wenlan-core/src/lint/kg/query.rs
+++ b/crates/wenlan-core/src/lint/kg/query.rs
@@ -45,41 +45,45 @@ pub(super) async fn load(context: &LintContext<'_, '_>, hub_cap: u64) -> Result<
     })
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The `e.space IS NOT
-// NULL AND NOT EXISTS(spaces…)` body below is not merely imprecise under the
-// shadow-page mirror -- it goes VACUOUSLY TRUE for every row. The mirror
-// folds NULL `entities.space` to the `UNFILED_SPACE_ID` sentinel on the page
-// row, so a shadow-page read would always see space as non-NULL, and the
-// sentinel never matches a real `spaces.name` row; every entity would flag
-// as a false integrity violation, not just a subtly different one. Stays on
-// `entities` until the space-sentinel audit (spec's 1.5b decision record).
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: the scope clause now uses `scope_clause_folded`, and
+// the integrity predicate excludes the `UNFILED_SPACE_ID` sentinel itself
+// (never a registered `spaces.name`) so a folded unfiled entity no longer
+// vacuously flags as an integrity violation. 1.5b Part 3 (item 8)
+// disposition: not a reader-migration target -- this audits the legacy
+// `entities` store's own data quality, and reading the shadow-page mirror
+// instead would validate the mirror rather than the store it exists to
+// check. Stays on `entities` until Stage 2 retires the store itself.
 async fn entity_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (clause, params) = scope_clause(context.scope().filter(), "e", false);
+    let (clause, params) = scope_clause_folded(context.scope().filter(), "e", false);
     row_check(
         context,
         &format!(
             "SELECT CASE WHEN TRIM(e.name)='' OR TRIM(e.entity_type)=''
                     OR COALESCE(e.confirmed,-1) NOT IN (0,1)
                     OR (e.confidence IS NOT NULL AND (e.confidence < 0 OR e.confidence > 1))
-                    OR (e.space IS NOT NULL AND NOT EXISTS(
+                    OR (e.space IS NOT NULL AND e.space != '{}' AND NOT EXISTS(
                         SELECT 1 FROM spaces s WHERE s.name=e.space))
                   THEN 1 ELSE 0 END
-               FROM entities e{clause} ORDER BY e.id"
+               FROM entities e{clause} ORDER BY e.id",
+            crate::db::UNFILED_SPACE_ID
         ),
         params,
     )
     .await
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated (entity-existence side
-// -- observation content itself is out of scope for this stage regardless,
-// see the spec's 1.5b observations ruling). `scope_clause` below filters on
-// `e.space`/`e.id` directly against `entities`; the shadow-page mirror folds
-// NULL `entities.space` to the `UNFILED_SPACE_ID` sentinel, so a migrated
-// read would silently change which rows a space-scoped query matches. Stays
-// on `entities` until the space-sentinel audit.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `e.space`/`e.id` now uses `scope_clause_folded`,
+// sentinel-aware (entity-existence side only -- observation content itself
+// is out of scope for this stage regardless, see the spec's 1.5b
+// observations ruling). 1.5b Part 3 (item 8) disposition: not a
+// reader-migration target -- this audits the legacy `entities` store's own
+// data quality, and reading the shadow-page mirror instead would validate
+// the mirror rather than the store it exists to check. Stays on `entities`
+// until Stage 2 retires the store itself.
 async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (clause, params) = scope_clause(context.scope().filter(), "e", true);
+    let (clause, params) = scope_clause_folded(context.scope().filter(), "e", true);
     row_check(
         context,
         &format!(
@@ -95,14 +99,15 @@ async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck
     .await
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. `scope_clause` below
-// filters on `f.space`/`f.id` (the src-entity alias) directly against
-// `entities`; the shadow-page mirror folds NULL `entities.space` to the
-// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
-// which rows a space-scoped query matches. Stays on `entities` until the
-// space-sentinel audit.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `f.space`/`f.id` (the src-entity alias) now uses
+// `scope_clause_folded`, sentinel-aware. 1.5b Part 3 (item 8) disposition:
+// not a reader-migration target -- this audits the legacy `entities`
+// store's own data quality, and reading the shadow-page mirror instead
+// would validate the mirror rather than the store it exists to check.
+// Stays on `entities` until Stage 2 retires the store itself.
 async fn relation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (clause, params) = scope_clause(context.scope().filter(), "f", true);
+    let (clause, params) = scope_clause_folded(context.scope().filter(), "f", true);
     row_check(
         context,
         &format!(
@@ -186,6 +191,35 @@ pub(super) fn scope_clause(
         ScopeFilter::Uncategorized => (
             format!(
                 " WHERE {alias}.space IS NULL{}",
+                if exclude_missing_owner {
+                    format!(" AND {alias}.id IS NOT NULL")
+                } else {
+                    String::new()
+                }
+            ),
+            libsql::params::Params::None,
+        ),
+    }
+}
+
+/// Same as `scope_clause`, but for an `entities.space` alias folded by the
+/// 1.5b space-sentinel migration: an unfiled row stores `UNFILED_SPACE_ID`,
+/// not SQL NULL, so `Uncategorized` must match either.
+pub(super) fn scope_clause_folded(
+    scope: &ScopeFilter,
+    alias: &str,
+    exclude_missing_owner: bool,
+) -> (String, libsql::params::Params) {
+    match scope {
+        ScopeFilter::Global => (String::new(), libsql::params::Params::None),
+        ScopeFilter::Registered(space) => (
+            format!(" WHERE {alias}.space=?1"),
+            libsql::params::Params::Positional(vec![libsql::Value::Text(space.clone())]),
+        ),
+        ScopeFilter::Uncategorized => (
+            format!(
+                " WHERE ({alias}.space IS NULL OR {alias}.space = '{}'){}",
+                crate::db::UNFILED_SPACE_ID,
                 if exclude_missing_owner {
                     format!(" AND {alias}.id IS NOT NULL")
                 } else {

--- a/crates/wenlan-core/src/lint/kg/query/aggregate.rs
+++ b/crates/wenlan-core/src/lint/kg/query/aggregate.rs
@@ -1,4 +1,4 @@
-use super::scope_clause;
+use super::{scope_clause, scope_clause_folded};
 use crate::lint::context::LintContext;
 use wenlan_types::lint::{LintMetric, LintMetricCode, LintMetricValue};
 
@@ -27,28 +27,28 @@ impl AggregateCounts {
     }
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. This is a space-count
-// partition, not a well-formedness check -- `KgEntitiesScoped` vs
-// `KgEntitiesUncategorized` IS the NULL-vs-non-NULL `entities.space` split.
-// The shadow-page mirror folds NULL to the `UNFILED_SPACE_ID` sentinel, so a
-// migrated read would see `pages.space` as never NULL and
-// `KgEntitiesUncategorized` would always report 0. Known transitional skew:
-// the `KgEntities` metric emitted here is legacy-derived (`COUNT(*) FROM
-// entities`), while `aggregate_counts` below emits the same metric code
-// shadow-derived (`entity_page_map` JOIN `pages`) -- the two only diverge if
-// the mirror invariant breaks. This function retires with the `entities`
-// store, not before.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `KgEntitiesScoped` vs `KgEntitiesUncategorized` is
+// still the "has a real space" vs "unfiled" split -- the SUM predicates below
+// now test against the `UNFILED_SPACE_ID` sentinel too, so a folded row keeps
+// classifying as Uncategorized instead of silently reporting 0. Known
+// transitional skew: the `KgEntities` metric emitted here is legacy-derived
+// (`COUNT(*) FROM entities`), while `aggregate_counts` below emits the same
+// metric code shadow-derived (`entity_page_map` JOIN `pages`) -- the two only
+// diverge if the mirror invariant breaks. This function retires with the
+// `entities` store, not before.
 pub(super) async fn entity_partitions(
     context: &LintContext<'_, '_>,
 ) -> Result<Vec<LintMetric>, ()> {
-    let (clause, params) = scope_clause(context.scope().filter(), "e", false);
+    let (clause, params) = scope_clause_folded(context.scope().filter(), "e", false);
     let values = scalar_row(
         context,
         &format!(
             "SELECT COUNT(*), SUM(CASE WHEN e.confirmed=1 THEN 1 ELSE 0 END),
-                    SUM(CASE WHEN e.space IS NOT NULL THEN 1 ELSE 0 END),
-                    SUM(CASE WHEN e.space IS NULL THEN 1 ELSE 0 END)
-               FROM entities e{clause}"
+                    SUM(CASE WHEN e.space IS NOT NULL AND e.space != '{unfiled}' THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN e.space IS NULL OR e.space = '{unfiled}' THEN 1 ELSE 0 END)
+               FROM entities e{clause}",
+            unfiled = crate::db::UNFILED_SPACE_ID
         ),
         params,
         4,

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -226,7 +226,7 @@ async fn seed_corrupt_graph(db: &crate::db::MemoryDB) {
     let conn = db.test_primary_session().await;
     conn.execute("PRAGMA foreign_keys = OFF", ()).await.unwrap();
     conn.execute_batch(
-        "INSERT INTO entities (id,name,entity_type,space,confidence,confirmed,created_at,updated_at) VALUES ('entity-ok','Secret Entity','concept',NULL,0.8,0,1,1),('entity-bad',' ','', 'missing-space',1.5,2,1,1);
+        "INSERT INTO entities (id,name,entity_type,space,confidence,confirmed,created_at,updated_at) VALUES ('entity-ok','Secret Entity','concept','00000000-0000-4000-8000-000000000001',0.8,0,1,1),('entity-bad',' ','', 'missing-space',1.5,2,1,1);
          INSERT INTO observations (id,entity_id,content,confidence,confirmed,created_at) VALUES ('obs-orphan','missing-id','secret observation',0.5,0,1),('obs-invalid','entity-ok',' ',2.0,2,1);
          INSERT INTO relations (id,from_entity,to_entity,relation_type,created_at) VALUES ('relation-from','missing-id','entity-ok','secret_relation',1),('relation-to','entity-ok','missing-id','secret_relation',1);
          INSERT INTO memory_entities (memory_id,entity_id) VALUES ('missing-id','entity-ok'),('memory-ok','missing-id'),('entity-ok','entity-ok');

--- a/crates/wenlan-core/src/lint/semantic_candidates.rs
+++ b/crates/wenlan-core/src/lint/semantic_candidates.rs
@@ -753,7 +753,16 @@ async fn load_entities(context: &LintContext<'_, '_>) -> Result<Vec<Entity>, ()>
     ).await.map_err(|_| ())?;
     let mut output = Vec::new();
     while let Some(row) = rows.next().await.map_err(|_| ())? {
-        let space: Option<String> = row.get(2).map_err(|_| ())?;
+        // G6 Stage 1.5b: `entities.space` is NOT NULL as of the space-sentinel
+        // fold migration, so an unfiled entity now carries the reserved
+        // `UNFILED_SPACE_ID` sentinel rather than NULL. Translate it back to
+        // None here, same as load_memories already does for `m.space` (M3
+        // PR-1 stage e), so scope_matches's Uncategorized branch still sees
+        // "no space" as None instead of the sentinel.
+        let space: Option<String> = row
+            .get::<Option<String>>(2)
+            .map_err(|_| ())?
+            .filter(|s| s != crate::db::UNFILED_SPACE_ID);
         output.push(Entity {
             id: row.get(0).map_err(|_| ())?,
             name: row.get(1).map_err(|_| ())?,
@@ -766,6 +775,7 @@ async fn load_entities(context: &LintContext<'_, '_>) -> Result<Vec<Entity>, ()>
 
 fn entity_scope_clause(scope: &ScopeFilter) -> (String, libsql::params::Params) {
     let memory_filter = "m.source='memory' AND m.pending_revision=0 AND COALESCE(m.is_recap,0)=0 AND m.supersede_mode!='evicted'";
+    let unfiled = crate::db::UNFILED_SPACE_ID;
     match scope {
         ScopeFilter::Global => (String::new(), libsql::params::Params::None),
         ScopeFilter::Registered(value) => (
@@ -785,9 +795,14 @@ fn entity_scope_clause(scope: &ScopeFilter) -> (String, libsql::params::Params) 
             ),
             libsql::params::Params::Positional(vec![libsql::Value::Text(value.clone())]),
         ),
+        // G6 Stage 1.5b: `entities.space` is folded (never NULL; unfiled rows
+        // carry `UNFILED_SPACE_ID`), so the `e.space`/`source.space` legs
+        // below match the sentinel too. `m.space` is untouched here — that's
+        // `memories.space`'s own pre-existing fold (M3 PR-1 stage e),
+        // unrelated to this migration.
         ScopeFilter::Uncategorized => (
             format!(
-                " AND (e.space IS NULL
+                " AND ((e.space IS NULL OR e.space = '{unfiled}')
                     OR e.id IN (
                         SELECT me.entity_id FROM memory_entities me
                         JOIN memories m ON m.source_id=me.memory_id
@@ -797,7 +812,7 @@ fn entity_scope_clause(scope: &ScopeFilter) -> (String, libsql::params::Params) 
                         SELECT r.dst_id FROM edges r
                         JOIN entities source ON source.id=r.src_id
                         WHERE r.edge_type='relates' AND r.valid_until IS NULL
-                          AND source.space IS NULL
+                          AND (source.space IS NULL OR source.space = '{unfiled}')
                     ))"
             ),
             libsql::params::Params::None,
@@ -828,14 +843,19 @@ async fn load_memory_entity_links(
     Ok(output)
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. `scope_clause` below
-// filters on `source.space` (the src-entity alias) directly against
-// `entities`; the shadow-page mirror folds NULL `entities.space` to the
-// `UNFILED_SPACE_ID` sentinel, so a migrated read would silently change
-// which rows a space-scoped query matches. Stays on `entities` until the
-// space-sentinel audit.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: `source.space` now uses `scope_clause_folded`,
+// sentinel-aware. The `source`-aliased `entities` join itself is a separate,
+// still-legacy concern. 1.5b Part 3 (item 8) disposition, correcting the
+// note above: NOT a reader-migration target -- Part 3's 9-item list (spec
+// `docs/plans/2026-08-05-g6-stage15b-entity-reader-completion-spec.md`)
+// does not name this function. Like its `lint/deep.rs`/`lint/kg/query.rs`
+// siblings, this audits the legacy `entities` store's own data quality;
+// reading the shadow-page mirror instead would validate the mirror rather
+// than the store it exists to check. Stays on `entities` until Stage 2
+// retires the store itself.
 async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<Relation>, ()> {
-    let (scope, params) = scope_clause(context.scope().filter(), "source.space");
+    let (scope, params) = scope_clause_folded(context.scope().filter(), "source.space");
     let mut rows = context.snapshot().query(
         &format!("SELECT r.src_id,r.dst_id,r.semantic_type FROM edges r JOIN entities source ON source.id=r.src_id WHERE r.edge_type='relates' AND r.valid_until IS NULL AND r.semantic_type IS NOT NULL{scope} ORDER BY r.src_id,r.dst_id,r.edge_id"),
         params,
@@ -908,6 +928,27 @@ fn scope_clause(scope: &ScopeFilter, column: &str) -> (String, libsql::params::P
         ),
         ScopeFilter::Uncategorized => (
             format!(" AND {column} IS NULL"),
+            libsql::params::Params::None,
+        ),
+    }
+}
+
+/// Same as `scope_clause`, but for an `entities.space` column folded by the
+/// 1.5b space-sentinel migration: an unfiled row stores `UNFILED_SPACE_ID`,
+/// not SQL NULL, so `Uncategorized` must match either. Mirrors
+/// `push_read_scope_filter_folded` (db.rs).
+fn scope_clause_folded(scope: &ScopeFilter, column: &str) -> (String, libsql::params::Params) {
+    match scope {
+        ScopeFilter::Global => (String::new(), libsql::params::Params::None),
+        ScopeFilter::Registered(value) => (
+            format!(" AND {column}=?1"),
+            libsql::params::Params::Positional(vec![libsql::Value::Text(value.clone())]),
+        ),
+        ScopeFilter::Uncategorized => (
+            format!(
+                " AND ({column} IS NULL OR {column} = '{}')",
+                crate::db::UNFILED_SPACE_ID
+            ),
             libsql::params::Params::None,
         ),
     }
@@ -1248,5 +1289,66 @@ mod excerpt_tests {
 
         assert_eq!(excerpt, "[lint_context scope=redacted]\nvisible evidence");
         assert!(!excerpt.contains("/Users/alice"));
+    }
+}
+
+#[cfg(test)]
+mod scope_matches_tests {
+    use super::load_entities;
+    use crate::db::tests::test_db;
+    use crate::lint::context::{
+        AppliedScope, CancellationToken, ExecutionGate, LintClock, LintContext,
+    };
+
+    /// G6 Stage 1.5b Part 2 (space-sentinel fold, migration 118): pins
+    /// `scope_matches`'s Uncategorized branch against the folded sentinel via
+    /// its real consumer, `load_entities`/`entity_scope_clause`. An unfiled
+    /// entity now stores `UNFILED_SPACE_ID` in `entities.space`, never NULL;
+    /// without the sentinel-aware translation this entity would silently
+    /// drop out of "uncategorized" scope after the fold.
+    #[tokio::test]
+    async fn uncategorized_scope_selects_the_unfiled_sentinel_entity() {
+        let (db, _tmp) = test_db().await;
+        let unfiled_id = db
+            .store_entity("G6 Unfiled", "person", None, None, None)
+            .await
+            .unwrap();
+        let filed_id = db
+            .store_entity("G6 Filed", "person", Some("space_a"), None, None)
+            .await
+            .unwrap();
+
+        let snapshot = db
+            .open_isolated_lint_snapshot_for_test()
+            .await
+            .expect("snapshot");
+        let scope = AppliedScope::uncategorized();
+        let clock = LintClock::fixed();
+        let gate = ExecutionGate::new(CancellationToken::new());
+        let context = LintContext::new(
+            &snapshot,
+            &scope,
+            None,
+            &clock,
+            &gate,
+            wenlan_types::lint::LintProfile::General,
+        );
+
+        let entities = load_entities(&context).await.expect("load_entities");
+
+        let unfiled = entities
+            .iter()
+            .find(|e| e.id == unfiled_id)
+            .expect("unfiled entity must be visible under Uncategorized scope");
+        assert!(
+            unfiled.selected,
+            "the unfiled sentinel entity must be selected under Uncategorized scope"
+        );
+        assert!(
+            entities.iter().all(|e| e.id != filed_id),
+            "a space-filed entity must not appear under Uncategorized scope"
+        );
+
+        snapshot.finish().await.expect("finish snapshot");
     }
 }

--- a/crates/wenlan-core/src/repair.rs
+++ b/crates/wenlan-core/src/repair.rs
@@ -4706,12 +4706,14 @@ fn decode_entity_extraction_space(encoded: &str) -> Result<Option<String>, Wenla
         .map_err(|_| WenlanError::Validation("repair_target_schema_mismatch".to_string()))
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated. The `(?2 IS NULL AND
-// space IS NULL) OR space=?2` guard below distinguishes a literal NULL
-// `entities.space` from a registered space; the shadow-page mirror folds
-// NULL to the `UNFILED_SPACE_ID` sentinel, so a migrated read would silently
-// change which rows validate. Stays on `entities` until the space-sentinel
-// audit.
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: the `(?2 IS NULL AND (space IS NULL OR space =
+// sentinel)) OR space=?2` guard below now matches a folded `entities.space`
+// too, so an "expects uncategorized" caller (`space=None`) still validates
+// against a row now carrying the `UNFILED_SPACE_ID` sentinel. 1.5b Part 3
+// (item 8) disposition: writer-coupled discovery read, not a reader-migration
+// target -- re-verifies rows a caller is about to hand to `store_entity`
+// et al, so it flips with those writers in Stage 2, not ahead of them.
 async fn validate_selected_entities_on_snapshot(
     snapshot: &LintReadSnapshot<'_>,
     entity_ids: &[String],
@@ -4721,7 +4723,7 @@ async fn validate_selected_entities_on_snapshot(
         let mut rows = snapshot
             .query(
                 "SELECT 1 FROM entities
-                 WHERE id=?1 AND ((?2 IS NULL AND space IS NULL) OR space=?2)
+                 WHERE id=?1 AND ((?2 IS NULL AND (space IS NULL OR space = '00000000-0000-4000-8000-000000000001')) OR space=?2)
                  LIMIT 2",
                 libsql::params::Params::Positional(vec![
                     libsql::Value::Text(entity_id.clone()),
@@ -4741,14 +4743,13 @@ async fn validate_selected_entities_on_snapshot(
     Ok(())
 }
 
-// G6 Stage 1.5a carryover (2026-08-05): NOT migrated, for two independent
-// reasons. (1) Same space-sentinel trap as the snapshot variant above -- the
-// `(?2 IS NULL AND space IS NULL) OR space=?2` guard distinguishes a literal
-// NULL `entities.space` from a registered space, which the shadow-page
-// mirror's NULL-to-sentinel fold would silently change. (2) This variant
-// runs on the shared-mutex connection inside the entity-extraction repair's
-// own `BEGIN IMMEDIATE` (`db/repair_memory_cas.rs`), re-verifying entities
-// that repair batch itself just wrote -- Stage-2 writer-batch alignment, NOT
+// G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
+// space-sentinel fold: the `(?2 IS NULL AND (space IS NULL OR space =
+// sentinel)) OR space=?2` guard below now matches a folded `entities.space`
+// too, same fix as the snapshot variant above. This variant runs on the
+// shared-mutex connection inside the entity-extraction repair's own `BEGIN
+// IMMEDIATE` (`db/repair_memory_cas.rs`), re-verifying entities that repair
+// batch itself just wrote -- Stage-2 writer-batch alignment, NOT
 // connection-level coupling (the shared-mutex conn can never see uncommitted
 // foreign state from another writer). Flips with `store_entity` in Stage 2.
 pub(crate) async fn validate_selected_entities_on_connection(
@@ -4760,7 +4761,7 @@ pub(crate) async fn validate_selected_entities_on_connection(
         let mut rows = connection
             .query(
                 "SELECT 1 FROM entities
-                 WHERE id=?1 AND ((?2 IS NULL AND space IS NULL) OR space=?2)
+                 WHERE id=?1 AND ((?2 IS NULL AND (space IS NULL OR space = '00000000-0000-4000-8000-000000000001')) OR space=?2)
                  LIMIT 2",
                 libsql::params![entity_id.clone(), space.map(str::to_string)],
             )

--- a/crates/wenlan-core/src/space_context.rs
+++ b/crates/wenlan-core/src/space_context.rs
@@ -19,6 +19,18 @@ impl ResolvedWriteSpace {
     }
 }
 
+/// Normalizes a folded space column at the wire boundary: an unfiled row
+/// (`entities.space` as of the G6 Stage 1.5b Part 2 space-sentinel fold,
+/// same as the earlier `memories.space`/`pages.workspace` folds) stores
+/// `UNFILED_SPACE_ID`, never SQL NULL -- but the external wire contract for
+/// "unfiled" stays `null`. `wenlan-server`'s HTTP routes never call this
+/// directly: they read already-normalized values from `entity_from_row`
+/// (`db/scoped_entities.rs`), which is the sole crate-boundary crossing --
+/// every call site lives inside `wenlan-core`.
+pub(crate) fn normalize_unfiled_space(space: Option<String>) -> Option<String> {
+    space.filter(|value| value != crate::db::UNFILED_SPACE_ID)
+}
+
 #[derive(Debug)]
 pub struct LegacyDefaultImport {
     pub already_processed: bool,
@@ -33,6 +45,29 @@ mod tests {
     use crate::events::NoopEmitter;
     use crate::WenlanError;
     use wenlan_types::{WriteSpaceSource, WriteSpaceTarget};
+
+    /// G6 Stage 1.5b Part 2 pin test: `normalize_unfiled_space` must fold
+    /// the `UNFILED_SPACE_ID` sentinel back to `None` (so the wire contract
+    /// keeps `null` for "unfiled") while leaving a real space name and an
+    /// already-`None` value untouched.
+    #[test]
+    fn normalize_unfiled_space_folds_sentinel_to_none() {
+        assert_eq!(
+            super::normalize_unfiled_space(Some(UNFILED_SPACE_ID.to_string())),
+            None,
+            "the sentinel must normalize to None at the wire boundary"
+        );
+        assert_eq!(
+            super::normalize_unfiled_space(Some("work".to_string())),
+            Some("work".to_string()),
+            "a real space name must pass through unchanged"
+        );
+        assert_eq!(
+            super::normalize_unfiled_space(None),
+            None,
+            "an already-None value must pass through unchanged"
+        );
+    }
 
     #[tokio::test]
     async fn default_space_set_replace_rename_delete_lifecycle() {

--- a/crates/wenlan-server/tests/entity_graph_route_contracts.rs
+++ b/crates/wenlan-server/tests/entity_graph_route_contracts.rs
@@ -20,6 +20,7 @@ use wenlan_types::responses::{
     AddObservationResponse, CreateEntityResponse, CreateRelationResponse, ListEntitiesResponse,
     SearchEntitiesResponse, SuccessResponse,
 };
+use wenlan_types::{WriteOutcome, WriteSpaceSource, WriteSpaceTarget};
 
 #[derive(Debug, Deserialize)]
 struct ErrorEnvelope {
@@ -394,4 +395,41 @@ async fn moved_entity_graph_handlers_preserve_typed_contracts() {
         );
         assert_eq!(error.error, "Database not initialized");
     }
+}
+
+/// G6 Stage 1.5b Part 2 pin test: the `entities.space` space-sentinel fold
+/// is an internal storage detail -- `POST /api/memory/entities` for an
+/// unfiled entity must still return `space: null` and
+/// `space_source: "uncategorized"` on the wire, exactly as it did when the
+/// column was literal SQL NULL. Locks the wire contract now, ahead of the
+/// writer-side fold migration landing later in the same PR.
+#[tokio::test]
+async fn create_entity_unfiled_reports_null_space_on_wire() {
+    let (router, _tmp, _db) = common::test_app_no_gate().await;
+
+    let request = CreateEntityRequest {
+        name: "Wire Contract Co".to_string(),
+        entity_type: "org".to_string(),
+        space: WriteSpaceTarget::Uncategorized,
+        source_agent: Some("entity-graph-route-contract".to_string()),
+        confidence: Some(0.9),
+    };
+    let (status, created): (StatusCode, CreateEntityResponse) = request_typed(
+        &router,
+        Method::POST,
+        "/api/memory/entities",
+        json_body(&request),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        created.space, None,
+        "an unfiled entity must report space: null on the wire, not the sentinel"
+    );
+    assert_eq!(
+        created.space_source,
+        Some(WriteSpaceSource::Uncategorized),
+        "an unfiled entity must report space_source: uncategorized"
+    );
+    assert_eq!(created.write_outcome, Some(WriteOutcome::Created));
 }

--- a/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
+++ b/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
@@ -898,6 +898,7 @@ carrying the authority of agreement.
 | `core/db.rs::find_matching_page_scoped` | `pub` | no | no | — | — |
 | `core/db.rs::find_stale_archived_pages` | `pub` | no | **yes** | `server/cmd_backfill.rs::run` | — |
 | `core/db.rs::find_unique_active_page_id_by_title_scoped` | `pub` | no | no | — | — |
+| `core/db.rs::get_entity_detail` | `pub` | no | **yes** | `server/entity_graph_routes.rs::handle_create_entity` | — |
 | `core/db.rs::get_entity_name_type` | `pub` | no | **yes** | `server/page_map_routes.rs::compute_ref_state` | — |
 | `core/db.rs::get_page_by_entity` | `pub` | no | no | — | — |
 | `core/db.rs::get_page_inner` | `private` | no | no | — | — |
@@ -905,11 +906,13 @@ carrying the authority of agreement.
 | `core/db.rs::get_stale_page_after` | `pub` | no | no | — | — |
 | `core/db.rs::insert_page_with_kind_inner` | `private` | no | no | — | — |
 | `core/db.rs::list_active_page_titles_scoped` | `pub` | no | no | — | — |
+| `core/db.rs::list_entities` | `pub` | no | no | — | — |
 | `core/db.rs::list_pages_by_space` | `pub` | no | no | — | — |
 | `core/db.rs::list_pages_inner` | `private` | no | no | — | — |
 | `core/db.rs::list_pages_stale` | `pub` | no | no | — | — |
 | `core/db.rs::list_recent_changes` | `pub` | no | no | — | — |
 | `core/db.rs::list_recent_pages_with_badges` | `pub` | no | no | — | — |
+| `core/db.rs::list_recent_relations` | `pub` | no | no | — | — |
 | `core/db.rs::list_recent_retrievals` | `pub` | no | no | — | — |
 | `core/db.rs::list_recent_retrievals_scoped` | `pub` | no | **yes** | `server/routes.rs::handle_recent_retrievals` | — |
 | `core/db.rs::list_relevant_active_page_titles` | `pub` | no | no | — | — |
@@ -925,11 +928,14 @@ carrying the authority of agreement.
 | `core/db.rs::reconcile_entity_page_parity` | `pub` | no | **yes** | `server/scheduler/ambient.rs::run_ambient_job` | — |
 | `core/db.rs::resolve_entity_by_name` | `pub` | no | **yes** | `server/memory_routes.rs::handle_store_memory` | — |
 | `core/db.rs::run_migrations` | `pub` | no | no | — | — |
+| `core/db.rs::search_entities_by_name` | `pub` | no | no | — | — |
+| `core/db.rs::search_entities_by_vector` | `pub` | no | no | — | — |
 | `core/db.rs::search_memory_with_cue` | `private` | no | no | — | — |
 | `core/db/claim_derivation.rs::derive_leased_page_claims` | `pub(super)` | no | no | — | — |
 | `core/db/claim_derivation.rs::evaluate_support_on` | `private` | no | no | — | — |
 | `core/db/claim_derivation.rs::load_linked_memory_chunks` | `private` | no | no | — | — |
 | `core/db/kg_quality_diagnostics.rs::list_contradiction_observation_counts` | `pub(crate)` | no | no | — | — |
+| `core/db/kg_quality_embedding_refresh.rs::stale_entity_embedding_candidates_for_refresh` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_duplicate_reads.rs::embedding_near_duplicate_pairs` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_duplicate_reads.rs::scan_near_duplicate_slice` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_retro_scan.rs::scan_automatic_retro_stub_slice` | `pub(crate)` | no | no | — | — |
@@ -977,6 +983,7 @@ carrying the authority of agreement.
 | `core/db.rs::find_distillation_clusters_scoped` | `pub` | no | no | — | `core/db.rs::query_distillation_staging_pool` |
 | `core/db.rs::get_page` | `pub` | no | **yes** | `server/page_map_routes.rs::ensure_page_is_active`, `server/page_map_routes.rs::visible_page`, `server/page_routes.rs::handle_create_page`, `server/page_routes.rs::handle_refresh_page`, `server/page_routes.rs::handle_update_page` | `core/db.rs::get_page_inner` |
 | `core/db.rs::get_page_browse` | `pub` | no | no | — | `core/db.rs::get_page_inner` |
+| `core/db.rs::graph_stream_touches` | `pub` | no | no | — | `core/db.rs::search_entities_by_vector` |
 | `core/db.rs::insert_document_source_page_at_hash` | `pub(crate)` | no | no | — | `core/db.rs::insert_page_with_kind_inner` |
 | `core/db.rs::insert_page_with_kind` | `pub(crate)` | no | no | — | `core/db.rs::insert_page_with_kind_inner` |
 | `core/db.rs::list_active_page_titles` | `pub` | no | no | — | `core/db.rs::list_active_page_titles_scoped` |
@@ -988,7 +995,9 @@ carrying the authority of agreement.
 | `core/db.rs::new_with_shared_embedder` | `pub` | no | no | — | `core/db.rs::run_migrations` |
 | `core/db.rs::rebind_source_id_inner` | `private` | no | no | — | `core/db.rs::rebind_source_page_in_transaction` |
 | `core/db.rs::replace_source_page_inner` | `private` | no | no | — | `core/db.rs::append_page_history` |
+| `core/db.rs::resolve_or_create_entity` | `pub` | no | no | — | `core/db.rs::search_entities_by_name`, `core/db.rs::search_entities_by_vector` |
 | `core/db.rs::resolve_orphan_page_links` | `pub` | no | **yes** | `server/routes.rs::handle_distill` | `core/db.rs::find_unique_active_page_id_by_title_scoped` |
+| `core/db.rs::run_entity_enrichment_slice_inner` | `private` | no | no | — | `core/db.rs::search_entities_by_vector` |
 | `core/db.rs::search_memory` | `pub` | no | **yes** | `server/brief_routes.rs::handle_read_brief`, `server/memory_routes.rs::handle_search_memory`, `server/routes.rs::handle_search` | `core/db.rs::search_memory_with_cue` |
 | `core/db.rs::search_memory_cross_rerank_cued` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
 | `core/db.rs::search_memory_expanded` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
@@ -1003,7 +1012,10 @@ carrying the authority of agreement.
 | `core/db/scoped_pages.rs::list_recent_pages_with_badges_scoped` | `pub` | no | **yes** | `server/routes.rs::handle_recent_pages` | `core/db.rs::list_recent_pages_with_badges` |
 | `core/db/truth_exposure.rs::page_visibility` | `pub` | no | no | — | `core/db/truth_exposure.rs::page_truth_states` |
 | `core/export/knowledge.rs::plan_truth_cutover` | `pub` | no | **yes** | `server/cmd_cutover.rs::run` | `core/db/truth_exposure.rs::page_truth_states` |
+| `core/kg/reweave.rs::reweave_entity_links` | `pub` | no | no | — | `core/db.rs::search_entities_by_vector` |
+| `core/kg_quality.rs::refresh_stale_entity_embeddings` | `pub` | no | no | — | `core/db/kg_quality_embedding_refresh.rs::stale_entity_embedding_candidates_for_refresh` |
 | `core/kg_quality.rs::scan_contradictions` | `pub` | no | no | — | `core/db/kg_quality_diagnostics.rs::list_contradiction_observation_counts` |
+| `core/kg_quality.rs::verify_entity` | `pub` | no | no | — | `core/db.rs::search_entities_by_vector` |
 | `core/lint/deep.rs::run` | `pub(super)` | yes | no | — | `core/lint/deep.rs::page_body_result`, `core/lint/deep.rs::page_duplicates` |
 | `core/lint/kg/query.rs::load` | `pub(super)` | yes | no | — | `core/lint/kg/query/aggregate.rs::advisory_metrics` |
 | `core/lint/pages/db_checks.rs::run` | `pub(crate)` | yes | no | — | `core/lint/pages/db_checks.rs::load_rows` |
@@ -1016,9 +1028,12 @@ carrying the authority of agreement.
 | `core/maintenance/duplicates.rs::detect_near_duplicate_pages_inner` | `private` | no | no | — | `core/db/maintenance_duplicate_reads.rs::embedding_near_duplicate_pairs` |
 | `core/onboarding.rs::check_after_refinery_pass` | `pub` | no | no | — | `core/db.rs::oldest_active_page` |
 | `core/page_map_improve.rs::source_suggestions` | `private` | no | no | — | `core/db.rs::find_active_page_id_by_title` |
+| `core/post_ingest.rs::auto_link_entity` | `pub(crate)` | no | no | — | `core/db.rs::search_entities_by_vector` |
 | `core/post_ingest.rs::grow_page` | `pub(crate)` | no | no | — | `core/db.rs::find_matching_page_scoped` |
 | `core/post_ingest.rs::run_page_growth_slice` | `pub` | no | **yes** | `server/scheduler/ambient.rs::run_ambient_job` | `core/db.rs::find_matching_page_scoped` |
+| `core/post_ingest.rs::run_post_ingest_enrichment` | `pub` | no | no | — | `core/db.rs::get_entity_detail` |
 | `core/post_write.rs::rename_page_title_cas` | `pub(crate)` | no | no | — | `core/db/repair_page_rename.rs::rename_page_title_cas_inner` |
+| `core/post_write/entity_graph.rs::create_entity` | `pub` | yes | no | — | `core/db.rs::search_entities_by_vector` |
 | `core/post_write/page_create.rs::create_page_impl` | `pub(super)` | no | no | — | `core/db.rs::find_matching_page_scoped` |
 | `core/refinery/mod.rs::run_redistill_page_slice` | `pub` | no | no | — | `core/db.rs::get_stale_page_after` |
 | `core/repair.rs::apply_repair_with_pages_inner` | `private` | no | no | — | `core/db/repair_deterministic.rs::apply_deterministic_repair_cas` |
@@ -1035,6 +1050,7 @@ carrying the authority of agreement.
 | `core/synthesis/wikilinks.rs::resolve_against_pages` | `pub` | no | no | — | `core/db.rs::find_unique_active_page_id_by_title_scoped` |
 | `core/truth_adapter.rs::verdicts` | `private` | no | no | — | `core/db/truth_exposure.rs::page_truth_states` |
 | `server/cmd_backfill.rs::run` | `pub` | yes | no | — | `core/db.rs::find_stale_archived_pages` |
+| `server/entity_graph_routes.rs::handle_create_entity` | `pub` | no | no | — | `core/db.rs::get_entity_detail` |
 | `server/entity_graph_routes.rs::handle_get_entity_detail` | `pub` | no | no | — | `core/db/scoped_entities.rs::get_entity_detail_scoped` |
 | `server/entity_graph_routes.rs::handle_list_entities` | `pub` | no | no | — | `core/db/scoped_entities.rs::list_entities_scoped` |
 | `server/entity_graph_routes.rs::handle_search_entities` | `pub` | no | no | — | `core/db/scoped_entities.rs::search_entities_by_vector_scoped` |
@@ -1064,7 +1080,8 @@ carrying the authority of agreement.
 | `core/db.rs::refresh_page_wikilinks` | `pub` | no | no | — | `core/db.rs::get_page`, `core/synthesis/wikilinks.rs::resolve_against_pages` |
 | `core/db.rs::replace_source_page` | `pub(crate)` | no | no | — | `core/db.rs::replace_source_page_inner` |
 | `core/db.rs::replace_source_page_at_document_hash` | `pub(crate)` | no | no | — | `core/db.rs::replace_source_page_inner` |
-| `core/db.rs::resolve_or_create_entity` | `pub` | no | no | — | `core/db.rs::minhash_resolve_candidate` |
+| `core/db.rs::run_entity_enrichment_slice` | `pub` | no | no | — | `core/db.rs::run_entity_enrichment_slice_inner` |
+| `core/db.rs::run_entity_enrichment_slice_with_auto_link` | `pub` | no | **yes** | `server/scheduler/ambient.rs::run_ambient_job` | `core/db.rs::run_entity_enrichment_slice_inner` |
 | `core/db.rs::search_corrections_by_topic_scoped` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/db.rs::search_memory_cross_rerank` | `pub` | no | **yes** | `server/memory_routes.rs::handle_search_memory` | `core/db.rs::search_memory_cross_rerank_cued` |
 | `core/db.rs::search_memory_decomposed` | `pub` | no | no | — | `core/db.rs::search_memory` |
@@ -1094,7 +1111,7 @@ carrying the authority of agreement.
 | `core/eval/context_path.rs::run_context_path_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
 | `core/eval/lifecycle.rs::measure_phase` | `private` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/lifecycle.rs::run_lifecycle_fixture` | `pub` | no | no | — | `core/db.rs::search_memory` |
-| `core/eval/lifecycle.rs::run_lifecycle_phases` | `private` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/lifecycle.rs::run_lifecycle_phases` | `private` | no | no | — | `core/db.rs::search_memory`, `core/post_ingest.rs::run_post_ingest_enrichment` |
 | `core/eval/locomo.rs::run_locomo_eval_core` | `private` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/locomo.rs::run_locomo_eval_cross_rerank_temporal_collect` | `pub` | no | no | — | `core/db.rs::search_memory_cross_rerank_cued` |
 | `core/eval/locomo.rs::run_locomo_eval_expanded_intent_collect` | `pub` | no | no | — | `core/db.rs::search_memory_expanded` |
@@ -1126,10 +1143,16 @@ carrying the authority of agreement.
 | `core/eval/retrieval.rs::run_scaling_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
 | `core/eval/retrieval_drift.rs::capture_rankings` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
 | `core/eval/runner.rs::run_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/shared.rs::base_channel_touched` | `pub` | no | no | — | `core/db.rs::graph_stream_touches` |
+| `core/eval/shared.rs::ce_channel_touched` | `pub` | no | no | — | `core/db.rs::graph_stream_touches` |
+| `core/eval/shared.rs::enrich_db_for_eval_local` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
+| `core/eval/shared.rs::enrich_post_ingest_batched` | `pub(crate)` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
 | `core/eval/shared.rs::open_or_seed_scenario_db` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
 | `core/export/knowledge.rs::enforce_projection_directory_invariant#1` | `pub` | yes | no | — | `core/db/truth_exposure.rs::page_visibility` |
 | `core/export/knowledge.rs::run_truth_cutover` | `pub` | no | **yes** | `server/cmd_cutover.rs::run` | `core/export/knowledge.rs::plan_truth_cutover` |
-| `core/kg_quality.rs::run_rethink` | `pub` | no | no | — | `core/kg_quality.rs::scan_contradictions` |
+| `core/importer.rs::resolve_entity_bulk` | `pub(crate)` | no | no | — | `core/db.rs::resolve_or_create_entity` |
+| `core/ingest.rs::run_canonical_enrichment` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
+| `core/kg_quality.rs::run_rethink` | `pub` | no | no | — | `core/kg_quality.rs::refresh_stale_entity_embeddings`, `core/kg_quality.rs::scan_contradictions` |
 | `core/kg_quality.rs::verify_page` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/lint/semantic.rs::run_agent_submit` | `private` | no | no | — | `core/truth_adapter.rs::verdicts` |
 | `core/m6/oracle.rs::recompute_full` | `pub` | no | no | — | `core/m6/signals.rs::community_overview`, `core/m6/signals.rs::evidence_cluster`, `core/m6/signals.rs::orphan_wikilink`, `core/m6/signals.rs::space_overview` |
@@ -1142,7 +1165,6 @@ carrying the authority of agreement.
 | `core/maintenance/page_merge_order.rs::load_candidate` | `private` | no | no | — | `core/db.rs::get_page` |
 | `core/page_map_improve.rs::improve_page_map` | `pub` | no | **yes** | `server/page_map_routes.rs::handle_improve_page_map` | `core/db.rs::get_page`, `core/page_map_improve.rs::source_suggestions` |
 | `core/page_map_improve.rs::run_proactive_page_maps` | `pub` | no | no | — | `core/db.rs::list_pages` |
-| `core/post_ingest.rs::run_post_ingest_enrichment` | `pub` | no | no | — | `core/post_ingest.rs::grow_page` |
 | `core/post_write/page_create.rs::replace_source_page_impl` | `pub(super)` | no | no | — | `core/db.rs::get_page` |
 | `core/post_write/page_create.rs::write_document_source_page_impl` | `pub(super)` | no | no | — | `core/db.rs::insert_document_source_page_at_hash` |
 | `core/post_write/page_dispatch.rs::page_write` | `pub` | no | no | — | `core/post_write/page_create.rs::create_page_impl` |
@@ -1151,7 +1173,7 @@ carrying the authority of agreement.
 | `core/refinery/mod.rs::enqueue_changed_pages` | `pub(crate)` | no | no | — | `core/db.rs::list_pages` |
 | `core/refinery/mod.rs::re_distill_stale_pages` | `pub(crate)` | no | no | — | `core/db.rs::list_stale_pages` |
 | `core/refinery/mod.rs::run_periodic_steep_phase_with_api` | `pub` | no | **yes** | `server/scheduler.rs::fire_steep_phase` | `core/refinery/mod.rs::run_redistill_page_slice` |
-| `core/refinery/mod.rs::run_periodic_steep_with_api_scope` | `private` | no | no | — | `core/db.rs::resolve_orphan_page_links`, `core/onboarding.rs::check_after_refinery_pass`, `core/synthesis/detect.rs::detect_page_candidates` |
+| `core/refinery/mod.rs::run_periodic_steep_with_api_scope` | `private` | no | no | — | `core/db.rs::resolve_orphan_page_links`, `core/kg/reweave.rs::reweave_entity_links`, `core/onboarding.rs::check_after_refinery_pass`, `core/synthesis/detect.rs::detect_page_candidates` |
 | `core/repair.rs::apply_rename_page_title` | `private` | no | no | — | `core/post_write.rs::rename_page_title_cas` |
 | `core/repair.rs::apply_repair_with_pages` | `pub` | no | **yes** | `server/repair_routes.rs::handle_apply` | `core/repair.rs::apply_repair_with_pages_inner` |
 | `core/repair.rs::capture_page_projection_rollback` | `pub(crate)` | no | no | — | `core/repair.rs::projection_page_row_from_snapshot` |
@@ -1194,7 +1216,6 @@ carrying the authority of agreement.
 | `core/citations.rs::run_citation_backfill_slice` | `pub` | no | **yes** | `server/scheduler/ambient.rs::run_ambient_job` | `core/citations.rs::run_citation_backfill_with_page_limit` |
 | `core/citations.rs::run_citation_backfill_tick` | `pub` | no | no | — | `core/citations.rs::run_citation_backfill_with_page_limit` |
 | `core/db.rs::augment_with_graph_seeded` | `pub` | no | no | — | `core/db.rs::augment_with_graph_seeded_scoped` |
-| `core/db.rs::run_entity_enrichment_slice_inner` | `private` | no | no | — | `core/db.rs::commit_entity_enrichment_at_version` |
 | `core/db.rs::search_corrections_by_topic` | `pub` | no | no | — | `core/db.rs::search_corrections_by_topic_scoped` |
 | `core/db/repair_verification.rs::record_repair_verification_atomic` | `pub(crate)` | no | no | — | `core/repair.rs::projection_page_row_on_connection` |
 | `core/db/scoped_pages.rs::get_page_scoped` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_page` | `core/db/scoped_pages.rs::get_page_scoped_inner` |
@@ -1218,13 +1239,13 @@ carrying the authority of agreement.
 | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect_core` |
 | `core/eval/pipeline.rs::evaluate_condition` | `private` | no | no | — | `core/eval/pipeline.rs::run_strategy_search` |
 | `core/eval/retrieval.rs::run_native_memory_comparison` | `pub` | no | no | — | `core/eval/retrieval.rs::run_native_memory_augmentation` |
-| `core/eval/shared.rs::enrich_db_for_eval_local` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
-| `core/eval/shared.rs::enrich_post_ingest_batched` | `pub(crate)` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
+| `core/eval/shared.rs::enrich_db_for_eval` | `pub` | no | no | — | `core/eval/shared.rs::enrich_db_for_eval_local` |
 | `core/eval/shared.rs::run_concept_distillation_batch_api` | `pub` | no | no | — | `core/db.rs::find_distillation_clusters`, `core/db.rs::max_page_overlap` |
+| `core/eval/shared.rs::run_enrichment_batch_api` | `pub` | no | no | — | `core/importer.rs::resolve_entity_bulk` |
+| `core/eval/shared.rs::run_entity_extraction_for_eval_cli` | `pub` | no | no | — | `core/importer.rs::resolve_entity_bulk` |
 | `core/export/knowledge.rs::write_page_gated#1` | `pub` | yes | no | — | `core/truth_adapter.rs::page_write_permit` |
 | `core/export/knowledge.rs::write_page_gated#2` | `pub` | yes | no | — | `core/truth_adapter.rs::page_write_permit` |
-| `core/importer.rs::resolve_entity_bulk` | `pub(crate)` | no | no | — | `core/db.rs::resolve_or_create_entity` |
-| `core/ingest.rs::run_canonical_enrichment` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
+| `core/importer.rs::import_phase3_store` | `pub` | no | no | — | `core/importer.rs::resolve_entity_bulk` |
 | `core/lint/semantic.rs::run` | `pub(super)` | yes | no | — | `core/lint/semantic.rs::run_agent_submit` |
 | `core/m6/shadow.rs::prepare` | `private` | yes | no | — | `core/m6/shadow.rs::admitted_proposals` |
 | `core/m6/shadow.rs::sample_oracle` | `private` | no | no | — | `core/m6/oracle.rs::recompute_full` |
@@ -1232,13 +1253,13 @@ carrying the authority of agreement.
 | `core/maintenance/duplicates.rs::source_overlap_pairs` | `private` | no | no | — | `core/maintenance/duplicates.rs::list_page_source_sets` |
 | `core/maintenance/page_merge_order.rs::order_survivor` | `pub(super)` | no | no | — | `core/maintenance/page_merge_order.rs::load_candidate` |
 | `core/post_ingest.rs::write_grown_page` | `private` | no | no | — | `core/db.rs::find_page_by_source_memory` |
-| `core/post_write/entity_graph.rs::create_entity` | `pub` | yes | no | — | `core/db.rs::resolve_or_create_entity` |
 | `core/post_write/page_dispatch.rs::create_page_with_tuning` | `pub` | no | **yes** | `server/page_routes.rs::handle_create_page` | `core/post_write/page_dispatch.rs::page_write` |
 | `core/post_write/page_dispatch.rs::update_page` | `pub` | no | **yes** | `server/page_routes.rs::handle_refresh_page` | `core/post_write/page_dispatch.rs::page_write` |
 | `core/post_write/page_dispatch.rs::update_page_at_source_revision` | `pub(crate)` | no | no | — | `core/post_write/page_dispatch.rs::page_write` |
 | `core/post_write/page_dispatch.rs::update_page_growth_at_versions` | `pub(crate)` | no | no | — | `core/post_write/page_update.rs::update_page_impl` |
 | `core/post_write/page_dispatch.rs::update_page_preserving_sources` | `pub` | no | **yes** | `server/page_routes.rs::handle_update_page` | `core/post_write/page_dispatch.rs::page_write` |
 | `core/post_write/page_revision.rs::accept_pending_revision_with_knowledge_path` | `pub` | no | **yes** | `server/memory_routes.rs::handle_accept_revision` | `core/post_write/page_revision.rs::accept_page_revision_card` |
+| `core/reconcile.rs::write_revision` | `pub` | no | no | — | `core/ingest.rs::run_canonical_enrichment` |
 | `core/refinery/mod.rs::maybe_refresh_overview_page` | `private` | no | no | — | `core/synthesis/overview.rs::refresh_overview_page` |
 | `core/refinery/mod.rs::run_periodic_steep_with_api` | `pub` | no | **yes** | `server/routes.rs::handle_steep` | `core/refinery/mod.rs::run_periodic_steep_with_api_scope` |
 | `core/repair.rs::apply_repair` | `pub` | no | no | — | `core/repair.rs::apply_repair_with_pages` |

--- a/docs/plans/2026-08-04-g6-retirement-program.md
+++ b/docs/plans/2026-08-04-g6-retirement-program.md
@@ -181,6 +181,33 @@ Order by measured entanglement:
    writers in Stage 2. Empirically backed on the live DB (swept 2026-08-05 07:30,
    post-migrations 113/114): `entity_page_parity_watermark` drift 0, 907/907
    expected-vs-actual shadow pages, 0 `entities` rows without a live shadow page.
+   **Stage 1.5b — status (2026-08-05):** Part 1 (migration 117) extended the
+   shadow-page scalar mirror to `source_agent`/`entity_created_at`/
+   `entity_updated_at`. Part 2 (migration 118) folded `entities.space` NULL to
+   the `UNFILED_SPACE_ID` sentinel (matching the `memories`/`pages` folds),
+   making every space-sensitive reader safe to trust off the mirror. Part 3
+   (spec `docs/plans/2026-08-05-g6-stage15b-entity-reader-completion-spec.md`)
+   migrated the 9 reader targets 1.5a's CLEAN-reader spec had excluded as
+   space-sensitive or structurally coupled: `list_entities`, `get_entity_detail`
+   (entity-half), `search_entities_by_name` (same unconditional-cutover shape
+   as 1.5a); `search_entities_by_vector`/`_scoped` (the row set stays on
+   `entities` -- the DiskANN index lives there -- but every display field is
+   unconditionally hydrated from the shadow page); `load_summary_buckets`'s
+   legacy branch + `summary_eligible_predicate`; the embedding-refresh
+   staleness sweep; and `list_recent_relations`/`_scoped` (structural rework,
+   not a hydration overlay -- the join itself was legacy-shaped even when
+   gated). This collapses the last `reader_uses_entity_pages` gated hybrid in
+   `scoped_entities.rs`; the gate and `SCOPED_ENTITIES_CONSUMER` are left
+   dead-but-present (retire with the writers in Stage 2, per the spec). Of
+   1.5a's 10 CARRYOVER sites, 3 were already self-documented as writer-coupled
+   (defer to Stage 2) or intentionally legacy (dual-metric emission); the
+   remaining 7 are lint/integrity audits of the `entities` store's own data
+   quality and are reclassified intentionally-legacy -- auditing the shadow
+   mirror instead would validate the mirror, not the store the check exists to
+   audit. Verification: `cargo test -p wenlan-core --lib` -- 4083 passed, 0
+   failed, 33 ignored (GPU-gated), 0 filtered; fmt + clippy (`--lib --bins` and
+   `--all-targets`) clean; M5 reader-inventory and R4 test-support census
+   regenerated.
 
 Each store's migration is one PR: readers redirected to `edges`/shadow pages,
 behavior-equivalence tests, and the store's parity derivation dropped from

--- a/docs/plans/2026-08-05-g6-stage15b-entity-reader-completion-spec.md
+++ b/docs/plans/2026-08-05-g6-stage15b-entity-reader-completion-spec.md
@@ -1,0 +1,165 @@
+# G6 Stage 1.5b — scalar mirror extension + entity reader completion
+
+Parent program: `docs/plans/2026-08-04-g6-retirement-program.md` (Stage 1, store 5,
+second half). Prerequisite: Stage 1.5a merged. Design decisions here were ruled
+in-session 2026-08-05 and recorded in the 1.5a spec
+(`docs/plans/2026-08-05-g6-stage15a-entity-clean-readers-spec.md`, "1.5b decisions
+recorded"); this spec turns them into an executable contract. The implementer
+verifies every site at the code level before editing and bounces back any site
+whose read contradicts this spec rather than improvising.
+
+## Goal
+
+After 1.5b, every entity READER in the tree is either (a) on the shadow-page
+store, or (b) a writer-coupled read that flips with the writers in Stage 2, or
+(c) a cross-store consistency check (parity/reconcile machinery) that retires in
+Stage 2. No reader remains blocked on unmirrored fields, and the
+`reader_uses_entity_pages` gated hybrids become unconditional canonical reads
+(the gate itself and `entity_reader_cutover` retire in Stage 2 with the writers).
+
+## Part 1 — m117: scalar mirror extension
+
+New migration (next free slot; 117 assumed — verify against the migration table)
+adds entity-page columns per the M3 precedent (entity_type / confidence /
+entity_confirmed are already real `pages` columns):
+
+- `source_agent TEXT`
+- `entity_created_at INTEGER`
+- `entity_updated_at INTEGER`
+- `community_id TEXT` (ruled 2026-08-05 after a false-start INTEGER
+  correction: the source column `entities.community_id` is INTEGER, but every
+  consumer already reads it as a string — `CAST(e.community_id AS TEXT)` into
+  `Option<String>` durable-community fields, and the m4 `communities` table
+  keys are TEXT — so the mirror matches the read side; parity compares via
+  the entities-side integer's string form, commented at the compare site)
+- `embedding_updated_at INTEGER`
+
+Naming note: `pages` already has its own `created_at`/`updated_at` — the entity
+timestamps get the `entity_` prefix to avoid capture. Backfill in the same
+migration from `entities` via `entity_page_map`. Writer thread-through: every
+shared-CRUD writer that sets one of these on `entities` (`store_entity`,
+`merge_entities`, `commit_entity_enrichment_at_version`,
+`refresh_entity_embedding`, `confirm_entity`, community assignment) mirrors it
+onto the shadow page in the same transaction, following the existing
+`insert_entity_shadow_page`/`update_entity_shadow_page` pattern. Parity:
+`reconcile_entity_page_parity` extends its field comparison to the new columns
+so drift is observable until Stage 2 retires it.
+
+## Part 2 — space-sentinel canonicalization
+
+Target state: "space is never NULL". A data migration (its own number after
+m117 — ruled 2026-08-05: the fold does not ride m117, so a failed scalar
+backfill and a failed fold stay distinguishable in the wild) folds NULL
+`entities.space` → `UNFILED_SPACE_ID` in `entities` itself, making
+`pages.space` and `entities.space` semantically identical from then on.
+
+Audit outcome (2026-08-05, pre-fold gate): 17 load-bearing consumer sites, not
+just the one named `scope_matches` caller. Governing ruling: **the fold changes
+the SPELLING of "unfiled," never the semantics** — every consumer that
+distinguished NULL now distinguishes the sentinel, and the external wire
+contract keeps `null`. All three tiers ride this PR, reworked ahead of the
+fold in edit order:
+
+- **Tier 1 (13 sites, mechanical):** swap to the established sentinel-aware
+  tools (`push_read_scope_filter_folded`, db.rs:190; the
+  `!= UNFILED_SPACE_ID` Rust-side filter pattern) — semantic_candidates
+  (`load_entities`/`entity_scope_clause`/`load_relations`), scoped_entities
+  `get_entity_detail_scoped`:211 / `search_entities_by_vector_scoped`:676,
+  the lint deep/kg/aggregate carryover sites, repair
+  `validate_selected_entities_*`.
+- **Tier 2 (2 sites, classification counts):** preserve classification
+  behavior with the sentinel as the unfiled marker.
+  `audit_legacy_cross_space_links` (db.rs:20488): sentinel endpoints classify
+  into `null_space`, not same/cross. Community adjacency builder
+  (db.rs:35459): sentinel endpoint stays "indeterminate, not excluded" — the
+  admitted edge set is IDENTICAL pre/post fold, pinned by a test on the same
+  fixture.
+- **Tier 3 (wire boundary):** sentinel → `null` at serialization —
+  `entity_from_row` (scoped_entities.rs:973) and `handle_create_entity`
+  (entity_graph_routes.rs:103, response `space` AND the `space_source` pick,
+  normalized before `.is_some()`). Reuse the memories/pages post-fold
+  boundary helper if one exists. CLI/MCP see no wire change. Server test:
+  `CreateEntityResponse.space == null` + correct `space_source` for an
+  unfiled write.
+- **Writer-side fold:** `store_entity` (and any writer accepting an Option
+  space) folds NULL→sentinel at write time, else NULLs recur post-migration.
+  Invariant test: 0 NULL spaces post-fold AND after a `store_entity`
+  round-trip with `space: None`.
+
+## Part 3 — migration targets
+
+Unblocked by Part 1 (scalars) and Part 2 (space semantics). Same target shape
+as 1.5a: `pages` joined via `entity_page_map` (`kind='entity'`,
+`status='active'`), result shapes and ordering byte-compatible.
+
+1. `list_entities` (db.rs:33247) and `list_entities_scoped`
+   (db/scoped_entities.rs:12)
+2. `get_entity_detail` entity-half (db.rs:33301) and `get_entity_detail_scoped`
+   (db/scoped_entities.rs:84) — the observations/relations halves stay on their
+   own stores
+3. `search_entities_by_vector` (db.rs:27295) and `_scoped`
+   (db/scoped_entities.rs:640) — unblocks the `resolve_entity_by_name` vector
+   fallthrough left legacy in 1.5a
+4. `search_entities_by_name` (db.rs:32179)
+5. `load_summary_buckets` legacy branch (db.rs:27555) and the
+   summary-eligibility predicate's legacy branch (locate; name drifted —
+   verify against the current tree)
+6. embedding-refresh sweep (db/kg_quality_embedding_refresh.rs:22) — needs
+   `embedding_updated_at` from Part 1; its `observations` join stays
+7. `list_recent_relations` (db.rs:37171) and `_scoped`
+   (db/scoped_entities.rs:297) — structural rework: the entity join is
+   structurally legacy even when gated (the gate only overlays title
+   hydration); rebuild the join on shadow pages outright
+8. The 1.5a dated carryovers (10 sites, grep `G6 Stage 1.5a` carryover
+   comments) — each either migrates here (space-sensitivity dissolved by
+   Part 2) or is reclassified writer-coupled with a dated Stage 2 comment
+9. `reader_uses_entity_pages` gated hybrids in `db/scoped_entities.rs` —
+   collapse to the canonical branch unconditionally (hard-cut, same program
+   contract as 1.5a; the gate function itself is deleted in Stage 2, so leave
+   it dead-but-present here only if deleting it would touch writer code)
+
+NOT in 1.5b: writers and writer-coupled discovery reads (Stage 2);
+`assert_entities_have_shadow_pages` / `reconcile_entity_page_parity`
+(cross-store by definition, Stage 2); `observations` content reads (survive per
+the observations ruling — user veto still open).
+
+## Tests (RED-control discipline as 1.2/1.3/1.5a)
+
+1. m117 migration test: backfill correctness on a raw-seeded pre-m117 fixture
+   (columns land, values match `entities` row-for-row).
+2. Writer thread-through: `store_entity`/`merge_entities`/
+   `refresh_entity_embedding`/`confirm_entity` round-trip the new scalars onto
+   the page row.
+3. Equivalence + asymmetric-divergence tests for the newly migrated
+   product-surface readers (list/detail/search-by-name/vector), seeded via real
+   writers; RED via prove-then-revert on one reader.
+4. Space fold: post-migration, no NULL `entities.space` remains; a
+   `scope_matches`-consumer test pinning the post-fold behavior.
+5. Existing gated-hybrid legacy-vs-canonical A/B tests
+   (scoped_entities_test.rs) rework or retire with the gate collapse —
+   whichever the implementer picks, state it in the report.
+
+## Gates
+
+fmt, clippy both variants, focused modules; full suites queued by the session
+lead at integration time. Program-doc status note for 1.5b in the same PR.
+
+## Why the hard cut is safe where the gate was once load-bearing
+
+(Recorded 2026-08-05, closing the reviewer's standing question from the 1.5a
+round.) The gate's "only thing standing between a premature flip and a wrong
+read" framing was true when the shadow store was young: the mirror could be
+incomplete, and the gate's drift check was the guard. Three things changed
+since: migrations 113/114 backfilled and asserted mirror completeness for the
+whole store; the live-DB sweep receipts show sustained drift 0
+(entity_page_parity 907/907, 0 entities without an active shadow page); and
+every writer mints or updates the shadow page in the same transaction as the
+legacy row, so incompleteness cannot recur short of a bug — which the
+still-running parity reconciler would surface as nonzero drift. Stage 1's
+program contract (readers cut hard, gates retire with the writers in Stage 2)
+therefore rests on invariants that are enforced, not assumed.
+
+Downgrade note (release-note material, not a code concern): after the space
+fold, an old binary reading `space IS NULL` for uncategorized sees zero
+unfiled entities — the same rollback property migration 91 established for
+memories.


### PR DESCRIPTION
## G6 Stage 1.5b — scalar mirror extension + entity reader completion

Fifth and final reader cutover of the G6 retirement program (`docs/plans/2026-08-04-g6-retirement-program.md`, Stage 1 store 5, second half; spec `docs/plans/2026-08-05-g6-stage15b-entity-reader-completion-spec.md`, included in this PR with all in-flight rulings recorded). After this PR, every entity reader is on the shadow-page store, writer-coupled (flips with the writers in Stage 2), or a cross-store consistency check that retires in Stage 2.

### Two migrations

- **m117 — scalar mirror extension**: adds `source_agent`, `entity_created_at`, `entity_updated_at`, `community_id` (TEXT — matches how every consumer reads it, see the spec's ruling), `embedding_updated_at` to `pages`; backfills existing shadow pages via `entity_page_map`; threads writers through via `update_entity_shadow_page`'s SET clause. Found-and-fixed gap: `detect_communities`' label-propagation loop wrote `entities.community_id` with no shadow re-sync.
- **m118 — space-sentinel fold**: folds NULL `entities.space` → the UNFILED sentinel and installs NOT NULL (batched backfill, hard-fail assert, index rebuild, writable_schema patch — mirrors migrate_91's structure). Writer-side fold ships alongside so NULLs never recur. Separate migration numbers by design: a failed scalar backfill and a failed fold stay distinguishable in the wild.

### The sentinel audit (gate did its job)

The spec's pre-fold audit gate surfaced 17 load-bearing consumers of the NULL-vs-sentinel distinction — 13 mechanical filter sites, 2 classification counters, and an HTTP wire leak. Governing ruling: **the fold changes the spelling of "unfiled," never the semantics.** Mechanical sites moved to the established sentinel-aware helpers; `detect_communities` adjacency admission and `audit_legacy_cross_space_links` bucketing are pinned identical pre/post fold (RED-controlled test on community admission); a new shared `normalize_unfiled_space` boundary helper keeps entity API responses returning `null` — CLI/MCP see no wire change.

### Reader completion (9 targets)

`list_entities(_scoped)`, `get_entity_detail(_scoped)` entity-half, `search_entities_by_name`, `load_summary_buckets` + summary-eligibility `community_id` reads, the embedding-refresh sweep, and a structural rebuild of `list_recent_relations(_scoped)` all cut over to `entity_page_map`/`pages` (kind='entity', status='active'). Sanctioned deviation: `search_entities_by_vector(_scoped)` keeps its ANN join on `entities` (the vector index physically lives there) with an unconditional shadow-page hydration overlay and legacy fallback on miss. The `reader_uses_entity_pages` gate collapsed — all 4 call sites unconditional; the gate fn stays dead-but-present (`#[allow(dead_code)]`) and retires with the writers in Stage 2. The 10 dated 1.5a carryovers are all dispositioned: 3 writer-coupled (Stage 2), 7 lint audits intentionally legacy (their job is auditing the legacy store's own data quality, per the 1.2/1.3 precedent).

### Tests

Migration tests RED-controlled one-for-one against the migrate_91 family pattern (backfill, NOT NULL rejection, raw-insert default, index rebuild, assert); writer thread-through covered across all four writers; community-adjacency pre/post-fold pin; wire contract test (`CreateEntityResponse.space == null` for an unfiled create); `scope_matches` post-fold pin. Suite fallout: 5 fixtures seeding literal NULL space updated to the sentinel (the NOT NULL constraint doing its job); 3 gated-path A/B tests retired as vacuous after the gate collapse (both arms identical), 1 reworked to a direct positive control; census teeth regenerated (m5 inventory 393 rows; r4 manifest frozen count 1007) with drift fully attributed to this branch.

Suites (full capture): core 4082 passed / 0 failed / 33 ignored; m4_community_gates 20 passed / 0 failed / 6 ignored; server 620 passed / 0 failed / 3 ignored over 43 binaries; CLI 106 passed / 0 failed / 1 ignored over 11 binaries. fmt clean; clippy clean on both variants.

### Review-driven fixes

Fresh Opus-lane review of the integrated diff returned SHIP-with-fixes; all seven scrutiny areas (m118 patch safety, Tier-2 semantics preservation, wire contract, ANN-overlay fallback, relations scope parity, mixed-window closure, census exactness) verified clean. Fixes applied: (1) mirror-write gap closed — `add_observation` and the enrichment observation loop now re-sync the shadow page after bumping `entities.updated_at` (`add_observation` rewritten from best-effort to transactional; closure-reviewed across all four call sites), with an `add_observation` leg added to the writer thread-through pin test; (2) two gate-flip tests that could no longer fail retired/reworked (wire-invariant test retired, scale bench reduced to a single un-gated timing pass); (3) `, r.edge_id DESC` tiebreaker on both `list_recent_relations` endpoints so the LIMIT boundary is deterministic; (4) wrong doc claim reworded; (5) `normalize_unfiled_space` narrowed to `pub(crate)`.

**Downgrade note**: after m118, an old binary reading `space IS NULL` for uncategorized sees zero unfiled entities — the same rollback property migration 91 established for memories. Release-note material; the spec records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
