### PR TITLE
fix(kg): edges-parity repair — doc-source-page over-retire + kind-derivation drift (m119)

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -808,7 +808,7 @@ pub const EMBEDDING_DIM: usize = 768;
 /// `embedding_updated_at` (G6 Stage 1.5b Part 1). Migration 118 folds NULL
 /// `entities.space` -> `UNFILED_SPACE_ID` and stamps NOT NULL DEFAULT (G6
 /// Stage 1.5b Part 2).
-pub const SCHEMA_VERSION: u32 = 118;
+pub const SCHEMA_VERSION: u32 = 119;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -8691,6 +8691,17 @@ impl MemoryDB {
             if version < 118 {
                 self.migrate_118_entity_space_fold(version).await?;
             }
+
+            // Migration 119 (G6 edges-parity repair): reactivates every
+            // retired, non-superseded `cites` edge whose derived active
+            // `page_evidence` backing still exists -- repairs the damage
+            // from the over-retire (`replace_source_page_inner`) and
+            // kind-derivation (page_sources contributor/backfill) defects
+            // fixed in this same PR. No edge is minted. See
+            // migrate_119_edges_reactivate_backed.
+            if version < 119 {
+                self.migrate_119_edges_reactivate_backed(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -13938,6 +13949,98 @@ impl MemoryDB {
         log::info!(
             "[migration] Migration 118 applied: entities.space unfiled fold + NOT NULL (G6 Stage 1.5b Part 2)"
         );
+        Ok(())
+    }
+
+    /// Migration 119 (G6 edges-parity repair): reactivate every retired,
+    /// non-superseded `cites` edge whose derived active `page_evidence`
+    /// backing still exists. Two defects fixed earlier in this same PR
+    /// over-retired live edges -- `replace_source_page_inner`'s over-retire
+    /// of carried-over evidence, and the `page_sources` contributor/backfill
+    /// kind-derivation disagreement with the live writer -- so a repair,
+    /// not just the forward fix, is needed to un-stick already-damaged
+    /// databases. Reactivate-only: for each `page_evidence` row the
+    /// derived `edge_id` is recomputed with the same kind-resolution rule
+    /// the live writer uses, and `valid_until` is cleared iff the edge
+    /// exists retired-and-not-superseded. No edge is minted, so a database
+    /// with no legacy backing for a given locator is left untouched.
+    /// Idempotent: a second run's UPDATE matches zero rows.
+    async fn migrate_119_edges_reactivate_backed(
+        &self,
+        prior_version: i64,
+    ) -> Result<(), WenlanError> {
+        self.backup_before_migration(119, prior_version).await?;
+        let conn = self.conn.lock().await;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m119 begin: {e}")))?;
+
+        let result: Result<u64, WenlanError> = async {
+            let mut rows = conn
+                .query(
+                    "SELECT page_id, source_kind, locator FROM page_evidence \
+                     WHERE locator IS NOT NULL",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m119 select page_evidence: {e}")))?;
+            let mut evidence: Vec<(String, String, String)> = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m119 page_evidence row: {e}")))?
+            {
+                evidence.push((
+                    row.get::<String>(0).unwrap_or_default(),
+                    row.get::<String>(1).unwrap_or_default(),
+                    row.get::<String>(2).unwrap_or_default(),
+                ));
+            }
+            drop(rows);
+
+            let mut reactivated = 0u64;
+            for (page_id, source_kind, locator) in evidence {
+                let dst_kind = if source_kind == "memory" {
+                    "memory"
+                } else {
+                    "external"
+                };
+                let edge_id = crate::provenance::compute_edge_id(
+                    "cites", "page", &page_id, dst_kind, &locator, &locator,
+                );
+                let affected = conn
+                    .execute(
+                        "UPDATE edges SET valid_until = NULL \
+                         WHERE edge_id = ?1 AND valid_until IS NOT NULL \
+                           AND superseded_by IS NULL",
+                        libsql::params![edge_id],
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m119 reactivate: {e}")))?;
+                reactivated += affected;
+            }
+            Ok(reactivated)
+        }
+        .await;
+
+        let reactivated = match result {
+            Ok(count) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m119 commit: {e}")))?;
+                count
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+
+        conn.execute("PRAGMA user_version = 119", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m119 bump: {e}")))?;
+        log::info!("[migration] Migration 119 applied: {reactivated} cites edge(s) reactivated");
         Ok(())
     }
 
@@ -19250,8 +19353,12 @@ impl MemoryDB {
             contributed.insert("relations".to_string(), n);
         }
 
-        // page_sources -> cites (page->memory, discriminator memory_source_id).
-        // Mirrors backfill_edges_from_page_sources: every row, none skipped.
+        // page_sources -> cites (page->memory|external, discriminator
+        // memory_source_id). Mirrors backfill_edges_from_page_sources:
+        // every row, none skipped; dst_kind resolved via the same shared
+        // rule insert_resolved_page_evidence uses (G6 edges-parity repair
+        // fix a), not hard-coded, so a folder-doc source page's expected id
+        // agrees with what the live writer minted.
         {
             let mut n = 0u64;
             let mut rows = conn
@@ -19265,8 +19372,19 @@ impl MemoryDB {
             {
                 let page_id: String = row.get(0).unwrap_or_default();
                 let msid: String = row.get(1).unwrap_or_default();
+                let source_kind =
+                    Self::resolve_one_source_kind(&conn, &msid)
+                        .await
+                        .map_err(|e| {
+                            WenlanError::VectorDb(format!("reconcile page_sources kind: {e}"))
+                        })?;
+                let dst_kind = if source_kind == "memory" {
+                    "memory"
+                } else {
+                    "external"
+                };
                 let id = crate::provenance::compute_edge_id(
-                    "cites", "page", &page_id, "memory", &msid, &msid,
+                    "cites", "page", &page_id, dst_kind, &msid, &msid,
                 );
                 expected.insert(
                     id,
@@ -19274,7 +19392,7 @@ impl MemoryDB {
                         "cites".into(),
                         "page".into(),
                         page_id,
-                        "memory".into(),
+                        dst_kind.into(),
                         msid,
                     ),
                 );
@@ -20667,12 +20785,24 @@ impl MemoryDB {
                 counts.unknown_inserted += 1;
                 "legacy"
             };
+            // dst_kind resolved via the same shared rule
+            // insert_resolved_page_evidence uses (G6 edges-parity repair fix
+            // a), not hard-coded, so a folder-doc source's backfilled edge
+            // agrees with what a live re-enrichment would mint.
+            let source_kind = Self::resolve_one_source_kind(conn, &memory_source_id)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m81 page_sources kind: {e}")))?;
+            let dst_kind = if source_kind == "memory" {
+                "memory"
+            } else {
+                "external"
+            };
             Self::insert_backfilled_edge(
                 conn,
                 "cites",
                 "page",
                 &page_id,
-                "memory",
+                dst_kind,
                 &memory_source_id,
                 &memory_source_id,
                 lineage,
@@ -45157,8 +45287,13 @@ impl MemoryDB {
             // DELETEs below un-imply so their canonical cites edges retire in
             // this transaction (the pages UPDATE above already NULLed
             // `citations`, so a removed row keeps no legacy backing). Kept
-            // memory sids re-assert through `insert_resolved_page_evidence`'s
-            // dual-write.
+            // sids re-assert through `insert_resolved_page_evidence`'s
+            // dual-write, so the subtraction below (old set minus new set)
+            // must resolve kinds via the SAME shared rule
+            // (`resolve_one_source_kind`) on both sides -- G6 edges-parity
+            // repair fix b: a carried-over external-kind locator (folder-doc
+            // source) must not survive as a phantom `memory`-kind entry that
+            // the subtraction never matches.
             let mut removed: std::collections::BTreeSet<(String, String)> = Default::default();
             let mut sid_rows = conn
                 .query(
@@ -45169,17 +45304,28 @@ impl MemoryDB {
                 .map_err(|e| {
                     WenlanError::VectorDb(format!("replace_source_page removed scan: {e}"))
                 })?;
+            let mut old_sids: Vec<String> = Vec::new();
             while let Some(row) = sid_rows
                 .next()
                 .await
                 .map_err(|e| WenlanError::VectorDb(e.to_string()))?
             {
-                removed.insert((
-                    "memory".to_string(),
-                    row.get::<String>(0).unwrap_or_default(),
-                ));
+                old_sids.push(row.get::<String>(0).unwrap_or_default());
             }
             drop(sid_rows);
+            for sid in &old_sids {
+                let kind = Self::resolve_one_source_kind(&conn, sid)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_source_page kind resolve: {e}"))
+                    })?;
+                let dst = if kind == "memory" {
+                    "memory"
+                } else {
+                    "external"
+                };
+                removed.insert((dst.to_string(), sid.clone()));
+            }
             let mut ev_rows = conn
                 .query(
                     "SELECT source_kind, locator FROM page_evidence \
@@ -45205,7 +45351,43 @@ impl MemoryDB {
             }
             drop(ev_rows);
             for sid in source_memory_ids {
-                removed.remove(&("memory".to_string(), (*sid).to_string()));
+                let kind = Self::resolve_one_source_kind(&conn, sid)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_source_page kind resolve: {e}"))
+                    })?;
+                let dst = if kind == "memory" {
+                    "memory"
+                } else {
+                    "external"
+                };
+                removed.remove(&(dst.to_string(), (*sid).to_string()));
+            }
+            // Retire BEFORE the evidence insert below (mirrors
+            // `try_update_page_content`'s shape) so a carried-over locator is
+            // never re-asserted then immediately killed in the same
+            // transaction. The `cites_backed_by_page_citations` guard below
+            // is kept as a defensive mirror of the sibling shape, but it can
+            // never actually fire on this path: it matches `source_kind =
+            // 'memory'` only, and the pages UPDATE earlier in this same
+            // transaction already NULLs `citations` (F2, review round 13).
+            for (dst_kind, locator) in &removed {
+                if Self::cites_backed_by_page_citations(&conn, id, locator)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_source_page citations check: {e}"))
+                    })?
+                {
+                    continue;
+                }
+                let edge_id = crate::provenance::compute_edge_id(
+                    "cites", "page", id, dst_kind, locator, locator,
+                );
+                Self::dual_write_invalidate_edge(&conn, &edge_id, None)
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("replace_source_page retire edge: {e}"))
+                    })?;
             }
             conn.execute(
                 "DELETE FROM page_sources WHERE page_id=?1",
@@ -45236,16 +45418,6 @@ impl MemoryDB {
                 .map_err(|e| {
                     WenlanError::VectorDb(format!("replace_source_page evidence insert: {e}"))
                 })?;
-            for (dst_kind, locator) in &removed {
-                let edge_id = crate::provenance::compute_edge_id(
-                    "cites", "page", id, dst_kind, locator, locator,
-                );
-                Self::dual_write_invalidate_edge(&conn, &edge_id, None)
-                    .await
-                    .map_err(|e| {
-                        WenlanError::VectorDb(format!("replace_source_page retire edge: {e}"))
-                    })?;
-            }
             // Same transaction as the version bump above: a re-enriched source
             // page is a new version like any other, and leaves the same durable
             // row behind.
@@ -48831,7 +49003,15 @@ impl MemoryDB {
             // Retire the pruned rows' canonical edges (kept sids are
             // re-asserted just below via `insert_resolved_page_evidence`'s
             // dual-write, which reactivates on the same content-addressed
-            // edge id if one was ever retired).
+            // edge id if one was ever retired). dst_kind stays hard-coded
+            // "memory": this site's page_evidence prune above is
+            // memory-kind-only by design, so a pruned folder-doc sid's
+            // external-kind evidence row survives and keeps its real edge
+            // legitimately expected -- resolving the kind here would retire
+            // a still-backed edge (G6 edges-parity repair, fold-in
+            // RETRACTED in review; the memory-kind id below was never
+            // minted for such a sid, so this retire is a harmless no-op for
+            // it).
             for sid in &removed {
                 let edge_id = crate::provenance::compute_edge_id(
                     "cites", "page", page_id, "memory", sid, sid,

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -30865,6 +30865,210 @@ async fn migration_118_assertion_detects_unresolved_space() {
     );
 }
 
+/// G6 edges-parity repair: a `cites` edge wrongly retired by the Defect
+/// 1/2 over-retire (see `replace_source_page_inner`/`page_sources`
+/// contributor fixes in the same PR) must reactivate when its
+/// `page_evidence` backing is still active -- no new edge is minted, the
+/// existing row's `valid_until` is just cleared. Uses an `external_file`
+/// (folder-doc) locator deliberately: that is the exact shape Defect 2's
+/// kind-derivation disagreement mis-retired.
+#[tokio::test]
+async fn migration_119_reactivates_qualifying_retired_edge() {
+    let (db, _dir) = test_db().await;
+    db.insert_page(
+        "pg_m119",
+        "M119 Page",
+        None,
+        "",
+        None,
+        Some("space_a"),
+        &[],
+        "2026-08-05T00:00:00Z",
+    )
+    .await
+    .unwrap();
+    let edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "pg_m119",
+        "external",
+        "src_doc_locator",
+        "src_doc_locator",
+    );
+    {
+        let conn = db.conn.lock().await;
+        conn.execute_batch(&format!(
+            "INSERT INTO page_evidence (page_id, source_kind, locator, linked_at)
+             VALUES ('pg_m119', 'external_file', 'src_doc_locator', 0);
+             INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+                                lineage, grounded, space, created_at, valid_until)
+             VALUES ('{edge_id}', 'pg_m119', 'page', 'src_doc_locator', 'external', 'cites',
+                     'evidence', 0, 'space_a', 0, 100);"
+        ))
+        .await
+        .unwrap();
+    }
+
+    db.migrate_119_edges_reactivate_backed(118).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT valid_until FROM edges WHERE edge_id = ?1",
+            libsql::params![edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    let valid_until: Option<i64> = rows
+        .next()
+        .await
+        .unwrap()
+        .expect("edge row")
+        .get(0)
+        .unwrap();
+    assert_eq!(
+        valid_until, None,
+        "a retired edge backed by an active page_evidence row must reactivate"
+    );
+}
+
+/// A retired edge that was superseded (replaced by a different edge_id,
+/// e.g. a renamed identity) must NOT reactivate -- `superseded_by` marks
+/// it permanently retracted regardless of legacy backing.
+#[tokio::test]
+async fn migration_119_leaves_superseded_edge_alone() {
+    let (db, _dir) = test_db().await;
+    db.insert_page(
+        "pg_m119_sup",
+        "M119 Superseded Page",
+        None,
+        "",
+        None,
+        Some("space_a"),
+        &[],
+        "2026-08-05T00:00:00Z",
+    )
+    .await
+    .unwrap();
+    let old_edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "pg_m119_sup",
+        "external",
+        "src_old_locator",
+        "src_old_locator",
+    );
+    let new_edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "pg_m119_sup",
+        "external",
+        "src_new_locator",
+        "src_new_locator",
+    );
+    {
+        let conn = db.conn.lock().await;
+        conn.execute_batch(&format!(
+            "INSERT INTO page_evidence (page_id, source_kind, locator, linked_at)
+             VALUES ('pg_m119_sup', 'external_file', 'src_old_locator', 0);
+             INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+                                lineage, grounded, space, created_at, valid_until)
+             VALUES ('{new_edge_id}', 'pg_m119_sup', 'page', 'src_new_locator', 'external',
+                     'cites', 'evidence', 0, 'space_a', 0, NULL);
+             INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+                                lineage, grounded, space, created_at, valid_until, superseded_by)
+             VALUES ('{old_edge_id}', 'pg_m119_sup', 'page', 'src_old_locator', 'external',
+                     'cites', 'evidence', 0, 'space_a', 0, 100, '{new_edge_id}');"
+        ))
+        .await
+        .unwrap();
+    }
+
+    db.migrate_119_edges_reactivate_backed(118).await.unwrap();
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT valid_until FROM edges WHERE edge_id = ?1",
+            libsql::params![old_edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    let valid_until: Option<i64> = rows
+        .next()
+        .await
+        .unwrap()
+        .expect("edge row")
+        .get(0)
+        .unwrap();
+    assert_eq!(
+        valid_until,
+        Some(100),
+        "a superseded edge must stay retired even though its legacy backing still exists"
+    );
+}
+
+/// Re-running migration 119 against an already-reactivated database must
+/// be a no-op: the UPDATE's `valid_until IS NOT NULL` guard matches zero
+/// rows the second time, so a re-run neither errors nor un-does anything.
+#[tokio::test]
+async fn migration_119_idempotent_on_rerun() {
+    let (db, _dir) = test_db().await;
+    db.insert_page(
+        "pg_m119_idem",
+        "M119 Idempotent Page",
+        None,
+        "",
+        None,
+        Some("space_a"),
+        &[],
+        "2026-08-05T00:00:00Z",
+    )
+    .await
+    .unwrap();
+    let edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "pg_m119_idem",
+        "external",
+        "src_idem_locator",
+        "src_idem_locator",
+    );
+    {
+        let conn = db.conn.lock().await;
+        conn.execute_batch(&format!(
+            "INSERT INTO page_evidence (page_id, source_kind, locator, linked_at)
+             VALUES ('pg_m119_idem', 'external_file', 'src_idem_locator', 0);
+             INSERT INTO edges (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type,
+                                lineage, grounded, space, created_at, valid_until)
+             VALUES ('{edge_id}', 'pg_m119_idem', 'page', 'src_idem_locator', 'external',
+                     'cites', 'evidence', 0, 'space_a', 0, 100);"
+        ))
+        .await
+        .unwrap();
+    }
+
+    for pass in 1..=2 {
+        db.migrate_119_edges_reactivate_backed(118).await.unwrap();
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                libsql::params![edge_id.as_str()],
+            )
+            .await
+            .unwrap();
+        let valid_until: Option<i64> = rows
+            .next()
+            .await
+            .unwrap()
+            .expect("edge row")
+            .get(0)
+            .unwrap();
+        assert_eq!(valid_until, None, "pass {pass}: edge must be active");
+    }
+}
+
 /// G6 Stage 1.2 divergence test (Sol review S3): no other test can tell
 /// whether a migrated reader actually reads `edges` versus `relations`, since
 /// every OTHER fixture keeps both stores in parity via the dual-write. Here
@@ -49611,6 +49815,121 @@ async fn replace_page_sources_retires_pruned_cites_edges() {
         report.drift_count, 0,
         "an empty-set replace must not re-drift edges parity (missing={}, extra={}, corrupt={})",
         report.missing_count, report.extra_count, report.corrupt_count
+    );
+}
+
+/// G6 edges-parity repair, post-retraction shape (fold-in of fix (a) into
+/// this site was RULED OUT in review round 13): `replace_page_sources`'s
+/// `page_evidence` prune is memory-kind-only, so a pruned folder-doc row's
+/// external-kind evidence survives -- the sweep still legitimately expects
+/// its `external`-kind edge, and the retire loop's hard-coded `"memory"`
+/// dst_kind is a no-op for it (no memory-kind edge was ever minted for a
+/// folder-doc sid). Pruning a folder-doc row must therefore leave the REAL
+/// `external`-kind edge ACTIVE, and parity must stay clean immediately
+/// after the prune (the settling check that caught the original fold-in
+/// ruling: on that tree this assertion failed with drift 1).
+#[tokio::test]
+async fn replace_page_sources_prunes_external_kind_edge_not_phantom_memory() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_g6_prune_ext",
+        "Prune External Target",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    let keep_sid = "mem_g6_ext_keep";
+    let drop_sid = "doc_g6_ext_drop::v1";
+    let doc = make_memory_doc(keep_sid, "Kept content.", "knowledge", "work", "agent");
+    db.upsert_documents(vec![doc]).await.unwrap();
+    let folder_doc = make_memory_doc(
+        drop_sid,
+        "Folder-doc content.",
+        "knowledge",
+        "work",
+        "folder",
+    );
+    db.upsert_documents(vec![folder_doc]).await.unwrap();
+    for sid in [keep_sid, drop_sid] {
+        db.link_page_source("page_g6_prune_ext", sid, "distill")
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "fixture precondition: linked sources leave parity clean"
+    );
+
+    // `replace_page_sources`'s own page_evidence prune is memory-kind-only by
+    // design ("external/authored evidence, if any, is preserved" -- see the
+    // comment on that DELETE), so the external-kind page_evidence row for
+    // `drop_sid` survives even though `page_sources` drops the sid. That
+    // surviving evidence row legitimately backs the edge, so this prune
+    // must leave the REAL external-kind edge ACTIVE (fold-in of fix (a)
+    // into this site's retire was RULED OUT in review -- see the doc
+    // comment above).
+    db.replace_page_sources("page_g6_prune_ext", &[keep_sid], "reconcile")
+        .await
+        .unwrap();
+
+    // Settling check: the prune above must not manufacture parity drift.
+    assert_eq!(
+        db.reconcile_edges_parity().await.unwrap().drift_count,
+        0,
+        "post-prune parity must be clean"
+    );
+
+    let conn = db.conn.lock().await;
+    let real_edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "page_g6_prune_ext",
+        "external",
+        drop_sid,
+        drop_sid,
+    );
+    let mut rows = conn
+        .query(
+            "SELECT valid_until FROM edges WHERE edge_id = ?1",
+            libsql::params![real_edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    let row = rows
+        .next()
+        .await
+        .unwrap()
+        .expect("real external-kind edge exists");
+    assert!(
+        row.get::<Option<i64>>(0).unwrap().is_none(),
+        "the real external-kind edge must stay active -- its evidence row survives the prune"
+    );
+
+    let phantom_edge_id = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "page_g6_prune_ext",
+        "memory",
+        drop_sid,
+        drop_sid,
+    );
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM edges WHERE edge_id = ?1",
+            libsql::params![phantom_edge_id.as_str()],
+        )
+        .await
+        .unwrap();
+    assert!(
+        rows.next().await.unwrap().is_none(),
+        "no phantom memory-kind edge should ever exist for a folder-doc locator"
     );
 }
 

--- a/crates/wenlan-core/src/document_enrichment.rs
+++ b/crates/wenlan-core/src/document_enrichment.rs
@@ -2010,6 +2010,150 @@ mod tests {
         assert_eq!(after.version, before.version);
     }
 
+    /// G6 edges-parity repair: drives the real `write_document_source_page`
+    /// path (the production route, not the `#[cfg(test)]` `write_source_page`
+    /// shim) twice over the same folder-doc source page with a growing chunk
+    /// set -- the 29->48 shape from the incident, reduced to a deterministic
+    /// keep/drop/add triple. Both prior defects fired in this exact call
+    /// path: `replace_source_page_inner`'s over-retire of carried-over
+    /// evidence (fix b) and the page_sources/backfill kind-derivation
+    /// disagreement with the live writer (fix a). Folder-agent sids (source_id
+    /// containing "::") resolve via `resolve_page_evidence_source_kind` to
+    /// `external_file` -> `dst_kind="external"`, the same rule
+    /// `insert_resolved_page_evidence` uses.
+    ///
+    /// RED control (source mutation, run by hand 2026-08-05): reverting fix
+    /// (a) alone (hard-coding `dst_kind="memory"` back into the
+    /// `reconcile_edges_parity` page_sources contributor) fails the FIRST
+    /// `drift_count == 0` assertion (left=2, right=0), because the sweep then
+    /// expects a memory-kind edge no writer ever mints. Reverting fix (b)
+    /// alone (restoring `replace_source_page_inner`'s retire loop to run
+    /// AFTER `insert_resolved_page_evidence`, with the old memory-kind-only
+    /// subtraction) fails the SECOND `drift_count == 0` assertion instead
+    /// (left=1, right=0): the over-retire kills the carried-over `keep_sid`
+    /// edge after `insert_resolved_page_evidence` re-asserts it, and the
+    /// still-intact `page_sources`/`page_evidence` rows then disagree with
+    /// the now-retired live edge. Both reverts confirmed to fail by hand,
+    /// then the fix restored and this test re-confirmed green.
+    #[tokio::test]
+    async fn write_document_source_page_replace_keeps_carried_over_retires_dropped() {
+        use crate::sources::RawDocument;
+
+        let (db, _dir) = test_db().await;
+        let file_path = "fake/g6-red-control-doc.md".to_string();
+        db.enqueue_document("folder-notes", &file_path, Some("hash-v1"))
+            .await
+            .unwrap();
+        let entry = db.claim_next_pending().await.unwrap().expect("claim");
+
+        let keep_sid = "doc_g6_red::chunk_keep";
+        let drop_sid = "doc_g6_red::chunk_drop";
+        let new_sid = "doc_g6_red::chunk_new";
+        for sid in [keep_sid, drop_sid, new_sid] {
+            let doc = RawDocument {
+                source: "memory".to_string(),
+                source_id: sid.to_string(),
+                title: format!("chunk-{sid}"),
+                summary: None,
+                content: format!("Folder-doc content for {sid}."),
+                url: None,
+                last_modified: chrono::Utc::now().timestamp(),
+                metadata: std::collections::HashMap::new(),
+                memory_type: Some("fact".to_string()),
+                space: Some("work".to_string()),
+                source_agent: Some("folder".to_string()),
+                confidence: Some(0.9),
+                confirmed: Some(false),
+                ..Default::default()
+            };
+            db.upsert_documents(vec![doc]).await.unwrap();
+        }
+
+        write_document_source_page(
+            &db,
+            &entry,
+            "page_g6_red_control",
+            "Source page v1",
+            None,
+            "content v1",
+            &[keep_sid.to_string(), drop_sid.to_string()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            db.reconcile_edges_parity().await.unwrap().drift_count,
+            0,
+            "first write must leave parity clean"
+        );
+
+        write_document_source_page(
+            &db,
+            &entry,
+            "page_g6_red_control",
+            "Source page v2",
+            None,
+            "content v2, grown",
+            &[keep_sid.to_string(), new_sid.to_string()],
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            db.reconcile_edges_parity().await.unwrap().drift_count,
+            0,
+            "second write (growing chunk set) must leave parity clean"
+        );
+
+        let conn = db.test_primary_session().await;
+        let keep_edge_id = crate::provenance::compute_edge_id(
+            "cites",
+            "page",
+            "page_g6_red_control",
+            "external",
+            keep_sid,
+            keep_sid,
+        );
+        let drop_edge_id = crate::provenance::compute_edge_id(
+            "cites",
+            "page",
+            "page_g6_red_control",
+            "external",
+            drop_sid,
+            drop_sid,
+        );
+        let new_edge_id = crate::provenance::compute_edge_id(
+            "cites",
+            "page",
+            "page_g6_red_control",
+            "external",
+            new_sid,
+            new_sid,
+        );
+        for (edge_id, label, expect_active) in [
+            (keep_edge_id.as_str(), "carried-over", true),
+            (drop_edge_id.as_str(), "dropped", false),
+            (new_edge_id.as_str(), "newly added", true),
+        ] {
+            let mut rows = conn
+                .query(
+                    "SELECT valid_until FROM edges WHERE edge_id = ?1",
+                    libsql::params![edge_id],
+                )
+                .await
+                .unwrap();
+            let row = rows
+                .next()
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("{label} edge must exist"));
+            let valid_until: Option<u64> = row.get(0).unwrap();
+            assert_eq!(
+                valid_until.is_none(),
+                expect_active,
+                "{label} locator's cites edge active-state mismatch"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn source_page_replacement_failure_preserves_last_valid_page_and_provenance() {
         let (db, dir) = test_db().await;

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -648,6 +648,9 @@ crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests:
 crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::sync_receipt_failure_does_not_leave_same_hash_queue_terminal|TestDbSession::execute_batch|1
 crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::sync_receipt_failure_does_not_leave_same_hash_queue_terminal|test_primary_session|1
 crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::sync_receipt_failure_does_not_leave_same_hash_queue_terminal|test_primary_session|2
+crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::write_document_source_page_replace_keeps_carried_over_retires_dropped|TestDbRows::next|1
+crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::write_document_source_page_replace_keeps_carried_over_retires_dropped|TestDbSession::query|1
+crates/wenlan-core/src/document_enrichment.rs|crate::document_enrichment::tests::write_document_source_page_replace_keeps_carried_over_retires_dropped|test_primary_session|1
 crates/wenlan-core/src/eval/shared.rs|crate::eval::shared::tests::batched_path_meets_graph_contract|TestDbSession::check_seed_contract|1
 crates/wenlan-core/src/eval/shared.rs|crate::eval::shared::tests::batched_path_meets_graph_contract|test_primary_session|1
 crates/wenlan-core/src/eval/shared.rs|crate::eval::shared::tests::collect_fingerprint|TestDbRow::get|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,15 +3229,17 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        1007,
+        1010,
         "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
          the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, \
          the 8 G6 BindPageLink repair-test calls, the 9 G6 Stage 1.5a \
          raw_seeded_entity_without_shadow_page_deletes_via_applier_shadow_page_guard calls, \
-         the 1 G6 Stage 1.5b uncategorized_scope_selects_the_unfiled_sentinel_entity call, and \
+         the 1 G6 Stage 1.5b uncategorized_scope_selects_the_unfiled_sentinel_entity call, \
          the 1 G6 Stage 1.5b Part 3 second test_primary_session re-acquire in \
          summary_eligibility_requires_a_qualifying_community_and_candidate (drop/reseed/reacquire \
-         around test_seed_entity_shadow_page's internal conn lock)"
+         around test_seed_entity_shadow_page's internal conn lock), and the 3 G6 edges-parity \
+         repair RED-controlled test calls in \
+         write_document_source_page_replace_keeps_carried_over_retires_dropped"
     );
 }
 

--- a/docs/plans/2026-08-05-g6-edges-parity-repair-spec.md
+++ b/docs/plans/2026-08-05-g6-edges-parity-repair-spec.md
@@ -1,0 +1,135 @@
+# G6 edges-parity repair — doc-source-page drift (77 missing)
+
+Status: fix spec, ships as its own PR before the Stage 2 spec. Root-cause
+investigation: Opus lane, 2026-08-05, reproduced the live watermark
+byte-for-byte (expected 2464 / actual 2387 / missing 77 / extra 0 / corrupt 0)
+and confirmed all 77 missing edges belong to one page,
+`src_4e030cfe8f424bd4` (the doc-enrich source page for
+`~/.wenlan/sources/2026-07-23-mcp-surface-consolidation-plan.md`).
+Two independent defects fired in the same `replace_source_page_inner`
+transaction at ts 1785954012. Blocks Stage 2: the parity oracle must read
+drift 0 before the parity machinery retires.
+
+## Root cause (confirmed)
+
+**Defect 1 — 29 edges, over-retire of carried-over evidence.**
+`replace_source_page_inner` (`crates/wenlan-core/src/db.rs:45024`): the
+`removed` snapshot (db.rs:45162-45206) collects every `(dst_kind, locator)`
+the page's current `page_sources` + `page_evidence` imply — external kinds
+included — but the subtraction (db.rs:45207-45209) removes only the
+*memory*-kind re-asserted sids. An external-kind locator present in BOTH the
+old and new evidence sets is never subtracted. The retire loop runs AFTER
+`insert_resolved_page_evidence` re-asserts the new edges, and
+`dual_write_invalidate_edge` (db.rs:15147) has no refcount guard — so the 29
+carried-over chunks were re-asserted and immediately killed in the same
+transaction. Introduced by commit `1658e4dc` (PR #482); the intent was right,
+the subtraction is incomplete.
+
+**Defect 2 — 48 edges, kind-derivation disagreement.** The sweep's
+`page_sources` contributor hard-codes `dst_kind="memory"` (db.rs:19268-19270),
+mirroring the one-time backfill (`backfill_edges_from_page_sources`,
+db.rs:20675). The only live writer minting cites edges for a page's sources,
+`insert_resolved_page_evidence` (db.rs:44472), RESOLVES the kind via
+`resolve_page_evidence_source_kind` (`citations.rs:48-70`) — a
+`source_agent='folder'` memory resolves to `external_file` →
+`dst_kind='external'`. For a doc source page the sweep therefore expects
+`cites/page:P/memory:chunk` while the writer minted
+`cites/page:P/external:chunk`: a permanently unbacked expectation per row.
+Coincides for every normal page (memory both sides), which is why it never
+fired elsewhere. Self-heal: none — the ambient sweep is read-only, the
+backfills run only from m81/m111, and any re-enrichment of the same document
+re-opens the hole.
+
+## Fix targets (three, ruled)
+
+**(a) One kind-resolution rule everywhere.** The sweep's `page_sources`
+contributor (db.rs:19253-19284) and `backfill_edges_from_page_sources`
+(db.rs:20639-20685) resolve `dst_kind` exactly as
+`insert_resolved_page_evidence` does — via the SAME shared helper
+(`resolve_page_evidence_source_kind` / `resolve_one_source_kind`), never a
+copied match. For every row whose source is a memory the derived id is
+unchanged, so this is a no-op on the rest of the corpus (simulation:
+expected 2464 → 2417, page_sources drift half disappears entirely).
+
+*Fold-in RETRACTED (review round 13):* the original ruling folded
+`replace_page_sources`' retire site into (a). The scoped review proved that
+wrong: that site's `page_evidence` prune is memory-kind-only, so a pruned
+folder-doc sid's evidence row SURVIVES the prune — the sweep's evidence
+contributor therefore still *expects* the edge, and resolving the kind at the
+retire makes the site kill a still-backed edge (the same over-retire class as
+Defect 1). The pre-existing hard-coded `"memory"` retire is a harmless no-op
+there (the memory-kind id was never minted), and prune scope must match
+retire scope — the pairing `try_update_page_content` keeps. Ruling: the
+retire stays hard-coded `"memory"`; the leg test asserts
+`reconcile_edges_parity()` drift 0 AFTER the prune (settling check first: on
+the fold-in tree that assertion must fail with drift 1, then pass on the
+revert). The site's memory-kind-only evidence prune remains genuinely out of
+scope — a stale external evidence row keeps its edge legitimately alive.
+
+**(b) Fix the over-retire in `replace_source_page_inner`.** Mirror the
+sibling `try_update_page_content` shape (db.rs:46539-46558): retire loop runs
+BEFORE the evidence insert, `removed` computed as old-set-minus-new-set with
+kinds resolved by the shared rule, and each retire guarded by the refcount
+check (`cites_backed_by_page_citations`, db.rs:46540). End-state invariant: a
+locator present in both the old and new sets keeps one active edge across the
+replace; a locator only in the old set retires. If the sibling shape
+genuinely doesn't fit this call path, the order-independent variant
+(post-insert re-read of implied set, subtract, then retire) is the sanctioned
+fallback — flag the deviation, don't silently pick it.
+
+**(c) m119 — repair migration: reactivate, don't re-mint.** For every active
+`page_evidence` row with a non-NULL locator whose derived edge exists with
+`valid_until IS NOT NULL AND superseded_by IS NULL`, clear `valid_until`.
+Narrow by construction (only revives edges whose legacy backing still
+exists), idempotent, logs the reactivated count. `SCHEMA_VERSION` → 119.
+Simulation receipt: with (a) + (c), drift 0, zero new edge rows minted.
+
+## Tests
+
+- RED-controlled integration test per the #482 convention: drive the real
+  `write_document_source_page` path twice over a folder-doc source page with
+  a growing chunk set (the 29→48 shape), then assert
+  `reconcile_edges_parity()` drift 0 AND the specific end state: carried-over
+  locators still active, dropped locators retired. This catches both defects;
+  a RED control on (b) alone would not, because (a) fires independently.
+- m119 migration test family per the established migration-test pattern
+  (reactivates a qualifying retired edge; leaves a superseded edge alone;
+  idempotent on re-run).
+- `replace_page_sources` leg (post-retraction shape): prune of a
+  folder-doc-backed row leaves the external-kind edge ACTIVE (its surviving
+  `page_evidence` row is live backing) and asserts
+  `reconcile_edges_parity()` drift 0 after the prune.
+
+## Post-review addenda (round 13)
+
+- F2 (nit): the `cites_backed_by_page_citations` guard in
+  `replace_source_page_inner`'s retire loop can never fire on that path (the
+  pages UPDATE NULLs `citations` earlier in the same transaction, and the
+  guard matches memory-kind only). Kept as a defensive mirror of the sibling
+  shape; the comment must say it cannot fire here, not claim protection.
+- PR-body operator note: m119 does not touch `edges_parity_watermark`, so the
+  watermark stays stale at 77 until one sweep runs post-migration;
+  `reader_uses_edges` fail-closes on staleness. Run one sweep after
+  migrating, or the cutover stays blocked for a reason that looks like the
+  old bug.
+
+## Out of scope
+
+- The 2026-08-04 "32-row repair" forensics (how the earlier 29 were cleared)
+  — settled enough: no memory-kind edge for this page exists in any snapshot,
+  so the repair didn't mint them; nothing about it changes the fix targets.
+- Stage 2 retirement of the parity machinery itself — separate spec, blocked
+  on this PR reaching live drift 0.
+- Pre-existing, review-round-13 side-find (`accept_page_merge`, db.rs:47458):
+  the `page_links` repoint retires the old `links` edge passing
+  `new_edge_id.as_deref()`, which is `None` when the source page has a NULL
+  space (the replacement mint is computed only inside the
+  `if let Some(space)` arm) — a space-less source page retires bare with no
+  replacement, reading as missing-drift on the survivor-target `links` edge.
+  Outside m119's reach (cites-only). Separate ticket if a sweep ever shows it.
+- m119 risk-surface closure (round 13): all three page-lifecycle paths
+  verified — `delete_page` (bulk retire then FK-cascade drops evidence),
+  `archive_page` (touches neither), `accept_page_merge` (copies evidence,
+  adds edges, supersedes where it retires) — none leaves a retired `cites`
+  edge with live `page_evidence`. The reverted fold-in would have been the
+  first.


### PR DESCRIPTION
## G6 — edges-parity repair: doc-source-page drift (77 missing edges)

Fixes the 77-edge parity drift discovered during the Stage 1.5b post-merge sweep (watermark: expected 2464 / actual 2387 / missing 77 / extra 0). Root-caused by Opus-lane investigation with a byte-for-byte reproduction against the live DB: all 77 missing edges belong to ONE page — the doc-enrich source page for a folder-ingested document — hit by two independent defects in the same `replace_source_page_inner` transaction. Spec with the full evidence trail, rulings, and one recorded retraction: `docs/plans/2026-08-05-g6-edges-parity-repair-spec.md` (in this PR). Blocks G6 Stage 2: the parity oracle must read drift 0 before the parity machinery retires.

### The two defects

- **Over-retire (29 edges)**: `replace_source_page_inner`'s `removed` bookkeeping collected external-kind locators but subtracted back only memory-kind re-asserted sids, and its retire loop ran AFTER the evidence re-insert with no guard — so carried-over document chunks had their edges re-asserted and immediately killed in the same transaction (introduced in PR #482).
- **Kind-derivation disagreement (48 edges)**: the parity sweep's `page_sources` contributor and the m81 backfill hard-coded `dst_kind="memory"`, while the live writer resolves a folder-document source to `external` — so for a doc source page the sweep expected edges nobody ever mints. Coincides for normal pages, which is why it never fired elsewhere.

Neither self-heals: the sweep is read-only, the backfills run only from m81/m111, and re-enriching the same document re-opens the hole.

### The fix

- **(a) One kind-resolution rule**: the sweep's `page_sources` contributor and `backfill_edges_from_page_sources` now resolve `dst_kind` through the same shared helper the live writer uses (`resolve_one_source_kind`). Byte-identical edge ids for every memory-kind row (the rest of the corpus is a no-op); measured cost 0.14s per sweep pass over ~2k rows on the live DB.
- **(b) Retire-before-insert**: `replace_source_page_inner` restructured to mirror `try_update_page_content` — the retire loop runs before the evidence insert, with `removed` computed as old-set-minus-new-set and kinds resolved on both sides, so a carried-over locator keeps exactly one active edge across a replace.
- **(c) m119 — reactivate, don't re-mint**: for every retired, non-superseded `cites` edge whose active `page_evidence` backing still exists, clear `valid_until`. Narrow by construction, idempotent, mints nothing. Investigator simulation on the live DB: (a)+(c) reach drift 0 with zero new edge rows.

### Review (Opus lane, round 13: SHIP-with-fixes — all applied)

The one required fix was a retraction of an orchestrator ruling: an initial fold-in of `replace_page_sources`' retire site into (a) was proven to *reintroduce* the over-retire class (that site's evidence prune is memory-kind-only, so a pruned folder-doc row's surviving evidence keeps its edge legitimately expected — prune scope must match retire scope). The reviewer's settling check was run as an empirical control before the revert: the post-prune drift assertion failed with drift 1 on the fold-in tree, exactly as predicted, and passes on the reverted tree — the assertion stays in the test permanently. m119's risk surface was closed by tracing all three page-lifecycle paths (`delete_page`, `archive_page`, `accept_page_merge`): none leaves a retired cites edge with live evidence; the reverted fold-in would have been the first. Also fixed: a comment claiming a refcount guard protects a path where it structurally cannot fire.

### Tests

RED-controlled integration test driving the real `write_document_source_page` path twice with a keep/drop/add chunk set, asserting `reconcile_edges_parity()` drift 0 after both writes plus the exact end state (carried-over active, dropped retired, added active) — hand-verified by reverting each fix in turn (reverting (a) alone and (b) alone each fails a distinct assertion). Migration 119 family (reactivates qualifying edge, leaves superseded alone, idempotent). `replace_page_sources` leg pinning the corrected prune behavior with a permanent post-prune drift-0 assertion. r4 census manifest regenerated (frozen count 1007→1010, all three rows attributed).

Suites (full capture): core 4087 passed / 0 failed / 33 ignored; m4_community_gates 20 passed / 0 failed / 6 ignored; server 620 passed / 0 failed / 3 ignored over 43 binaries; CLI 106 passed / 0 failed / 1 ignored over 11 binaries. fmt clean; clippy clean on both variants.

### Operator note (deployment)

m119 does not touch `edges_parity_watermark` — after migrating, the watermark stays stale at 77 until one parity sweep runs, and `reader_uses_edges` fail-closes on staleness. Run one sweep post-migration to clear it; a stale-blocked cutover after this PR looks like the old bug but isn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91
