### PR TITLE
fix(test): quarantine three flaky tests behind serialization and CI retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -26,36 +26,17 @@ threads-required = "num-test-threads"
 filter = 'test(folder_ingest_full_pipeline_e2e)'
 slow-timeout = { period = "60s", terminate-after = 3 }
 
-# The three data_root_lock_* tests contend on a shared fs2/flock EAGAIN (os
-# error 35) when they race; characterized 2026-08-01 at a 2/5 failure rate at
-# identical positions, 3/3 green in single-test isolation. bind_addr_tests.rs
-# also serializes them behind an in-process static Mutex, but nextest runs
-# each test as its own process, so that mutex never engages here — this
-# retry is the only protection in this lane (the mutex covers plain
-# `cargo test`, where all three land in one process).
+# These tests contend on a shared flock; the in-process mutex in bind_addr_tests.rs never engages under nextest's process-per-test model.
 [[profile.default.overrides]]
 filter = 'test(/^bind_addr_tests::data_root_lock_/)'
 retries = 2
 
-# m4_real_job_mutex_and_correction_latency_gate's p95 wall-clock bar can spike
-# under parallel-cargo load (observed 1.01s vs 164ms isolated, 2026-08-01).
-# The bar itself stays at 500ms — a looser bar would let a real multi-x
-# regression pass silently at nearest-rank p95. This retry is the flake
-# protection instead: a load flake passes on retry, a real regression fails
-# all three attempts deterministically.
+# p95 bar spikes under parallel-cargo load; a load flake passes on retry, a real regression fails all attempts.
 [[profile.default.overrides]]
 filter = 'test(m4_real_job_mutex_and_correction_latency_gate)'
 retries = 2
 
-# back_pressure_holds_sweep_at_pending_cap failed once at SETUP under
-# parallel-cargo load with `open temp MemoryDB: VectorDb("PRAGMA page_count:
-# SQLite failure: bad parameter or other API misuse")` (2026-08-01; 8/8 green
-# isolated). That message can only come from pragma_i64 in db.rs, whose only
-# callers are the online_backup tests in the db lib test binary — MemoryDB::new
-# cannot emit it, so the single sighting's attribution is uncertain (most
-# likely interleaved stdout from a parallel binary, not this test's own
-# setup). This retry is the whole mechanism: whatever actually failed gets
-# quarantined without pinning a diagnosis to unverified output.
+# One unattributed setup failure under parallel load; retry rather than pin a diagnosis.
 [[profile.default.overrides]]
 filter = 'test(back_pressure_holds_sweep_at_pending_cap)'
 retries = 2

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -25,3 +25,37 @@ threads-required = "num-test-threads"
 [[profile.default.overrides]]
 filter = 'test(folder_ingest_full_pipeline_e2e)'
 slow-timeout = { period = "60s", terminate-after = 3 }
+
+# The three data_root_lock_* tests contend on a shared fs2/flock EAGAIN (os
+# error 35) when they race; characterized 2026-08-01 at a 2/5 failure rate at
+# identical positions, 3/3 green in single-test isolation. bind_addr_tests.rs
+# also serializes them behind an in-process static Mutex, but nextest runs
+# each test as its own process, so that mutex never engages here — this
+# retry is the only protection in this lane (the mutex covers plain
+# `cargo test`, where all three land in one process).
+[[profile.default.overrides]]
+filter = 'test(/^bind_addr_tests::data_root_lock_/)'
+retries = 2
+
+# m4_real_job_mutex_and_correction_latency_gate's p95 wall-clock bar can spike
+# under parallel-cargo load (observed 1.01s vs 164ms isolated, 2026-08-01).
+# The bar itself stays at 500ms — a looser bar would let a real multi-x
+# regression pass silently at nearest-rank p95. This retry is the flake
+# protection instead: a load flake passes on retry, a real regression fails
+# all three attempts deterministically.
+[[profile.default.overrides]]
+filter = 'test(m4_real_job_mutex_and_correction_latency_gate)'
+retries = 2
+
+# back_pressure_holds_sweep_at_pending_cap failed once at SETUP under
+# parallel-cargo load with `open temp MemoryDB: VectorDb("PRAGMA page_count:
+# SQLite failure: bad parameter or other API misuse")` (2026-08-01; 8/8 green
+# isolated). That message can only come from pragma_i64 in db.rs, whose only
+# callers are the online_backup tests in the db lib test binary — MemoryDB::new
+# cannot emit it, so the single sighting's attribution is uncertain (most
+# likely interleaved stdout from a parallel binary, not this test's own
+# setup). This retry is the whole mechanism: whatever actually failed gets
+# quarantined without pinning a diagnosis to unverified output.
+[[profile.default.overrides]]
+filter = 'test(back_pressure_holds_sweep_at_pending_cap)'
+retries = 2

--- a/crates/wenlan-core/tests/m4_community_gates.rs
+++ b/crates/wenlan-core/tests/m4_community_gates.rs
@@ -1211,12 +1211,7 @@ async fn m4_real_job_mutex_and_correction_latency_gate() {
     );
     let mutex_p95 = duration_p95(&mutex_holds);
     let mutex_max = mutex_holds.iter().copied().max().expect("mutex receipts");
-    // Keep the 500ms bar tight enough to catch a real regression (at
-    // nearest-rank p95 over ~20 samples, a looser bar hides a multi-x
-    // slowdown). Load flakiness under parallel-cargo (observed 1.01s vs
-    // 164ms isolated, 2026-08-01) is handled by the nextest `retries = 2`
-    // override instead: a load flake passes on retry, a real regression
-    // fails all three attempts deterministically.
+    // Bar stays 500ms; load flakes are absorbed by the nextest retries override.
     assert!(
         mutex_p95 <= Duration::from_millis(500),
         "Gate 1.4 real-path DB-mutex p95 {mutex_p95:?} exceeds 500 ms"
@@ -1232,8 +1227,6 @@ async fn m4_real_job_mutex_and_correction_latency_gate() {
         .copied()
         .max()
         .expect("foreground latency receipts");
-    // Same tight bar and same reasoning as the mutex p95 above: nextest
-    // retries absorb load flakiness, the bar itself stays a real gate.
     assert!(
         foreground_p95 <= Duration::from_millis(500),
         "independent foreground-query p95 {foreground_p95:?} exceeds the mutex bar"

--- a/crates/wenlan-core/tests/m4_community_gates.rs
+++ b/crates/wenlan-core/tests/m4_community_gates.rs
@@ -1211,6 +1211,12 @@ async fn m4_real_job_mutex_and_correction_latency_gate() {
     );
     let mutex_p95 = duration_p95(&mutex_holds);
     let mutex_max = mutex_holds.iter().copied().max().expect("mutex receipts");
+    // Keep the 500ms bar tight enough to catch a real regression (at
+    // nearest-rank p95 over ~20 samples, a looser bar hides a multi-x
+    // slowdown). Load flakiness under parallel-cargo (observed 1.01s vs
+    // 164ms isolated, 2026-08-01) is handled by the nextest `retries = 2`
+    // override instead: a load flake passes on retry, a real regression
+    // fails all three attempts deterministically.
     assert!(
         mutex_p95 <= Duration::from_millis(500),
         "Gate 1.4 real-path DB-mutex p95 {mutex_p95:?} exceeds 500 ms"
@@ -1226,6 +1232,8 @@ async fn m4_real_job_mutex_and_correction_latency_gate() {
         .copied()
         .max()
         .expect("foreground latency receipts");
+    // Same tight bar and same reasoning as the mutex p95 above: nextest
+    // retries absorb load flakiness, the bar itself stays a real gate.
     assert!(
         foreground_p95 <= Duration::from_millis(500),
         "independent foreground-query p95 {foreground_p95:?} exceeds the mutex bar"

--- a/crates/wenlan-core/tests/m4_community_gates.rs
+++ b/crates/wenlan-core/tests/m4_community_gates.rs
@@ -2597,7 +2597,7 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
         .store_entity("Merge Neighbor", "concept", Some(SPACE), None, None)
         .await
         .expect("create merge neighbor");
-    let merge_relation = db
+    let _merge_relation = db
         .create_relation(
             &alias,
             &neighbor,
@@ -2690,7 +2690,7 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
         .store_entity("Restart Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create restart right");
-    let restart_relation = db
+    let _restart_relation = db
         .create_relation(
             &restart_left,
             &restart_right,
@@ -2806,7 +2806,7 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
         .store_entity("Delete Cascade Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create delete-cascade right");
-    let delete_relation = reopened
+    let _delete_relation = reopened
         .create_relation(
             &delete_left,
             &delete_right,
@@ -2895,7 +2895,7 @@ async fn m4_generation_tracks_grounded_retraction_reactivation_and_entity_merge(
         .store_entity("Refresh Cascade Right", "concept", Some(SPACE), None, None)
         .await
         .expect("create refresh-cascade right");
-    let refresh_relation = reopened
+    let _refresh_relation = reopened
         .create_relation(
             &refresh_left,
             &refresh_right,

--- a/crates/wenlan-server/src/bind_addr_tests.rs
+++ b/crates/wenlan-server/src/bind_addr_tests.rs
@@ -18,6 +18,18 @@ fn subprocess_lock() -> &'static Mutex<()> {
     TEST_SUBPROCESS_LOCK.get_or_init(|| Mutex::new(()))
 }
 
+// Recovers from poisoning so one panicking holder (any test below) can't
+// cascade a misleading second failure into whichever test locks next.
+// Serializes the three data_root_lock_* tests, characterized 2026-08-01 at a
+// 2/5 failure rate on a shared fs2/flock EAGAIN (os error 35) when they race
+// in one `cargo test` process (3/3 green in single-test isolation), plus
+// daemon_exit_skips_c_exit_handlers, which spawns a subprocess the same way.
+fn subprocess_lock_guard() -> std::sync::MutexGuard<'static, ()> {
+    subprocess_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 #[cfg(unix)]
 extern "C" fn fail_if_c_exit_handlers_run() {
     // SAFETY: This callback runs only in the dedicated child below. `_exit`
@@ -36,7 +48,7 @@ fn daemon_exit_skips_c_exit_handlers() {
         exit_daemon(0);
     }
 
-    let _guard = subprocess_lock().lock().unwrap();
+    let _guard = subprocess_lock_guard();
     let status = std::process::Command::new(std::env::current_exe().unwrap())
         .args([
             "--exact",
@@ -347,7 +359,7 @@ fn data_root_lock_excludes_a_second_daemon_for_the_same_root() {
     // A concurrently spawned test child inherits open Unix file descriptors,
     // including this lock. Keep the drop-and-reacquire proof isolated from
     // every test in this module that launches the current test executable.
-    let _guard = subprocess_lock().lock().unwrap();
+    let _guard = subprocess_lock_guard();
     let parent = tempfile::tempdir().unwrap();
     let root = parent.path().join("wenlan");
     let first = DaemonDataLock::acquire(&root, false).unwrap();
@@ -392,6 +404,7 @@ fn normal_data_root_lock_does_not_suppress_legacy_migration() {
 
 #[test]
 fn data_root_lock_child_process_holds_lock() {
+    let _guard = subprocess_lock_guard();
     let Some(root) = std::env::var_os("WENLAN_DATA_LOCK_CHILD_ROOT") else {
         return;
     };
@@ -410,7 +423,7 @@ fn data_root_lock_child_process_holds_lock() {
 
 #[test]
 fn data_root_lock_excludes_another_process_with_a_different_temp_dir() {
-    let _guard = subprocess_lock().lock().unwrap();
+    let _guard = subprocess_lock_guard();
     let parent = tempfile::tempdir().unwrap();
     let root = parent.path().join("wenlan");
     let child_tmp = parent.path().join("other-tmp");

--- a/crates/wenlan-server/src/bind_addr_tests.rs
+++ b/crates/wenlan-server/src/bind_addr_tests.rs
@@ -18,12 +18,8 @@ fn subprocess_lock() -> &'static Mutex<()> {
     TEST_SUBPROCESS_LOCK.get_or_init(|| Mutex::new(()))
 }
 
-// Recovers from poisoning so one panicking holder (any test below) can't
-// cascade a misleading second failure into whichever test locks next.
-// Serializes the three data_root_lock_* tests, characterized 2026-08-01 at a
-// 2/5 failure rate on a shared fs2/flock EAGAIN (os error 35) when they race
-// in one `cargo test` process (3/3 green in single-test isolation), plus
-// daemon_exit_skips_c_exit_handlers, which spawns a subprocess the same way.
+// Serializes tests that spawn subprocesses or contend on the data-root
+// flock; poison recovery keeps one panicking test from failing the next.
 fn subprocess_lock_guard() -> std::sync::MutexGuard<'static, ()> {
     subprocess_lock()
         .lock()


### PR DESCRIPTION
Quarantines three tests with characterized environmental flakes (2026-08-01, kg-revamp session) without weakening what they prove:

- **bind_addr_tests**: the three `data_root_lock_*` tests and `daemon_exit_skips_c_exit_handlers` contend on a shared fs2/flock (EAGAIN, os error 35) when racing in one `cargo test` process (2/5 failure rate; 3/3 green isolated). Now serialized through `subprocess_lock_guard()`, which also recovers from poisoning so one panicking holder can't cascade a misleading second failure.
- **m4_real_job_mutex_and_correction_latency_gate**: keeps its tight 500ms p95 bars (a looser bar hides a multi-x regression at nearest-rank p95 over ~20 samples). Load flakiness (1.01s under parallel-cargo vs 164ms isolated) is absorbed by a nextest `retries = 2` override instead — a load flake passes on retry, a real regression fails all three attempts.
- **back_pressure_holds_sweep_at_pending_cap**: single environmental setup failure sighting; review traced the quoted error string to a different test binary (misattributed interleaved output), so no code change — a nextest retry override quarantines whatever actually failed, attribution-free.

Under nextest each test runs in its own process, so the mutex covers plain `cargo test` and the retries cover the nextest lane; the override comments state this so nobody assumes double protection.

Verified: bind_addr_tests filter 5/5 runs green (26 passed each), latency gate green post-revert, back_pressure green, fmt + pre-commit clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pNJDWGNL5LdnchSZgH1Np