### PR TITLE
ci: scope the release validator's Cargo.lock check to workspace stanzas

### DIFF
--- a/scripts/validate-release-candidate.py
+++ b/scripts/validate-release-candidate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import copy
 import datetime
 import difflib
 import hashlib
@@ -15,6 +16,7 @@ import re
 import shutil
 import sys
 import tempfile
+import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -69,6 +71,19 @@ RELEASE_MANAGED_PATHS = frozenset(
     }
 )
 REQUIRED_RELEASE_PATHS = RELEASE_MANAGED_PATHS
+# Cargo.lock aggregates third-party versions, so a workspace release version can
+# legitimately collide with a dependency's version string (hashbrown 0.15.5 vs
+# release 0.15.5 → 0.15.6). Its transform is therefore scoped to exactly these
+# workspace package stanzas instead of a whole-file version replace.
+WORKSPACE_LOCK_PACKAGES = frozenset(
+    {"wenlan", "wenlan-core", "wenlan-mcp", "wenlan-server", "wenlan-types"}
+)
+WORKSPACE_LOCK_QUALIFIED_REF_PATTERNS = {
+    name: re.compile(
+        rf"(?:^|\s){re.escape(name)} [0-9]+\.[0-9]+\.[0-9]+(?![0-9A-Za-z])"
+    )
+    for name in WORKSPACE_LOCK_PACKAGES
+}
 
 
 class CandidateError(RuntimeError):
@@ -296,6 +311,125 @@ def _version(value: str, label: str) -> tuple[int, int, int]:
     return tuple(int(part) for part in value.split("."))
 
 
+def _expected_lock_transform(old: str, old_version: str, new_version: str) -> str:
+    """Bump workspace versions in Cargo.lock, refusing ambiguous stanza shapes.
+
+    Only ``[[package]]`` stanzas that name a workspace member and carry no
+    ``source`` key (path dependencies) are rewritten, and each member must match
+    the base version exactly once. Every other line — including a registry
+    package that squats a workspace name, and ``[[patch.unused]]`` stanzas — is
+    preserved byte-for-byte, so the candidate has zero degrees of freedom
+    against the returned content. A version-qualified dependency reference to a
+    workspace member ("wenlan-core 0.15.5", emitted only when a same-name
+    package shadows a member) is rejected outright rather than transformed —
+    extend this function before releasing such a lock. That rejection runs on
+    the TOML-decoded strings, so escape sequences cannot smuggle one past it.
+    """
+    lines = old.split("\n")
+    expected = list(lines)
+    replaced = dict.fromkeys(WORKSPACE_LOCK_PACKAGES, 0)
+    index = 0
+    total = len(lines)
+    while index < total:
+        if lines[index] != "[[package]]":
+            index += 1
+            continue
+        start = index + 1
+        index = start
+        while index < total and not lines[index].startswith("["):
+            index += 1
+        name: str | None = None
+        has_source = False
+        version_rows: list[int] = []
+        for row in range(start, index):
+            line = lines[row]
+            if line.startswith('name = "') and line.endswith('"'):
+                name = line[len('name = "') : -1]
+            elif line == f'version = "{old_version}"':
+                version_rows.append(row)
+            elif line.startswith("source = "):
+                has_source = True
+        if name not in WORKSPACE_LOCK_PACKAGES or has_source:
+            continue
+        if len(version_rows) != 1:
+            raise CandidateError(
+                f"Cargo.lock workspace stanza for {name!r} does not pin exactly the base version"
+            )
+        expected[version_rows[0]] = f'version = "{new_version}"'
+        replaced[name] += 1
+    for name in sorted(replaced):
+        if replaced[name] != 1:
+            raise CandidateError(
+                f"Cargo.lock does not contain exactly one workspace stanza for {name!r}"
+            )
+    try:
+        parsed = tomllib.loads(old)
+    except tomllib.TOMLDecodeError as error:
+        raise CandidateError("Cargo.lock base content is not valid TOML") from error
+    _reject_qualified_workspace_refs(parsed)
+    expected_content = "\n".join(expected)
+    try:
+        parsed_expected = tomllib.loads(expected_content)
+    except tomllib.TOMLDecodeError as error:
+        raise CandidateError("Cargo.lock expected transform is not valid TOML") from error
+
+    packages = parsed.get("package", [])
+    selected = [
+        package
+        for package in packages
+        if isinstance(package, dict)
+        and isinstance(package.get("name"), str)
+        and package["name"] in WORKSPACE_LOCK_PACKAGES
+        and "source" not in package
+    ] if isinstance(packages, list) else []
+    selected_names = {package["name"] for package in selected}
+    if (
+        len(selected) != len(WORKSPACE_LOCK_PACKAGES)
+        or selected_names != WORKSPACE_LOCK_PACKAGES
+    ):
+        raise CandidateError("Cargo.lock does not contain exactly the workspace package set")
+    for package in selected:
+        if package.get("version") != old_version:
+            raise CandidateError(
+                f"Cargo.lock workspace package {package['name']!r} is not at the base version"
+            )
+
+    bumped = copy.deepcopy(parsed)
+    bumped_packages = bumped.get("package", [])
+    if isinstance(bumped_packages, list):
+        for package in bumped_packages:
+            if (
+                isinstance(package, dict)
+                and isinstance(package.get("name"), str)
+                and package["name"] in WORKSPACE_LOCK_PACKAGES
+                and "source" not in package
+            ):
+                package["version"] = new_version
+    if bumped != parsed_expected:
+        raise CandidateError(
+            "Cargo.lock transform does not reduce to the exact workspace version bump"
+        )
+    return expected_content
+
+
+def _reject_qualified_workspace_refs(value: object) -> None:
+    if isinstance(value, str):
+        for name in sorted(WORKSPACE_LOCK_PACKAGES):
+            if WORKSPACE_LOCK_QUALIFIED_REF_PATTERNS[name].search(value):
+                raise CandidateError(
+                    f"Cargo.lock contains a version-qualified reference to"
+                    f" workspace package {name!r}; extend the validator before"
+                    " releasing it"
+                )
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _reject_qualified_workspace_refs(key)
+            _reject_qualified_workspace_refs(item)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_qualified_workspace_refs(item)
+
+
 def _validate_content_delta(path: str, old: str, new: str, old_version: str, new_version: str) -> None:
     removed: list[str] = []
     added: list[str] = []
@@ -311,6 +445,13 @@ def _validate_content_delta(path: str, old: str, new: str, old_version: str, new
     if path == "CHANGELOG.md":
         if removed or not any(line.startswith(f"## [{new_version}]") for line in added):
             raise CandidateError("CHANGELOG.md is not an additive current-version entry")
+        return
+    if path == "Cargo.lock":
+        if new != _expected_lock_transform(old, old_version, new_version):
+            raise CandidateError(
+                "release-managed file 'Cargo.lock' is not the exact"
+                " workspace-stanza version-only transform"
+            )
         return
     if old_version not in old:
         raise CandidateError(f"release-managed file {path!r} has no base version to replace")

--- a/scripts/validate-release-candidate.test.py
+++ b/scripts/validate-release-candidate.test.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+import tomllib
 import unittest
 import urllib.request
 import zipfile
@@ -155,6 +156,41 @@ class DownloadApi:
         return len(raw), hashlib.sha256(raw).hexdigest()
 
 
+def lock_contents(
+    workspace_version: str,
+    dep_version: str,
+    *,
+    squat_version: str | None = None,
+    patch_version: str | None = None,
+) -> str:
+    squat_version = squat_version or dep_version
+    patch_version = patch_version or dep_version
+    stanzas = [
+        "version = 3",
+        f'[[package]]\nname = "decoy-dep"\nversion = "{dep_version}"\n'
+        'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+        'checksum = "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface"',
+        # a registry package squatting a workspace name must never be rewritten
+        f'[[package]]\nname = "wenlan-core"\nversion = "{squat_version}"\n'
+        'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+        'checksum = "cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"',
+    ]
+    for name in sorted(VALIDATOR.WORKSPACE_LOCK_PACKAGES):
+        stanza = f'[[package]]\nname = "{name}"\nversion = "{workspace_version}"'
+        if name == "wenlan":
+            stanza += (
+                "\ndependencies = [\n"
+                ' "decoy-dep",\n'
+                ' "wenlan-core",\n'
+                "]"
+            )
+        stanzas.append(stanza)
+    stanzas.append(
+        f'[[patch.unused]]\nname = "wenlan-types"\nversion = "{patch_version}"'
+    )
+    return "\n\n".join(stanzas) + "\n"
+
+
 def release_contents() -> tuple[dict[str, str], dict[str, str]]:
     old_version = "0.15.3"
     new_version = "0.15.4"
@@ -182,6 +218,10 @@ def release_contents() -> tuple[dict[str, str], dict[str, str]]:
     new[codex] = json.dumps({"version": f"{new_version}+codex"})
     old["Cargo.toml"] = f'version = "{old_version}"   # x-release-please-version\n'
     new["Cargo.toml"] = f'version = "{new_version}"   # x-release-please-version\n'
+    # The decoy dependency legitimately sits at the workspace's old version and
+    # must survive the release untouched (the hashbrown 0.15.5 collision).
+    old["Cargo.lock"] = lock_contents(old_version, dep_version=old_version)
+    new["Cargo.lock"] = lock_contents(new_version, dep_version=old_version)
     old["release-please-config.json"] = json.dumps(
         {
             "packages": {
@@ -1147,6 +1187,211 @@ class ValidateReleaseCandidateTests(unittest.TestCase):
                     VALIDATOR.validate_release_pr_content(
                         FakeContentApi(old, new), "7xuanlu/wenlan", candidate_pr()
                     )
+
+    def test_lock_transform_tolerates_dependency_at_the_old_release_version(self) -> None:
+        # Regression: hashbrown sat at 0.15.5 while the release moved
+        # 0.15.5 → 0.15.6, so a whole-file replace demanded a hashbrown bump
+        # the candidate correctly does not make. The stanza-scoped transform
+        # must accept the untouched dependency (covered by the fixture decoy)
+        # and still reject any dependency-stanza mutation.
+        old, new = release_contents()
+        version, _, _ = VALIDATOR.validate_release_pr_content(
+            FakeContentApi(old, new), "7xuanlu/wenlan", candidate_pr()
+        )
+        self.assertEqual(version, "0.15.4")
+
+        hostile_lock_mutations = {
+            "dependency version bumped": lock_contents("0.15.4", dep_version="0.15.4"),
+            "dependency checksum changed": new["Cargo.lock"].replace(
+                "feedface", "deadbeef", 1
+            ),
+            "trailing content appended": new["Cargo.lock"] + 'name = "extra"\n',
+            "registry squat bumped": lock_contents(
+                "0.15.4", dep_version="0.15.3", squat_version="0.15.4"
+            ),
+            "patch.unused stanza bumped": lock_contents(
+                "0.15.4", dep_version="0.15.3", patch_version="0.15.4"
+            ),
+        }
+        for label, hostile in hostile_lock_mutations.items():
+            with self.subTest(label=label):
+                old, new = release_contents()
+                new["Cargo.lock"] = hostile
+                with self.assertRaisesRegex(
+                    VALIDATOR.CandidateError, "workspace-stanza version-only"
+                ):
+                    VALIDATOR.validate_release_pr_content(
+                        FakeContentApi(old, new), "7xuanlu/wenlan", candidate_pr()
+                    )
+
+    def test_unchanged_lock_is_rejected_before_the_lock_transform(self) -> None:
+        old, new = release_contents()
+        stale = lock_contents("0.15.3", dep_version="0.15.3")
+        old["Cargo.lock"] = stale
+        new["Cargo.lock"] = stale
+        with self.assertRaisesRegex(VALIDATOR.CandidateError, "did not change"):
+            VALIDATOR.validate_release_pr_content(
+                FakeContentApi(old, new), "7xuanlu/wenlan", candidate_pr()
+            )
+
+    def test_lock_transform_refuses_ambiguous_workspace_stanzas(self) -> None:
+        transform = VALIDATOR._expected_lock_transform
+        base = lock_contents("0.15.3", dep_version="0.15.3")
+
+        # keys reordered inside a stanza are still recognized and bumped
+        reordered = base.replace(
+            '[[package]]\nname = "wenlan"\nversion = "0.15.3"',
+            '[[package]]\nversion = "0.15.3"\nname = "wenlan"',
+        )
+        self.assertIn(
+            '[[package]]\nversion = "0.15.4"\nname = "wenlan"',
+            transform(reordered, "0.15.3", "0.15.4"),
+        )
+
+        # a second source-less stanza for one member is ambiguous
+        duplicated = base + '\n[[package]]\nname = "wenlan"\nversion = "0.15.3"\n'
+        with self.assertRaisesRegex(
+            VALIDATOR.CandidateError, "exactly one workspace stanza"
+        ):
+            transform(duplicated, "0.15.3", "0.15.4")
+
+        # every workspace member must be present in the lock
+        missing = base.replace('name = "wenlan-mcp"', 'name = "renamed-mcp"')
+        with self.assertRaisesRegex(
+            VALIDATOR.CandidateError, "exactly one workspace stanza"
+        ):
+            transform(missing, "0.15.3", "0.15.4")
+
+        # a workspace stanza off the base version is never silently skipped
+        off_version = base.replace(
+            'name = "wenlan-server"\nversion = "0.15.3"',
+            'name = "wenlan-server"\nversion = "0.15.2"',
+        )
+        with self.assertRaisesRegex(
+            VALIDATOR.CandidateError, "does not pin exactly the base version"
+        ):
+            transform(off_version, "0.15.3", "0.15.4")
+
+        # a CRLF version line cannot slip through as an untouched stale stanza
+        crlf = base.replace(
+            'name = "wenlan-types"\nversion = "0.15.3"',
+            'name = "wenlan-types"\nversion = "0.15.3"\r',
+            1,
+        )
+        with self.assertRaisesRegex(
+            VALIDATOR.CandidateError, "does not pin exactly the base version"
+        ):
+            transform(crlf, "0.15.3", "0.15.4")
+
+        # a version-qualified reference to a workspace member is refused
+        # outright — in every form Cargo can emit it, wherever it appears, and
+        # even hidden behind a TOML escape sequence
+        qualified_locks = [
+            base.replace(' "wenlan-core",', ' "wenlan-core 0.15.3",', 1),
+            base.replace(' "wenlan-core",', '  "wenlan-core 0.15.3"', 1),
+            base.replace(
+                ' "wenlan-core",',
+                ' "wenlan-core 0.15.3 (registry+https://github.com'
+                "/rust-lang/crates.io-index)\",",
+                1,
+            ),
+            base.replace(' "wenlan-core",', ' "wenlan-core\\u00200.15.3",', 1),
+            base + '\n[extra]\nnote = "wenlan-server 0.15.3"\n',
+            base
+            + '\n[metadata]\n'
+            + '"checksum wenlan-core 0.15.3 '
+            + '(registry+https://github.com/rust-lang/crates.io-index)" = "abc"\n',
+        ]
+        for qualified in qualified_locks:
+            with self.assertRaisesRegex(
+                VALIDATOR.CandidateError, "version-qualified reference"
+            ):
+                transform(qualified, "0.15.3", "0.15.4")
+
+        # the rejection is semantic, not textual: a comment mentioning a
+        # member is tolerated, while a base that is not TOML at all is refused
+        commented = base + '# "wenlan-core release note"\n'
+        self.assertIn('version = "0.15.4"', transform(commented, "0.15.3", "0.15.4"))
+        metadata_note = base + '\n[metadata]\nnote = "wenlan-core release note"\n'
+        self.assertIn(
+            'version = "0.15.4"', transform(metadata_note, "0.15.3", "0.15.4")
+        )
+        with self.assertRaisesRegex(VALIDATOR.CandidateError, "not valid TOML"):
+            transform(base + ' "dangling-line",\n', "0.15.3", "0.15.4")
+
+    def test_lock_transform_rejects_raw_parser_disagreement(self) -> None:
+        transform = VALIDATOR._expected_lock_transform
+        real_packages = "\n\n".join(
+            f' [[package]]\nname = "{name}"\nversion = "0.15.3"'
+            for name in sorted(VALIDATOR.WORKSPACE_LOCK_PACKAGES)
+        )
+        fake_packages = "\n".join(
+            f'[[package]]\nname = "{name}"\nversion = "0.15.3"'
+            for name in sorted(VALIDATOR.WORKSPACE_LOCK_PACKAGES)
+        )
+        base = (
+            "version = 3\n\n"
+            + real_packages
+            + '\n\n[metadata]\nnote = """\n'
+            + fake_packages
+            + '\n"""\n'
+        )
+        self.assertIsInstance(tomllib.loads(base)["package"], list)
+        with self.assertRaisesRegex(
+            VALIDATOR.CandidateError, "transform does not reduce"
+        ):
+            transform(base, "0.15.3", "0.15.4")
+
+    def test_lock_transform_rejects_indented_stale_workspace_package(self) -> None:
+        transform = VALIDATOR._expected_lock_transform
+        hostile = (
+            lock_contents("0.15.3", dep_version="0.15.3")
+            + '\n [[package]]\nname = "wenlan-core"\nversion = "0.15.2"\n'
+        )
+        parsed = tomllib.loads(hostile)
+        self.assertEqual(
+            sum(
+                package.get("name") == "wenlan-core"
+                and "source" not in package
+                for package in parsed["package"]
+            ),
+            2,
+        )
+        self.assertIn(
+            "0.15.2",
+            [
+                package["version"]
+                for package in parsed["package"]
+                if package.get("name") == "wenlan-core" and "source" not in package
+            ],
+        )
+        with self.assertRaisesRegex(
+            VALIDATOR.CandidateError,
+            "does not contain exactly the workspace package set",
+        ):
+            transform(hostile, "0.15.3", "0.15.4")
+
+    def test_lock_transform_accepts_version_shaped_prose_suffix(self) -> None:
+        transform = VALIDATOR._expected_lock_transform
+        base = lock_contents("0.15.3", dep_version="0.15.3")
+        noted = base + '\n[metadata]\nnote = "wenlan-core 0.15.6th release note"\n'
+        transformed = transform(noted, "0.15.3", "0.15.4")
+        self.assertIn('name = "wenlan-core"\nversion = "0.15.4"', transformed)
+
+    def test_lock_transform_rejects_qualified_version_extensions(self) -> None:
+        transform = VALIDATOR._expected_lock_transform
+        base = lock_contents("0.15.3", dep_version="0.15.3")
+        for note in (
+            "wenlan-core 0.15.3-alpha",
+            "wenlan-core 0.15.55",
+            "wenlan-core 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
+        ):
+            with self.subTest(note=note):
+                qualified = base + f'\n[metadata]\nnote = "{note}"\n'
+                with self.assertRaisesRegex(
+                    VALIDATOR.CandidateError, "version-qualified reference"
+                ):
+                    transform(qualified, "0.15.3", "0.15.4")
 
     def test_release_runner_mode_change_is_rejected(self) -> None:
         old, new = release_contents()


### PR DESCRIPTION
## Why

The release-candidate observer blocked the v0.15.6 promotion: its whole-file version-only transform for release-managed files demanded that `hashbrown` (a third-party crate that happens to sit at version 0.15.5) be bumped alongside the workspace's 0.15.5 → 0.15.6 move. First collision cycle between the workspace version string and a dependency version in `Cargo.lock`.

## What

`Cargo.lock` gets its own transform in `scripts/validate-release-candidate.py`, fail-closed at three mutually checking layers:

- **Byte layer** — a stanza parser bumps `version` only in source-less workspace `[[package]]` stanzas, exactly once per member; the candidate must byte-equal the result.
- **Reference layer** — version-qualified references to workspace members are rejected on the TOML-decoded content (escapes can't smuggle one past; version-shaped matching avoids prose false positives).
- **Semantic layer** — a `tomllib` postcondition selects the source-less workspace package set, requires exactly the five members at the base version, bumps them, and deep-compares against the parsed expected content — closing raw-walker/TOML parser disagreements.

## Verification

- `validate-release-candidate.test.py`: 37 tests OK (10 new lock-transform cases: squat stanza, patch.unused, escaped refs, indented stale duplicate, prose tolerance, and more)
- `release-workflow-contract.test.py`: PASS
- Real-pair proof: the genuine `0aaa695e` → merged-0.15.6 `Cargo.lock` delta is ACCEPTED; a hostile partial bump of it is REJECTED
- Six-round adversarial review by Codex Sol, closed APPROVE

## Release recovery context

Merging this is step 1 of the v0.15.6 recovery: next the unreleased version-bump merge `87ee2831` gets reverted, and the regenerated release PR (whose observer runs this fixed code) publishes v0.15.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JmrDX8z66BwPFbL525xw91