### PR TITLE
test: CI routing probe — app-only touch (close unmerged)

### DIFF
--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -8,3 +8,5 @@ fn main() {
     #[cfg(not(feature = "review-fixtures"))]
     wenlan_lib::run()
 }
+
+// CI routing probe: app-only change must run app-check and no rust test lanes (PR closed unmerged).


### PR DESCRIPTION
Probe (a) from the monorepo-fold migration plan, run immediately post-merge of #374.

Expected routing for an app-only diff: `app-check` RUNS; no Rust test suites (nextest partitions, platform-compile, contract integration all skip); `conclusion` green.

Will be closed unmerged once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCsZFCHXHjZhHKwsUTDmU6