### PR TITLE
test: CI routing probe — daemon-only touch (close unmerged)

### DIFF
--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -952,3 +952,5 @@ async fn main() -> anyhow::Result<()> {
     }
     result
 }
+
+// CI routing probe: daemon-only change must skip app-check (PR closed unmerged).


### PR DESCRIPTION
Probe (b) from the monorepo-fold migration plan, run immediately post-merge of #374.

Expected routing for a daemon-only diff: `app-check` SKIPPED; Rust lanes run for the affected closure; `conclusion` green.

Will be closed unmerged once verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCsZFCHXHjZhHKwsUTDmU6