### PR TITLE
feat: source app sidecars from the monorepo tree

### DIFF
--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -6,8 +6,8 @@ name: Release
 # origin-app repo for the .dmg" but a release workflow was never added here —
 # this repo has only ever had the test-only ci.yml. This file closes that
 # gap. Renamed origin -> wenlan throughout; adapted to the current
-# cross-repo sidecar build (scripts/prepare-sidecars.sh, which needs a
-# sibling wenlan backend checkout) and current secret names.
+# in-tree sidecar build (scripts/prepare-sidecars.sh, which compiles from the
+# checked-out monorepo) and current secret names.
 #
 # Signing key: rotated 2026-07-01 to ~/.tauri/wenlan-updater.key (the prior
 # origin-updater.key was retired after its encrypted blob was accidentally
@@ -222,12 +222,7 @@ jobs:
           TAURI_DIR: app
           CXXFLAGS: "-std=c++17"
           CLOUDFLARED_BIN: ${{ env.CLOUDFLARED_BIN }}
-          # Daemon sidecars come from the pinned RELEASED asset: tauri's
-          # beforeBuildCommand runs prepare-tauri-build-sidecars.sh, which honors
-          # WENLAN_DOWNLOAD_SIDECARS=1 to download instead of compiling from a
-          # backend checkout. GH_TOKEN authenticates the cross-repo gh download.
-          WENLAN_DOWNLOAD_SIDECARS: '1'
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Milestone B phase 4a: daemon sidecars compile from this same tree.
           # Ad-hoc sign ("-") when no Apple Developer cert is configured.
           # APPLE_ID/PASSWORD/TEAM_ID must be omitted (not empty) or Tauri
           # attempts notarization and fails on "Team ID must be at least 3 characters".

--- a/.github/workflows/app-release.yml
+++ b/.github/workflows/app-release.yml
@@ -123,7 +123,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            wenlan-app/app
+            wenlan-app
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/scripts/prepare-sidecars.test.ts
+++ b/scripts/prepare-sidecars.test.ts
@@ -136,7 +136,16 @@ describe("prepare-sidecars backend discovery", () => {
   });
 
   it("defaults to the monorepo root when no backend override is set", () => {
-    expect(resolveBackend(root)).toBe(root);
+    const base = makeTempRoot();
+    // Deliberately not named "wenlan": the old resolver's sibling probe
+    // ($REPO_ROOT/../wenlan) would otherwise resolve back to this same
+    // directory whenever the checkout happens to be named "wenlan" (true
+    // locally and on GitHub runners), making this case pass vacuously.
+    const monoRoot = resolve(base, "monorepo");
+    writeAppScripts(monoRoot);
+    writeBackendRepo(monoRoot);
+
+    expect(resolveBackend(monoRoot)).toBe(monoRoot);
   });
 
   it("keeps relative WENLAN_BACKEND_DIR overrides relative to the app checkout", () => {

--- a/scripts/prepare-sidecars.test.ts
+++ b/scripts/prepare-sidecars.test.ts
@@ -135,6 +135,10 @@ describe("prepare-sidecars backend discovery", () => {
     expect(output).toContain(`cli_src=${backendRoot}/target/debug/wenlan`);
   });
 
+  it("defaults to the monorepo root when no backend override is set", () => {
+    expect(resolveBackend(root)).toBe(root);
+  });
+
   it("keeps relative WENLAN_BACKEND_DIR overrides relative to the app checkout", () => {
     const base = makeTempRoot();
     const appRoot = resolve(base, "wenlan-app");

--- a/scripts/resolve-backend-dir.sh
+++ b/scripts/resolve-backend-dir.sh
@@ -6,11 +6,15 @@ DEFAULT_REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="${1:-$DEFAULT_REPO_ROOT}"
 REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
 
+# The monorepo checkout is the normal backend source. Sibling probes below are
+# legacy fallbacks for standalone app checkouts and older worktrees.
+
 is_wenlan_backend_dir() {
   local dir="$1"
   [[ -f "$dir/Cargo.toml" && -d "$dir/crates/wenlan-server" && -d "$dir/crates/wenlan-mcp" && -d "$dir/crates/wenlan-cli" ]]
 }
 
+# An explicit WENLAN_BACKEND_DIR override always has the highest priority.
 if [[ -n "${WENLAN_BACKEND_DIR:-}" ]]; then
   candidate="$WENLAN_BACKEND_DIR"
   if [[ "$candidate" != /* ]]; then
@@ -25,6 +29,7 @@ if [[ -n "${WENLAN_BACKEND_DIR:-}" ]]; then
 fi
 
 for candidate in \
+  "$REPO_ROOT" \
   "$REPO_ROOT/../wenlan" \
   "$REPO_ROOT/../../../wenlan" \
   "$REPO_ROOT/../.."


### PR DESCRIPTION
Milestone B phase 4a of the app-monorepo migration.

- `scripts/resolve-backend-dir.sh`: the repo root is now the first backend candidate (the fold made this repo the backend). The sibling-checkout probes remain as legacy fallbacks; `WENLAN_BACKEND_DIR` keeps highest priority.
- `.github/workflows/app-release.yml`: drops `WENLAN_DOWNLOAD_SIDECARS: '1'` (and the paired `GH_TOKEN`) from the Tauri build step, so `prepare-tauri-build-sidecars.sh` compiles `wenlan-server`/`wenlan-mcp`/`wenlan` from the checked-out tree instead of downloading the pinned released asset. The workflow's other `GH_TOKEN` uses are untouched.
- `scripts/prepare-sidecars.test.ts`: new case asserting the resolver returns the monorepo root when no override is set.

Local proof: `env -u WENLAN_DOWNLOAD_SIDECARS TAURI_ENV_DEBUG=true bash scripts/prepare-tauri-build-sidecars.sh` builds from this tree and the installed sidecar reports `wenlan-server 0.15.6`, matching `version.txt` (previously it shipped the pinned 0.14.0 asset). Resolver returns the repo root; vitest file 20/20.

Not in scope, deliberately: the `workflow_dispatch` CI proof is deferred until the app version moves off 0.14.0 — tauri-action's `tagName: v__VERSION__` collides with the existing published daemon release `v0.14.0` and uploads onto it even with `draft: true` (that happened once on 2026-08-09 and was cleaned up; see the migration plan's hazard list). Also flagged for a possible follow-up: `prepare-sidecars.sh` reuses existing `target/` binaries without rebuilding in local dev loops, which can ship a stale sidecar locally (CI always builds clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZCe7EkudPghv2GjDLKcKb