### PR TITLE
feat: build and promote the macOS app bundle in the unified release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -436,9 +436,147 @@ jobs:
           echo "ERROR: legacy tag-push Release run $legacy_run_id did not reach cancelled."
           exit 1
 
+  app-bundle:
+    name: Build macOS desktop app bundle
+    needs: [resolve-promotion, bind-release-tag]
+    runs-on: macos-14
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    outputs:
+      dmg_filename: ${{ steps.stage.outputs.dmg_filename }}
+      tarball_filename: ${{ steps.stage.outputs.tarball_filename }}
+      sig_filename: ${{ steps.stage.outputs.sig_filename }}
+      dmg_sha256: ${{ steps.stage.outputs.dmg_sha256 }}
+      tarball_sha256: ${{ steps.stage.outputs.tarball_sha256 }}
+      sig_sha256: ${{ steps.stage.outputs.sig_sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify release checkout
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          checkout_sha="$(git rev-parse HEAD)"
+          tag_sha="$(gh api --method GET \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            "/repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '.object.sha')"
+          if [[ "$checkout_sha" != "$RELEASE_SHA" || "$tag_sha" != "$RELEASE_SHA" ]]; then
+            echo "ERROR: release SHA $RELEASE_SHA, checkout $checkout_sha, and current tag $tag_sha differ."
+            exit 1
+          fi
+
+      - name: Milestone-B 4b app version lockstep guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP_VERSION="$(jq -er '.version | strings' app/tauri.conf.json)"
+          if [[ "v$APP_VERSION" != "$RELEASE_TAG" ]]; then
+            echo "ERROR: Milestone-B 4b lockstep guard: app/tauri.conf.json version $APP_VERSION does not match release tag $RELEASE_TAG; stays red until phase 4c bumps the app version."
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
+        with:
+          toolchain: 1.95.0
+          targets: aarch64-apple-darwin
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: app-bundle
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download cloudflared sidecar
+        run: |
+          mkdir -p app/binaries
+          curl -fsSL -o /tmp/cloudflared.tgz \
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-arm64.tgz
+          tar -xzf /tmp/cloudflared.tgz -C /tmp
+          chmod 755 /tmp/cloudflared
+          xattr -cr /tmp/cloudflared
+          echo "CLOUDFLARED_BIN=/tmp/cloudflared" >> "$GITHUB_ENV"
+
+      - name: Build macOS desktop app bundle
+        shell: bash
+        env:
+          CXXFLAGS: "-std=c++17"
+          CLOUDFLARED_BIN: ${{ env.CLOUDFLARED_BIN }}
+          # Ad-hoc sign ("-") when no Apple Developer cert is configured.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '-' }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm tauri build --target aarch64-apple-darwin
+
+      - name: Stage app bundle assets and checksums
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP_VERSION="$(jq -er '.version | strings' app/tauri.conf.json)"
+          bundle_dir="$GITHUB_WORKSPACE/target/aarch64-apple-darwin/release/bundle"
+          dmg="$(find "$bundle_dir/dmg" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
+          tarball="$(find "$bundle_dir/macos" -maxdepth 1 -type f -name '*.app.tar.gz' -print -quit)"
+          sig="${tarball}.sig"
+          [[ -n "$dmg" && -f "$dmg" ]] || { echo "ERROR: Tauri did not emit a .dmg under $bundle_dir/dmg."; exit 1; }
+          [[ -n "$tarball" && -f "$tarball" ]] || { echo "ERROR: Tauri did not emit an .app.tar.gz under $bundle_dir/macos."; exit 1; }
+          [[ -f "$sig" ]] || { echo "ERROR: Tauri did not emit $sig."; exit 1; }
+
+          staged="$RUNNER_TEMP/app-bundle-staging"
+          rm -rf "$staged"
+          mkdir -p "$staged"
+          dmg_name="Wenlan_${APP_VERSION}_aarch64.dmg"
+          tarball_name="Wenlan_aarch64.app.tar.gz"
+          sig_name="${tarball_name}.sig"
+          cp "$dmg" "$staged/$dmg_name"
+          cp "$tarball" "$staged/$tarball_name"
+          cp "$sig" "$staged/$sig_name"
+
+          dmg_sha256="$(shasum -a 256 "$staged/$dmg_name" | awk '{print $1}')"
+          tarball_sha256="$(shasum -a 256 "$staged/$tarball_name" | awk '{print $1}')"
+          sig_sha256="$(shasum -a 256 "$staged/$sig_name" | awk '{print $1}')"
+          echo "Tauri DMG: $dmg"
+          echo "Tauri updater bundle: $tarball"
+          echo "Tauri updater signature: $sig"
+          echo "Staged checksums: $dmg_sha256 $tarball_sha256 $sig_sha256"
+          {
+            echo "dmg_filename=$dmg_name"
+            echo "tarball_filename=$tarball_name"
+            echo "sig_filename=$sig_name"
+            echo "dmg_sha256=$dmg_sha256"
+            echo "tarball_sha256=$tarball_sha256"
+            echo "sig_sha256=$sig_sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload macOS app bundle artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: app-bundle-${{ github.run_id }}
+          path: ${{ runner.temp }}/app-bundle-staging
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
   promote-assets:
     name: Promote exact validated release assets
-    needs: [resolve-promotion, bind-release-tag, prepare-release]
+    needs: [resolve-promotion, bind-release-tag, prepare-release, app-bundle]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -496,6 +634,90 @@ jobs:
               gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY"
             fi
           done
+      - name: Download macOS app bundle artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: app-bundle-${{ github.run_id }}
+          path: ${{ runner.temp }}/app-bundle
+      - name: Verify macOS app bundle bytes before promotion
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_sha256() {
+            local name="$1" expected="$2" actual path
+            path="$RUNNER_TEMP/app-bundle/$name"
+            [[ -f "$path" ]] || { echo "ERROR: missing app bundle artifact $name."; exit 1; }
+            actual="$(sha256sum "$path" | awk '{print $1}')"
+            if [[ "$actual" != "$expected" ]]; then
+              echo "ERROR: app bundle asset $name SHA-256 mismatch: expected $expected, got $actual."
+              exit 1
+            fi
+            echo "$name: $actual"
+          }
+          verify_sha256 "${{ needs.app-bundle.outputs.dmg_filename }}" "${{ needs.app-bundle.outputs.dmg_sha256 }}"
+          verify_sha256 "${{ needs.app-bundle.outputs.tarball_filename }}" "${{ needs.app-bundle.outputs.tarball_sha256 }}"
+          verify_sha256 "${{ needs.app-bundle.outputs.sig_filename }}" "${{ needs.app-bundle.outputs.sig_sha256 }}"
+      - name: Upload macOS app assets and updater metadata without clobbering
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing="$RUNNER_TEMP/existing-app-release-assets"
+          mkdir -p "$existing"
+
+          upload_without_clobber() {
+            local asset="$1" name tag_sha
+            name="$(basename "$asset")"
+            tag_sha="$(gh api --method GET \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2026-03-10' \
+              "/repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq '.object.sha')"
+            if [[ "$tag_sha" != "$RELEASE_SHA" ]]; then
+              echo "ERROR: $RELEASE_TAG moved from release SHA $RELEASE_SHA to $tag_sha."
+              exit 1
+            fi
+            if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+              --json assets --jq '.assets[].name' | grep -Fxq "$name"; then
+              gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+                --pattern "$name" --dir "$existing"
+              cmp "$asset" "$existing/$name" || {
+                echo "Existing release asset $name differs; refusing to clobber."
+                exit 1
+              }
+              echo "$name already exists with identical bytes."
+            else
+              gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY"
+            fi
+          }
+
+          upload_without_clobber "$RUNNER_TEMP/app-bundle/${{ needs.app-bundle.outputs.dmg_filename }}"
+          upload_without_clobber "$RUNNER_TEMP/app-bundle/${{ needs.app-bundle.outputs.tarball_filename }}"
+          upload_without_clobber "$RUNNER_TEMP/app-bundle/${{ needs.app-bundle.outputs.sig_filename }}"
+
+          # Installed clients still read the OLD repo endpoint until the phase-5 cutover;
+          # this file must exist on the unified release BEFORE that cutover.
+          version="${RELEASE_TAG#v}"
+          notes="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')"
+          pub_date="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")"
+          signature="$(cat "$RUNNER_TEMP/app-bundle/${{ needs.app-bundle.outputs.sig_filename }}")"
+          tarball_name="${{ needs.app-bundle.outputs.tarball_filename }}"
+          jq -n \
+            --arg version "$version" \
+            --arg notes "$notes" \
+            --arg pub_date "$pub_date" \
+            --arg signature "$signature" \
+            --arg url "https://github.com/7xuanlu/wenlan/releases/download/$RELEASE_TAG/$tarball_name" \
+            '{
+              version: $version,
+              notes: $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "darwin-aarch64": {signature: $signature, url: $url},
+                "darwin-aarch64-app": {signature: $signature, url: $url}
+              }
+            }' > "$RUNNER_TEMP/app-bundle/latest.json"
+          upload_without_clobber "$RUNNER_TEMP/app-bundle/latest.json"
       - name: Publish exact Homebrew inputs for this run
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,11 +488,6 @@ jobs:
         with:
           toolchain: 1.95.0
           targets: aarch64-apple-darwin
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: app-bundle
-          cache-all-crates: "true"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -440,7 +440,7 @@ jobs:
     name: Build macOS desktop app bundle
     needs: [resolve-promotion, bind-release-tag]
     runs-on: macos-14
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
     outputs:
@@ -457,6 +457,7 @@ jobs:
           ref: ${{ env.RELEASE_SHA }}
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Verify release checkout
         shell: bash
@@ -499,7 +500,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Download cloudflared sidecar
+        shell: bash
         run: |
+          set -euo pipefail
           mkdir -p app/binaries
           curl -fsSL -o /tmp/cloudflared.tgz \
             https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-darwin-arm64.tgz
@@ -629,6 +632,41 @@ jobs:
               gh release upload "$RELEASE_TAG" "$asset" --repo "$GITHUB_REPOSITORY"
             fi
           done
+      - name: Publish exact Homebrew inputs for this run
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: homebrew-artifacts
+          path: |
+            ${{ runner.temp }}/promoted-assets/wenlan-cli-darwin-arm64.tar.gz
+            ${{ runner.temp }}/promoted-assets/wenlan-mcp-darwin-arm64.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+          # Internal retry locator. The uploaded archives are still the exact
+          # receipt-validated bytes, and every rerun creates a fresh artifact ID.
+          overwrite: true
+      # upload-artifact roots the archive at the common ancestor of its paths,
+      # so listing promoted-assets/ and promotion-plan/ together nests both
+      # under the runner temp root while the Docker job reads them flat. Stage
+      # one directory so the producer and the consumer agree on the layout.
+      - name: Stage exact Docker runtime inputs
+        run: |
+          set -euo pipefail
+          staged="$RUNNER_TEMP/docker-runtime-staging"
+          mkdir -p "$staged"
+          cp "$RUNNER_TEMP/promoted-assets/wenlan-linux-x64.tar.gz" "$staged/"
+          cp "$RUNNER_TEMP/promoted-assets/wenlan-linux-arm64.tar.gz" "$staged/"
+          cp "$RUNNER_TEMP/promotion-plan/release-promotion-plan.json" "$staged/"
+      - name: Publish exact Docker runtime inputs for this run
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: docker-runtime-inputs
+          path: ${{ runner.temp }}/docker-runtime-staging
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+          # Internal retry locator; Docker revalidates the receipt and archive
+          # hashes before it executes the copied server binary.
+          overwrite: true
       - name: Download macOS app bundle artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -694,7 +732,7 @@ jobs:
           # this file must exist on the unified release BEFORE that cutover.
           version="${RELEASE_TAG#v}"
           notes="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json body --jq '.body')"
-          pub_date="$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")"
+          pub_date="$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_SHA" --jq '.commit.committer.date')"
           signature="$(cat "$RUNNER_TEMP/app-bundle/${{ needs.app-bundle.outputs.sig_filename }}")"
           tarball_name="${{ needs.app-bundle.outputs.tarball_filename }}"
           jq -n \
@@ -713,41 +751,6 @@ jobs:
               }
             }' > "$RUNNER_TEMP/app-bundle/latest.json"
           upload_without_clobber "$RUNNER_TEMP/app-bundle/latest.json"
-      - name: Publish exact Homebrew inputs for this run
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: homebrew-artifacts
-          path: |
-            ${{ runner.temp }}/promoted-assets/wenlan-cli-darwin-arm64.tar.gz
-            ${{ runner.temp }}/promoted-assets/wenlan-mcp-darwin-arm64.tar.gz
-          retention-days: 1
-          if-no-files-found: error
-          # Internal retry locator. The uploaded archives are still the exact
-          # receipt-validated bytes, and every rerun creates a fresh artifact ID.
-          overwrite: true
-      # upload-artifact roots the archive at the common ancestor of its paths,
-      # so listing promoted-assets/ and promotion-plan/ together nests both
-      # under the runner temp root while the Docker job reads them flat. Stage
-      # one directory so the producer and the consumer agree on the layout.
-      - name: Stage exact Docker runtime inputs
-        run: |
-          set -euo pipefail
-          staged="$RUNNER_TEMP/docker-runtime-staging"
-          mkdir -p "$staged"
-          cp "$RUNNER_TEMP/promoted-assets/wenlan-linux-x64.tar.gz" "$staged/"
-          cp "$RUNNER_TEMP/promoted-assets/wenlan-linux-arm64.tar.gz" "$staged/"
-          cp "$RUNNER_TEMP/promotion-plan/release-promotion-plan.json" "$staged/"
-      - name: Publish exact Docker runtime inputs for this run
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: docker-runtime-inputs
-          path: ${{ runner.temp }}/docker-runtime-staging
-          compression-level: 0
-          retention-days: 1
-          if-no-files-found: error
-          # Internal retry locator; Docker revalidates the receipt and archive
-          # hashes before it executes the copied server binary.
-          overwrite: true
 
   docker:
     name: Verify & Push Runtime Image (${{ matrix.platform }})

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -4925,7 +4925,12 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     if job_needs(&release, "bind-release-tag") != ["resolve-promotion"]
         || job_needs(&release, "prepare-release") != ["resolve-promotion", "bind-release-tag"]
         || job_needs(&release, "promote-assets")
-            != ["resolve-promotion", "bind-release-tag", "prepare-release", "app-bundle"]
+            != [
+                "resolve-promotion",
+                "bind-release-tag",
+                "prepare-release",
+                "app-bundle",
+            ]
     {
         violations.push("tag release artifact-promotion DAG bypasses receipt resolution".into());
     }
@@ -6073,7 +6078,12 @@ fn release_promotion_contract_violations(
         || !resolve.contains(".main_sha == $sha and .main_run == null")
         || job_needs(&release, "prepare-release") != ["resolve-promotion", "bind-release-tag"]
         || job_needs(&release, "promote-assets")
-            != ["resolve-promotion", "bind-release-tag", "prepare-release", "app-bundle"]
+            != [
+                "resolve-promotion",
+                "bind-release-tag",
+                "prepare-release",
+                "app-bundle",
+            ]
     {
         violations
             .push("tag release does not resolve the main receipt before asset promotion".into());

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -567,6 +567,11 @@ fn coverage_single_test_execution_violations(workflow: &str) -> Vec<String> {
     violations
 }
 
+// Daemon promotion assets must still come from receipt-bound archives without
+// rebuilding; the app-bundle job is the sanctioned exception that compiles the
+// desktop app (and its sidecar daemon binary) from the tag-verified SHA, because no
+// receipt path exists for the app. The forbidden-string list intentionally still
+// bans compiler caches everywhere, including that job.
 fn release_rust_cache_violations(workflow: &str) -> Vec<String> {
     let parsed: serde_yaml::Value = serde_yaml::from_str(workflow).expect("parse release.yml");
     let mut violations = Vec::new();
@@ -786,9 +791,11 @@ fn release_reuses_receipt_bound_archives_without_compiling() {
     let violations = release_rust_cache_violations(&workflow);
     assert!(
         violations.is_empty(),
-        "Release artifact-reuse contract drift — release.yml must consume receipt-bound \
-         archives without compiling or restoring compiler caches. Fix \
-         .github/workflows/release.yml; an intentional contract change also updates \
+        "Release artifact-reuse contract drift — daemon promotion assets in release.yml \
+         must still come from receipt-bound archives without compiling or restoring \
+         compiler caches; the app-bundle job is the sole sanctioned exception, compiling \
+         the desktop app from the tag-verified SHA because no receipt path exists for it. \
+         Fix .github/workflows/release.yml; an intentional contract change also updates \
          release_rust_cache_violations() and its positive control:\n{}",
         violations.join("\n")
     );

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -4925,7 +4925,7 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
     if job_needs(&release, "bind-release-tag") != ["resolve-promotion"]
         || job_needs(&release, "prepare-release") != ["resolve-promotion", "bind-release-tag"]
         || job_needs(&release, "promote-assets")
-            != ["resolve-promotion", "bind-release-tag", "prepare-release"]
+            != ["resolve-promotion", "bind-release-tag", "prepare-release", "app-bundle"]
     {
         violations.push("tag release artifact-promotion DAG bypasses receipt resolution".into());
     }
@@ -6073,7 +6073,7 @@ fn release_promotion_contract_violations(
         || !resolve.contains(".main_sha == $sha and .main_run == null")
         || job_needs(&release, "prepare-release") != ["resolve-promotion", "bind-release-tag"]
         || job_needs(&release, "promote-assets")
-            != ["resolve-promotion", "bind-release-tag", "prepare-release"]
+            != ["resolve-promotion", "bind-release-tag", "prepare-release", "app-bundle"]
     {
         violations
             .push("tag release does not resolve the main receipt before asset promotion".into());

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -419,7 +419,7 @@ def contract_violations(
         "update-homebrew": 20,
         "docker-manifest": 10,
         "finalize-release": 10,
-        "app-bundle": 60,
+        "app-bundle": 90,
     }.items():
         if not re.search(
             rf"^    timeout-minutes: {timeout}\s*$",
@@ -511,7 +511,7 @@ def contract_violations(
         "TAURI_SIGNING_PRIVATE_KEY"
     ):
         violations.append("Tauri signing key leaks outside the app-bundle job")
-    for marker in ["latest.json", "darwin-aarch64-app"]:
+    for marker in ["latest.json", "darwin-aarch64-app", "needs.app-bundle.outputs.dmg_sha256"]:
         if marker not in promote:
             violations.append(f"validated asset promotion omits updater manifest {marker!r}")
     verify_idx = promote.find("Verify macOS app bundle bytes before promotion")

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -511,9 +511,13 @@ def contract_violations(
         "TAURI_SIGNING_PRIVATE_KEY"
     ):
         violations.append("Tauri signing key leaks outside the app-bundle job")
-    for marker in ["latest.json", "darwin-aarch64-app", "needs.app-bundle.outputs.dmg_sha256"]:
+    for marker in ["latest.json", "darwin-aarch64-app"]:
         if marker not in promote:
             violations.append(f"validated asset promotion omits updater manifest {marker!r}")
+    if "needs.app-bundle.outputs.dmg_sha256" not in promote:
+        violations.append(
+            "app bundle SHA-256 re-verification is not wired to the app-bundle job outputs"
+        )
     verify_idx = promote.find("Verify macOS app bundle bytes before promotion")
     upload_idx = promote.find(
         "Upload macOS app assets and updater metadata without clobbering"

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -419,6 +419,7 @@ def contract_violations(
         "update-homebrew": 20,
         "docker-manifest": 10,
         "finalize-release": 10,
+        "app-bundle": 60,
     }.items():
         if not re.search(
             rf"^    timeout-minutes: {timeout}\s*$",
@@ -432,6 +433,7 @@ def contract_violations(
         "resolve-promotion",
         "bind-release-tag",
         "prepare-release",
+        "app-bundle",
         "promote-assets",
         "docker",
         "docker-manifest",
@@ -441,10 +443,10 @@ def contract_violations(
             violations.append(f"tag release omits artifact-promotion job {job!r}")
     if "    needs: [resolve-promotion, bind-release-tag]" not in job_body(release, "prepare-release"):
         violations.append("release preparation can start before receipt-derived tag binding")
-    if "    needs: [resolve-promotion, bind-release-tag, prepare-release]" not in job_body(
+    if "    needs: [resolve-promotion, bind-release-tag, prepare-release, app-bundle]" not in job_body(
         release, "promote-assets"
     ):
-        violations.append("asset publication bypasses receipt resolution, tag binding, or prerelease gate")
+        violations.append("asset publication bypasses receipt resolution, tag binding, prerelease gate, or app bundling")
     resolve = job_body(release, "resolve-promotion")
     for marker in [
         "scripts/release-promotion.py gate-main",
@@ -464,6 +466,7 @@ def contract_violations(
         "prepare-release",
         "resolve-promotion",
         "bind-release-tag",
+        "app-bundle",
         "promote-assets",
         "docker",
         "docker-manifest",
@@ -496,6 +499,31 @@ def contract_violations(
     ]:
         if marker not in promote:
             violations.append(f"validated asset promotion omits {marker!r}")
+
+    app_bundle = job_body(release, "app-bundle")
+    if "tauri-action" in release:
+        violations.append("app bundling must build directly, never via tauri-action")
+    if "contents: read" not in app_bundle:
+        violations.append("app bundle job does not scope permissions to contents: read")
+    if "TAURI_SIGNING_PRIVATE_KEY" not in app_bundle:
+        violations.append("app bundle job omits the Tauri updater signing key")
+    elif release.count("TAURI_SIGNING_PRIVATE_KEY") != app_bundle.count(
+        "TAURI_SIGNING_PRIVATE_KEY"
+    ):
+        violations.append("Tauri signing key leaks outside the app-bundle job")
+    for marker in ["latest.json", "darwin-aarch64-app"]:
+        if marker not in promote:
+            violations.append(f"validated asset promotion omits updater manifest {marker!r}")
+    verify_idx = promote.find("Verify macOS app bundle bytes before promotion")
+    upload_idx = promote.find(
+        "Upload macOS app assets and updater metadata without clobbering"
+    )
+    if verify_idx == -1 or upload_idx == -1:
+        violations.append(
+            "validated asset promotion omits app bundle SHA-256 re-verification before upload"
+        )
+    elif verify_idx > upload_idx:
+        violations.append("app bundle assets are uploaded before their SHA-256 re-verification")
 
     docker = job_body(release, "docker")
     if "    needs: [promote-assets, bind-release-tag]" not in docker:


### PR DESCRIPTION
Milestone B phase 4b of the app-monorepo fold.

## What
- New `app-bundle` job in `release.yml`: macos-14, `contents: read`, checkout-SHA + live-tag verification, a version-lockstep guard, direct `pnpm tauri build` (never tauri-action), updater signing keys scoped to the single build step, and SHA-256 checksums exported as job outputs. No compiler-cache actions — the drift-guard tooth banning them in release.yml stays at full strictness, so the app builds cold (90-minute bound; measured warm datapoints 10.2 min daemon + 10.5 min app leave ample cold headroom).
- `promote-assets` now needs `app-bundle`, re-verifies every app asset hash before touching the release, uploads `.dmg` / `.app.tar.gz` / `.sig` with a no-clobber byte-compare, and assembles `latest.json` from the signed tarball. `pub_date` derives from the release commit's committer date, so latest.json is byte-stable and job reruns stay possible (every asset cmp's clean on retry). The app steps sit at the end of the job so an app-side failure can't block the Homebrew/Docker input staging that unrelated downstream jobs consume. Platform keys match the old repo's updater manifest; installed clients keep reading the old endpoint until the phase-5 cutover.
- `scripts/release-workflow-contract.test.py` encodes the new contract: app-bundle presence, 90-minute bound, immutable-tag checks, the extended needs list, no `tauri-action` anywhere, signing keys confined to the bundle job, hash re-verification wired to the real job outputs and ordered before upload.

## Expected RED until the version-lockstep PR (deliberate release freeze)
The lockstep guard fails any release run while `app/tauri.conf.json` is still 0.14.0. Blast radius, understood and accepted: because promote-assets needs app-bundle, a tag pushed in this window produces a zero-asset prerelease and nothing publishes to crates.io, npm, Docker, or Homebrew until the version bump lands (the immediate next PR). The guard is also load-bearing against forged job outputs (it pins the app version, which flows into asset filenames, to the git-ref-constrained tag) — it must survive phase 4c in equivalent form.

## Verification
- `release-workflow-contract.test.py`, `validate-versions.test.sh`, and the release drift-guard tooth all pass locally (rc captured at the command).
- Mutation-proven: dropping `app-bundle` from the needs list, reintroducing a `tauri-action` reference, and leaking the signing key outside the bundle job each turn the contract test red.
- Independent investigator review completed; all findings addressed (deterministic latest.json, step reordering, cold-build bound, shell hardening, checkout credential scoping, contract-marker hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZCe7EkudPghv2GjDLKcKb