### PR TITLE
feat: point the app updater at the unified release manifest

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=7bbf1b1a901c212818cfa814b34f772c3eb388959add7c1c4097db1af6562f69 -->
+<!-- README_SYNC: source=README.md sha256=4a3802a3bebf6dd84fdff116e3a9f5582876770641175974ee226853ee49956b -->
 
 <p align="center">
   <picture>

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -54,7 +54,7 @@ La aplicación de escritorio es la forma más rápida de ver el flujo de trabajo
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-El [instalador es inspeccionable](scripts/install-macos-app.sh). Verifica el archivo de la versión contra el SHA-256 publicado en GitHub antes de reemplazar una aplicación existente. ¿Prefieres el DMG o quieres inspeccionar el código fuente de la aplicación? Consulta las [versiones de wenlan-app](https://github.com/7xuanlu/wenlan-app/releases/latest) o el crate [`app/`](app/) dentro de este repositorio.
+El [instalador es inspeccionable](scripts/install-macos-app.sh). Verifica el archivo de la versión contra el SHA-256 publicado en GitHub antes de reemplazar una aplicación existente. ¿Prefieres el DMG o quieres inspeccionar el código fuente de la aplicación? Consulta las [versiones de wenlan](https://github.com/7xuanlu/wenlan/releases/latest) o el crate [`app/`](app/) dentro de este repositorio.
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The desktop app is the fastest way to see the complete workflow: read pages, ins
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-The [installer is inspectable](scripts/install-macos-app.sh). It checks the release archive against GitHub's published SHA-256 before replacing an existing app. Prefer the DMG or want to inspect the app source? See [wenlan-app releases](https://github.com/7xuanlu/wenlan-app/releases/latest) or the in-tree [`app/`](app/) crate.
+The [installer is inspectable](scripts/install-macos-app.sh). It checks the release archive against GitHub's published SHA-256 before replacing an existing app. Prefer the DMG or want to inspect the app source? See [wenlan releases](https://github.com/7xuanlu/wenlan/releases/latest) or the in-tree [`app/`](app/) crate.
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -54,7 +54,7 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-你可以直接[检查安装器源码](scripts/install-macos-app.sh)。安装器会先用 GitHub 发布的 SHA-256 核对下载文件，再替换现有 app。偏好 DMG 或想查看 app 源码？请前往 [wenlan-app releases](https://github.com/7xuanlu/wenlan-app/releases/latest)，或查看本仓库内的 [`app/`](app/) crate。
+你可以直接[检查安装器源码](scripts/install-macos-app.sh)。安装器会先用 GitHub 发布的 SHA-256 核对下载文件，再替换现有 app。偏好 DMG 或想查看 app 源码？请前往 [wenlan releases](https://github.com/7xuanlu/wenlan/releases/latest)，或查看本仓库内的 [`app/`](app/) crate。
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=7bbf1b1a901c212818cfa814b34f772c3eb388959add7c1c4097db1af6562f69 -->
+<!-- README_SYNC: source=README.md sha256=4a3802a3bebf6dd84fdff116e3a9f5582876770641175974ee226853ee49956b -->
 
 <p align="center">
   <picture>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=7bbf1b1a901c212818cfa814b34f772c3eb388959add7c1c4097db1af6562f69 -->
+<!-- README_SYNC: source=README.md sha256=4a3802a3bebf6dd84fdff116e3a9f5582876770641175974ee226853ee49956b -->
 
 <p align="center">
   <picture>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -54,7 +54,7 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-你可以直接[檢查安裝器原始碼](scripts/install-macos-app.sh)。安裝器會先用 GitHub 發布的 SHA-256 核對下載檔案，再替換現有 app。偏好 DMG 或想查看 app 原始碼？請前往 [wenlan-app releases](https://github.com/7xuanlu/wenlan-app/releases/latest)，或檢視本儲存庫內的 [`app/`](app/) crate。
+你可以直接[檢查安裝器原始碼](scripts/install-macos-app.sh)。安裝器會先用 GitHub 發布的 SHA-256 核對下載檔案，再替換現有 app。偏好 DMG 或想查看 app 原始碼？請前往 [wenlan releases](https://github.com/7xuanlu/wenlan/releases/latest)，或檢視本儲存庫內的 [`app/`](app/) crate。
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/app/tauri.conf.json
+++ b/app/tauri.conf.json
@@ -75,7 +75,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://github.com/7xuanlu/wenlan-app/releases/latest/download/latest.json"
+        "https://github.com/7xuanlu/wenlan/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI0REU1Mzc1REZDMTNCRTUKUldUbE84SGZkVlBlSkxxSzlEV2tJZWE1UVlsOFVhaE1za2IxWFdMNk9sTFo5WWhNa1FPWTBYSHgK"
     }

--- a/scripts/install-macos-app.sh
+++ b/scripts/install-macos-app.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-RELEASE_JSON_URL=${WENLAN_APP_RELEASE_JSON_URL:-https://api.github.com/repos/7xuanlu/wenlan-app/releases/latest}
+RELEASE_JSON_URL=${WENLAN_APP_RELEASE_JSON_URL:-https://api.github.com/repos/7xuanlu/wenlan/releases/latest}
 ASSET_NAME=${WENLAN_APP_ASSET_NAME:-Wenlan_aarch64.app.tar.gz}
 
 die() {

--- a/src/runtimeIdentity.test.ts
+++ b/src/runtimeIdentity.test.ts
@@ -61,7 +61,7 @@ describe("runtime product identity", () => {
     );
 
     expect(tauri.plugins.updater.endpoints[0]).toBe(
-      "https://github.com/7xuanlu/wenlan-app/releases/latest/download/latest.json",
+      "https://github.com/7xuanlu/wenlan/releases/latest/download/latest.json",
     );
   });
 


### PR DESCRIPTION
## Why

Phase-5 step 1 of the app-monorepo migration: new app builds must self-update from the monorepo's `latest.json` (published on every unified release since v0.15.7). Existing installs keep updating via the old-repo bridge until it lands (step 2).

## What

- `app/tauri.conf.json`: updater endpoint `7xuanlu/wenlan-app` → `7xuanlu/wenlan/releases/latest/download/latest.json` (pubkey unchanged — same rotated key signs the unified assets).
- `src/runtimeIdentity.test.ts`: the existing endpoint pin updated to the new URL.
- `scripts/install-macos-app.sh`: first-install download URL repointed too — the old repo stopped publishing app releases when `app-release.yml` was deleted, and v0.15.7 on the new repo carries the exact asset name this script expects.

Receipts: vitest 18/18, workflow contract 11 OK, tauri.conf.json parses, drift teeth 156/156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZCe7EkudPghv2GjDLKcKb