### PR TITLE
fix: keep isolated app launches off the shared daemon; deliver update prompts during setup

### DIFF
--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -158,6 +158,13 @@ fn current_app_path() -> Result<PathBuf> {
     std::fs::canonicalize(&exe).context("canonicalize current_exe")
 }
 
+/// True when the process was launched with an explicit data-dir override
+/// (WENLAN_DATA_DIR / ORIGIN_DATA_DIR) — an isolated dev/smoke run. Such a
+/// run must never mutate the user's LaunchAgents or the shared daemon.
+pub fn data_dir_env_overridden() -> bool {
+    std::env::var_os("WENLAN_DATA_DIR").is_some() || std::env::var_os("ORIGIN_DATA_DIR").is_some()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StableLaunchAgentTarget {
     Current,
@@ -474,6 +481,34 @@ fn ensure_server_plist_data_dir_env(launchctl: &dyn LaunchctlExec) -> Result<()>
 }
 
 pub fn prepare_server_plist_for_startup(launchctl: &dyn LaunchctlExec) -> Result<()> {
+    if data_dir_env_overridden() {
+        log::info!(
+            "[lifecycle] skipping server plist startup preflight: isolated run (data-dir env override)"
+        );
+        return Ok(());
+    }
+
+    // Isolated launches and non-stable app paths leave the shared LaunchAgent
+    // untouched. In the isolated case, lib.rs then sees that the plist does
+    // not match the selected scratch data dir and starts the sidecar, whose
+    // child inherits the app process environment (including WENLAN_PORT).
+    let app_path = match current_app_path() {
+        Ok(path) => path,
+        Err(error) => {
+            log::info!(
+                "[lifecycle] skipping server plist startup preflight: non-stable app path ({error})"
+            );
+            return Ok(());
+        }
+    };
+    if !is_stable_launch_agent_target(&app_path) {
+        log::info!(
+            "[lifecycle] skipping server plist startup preflight: non-stable app path ({})",
+            app_path.display()
+        );
+        return Ok(());
+    }
+
     ensure_server_plist_data_dir_env(launchctl)
 }
 
@@ -515,6 +550,13 @@ pub fn is_run_at_login_enabled(launchctl: &dyn LaunchctlExec) -> bool {
 /// and re-installs when the embedded path doesn't match the current binary.
 /// Returns Ok(()) if the install completed or was unnecessary.
 pub fn first_run_install_if_needed(launchctl: &dyn LaunchctlExec) -> Result<()> {
+    if data_dir_env_overridden() {
+        log::info!(
+            "[lifecycle] skipping first-run LaunchAgent install: isolated run (data-dir env override)"
+        );
+        return Ok(());
+    }
+
     if user_opted_out() {
         if let Err(e) = remove_legacy_app_plist_file_if_owned() {
             log::warn!("[first-run] legacy app plist cleanup failed: {e}");
@@ -601,6 +643,15 @@ pub fn first_run_install_if_needed(launchctl: &dyn LaunchctlExec) -> Result<()> 
 /// line 198).
 pub async fn set_run_at_login(enabled: bool, launchctl: &dyn LaunchctlExec) -> Result<()> {
     let _guard = RUN_AT_LOGIN_LOCK.lock().await;
+    if data_dir_env_overridden() {
+        log::info!(
+            "[lifecycle] skipping Run at Login change: isolated run (data-dir env override)"
+        );
+        anyhow::bail!(
+            "refusing to change Run at Login during an isolated run with a data-dir env override"
+        );
+    }
+
     if enabled {
         let exe = current_app_path()?;
         if !is_stable_launch_agent_target(&exe) {
@@ -631,6 +682,13 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
     let Some(attempt) = QuitAttemptGuard::try_begin(&QUITTING) else {
         return Ok(());
     };
+
+    if data_dir_env_overridden() {
+        log::info!("[lifecycle] skipping quit teardown: isolated run (data-dir env override)");
+        app_handle.exit(0);
+        attempt.commit();
+        return Ok(());
+    }
 
     // Spec lifecycle invariant #4: "Quit Wenlan = full off; both plists
     // unloaded, both processes exit, no auto-restart on reboot." (H2)
@@ -871,6 +929,22 @@ mod tests {
 
         assert!(current.path().join("auto_start_disabled.flag").exists());
         assert!(!legacy.path().join("auto_start_disabled.flag").exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn data_dir_env_overridden_reports_either_override_key() {
+        let _env = EnvGuard::capture();
+        std::env::remove_var("WENLAN_DATA_DIR");
+        std::env::remove_var("ORIGIN_DATA_DIR");
+        assert!(!data_dir_env_overridden());
+
+        std::env::set_var("WENLAN_DATA_DIR", "/tmp/wenlan-isolated");
+        assert!(data_dir_env_overridden());
+
+        std::env::remove_var("WENLAN_DATA_DIR");
+        std::env::set_var("ORIGIN_DATA_DIR", "/tmp/origin-isolated");
+        assert!(data_dir_env_overridden());
     }
 
     #[test]
@@ -1351,9 +1425,8 @@ mod tests {
     fn first_run_install_cleans_legacy_plists_even_when_user_opted_out() {
         let _env = EnvGuard::capture();
         let tmp = tempfile::tempdir().unwrap();
-        let data = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", tmp.path());
-        std::env::set_var("WENLAN_DATA_DIR", data.path());
+        std::env::remove_var("WENLAN_DATA_DIR");
         std::env::remove_var("ORIGIN_DATA_DIR");
 
         let legacy_app = legacy_app_plist_path().unwrap();
@@ -1388,9 +1461,8 @@ mod tests {
     fn first_run_preserves_legacy_plists_when_current_app_path_is_rejected() {
         let _env = EnvGuard::capture();
         let tmp = tempfile::tempdir().unwrap();
-        let data = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", tmp.path());
-        std::env::set_var("WENLAN_DATA_DIR", data.path());
+        std::env::remove_var("WENLAN_DATA_DIR");
         std::env::remove_var("ORIGIN_DATA_DIR");
         set_user_opted_out(false).unwrap();
 
@@ -1422,9 +1494,8 @@ mod tests {
     async fn set_run_at_login_false_cleans_legacy_app_and_server_plists() {
         let _env = EnvGuard::capture();
         let tmp = tempfile::tempdir().unwrap();
-        let data = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", tmp.path());
-        std::env::set_var("WENLAN_DATA_DIR", data.path());
+        std::env::remove_var("WENLAN_DATA_DIR");
         std::env::remove_var("ORIGIN_DATA_DIR");
 
         let current_app = tmp
@@ -1443,6 +1514,111 @@ mod tests {
         assert!(!current_app.exists(), "current Wenlan app plist removed");
         assert!(!legacy_app.exists(), "owned legacy app plist removed");
         assert!(!legacy_server.exists(), "owned legacy server plist removed");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prepare_server_plist_skips_isolated_override_without_mutation() {
+        let _env = EnvGuard::capture();
+        let tmp = tempfile::tempdir().unwrap();
+        let selected_data = tempfile::tempdir().unwrap();
+        let live_data = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("WENLAN_DATA_DIR", selected_data.path());
+        std::env::remove_var("ORIGIN_DATA_DIR");
+
+        let plist = server_plist_path().unwrap();
+        std::fs::create_dir_all(plist.parent().unwrap()).unwrap();
+        let original = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wenlan.server</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>WENLAN_DATA_DIR</key>
+        <string>{}</string>
+    </dict>
+</dict>
+</plist>
+"#,
+            live_data.path().display()
+        );
+        std::fs::write(&plist, &original).unwrap();
+
+        let mock = MockLaunchctl::default();
+        prepare_server_plist_for_startup(&mock).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&plist).unwrap(), original);
+        assert!(mock.calls.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn first_run_install_skips_isolated_override_without_touching_plists() {
+        let _env = EnvGuard::capture();
+        let tmp = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("WENLAN_DATA_DIR", data.path());
+        std::env::remove_var("ORIGIN_DATA_DIR");
+
+        let app_plist = app_plist_path().unwrap();
+        let server_plist = server_plist_path().unwrap();
+        let legacy_app = legacy_app_plist_path().unwrap();
+        let legacy_server = legacy_server_plist_path().unwrap();
+        std::fs::create_dir_all(app_plist.parent().unwrap()).unwrap();
+        let legacy_app_content = owned_legacy_app_plist();
+        let legacy_server_content = owned_legacy_server_plist();
+        let originals = [
+            (app_plist.as_path(), b"current app".as_slice()),
+            (server_plist.as_path(), b"current server".as_slice()),
+            (legacy_app.as_path(), legacy_app_content.as_bytes()),
+            (legacy_server.as_path(), legacy_server_content.as_bytes()),
+        ];
+        for (path, content) in originals {
+            std::fs::write(path, content).unwrap();
+        }
+        let original_bytes: Vec<_> = [&app_plist, &server_plist, &legacy_app, &legacy_server]
+            .into_iter()
+            .map(|path| std::fs::read(path).unwrap())
+            .collect();
+
+        let mock = MockLaunchctl::default();
+        first_run_install_if_needed(&mock).unwrap();
+
+        for (path, original) in [&app_plist, &server_plist, &legacy_app, &legacy_server]
+            .into_iter()
+            .zip(original_bytes)
+        {
+            assert_eq!(std::fs::read(path).unwrap(), original);
+        }
+        assert!(mock.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn set_run_at_login_rejects_isolated_override_without_launchctl() {
+        let _env = EnvGuard::capture();
+        let tmp = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("WENLAN_DATA_DIR", data.path());
+        std::env::remove_var("ORIGIN_DATA_DIR");
+        let mock = MockLaunchctl::default();
+
+        let enable_error = set_run_at_login(true, &mock)
+            .await
+            .expect_err("isolated enable must be rejected");
+        let disable_error = set_run_at_login(false, &mock)
+            .await
+            .expect_err("isolated disable must be rejected");
+
+        assert!(enable_error.to_string().contains("isolated run"));
+        assert!(disable_error.to_string().contains("isolated run"));
+        assert!(mock.calls.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -1600,13 +1776,12 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
-    fn startup_server_plist_preflight_repairs_stale_data_dir_before_selection() {
+    fn startup_server_plist_preflight_skips_non_stable_app_path() {
         let _env = EnvGuard::capture();
         let tmp = tempfile::tempdir().unwrap();
-        let selected_data = tempfile::tempdir().unwrap();
         let stale_data = tempfile::tempdir().unwrap();
         std::env::set_var("HOME", tmp.path());
-        std::env::set_var("WENLAN_DATA_DIR", selected_data.path());
+        std::env::remove_var("WENLAN_DATA_DIR");
         std::env::remove_var("ORIGIN_DATA_DIR");
 
         let plist = server_plist_path().unwrap();
@@ -1632,29 +1807,22 @@ mod tests {
             ),
         )
         .unwrap();
-        assert!(!current_server_plist_matches_selected_data_dir());
+        let original = std::fs::read(&plist).unwrap();
 
         let mock = MockLaunchctl::default();
         prepare_server_plist_for_startup(&mock).unwrap();
 
-        assert!(
-            current_server_plist_matches_selected_data_dir(),
-            "startup preflight must repair stale launchd data root before daemon selection"
-        );
+        assert_eq!(std::fs::read(&plist).unwrap(), original);
         let calls = mock.calls.lock().unwrap();
         assert!(
-            calls.iter().any(|c| c[0] == "unload"),
-            "stale running daemon should be unloaded before health/config hydration"
-        );
-        assert!(
-            calls.iter().any(|c| c[0] == "load"),
-            "patched daemon should be reloaded before health/config hydration"
+            calls.is_empty(),
+            "non-stable app path must not call launchctl"
         );
     }
 
     #[test]
     #[serial_test::serial]
-    fn startup_server_plist_preflight_rolls_back_file_when_reload_fails() {
+    fn server_plist_data_dir_env_rolls_back_file_when_reload_fails() {
         let _env = EnvGuard::capture();
         let tmp = tempfile::tempdir().unwrap();
         let selected_data = tempfile::tempdir().unwrap();
@@ -1688,8 +1856,8 @@ mod tests {
             load_status: Mutex::new(256),
             ..Default::default()
         };
-        let err = prepare_server_plist_for_startup(&mock)
-            .expect_err("reload failure must make startup preflight fail");
+        let err = ensure_server_plist_data_dir_env(&mock)
+            .expect_err("reload failure must make data-dir patch fail");
         assert!(
             err.to_string().contains("launchctl load failed"),
             "unexpected error: {err}"

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -481,17 +481,17 @@ fn ensure_server_plist_data_dir_env(launchctl: &dyn LaunchctlExec) -> Result<()>
 }
 
 pub fn prepare_server_plist_for_startup(launchctl: &dyn LaunchctlExec) -> Result<()> {
+    // Isolated launches and non-stable app paths leave the shared LaunchAgent
+    // untouched. In the isolated case, lib.rs then sees that the plist does
+    // not match the selected scratch data dir and starts the sidecar, whose
+    // child inherits the app process environment (including WENLAN_PORT).
     if data_dir_env_overridden() {
-        log::info!(
+        log::warn!(
             "[lifecycle] skipping server plist startup preflight: isolated run (data-dir env override)"
         );
         return Ok(());
     }
 
-    // Isolated launches and non-stable app paths leave the shared LaunchAgent
-    // untouched. In the isolated case, lib.rs then sees that the plist does
-    // not match the selected scratch data dir and starts the sidecar, whose
-    // child inherits the app process environment (including WENLAN_PORT).
     let app_path = match current_app_path() {
         Ok(path) => path,
         Err(error) => {
@@ -551,7 +551,7 @@ pub fn is_run_at_login_enabled(launchctl: &dyn LaunchctlExec) -> bool {
 /// Returns Ok(()) if the install completed or was unnecessary.
 pub fn first_run_install_if_needed(launchctl: &dyn LaunchctlExec) -> Result<()> {
     if data_dir_env_overridden() {
-        log::info!(
+        log::warn!(
             "[lifecycle] skipping first-run LaunchAgent install: isolated run (data-dir env override)"
         );
         return Ok(());
@@ -1549,6 +1549,10 @@ mod tests {
         std::fs::write(&plist, &original).unwrap();
 
         let mock = MockLaunchctl::default();
+        // This assertion pins both gates together: the env override and the
+        // stable-path check. current_exe() cannot be faked to /Applications
+        // from a unit test, so removing only the env gate still leaves this
+        // test protected by the non-stable-path gate.
         prepare_server_plist_for_startup(&mock).unwrap();
 
         assert_eq!(std::fs::read_to_string(&plist).unwrap(), original);
@@ -1587,6 +1591,10 @@ mod tests {
             .collect();
 
         let mock = MockLaunchctl::default();
+        // This assertion pins both gates together: the env override and the
+        // stable-path check. current_exe() cannot be faked to /Applications
+        // from a unit test, so removing only the env gate still leaves this
+        // test protected by the non-stable-path gate.
         first_run_install_if_needed(&mock).unwrap();
 
         for (path, original) in [&app_plist, &server_plist, &legacy_app, &legacy_server]

--- a/app/src/updater.rs
+++ b/app/src/updater.rs
@@ -62,12 +62,13 @@ fn emit_available(app: &AppHandle, version: &str) {
 }
 
 /// Emit `updater://available` to the main webview and wait for the user's
-/// choice via the `updater://action` event. The UI announces
-/// `updater://ui-ready` after mounting, so a prompt emitted before the
-/// webview or a non-main App branch is ready is replayed until answered.
-/// The actual UI is rendered by `UpdaterDialog` inside the main window's
-/// React tree (see `src/components/UpdaterDialog.tsx`), so the dialog stays
-/// attached to the app window and travels with it.
+/// choice via the `updater://action` event. RuntimeOverlays mounts once as a
+/// stable sibling of App's branch body and is reconciled in place, rather than
+/// remounted as App moves between branches. The `updater://ui-ready` handshake
+/// covers webview-load timing: UpdaterDialog emits one ready event after its
+/// listeners register, and the backend re-emits availability if the prompt
+/// predates it. The actual UI is rendered by `UpdaterDialog` inside the main
+/// window's React tree (see `src/components/UpdaterDialog.tsx`).
 async fn prompt_via_overlay(app: &AppHandle, version: &str) -> bool {
     let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
     let tx = Arc::new(Mutex::new(Some(tx)));
@@ -104,6 +105,11 @@ async fn prompt_via_overlay(app: &AppHandle, version: &str) -> bool {
 /// relaunch with progress events. Failures are logged and surfaced in the
 /// overlay, never blocking.
 pub async fn check_and_prompt(app: AppHandle) {
+    if crate::lifecycle::data_dir_env_overridden() {
+        log::warn!("[updater] skipping update check: isolated run (data-dir env override)");
+        return;
+    }
+
     tokio::time::sleep(STARTUP_DELAY).await;
 
     let updater = match app.updater() {

--- a/app/src/updater.rs
+++ b/app/src/updater.rs
@@ -54,17 +54,21 @@ fn record_dismissal(app: &AppHandle, version: &str) {
     }
 }
 
-/// Emit `updater://available` to the main webview and wait for the user's
-/// choice via the `updater://action` event. The actual UI is rendered by
-/// `UpdaterDialog` inside the main window's React tree (see
-/// `src/components/UpdaterDialog.tsx`), so the dialog stays attached to the
-/// app window and travels with it.
-async fn prompt_via_overlay(app: &AppHandle, version: &str) -> bool {
+fn emit_available(app: &AppHandle, version: &str) {
     let _ = app.emit(
         "updater://available",
         serde_json::json!({ "version": version }),
     );
+}
 
+/// Emit `updater://available` to the main webview and wait for the user's
+/// choice via the `updater://action` event. The UI announces
+/// `updater://ui-ready` after mounting, so a prompt emitted before the
+/// webview or a non-main App branch is ready is replayed until answered.
+/// The actual UI is rendered by `UpdaterDialog` inside the main window's
+/// React tree (see `src/components/UpdaterDialog.tsx`), so the dialog stays
+/// attached to the app window and travels with it.
+async fn prompt_via_overlay(app: &AppHandle, version: &str) -> bool {
     let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
     let tx = Arc::new(Mutex::new(Some(tx)));
 
@@ -79,15 +83,26 @@ async fn prompt_via_overlay(app: &AppHandle, version: &str) -> bool {
         }
     });
 
+    let app_for_ready = app.clone();
+    let version_for_ready = version.to_string();
+    let ui_ready_id = app.listen("updater://ui-ready", move |_| {
+        emit_available(&app_for_ready, &version_for_ready);
+    });
+
+    emit_available(app, version);
+
     let accepted = rx.await.unwrap_or(false);
     app.unlisten(action_id);
+    app.unlisten(ui_ready_id);
     accepted
 }
 
 /// Check for an update on startup. If one exists and the user hasn't dismissed
-/// it within the last 24 hours, prompt via an in-app overlay; on accept,
-/// download + install + relaunch with progress events. Failures are logged
-/// and surfaced in the overlay, never blocking.
+/// it within the last 24 hours, prompt via an in-app overlay. The overlay uses
+/// a `updater://ui-ready` handshake so the one-shot availability event is
+/// replayed while the user has not answered; on accept, download + install +
+/// relaunch with progress events. Failures are logged and surfaced in the
+/// overlay, never blocking.
 pub async fn check_and_prompt(app: AppHandle) {
     tokio::time::sleep(STARTUP_DELAY).await;
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -78,7 +78,9 @@ vi.mock("./components/SetupWizard", () => ({
 }));
 
 vi.mock("./components/RuntimeOverlays", () => ({
-  RuntimeOverlays: () => <div data-testid="runtime-overlays">runtime overlays</div>,
+  RuntimeOverlays: ({ variant = "main" }: { variant?: string }) => (
+    <div data-testid="runtime-overlays" data-variant={variant}>runtime overlays</div>
+  ),
 }));
 
 // EntityDetail transitively imports AtlasView → sigma, whose dist touches
@@ -128,6 +130,7 @@ describe("App - first-run wizard gate", () => {
 
     expect(await screen.findByTestId("home-main")).toBeInTheDocument();
     expect(screen.queryByTestId("setup-wizard")).not.toBeInTheDocument();
+    expect(screen.getByTestId("runtime-overlays")).toHaveAttribute("data-variant", "main");
   });
 
   it("renders SetupWizard when shouldShowWizard resolves true", async () => {
@@ -135,7 +138,10 @@ describe("App - first-run wizard gate", () => {
     renderApp();
 
     expect(await screen.findByTestId("setup-wizard")).toBeInTheDocument();
-    expect(screen.getByTestId("runtime-overlays")).toBeInTheDocument();
+    expect(screen.getByTestId("runtime-overlays")).toHaveAttribute(
+      "data-variant",
+      "updater-only",
+    );
     expect(screen.queryByTestId("home-main")).not.toBeInTheDocument();
   });
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -77,6 +77,10 @@ vi.mock("./components/SetupWizard", () => ({
   default: () => <div data-testid="setup-wizard">wizard</div>,
 }));
 
+vi.mock("./components/RuntimeOverlays", () => ({
+  RuntimeOverlays: () => <div data-testid="runtime-overlays">runtime overlays</div>,
+}));
+
 // EntityDetail transitively imports AtlasView → sigma, whose dist touches
 // WebGL2RenderingContext at module scope — jsdom has no such global, so the
 // real import crashes this whole suite before a single test runs.
@@ -131,6 +135,7 @@ describe("App - first-run wizard gate", () => {
     renderApp();
 
     expect(await screen.findByTestId("setup-wizard")).toBeInTheDocument();
+    expect(screen.getByTestId("runtime-overlays")).toBeInTheDocument();
     expect(screen.queryByTestId("home-main")).not.toBeInTheDocument();
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-import { useCallback, useState, useEffect, useRef } from "react";
+import { useCallback, useState, useEffect, useRef, type ReactNode } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -231,22 +231,19 @@ export default function App() {
   // isPending, not isLoading: isLoading is (isPending && isFetching), which goes
   // false whenever the query is paused rather than fetching — that would fall
   // through to Home with no answer. isPending is true until we actually have one.
+  let body: ReactNode;
   if (wizardPending) {
-    return <div className="w-screen min-h-screen bg-[var(--bg-secondary)]" />;
-  }
-
-  // ponytail: fail CLOSED. If the daemon is still unreachable after retries,
-  // show the wizard rather than silently falling through to Home — an
-  // existing user whose daemon is dead for 15s+ sees the wizard too, but its
-  // step-5 task thread already surfaces "daemon isn't reachable" + Retry,
-  // which is the intended repair surface for that tradeoff.
-  if (showWizard || wizardError) {
-    return <SetupWizard onComplete={handleWizardComplete} />;
-  }
-
-  if (migration) {
+    body = <div className="w-screen min-h-screen bg-[var(--bg-secondary)]" />;
+  } else if (showWizard || wizardError) {
+    // ponytail: fail CLOSED. If the daemon is still unreachable after retries,
+    // show the wizard rather than silently falling through to Home — an
+    // existing user whose daemon is dead for 15s+ sees the wizard too, but its
+    // step-5 task thread already surfaces "daemon isn't reachable" + Retry,
+    // which is the intended repair surface for that tradeoff.
+    body = <SetupWizard onComplete={handleWizardComplete} />;
+  } else if (migration) {
     const pct = migration.total > 0 ? Math.round((migration.current / migration.total) * 100) : 0;
-    return (
+    body = (
       <div className="flex flex-col items-center justify-center h-screen bg-zinc-950 text-zinc-200">
         <p className="text-lg mb-4">{migration.phase}</p>
         <div className="w-64 h-2 bg-zinc-800 rounded-full overflow-hidden">
@@ -255,42 +252,48 @@ export default function App() {
         <p className="text-sm text-zinc-500 mt-2">{migration.current} / {migration.total}</p>
       </div>
     );
+  } else {
+    body = (
+      <div className="w-screen min-h-screen bg-[var(--bg-secondary)]">
+        {page === "spotlight" && (
+          <Spotlight
+            onOpenMemory={() => { setSelectedPageId(null); setPage("home"); }}
+            onOpenPage={(pageId) => { setSelectedPageId(pageId); setSelectedMemoryId(null); setInitialView(null); setPage("home"); }}
+            onOpenRecap={(snap) => { setSelectedPageId(null); setSelectedSnapshot(snap); setPrevPage("spotlight"); setPage("recap"); }}
+            onEntityClick={(id) => { setSelectedPageId(null); setSelectedEntityId(id); setPrevPage("spotlight"); setPage("entity"); }}
+          />
+        )}
+        {page === "home" && (
+          <Main
+            initialMemoryId={selectedMemoryId}
+            initialPageId={selectedPageId}
+            initialView={initialView}
+            onRegisterQuitGuard={registerQuitGuard}
+            onBackFromDetail={() => { setSelectedMemoryId(null); setSelectedPageId(null); setPage("home"); }}
+          />
+        )}
+        {page === "recap" && selectedSnapshot && (
+          <RecapDetail snapshot={selectedSnapshot} onBack={() => setPage(prevPage)} />
+        )}
+        {page === "entity" && selectedEntityId && (
+          <div className="h-screen overflow-y-auto">
+            <EntityDetail
+              key={selectedEntityId}
+              entityId={selectedEntityId}
+              onBack={() => setPage(prevPage)}
+              onEntityClick={(id) => setSelectedEntityId(id)}
+              onMemoryClick={(sid) => { setSelectedMemoryId(sid); setSelectedPageId(null); setInitialView(null); setPage("home"); }}
+            />
+          </div>
+        )}
+      </div>
+    );
   }
 
   return (
-    <div className="w-screen min-h-screen bg-[var(--bg-secondary)]">
-      {page === "spotlight" && (
-        <Spotlight
-          onOpenMemory={() => { setSelectedPageId(null); setPage("home"); }}
-          onOpenPage={(pageId) => { setSelectedPageId(pageId); setSelectedMemoryId(null); setInitialView(null); setPage("home"); }}
-          onOpenRecap={(snap) => { setSelectedPageId(null); setSelectedSnapshot(snap); setPrevPage("spotlight"); setPage("recap"); }}
-          onEntityClick={(id) => { setSelectedPageId(null); setSelectedEntityId(id); setPrevPage("spotlight"); setPage("entity"); }}
-        />
-      )}
-      {page === "home" && (
-        <Main
-          initialMemoryId={selectedMemoryId}
-          initialPageId={selectedPageId}
-          initialView={initialView}
-          onRegisterQuitGuard={registerQuitGuard}
-          onBackFromDetail={() => { setSelectedMemoryId(null); setSelectedPageId(null); setPage("home"); }}
-        />
-      )}
-      {page === "recap" && selectedSnapshot && (
-        <RecapDetail snapshot={selectedSnapshot} onBack={() => setPage(prevPage)} />
-      )}
-      {page === "entity" && selectedEntityId && (
-        <div className="h-screen overflow-y-auto">
-          <EntityDetail
-            key={selectedEntityId}
-            entityId={selectedEntityId}
-            onBack={() => setPage(prevPage)}
-            onEntityClick={(id) => setSelectedEntityId(id)}
-            onMemoryClick={(sid) => { setSelectedMemoryId(sid); setSelectedPageId(null); setInitialView(null); setPage("home"); }}
-          />
-        </div>
-      )}
+    <>
+      {body}
       <RuntimeOverlays />
-    </div>
+    </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -293,7 +293,13 @@ export default function App() {
   return (
     <>
       {body}
-      <RuntimeOverlays />
+      <RuntimeOverlays
+        variant={
+          wizardPending || showWizard || wizardError || migration
+            ? "updater-only"
+            : "main"
+        }
+      />
     </>
   );
 }

--- a/src/components/RuntimeOverlays.test.tsx
+++ b/src/components/RuntimeOverlays.test.tsx
@@ -24,4 +24,11 @@ describe("RuntimeOverlays", () => {
     expect(screen.getByText("milestone runtime")).toBeInTheDocument();
     expect(screen.getByText("updater runtime")).toBeInTheDocument();
   });
+
+  it("keeps the milestone toaster off non-main branches", () => {
+    render(<RuntimeOverlays review={false} variant="updater-only" />);
+
+    expect(screen.queryByText("milestone runtime")).not.toBeInTheDocument();
+    expect(screen.getByText("updater runtime")).toBeInTheDocument();
+  });
 });

--- a/src/components/RuntimeOverlays.tsx
+++ b/src/components/RuntimeOverlays.tsx
@@ -3,14 +3,18 @@ import UpdaterDialog from "./UpdaterDialog";
 
 type RuntimeOverlaysProps = {
   readonly review?: boolean;
+  readonly variant?: "main" | "updater-only";
 };
 
-export function RuntimeOverlays({ review = __WENLAN_REVIEW__ }: RuntimeOverlaysProps) {
+export function RuntimeOverlays({
+  review = __WENLAN_REVIEW__,
+  variant = "main",
+}: RuntimeOverlaysProps) {
   if (review) return null;
 
   return (
     <>
-      <MilestoneToaster />
+      {variant === "main" && <MilestoneToaster />}
       <UpdaterDialog />
     </>
   );

--- a/src/components/UpdaterDialog.test.tsx
+++ b/src/components/UpdaterDialog.test.tsx
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const emitMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: emitMock,
+  listen: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+import UpdaterDialog from "./UpdaterDialog";
+
+describe("UpdaterDialog", () => {
+  beforeEach(() => {
+    emitMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("announces that the updater UI is ready after mounting", async () => {
+    render(<UpdaterDialog />);
+
+    await waitFor(() => expect(emitMock).toHaveBeenCalledWith("updater://ui-ready"));
+  });
+});

--- a/src/components/UpdaterDialog.tsx
+++ b/src/components/UpdaterDialog.tsx
@@ -49,7 +49,9 @@ export default function UpdaterDialog() {
       if (p.chunk) setDownloaded((prev) => prev + (p.chunk ?? 0));
       if (p.total !== undefined && p.total !== null) setTotal(p.total);
     });
-    void Promise.all([unlistenAvail, unlistenProg]).then(() => emit("updater://ui-ready"));
+    void Promise.all([unlistenAvail, unlistenProg])
+      .then(() => emit("updater://ui-ready"))
+      .catch(() => {});
     return () => {
       unlistenAvail.then((fn) => fn());
       unlistenProg.then((fn) => fn());

--- a/src/components/UpdaterDialog.tsx
+++ b/src/components/UpdaterDialog.tsx
@@ -18,6 +18,7 @@ interface ProgressPayload {
  * Driven by Tauri events from `app/src/updater.rs`:
  *   - `updater://available`  payload `{ version }` → show toast
  *   - `updater://progress`   payload `{ chunk, total, error }`
+ *   - `updater://ui-ready`   → ask the backend to replay a pending prompt
  * Sends back:
  *   - `updater://action`     payload `"install"` | `"later"`
  */
@@ -48,6 +49,7 @@ export default function UpdaterDialog() {
       if (p.chunk) setDownloaded((prev) => prev + (p.chunk ?? 0));
       if (p.total !== undefined && p.total !== null) setTotal(p.total);
     });
+    void Promise.all([unlistenAvail, unlistenProg]).then(() => emit("updater://ui-ready"));
     return () => {
       unlistenAvail.then((fn) => fn());
       unlistenProg.then((fn) => fn());


### PR DESCRIPTION
Fixes the two shipped desktop-app bugs found during the v0.15.8 auto-update proof (2026-08-09).

## Bug 1 — launch-time LaunchAgent clobber / live-daemon hijack

Any app launch with `WENLAN_DATA_DIR`/`ORIGIN_DATA_DIR` set (an isolated dev/smoke run) rewrote `~/Library/LaunchAgents/com.wenlan.server.plist` to embed the scratch data dir, then unload+loaded it — killing the user's live :7878 daemon and respawning it on the scratch dir. Observed hijacking prod three times.

**Fix:** `lifecycle::data_dir_env_overridden()` gates all four mutating entry points — `prepare_server_plist_for_startup` (which also gains the stable-app-path check the first-run installer already had), `first_run_install_if_needed`, `set_run_at_login`, and `quit_origin` (no plist uninstalls, no :7878 shutdown POST; just exit). An isolated launch now coherently takes the sidecar path with its own data dir and port. Skips log at `warn!`.

Same-class hole closed on review: `updater::check_and_prompt` is now also gated, so an isolated smoke run can no longer install a real update over the user's `/Applications` bundle.

## Bug 2 — update prompt lost while SetupWizard is showing

The backend emits `updater://available` once ~3s after launch, but the listener component only mounted on App's main branch — fresh installs sitting in SetupWizard never saw update offers.

**Fix:** `<RuntimeOverlays />` now renders on every App branch (a `variant` prop keeps the milestone toaster main-only so it can't cover the wizard's Continue button), and a `updater://ui-ready` handshake makes the emit race-proof: the frontend announces readiness after registering listeners, the backend re-emits a still-unanswered prompt.

## Verification

- `cargo fmt --all -- --check`, `cargo clippy -p wenlan-app --all-targets`: clean
- `cargo test -p wenlan-app`: 359 passed / 0 failed (guard tests rework `WENLAN_DATA_DIR`-based isolation to `HOME`-based so the tests don't trip the new gates; 5 new gate tests)
- `pnpm test`: 1536 passed / 0 failed (one unrelated `SetupWizard.test.tsx` timing flake was checked on the pre-fix base: it does not reproduce there or on this branch in 5 follow-up runs)
- Independent diff review: needs-changes findings all addressed in the second commit; final verdict clean
- **Real-surface proof (attested):** built app launched with `WENLAN_PORT=17878 WENLAN_DATA_DIR=<scratch>` against the live setup — LaunchAgent plist byte-identical before/after (SHA-256 `1130b0e8…`), prod daemon on :7878 same PID and healthy, real page vault untouched, app log shows all three guards firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZCe7EkudPghv2GjDLKcKb