### PR TITLE
fix(core): close the page-history bypasses and cap poison-document retries

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -52237,7 +52237,12 @@ impl MemoryDB {
     /// the count of not-`done` rows; the paused fields describe the
     /// soonest-to-retry paused row (a NULL `next_retry_at` — immediately
     /// eligible — sorts first), excluding exhausted rows. `exhausted` counts
-    /// paused rows at or above the retry cap.
+    /// paused rows at or above the retry cap. `paused_reason` also surfaces
+    /// exhaustion: a caller mapping `paused_reason.is_some()` to a stalled
+    /// queue (e.g. the wire `QueueStatus::Paused`) must see an all-exhausted
+    /// queue as stalled too, not silently `Active` forever. `next_retry_at`
+    /// stays `None` when every paused row is exhausted, since there is no
+    /// next retry to report.
     pub async fn document_enrichment_queue_status(
         &self,
     ) -> Result<DocEnrichmentQueueStatus, WenlanError> {
@@ -52285,7 +52290,7 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("queue_status paused: {e}")))?;
-        let (paused_reason, next_retry_at) = match paused_rows
+        let (retryable_paused_reason, next_retry_at) = match paused_rows
             .next()
             .await
             .map_err(|e| WenlanError::VectorDb(format!("queue_status paused row: {e}")))?
@@ -52295,6 +52300,20 @@ impl MemoryDB {
                 row.get::<Option<i64>>(1).unwrap_or(None),
             ),
             None => (None, None),
+        };
+
+        // Fold exhaustion into `paused_reason` so a caller that treats
+        // `paused_reason.is_some()` as "queue is stalled" (the wire mapping
+        // in wenlan-server) still sees a stall when the queue holds only
+        // permanently-exhausted documents, instead of reporting them as
+        // ordinary `pending` work forever.
+        let paused_reason = match (retryable_paused_reason, exhausted) {
+            (reason, 0) => reason,
+            (Some(reason), n) => Some(format!("{reason}; {n} documents exhausted retries")),
+            (None, n) => Some(format!(
+                "{n} documents exhausted enrichment retries (max {} attempts) and will not be retried",
+                Self::DOC_ENRICHMENT_MAX_ATTEMPTS
+            )),
         };
 
         Ok(DocEnrichmentQueueStatus {

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -3032,12 +3032,14 @@ pub struct DocEnrichmentQueueEntry {
 /// Aggregate state of the document-enrichment queue, for `/api/status`
 /// observability. `pending` counts rows not yet `done` (pending + in_progress +
 /// paused); `paused_reason` / `next_retry_at` describe the soonest-to-retry
-/// paused row (present only when at least one row is paused).
+/// paused row; `exhausted` counts paused rows that reached the retry cap and are
+/// no longer eligible for a claim.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct DocEnrichmentQueueStatus {
     pub pending: u64,
     pub paused_reason: Option<String>,
     pub next_retry_at: Option<i64>,
+    pub exhausted: u64,
 }
 
 /// Durable store-time choices needed by restart-safe fixed-stage enrichment.
@@ -45507,6 +45509,7 @@ impl MemoryDB {
         source_ids: &[&str],
         linked_at: i64,
         link_reason: &str,
+        operation_id: Option<&str>,
     ) -> Result<(), libsql::Error> {
         // Dual-write (M2 PR-1): one SELECT for the page's space, then per
         // source id mirror `backfill_edges_from_page_evidence`'s
@@ -45620,7 +45623,7 @@ impl MemoryDB {
                     lineage,
                     space,
                     cross_space_downgrade,
-                    None,
+                    operation_id,
                     None,
                     None,
                     Some(&semantic_patch),
@@ -45947,9 +45950,15 @@ impl MemoryDB {
         // Dual-write to page_evidence (P2 typed provenance) with each source's
         // resolved source_kind (memory / external_url / external_file /
         // authored). INSERT OR IGNORE keeps this idempotent on re-distill.
-        if let Err(e) =
-            Self::insert_resolved_page_evidence(&conn, id, source_memory_ids, linked_at, "distill")
-                .await
+        if let Err(e) = Self::insert_resolved_page_evidence(
+            &conn,
+            id,
+            source_memory_ids,
+            linked_at,
+            "distill",
+            None,
+        )
+        .await
         {
             let _ = conn.execute("ROLLBACK", ()).await;
             return Err(WenlanError::VectorDb(format!(
@@ -46248,11 +46257,18 @@ impl MemoryDB {
             // frozen (`page_sources` here; `page_evidence` inside
             // `insert_resolved_page_evidence`, called next). It dual-writes
             // the canonical `cites` edge for every kept/new source id.
-            Self::insert_resolved_page_evidence(&conn, id, source_memory_ids, now_ts, link_reason)
-                .await
-                .map_err(|e| {
-                    WenlanError::VectorDb(format!("replace_source_page evidence insert: {e}"))
-                })?;
+            Self::insert_resolved_page_evidence(
+                &conn,
+                id,
+                source_memory_ids,
+                now_ts,
+                link_reason,
+                None,
+            )
+            .await
+            .map_err(|e| {
+                WenlanError::VectorDb(format!("replace_source_page evidence insert: {e}"))
+            })?;
             // Same transaction as the version bump above: a re-enriched source
             // page is a new version like any other, and leaves the same durable
             // row behind.
@@ -47434,9 +47450,15 @@ impl MemoryDB {
             }
         }
 
-        if let Err(e) =
-            Self::insert_resolved_page_evidence(&conn, id, source_memory_ids, now_ts, link_reason)
-                .await
+        if let Err(e) = Self::insert_resolved_page_evidence(
+            &conn,
+            id,
+            source_memory_ids,
+            now_ts,
+            link_reason,
+            receipt.map(|r| r.operation_id),
+        )
+        .await
         {
             let _ = conn.execute("ROLLBACK", ()).await;
             return Err(WenlanError::VectorDb(format!(
@@ -47816,18 +47838,26 @@ impl MemoryDB {
 
     /// Archive a page (set status to 'archived').
     pub async fn archive_page(&self, id: &str) -> Result<(), WenlanError> {
-        let now = chrono::Utc::now().to_rfc3339();
+        let now = chrono::Utc::now();
+        let now_rfc3339 = now.to_rfc3339();
+        let now_ts = now.timestamp();
         let conn = self.conn.lock().await;
         Self::reject_entity_shadow_page_on_conn(&conn, id).await?;
         Self::reject_page_draft_on_conn(&conn, id).await?;
-        conn.execute(
-            "UPDATE pages
+        let affected = conn
+            .execute(
+                "UPDATE pages
              SET status = 'archived', version = version + 1, last_modified = ?1
              WHERE id = ?2 AND status = 'active'",
-            libsql::params![now, id],
-        )
-        .await
-        .map_err(|e| WenlanError::VectorDb(format!("archive_page: {e}")))?;
+                libsql::params![now_rfc3339, id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("archive_page: {e}")))?;
+        if affected == 1 {
+            Self::append_page_history(&conn, id, "archive", now_ts)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("archive_page history: {e}")))?;
+        }
         Ok(())
     }
 
@@ -47937,6 +47967,11 @@ impl MemoryDB {
                     "page_merge survivor {survivor_id} could not be updated"
                 )));
             }
+            Self::append_page_history(&conn, survivor_id, "page_merge", now_ts)
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("accept_page_merge survivor history: {e}"))
+                })?;
 
             // G6 Stage 2 PR 2b: the `page_sources` INSERT loop and the
             // `page_evidence` INSERT..SELECT copy that used to run here stop
@@ -48051,6 +48086,7 @@ impl MemoryDB {
                 &source_refs,
                 now_ts,
                 "page_merge",
+                None,
             )
             .await
             .map_err(|e| {
@@ -48072,6 +48108,11 @@ impl MemoryDB {
                     "page_merge absorbed page {absorbed_id} could not be archived"
                 )));
             }
+            Self::append_page_history(&conn, absorbed_id, "archive", now_ts)
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("accept_page_merge archive history: {e}"))
+                })?;
 
             let absorbed_title_key = absorbed.title.to_lowercase();
             // Dual-write (G6 Stage 0): the repoint below moves inbound and
@@ -49469,6 +49510,7 @@ impl MemoryDB {
                 &[memory_source_id],
                 now,
                 link_reason,
+                None,
             )
             .await
             {
@@ -49694,6 +49736,7 @@ impl MemoryDB {
                 memory_source_ids,
                 now,
                 link_reason,
+                None,
             )
             .await
             {
@@ -51642,6 +51685,10 @@ impl MemoryDB {
 
     // ===== Document Enrichment Queue Methods =====
 
+    /// Maximum document-enrichment attempts before a paused poison row is
+    /// terminally excluded from future claims.
+    pub(crate) const DOC_ENRICHMENT_MAX_ATTEMPTS: i64 = 5;
+
     /// Enqueue a document for enrichment. Idempotent upsert: re-enqueuing a
     /// live row or a `done` row with the SAME content hash is a no-op — it never
     /// resets an in-progress checkpoint. Any row with a DIFFERENT hash is reset
@@ -51709,10 +51756,11 @@ impl MemoryDB {
                         OR (?2 AND status = 'waiting_for_provider')
                         OR (status = 'paused'
                             AND (next_retry_at IS NULL OR next_retry_at <= ?1)
-                            AND (?2 OR last_completed_chunk = -1))
+                            AND (?2 OR last_completed_chunk = -1)
+                            AND attempt_count < ?3)
                      ORDER BY enqueued_at ASC, rowid ASC
                      LIMIT 1",
-                    libsql::params![now, provider_available],
+                    libsql::params![now, provider_available, Self::DOC_ENRICHMENT_MAX_ATTEMPTS],
                 )
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("claim_next_pending select: {}", e)))?;
@@ -52188,7 +52236,8 @@ impl MemoryDB {
     /// Summarize the document-enrichment queue for `/api/status`. `pending` is
     /// the count of not-`done` rows; the paused fields describe the
     /// soonest-to-retry paused row (a NULL `next_retry_at` — immediately
-    /// eligible — sorts first), or are `None` when nothing is paused.
+    /// eligible — sorts first), excluding exhausted rows. `exhausted` counts
+    /// paused rows at or above the retry cap.
     pub async fn document_enrichment_queue_status(
         &self,
     ) -> Result<DocEnrichmentQueueStatus, WenlanError> {
@@ -52209,13 +52258,30 @@ impl MemoryDB {
             .max(0) as u64;
         drop(pending_rows);
 
+        let mut exhausted_rows = conn
+            .query(
+                "SELECT COUNT(*) FROM document_enrichment_queue
+                 WHERE status = 'paused' AND attempt_count >= ?1",
+                libsql::params![Self::DOC_ENRICHMENT_MAX_ATTEMPTS],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("queue_status exhausted: {e}")))?;
+        let exhausted = exhausted_rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("queue_status exhausted row: {e}")))?
+            .and_then(|r| r.get::<i64>(0).ok())
+            .unwrap_or(0)
+            .max(0) as u64;
+        drop(exhausted_rows);
+
         let mut paused_rows = conn
             .query(
                 "SELECT error_detail, next_retry_at FROM document_enrichment_queue
-                 WHERE status = 'paused'
+                 WHERE status = 'paused' AND attempt_count < ?1
                  ORDER BY next_retry_at ASC, rowid ASC
                  LIMIT 1",
-                (),
+                libsql::params![Self::DOC_ENRICHMENT_MAX_ATTEMPTS],
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("queue_status paused: {e}")))?;
@@ -52235,6 +52301,7 @@ impl MemoryDB {
             pending,
             paused_reason,
             next_retry_at,
+            exhausted,
         })
     }
 

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -20209,6 +20209,59 @@ async fn update_page_content_preserves_delimiter_free_content_exactly() {
 }
 
 #[tokio::test]
+async fn page_write_threads_operation_id_to_new_cites_edges() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_operation_edge",
+        "Operation edge",
+        None,
+        "seed",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+
+    let receipt = OperationReceipt {
+        caller_id: "test-caller",
+        operation_id: "page-operation-1",
+        request_digest: "page-digest",
+        response: "{}",
+    };
+    assert!(db
+        .try_update_page_content_with_changelog_at_version(
+            "page_operation_edge",
+            "updated",
+            &["source-operation"],
+            "manual_edit",
+            "[]",
+            None,
+            1,
+            Some(receipt),
+        )
+        .await
+        .unwrap());
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT operation_id FROM edges
+             WHERE edge_type = 'cites' AND src_id = ?1 AND dst_id = ?2",
+            libsql::params!["page_operation_edge", "source-operation"],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("page cites edge");
+    assert_eq!(
+        row.get::<Option<String>>(0).unwrap(),
+        Some("page-operation-1".to_string())
+    );
+}
+
+#[tokio::test]
 async fn insert_page_rejects_reserved_sources_delimiter_without_mutation() {
     use crate::export::provenance::{SOURCES_BLOCK_END, SOURCES_BLOCK_START};
     let (db, _dir) = test_db().await;
@@ -23928,6 +23981,27 @@ async fn accepted_page_merge_advances_survivor_source_revision() {
         .await
         .unwrap()
         .unwrap();
+    let absorbed = db
+        .get_page("page-merge-revision-absorbed")
+        .await
+        .unwrap()
+        .unwrap();
+    let survivor_history = db
+        .list_page_history("page-merge-revision-survivor", 10)
+        .await
+        .unwrap();
+    let absorbed_history = db
+        .list_page_history("page-merge-revision-absorbed", 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        survivor_history.first().map(|entry| entry.version),
+        Some(survivor.version)
+    );
+    assert_eq!(
+        absorbed_history.first().map(|entry| entry.version),
+        Some(absorbed.version)
+    );
     assert_eq!(survivor.stale_reason.as_deref(), Some("source_updated"));
     assert_eq!(
         survivor
@@ -26538,6 +26612,45 @@ async fn test_get_truncated_title_memories() {
         !ids.contains(&"mem_good_title"),
         "should not include good title"
     );
+}
+
+#[tokio::test]
+async fn archive_page_records_history_once_for_status_flip() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page-archive-history",
+        "Archive history",
+        None,
+        "body",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+
+    db.archive_page("page-archive-history").await.unwrap();
+    let archived = db.get_page("page-archive-history").await.unwrap().unwrap();
+    let history = db
+        .list_page_history("page-archive-history", 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        history.first().map(|entry| entry.version),
+        Some(archived.version)
+    );
+    assert_eq!(history.len(), 2, "archive adds the version history row");
+
+    db.archive_page("page-archive-history").await.unwrap();
+    let archived_again = db.get_page("page-archive-history").await.unwrap().unwrap();
+    let history_again = db
+        .list_page_history("page-archive-history", 10)
+        .await
+        .unwrap();
+    assert_eq!(archived_again.version, archived.version);
+    assert_eq!(history_again, history, "idempotent archive adds no row");
 }
 
 #[tokio::test]
@@ -49775,7 +49888,8 @@ async fn insert_resolved_page_evidence_rejects_autocommit_connection() {
     let conn = db.conn.lock().await;
     insert_raw_page_for_m81_test(&conn, "page_ac", "space_a").await;
     let result =
-        MemoryDB::insert_resolved_page_evidence(&conn, "page_ac", &["mem_ac"], 1, "test").await;
+        MemoryDB::insert_resolved_page_evidence(&conn, "page_ac", &["mem_ac"], 1, "test", None)
+            .await;
     assert!(
         result.is_err(),
         "must reject an autocommit connection (release-enforced, not debug_assert)"

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -24002,6 +24002,18 @@ async fn accepted_page_merge_advances_survivor_source_revision() {
         absorbed_history.first().map(|entry| entry.version),
         Some(absorbed.version)
     );
+    assert_eq!(
+        survivor_history
+            .first()
+            .map(|entry| entry.edited_by.as_str()),
+        Some("page_merge")
+    );
+    assert_eq!(
+        absorbed_history
+            .first()
+            .map(|entry| entry.edited_by.as_str()),
+        Some("archive")
+    );
     assert_eq!(survivor.stale_reason.as_deref(), Some("source_updated"));
     assert_eq!(
         survivor
@@ -26642,6 +26654,10 @@ async fn archive_page_records_history_once_for_status_flip() {
         Some(archived.version)
     );
     assert_eq!(history.len(), 2, "archive adds the version history row");
+    assert_eq!(
+        history.first().map(|entry| entry.edited_by.as_str()),
+        Some("archive")
+    );
 
     db.archive_page("page-archive-history").await.unwrap();
     let archived_again = db.get_page("page-archive-history").await.unwrap().unwrap();

--- a/crates/wenlan-core/src/document_enrichment.rs
+++ b/crates/wenlan-core/src/document_enrichment.rs
@@ -2372,10 +2372,14 @@ mod tests {
         );
         let status = db.document_enrichment_queue_status().await.unwrap();
         assert_eq!(status.exhausted, 1);
-        assert!(
-            status.paused_reason.is_none(),
-            "exhausted rows are not reported as waiting for another retry"
-        );
+        // The exhausted poison row is not "waiting for another retry" (no
+        // retryable paused row exists), but it must still surface as a
+        // paused reason rather than reading as ordinary `Active` pending
+        // work forever.
+        let reason = status
+            .paused_reason
+            .expect("an exhausted document surfaces as paused, not silently active");
+        assert!(reason.contains("exhausted"), "reason: {reason}");
     }
 
     // ── queue observability: status summary reflects pending + paused ─────────
@@ -2421,6 +2425,90 @@ mod tests {
         assert!(drained.paused_reason.is_none());
         assert!(drained.next_retry_at.is_none());
         assert_eq!(drained.exhausted, 0);
+    }
+
+    #[tokio::test]
+    async fn queue_status_surfaces_all_exhausted_queue_as_paused() {
+        let (db, _dir) = test_db().await;
+        db.enqueue_document("folder", "/poison.md", Some("poison-hash"))
+            .await
+            .unwrap();
+        for _ in 0..MemoryDB::DOC_ENRICHMENT_MAX_ATTEMPTS {
+            db.mark_paused(
+                "folder",
+                "/poison.md",
+                "poison document",
+                Some(chrono::Utc::now().timestamp() - 1),
+            )
+            .await
+            .unwrap();
+        }
+
+        let status = db.document_enrichment_queue_status().await.unwrap();
+        assert_eq!(status.exhausted, 1);
+        // The wire mapping (`crates/wenlan-server/src/routes.rs`) reports
+        // `Paused` whenever `paused_reason.is_some()`; a queue holding only
+        // exhausted rows must clear that bar instead of reading as `Active`
+        // forever.
+        let reason = status
+            .paused_reason
+            .expect("all-exhausted queue reports a paused reason");
+        assert!(
+            reason.contains("exhausted"),
+            "reason mentions exhaustion: {reason}"
+        );
+        assert!(
+            status.next_retry_at.is_none(),
+            "an all-exhausted queue has no next retry to report"
+        );
+    }
+
+    #[tokio::test]
+    async fn queue_status_paused_reason_mentions_both_exhausted_and_retryable() {
+        let (db, _dir) = test_db().await;
+        db.enqueue_document("folder", "/poison.md", Some("poison-hash"))
+            .await
+            .unwrap();
+        for _ in 0..MemoryDB::DOC_ENRICHMENT_MAX_ATTEMPTS {
+            db.mark_paused(
+                "folder",
+                "/poison.md",
+                "poison document",
+                Some(chrono::Utc::now().timestamp() - 1),
+            )
+            .await
+            .unwrap();
+        }
+        db.enqueue_document("folder", "/retrying.md", Some("retrying-hash"))
+            .await
+            .unwrap();
+        db.mark_paused(
+            "folder",
+            "/retrying.md",
+            "analysis LLM failed",
+            Some(1_712_678_400),
+        )
+        .await
+        .unwrap();
+
+        let status = db.document_enrichment_queue_status().await.unwrap();
+        assert_eq!(status.exhausted, 1);
+        let reason = status
+            .paused_reason
+            .expect("mixed queue reports a paused reason");
+        assert!(
+            reason.contains("analysis LLM failed"),
+            "reason mentions the retryable pause: {reason}"
+        );
+        assert!(
+            reason.contains("exhausted"),
+            "reason also mentions the exhausted document: {reason}"
+        );
+        assert_eq!(
+            status.next_retry_at,
+            Some(1_712_678_400),
+            "next_retry_at still tracks the retryable row"
+        );
     }
 
     // ── restart resume: in_progress rows are requeued (checkpoint preserved) ──

--- a/crates/wenlan-core/src/document_enrichment.rs
+++ b/crates/wenlan-core/src/document_enrichment.rs
@@ -2329,6 +2329,55 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn exhausted_document_is_not_claimed_while_fresh_pending_claims() {
+        let (db, _dir) = test_db().await;
+        db.enqueue_document("folder", "/poison.md", Some("poison-hash"))
+            .await
+            .unwrap();
+        for _ in 0..MemoryDB::DOC_ENRICHMENT_MAX_ATTEMPTS {
+            db.mark_paused(
+                "folder",
+                "/poison.md",
+                "poison document",
+                Some(chrono::Utc::now().timestamp() - 1),
+            )
+            .await
+            .unwrap();
+        }
+        db.enqueue_document("folder", "/fresh.md", Some("fresh-hash"))
+            .await
+            .unwrap();
+
+        let claimed = db
+            .claim_next_pending()
+            .await
+            .unwrap()
+            .expect("fresh pending document remains claimable");
+        assert_eq!(claimed.file_path, "/fresh.md");
+        assert!(
+            db.claim_next_pending().await.unwrap().is_none(),
+            "the capped poison document is not claimable"
+        );
+
+        let poison = db
+            .get_queue_entry("folder", "/poison.md")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            poison.attempt_count,
+            MemoryDB::DOC_ENRICHMENT_MAX_ATTEMPTS,
+            "poison row reaches the retry cap"
+        );
+        let status = db.document_enrichment_queue_status().await.unwrap();
+        assert_eq!(status.exhausted, 1);
+        assert!(
+            status.paused_reason.is_none(),
+            "exhausted rows are not reported as waiting for another retry"
+        );
+    }
+
     // ── queue observability: status summary reflects pending + paused ─────────
 
     #[tokio::test]
@@ -2340,6 +2389,7 @@ mod tests {
         assert_eq!(empty.pending, 0);
         assert!(empty.paused_reason.is_none());
         assert!(empty.next_retry_at.is_none());
+        assert_eq!(empty.exhausted, 0);
 
         // Two enqueued, one paused with a reason + retry time.
         db.enqueue_document("folder", "/a.md", Some("h"))
@@ -2361,6 +2411,7 @@ mod tests {
         assert_eq!(status.pending, 2, "pending counts all not-done rows");
         assert_eq!(status.paused_reason.as_deref(), Some("analysis LLM failed"));
         assert_eq!(status.next_retry_at, Some(1_712_678_400));
+        assert_eq!(status.exhausted, 0);
 
         // Once done, rows drop out of the pending count and the pause clears.
         db.mark_done("folder", "/a.md").await.unwrap();
@@ -2369,6 +2420,7 @@ mod tests {
         assert_eq!(drained.pending, 0);
         assert!(drained.paused_reason.is_none());
         assert!(drained.next_retry_at.is_none());
+        assert_eq!(drained.exhausted, 0);
     }
 
     // ── restart resume: in_progress rows are requeued (checkpoint preserved) ──

--- a/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
+++ b/docs/plans/2026-07-27-m5-reader-manifest-inventory.md
@@ -985,7 +985,8 @@ carrying the authority of agreement.
 
 | Reader | Visibility | Ambiguous | Exposure | External callers | Reaches prose via |
 |---|---|---|---|---|---|
-| `core/db.rs::accept_page_merge` | `pub` | no | no | — | `core/db.rs::page_merge_row` |
+| `core/db.rs::accept_page_merge` | `pub` | no | no | — | `core/db.rs::append_page_history`, `core/db.rs::page_merge_row` |
+| `core/db.rs::archive_page` | `pub` | no | **yes** | `server/page_routes.rs::handle_archive_page` | `core/db.rs::append_page_history` |
 | `core/db.rs::augment_with_graph_gated` | `private` | no | no | — | `core/db/scoped_entities.rs::get_observations_for_entities_scoped`, `core/db/scoped_entities.rs::search_entities_by_vector_scoped` |
 | `core/db.rs::augment_with_graph_seeded_scoped` | `private` | no | no | — | `core/db/scoped_entities.rs::get_observations_for_entities_scoped` |
 | `core/db.rs::find_best_overlapping_page` | `pub` | no | no | — | `core/db.rs::load_page_source_index` |
@@ -1213,6 +1214,7 @@ carrying the authority of agreement.
 | `server/page_map_routes.rs::ensure_page_is_active` | `private` | no | no | `server/page_map_routes.rs::handle_create_map_edge`, `server/page_map_routes.rs::handle_create_map_node`, `server/page_map_routes.rs::handle_delete_map_edge`, `server/page_map_routes.rs::handle_delete_map_node`, `server/page_map_routes.rs::handle_improve_page_map`, `server/page_map_routes.rs::handle_patch_map_edge`, `server/page_map_routes.rs::handle_patch_map_node`, `server/page_map_routes.rs::handle_put_page_map_layout`, `server/page_map_routes.rs::handle_reset_page_map` | `core/db.rs::get_page` |
 | `server/page_map_routes.rs::visible_page` | `private` | no | no | `server/page_map_routes.rs::compute_ref_state`, `server/page_map_routes.rs::ensure_page_exists` | `core/db.rs::get_page` |
 | `server/page_map_routes.rs::wire_node` | `private` | no | no | `server/page_map_routes.rs::build_map_response`, `server/page_map_routes.rs::handle_create_map_node`, `server/page_map_routes.rs::handle_delete_map_node`, `server/page_map_routes.rs::handle_patch_map_node` | `server/page_map_routes.rs::compute_ref_state` |
+| `server/page_routes.rs::handle_archive_page` | `pub` | no | no | — | `core/db.rs::archive_page` |
 | `server/page_routes.rs::handle_create_page` | `pub` | no | no | — | `core/db.rs::get_page` |
 | `server/page_routes.rs::handle_refresh_page` | `pub` | no | no | — | `core/db.rs::get_page` |
 | `server/page_routes.rs::handle_update_page` | `pub` | no | no | — | `core/db.rs::get_page` |


### PR DESCRIPTION
Closes four daemon-side holes found in the page-history / enrichment-queue audit (task #13). Two of the six audited holes were already fixed on main and are not touched here.

## What changed

**Page history bypasses** — `archive_page` and both arms of `accept_page_merge` (survivor rewrite + absorbed archive) now append page-history rows, so these edits are no longer invisible to `get_page_revisions`. `edited_by` literals: `"archive"` (archive + absorbed arm), `"page_merge"` (survivor arm), pinned by tests.

**Poison-document retry cap** — `DOC_ENRICHMENT_MAX_ATTEMPTS = 5` claim gate: a document that fails enrichment five times stops being claimed instead of burning the worker forever. A content-hash change resets `attempt_count` and revives the row.

**Exhausted-queue visibility** (second commit, from review) — `document_enrichment_queue_status` folds exhausted counts into `paused_reason`, so an all-exhausted queue reports `Paused { reason: "N documents exhausted enrichment retries (max 5 attempts) and will not be retried" }` on the wire instead of `Active { pending: N }` forever. Mixed queues get both reasons; `next_retry_at` stays `None` when nothing is retryable. No wire-shape change.

**Operation-id provenance** — `operation_id` threaded into `insert_resolved_page_evidence` where a receipt is in scope; manifest-inventory doc rows added.

## Review trail

Blind review NEEDS-CHANGES (caught the exhausted-queue `Active`-forever regression before it shipped) → fix commit → delta review SHIP (verified both wire legs — `routes.rs` status mapping and `source_routes.rs` stall signal — regain the paused signal; the `Idle` arm is unreachable when exhausted > 0).

One pre-existing test added in the first commit asserted the buggy behavior (`paused_reason.is_none()` for an all-exhausted queue); it now asserts the fix. That is the only test whose expectation changed.

## Gates

`cargo fmt` clean · `cargo clippy` clean · `cargo check -p wenlan-server` clean · `document_enrichment` 29 passed · targeted + drift_guard 159 passed · full `cargo test -p wenlan-core --lib` 4108 passed / 31 ignored (first commit) · pre-push affected-closure hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCpjjC1WANBMG1jMSXkFgK