### PR TITLE
feat(app): restore the community-map overlay lost in the monorepo migration

### DIFF
--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -231,6 +231,77 @@ struct OnDeviceModelRequest {
     model_id: String,
 }
 
+// ── Communities (M6 cartography) ────────────────────────────────────────
+// Wire shapes hand-mirrored from `crates/wenlan-types/src/communities.rs`
+// (`community-read-v1`): the community read routes are merged to the
+// daemon but the pinned wenlan-types 0.14.1 predates the crate module —
+// same situation as the page-map types above. Read-tolerant (no
+// `deny_unknown_fields`): any future additions are ignored rather than
+// rejected. `scope` is carried (not ignored) — these structs are
+// re-serialized verbatim for the frontend by the Tauri commands below, so a
+// field this struct doesn't declare doesn't just go unread here, it's
+// dropped from what the frontend ever sees.
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommunityScope {
+    pub kind: String,
+    /// Present only on the `space` variant. The daemon's `CommunityReadScope`
+    /// is an internally tagged enum, so `global` and `uncategorized` serialize
+    /// as `{"kind":"global"}` with no `name` at all — a required String here
+    /// would fail the whole read for those scopes, and every space is then
+    /// stuck reporting `partial-error`. A Space is resolved as
+    /// `uncategorized` whenever an entity carries that literal as its space or
+    /// domain and no Space by that name is registered, which is exactly how
+    /// the Atlas enumerates spaces, so this is reachable and not theoretical.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommunitySummary {
+    pub community_id: String,
+    pub space: String,
+    pub display_name: Option<String>,
+    pub member_count: u64,
+    pub published_generation: i64,
+    pub algo_version: String,
+    pub projection_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommunityListResponse {
+    pub schema_version: String,
+    #[serde(default)]
+    pub scope: Option<CommunityScope>,
+    pub communities: Vec<CommunitySummary>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommunityMember {
+    pub space: String,
+    pub node_id: String,
+    pub node_kind: String,
+    pub community_id: String,
+    pub published_generation: i64,
+    pub attachment: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CommunityMemberCursor {
+    pub space: String,
+    pub node_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CommunityMembersResponse {
+    pub schema_version: String,
+    #[serde(default)]
+    pub scope: Option<CommunityScope>,
+    pub members: Vec<CommunityMember>,
+    pub next_cursor: Option<CommunityMemberCursor>,
+}
+
 impl Default for WenlanClient {
     fn default() -> Self {
         Self::new()
@@ -767,6 +838,30 @@ impl WenlanClient {
             .map_err(|e| format!("Parse {}: {}", path, e))
     }
 
+    /// Like `get_json`, but on non-2xx returns `Err(json)` where json is
+    /// `{"status":<u16>,"error":"<body text>"}` (same envelope as
+    /// `page_map_call`) instead of a formatted string. The community
+    /// readiness engine needs the raw status to distinguish an old daemon
+    /// (404/405 — route doesn't exist yet) from any other failure.
+    async fn get_json_with_status<T: DeserializeOwned>(&self, path: &str) -> Result<T, String> {
+        let resp = self
+            .client
+            .get(self.url(path))
+            .send()
+            .await
+            .map_err(|e| format!("HTTP GET {}: {}", path, e))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(
+                serde_json::json!({ "status": status.as_u16(), "error": text }).to_string(),
+            );
+        }
+        resp.json()
+            .await
+            .map_err(|e| format!("Parse {}: {}", path, e))
+    }
+
     pub async fn get_page_map(&self, page_id: &str) -> Result<serde_json::Value, String> {
         let path = format!("/api/pages/{}/map", page_id);
         self.page_map_call(reqwest::Method::GET, &path, None).await
@@ -818,6 +913,50 @@ impl WenlanClient {
         let path = format!("/api/pages/{}/map/layout", page_id);
         self.page_map_call(reqwest::Method::PUT, &path, Some(body))
             .await
+    }
+
+    // ── Communities (M6 cartography) ────────────────────────────────────
+
+    pub async fn list_communities(
+        &self,
+        space: &str,
+        cursor: Option<&str>,
+        limit: Option<usize>,
+    ) -> Result<CommunityListResponse, String> {
+        let mut path = format!(
+            "/api/communities?space={}",
+            percent_encode_path_segment(space)
+        );
+        if let Some(cursor) = cursor {
+            path.push_str(&format!("&cursor={}", percent_encode_path_segment(cursor)));
+        }
+        if let Some(limit) = limit {
+            path.push_str(&format!("&limit={}", limit));
+        }
+        self.get_json_with_status(&path).await
+    }
+
+    pub async fn list_community_members(
+        &self,
+        space: &str,
+        cursor: Option<&CommunityMemberCursor>,
+        limit: Option<usize>,
+    ) -> Result<CommunityMembersResponse, String> {
+        let mut path = format!(
+            "/api/communities/members?space={}",
+            percent_encode_path_segment(space)
+        );
+        if let Some(cursor) = cursor {
+            path.push_str(&format!(
+                "&cursor_space={}&cursor_node_id={}",
+                percent_encode_path_segment(&cursor.space),
+                percent_encode_path_segment(&cursor.node_id)
+            ));
+        }
+        if let Some(limit) = limit {
+            path.push_str(&format!("&limit={}", limit));
+        }
+        self.get_json_with_status(&path).await
     }
 
     pub async fn test_llm(
@@ -2227,5 +2366,182 @@ mod tests {
             page.entries[0].incoming_source_ids.as_ref().unwrap(),
             &vec!["mem-1".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn list_communities_builds_scoped_query_and_parses_the_response() {
+        let (base_url, request) = serve_json_once(
+            r#"{"schema_version":"community-read-v1","scope":{"kind":"space","name":"Work"},"communities":[{"community_id":"c1","space":"Work","display_name":"Core","member_count":5,"published_generation":3,"algo_version":"v1","projection_version":"v1"}],"next_cursor":"c1"}"#,
+        )
+        .await;
+        let client = WenlanClient {
+            client: reqwest::Client::new(),
+            base_url,
+        };
+
+        let response = client
+            .list_communities("Work", None, None)
+            .await
+            .expect("list_communities succeeds");
+
+        assert_eq!(response.schema_version, "community-read-v1");
+        assert_eq!(response.communities.len(), 1);
+        assert_eq!(response.communities[0].community_id, "c1");
+        assert_eq!(response.communities[0].published_generation, 3);
+        assert_eq!(response.next_cursor.as_deref(), Some("c1"));
+        // The daemon's `scope` must survive the round trip — the Tauri
+        // command re-serializes this struct verbatim for the frontend, so a
+        // field the struct doesn't carry is silently dropped, not merely
+        // unread.
+        assert_eq!(
+            response.scope,
+            Some(CommunityScope {
+                kind: "space".to_string(),
+                name: Some("Work".to_string()),
+            })
+        );
+        let request = request.await.unwrap();
+        assert_eq!(
+            request.lines().next().unwrap_or_default(),
+            "GET /api/communities?space=Work HTTP/1.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_communities_parses_the_nameless_scopes() {
+        // `CommunityReadScope` is internally tagged: only the `space` variant
+        // carries a name. A required `name` here failed the entire read for a
+        // global or uncategorized scope, which surfaced as a permanent
+        // `partial-error` for that space rather than as anything diagnosable.
+        const BODIES: [(&str, &str); 2] = [
+            (
+                "global",
+                r#"{"schema_version":"community-read-v1","scope":{"kind":"global"},"communities":[],"next_cursor":null}"#,
+            ),
+            (
+                "uncategorized",
+                r#"{"schema_version":"community-read-v1","scope":{"kind":"uncategorized"},"communities":[],"next_cursor":null}"#,
+            ),
+        ];
+
+        for (kind, body) in BODIES {
+            let (base_url, _request) = serve_json_once(body).await;
+            let client = WenlanClient {
+                client: reqwest::Client::new(),
+                base_url,
+            };
+
+            let response = client
+                .list_communities("uncategorized", None, None)
+                .await
+                .unwrap_or_else(|e| panic!("{kind} scope parses: {e}"));
+
+            assert_eq!(
+                response.scope,
+                Some(CommunityScope {
+                    kind: kind.to_string(),
+                    name: None,
+                })
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn list_community_members_tolerates_a_response_with_no_scope_field() {
+        // Read-tolerant: an older daemon (or a members route that never
+        // added scope) omitting the field entirely must still parse.
+        let (base_url, _request) = serve_json_once(
+            r#"{"schema_version":"community-read-v1","members":[],"next_cursor":null}"#,
+        )
+        .await;
+        let client = WenlanClient {
+            client: reqwest::Client::new(),
+            base_url,
+        };
+
+        let response = client
+            .list_community_members("Work", None, None)
+            .await
+            .expect("list_community_members succeeds");
+
+        assert_eq!(response.scope, None);
+    }
+
+    #[tokio::test]
+    async fn list_communities_percent_encodes_space_and_cursor_and_appends_limit() {
+        let (base_url, request) = serve_json_once(
+            r#"{"schema_version":"community-read-v1","communities":[],"next_cursor":null}"#,
+        )
+        .await;
+        let client = WenlanClient {
+            client: reqwest::Client::new(),
+            base_url,
+        };
+
+        client
+            .list_communities("Work/Clients", Some("cursor?"), Some(50))
+            .await
+            .expect("list_communities succeeds");
+
+        let request = request.await.unwrap();
+        assert_eq!(
+            request.lines().next().unwrap_or_default(),
+            "GET /api/communities?space=Work%2FClients&cursor=cursor%3F&limit=50 HTTP/1.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_community_members_builds_scoped_query_with_cursor_and_parses_the_response() {
+        let (base_url, request) = serve_json_once(
+            r#"{"schema_version":"community-read-v1","members":[{"space":"Work","node_id":"e1","node_kind":"entity","community_id":"c1","published_generation":3,"attachment":"core"}],"next_cursor":{"space":"Work","node_id":"e2"}}"#,
+        )
+        .await;
+        let client = WenlanClient {
+            client: reqwest::Client::new(),
+            base_url,
+        };
+
+        let cursor = CommunityMemberCursor {
+            space: "Work".to_string(),
+            node_id: "e0".to_string(),
+        };
+        let response = client
+            .list_community_members("Work", Some(&cursor), Some(25))
+            .await
+            .expect("list_community_members succeeds");
+
+        assert_eq!(response.members.len(), 1);
+        assert_eq!(response.members[0].node_id, "e1");
+        assert_eq!(response.members[0].published_generation, 3);
+        assert_eq!(
+            response.next_cursor,
+            Some(CommunityMemberCursor {
+                space: "Work".to_string(),
+                node_id: "e2".to_string(),
+            })
+        );
+        let request = request.await.unwrap();
+        assert_eq!(
+            request.lines().next().unwrap_or_default(),
+            "GET /api/communities/members?space=Work&cursor_space=Work&cursor_node_id=e0&limit=25 HTTP/1.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_communities_surfaces_status_for_an_old_daemon_missing_the_route() {
+        let (base_url, _request) =
+            serve_response_once("404 Not Found", r#"{"error":"no route"}"#).await;
+        let client = WenlanClient {
+            client: reqwest::Client::new(),
+            base_url,
+        };
+
+        let err = client
+            .list_communities("Work", None, None)
+            .await
+            .expect_err("404 surfaces as an error");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&err).expect("status envelope is JSON");
+        assert_eq!(parsed["status"], 404);
     }
 }

--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -233,14 +233,23 @@ struct OnDeviceModelRequest {
 
 // ── Communities (M6 cartography) ────────────────────────────────────────
 // Wire shapes hand-mirrored from `crates/wenlan-types/src/communities.rs`
-// (`community-read-v1`): the community read routes are merged to the
-// daemon but the pinned wenlan-types 0.14.1 predates the crate module —
-// same situation as the page-map types above. Read-tolerant (no
-// `deny_unknown_fields`): any future additions are ignored rather than
-// rejected. `scope` is carried (not ignored) — these structs are
-// re-serialized verbatim for the frontend by the Tauri commands below, so a
-// field this struct doesn't declare doesn't just go unread here, it's
-// dropped from what the frontend ever sees.
+// (`community-read-v1`). This section deliberately TYPES the response, unlike
+// the page-map section below, which forwards `serde_json::Value` untouched:
+// the community read is classified here in Rust-adjacent code and by
+// src/lib/graph/community.ts, and a field-level mismatch has to fail where a
+// test can see it.
+//
+// The types are hand-mirrored rather than taken from `wenlan_types` (which
+// the app now depends on directly, so the module IS reachable) because
+// `CommunityReadScope` is an internally tagged enum: a `kind` the app has not
+// been taught would fail the WHOLE response to deserialize, and the response
+// is a read the UI must degrade on rather than lose. `kind: String` here
+// accepts a future variant and lets the frontend decide. Everything else is
+// read-tolerant for the same reason: no `deny_unknown_fields`, so additions
+// are ignored rather than rejected. `scope` is carried (not ignored) — these
+// structs are re-serialized verbatim for the frontend by the Tauri commands
+// below, so a field this struct doesn't declare doesn't just go unread here,
+// it's dropped from what the frontend ever sees.
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CommunityScope {

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1307,6 +1307,9 @@ pub fn run() {
             search::patch_page_map_node,
             search::delete_page_map_node,
             search::put_page_map_layout,
+            // Community commands (M6 cartography)
+            search::list_communities,
+            search::list_community_members,
             // Home delta feed commands
             search::list_recent_retrievals,
             search::list_recent_changes,

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -3910,6 +3910,34 @@ pub async fn put_page_map_layout(
     client.put_page_map_layout(&page_id, body).await
 }
 
+// ── Communities (M6 cartography) ────────────────────────────────────────
+
+#[tauri::command]
+pub async fn list_communities(
+    state: tauri::State<'_, State>,
+    space: String,
+    cursor: Option<String>,
+    limit: Option<usize>,
+) -> Result<crate::api::CommunityListResponse, String> {
+    let client = { state.read().await.client.clone() };
+    client
+        .list_communities(&space, cursor.as_deref(), limit)
+        .await
+}
+
+#[tauri::command]
+pub async fn list_community_members(
+    state: tauri::State<'_, State>,
+    space: String,
+    cursor: Option<crate::api::CommunityMemberCursor>,
+    limit: Option<usize>,
+) -> Result<crate::api::CommunityMembersResponse, String> {
+    let client = { state.read().await.client.clone() };
+    client
+        .list_community_members(&space, cursor.as_ref(), limit)
+        .await
+}
+
 #[tauri::command]
 pub async fn export_pages_to_obsidian(
     state: tauri::State<'_, State>,

--- a/e2e/tauriMock/baseResponses.ts
+++ b/e2e/tauriMock/baseResponses.ts
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import { UnknownTauriCommandError } from "./errors";
 
+// Mirrors `COMMUNITY_READ_SCHEMA_VERSION` in src/lib/tauri.ts; kept as a
+// literal here for the same reason runtime.ts keeps PAGE_EDIT_DAEMON_FLOOR —
+// the mock must not import back through the review invoke alias.
+const COMMUNITY_READ_SCHEMA_VERSION = "community-read-v1";
+
 type BaseResponseContext = {
   readonly activityRows: readonly Record<string, unknown>[];
   readonly memoryCount: number;
@@ -28,6 +33,8 @@ export function baseResponse(command: string, args: unknown, context: BaseRespon
     case "list_all_tags": return { tags: [], document_tags: {}, categories: [], document_categories: {} };
     case "get_page_links": return { outbound: [], inbound: [] };
     case "get_page_sources": case "list_registered_sources": return [];
+    case "list_communities": return { schema_version: COMMUNITY_READ_SCHEMA_VERSION, communities: [], next_cursor: null };
+    case "list_community_members": return { schema_version: COMMUNITY_READ_SCHEMA_VERSION, members: [], next_cursor: null };
     case "get_page_revisions": return { page_id: optionalString(args, "pageId") ?? "", current_version: 1, user_edited: false, entries: [] };
     default: throw new UnknownTauriCommandError(command);
   }

--- a/preview/mocks/live-invoke.ts
+++ b/preview/mocks/live-invoke.ts
@@ -520,6 +520,22 @@ export const HANDLERS: Record<string, (a: any) => Promise<unknown>> = {
   delete_page_map_node: (a) =>
     http("DELETE", `/api/pages/${enc(a.pageId)}/map/nodes/${enc(a.nodeId)}`, a.body),
   put_page_map_layout: (a) => put(`/api/pages/${enc(a.pageId)}/map/layout`, a.body),
+
+  // Communities (M6 cartography) — mirrors WenlanClient::list_communities /
+  // list_community_members in app/src/api.rs.
+  list_communities: (a) =>
+    get(`/api/communities${qs({ space: a.space, cursor: a.cursor, limit: a.limit })}`),
+  list_community_members: (a) => {
+    const cursor = a.cursor as { space: string; node_id: string } | null | undefined;
+    return get(
+      `/api/communities/members${qs({
+        space: a.space,
+        cursor_space: cursor?.space,
+        cursor_node_id: cursor?.node_id,
+        limit: a.limit,
+      })}`,
+    );
+  },
   get_page_revisions: (a) => get(`/api/pages/${enc(a.pageId)}/revisions`),
   redistill_page: (a) => post(`/api/distill/${enc(a.pageId)}`, {}),
   update_page: async (a) => {

--- a/review/commandCapabilities.ts
+++ b/review/commandCapabilities.ts
@@ -55,6 +55,14 @@ export const REVIEW_COMMAND_CAPABILITIES = {
     "publish_page_draft",
     "discard_page_draft",
   ],
+  pageMap: [
+    "get_page_map",
+    "improve_page_map",
+    "create_page_map_node",
+    "patch_page_map_node",
+    "delete_page_map_node",
+    "put_page_map_layout",
+  ],
   refinement: [
     "distill_review",
     "list_refinements",
@@ -95,6 +103,10 @@ export const REVIEW_COMMAND_CAPABILITIES = {
     "confirm_observation_cmd",
     "confirm_entity_cmd",
     "delete_entity_cmd",
+  ],
+  cartography: [
+    "list_communities",
+    "list_community_members",
   ],
   existingUtilityReads: [
     "get_clipboard_enabled",

--- a/src/components/memory/AtlasView.test.tsx
+++ b/src/components/memory/AtlasView.test.tsx
@@ -2,11 +2,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { i18n } from "../../i18n";
 
-vi.mock("../../lib/tauri", () => ({
-  listEntities: vi.fn(),
-  getEntityDetail: vi.fn(),
-}));
+vi.mock("../../lib/tauri", async () => {
+  const actual = await vi.importActual<typeof import("../../lib/tauri")>("../../lib/tauri");
+  return {
+    ...actual,
+    listEntities: vi.fn(),
+    getEntityDetail: vi.fn(),
+    listCommunities: vi.fn(),
+    listCommunityMembers: vi.fn(),
+  };
+});
 
 // jsdom has no WebGL context — a real Sigma would throw trying to acquire
 // one. Mocked at module level per repo convention for canvas/WebGL surfaces;
@@ -76,18 +83,25 @@ vi.mock("sigma", () => {
       y: pos.y,
       ratio,
     }));
-    refresh() {}
+    // Real sigma renders synchronously on refresh() and fires afterRender at
+    // the end of the frame. The underlay repaint hangs off that event, so a
+    // no-op here would silently pass any "it repainted" assertion.
+    refresh() {
+      this.handlers.get("afterRender")?.({});
+    }
     setSetting(_key: string, _value: unknown) {}
     kill() {}
   }
   return { default: SigmaMock };
 });
 
-import { listEntities, getEntityDetail } from "../../lib/tauri";
+import { listEntities, getEntityDetail, listCommunities, listCommunityMembers } from "../../lib/tauri";
 import AtlasView from "./AtlasView";
 
 const mockListEntities = vi.mocked(listEntities);
 const mockGetEntityDetail = vi.mocked(getEntityDetail);
+const mockListCommunities = vi.mocked(listCommunities);
+const mockListCommunityMembers = vi.mocked(listCommunityMembers);
 
 function renderWithQuery(ui: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
@@ -100,6 +114,9 @@ function makeEntity(overrides: Partial<import("../../lib/tauri").Entity> = {}): 
     name: overrides.name ?? "Entity",
     entity_type: overrides.entity_type ?? "concept",
     domain: overrides.domain ?? null,
+    // Kept distinct from domain: an entity can carry space: null or the empty
+    // string while domain says nothing, and all of those mean "unscoped".
+    space: overrides.space ?? null,
     source_agent: overrides.source_agent ?? null,
     confidence: overrides.confidence ?? null,
     confirmed: overrides.confirmed ?? false,
@@ -112,6 +129,19 @@ describe("AtlasView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedSigmaInstances.length = 0;
+    // Ordinary "no durable data published yet" default — most tests carry
+    // no space at all (so this never fires), and the ones that do only care
+    // about entities/relations, not cartography.
+    mockListCommunities.mockResolvedValue({
+      schema_version: "community-read-v1",
+      communities: [],
+      next_cursor: null,
+    });
+    mockListCommunityMembers.mockResolvedValue({
+      schema_version: "community-read-v1",
+      members: [],
+      next_cursor: null,
+    });
   });
 
   it("shows a distinct loading state while entities are in flight, then resolves to empty", async () => {
@@ -903,6 +933,441 @@ describe("AtlasView", () => {
     // Toolbar is provably rendered (Regions chip present) before the absence claim.
     expect(screen.getByRole("button", { name: "Regions" })).toBeInTheDocument();
     expect(screen.queryByRole("combobox", { name: "Space" })).not.toBeInTheDocument();
+  });
+
+  // A single entity carrying a space — the minimum needed to put the
+  // cartography query in flight for the badge tests below.
+  function mockOneSpaceEntity(domain = "wenlan-dev") {
+    const entity = makeEntity({ id: "e1", domain });
+    mockListEntities.mockResolvedValue([entity]);
+    mockGetEntityDetail.mockResolvedValue({ entity, observations: [], relations: [] });
+    return entity;
+  }
+
+  function readyCommunityPages(space: string) {
+    return {
+      communities: {
+        schema_version: "community-read-v1" as const,
+        communities: [
+          {
+            community_id: "c1",
+            space,
+            display_name: null,
+            member_count: 1,
+            published_generation: 1,
+            algo_version: "v1",
+            projection_version: "v1",
+          },
+        ],
+        next_cursor: null,
+      },
+      members: {
+        schema_version: "community-read-v1" as const,
+        members: [
+          {
+            space,
+            node_id: "e1",
+            node_kind: "entity",
+            community_id: "c1",
+            published_generation: 1,
+            attachment: "core",
+          },
+        ],
+        next_cursor: null,
+      },
+    };
+  }
+
+  it("badges the toolbar with durable-regions once the space's community read comes back ready", async () => {
+    mockOneSpaceEntity();
+    const pages = readyCommunityPages("wenlan-dev");
+    mockListCommunities.mockResolvedValue(pages.communities);
+    mockListCommunityMembers.mockResolvedValue(pages.members);
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    expect(await screen.findByText("Durable regions")).toBeInTheDocument();
+  });
+
+  it("keeps the badge honest when a null-space relation neighbor sits beside an otherwise-ready space", async () => {
+    // "e1" carries a real space and its own community read comes back
+    // ready; "ghost" only ever appears as a relation target (model.ts
+    // synthesizes it with space: null) — the aggregate must never read as
+    // all-durable while that unreported fallback node is on the map.
+    const entity = mockOneSpaceEntity();
+    mockGetEntityDetail.mockResolvedValue({
+      entity,
+      observations: [],
+      relations: [
+        {
+          id: "rel-1",
+          relation_type: "knows",
+          direction: "outgoing" as const,
+          entity_id: "ghost",
+          entity_name: "Ghost",
+          entity_type: "concept",
+          source_agent: null,
+          created_at: Math.floor(Date.now() / 1000),
+        },
+      ],
+    });
+    const pages = readyCommunityPages("wenlan-dev");
+    mockListCommunities.mockResolvedValue(pages.communities);
+    mockListCommunityMembers.mockResolvedValue(pages.members);
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    expect(await screen.findByText("Estimated regions")).toBeInTheDocument();
+    expect(screen.queryByText("Durable regions")).not.toBeInTheDocument();
+  });
+
+  it("badges the toolbar with estimated-regions while no durable data has been published for the space yet", async () => {
+    mockOneSpaceEntity();
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    expect(await screen.findByText("Estimated regions")).toBeInTheDocument();
+  });
+
+  // An entity's OWN space can be null or empty (model.ts's GraphNode.space) —
+  // it does not take a relation-only neighbor to put unscoped nodes on the
+  // map. Such a graph renders entirely on the fallback climb, so the badge
+  // must say so even though there is no relation, and no known space, to give
+  // it away.
+  it.each([
+    ["null", null],
+    ["empty-string", ""],
+  ])("badges the toolbar as estimated for a relation-free graph whose entity carries a %s space", async (_label, space) => {
+    const entity = makeEntity({ id: "e1", name: "Alice", domain: null, space });
+    mockListEntities.mockResolvedValue([entity]);
+    mockGetEntityDetail.mockResolvedValue({ entity, observations: [], relations: [] });
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    // Toolbar is provably rendered before the badge claim.
+    expect(screen.getByRole("button", { name: "Regions" })).toBeInTheDocument();
+    expect(await screen.findByText("Estimated regions")).toBeInTheDocument();
+  });
+
+  // Scoping to a space drops the other space's entities from the model inputs
+  // but keeps the relations pointing at them, so buildGraphModel synthesizes
+  // those endpoints with space: null — real unscoped nodes, drawn on the
+  // fallback climb, that exist ONLY in the filtered model. A badge derived
+  // from the unfiltered entity list cannot see them and keeps claiming
+  // durable while the map shows otherwise.
+  it("badges the toolbar as estimated once a space filter synthesizes an unscoped bridge neighbor", async () => {
+    const entities = [
+      makeEntity({ id: "e1", name: "Alice", domain: "Work" }),
+      makeEntity({ id: "e2", name: "Bob", domain: "Personal" }),
+    ];
+    mockListEntities.mockResolvedValue(entities);
+    mockGetEntityDetail.mockImplementation(async (id: string) => ({
+      entity: entities.find((e) => e.id === id)!,
+      observations: [],
+      relations:
+        id === "e1"
+          ? [
+              {
+                id: "rel-1",
+                relation_type: "knows",
+                direction: "outgoing" as const,
+                entity_id: "e2",
+                entity_name: "Bob",
+                entity_type: "person",
+                source_agent: null,
+                created_at: Math.floor(Date.now() / 1000),
+              },
+            ]
+          : [],
+    }));
+    // Both spaces publish durable cartography, so nothing about the daemon
+    // reads is degraded — only the filtered view is.
+    const communityId = (space: string) => (space === "Work" ? "c1" : "c2");
+    const nodeId = (space: string) => (space === "Work" ? "e1" : "e2");
+    mockListCommunities.mockImplementation(async (space: string) => ({
+      schema_version: "community-read-v1" as const,
+      communities: [
+        {
+          community_id: communityId(space),
+          space,
+          display_name: null,
+          member_count: 1,
+          published_generation: 1,
+          algo_version: "v1",
+          projection_version: "v1",
+        },
+      ],
+      next_cursor: null,
+    }));
+    mockListCommunityMembers.mockImplementation(async (space: string) => ({
+      schema_version: "community-read-v1" as const,
+      members: [
+        {
+          space,
+          node_id: nodeId(space),
+          node_kind: "entity",
+          community_id: communityId(space),
+          published_generation: 1,
+          attachment: "core",
+        },
+      ],
+      next_cursor: null,
+    }));
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    // Unfiltered, every rendered node carries a ready space.
+    expect(await screen.findByText("Durable regions")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Space" }), {
+      target: { value: "Work" },
+    });
+
+    // Bob is now a synthesized, space-less endpoint on the map.
+    expect(await screen.findByText("Estimated regions")).toBeInTheDocument();
+    expect(screen.queryByText("Durable regions")).not.toBeInTheDocument();
+  });
+
+  it("badges the toolbar with an alerting sync-issue state when a space's community read fails", async () => {
+    mockOneSpaceEntity();
+    mockListCommunities.mockRejectedValue(new Error("connection reset"));
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    const badge = await screen.findByText("Region sync issue");
+    expect(badge).toHaveAttribute("role", "alert");
+  });
+
+  // Same two-triangles-one-bridge shape as mockTwoTriangles, but every
+  // entity carries a space so the cartography query actually fires (a bare
+  // mockTwoTriangles never puts the constellation-cartography query in
+  // flight — see mockOneSpaceEntity's comment above).
+  function mockTwoTrianglesInSpace(domain = "wenlan-dev") {
+    const names: Record<string, string> = {
+      a1: "Alice",
+      a2: "Anna",
+      a3: "Ada",
+      b1: "Bob",
+      b2: "Ben",
+      b3: "Bea",
+    };
+    const entities = Object.entries(names).map(([id, name]) => makeEntity({ id, name, domain }));
+    const rel = (id: string, target: string) => ({
+      id,
+      relation_type: "knows",
+      direction: "outgoing" as const,
+      entity_id: target,
+      entity_name: names[target],
+      entity_type: "concept",
+      source_agent: null,
+      created_at: Math.floor(Date.now() / 1000),
+    });
+    mockListEntities.mockResolvedValue(entities);
+    mockGetEntityDetail.mockImplementation(async (id: string) => {
+      const relations =
+        id === "a1"
+          ? [rel("r1", "a2"), rel("r2", "a3"), rel("rb", "b1")]
+          : id === "a2"
+            ? [rel("r3", "a3")]
+            : id === "b1"
+              ? [rel("r4", "b2"), rel("r5", "b3")]
+              : id === "b2"
+                ? [rel("r6", "b3")]
+                : [];
+      return { entity: entities.find((e) => e.id === id)!, observations: [], relations };
+    });
+  }
+
+  // Records what the cartography underlay actually painted. drawCartography
+  // clears once per paint before drawing, so resetting on clearRect leaves
+  // `regionNames` holding the MOST RECENT paint only — immune to however many
+  // extra repaints a render happens to trigger — while `paints` counts them.
+  function recordingUnderlayCtx() {
+    const state = { paints: 0, regionNames: [] as string[] };
+    const ctx = {
+      strokeStyle: "",
+      fillStyle: "",
+      lineWidth: 0,
+      lineJoin: "",
+      lineCap: "",
+      font: "",
+      letterSpacing: "",
+      textAlign: "",
+      textBaseline: "",
+      setTransform: vi.fn(),
+      clearRect: vi.fn(() => {
+        state.paints += 1;
+        state.regionNames.length = 0;
+      }),
+      save: vi.fn(),
+      restore: vi.fn(),
+      beginPath: vi.fn(),
+      closePath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      bezierCurveTo: vi.fn(),
+      arc: vi.fn(),
+      setLineDash: vi.fn(),
+      stroke: vi.fn(),
+      fill: vi.fn(),
+      fillText: vi.fn((text: string) => {
+        state.regionNames.push(text);
+      }),
+    };
+    return { ctx, state };
+  }
+
+  it("paints the underlay on mount through the post-mount effects, with no second draw of its own", async () => {
+    mockTwoTrianglesInSpace();
+    // The underlay canvas only exists once the mount effect has run, so stub
+    // the prototype to catch the very first paint.
+    const painter = recordingUnderlayCtx();
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue(painter.ctx) as any;
+    try {
+      renderWithQuery(<AtlasView />);
+      await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+      // Nothing here fired afterRender by hand: the theme and cartography
+      // effects both refresh() right after the mount effect, and that is the
+      // whole initial paint path — so the mount effect must not draw as well.
+      expect(painter.state.paints).toBeGreaterThan(0);
+      expect(painter.state.regionNames).toEqual(["Alice", "Bob"]);
+    } finally {
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    }
+  });
+
+  it("re-renders bridges and hulls when a space's cartography status changes, without a full remount", async () => {
+    mockTwoTrianglesInSpace();
+    // Starts on the default (empty) fallback climb: two 3-cliques, "rb" is
+    // the one cross-region bridge.
+    const { qc } = renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+    const instance = capturedSigmaInstances[0];
+    const graph = instance.graph;
+
+    expect(graph.getEdgeAttribute("rb", "bridge")).toBe(true);
+
+    // Watch the hulls, not just the edge colours: on the fallback climb the
+    // two triangles are two named regions (leaders a1/b1 — the degree-3 hubs).
+    const underlay = document.querySelector(
+      'canvas[data-testid="atlas-cartography"]',
+    ) as HTMLCanvasElement;
+    const painter = recordingUnderlayCtx();
+    underlay.getContext = vi.fn().mockReturnValue(painter.ctx) as any;
+    instance.handlers.get("afterRender")!({});
+    expect(painter.state.regionNames).toEqual(["Alice", "Bob"]);
+    const paintsBeforeChange = painter.state.paints;
+
+    // Durable arrives: the daemon puts all 6 members in ONE community, so
+    // the bridge collapses into an ordinary intra-region edge.
+    const allOneCommunity = {
+      communities: {
+        schema_version: "community-read-v1" as const,
+        communities: [
+          {
+            community_id: "one",
+            space: "wenlan-dev",
+            display_name: null,
+            member_count: 6,
+            published_generation: 1,
+            algo_version: "v1",
+            projection_version: "v1",
+          },
+        ],
+        next_cursor: null,
+      },
+      members: {
+        schema_version: "community-read-v1" as const,
+        members: ["a1", "a2", "a3", "b1", "b2", "b3"].map((node_id) => ({
+          space: "wenlan-dev",
+          node_id,
+          node_kind: "entity",
+          community_id: "one",
+          published_generation: 1,
+          attachment: "core",
+        })),
+        next_cursor: null,
+      },
+    };
+    mockListCommunities.mockResolvedValue(allOneCommunity.communities);
+    mockListCommunityMembers.mockResolvedValue(allOneCommunity.members);
+    await qc.invalidateQueries({ queryKey: ["constellation-cartography"] });
+
+    await waitFor(() => expect(graph.getEdgeAttribute("rb", "bridge")).toBe(false));
+    // The hulls repainted on their OWN — no test-fired afterRender here — and
+    // the two regions have become the one merged region the daemon declared.
+    // Recolouring the edges alone would leave the old two-hull picture on the
+    // underlay, which is exactly what the round-1 test could not see.
+    expect(painter.state.paints).toBeGreaterThan(paintsBeforeChange);
+    expect(painter.state.regionNames).toEqual(["Alice"]);
+    // Same sigma instance and the same graphology graph — no remount, no
+    // layout/camera reset.
+    expect(capturedSigmaInstances).toHaveLength(1);
+    expect(capturedSigmaInstances[0].graph).toBe(graph);
+
+    // ready -> error: the space's community read starts failing, so the
+    // renderer must fall back to the client-side climb again — bridge back.
+    mockListCommunities.mockRejectedValue(new Error("connection reset"));
+    await qc.invalidateQueries({ queryKey: ["constellation-cartography"] });
+
+    await waitFor(() => expect(graph.getEdgeAttribute("rb", "bridge")).toBe(true));
+    expect(capturedSigmaInstances).toHaveLength(1);
+  });
+
+  it("aggregates worst-first across spaces: one failed space taints the badge even though another is ready", async () => {
+    const entities = [
+      makeEntity({ id: "e1", domain: "wenlan-dev" }),
+      makeEntity({ id: "e2", domain: "personal" }),
+    ];
+    mockListEntities.mockResolvedValue(entities);
+    mockGetEntityDetail.mockImplementation(async (id: string) => ({
+      entity: entities.find((e) => e.id === id)!,
+      observations: [],
+      relations: [],
+    }));
+    const ready = readyCommunityPages("wenlan-dev");
+    mockListCommunities.mockImplementation(async (space: string) =>
+      space === "wenlan-dev" ? ready.communities : Promise.reject(new Error("connection reset")),
+    );
+    mockListCommunityMembers.mockImplementation(async (space: string) =>
+      space === "wenlan-dev"
+        ? ready.members
+        : { schema_version: "community-read-v1" as const, members: [], next_cursor: null },
+    );
+
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+
+    expect(await screen.findByText("Region sync issue")).toBeInTheDocument();
+  });
+
+  it("renders the badge text in zh-Hans and zh-Hant, not just English", async () => {
+    mockOneSpaceEntity();
+    const pages = readyCommunityPages("wenlan-dev");
+    mockListCommunities.mockResolvedValue(pages.communities);
+    mockListCommunityMembers.mockResolvedValue(pages.members);
+
+    await i18n.changeLanguage("zh-Hans");
+    const simplified = renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+    expect(await screen.findByText("稳定区域")).toBeInTheDocument();
+    simplified.unmount();
+    capturedSigmaInstances.length = 0;
+
+    await i18n.changeLanguage("zh-Hant");
+    renderWithQuery(<AtlasView />);
+    await waitFor(() => expect(capturedSigmaInstances).toHaveLength(1));
+    expect(await screen.findByText("穩定區域")).toBeInTheDocument();
+
+    await i18n.changeLanguage("en");
   });
 
   it("jumps the camera instantly on search select under prefers-reduced-motion", async () => {

--- a/src/components/memory/AtlasView.tsx
+++ b/src/components/memory/AtlasView.tsx
@@ -8,7 +8,7 @@ import Sigma from "sigma";
 import type { Simulation } from "d3-force";
 import { listEntities, getEntityDetail } from "../../lib/tauri";
 import type { Entity, EntityDetail } from "../../lib/tauri";
-import { buildGraphModel } from "../../lib/graph/model";
+import { buildGraphModel, entitySpace } from "../../lib/graph/model";
 import type { GraphNode } from "../../lib/graph/model";
 import {
   buildAtlasGraph,
@@ -33,6 +33,13 @@ import {
 import { useGraphPalette, colorForEntityType, nodeFillFor } from "../../lib/graph/palette";
 import type { GraphPalette } from "../../lib/graph/palette";
 import { fetchCartographyForSpaces, aggregateCartographyStatus } from "../../lib/graph/community";
+import type { SpaceCartography } from "../../lib/graph/community";
+
+// One shared empty map for the unresolved query. An inline `new Map()` default
+// mints a fresh identity on every render, and this map feeds the memoized
+// community climb and the canvas underlay — a new identity re-runs the climb
+// and repaints every edge each render until the fetch lands.
+const EMPTY_CARTOGRAPHY: Map<string, SpaceCartography> = new Map();
 
 // Same 5-slot legend as the retired canvas graph (ConstellationMap): place,
 // event, and unknown types fold to neutral and get no swatch; concept is
@@ -126,11 +133,13 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
     staleTime: 120_000,
   });
 
-  // Same field precedence as the entity page (EntityDetail's `space ?? domain`).
+  // Same field precedence as the entity page (EntityDetail's space-then-domain
+  // rule), through model.ts's entitySpace so the list, the filter, and the
+  // graph nodes cannot disagree about which space an entity belongs to.
   const spaces = useMemo(
     () =>
       Array.from(
-        new Set(entities.map((e: Entity) => e.space ?? e.domain).filter((s): s is string => !!s)),
+        new Set(entities.map((e: Entity) => entitySpace(e)).filter((s): s is string => !!s)),
       ).sort(),
     [entities],
   );
@@ -141,7 +150,7 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
   // a partial read. Keyed on ALL known spaces regardless of spaceFilter, so
   // one space's trouble stays visible while another is being viewed; the
   // unscoped half of the badge is read off the filtered model instead (below).
-  const { data: cartographyBySpace = new Map() } = useQuery({
+  const { data: cartographyBySpace = EMPTY_CARTOGRAPHY } = useQuery({
     queryKey: ["constellation-cartography", spaces],
     queryFn: () => fetchCartographyForSpaces(spaces),
     enabled: spaces.length > 0,
@@ -153,8 +162,8 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
   const model = useMemo(() => {
     if (!spaceFilter) return buildGraphModel(entities, details);
     return buildGraphModel(
-      entities.filter((e: Entity) => (e.space ?? e.domain) === spaceFilter),
-      details.filter((d: EntityDetail) => (d.entity.space ?? d.entity.domain) === spaceFilter),
+      entities.filter((e: Entity) => entitySpace(e) === spaceFilter),
+      details.filter((d: EntityDetail) => entitySpace(d.entity) === spaceFilter),
     );
   }, [entities, details, spaceFilter]);
 

--- a/src/components/memory/AtlasView.tsx
+++ b/src/components/memory/AtlasView.tsx
@@ -27,10 +27,12 @@ import {
   drawCartography,
   bridgeEdgeTest,
   regionLeader,
+  isUnscopedSpace,
   MIN_REGION_SIZE,
 } from "../../lib/graph/cartography";
 import { useGraphPalette, colorForEntityType, nodeFillFor } from "../../lib/graph/palette";
 import type { GraphPalette } from "../../lib/graph/palette";
+import { fetchCartographyForSpaces, aggregateCartographyStatus } from "../../lib/graph/community";
 
 // Same 5-slot legend as the retired canvas graph (ConstellationMap): place,
 // event, and unknown types fold to neutral and get no swatch; concept is
@@ -134,6 +136,17 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
   );
   const [spaceFilter, setSpaceFilter] = useState<string | null>(null);
 
+  // D13/App-PR readiness, one fetch-and-classify per known space (community.ts):
+  // cursor-paginated to exhaustion, generation-checked, never declared ready off
+  // a partial read. Keyed on ALL known spaces regardless of spaceFilter, so
+  // one space's trouble stays visible while another is being viewed; the
+  // unscoped half of the badge is read off the filtered model instead (below).
+  const { data: cartographyBySpace = new Map() } = useQuery({
+    queryKey: ["constellation-cartography", spaces],
+    queryFn: () => fetchCartographyForSpaces(spaces),
+    enabled: spaces.length > 0,
+    refetchInterval: 120_000,
+  });
   // Scoping filters the model INPUTS: the space's own entities plus whatever
   // bridge neighbors their relations synthesize (those carry no space of their
   // own). Regions, counts, and insights all re-derive from the scoped model.
@@ -144,13 +157,42 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       details.filter((d: EntityDetail) => (d.entity.space ?? d.entity.domain) === spaceFilter),
     );
   }, [entities, details, spaceFilter]);
-  const communities = useMemo(() => communitiesFor(model), [model]);
+
+  // Anything in cartography.ts's unscoped bucket is drawn on the fallback
+  // climb, so the badge must never read all-durable while such a node is on
+  // the map. Asked of the RENDERED model — the very nodes communitiesFor
+  // partitions — so the badge and the drawn cartography cannot disagree.
+  // Reading the raw entity list instead misses the case the model CREATES
+  // rather than carries: under a space filter a relation to another space's
+  // entity keeps its endpoint while that entity is filtered away, so
+  // buildGraphModel synthesizes it with no space at all. Going through the
+  // model also covers the two unfiltered ways in — a relation-only neighbor,
+  // and an entity whose own space is null or empty.
+  const hasUnscopedFallback = useMemo(
+    () => model.nodes.some((n: GraphNode) => isUnscopedSpace(n.space)),
+    [model],
+  );
+  const cartographyStatus = useMemo(
+    () => aggregateCartographyStatus(cartographyBySpace, hasUnscopedFallback),
+    [cartographyBySpace, hasUnscopedFallback],
+  );
+  const communities = useMemo(
+    () => communitiesFor(model, cartographyBySpace),
+    [model, cartographyBySpace],
+  );
+  // Mirrors `communities` for the mount effect's afterRender closure (see
+  // the cartography-refresh effect below, by the theme-flip effect) — a
+  // space's durable status arriving or regressing must repaint bridges and
+  // hulls without tearing down the sim/camera, so drawUnderlay reads this
+  // ref at PAINT time instead of closing over the `communities` value that
+  // was current when the sigma renderer was built.
+  const communitiesRef = useRef<Map<string, string>>(communities);
 
   // Region count + names for the toolbar and rail — membership only, so it
   // agrees with the hulls drawCartography actually draws without needing
   // node positions; names share regionLeader with the drawn labels.
   const regionInfo = useMemo(() => {
-    const groups = new Map<number, GraphNode[]>();
+    const groups = new Map<string, GraphNode[]>();
     for (const node of model.nodes) {
       const community = communities.get(node.id);
       if (community === undefined) continue;
@@ -158,7 +200,7 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       if (list) list.push(node);
       else groups.set(community, [node]);
     }
-    const names = new Map<number, string>();
+    const names = new Map<string, string>();
     for (const [community, members] of groups) {
       if (members.length >= MIN_REGION_SIZE) names.set(community, regionLeader(members).name);
     }
@@ -407,13 +449,16 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       ctx.clearRect(0, 0, width, height);
       drawCartography(
         ctx,
-        cartographyScene(graph, communities),
+        cartographyScene(graph, communitiesRef.current),
         (pos) => renderer.graphToViewport(pos),
         paletteRef.current,
       );
     };
+    // First paint is NOT drawn here. The cartography effect below runs right
+    // after this one on mount (effects fire in declaration order, and both
+    // refs above are already assigned), and its refresh() fires afterRender —
+    // so painting here as well would just compute every hull twice.
     renderer.on("afterRender", drawUnderlay);
-    drawUnderlay();
     // Default zoom: sigma's fit stretches a small cluster edge-to-edge no
     // matter how big the container (7.3 px/graph-unit in preview) — links
     // render ~5x longer than the old graph's ("too wide"). A fixed density
@@ -599,6 +644,27 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
     // with the palette paletteRef now carries.
     renderer.refresh();
   }, [palette]);
+
+  // Cartography arriving or regressing (fallback -> ready, or ready -> a
+  // partial-error) must repaint bridges + hulls WITHOUT tearing down the
+  // sim/camera — the mount effect above only rebuilds on `model` changing,
+  // so a `cartographyBySpace` refetch that flips a space's status never
+  // reaches the renderer otherwise. Same "recolor in place" shape as the
+  // theme-flip effect: update edge attributes, point communitiesRef at the
+  // fresh map (drawUnderlay reads it at paint time), then refresh.
+  useEffect(() => {
+    communitiesRef.current = communities;
+    const graph = graphRef.current;
+    const renderer = sigmaRef.current;
+    if (!graph || !renderer) return;
+    const isBridge = bridgeEdgeTest(communities);
+    graph.updateEachEdgeAttributes((edgeKey, attrs) => {
+      const [source, target] = graph.extremities(edgeKey);
+      const bridge = isBridge(source, target);
+      return { ...attrs, bridge, color: bridge ? paletteRef.current.bridge : paletteRef.current.edge };
+    });
+    renderer.refresh();
+  }, [communities]);
 
   useEffect(() => {
     const underlay = underlayRef.current;
@@ -864,6 +930,30 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
               </option>
             ))}
           </select>
+        )}
+        {cartographyStatus && (
+          <span
+            role={cartographyStatus === "partial-error" ? "alert" : undefined}
+            style={{
+              fontSize: 11,
+              fontFamily: "var(--mem-font-mono)",
+              color:
+                cartographyStatus === "partial-error"
+                  ? "var(--mem-danger)"
+                  : "var(--mem-text-tertiary)",
+              border: `1px solid ${cartographyStatus === "partial-error" ? "var(--mem-danger)" : "var(--mem-border)"}`,
+              borderRadius: "var(--mem-radius-full)",
+              padding: "3px 10px",
+            }}
+          >
+            {t(
+              cartographyStatus === "ready"
+                ? "atlas.cartographyReady"
+                : cartographyStatus === "partial-error"
+                  ? "atlas.cartographyPartialError"
+                  : "atlas.cartographyFallback",
+            )}
+          </span>
         )}
         <span
           style={{

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -929,6 +929,9 @@ const en = {
     regionsToggle: "Regions",
     spaceLabel: "Space",
     spaceAll: "All spaces",
+    cartographyReady: "Durable regions",
+    cartographyFallback: "Estimated regions",
+    cartographyPartialError: "Region sync issue",
     rail: {
       gapTitle: "Gap",
       bridgeTitle: "Bridge",
@@ -2465,6 +2468,9 @@ const zhHans = {
     regionsToggle: "区域",
     spaceLabel: "空间",
     spaceAll: "全部空间",
+    cartographyReady: "稳定区域",
+    cartographyFallback: "估计区域",
+    cartographyPartialError: "区域同步异常",
     rail: {
       gapTitle: "缺口",
       bridgeTitle: "桥接",
@@ -3982,6 +3988,9 @@ const zhHant = {
     regionsToggle: "區域",
     spaceLabel: "空間",
     spaceAll: "全部空間",
+    cartographyReady: "穩定區域",
+    cartographyFallback: "估計區域",
+    cartographyPartialError: "區域同步異常",
     rail: {
       gapTitle: "缺口",
       bridgeTitle: "橋接",

--- a/src/lib/graph/atlas.test.ts
+++ b/src/lib/graph/atlas.test.ts
@@ -47,7 +47,7 @@ function node(overrides: Partial<GraphNode> = {}): GraphNode {
     // and ?? would silently promote it to confirmed.
     confirmed: "confirmed" in overrides ? (overrides.confirmed as boolean | null) : true,
     degree: overrides.degree ?? 0,
-    communityId: overrides.communityId ?? null,
+    space: "space" in overrides ? (overrides.space as string | null) : null,
     createdAt: overrides.createdAt ?? 100,
     updatedAt: overrides.updatedAt ?? 200,
   };
@@ -162,13 +162,13 @@ describe("buildAtlasGraph", () => {
         edge({ id: "bridge", source: "a1", target: "b1" }),
       ],
     );
-    const communities = new Map<string, number>([
-      ["a1", 0],
-      ["a2", 0],
-      ["a3", 0],
-      ["b1", 1],
-      ["b2", 1],
-      ["b3", 1],
+    const communities = new Map<string, string>([
+      ["a1", "0"],
+      ["a2", "0"],
+      ["a3", "0"],
+      ["b1", "1"],
+      ["b2", "1"],
+      ["b3", "1"],
     ]);
     const graph = buildAtlasGraph(model, PALETTE, communities);
     expect(graph.getEdgeAttribute("bridge", "color")).toBe(PALETTE.bridge);

--- a/src/lib/graph/atlas.ts
+++ b/src/lib/graph/atlas.ts
@@ -35,7 +35,7 @@ function nodeSizeFor(confirmed: boolean | null, degree: number): number {
 export function buildAtlasGraph(
   model: GraphModel,
   palette: GraphPalette,
-  communities?: Map<string, number>,
+  communities?: Map<string, string>,
 ): Graph {
   const graph = new Graph({ multi: true });
   // ponytail: the old graph's confirmed-glow halo (r+3 disc at 0.1 alpha) is

--- a/src/lib/graph/cartography.test.ts
+++ b/src/lib/graph/cartography.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from "vitest";
 import Graph from "graphology";
 import type { GraphModel, GraphNode, GraphEdge } from "./model";
 import type { GraphPalette } from "./palette";
+import type { SpaceCartography } from "./community";
 import {
   communitiesFor,
   bridgeEdgeTest,
@@ -39,7 +40,7 @@ function node(id: string, overrides: Partial<GraphNode> = {}): GraphNode {
     entityType: "concept",
     confirmed: true,
     degree: 0,
-    communityId: "communityId" in overrides ? (overrides.communityId as number | null) : null,
+    space: "space" in overrides ? (overrides.space as string | null) : null,
     createdAt: 100,
     updatedAt: 200,
   };
@@ -75,8 +76,10 @@ function twoTriangles(): GraphModel {
 }
 
 describe("communitiesFor", () => {
+  const noCartography = new Map<string, SpaceCartography>();
+
   it("splits two hub-bridged triangles into two communities instead of leaking across the bridge", () => {
-    const communities = communitiesFor(twoTriangles());
+    const communities = communitiesFor(twoTriangles(), noCartography);
     const a = [communities.get("a1"), communities.get("a2"), communities.get("a3")];
     const b = [communities.get("b1"), communities.get("b2"), communities.get("b3")];
     expect(new Set(a).size).toBe(1);
@@ -96,7 +99,7 @@ describe("communitiesFor", () => {
         edge("e6", "hubB", "t3"),
       ],
     );
-    const communities = communitiesFor(m);
+    const communities = communitiesFor(m, noCartography);
     expect(communities.get("s1")).toBe(communities.get("hubA"));
     expect(communities.get("s3")).toBe(communities.get("hubA"));
     expect(communities.get("t2")).toBe(communities.get("hubB"));
@@ -122,36 +125,266 @@ describe("communitiesFor", () => {
         edge("e8", "big", "shared"),
       ],
     );
-    const communities = communitiesFor(m);
+    const communities = communitiesFor(m, noCartography);
     expect(communities.get("shared")).toBe(communities.get("hub"));
   });
 
-  it("uses daemon community ids verbatim when any node carries one, and never groups the nulls", () => {
+  it("uses the daemon's community ids verbatim for a ready space, never falling back to the climb", () => {
     const m = modelOf(
       [
-        node("x1", { communityId: 7 }),
-        node("x2", { communityId: 7 }),
-        node("x3", { communityId: 9 }),
-        node("u1"),
-        node("u2"),
+        node("x1", { space: "Work" }),
+        node("x2", { space: "Work" }),
+        node("x3", { space: "Work" }),
+        node("u1", { space: "Work" }),
+        node("u2", { space: "Work" }),
       ],
-      // Heavily connected nulls — a fallback detector would group them; the
-      // daemon path must NOT.
+      // Heavily connected — a fallback climb would group these; the ready
+      // daemon read must win regardless of edge shape.
       [edge("e1", "u1", "u2"), edge("e2", "u1", "x1")],
     );
-    const communities = communitiesFor(m);
-    expect(communities.get("x1")).toBe(7);
-    expect(communities.get("x2")).toBe(7);
-    expect(communities.get("x3")).toBe(9);
+    const cartographyBySpace = new Map<string, SpaceCartography>([
+      [
+        "Work",
+        {
+          status: "ready",
+          memberCommunityId: new Map([
+            ["x1", "c7"],
+            ["x2", "c7"],
+            ["x3", "c9"],
+          ]),
+        },
+      ],
+    ]);
+    const communities = communitiesFor(m, cartographyBySpace);
+    expect(communities.get("x1")).toBe("durable:sWork:c7");
+    expect(communities.get("x2")).toBe("durable:sWork:c7");
+    expect(communities.get("x3")).toBe("durable:sWork:c9");
+    // A member the daemon's read never covered gets its own singleton under
+    // the separate `unassigned:` family (never nested under `durable:` —
+    // see communitiesFor's collision note).
+    expect(communities.get("u1")).toBe("unassigned:sWork:u1");
+    expect(communities.get("u2")).toBe("unassigned:sWork:u2");
     expect(communities.get("u1")).not.toBe(communities.get("u2"));
-    expect([7, 9]).not.toContain(communities.get("u1"));
-    expect([7, 9]).not.toContain(communities.get("u2"));
+  });
+
+  it("keeps a not-ready space on the client-side fallback climb, namespaced by space", () => {
+    const m = modelOf(
+      [node("a1", { space: "Work" }), node("a2", { space: "Work" }), node("a3", { space: "Work" })],
+      [edge("e1", "a1", "a2"), edge("e2", "a2", "a3"), edge("e3", "a3", "a1")],
+    );
+    const cartographyBySpace = new Map<string, SpaceCartography>([["Work", { status: "fallback" }]]);
+    const communities = communitiesFor(m, cartographyBySpace);
+    for (const id of ["a1", "a2", "a3"]) {
+      expect(communities.get(id)).toMatch(/^fallback:sWork:/);
+    }
+  });
+
+  it("resolves each space independently in one render: one ready, one still on the fallback climb", () => {
+    const m = modelOf(
+      [
+        node("r1", { space: "Ready" }),
+        node("r2", { space: "Ready" }),
+        node("f1", { space: "Fallback" }),
+        node("f2", { space: "Fallback" }),
+        node("f3", { space: "Fallback" }),
+      ],
+      [edge("e1", "f1", "f2"), edge("e2", "f2", "f3"), edge("e3", "f3", "f1")],
+    );
+    const cartographyBySpace = new Map<string, SpaceCartography>([
+      [
+        "Ready",
+        {
+          status: "ready",
+          memberCommunityId: new Map([
+            ["r1", "c1"],
+            ["r2", "c1"],
+          ]),
+        },
+      ],
+    ]);
+    const communities = communitiesFor(m, cartographyBySpace);
+    expect(communities.get("r1")).toBe("durable:sReady:c1");
+    expect(communities.get("r2")).toBe("durable:sReady:c1");
+    expect(communities.get("f1")).toMatch(/^fallback:sFallback:/);
+  });
+
+  it("never merges two spaces' fallback climbs even when both land on the same local index and an edge crosses the boundary", () => {
+    const m = modelOf(
+      [
+        node("hubA", { space: "Alpha" }),
+        node("sA1", { space: "Alpha" }),
+        node("sA2", { space: "Alpha" }),
+        node("hubB", { space: "Beta" }),
+        node("sB1", { space: "Beta" }),
+        node("sB2", { space: "Beta" }),
+      ],
+      [
+        edge("ea1", "hubA", "sA1"),
+        edge("ea2", "hubA", "sA2"),
+        edge("eb1", "hubB", "sB1"),
+        edge("eb2", "hubB", "sB2"),
+        // Crosses the space boundary — must not factor into either climb.
+        edge("cross", "hubA", "hubB"),
+      ],
+    );
+    const communities = communitiesFor(m, noCartography);
+    expect(communities.get("hubA")).toBe("fallback:sAlpha:0");
+    expect(communities.get("sA1")).toBe("fallback:sAlpha:0");
+    expect(communities.get("hubB")).toBe("fallback:sBeta:0");
+    expect(communities.get("hubA")).not.toBe(communities.get("hubB"));
+  });
+
+  it("never collides a daemon community id containing 'unassigned:' with the generated unassigned-singleton id", () => {
+    const m = modelOf([node("e1", { space: "Work" }), node("e2", { space: "Work" })], []);
+    const cartographyBySpace = new Map<string, SpaceCartography>([
+      [
+        "Work",
+        {
+          status: "ready",
+          // e1 carries a daemon-assigned id that happens to spell out the
+          // OLD unassigned marker; e2's own read never covered it, so it
+          // gets the generated unassigned singleton — the two must never
+          // resolve to the same string.
+          memberCommunityId: new Map([["e1", "unassigned:e2"]]),
+        },
+      ],
+    ]);
+    const communities = communitiesFor(m, cartographyBySpace);
+    expect(communities.get("e1")).not.toBe(communities.get("e2"));
+  });
+
+  it("never collides two different (space, communityId) pairs that concatenate to the same string", () => {
+    const withPair = (space: string, communityId: string) => {
+      const m = modelOf([node("x", { space })], []);
+      const cartographyBySpace = new Map<string, SpaceCartography>([
+        [space, { status: "ready", memberCommunityId: new Map([["x", communityId]]) }],
+      ]);
+      return communitiesFor(m, cartographyBySpace).get("x");
+    };
+    // ("a", "b:c") and ("a:b", "c") concatenate to the identical raw string
+    // under an unescaped join — they must resolve to distinct ids.
+    expect(withPair("a", "b:c")).not.toBe(withPair("a:b", "c"));
+  });
+
+  it("never lets a daemon's empty-string-space cartography reach the unscoped bucket", () => {
+    const m = modelOf(
+      [
+        node("a1", { space: "Work" }),
+        node("a2", { space: "Work" }),
+        node("a3", { space: "Work" }),
+        node("n1", { space: null }),
+      ],
+      [edge("e1", "a1", "a2"), edge("e2", "a2", "a3"), edge("e3", "a3", "a1")],
+    );
+    // Even if a daemon reported cartography under the literal empty string
+    // (the space GraphNode.space can never actually equal, but the sentinel
+    // must be immune to it regardless), a null-space node must never pick
+    // it up as if it were durable.
+    const cartographyBySpace = new Map<string, SpaceCartography>([
+      ["Work", { status: "ready", memberCommunityId: new Map([["a1", "c1"], ["a2", "c1"], ["a3", "c1"]]) }],
+      ["", { status: "ready", memberCommunityId: new Map([["n1", "c9"]]) }],
+    ]);
+    const communities = communitiesFor(m, cartographyBySpace);
+    expect(communities.get("a1")).toMatch(/^durable:/);
+    expect(communities.get("n1")).toMatch(/^fallback:/);
+    expect(communities.get("n1")).not.toBe(communities.get("a1"));
+  });
+
+  // The daemon does not forbid NUL-bearing space names (create_space rejects
+  // only its own UUID sentinel), so ANY in-band magic value standing for "no
+  // space" is forgeable by a real space literally named it. "No space" is
+  // therefore represented out of band — see spaceSegment.
+  const FORGED_SENTINEL = " unscoped";
+
+  /** Two triangles joined by one cross edge: the first in `space`, the second
+   *  unscoped (space null). */
+  function scopedTriangleBesideUnscoped(space: string | null): GraphModel {
+    return modelOf(
+      [
+        node("s1", { space }),
+        node("s2", { space }),
+        node("s3", { space }),
+        node("n1", { space: null }),
+        node("n2", { space: null }),
+        node("n3", { space: null }),
+      ],
+      [
+        edge("es1", "s1", "s2"),
+        edge("es2", "s2", "s3"),
+        edge("es3", "s3", "s1"),
+        edge("en1", "n1", "n2"),
+        edge("en2", "n2", "n3"),
+        edge("en3", "n3", "n1"),
+        edge("cross", "s1", "n1"),
+      ],
+    );
+  }
+
+  it("never bridges a real space named exactly the old no-space sentinel to the unscoped bucket", () => {
+    const communities = communitiesFor(
+      scopedTriangleBesideUnscoped(FORGED_SENTINEL),
+      new Map<string, SpaceCartography>(),
+    );
+    expect(communities.get("s1")).not.toBe(communities.get("n1"));
+    expect(bridgeEdgeTest(communities)("s1", "n1")).toBe(false);
+  });
+
+  it("still honors durable cartography for a space named exactly the old no-space sentinel", () => {
+    const cartographyBySpace = new Map<string, SpaceCartography>([
+      [
+        FORGED_SENTINEL,
+        {
+          status: "ready",
+          memberCommunityId: new Map([
+            ["s1", "c1"],
+            ["s2", "c1"],
+            ["s3", "c1"],
+          ]),
+        },
+      ],
+    ]);
+    const communities = communitiesFor(
+      scopedTriangleBesideUnscoped(FORGED_SENTINEL),
+      cartographyBySpace,
+    );
+    // The real space keeps its daemon assignment; the unscoped nodes stay on
+    // the client climb and never pick that assignment up.
+    expect(communities.get("s1")).toMatch(/^durable:/);
+    expect(communities.get("s1")).toBe(communities.get("s3"));
+    expect(communities.get("n1")).toMatch(/^fallback:/);
+    expect(bridgeEdgeTest(communities)("s1", "n1")).toBe(false);
+  });
+
+  it("pools null-space and empty-string-space nodes into ONE unscoped bucket that may bridge itself", () => {
+    const m = modelOf(
+      [
+        node("p1", { space: null }),
+        node("p2", { space: null }),
+        node("p3", { space: null }),
+        node("q1", { space: "" }),
+        node("q2", { space: "" }),
+        node("q3", { space: "" }),
+      ],
+      [
+        edge("ep1", "p1", "p2"),
+        edge("ep2", "p2", "p3"),
+        edge("ep3", "p3", "p1"),
+        edge("eq1", "q1", "q2"),
+        edge("eq2", "q2", "q3"),
+        edge("eq3", "q3", "q1"),
+        edge("cross", "p1", "q1"),
+      ],
+    );
+    const communities = communitiesFor(m, new Map<string, SpaceCartography>());
+    // One bucket, so two unscoped regions CAN bridge each other.
+    expect(communities.get("p1")).not.toBe(communities.get("q1"));
+    expect(bridgeEdgeTest(communities)("p1", "q1")).toBe(true);
   });
 });
 
 describe("bridgeEdgeTest", () => {
   it("flags only edges spanning two regions of at least 3 members", () => {
-    const communities = communitiesFor(twoTriangles());
+    const communities = communitiesFor(twoTriangles(), new Map<string, SpaceCartography>());
     const isBridge = bridgeEdgeTest(communities);
     expect(isBridge("a1", "b1")).toBe(true);
     expect(isBridge("a1", "a2")).toBe(false);
@@ -160,16 +393,43 @@ describe("bridgeEdgeTest", () => {
 
   it("does not dress an edge into a sub-region islet as a bridge", () => {
     // Community 0 has 3 members, community 1 only 2.
-    const communities = new Map<string, number>([
-      ["r1", 0],
-      ["r2", 0],
-      ["r3", 0],
-      ["p1", 1],
-      ["p2", 1],
+    const communities = new Map<string, string>([
+      ["r1", "0"],
+      ["r2", "0"],
+      ["r3", "0"],
+      ["p1", "1"],
+      ["p2", "1"],
     ]);
     const isBridge = bridgeEdgeTest(communities);
     expect(isBridge("r1", "p1")).toBe(false);
     expect(isBridge("r1", "missing")).toBe(false);
+  });
+
+  it("never bridges across a space boundary, even between two real regions of the required size", () => {
+    // Two 3-member regions, one per space, joined by a cross-space edge —
+    // namespacing alone makes their community ids differ (see
+    // communitiesFor), so without an explicit same-space check this reads
+    // as two distinct real regions and gets flagged a bridge.
+    const m = modelOf(
+      [
+        node("hubA", { space: "Alpha" }),
+        node("sA1", { space: "Alpha" }),
+        node("sA2", { space: "Alpha" }),
+        node("hubB", { space: "Beta" }),
+        node("sB1", { space: "Beta" }),
+        node("sB2", { space: "Beta" }),
+      ],
+      [
+        edge("ea1", "hubA", "sA1"),
+        edge("ea2", "hubA", "sA2"),
+        edge("eb1", "hubB", "sB1"),
+        edge("eb2", "hubB", "sB2"),
+        edge("cross", "hubA", "hubB"),
+      ],
+    );
+    const communities = communitiesFor(m, new Map<string, SpaceCartography>());
+    const isBridge = bridgeEdgeTest(communities);
+    expect(isBridge("hubA", "hubB")).toBe(false);
   });
 });
 
@@ -236,15 +496,15 @@ describe("communityRegions", () => {
         ["b1", "b3"],
       ],
     );
-    const communities = new Map<string, number>([
-      ["a1", 0],
-      ["a2", 0],
-      ["a3", 0],
-      ["a4", 0],
-      ["b1", 1],
-      ["b2", 1],
-      ["b3", 1],
-      ["tiny", 2],
+    const communities = new Map<string, string>([
+      ["a1", "0"],
+      ["a2", "0"],
+      ["a3", "0"],
+      ["a4", "0"],
+      ["b1", "1"],
+      ["b2", "1"],
+      ["b3", "1"],
+      ["tiny", "2"],
     ]);
     const regions = communityRegions(graph, communities);
     expect(regions).toHaveLength(2);
@@ -260,10 +520,10 @@ describe("communityRegions", () => {
       { id: "a1", x: 0, y: 0, label: "A" },
       { id: "a2", x: 1, y: 0, label: "B" },
     ]);
-    const communities = new Map<string, number>([
-      ["a1", 0],
-      ["a2", 0],
-      ["ghost", 0],
+    const communities = new Map<string, string>([
+      ["a1", "0"],
+      ["a2", "0"],
+      ["ghost", "0"],
     ]);
     // 3 mapped members but only 2 present -> below MIN_REGION_SIZE.
     expect(communityRegions(graph, communities)).toHaveLength(0);
@@ -287,7 +547,7 @@ describe("cartographyScene", () => {
       { id: "a", x: 3, y: 4, label: "A" },
       { id: "b", x: -1, y: 0, label: "B" },
     ]);
-    const scene = cartographyScene(graph, new Map([["a", 0], ["b", 1]]));
+    const scene = cartographyScene(graph, new Map([["a", "0"], ["b", "1"]]));
     expect(scene.maxNodeRadius).toBe(5);
     expect(scene.regions).toHaveLength(0);
   });
@@ -353,10 +613,10 @@ describe("drawCartography", () => {
         ["a1", "a3"],
       ],
     );
-    const communities = new Map<string, number>([
-      ["a1", 0],
-      ["a2", 0],
-      ["a3", 0],
+    const communities = new Map<string, string>([
+      ["a1", "0"],
+      ["a2", "0"],
+      ["a3", "0"],
     ]);
     return cartographyScene(graph, communities);
   }
@@ -439,14 +699,14 @@ describe("drawCartography", () => {
         ["b1", "b3"],
       ],
     );
-    const communities = new Map<string, number>([
-      ["a1", 0],
-      ["a2", 0],
-      ["a3", 0],
-      ["a4", 0],
-      ["b1", 1],
-      ["b2", 1],
-      ["b3", 1],
+    const communities = new Map<string, string>([
+      ["a1", "0"],
+      ["a2", "0"],
+      ["a3", "0"],
+      ["a4", "0"],
+      ["b1", "1"],
+      ["b2", "1"],
+      ["b3", "1"],
     ]);
     const { ctx, texts } = mockCtx();
     drawCartography(ctx, cartographyScene(graph, communities), identity, PALETTE);
@@ -459,7 +719,7 @@ describe("drawCartography", () => {
     const { ctx } = mockCtx();
     const half = (pos: { x: number; y: number }) => ({ x: pos.x / 2, y: pos.y / 2 });
     const graph = graphOf([{ id: "a", x: 300, y: 0, label: "A" }]);
-    drawCartography(ctx, cartographyScene(graph, new Map([["a", 0]])), half, PALETTE);
+    drawCartography(ctx, cartographyScene(graph, new Map([["a", "0"]])), half, PALETTE);
     const arc = ctx.arc as ReturnType<typeof vi.fn>;
     // maxNodeRadius 300 → outer ring 315 graph units → 157.5 at half scale.
     expect(arc.mock.calls[2][2]).toBeCloseTo(157.5, 5);

--- a/src/lib/graph/cartography.ts
+++ b/src/lib/graph/cartography.ts
@@ -2,6 +2,7 @@
 import type Graph from "graphology";
 import type { GraphModel } from "./model";
 import type { GraphPalette } from "./palette";
+import type { SpaceCartography } from "./community";
 
 // The Atlas cartography layer (design-mockup artifact, screen 01 —
 // "Cartography, not physics"): named community regions wrapped in translucent
@@ -23,38 +24,55 @@ function pushInto<K, V>(map: Map<K, V[]>, key: K, value: V): void {
 }
 
 /**
- * Node id -> community id. Daemon truth wins: if ANY node carries a daemon
- * community_id, those ids are used verbatim and nodes without one become
- * singletons (never guessed into a group — the model.ts "absent stays null"
- * rule). Only when the daemon exposes nothing (wenlan-types 0.12.0 today)
- * does the client-side fallback run: steepest-ascent peak-climbing — every
- * node follows its highest-degree neighbor (strictly higher than its own
+ * "No space" is represented OUT OF BAND, never as a magic string. The daemon
+ * forbids only its own UUID sentinel in `create_space`, so ANY in-band value
+ * — NUL-prefixed included — is forgeable by a real space literally named it,
+ * and a forged one lands in the null bucket: a cross-space bridge, which
+ * D13/App-PR forbids.
+ *
+ * The space component of every community id is therefore TAG-DISCRIMINATED:
+ * a real space renders as `s` + encodeURIComponent(space), the unscoped
+ * bucket as the bare token `u`. No real segment can spell `u` (they all start
+ * with `s`), and encodeURIComponent is injective, so two segments compare
+ * equal iff they came from the same space. Neither tag can contain an
+ * unescaped ":", so the 3-segment split below still reads the space back
+ * whole.
+ */
+const UNSCOPED_SEGMENT = "u";
+
+/** Everything that lands in the unscoped bucket: null, undefined, and the
+ *  empty string alike — an empty space string is no more a space than a
+ *  missing one. AtlasView asks this same question of raw entities for the
+ *  fallback badge, so the rule lives here rather than in two places. */
+export function isUnscopedSpace(space: string | null | undefined): boolean {
+  return !space;
+}
+
+function spaceSegment(space: string | null | undefined): string {
+  return isUnscopedSpace(space) ? UNSCOPED_SEGMENT : `s${encodeURIComponent(space as string)}`;
+}
+
+/**
+ * Steepest-ascent peak-climbing over ONE space's nodes: every node follows
+ * its highest-degree same-space neighbor (strictly higher than its own
  * degree) upward until a local degree peak, and the peak is the community.
  * Deterministic (degree ties break on the smaller id), terminating (degree
  * strictly increases along a climb), and it can't leak across a hub–hub
  * bridge the way deterministic label propagation does: two equal-degree hubs
  * are each their own peak. ponytail: crude next to Louvain, but zero deps
- * and hub-shaped like this data; dies the day entities.community_id lands.
+ * and hub-shaped like this data. Returns node id -> a LOCAL (unqualified,
+ * still colliding across spaces) community id — callers namespace it.
  */
-export function communitiesFor(model: GraphModel): Map<string, number> {
-  const fromDaemon = model.nodes.some((n) => n.communityId !== null);
-  if (fromDaemon) {
-    const result = new Map<string, number>();
-    // Singletons start after the daemon's id range so they can never collide.
-    let nextSingleton =
-      Math.max(...model.nodes.map((n) => n.communityId ?? -1)) + 1;
-    for (const node of model.nodes) {
-      result.set(node.id, node.communityId ?? nextSingleton++);
-    }
-    return result;
-  }
-
+function climbFallback(nodeIds: string[], edges: { source: string; target: string }[]): Map<string, string> {
+  const idsInPartition = new Set(nodeIds);
   // Distinct-neighbor adjacency: parallel edges and self-loops must not
-  // inflate the degree that drives the climb.
+  // inflate the degree that drives the climb; edges leaving the partition
+  // (a different space, or the unscoped bucket) are simply not adjacency.
   const adjacency = new Map<string, Set<string>>();
-  for (const node of model.nodes) adjacency.set(node.id, new Set());
-  for (const edge of model.edges) {
+  for (const id of nodeIds) adjacency.set(id, new Set());
+  for (const edge of edges) {
     if (edge.source === edge.target) continue;
+    if (!idsInPartition.has(edge.source) || !idsInPartition.has(edge.target)) continue;
     adjacency.get(edge.source)?.add(edge.target);
     adjacency.get(edge.target)?.add(edge.source);
   }
@@ -85,20 +103,110 @@ export function communitiesFor(model: GraphModel): Map<string, number> {
     return peak;
   };
 
-  const peaks = [...new Set(model.nodes.map((n) => climb(n.id)))].sort();
+  const peaks = [...new Set(nodeIds.map(climb))].sort();
   const peakIndex = new Map(peaks.map((peak, i) => [peak, i]));
-  return new Map(model.nodes.map((n) => [n.id, peakIndex.get(peakOf.get(n.id)!)!]));
+  return new Map(nodeIds.map((id) => [id, String(peakIndex.get(peakOf.get(id)!))]));
+}
+
+/**
+ * Node id -> opaque community id, partitioned per space (D13/App-PR: no
+ * region or bridge edge may span spaces). Each space is handled
+ * independently and resolves to exactly one of three id families, never
+ * more than one per space:
+ *
+ * - READY (`cartographyBySpace.get(space)?.status === "ready"`): the
+ *   daemon's own community_id, namespaced `durable:<spaceSegment>:
+ *   <enc(community_id)>`.
+ * - a member the daemon's read didn't cover gets its own singleton under a
+ *   SEPARATE top-level family, `unassigned:<spaceSegment>:<enc(node id)>` —
+ *   never nested under `durable:`, so a daemon-assigned community_id that
+ *   happens to spell out the literal string "unassigned:<id>" can't forge
+ *   one (see the collision note below).
+ * - anything else (not ready — no durable data published yet, or a
+ *   partial-error): the client-side fallback climb, namespaced
+ *   `fallback:<spaceSegment>:<enc(local id)>`.
+ *
+ * The space component is the tag-discriminated segment above (`s<enc>` or
+ * `u`); community_id and node id are encodeURIComponent-escaped before
+ * joining. That does two things:
+ *   1. Collision-proofs the join itself — encodeURIComponent never leaves a
+ *      literal ":" unescaped, so `<prefix>:<encSpace>:<encRest>` always
+ *      splits back into exactly 3 parts; two different (space, id) pairs
+ *      can never concatenate to the same raw string the way an unescaped
+ *      join would (`("a","b:c")` vs `("a:b","c")`).
+ *   2. Keeps the three top-level prefixes (`durable:`, `unassigned:`,
+ *      `fallback:`) reserved: since escaped, space/id components can never
+ *      contain an unescaped ":", no daemon-controlled string can forge a
+ *      different family's prefix.
+ * Together, two different spaces' — or families' — community/local ids can
+ * never compare equal, so bridgeEdgeTest and communityRegions can't
+ * accidentally group members across a space boundary purely from id
+ * collision (bridgeEdgeTest also checks the space explicitly — see below —
+ * since namespacing alone only prevents accidental MERGING, not a
+ * cross-space pair from being flagged a bridge).
+ */
+export function communitiesFor(
+  model: GraphModel,
+  cartographyBySpace: Map<string, SpaceCartography>,
+): Map<string, string> {
+  // null keys the one unscoped bucket — an out-of-band key no space string
+  // can occupy, so the partition itself is unforgeable, not just the ids.
+  const bySpace = new Map<string | null, string[]>();
+  for (const node of model.nodes) {
+    pushInto(bySpace, isUnscopedSpace(node.space) ? null : node.space, node.id);
+  }
+
+  const result = new Map<string, string>();
+  for (const [space, nodeIds] of bySpace) {
+    const segment = spaceSegment(space);
+    const cartography = space !== null ? cartographyBySpace.get(space) : undefined;
+    if (cartography?.status === "ready" && cartography.memberCommunityId) {
+      for (const id of nodeIds) {
+        const communityId = cartography.memberCommunityId.get(id);
+        result.set(
+          id,
+          communityId !== undefined
+            ? `durable:${segment}:${encodeURIComponent(communityId)}`
+            : `unassigned:${segment}:${encodeURIComponent(id)}`,
+        );
+      }
+      continue;
+    }
+    const local = climbFallback(nodeIds, model.edges);
+    for (const [id, localId] of local) {
+      result.set(id, `fallback:${segment}:${encodeURIComponent(localId)}`);
+    }
+  }
+  return result;
+}
+
+/** Extract the tagged space segment from a namespaced community id
+ *  (`durable:<segment>:…` / `fallback:<segment>:…` / `unassigned:<segment>:…`)
+ *  — every family shares this exact 3-segment shape (see communitiesFor), so
+ *  a single split index reads the space regardless of prefix. Compared as the
+ *  tagged segment itself: `s<enc>` is injective in the space and `u` is
+ *  unreachable from any real name, so two ids carry the same space iff their
+ *  segments are equal, and unscoped only ever matches unscoped. */
+function communitySpace(id: string): string {
+  return id.split(":")[1] ?? "";
 }
 
 /**
  * Per-edge bridge test, sizes precomputed once. A bridge spans two DIFFERENT
- * communities that are both real regions (>= MIN_REGION_SIZE members) — an
- * edge poking out of a 2-node islet is not map furniture.
+ * communities, in the SAME space, that are both real regions
+ * (>= MIN_REGION_SIZE members) — an edge poking out of a 2-node islet is
+ * not map furniture, and a cross-space edge is never a bridge no matter how
+ * large the two communities are (D13/App-PR: no bridge may span spaces).
+ * Community ids are space-namespaced (see communitiesFor), which makes two
+ * same-space communities compare unequal when they should, but a
+ * cross-space PAIR also compares unequal — namespacing alone can't tell
+ * "different community" from "different space", so the space check below
+ * is required, not redundant.
  */
 export function bridgeEdgeTest(
-  communities: Map<string, number>,
+  communities: Map<string, string>,
 ): (source: string, target: string) => boolean {
-  const sizes = new Map<number, number>();
+  const sizes = new Map<string, number>();
   for (const community of communities.values()) {
     sizes.set(community, (sizes.get(community) ?? 0) + 1);
   }
@@ -109,6 +217,7 @@ export function bridgeEdgeTest(
       a !== undefined &&
       b !== undefined &&
       a !== b &&
+      communitySpace(a) === communitySpace(b) &&
       (sizes.get(a) ?? 0) >= MIN_REGION_SIZE &&
       (sizes.get(b) ?? 0) >= MIN_REGION_SIZE
     );
@@ -180,8 +289,8 @@ export function regionLeader<T extends { id: string; name: string; degree: numbe
   return hub;
 }
 
-export function communityRegions(graph: Graph, communities: Map<string, number>): Region[] {
-  const members = new Map<number, string[]>();
+export function communityRegions(graph: Graph, communities: Map<string, string>): Region[] {
+  const members = new Map<string, string[]>();
   for (const [id, community] of communities) {
     if (!graph.hasNode(id)) continue;
     pushInto(members, community, id);
@@ -226,7 +335,7 @@ export interface CartographyScene {
 }
 
 /** Everything drawCartography needs, computed once per paint from live state. */
-export function cartographyScene(graph: Graph, communities: Map<string, number>): CartographyScene {
+export function cartographyScene(graph: Graph, communities: Map<string, string>): CartographyScene {
   let maxNodeRadius = 0;
   graph.forEachNode((_id, attrs) => {
     maxNodeRadius = Math.max(maxNodeRadius, Math.hypot(attrs.x as number, attrs.y as number));

--- a/src/lib/graph/community.test.ts
+++ b/src/lib/graph/community.test.ts
@@ -267,6 +267,33 @@ describe("fetchSpaceCartography", () => {
     expect(result).toEqual({ status: "partial-error", reason: "old-daemon" });
   });
 
+  it("reads a 422 (space name the daemon never registered) as the ordinary fallback", async () => {
+    // The Atlas derives its space list from free-text entity space/domain, so
+    // a name no Space registry knows is routine. The daemon answers 422; that
+    // space simply has no durable community data. Calling it an error would
+    // paint the whole worst-first badge red for an ordinary corpus.
+    mockListCommunities.mockRejectedValue(
+      JSON.stringify({ status: 422, error: "unknown Space: Scratch" }),
+    );
+
+    const result = await fetchSpaceCartography("Scratch");
+
+    expect(result).toEqual({ status: "fallback" });
+  });
+
+  it("reads a 422 on the member read as fallback too", async () => {
+    // The two reads race against Space deletion: the summaries can land just
+    // before the Space goes away, leaving the member read to 422 on its own.
+    mockListCommunities.mockResolvedValue(communitiesPage());
+    mockListCommunityMembers.mockRejectedValue(
+      JSON.stringify({ status: 422, error: "unknown Space: Scratch" }),
+    );
+
+    const result = await fetchSpaceCartography("Scratch");
+
+    expect(result).toEqual({ status: "fallback" });
+  });
+
   it("surfaces a plain transport failure distinctly from an old daemon", async () => {
     mockListCommunities.mockRejectedValue(new Error("connection reset"));
 

--- a/src/lib/graph/community.test.ts
+++ b/src/lib/graph/community.test.ts
@@ -1,0 +1,383 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listCommunities, listCommunityMembers } from "../tauri";
+import type { CommunityListResponse, CommunityMembersResponse } from "../tauri";
+import {
+  fetchSpaceCartography,
+  fetchCartographyForSpaces,
+  aggregateCartographyStatus,
+} from "./community";
+
+vi.mock("../tauri", async () => {
+  const actual = await vi.importActual<typeof import("../tauri")>("../tauri");
+  return {
+    ...actual,
+    listCommunities: vi.fn(),
+    listCommunityMembers: vi.fn(),
+  };
+});
+
+const mockListCommunities = vi.mocked(listCommunities);
+const mockListCommunityMembers = vi.mocked(listCommunityMembers);
+
+function communitiesPage(
+  overrides: Partial<CommunityListResponse> = {},
+): CommunityListResponse {
+  return {
+    schema_version: "community-read-v1",
+    communities: [],
+    next_cursor: null,
+    ...overrides,
+  };
+}
+
+function membersPage(overrides: Partial<CommunityMembersResponse> = {}): CommunityMembersResponse {
+  return {
+    schema_version: "community-read-v1",
+    members: [],
+    next_cursor: null,
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<CommunityListResponse["communities"][number]> = {}) {
+  return {
+    community_id: "c1",
+    space: "Work",
+    display_name: null,
+    member_count: 1,
+    published_generation: 3,
+    algo_version: "v1",
+    projection_version: "v1",
+    ...overrides,
+  };
+}
+
+function member(overrides: Partial<CommunityMembersResponse["members"][number]> = {}) {
+  return {
+    space: "Work",
+    node_id: "e1",
+    node_kind: "entity",
+    community_id: "c1",
+    published_generation: 3,
+    attachment: "core",
+    ...overrides,
+  };
+}
+
+describe("fetchSpaceCartography", () => {
+  beforeEach(() => {
+    mockListCommunities.mockReset();
+    mockListCommunityMembers.mockReset();
+  });
+
+  it("parses a drained, generation-consistent read as ready with the member->community map", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ member_count: 2 })] }),
+    );
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({ members: [member({ node_id: "e1" }), member({ node_id: "e2" })] }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result.status).toBe("ready");
+    expect(result.memberCommunityId?.get("e1")).toBe("c1");
+    expect(result.memberCommunityId?.get("e2")).toBe("c1");
+  });
+
+  it("flags a community whose drained member rows fall short of its summary member_count as a partial-error, not vacuously ready", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ member_count: 3 })] }),
+    );
+    // Pagination drains to next_cursor: null after only 2 rows — the daemon
+    // said 3.
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({ members: [member({ node_id: "e1" }), member({ node_id: "e2" })] }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "member-count-mismatch" });
+  });
+
+  it("rejects a read that pads a community's member_count with duplicate rows instead of distinct members", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ member_count: 2 })] }),
+    );
+    // The same node twice across two pages. Counting raw rows reads 2 and
+    // calls the read complete, while only ONE member is actually assigned.
+    mockListCommunityMembers
+      .mockResolvedValueOnce(
+        membersPage({
+          members: [member({ node_id: "e1" })],
+          next_cursor: { space: "Work", node_id: "e1" },
+        }),
+      )
+      .mockResolvedValueOnce(membersPage({ members: [member({ node_id: "e1" })] }));
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "member-count-mismatch" });
+  });
+
+  it("rejects a node the same read assigns to two different communities", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({
+        communities: [
+          summary({ community_id: "c1", member_count: 1 }),
+          summary({ community_id: "c2", member_count: 1 }),
+        ],
+      }),
+    );
+    // Both summaries reconcile at one member each, so counting alone is happy
+    // — but a node cannot be in two communities, and last-write-wins would
+    // quietly hand the renderer c2.
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({
+        members: [
+          member({ node_id: "e1", community_id: "c1" }),
+          member({ node_id: "e1", community_id: "c2" }),
+        ],
+      }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "conflicting-assignment" });
+  });
+
+  it("rejects a member row pointing at a community id no summary ever declared", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ community_id: "c1", member_count: 1 })] }),
+    );
+    // c1 reconciles exactly, so a per-summary count check alone never even
+    // looks at the orphan row — but that row would still be handed to the
+    // renderer as a real community assignment.
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({
+        members: [
+          member({ node_id: "e1", community_id: "c1" }),
+          member({ node_id: "e2", community_id: "ghost" }),
+        ],
+      }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "unknown-community" });
+  });
+
+  it("returns ready when every community's drained member count matches its summary", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ member_count: 2 })] }),
+    );
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({ members: [member({ node_id: "e1" }), member({ node_id: "e2" })] }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result.status).toBe("ready");
+  });
+
+  // Deliberate semantic, pinned so it can't be "fixed" by accident: a
+  // community the daemon declares as empty is an EXACT match at zero members,
+  // not a suspiciously short read. It stays ready (with nothing to assign) —
+  // unlike a wholly empty response, which means no durable data was published
+  // for this space at all and classifies as fallback.
+  it("treats a community declared with member_count 0 and no member rows as ready", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ member_count: 0 })] }),
+    );
+    mockListCommunityMembers.mockResolvedValue(membersPage());
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result.status).toBe("ready");
+    expect(result.memberCommunityId?.size).toBe(0);
+  });
+
+  it("paginates both communities and members to exhaustion before deciding", async () => {
+    mockListCommunities
+      .mockResolvedValueOnce(
+        communitiesPage({ communities: [summary({ community_id: "c1" })], next_cursor: "cursor-1" }),
+      )
+      .mockResolvedValueOnce(communitiesPage({ communities: [summary({ community_id: "c2" })] }));
+    mockListCommunityMembers
+      .mockResolvedValueOnce(
+        membersPage({
+          members: [member({ node_id: "e1", community_id: "c1" })],
+          next_cursor: { space: "Work", node_id: "e1" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        membersPage({ members: [member({ node_id: "e2", community_id: "c2" })] }),
+      );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result.status).toBe("ready");
+    expect(result.memberCommunityId?.get("e1")).toBe("c1");
+    expect(result.memberCommunityId?.get("e2")).toBe("c2");
+    expect(mockListCommunities).toHaveBeenCalledTimes(2);
+    expect(mockListCommunities).toHaveBeenNthCalledWith(2, "Work", "cursor-1");
+    expect(mockListCommunityMembers).toHaveBeenCalledTimes(2);
+    expect(mockListCommunityMembers).toHaveBeenNthCalledWith(2, "Work", {
+      space: "Work",
+      node_id: "e1",
+    });
+  });
+
+  it("flags a member row whose generation moved mid-pagination as a generation mismatch, not ready", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ published_generation: 3 })] }),
+    );
+    mockListCommunityMembers
+      .mockResolvedValueOnce(
+        membersPage({
+          members: [member({ node_id: "e1", published_generation: 3 })],
+          next_cursor: { space: "Work", node_id: "e1" },
+        }),
+      )
+      // The daemon bumped the generation between the two member pages.
+      .mockResolvedValueOnce(
+        membersPage({ members: [member({ node_id: "e2", published_generation: 4 })] }),
+      );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "generation-mismatch" });
+  });
+
+  it("treats an empty-but-successful read (no durable data published yet) as the ordinary fallback, not an error", async () => {
+    mockListCommunities.mockResolvedValue(communitiesPage());
+    mockListCommunityMembers.mockResolvedValue(membersPage());
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "fallback" });
+  });
+
+  it("surfaces a 404/405 (route missing on an old daemon) as a visible partial-error, not a silent fallback", async () => {
+    mockListCommunities.mockRejectedValue(JSON.stringify({ status: 404, error: "no route" }));
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "old-daemon" });
+  });
+
+  it("surfaces a plain transport failure distinctly from an old daemon", async () => {
+    mockListCommunities.mockRejectedValue(new Error("connection reset"));
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "transport" });
+  });
+
+  it("surfaces a schema_version mismatch as its own partial-error reason", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ schema_version: "community-read-v2" }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "schema-mismatch" });
+  });
+
+  it("gives up as interrupted if a daemon never drains the cursor, instead of looping forever", async () => {
+    mockListCommunities.mockResolvedValue(communitiesPage({ communities: [summary()] }));
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({ members: [member()], next_cursor: { space: "Work", node_id: "e1" } }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "interrupted" });
+  });
+
+  it("treats members reported without any community summary as a generation mismatch instead of vacuously ready", async () => {
+    mockListCommunities.mockResolvedValue(communitiesPage());
+    mockListCommunityMembers.mockResolvedValue(membersPage({ members: [member()] }));
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "generation-mismatch" });
+  });
+
+  it("flags a member row from a different space than requested as a partial-error instead of silently mixing spaces", async () => {
+    mockListCommunities.mockResolvedValue(communitiesPage({ communities: [summary()] }));
+    mockListCommunityMembers.mockResolvedValue(
+      membersPage({ members: [member({ node_id: "e1", space: "OtherSpace" })] }),
+    );
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "foreign-space" });
+  });
+
+  it("flags a community summary row from a different space than requested as a partial-error", async () => {
+    mockListCommunities.mockResolvedValue(
+      communitiesPage({ communities: [summary({ space: "OtherSpace" })] }),
+    );
+    mockListCommunityMembers.mockResolvedValue(membersPage());
+
+    const result = await fetchSpaceCartography("Work");
+
+    expect(result).toEqual({ status: "partial-error", reason: "foreign-space" });
+  });
+});
+
+describe("fetchCartographyForSpaces / aggregateCartographyStatus", () => {
+  beforeEach(() => {
+    mockListCommunities.mockReset();
+    mockListCommunityMembers.mockReset();
+  });
+
+  it("classifies each space independently — one space's failure never blocks another's", async () => {
+    mockListCommunities.mockImplementation(async (space: string) =>
+      communitiesPage({
+        communities: space === "Ready" ? [summary({ space: "Ready" })] : [],
+      }),
+    );
+    mockListCommunityMembers.mockImplementation(async (space: string) => {
+      if (space === "Ready") return membersPage({ members: [member({ space: "Ready" })] });
+      if (space === "Broken") throw new Error("boom");
+      return membersPage();
+    });
+
+    const bySpace = await fetchCartographyForSpaces(["Ready", "Empty", "Broken"]);
+
+    expect(bySpace.get("Ready")?.status).toBe("ready");
+    expect(bySpace.get("Empty")?.status).toBe("fallback");
+    expect(bySpace.get("Broken")).toEqual({ status: "partial-error", reason: "transport" });
+  });
+
+  it("aggregates worst-first: partial-error beats fallback beats ready", () => {
+    const ready = new Map([["A", { status: "ready" as const, memberCommunityId: new Map() }]]);
+    const fallback = new Map([
+      ["A", { status: "ready" as const, memberCommunityId: new Map() }],
+      ["B", { status: "fallback" as const }],
+    ]);
+    const partialError = new Map([
+      ["A", { status: "fallback" as const }],
+      ["B", { status: "partial-error" as const, reason: "transport" as const }],
+    ]);
+
+    expect(aggregateCartographyStatus(ready)).toBe("ready");
+    expect(aggregateCartographyStatus(fallback)).toBe("fallback");
+    expect(aggregateCartographyStatus(partialError)).toBe("partial-error");
+    expect(aggregateCartographyStatus(new Map())).toBeNull();
+  });
+
+  it("never claims all-durable while a null-space (unscoped) node is present, even when every known space is ready", () => {
+    const ready = new Map([["A", { status: "ready" as const, memberCommunityId: new Map() }]]);
+
+    expect(aggregateCartographyStatus(ready, true)).toBe("fallback");
+    expect(aggregateCartographyStatus(ready, false)).toBe("ready");
+    // No known spaces at all, but an unscoped node still exists — the
+    // aggregate must report its presence instead of null ("nothing to
+    // report on").
+    expect(aggregateCartographyStatus(new Map(), true)).toBe("fallback");
+  });
+});

--- a/src/lib/graph/community.ts
+++ b/src/lib/graph/community.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import {
+  listCommunities,
+  listCommunityMembers,
+  asCommunityApiError,
+  COMMUNITY_READ_SCHEMA_VERSION,
+} from "../tauri";
+import type { CommunityMember, CommunityMemberCursor, CommunitySummary } from "../tauri";
+
+// D13/App-PR readiness contract: a space's durable community assignment is
+// authoritative only once BOTH cursor-paginated reads (communities, then
+// members) drain to exhaustion AND every member row's published_generation
+// agrees with the space's current generation (read off the community
+// summaries). Anything short of that keeps the numeric fallback — see
+// cartography.ts — but the two outcomes are NOT the same visible state:
+// "fallback" is the ordinary, silent case (no durable data published for
+// this space yet); "partial-error" means something is actually wrong (an
+// old daemon, a dropped connection, a schema change, or a generation that
+// moved mid-read) and must stay visible, never silently folded into
+// "fallback".
+
+export type CartographyStatus = "ready" | "fallback" | "partial-error";
+
+export type PartialErrorReason =
+  | "transport"
+  | "old-daemon"
+  | "schema-mismatch"
+  | "generation-mismatch"
+  | "interrupted"
+  | "member-count-mismatch"
+  | "unknown-community"
+  | "conflicting-assignment"
+  | "foreign-space";
+
+export interface SpaceCartography {
+  status: CartographyStatus;
+  /** Present only when status === "ready": every member node id the daemon
+   *  assigned under the space's currently published generation. */
+  memberCommunityId?: Map<string, string>;
+  /** Present only when status === "partial-error". */
+  reason?: PartialErrorReason;
+}
+
+// Guards against a daemon that never sets next_cursor to null (a bug, or a
+// pathologically huge space) turning a UI fetch into an infinite loop. 500
+// pages at the default page size of 100 is 50,000 rows — already far past
+// anything a desktop-scale corpus should produce.
+const MAX_PAGES = 500;
+
+function isOldDaemonStatus(status: number): boolean {
+  return status === 404 || status === 405;
+}
+
+type PageResult<T> = { rows: T[] } | { reason: PartialErrorReason };
+
+async function fetchAllCommunities(space: string): Promise<PageResult<CommunitySummary>> {
+  const rows: CommunitySummary[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    let response;
+    try {
+      response = await listCommunities(space, cursor);
+    } catch (e) {
+      const apiError = asCommunityApiError(e);
+      return { reason: apiError && isOldDaemonStatus(apiError.status) ? "old-daemon" : "transport" };
+    }
+    if (response.schema_version !== COMMUNITY_READ_SCHEMA_VERSION) {
+      return { reason: "schema-mismatch" };
+    }
+    // The daemon's `scope` isn't threaded through the Tauri command today
+    // (see app/src/api.rs's CommunityListResponse) — checking each row's own
+    // `space` field is what actually catches a daemon serving the wrong
+    // scope instead of silently mixing it into this space's read.
+    if (response.communities.some((c) => c.space !== space)) {
+      return { reason: "foreign-space" };
+    }
+    rows.push(...response.communities);
+    if (response.next_cursor === null) return { rows };
+    cursor = response.next_cursor;
+  }
+  return { reason: "interrupted" };
+}
+
+async function fetchAllMembers(space: string): Promise<PageResult<CommunityMember>> {
+  const rows: CommunityMember[] = [];
+  let cursor: CommunityMemberCursor | null = null;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    let response;
+    try {
+      response = await listCommunityMembers(space, cursor);
+    } catch (e) {
+      const apiError = asCommunityApiError(e);
+      return { reason: apiError && isOldDaemonStatus(apiError.status) ? "old-daemon" : "transport" };
+    }
+    if (response.schema_version !== COMMUNITY_READ_SCHEMA_VERSION) {
+      return { reason: "schema-mismatch" };
+    }
+    if (response.members.some((m) => m.space !== space)) {
+      return { reason: "foreign-space" };
+    }
+    rows.push(...response.members);
+    if (response.next_cursor === null) return { rows };
+    cursor = response.next_cursor;
+  }
+  return { reason: "interrupted" };
+}
+
+/**
+ * Fetch and classify one space's durable cartography. Pagination always
+ * runs to exhaustion (or the MAX_PAGES safety cap) before a verdict is
+ * reached — a space is never declared ready off a partial read.
+ */
+export async function fetchSpaceCartography(space: string): Promise<SpaceCartography> {
+  const communities = await fetchAllCommunities(space);
+  if ("reason" in communities) return { status: "partial-error", reason: communities.reason };
+
+  const members = await fetchAllMembers(space);
+  if ("reason" in members) return { status: "partial-error", reason: members.reason };
+
+  if (communities.rows.length === 0 && members.rows.length === 0) {
+    // No durable community data published for this space yet — the
+    // ordinary, expected pre-cutover state. Not an error.
+    return { status: "fallback" };
+  }
+
+  // The generation(s) this space's own community summaries were published
+  // under must agree — a daemon reporting two generations for one space is
+  // itself a consistency fault, not routine staleness. (Also catches the
+  // members-without-summaries case: an empty summaries set never has
+  // exactly one generation, so it falls through to generation-mismatch
+  // below rather than being silently treated as ready.)
+  const generations = new Set(communities.rows.map((c) => c.published_generation));
+  if (generations.size !== 1) {
+    return { status: "partial-error", reason: "generation-mismatch" };
+  }
+  const [currentGeneration] = generations;
+
+  const declaredCommunityIds = new Set(communities.rows.map((c) => c.community_id));
+  const memberCommunityId = new Map<string, string>();
+  // Members are collected as a SET of node ids per community, not a running
+  // row count: a daemon that repeats a row across pages must not be able to
+  // satisfy member_count with duplicates while memberCommunityId stays short.
+  const membersByCommunity = new Map<string, Set<string>>();
+  for (const member of members.rows) {
+    // Covers both a mid-pagination generation bump on the member stream and
+    // a member page landing on a generation the summary read never saw.
+    if (member.published_generation !== currentGeneration) {
+      return { status: "partial-error", reason: "generation-mismatch" };
+    }
+    // A row pointing at a community no summary declared is unreconcilable —
+    // the per-summary check below iterates summaries, so it would never
+    // inspect this row at all, yet the assignment would still reach the map.
+    if (!declaredCommunityIds.has(member.community_id)) {
+      return { status: "partial-error", reason: "unknown-community" };
+    }
+    // A node belongs to exactly one community. Two rows disagreeing about
+    // which is a contradiction the counts can't see — each community tallies
+    // the node separately, so both reconcile — and last-write-wins would pick
+    // a winner silently. Fail the space instead.
+    const assigned = memberCommunityId.get(member.node_id);
+    if (assigned !== undefined && assigned !== member.community_id) {
+      return { status: "partial-error", reason: "conflicting-assignment" };
+    }
+    memberCommunityId.set(member.node_id, member.community_id);
+    const seen = membersByCommunity.get(member.community_id);
+    if (seen) seen.add(member.node_id);
+    else membersByCommunity.set(member.community_id, new Set([member.node_id]));
+  }
+
+  // Generation agreement alone doesn't prove the member read is COMPLETE for
+  // each community — a daemon that drops rows mid-drain (or reports a stale
+  // next_cursor: null) still agrees on generation while quietly delivering
+  // fewer members than the summary promised. Reconcile every community's
+  // UNIQUE drained members against its own member_count before trusting it.
+  for (const community of communities.rows) {
+    if ((membersByCommunity.get(community.community_id)?.size ?? 0) !== community.member_count) {
+      return { status: "partial-error", reason: "member-count-mismatch" };
+    }
+  }
+
+  return { status: "ready", memberCommunityId };
+}
+
+/** Fan out `fetchSpaceCartography` across every known space. One space's
+ *  failure never blocks another's — each entry classifies independently. */
+export async function fetchCartographyForSpaces(
+  spaces: string[],
+): Promise<Map<string, SpaceCartography>> {
+  const entries = await Promise.all(
+    spaces.map(async (space): Promise<[string, SpaceCartography]> => [
+      space,
+      await fetchSpaceCartography(space),
+    ]),
+  );
+  return new Map(entries);
+}
+
+/** Worst-first aggregate for the toolbar badge: one bad space taints the
+ *  whole view rather than being averaged away. `hasUnscopedFallback` reports
+ *  whether anything at all sits in cartography.ts's unscoped bucket — a
+ *  relation-only synthesized neighbor, or an entity whose own space is null
+ *  or empty (see isUnscopedSpace). That bucket has no known space to be keyed
+ *  under in `bySpace`, so it can't otherwise be seen here, and it is always
+ *  rendered on the fallback climb. Its presence means the aggregate can never
+ *  claim all-durable. Null only when there are no known spaces AND no
+ *  unscoped presence to report on. */
+export function aggregateCartographyStatus(
+  bySpace: Map<string, SpaceCartography>,
+  hasUnscopedFallback = false,
+): CartographyStatus | null {
+  if (bySpace.size === 0 && !hasUnscopedFallback) return null;
+  let worst: CartographyStatus = "ready";
+  for (const { status } of bySpace.values()) {
+    if (status === "partial-error") return "partial-error";
+    if (status === "fallback") worst = "fallback";
+  }
+  if (hasUnscopedFallback && worst === "ready") worst = "fallback";
+  return worst;
+}

--- a/src/lib/graph/community.ts
+++ b/src/lib/graph/community.ts
@@ -51,7 +51,29 @@ function isOldDaemonStatus(status: number): boolean {
   return status === 404 || status === 405;
 }
 
-type PageResult<T> = { rows: T[] } | { reason: PartialErrorReason };
+/**
+ * The daemon only answers a community read for a REGISTERED Space or the
+ * literal "uncategorized"; anything else is a validation error and comes back
+ * 422 (`resolve_read_scope` in crates/wenlan-core/src/read_scope.rs returns
+ * `Unknown`, which crates/wenlan-server/src/read_scope.rs maps to
+ * `ValidationError` → 422).
+ *
+ * That is the ORDINARY case here, not a fault: the Atlas derives its space
+ * list from each entity's own `space`/`domain` text, which is free-form and
+ * routinely names something no Space registry ever knew. A name the daemon
+ * does not recognize genuinely has no durable community data, which is exactly
+ * what "fallback" means — reporting it as a partial error would paint the
+ * whole badge red off one such name, because the aggregate is worst-first.
+ */
+function isUnregisteredSpaceStatus(status: number): boolean {
+  return status === 422;
+}
+
+type PageResult<T> =
+  | { rows: T[] }
+  | { reason: PartialErrorReason }
+  /** The daemon does not know this space name — no durable data, not a fault. */
+  | { unregisteredSpace: true };
 
 async function fetchAllCommunities(space: string): Promise<PageResult<CommunitySummary>> {
   const rows: CommunitySummary[] = [];
@@ -62,15 +84,19 @@ async function fetchAllCommunities(space: string): Promise<PageResult<CommunityS
       response = await listCommunities(space, cursor);
     } catch (e) {
       const apiError = asCommunityApiError(e);
+      if (apiError && isUnregisteredSpaceStatus(apiError.status)) {
+        return { unregisteredSpace: true };
+      }
       return { reason: apiError && isOldDaemonStatus(apiError.status) ? "old-daemon" : "transport" };
     }
     if (response.schema_version !== COMMUNITY_READ_SCHEMA_VERSION) {
       return { reason: "schema-mismatch" };
     }
-    // The daemon's `scope` isn't threaded through the Tauri command today
-    // (see app/src/api.rs's CommunityListResponse) — checking each row's own
-    // `space` field is what actually catches a daemon serving the wrong
-    // scope instead of silently mixing it into this space's read.
+    // The daemon does send its resolved `scope`, and app/src/api.rs types it,
+    // but it is not on the TypeScript response interface, so nothing here can
+    // read it without widening that type. Checking each row's own `space`
+    // field catches the same fault — a daemon serving the wrong scope — from
+    // data the interface already declares, rather than mixing it in silently.
     if (response.communities.some((c) => c.space !== space)) {
       return { reason: "foreign-space" };
     }
@@ -90,6 +116,9 @@ async function fetchAllMembers(space: string): Promise<PageResult<CommunityMembe
       response = await listCommunityMembers(space, cursor);
     } catch (e) {
       const apiError = asCommunityApiError(e);
+      if (apiError && isUnregisteredSpaceStatus(apiError.status)) {
+        return { unregisteredSpace: true };
+      }
       return { reason: apiError && isOldDaemonStatus(apiError.status) ? "old-daemon" : "transport" };
     }
     if (response.schema_version !== COMMUNITY_READ_SCHEMA_VERSION) {
@@ -112,9 +141,11 @@ async function fetchAllMembers(space: string): Promise<PageResult<CommunityMembe
  */
 export async function fetchSpaceCartography(space: string): Promise<SpaceCartography> {
   const communities = await fetchAllCommunities(space);
+  if ("unregisteredSpace" in communities) return { status: "fallback" };
   if ("reason" in communities) return { status: "partial-error", reason: communities.reason };
 
   const members = await fetchAllMembers(space);
+  if ("unregisteredSpace" in members) return { status: "fallback" };
   if ("reason" in members) return { status: "partial-error", reason: members.reason };
 
   if (communities.rows.length === 0 && members.rows.length === 0) {

--- a/src/lib/graph/communitySchema.test.ts
+++ b/src/lib/graph/communitySchema.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `community-read-v1` is written out in three places that must agree, and
+ * nothing else makes them. The daemon's copy is the contract; the app's two
+ * copies decide whether a space is allowed to count as durably mapped, because
+ * `fetchSpaceCartography` refuses any response whose `schema_version` does not
+ * match and reports the space as `partial-error` instead.
+ *
+ * A daemon that moves to v2 while the app still says v1 is the failure this
+ * guards: every space would silently fall back to the client-side climb, which
+ * is exactly the state the community layer is waiting to leave.
+ *
+ * This reads the three source files rather than importing the values, because
+ * the app's own copy lives in the `lib/tauri` barrel, and importing that pulls
+ * in the Tauri runtime. Matching the constant's text is enough to catch a
+ * one-sided bump, which is the drift that actually happens.
+ */
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function declaredVersion(file: string, pattern: RegExp): string {
+  const source = readFileSync(resolve(root, file), "utf8");
+  const match = source.match(pattern);
+  expect(match, `${file} no longer declares the community read schema version`).not.toBeNull();
+  return match![1];
+}
+
+describe("community read schema version", () => {
+  it("is the same string the daemon publishes", () => {
+    const daemon = declaredVersion(
+      "crates/wenlan-types/src/communities.rs",
+      /pub const COMMUNITY_READ_SCHEMA_VERSION: &str = "([^"]+)";/,
+    );
+
+    expect(
+      declaredVersion(
+        "src/lib/tauri.ts",
+        /export const COMMUNITY_READ_SCHEMA_VERSION = "([^"]+)";/,
+      ),
+    ).toBe(daemon);
+
+    expect(
+      declaredVersion(
+        "e2e/tauriMock/baseResponses.ts",
+        /const COMMUNITY_READ_SCHEMA_VERSION = "([^"]+)";/,
+      ),
+    ).toBe(daemon);
+  });
+});

--- a/src/lib/graph/model.test.ts
+++ b/src/lib/graph/model.test.ts
@@ -180,13 +180,27 @@ describe("buildGraphModel / buildEgoModel", () => {
     expect(model.edges.find((e) => e.id === "r2")!.confidence).toBeNull();
   });
 
-  it("reads community_id when the entity carries it, else null", () => {
-    const withCid = { ...makeEntity({ id: "E" }), community_id: 7 } as Entity;
-    const withCidModel = buildGraphModel([withCid], [makeDetail(withCid, [])]);
-    expect(withCidModel.nodes.find((n) => n.id === "E")!.communityId).toBe(7);
-    const plain = makeEntity({ id: "F" });
-    const plainModel = buildGraphModel([plain], [makeDetail(plain, [])]);
-    expect(plainModel.nodes.find((n) => n.id === "F")!.communityId).toBeNull();
+  it("reads space from the entity, falling back to domain, else null", () => {
+    const withSpace = makeEntity({ id: "E", space: "Work", domain: "legacy" });
+    const withSpaceModel = buildGraphModel([withSpace], [makeDetail(withSpace, [])]);
+    expect(withSpaceModel.nodes.find((n) => n.id === "E")!.space).toBe("Work");
+
+    const domainOnly = makeEntity({ id: "F", space: null, domain: "legacy" });
+    const domainOnlyModel = buildGraphModel([domainOnly], [makeDetail(domainOnly, [])]);
+    expect(domainOnlyModel.nodes.find((n) => n.id === "F")!.space).toBe("legacy");
+
+    const neither = makeEntity({ id: "G", space: null, domain: null });
+    const neitherModel = buildGraphModel([neither], [makeDetail(neither, [])]);
+    expect(neitherModel.nodes.find((n) => n.id === "G")!.space).toBeNull();
+  });
+
+  it("leaves a relation-synthesized neighbor's space unknown (null), never guessed from the home entity", () => {
+    const e = makeEntity({ id: "E", space: "Work" });
+    const detail = makeDetail(e, [
+      makeRel({ id: "r1", direction: "outgoing", entity_id: "NEW", entity_name: "Newcomer" }),
+    ]);
+    const model = buildGraphModel([e], [detail]);
+    expect(model.nodes.find((n) => n.id === "NEW")!.space).toBeNull();
   });
 
   it("buildEgoModel keeps full center entity data and 1/1 coverage", () => {

--- a/src/lib/graph/model.test.ts
+++ b/src/lib/graph/model.test.ts
@@ -192,6 +192,16 @@ describe("buildGraphModel / buildEgoModel", () => {
     const neither = makeEntity({ id: "G", space: null, domain: null });
     const neitherModel = buildGraphModel([neither], [makeDetail(neither, [])]);
     expect(neitherModel.nodes.find((n) => n.id === "G")!.space).toBeNull();
+
+    // An empty space string is not a space. It has to fall through to the
+    // domain, or the node reads as unscoped and loses its grouping.
+    const emptySpace = makeEntity({ id: "H", space: "", domain: "legacy" });
+    const emptySpaceModel = buildGraphModel([emptySpace], [makeDetail(emptySpace, [])]);
+    expect(emptySpaceModel.nodes.find((n) => n.id === "H")!.space).toBe("legacy");
+
+    const bothEmpty = makeEntity({ id: "I", space: "", domain: "" });
+    const bothEmptyModel = buildGraphModel([bothEmpty], [makeDetail(bothEmpty, [])]);
+    expect(bothEmptyModel.nodes.find((n) => n.id === "I")!.space).toBeNull();
   });
 
   it("leaves a relation-synthesized neighbor's space unknown (null), never guessed from the home entity", () => {

--- a/src/lib/graph/model.ts
+++ b/src/lib/graph/model.ts
@@ -20,12 +20,16 @@ export interface GraphNode {
   name: string;
   /** Daemon vocabulary string, verbatim (e.g. "person", "technology"). */
   entityType: string;
-  /** null = unknown (matches the communityId convention below). */
+  /** null = unknown (matches the space convention below). */
   confirmed: boolean | null;
   /** Number of distinct edges touching this node in THIS model (a self-loop counts once, not twice). */
   degree: number;
-  /** null until wenlan-types exposes community_id on Entity. */
-  communityId: number | null;
+  /** Entity's space (falling back to domain), matching the entity page's
+   *  `space ?? domain` precedent. null for relation-only synthesized
+   *  neighbors, whose owning space this model never learns — the M6
+   *  cartography partition (see cartography.ts) treats that as its own
+   *  bucket rather than guessing. */
+  space: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -49,14 +53,9 @@ export interface GraphModel {
   coverage: { relationsFetchedFor: number; totalEntities: number };
 }
 
-// wenlan-types 0.12.0 carries neither field; read them defensively so the day
-// the daemon adds them the model lights up with zero call-site changes. Never
-// fabricate a value — absent stays null.
-function communityIdOf(entity: Entity): number | null {
-  const value = (entity as { community_id?: number | null }).community_id;
-  return typeof value === "number" ? value : null;
-}
-
+// wenlan-types 0.12.0 carries no confidence field; read it defensively so
+// the day the daemon adds it the model lights up with zero call-site
+// changes. Never fabricate a value — absent stays null.
 function confidenceOf(rel: RelationWithEntity): number | null {
   const value = (rel as { confidence?: number | null }).confidence;
   return typeof value === "number" ? value : null;
@@ -70,7 +69,7 @@ function nodeFromEntity(entity: Entity): GraphNode {
     entityType: entity.entity_type,
     confirmed: entity.confirmed,
     degree: 0,
-    communityId: communityIdOf(entity),
+    space: entity.space ?? entity.domain ?? null,
     createdAt: entity.created_at,
     updatedAt: entity.updated_at,
   };
@@ -90,7 +89,7 @@ function nodeFromRelation(rel: RelationWithEntity): GraphNode {
     entityType: rel.entity_type,
     confirmed: null,
     degree: 0,
-    communityId: null,
+    space: null,
     createdAt: rel.created_at,
     updatedAt: rel.created_at,
   };

--- a/src/lib/graph/model.ts
+++ b/src/lib/graph/model.ts
@@ -61,6 +61,17 @@ function confidenceOf(rel: RelationWithEntity): number | null {
   return typeof value === "number" ? value : null;
 }
 
+/**
+ * The space an entity is grouped under: its own `space`, else its `domain`.
+ * `||`, not `??` — an entity carrying an empty-string space still has a domain
+ * worth grouping under, and `??` would keep the "" and read as unscoped
+ * downstream (cartography's isUnscopedSpace treats it as falsy). Every place
+ * that derives a space from an entity goes through here so the rules agree.
+ */
+export function entitySpace(entity: Pick<Entity, "space" | "domain">): string | null {
+  return entity.space || entity.domain || null;
+}
+
 function nodeFromEntity(entity: Entity): GraphNode {
   return {
     id: entity.id,
@@ -69,7 +80,7 @@ function nodeFromEntity(entity: Entity): GraphNode {
     entityType: entity.entity_type,
     confirmed: entity.confirmed,
     degree: 0,
-    space: entity.space ?? entity.domain ?? null,
+    space: entitySpace(entity),
     createdAt: entity.created_at,
     updatedAt: entity.updated_at,
   };

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2613,3 +2613,84 @@ export async function putPageMapLayout(
 ): Promise<PageMap> {
   return invoke("put_page_map_layout", { pageId, body });
 }
+
+// ── Communities (M6 cartography) ────────────────────────────────────────
+// Wire shapes hand-mirrored from `crates/wenlan-types/src/communities.rs`
+// (`community-read-v1`): the community read routes are merged to the daemon
+// but the pinned wenlan-types release predates the crate module — same
+// situation as the page-map types above.
+
+export const COMMUNITY_READ_SCHEMA_VERSION = "community-read-v1";
+
+export interface CommunitySummary {
+  community_id: string;
+  space: string;
+  display_name: string | null;
+  member_count: number;
+  published_generation: number;
+  algo_version: string;
+  projection_version: string;
+}
+
+export interface CommunityListResponse {
+  schema_version: string;
+  communities: CommunitySummary[];
+  next_cursor: string | null;
+}
+
+export interface CommunityMember {
+  space: string;
+  node_id: string;
+  node_kind: string;
+  community_id: string;
+  published_generation: number;
+  attachment: string;
+}
+
+export interface CommunityMemberCursor {
+  space: string;
+  node_id: string;
+}
+
+export interface CommunityMembersResponse {
+  schema_version: string;
+  members: CommunityMember[];
+  next_cursor: CommunityMemberCursor | null;
+}
+
+export interface CommunityApiError {
+  status: number;
+  message: string;
+}
+
+/** Decodes the `{"status":N,"error":"..."}` payload community commands
+ *  reject with (same envelope as `asPageMapApiError`). Returns null for
+ *  transport/parse failures, which callers treat as a generic error. */
+export function asCommunityApiError(e: unknown): CommunityApiError | null {
+  if (typeof e !== "string") return null;
+  try {
+    const parsed = JSON.parse(e);
+    if (parsed && typeof parsed.status === "number") {
+      return { status: parsed.status, message: String(parsed.error ?? "") };
+    }
+  } catch {
+    // not JSON — transport/parse failure, treat as a generic error
+  }
+  return null;
+}
+
+export async function listCommunities(
+  space: string,
+  cursor?: string | null,
+  limit?: number,
+): Promise<CommunityListResponse> {
+  return invoke("list_communities", { space, cursor: cursor ?? null, limit: limit ?? null });
+}
+
+export async function listCommunityMembers(
+  space: string,
+  cursor?: CommunityMemberCursor | null,
+  limit?: number,
+): Promise<CommunityMembersResponse> {
+  return invoke("list_community_members", { space, cursor: cursor ?? null, limit: limit ?? null });
+}


### PR DESCRIPTION
Port E of the overnight arc: restores the Atlas community-map overlay (old wenlan-app #109, commit 5ffb3ca) — community regions drawn from daemon-published cartography, with per-space fetch of communities and members.

## What changed

- `fetchSpaceCartography` reads the daemon's community list + membership per space and derives region hulls; `EMPTY_CARTOGRAPHY` module constant for the no-data path.
- `CommunityScope.name` is `Option<String>` — the daemon's tagged enum serializes the global and uncategorized scopes namelessly; the old required-`name` shape failed to parse and would have shipped the feature dark (caught by the pre-review contract check).
- An unregistered space name now resolves to `fallback` status instead of a permanent red Atlas badge: the daemon's 422 on both read legs (`fetchAllCommunities`, `fetchAllMembers`) maps through `isUnregisteredSpaceStatus` (src/lib/graph/community.ts) rather than being misread as a transport error (caught in review).
- `entitySpace` helper (src/lib/graph/model.ts) unifies space-then-domain derivation at all four sites (`||`, not `??`, so empty-string spaces fall through).

## Review trail

Blind review SHIP-WITH-NITS → fix commit (the 422→fallback resolution, both legs) → delta review **SHIP**. Rebased onto main after the Page Map merge (#522); squash-identical content, clean rebase.

## Gates

`cargo fmt` clean · `cargo clippy -p wenlan-app` clean · `cargo test -p wenlan-app` 399 passed 2 ignored · `pnpm test` 1887 passed 1 skipped · `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCpjjC1WANBMG1jMSXkFgK