### PR TITLE
test(app): harden the port-scan tests and de-flake the avatar env guards

### DIFF
--- a/app/src/remote_access.rs
+++ b/app/src/remote_access.rs
@@ -1888,11 +1888,29 @@ mod tests {
     }
 
     #[test]
+    #[cfg(debug_assertions)]
+    #[serial_test::serial]
     fn test_find_available_port_returns_first_available() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::set(tmp.path());
+
+        // Scan from an OS-assigned held port instead of the fixed default range,
+        // which flakes under machine load. Re-bind if the port is above
+        // u16::MAX - 3: the 4-port scan window would otherwise overflow.
+        let (_held, held_port) = loop {
+            let held = TcpListener::bind("127.0.0.1:0").unwrap();
+            let held_port = held.local_addr().unwrap().port();
+            if held_port <= u16::MAX - 3 {
+                break (held, held_port);
+            }
+        };
+        std::env::set_var("WENLAN_DEV_REMOTE_PORT_START", held_port.to_string());
+
         let port = find_available_port();
         assert!(port.is_some());
         let p = port.unwrap();
-        assert!((PORT_RANGE_START..=PORT_RANGE_START + 3).contains(&p));
+        assert_ne!(p, held_port, "must skip the port already held");
+        assert!((held_port..=held_port + 3).contains(&p));
     }
 
     #[test]
@@ -2068,11 +2086,23 @@ mod tests {
     fn dev_remote_access_uses_its_worktree_port_range() {
         let tmp = tempfile::tempdir().unwrap();
         let _home = HomeGuard::set(tmp.path());
-        std::env::set_var("WENLAN_DEV_REMOTE_PORT_START", "23000");
+
+        // Scan from an OS-assigned held port instead of the fixed default range,
+        // which flakes under machine load. Re-bind if the port is above
+        // u16::MAX - 3: the 4-port scan window would otherwise overflow.
+        let (_held, held_port) = loop {
+            let held = TcpListener::bind("127.0.0.1:0").unwrap();
+            let held_port = held.local_addr().unwrap().port();
+            if held_port <= u16::MAX - 3 {
+                break (held, held_port);
+            }
+        };
+        std::env::set_var("WENLAN_DEV_REMOTE_PORT_START", held_port.to_string());
 
         let port = find_available_port().expect("dev remote access port");
 
-        assert!((23000..=23003).contains(&port));
+        assert_ne!(port, held_port, "must skip the port already held");
+        assert!((held_port..=held_port + 3).contains(&port));
     }
 
     #[test]

--- a/app/src/remote_access.rs
+++ b/app/src/remote_access.rs
@@ -1894,6 +1894,11 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let _home = HomeGuard::set(tmp.path());
 
+        // HomeGuard::set already cleared WENLAN_DEV_REMOTE_PORT_START, so this
+        // is the no-override fallback -- the one case the ephemeral-port scan
+        // below can't exercise, since it always sets the override.
+        assert_eq!(port_range_start(), PORT_RANGE_START);
+
         // Scan from an OS-assigned held port instead of the fixed default range,
         // which flakes under machine load. Re-bind if the port is above
         // u16::MAX - 3: the 4-port scan window would otherwise overflow.

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -4961,36 +4961,26 @@ mod tag_data_tests {
 #[cfg(test)]
 mod avatar_path_tests {
     use super::*;
-    use std::ffi::OsString;
+    use crate::test_env::EnvGuard;
 
-    fn restore_env(key: &str, previous: Option<OsString>) {
-        match previous {
-            Some(value) => std::env::set_var(key, value),
-            None => std::env::remove_var(key),
-        }
-    }
+    const AVATAR_ENV_KEYS: &[&str] = &["WENLAN_DATA_DIR", "ORIGIN_DATA_DIR"];
 
     #[test]
     #[serial_test::serial]
     fn avatar_storage_dir_prefers_wenlan_data_dir() {
-        let previous_wenlan = std::env::var_os("WENLAN_DATA_DIR");
-        let previous_origin = std::env::var_os("ORIGIN_DATA_DIR");
+        let _env = EnvGuard::capture(AVATAR_ENV_KEYS);
         let tmp = tempfile::tempdir().unwrap();
 
         std::env::set_var("WENLAN_DATA_DIR", tmp.path());
         std::env::set_var("ORIGIN_DATA_DIR", "/tmp/legacy-origin-avatar-root");
 
         assert_eq!(avatar_storage_dir(), tmp.path().join("avatars"));
-
-        restore_env("WENLAN_DATA_DIR", previous_wenlan);
-        restore_env("ORIGIN_DATA_DIR", previous_origin);
     }
 
     #[test]
     #[serial_test::serial]
     fn avatar_storage_dir_prefers_wenlan_data_dir_when_both_are_set() {
-        let previous_wenlan = std::env::var_os("WENLAN_DATA_DIR");
-        let previous_origin = std::env::var_os("ORIGIN_DATA_DIR");
+        let _env = EnvGuard::capture(AVATAR_ENV_KEYS);
         let current = tempfile::tempdir().unwrap();
         let legacy = tempfile::tempdir().unwrap();
 
@@ -4998,32 +4988,24 @@ mod avatar_path_tests {
         std::env::set_var("ORIGIN_DATA_DIR", legacy.path());
 
         assert_eq!(avatar_storage_dir(), current.path().join("avatars"));
-
-        restore_env("WENLAN_DATA_DIR", previous_wenlan);
-        restore_env("ORIGIN_DATA_DIR", previous_origin);
     }
 
     #[test]
     #[serial_test::serial]
     fn avatar_storage_dir_falls_back_to_legacy_origin_data_dir() {
-        let previous_wenlan = std::env::var_os("WENLAN_DATA_DIR");
-        let previous_origin = std::env::var_os("ORIGIN_DATA_DIR");
+        let _env = EnvGuard::capture(AVATAR_ENV_KEYS);
         let tmp = tempfile::tempdir().unwrap();
 
         std::env::remove_var("WENLAN_DATA_DIR");
         std::env::set_var("ORIGIN_DATA_DIR", tmp.path());
 
         assert_eq!(avatar_storage_dir(), tmp.path().join("avatars"));
-
-        restore_env("WENLAN_DATA_DIR", previous_wenlan);
-        restore_env("ORIGIN_DATA_DIR", previous_origin);
     }
 
     #[test]
     #[serial_test::serial]
     fn resolves_missing_legacy_avatar_to_wenlan_copy() {
-        let previous_wenlan = std::env::var_os("WENLAN_DATA_DIR");
-        let previous_origin = std::env::var_os("ORIGIN_DATA_DIR");
+        let _env = EnvGuard::capture(AVATAR_ENV_KEYS);
         let current = tempfile::tempdir().unwrap();
         let legacy = tempfile::tempdir().unwrap();
         let filename = "57515813-4419-4116-bea6-21bc66e1a511.jpg";
@@ -5046,16 +5028,12 @@ mod avatar_path_tests {
                     .to_string()
             )
         );
-
-        restore_env("WENLAN_DATA_DIR", previous_wenlan);
-        restore_env("ORIGIN_DATA_DIR", previous_origin);
     }
 
     #[test]
     #[serial_test::serial]
     fn does_not_resolve_arbitrary_missing_path_to_avatar_copy() {
-        let previous_wenlan = std::env::var_os("WENLAN_DATA_DIR");
-        let previous_origin = std::env::var_os("ORIGIN_DATA_DIR");
+        let _env = EnvGuard::capture(AVATAR_ENV_KEYS);
         let current = tempfile::tempdir().unwrap();
         let filename = "same-name.jpg";
 
@@ -5070,16 +5048,12 @@ mod avatar_path_tests {
             resolve_profile_avatar_path(Some(arbitrary_path.to_string_lossy().to_string())),
             None
         );
-
-        restore_env("WENLAN_DATA_DIR", previous_wenlan);
-        restore_env("ORIGIN_DATA_DIR", previous_origin);
     }
 
     #[test]
     #[serial_test::serial]
     fn does_not_resolve_non_origin_avatar_dir_to_wenlan_copy() {
-        let previous_wenlan = std::env::var_os("WENLAN_DATA_DIR");
-        let previous_origin = std::env::var_os("ORIGIN_DATA_DIR");
+        let _env = EnvGuard::capture(AVATAR_ENV_KEYS);
         let current = tempfile::tempdir().unwrap();
         let other = tempfile::tempdir().unwrap();
         let filename = "same-name.jpg";
@@ -5099,9 +5073,6 @@ mod avatar_path_tests {
             resolve_profile_avatar_path(Some(non_origin_avatar_path.to_string_lossy().to_string())),
             None
         );
-
-        restore_env("WENLAN_DATA_DIR", previous_wenlan);
-        restore_env("ORIGIN_DATA_DIR", previous_origin);
     }
 }
 


### PR DESCRIPTION
Port G, the last PR of the overnight arc: test hardening from old wenlan-app #118 + #119. 2 files, app/src only.

## What changed

- **remote_access.rs**: both port-scan tests now bind an OS-assigned ephemeral port (`TcpListener::bind("127.0.0.1:0")`) instead of hardcoded literals, and gain a genuinely new tooth — `assert_ne!(port, held_port, "must skip the port already held")` — proving the scan actually skips an occupied port rather than just landing in a range. Mutation-proven (scan broken to `.find(|_| true)` → both tests panic with exactly that message → restored byte-identical). The review-requested fallback assertion pins `port_range_start()` returning `PORT_RANGE_START` with no override set, deterministically (the HomeGuard clears the env var at construction; no port bound).
- **search.rs**: the 6 avatar-path tests move from hand-rolled env capture/restore onto PR A's shared panic-safe `test_env::EnvGuard` — assertions byte-identical, teardown now unwind-safe.
- Dropped as superseded: old #119's per-file `EnvVarGuard` for lib.rs — the three isolation tests there already use the shared guard.

## Review trail

Blind review SHIP-WITH-NITS (tooth verified genuine incl. matching u16::MAX-3 overflow bounds between test and production; EnvGuard move verified assertion-identical) → fix commit restoring the no-override fallback coverage → delta review **SHIP** (placement verified pre-override; all five test writers of the env var confirmed mutually excluded via serial_test). Two trivia recorded as follow-ups, not blocking: uncapped ephemeral re-bind loop, duplicated test preamble.

## Gates

`cargo fmt` clean · `cargo clippy -p wenlan-app --all-targets -- -D warnings` clean · `cargo test -p wenlan-app` 408 passed 2 ignored · `pnpm test` 1901 passed 1 skipped · `npx tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCpjjC1WANBMG1jMSXkFgK