### PR TITLE
ci(release): promote the desktop app separately, pin the Windows recipe, and update the README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -810,7 +810,7 @@ jobs:
 
   promote-assets:
     name: Promote exact validated release assets
-    needs: [resolve-promotion, bind-release-tag, prepare-release, app-bundle, app-bundle-windows]
+    needs: [resolve-promotion, bind-release-tag, prepare-release]
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -903,6 +903,22 @@ jobs:
           # Internal retry locator; Docker revalidates the receipt and archive
           # hashes before it executes the copied server binary.
           overwrite: true
+
+  promote-app-assets:
+    name: Promote the desktop app assets
+    # Split out of promote-assets deliberately. Both jobs upload to the same
+    # release, but only this one waits on the desktop builds, so a failed
+    # Windows bundle no longer skips the CLI tarballs, Docker, npm, crates and
+    # Homebrew along with it. Nothing ships quietly missing a platform:
+    # finalize-release needs this job, so a release whose app assets did not
+    # land stays a prerelease and never becomes `releases/latest`.
+    needs: [resolve-promotion, bind-release-tag, prepare-release, app-bundle, app-bundle-windows]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: write
+    steps:
       - name: Download macOS app bundle artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -1549,8 +1565,12 @@ jobs:
     # release stays a prerelease â€” never a `releases/latest` without artifacts.
     # docker-manifest is itself the fail-closed promotion barrier over every
     # required channel; only after it publishes the aliases may GitHub's
-    # prerelease become the latest stable release.
-    needs: [docker-manifest, bind-release-tag]
+    # prerelease become the latest stable release. promote-app-assets is named
+    # separately because nothing else waits on it any more: the desktop uploads
+    # were split out of promote-assets so a failed app build stops the app
+    # assets alone, and this `needs` entry is what still keeps a release
+    # missing its installers out of `releases/latest`.
+    needs: [docker-manifest, promote-app-assets, bind-release-tag]
     timeout-minutes: 10
     runs-on: ubuntu-latest
     permissions:

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=c076f706a1afb2debab4e24d319143c5d3e40fcee953cc7c44c6f21f08d0d861 -->
+<!-- README_SYNC: source=README.md sha256=547254c3bc862a3fbbe4daa5b34d23fba1546d8998704166d1a488a903fe7720 -->
 
 <p align="center">
   <picture>
@@ -61,7 +61,7 @@ Esta vista previa aún no está notarizada, así que macOS bloquea el primer arr
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-Hoy solo se publica la versión para macOS Apple Silicon. En Windows y Linux, usa el entorno de ejecución sin interfaz de abajo.
+En Windows x64, ejecuta el `-setup.exe` de la misma página de [Releases](https://github.com/7xuanlu/wenlan/releases/latest). Instala el daemon, la CLI y el conector MCP junto con las bibliotecas que necesitan en tiempo de ejecución, así que no hay nada más que instalar. Linux todavía no tiene versión de escritorio; usa el entorno de ejecución sin interfaz de abajo.
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This preview is not notarized yet, so macOS blocks the first launch. Allow it on
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-Only the macOS Apple Silicon build is published today. On Windows and Linux, use the headless runtime below.
+On Windows x64, run the `-setup.exe` from the same [Releases](https://github.com/7xuanlu/wenlan/releases/latest) page. It installs the daemon, CLI, and MCP connector along with the runtime libraries they load, so there is nothing else to install. Linux has no desktop build yet; use the headless runtime below.
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=c076f706a1afb2debab4e24d319143c5d3e40fcee953cc7c44c6f21f08d0d861 -->
+<!-- README_SYNC: source=README.md sha256=547254c3bc862a3fbbe4daa5b34d23fba1546d8998704166d1a488a903fe7720 -->
 
 <p align="center">
   <picture>
@@ -61,7 +61,7 @@ Wenlan 以单个本地 daemon 运行。桌面 app 内置这个 daemon；无 GUI 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-目前只发布 macOS Apple Silicon 版本。Windows 与 Linux 请使用下面的无 GUI runtime。
+Windows x64 请在同一个 [Releases](https://github.com/7xuanlu/wenlan/releases/latest) 页面下载 `-setup.exe` 并运行。安装包内含 daemon、CLI 与 MCP 连接器，以及它们运行时要加载的库，无需再装别的东西。Linux 暂时没有桌面版，请使用下面的无 GUI runtime。
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=c076f706a1afb2debab4e24d319143c5d3e40fcee953cc7c44c6f21f08d0d861 -->
+<!-- README_SYNC: source=README.md sha256=547254c3bc862a3fbbe4daa5b34d23fba1546d8998704166d1a488a903fe7720 -->
 
 <p align="center">
   <picture>
@@ -61,7 +61,7 @@ Wenlan 以單一本地 daemon 運行。桌面 app 內建這個 daemon；無 GUI 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"
 ```
 
-目前只發布 macOS Apple Silicon 版本。Windows 與 Linux 請使用下面的無 GUI runtime。
+Windows x64 請在同一個 [Releases](https://github.com/7xuanlu/wenlan/releases/latest) 頁面下載 `-setup.exe` 並執行。安裝包內含 daemon、CLI 與 MCP 連接器，以及它們執行時要載入的函式庫，不需要再裝別的東西。Linux 暫時沒有桌面版，請使用下面的無 GUI runtime。
 
 <a id="claude-code-in-30-seconds"></a>
 

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -4962,9 +4962,16 @@ fn release_preflight_contract_violations(ci_workflow: &str, release_workflow: &s
         violations
             .push("tag release retains duplicate compilation of PR-validated binaries".into());
     }
+    // The CLI wrappers and the desktop app are promoted by two jobs, and only
+    // the app one waits on the app builds, so a failed Windows bundle stops the
+    // app assets alone instead of the whole release. Both halves are pinned
+    // here: promote-assets must not name an app build at all, and
+    // promote-app-assets must name both.
     if job_needs(&release, "bind-release-tag") != ["resolve-promotion"]
         || job_needs(&release, "prepare-release") != ["resolve-promotion", "bind-release-tag"]
         || job_needs(&release, "promote-assets")
+            != ["resolve-promotion", "bind-release-tag", "prepare-release"]
+        || job_needs(&release, "promote-app-assets")
             != [
                 "resolve-promotion",
                 "bind-release-tag",
@@ -6085,6 +6092,7 @@ fn release_promotion_contract_violations(
         "resolve-promotion",
         "bind-release-tag",
         "promote-assets",
+        "promote-app-assets",
         "docker",
         "docker-manifest",
         "publish-crates",
@@ -6119,6 +6127,8 @@ fn release_promotion_contract_violations(
         || !resolve.contains(".main_sha == $sha and .main_run == null")
         || job_needs(&release, "prepare-release") != ["resolve-promotion", "bind-release-tag"]
         || job_needs(&release, "promote-assets")
+            != ["resolve-promotion", "bind-release-tag", "prepare-release"]
+        || job_needs(&release, "promote-app-assets")
             != [
                 "resolve-promotion",
                 "bind-release-tag",

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -1273,6 +1273,84 @@ def assert_mutation_detected(
         )
 
 
+# The Windows desktop bundle is built by two hand-copied recipes:
+# ci.yml's `app-windows-bundle`, which anyone can dispatch and which has
+# actually run, and release.yml's `app-bundle-windows`, which nothing exercises
+# until a real release is cut. Whatever the proven one needs to produce a
+# working installer, the unproven one needs too, and a change to either alone
+# is drift nobody would notice until release day.
+#
+# Each marker is asserted present in BOTH files, so editing one side is a
+# failure that names the other. That also keeps this list honest: a marker
+# deleted from CI cannot silently stop being checked.
+WINDOWS_BUILD_RECIPE_MARKERS = [
+    "runs-on: windows-2022",
+    "targets: x86_64-pc-windows-msvc",
+    "bash scripts/stabilize-rust-cache-toolchains.sh",
+    # libsql does not bundle SQLite on Windows.
+    "vcpkg install sqlite3:x64-windows-static-md",
+    "& scripts/setup-vulkan-sdk-windows.ps1",
+    "& scripts/setup-msvc-ninja-windows.ps1",
+    # The two libraries the daemon dynamically loads, staged where
+    # app/tauri.windows.conf.json bundles them from.
+    "& scripts/stage-onnxruntime-windows.ps1 -DestinationDirectory $dllDir",
+    "& scripts/stage-vulkan-loader-windows.ps1 -DestinationDirectory $dllDir",
+    "pnpm tauri build --target x86_64-pc-windows-msvc",
+    # Both jobs unpack the installer they produce and look inside it, and both
+    # refuse a hit in NSIS's scratch directory, which is deleted when the
+    # installer exits and so is not a file the app ships.
+    "onnxruntime.dll",
+    "vulkan-1.dll",
+    "VulkanRT-License.txt",
+    "$PLUGINSDIR",
+]
+
+
+def windows_recipe_drift_violations(ci: str, release: str) -> list[str]:
+    violations: list[str] = []
+    ci_job = job_body(ci, "app-windows-bundle")
+    release_job = job_body(release, "app-bundle-windows")
+    if not ci_job:
+        return ["ci.yml no longer defines app-windows-bundle, the proven Windows recipe"]
+    if not release_job:
+        return ["release.yml no longer defines app-bundle-windows"]
+    for marker in WINDOWS_BUILD_RECIPE_MARKERS:
+        in_ci = marker in ci_job
+        in_release = marker in release_job
+        if in_ci and in_release:
+            continue
+        missing, present = (
+            ("ci.yml app-windows-bundle", "release.yml app-bundle-windows")
+            if not in_ci
+            else ("release.yml app-bundle-windows", "ci.yml app-windows-bundle")
+        )
+        violations.append(
+            f"Windows build recipes have drifted: {marker!r} is in {present} "
+            f"but not in {missing}"
+        )
+    # The one difference that is deliberate. CI publishes nothing and nobody
+    # installs its output, so it mints a throwaway updater keypair per run
+    # instead of borrowing the real release secret; the release job is the only
+    # Windows job that may touch that secret.
+    if "tauri signer generate" not in ci_job:
+        violations.append(
+            "ci.yml app-windows-bundle no longer mints a throwaway updater key"
+        )
+    if "secrets.TAURI_SIGNING_PRIVATE_KEY" in ci_job:
+        violations.append(
+            "ci.yml app-windows-bundle borrows the real updater signing secret"
+        )
+    if "secrets.TAURI_SIGNING_PRIVATE_KEY" not in release_job:
+        violations.append(
+            "release.yml app-bundle-windows no longer signs with the release key"
+        )
+    if "tauri signer generate" in release_job:
+        violations.append(
+            "release.yml app-bundle-windows signs installers with a throwaway key"
+        )
+    return violations
+
+
 def main() -> None:
     publish_helper_tests = subprocess.run(
         [sys.executable, str(PUBLISH_CRATE_TEST_PATH)],
@@ -1300,6 +1378,7 @@ def main() -> None:
         promotion,
         sync_release_pr,
     )
+    violations.extend(windows_recipe_drift_violations(ci, release))
     violations.extend(candidate_observer_contract_violations(ci, observer, validator, archive))
     violations.extend(trusted_candidate_gate_violations(ci, classifier, validator))
     if violations:

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -437,6 +437,7 @@ def contract_violations(
         "app-bundle",
         "app-bundle-windows",
         "promote-assets",
+        "promote-app-assets",
         "docker",
         "docker-manifest",
         "finalize-release",
@@ -447,10 +448,27 @@ def contract_violations(
         violations.append("release preparation can start before receipt-derived tag binding")
     if "    needs: [resolve-promotion, bind-release-tag]" not in job_body(release, "app-bundle-windows"):
         violations.append("Windows app bundling can start before receipt-derived tag binding")
-    if "    needs: [resolve-promotion, bind-release-tag, prepare-release, app-bundle, app-bundle-windows]" not in job_body(
+    # The CLI wrappers and the desktop app are promoted by two jobs on
+    # purpose. Only the app job waits on the desktop builds, so a failed
+    # Windows bundle no longer skips Docker, npm, crates and Homebrew with it.
+    # The pair of assertions below is what keeps that split honest: the CLI job
+    # must NOT wait on an app build, and the app job must wait on both.
+    if "    needs: [resolve-promotion, bind-release-tag, prepare-release]" not in job_body(
         release, "promote-assets"
     ):
-        violations.append("asset publication bypasses receipt resolution, tag binding, prerelease gate, or app bundling")
+        violations.append("asset publication bypasses receipt resolution, tag binding, or the prerelease gate")
+    if re.search(r"app-bundle", job_body(release, "promote-assets").split("steps:")[0]):
+        violations.append(
+            "CLI asset publication waits on a desktop app build again; a failed "
+            "Windows bundle would take the whole release down with it"
+        )
+    if "    needs: [resolve-promotion, bind-release-tag, prepare-release, app-bundle, app-bundle-windows]" not in job_body(
+        release, "promote-app-assets"
+    ):
+        violations.append(
+            "desktop app promotion bypasses receipt resolution, tag binding, "
+            "the prerelease gate, or one of the two app bundles"
+        )
     resolve = job_body(release, "resolve-promotion")
     for marker in [
         "scripts/release-promotion.py gate-main",
@@ -473,6 +491,7 @@ def contract_violations(
         "app-bundle",
         "app-bundle-windows",
         "promote-assets",
+        "promote-app-assets",
         "docker",
         "docker-manifest",
         "publish-crates",
@@ -538,25 +557,26 @@ def contract_violations(
             violations.append(
                 f"Windows app bundling does not prove its installer payload: {marker!r}"
             )
+    promote_app = job_body(release, "promote-app-assets")
     for marker in ["latest.json", "darwin-aarch64-app", "windows-x86_64"]:
-        if marker not in promote:
-            violations.append(f"validated asset promotion omits updater manifest {marker!r}")
+        if marker not in promote_app:
+            violations.append(f"desktop app promotion omits updater manifest {marker!r}")
     for marker in [
         "needs.app-bundle.outputs.dmg_sha256",
         "needs.app-bundle-windows.outputs.setup_sha256",
         "needs.app-bundle-windows.outputs.sig_sha256",
     ]:
-        if marker not in promote:
+        if marker not in promote_app:
             violations.append(
                 f"app bundle SHA-256 re-verification is not wired to {marker!r}"
             )
-    verify_idx = promote.find("Verify app bundle bytes before promotion")
-    upload_idx = promote.find(
+    verify_idx = promote_app.find("Verify app bundle bytes before promotion")
+    upload_idx = promote_app.find(
         "Upload desktop app assets and updater metadata without clobbering"
     )
     if verify_idx == -1 or upload_idx == -1:
         violations.append(
-            "validated asset promotion omits app bundle SHA-256 re-verification before upload"
+            "desktop app promotion omits app bundle SHA-256 re-verification before upload"
         )
     elif verify_idx > upload_idx:
         violations.append("app bundle assets are uploaded before their SHA-256 re-verification")
@@ -610,8 +630,15 @@ def contract_violations(
     if "    needs: [promote-assets, bind-release-tag]" not in npm or "needs: publish-crates" in npm:
         violations.append("npm publishing is serialized behind crates.io propagation")
     finalize = job_body(release, "finalize-release")
-    if "    needs: [docker-manifest, bind-release-tag]" not in finalize:
-        violations.append("GitHub release finalization bypasses the GHCR promotion barrier")
+    # promote-app-assets is listed here and nowhere downstream. That is the
+    # whole fail-closed half of the promote-assets split: the desktop uploads
+    # no longer block the CLI channels, so this entry is the only thing left
+    # keeping a release whose installers never landed out of releases/latest.
+    if "    needs: [docker-manifest, promote-app-assets, bind-release-tag]" not in finalize:
+        violations.append(
+            "GitHub release finalization bypasses the GHCR promotion barrier or "
+            "would promote a release whose desktop app assets never landed"
+        )
     # The lifecycle step resolves the merged release PR through
     # GET /commits/{sha}/pulls, then POSTs and DELETEs on /issues/{pr}/labels to
     # move it from pending to tagged. The /issues/ path is only the REST


### PR DESCRIPTION
Three follow-ups to #528, plus the guard update the first one turned red.
Each is proved by a gate that goes red when the change is removed, and every
mutation below was run.

## 1. A Windows app failure no longer stops the whole release

`promote-assets` did two unrelated jobs at once. It uploaded the command-line
tarballs and staged the Docker and Homebrew inputs, and it also uploaded the
desktop app assets and `latest.json`. Because it waited on both app bundling
jobs, a failed Windows build skipped it and took Docker, npm, crates.io and
Homebrew down with it — none of which have anything to do with the desktop
app.

The desktop uploads move into their own job, `promote-app-assets`, which is
now the only job waiting on the app builds. The command-line chain depends on
`prepare-release` alone.

**This does not make Windows best-effort.** `finalize-release` gains
`promote-app-assets` in its `needs`, so a release whose installers never
landed stays a prerelease and never becomes `releases/latest`. A broken
Windows build still fails the run loudly. It just no longer stops everything
else from shipping.

| Before | After |
|---|---|
| Windows fails → no CLI tarballs, no Docker, no npm, no crates, no Homebrew, no app | Windows fails → everything but the app publishes; the release stays a prerelease |

**Gate:** `python3 scripts/release-workflow-contract.test.py`, mutation-proved
three ways.

```
# drop app-bundle-windows from promote-app-assets
desktop app promotion bypasses receipt resolution, tag binding, the prerelease gate, or one of the two app bundles

# make promote-assets wait on the app builds again
CLI asset publication waits on a desktop app build again; a failed Windows bundle would take the whole release down with it

# drop promote-app-assets from finalize-release
GitHub release finalization bypasses the GHCR promotion barrier or would promote a release whose desktop app assets never landed
```

### The Rust guards that read release.yml

`wenlan-core`'s `drift_guard` module reads `release.yml` and pins the same
graph, so the split turned two of its tests red — exactly as designed:

```
tag release artifact-promotion DAG bypasses receipt resolution
tag release does not resolve the main receipt before asset promotion
```

They now expect the split shape and pin both halves the same way the Python
contract test does. `promote-app-assets` also joins the set of jobs required
to re-check that the release tag still points at the release commit before
uploading, which every other publishing job already carries.

**Gate:** `cargo test -p wenlan-core --lib drift_guard` — 157 passed.
Mutation-proved by re-coupling the two jobs, which turns both tests red again
with the messages above.

Worth recording: this is why the local push planner runs the full Rust suite
on a workflow-only change. It looks like overkill until you remember these
guards read the workflow files, and a narrower plan would have let a real
failure through.

## 2. The release Windows job can no longer drift from the CI one

`release.yml`'s `app-bundle-windows` does not run until a real release is cut.
`ci.yml`'s `app-windows-bundle` can be dispatched, and has been — that is the
job that proved the installers carry their runtime libraries. They are two
hand-copies of one recipe, so the leg nobody exercises could drift from the
leg that is proven and nobody would find out until release day.

Every load-bearing step is now asserted present in **both** jobs: the runner
image, the Rust target, the sqlite3 install libsql needs on Windows, the
Vulkan SDK and MSVC Ninja setup, both library staging scripts, the `tauri
build` invocation, and an installer payload check that refuses a hit in
NSIS's scratch directory. Editing either job alone fails the test naming the
other, which also keeps the marker list honest: a step deleted from CI cannot
quietly stop being checked.

The signing key is the one deliberate difference and is encoded as such. CI
mints a throwaway keypair because it publishes nothing; the release job uses
the real secret; neither may do what the other does.

**Gate:** the same contract test, mutation-proved from both sides plus the
signing guard.

```
# remove the Vulkan SDK step from release.yml only
Windows build recipes have drifted: '& scripts/setup-vulkan-sdk-windows.ps1' is in ci.yml app-windows-bundle but not in release.yml app-bundle-windows

# remove the ONNX staging call from ci.yml only
Windows build recipes have drifted: '& scripts/stage-onnxruntime-windows.ps1 -DestinationDirectory $dllDir' is in release.yml app-bundle-windows but not in ci.yml app-windows-bundle

# let CI borrow the real signing secret
ci.yml app-windows-bundle borrows the real updater signing secret
```

This is not the same thing as proving the release path. Only cutting a real
release does that. It removes the failure mode where the unproven copy
silently stops matching the proven one.

## 3. The README says the desktop app installs on Windows

`README.md` said only the macOS Apple Silicon build was published and sent
Windows readers to the headless runtime. The replacement points at the same
Releases page rather than asserting what is on it, so a reader checks the
source of truth directly, and it names what the installer carries. Linux still
has no desktop build and now says so. The Spanish and both Chinese
translations carry the same claim and are restamped.

**Gate:** `python3 scripts/check-readme-translations.py` — "README
translations are in sync".

**One timing note.** This claim becomes true with the first release that
publishes a Windows installer, which is the next one. Between merging this and
that release, the README describes a page that does not have the `.exe` on it
yet. It is worth merging this close to a release for that reason.

## Everything that was run

| Check | Result |
|---|---|
| `python3 scripts/release-workflow-contract.test.py` | PASS |
| `python3 scripts/check-readme-translations.py` | PASS |
| `python3 scripts/ci_test_plan.test.py` | PASS, 93 tests |
| `cargo test -p wenlan-core --lib drift_guard` | PASS, 157 tests |
| `cargo fmt --all -- --check` | clean |
| pre-push affected closure (`ci_test_plan.py local --level push`) | PASS |
| `actionlint .github/workflows/release.yml` | clean, exit 0 |
| 6 mutation controls | each red with the intended message, tree restored clean |

`ci.yml` is untouched on this branch; it appears above only as a mutation
target that was reverted.
