### PR TITLE
ci: give the release base main CI proof time to outlast main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -754,7 +754,11 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # The release branch is pushed seconds after the main merge, so this proof
+    # starts while the base's own push CI is still running. Recent main push CI
+    # runs take 18-27 minutes, so the wait window must outlast a slow main run;
+    # a shorter one fails the release PR on a pure start-order race.
+    timeout-minutes: 45
     permissions:
       actions: read
       contents: read
@@ -773,7 +777,7 @@ jobs:
           python3 trusted-main-ci-proof/scripts/release-promotion.py verify-main-ci
           --repository "$GITHUB_REPOSITORY"
           --sha "${{ github.event.pull_request.base.sha }}"
-          --wait-seconds 1080
+          --wait-seconds 2400
 
   # On PRs and main pushes, Rust fmt + lint run only when their exact source
   # classes changed. Non-Rust changes still get the required aggregate

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -2188,7 +2188,7 @@ fn ci_routing_contract_violations(
             != Some(
                 "needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.trusted-release-candidate == 'true'",
             )
-        || base_proof["timeout-minutes"].as_u64() != Some(20)
+        || base_proof["timeout-minutes"].as_u64() != Some(45)
         || base_proof["permissions"]["actions"].as_str() != Some("read")
         || base_proof["permissions"]["contents"].as_str() != Some("read")
         || base_proof_checkout.and_then(|step| step["uses"].as_str())
@@ -2207,7 +2207,7 @@ fn ci_routing_contract_violations(
             .contains("trusted-main-ci-proof/scripts/release-promotion.py verify-main-ci")
         || !base_proof_command.contains("--repository \"$GITHUB_REPOSITORY\"")
         || !base_proof_command.contains("--sha \"${{ github.event.pull_request.base.sha }}\"")
-        || !base_proof_command.contains("--wait-seconds 1080")
+        || !base_proof_command.contains("--wait-seconds 2400")
     {
         violations.push(
             "trusted release candidate skip is not backed by exact successful base main CI"

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -1178,7 +1178,7 @@ def trusted_candidate_gate_violations(
     for marker in [
         "needs: [detect-changes]",
         "trusted-release-candidate == 'true'",
-        "timeout-minutes: 20",
+        "timeout-minutes: 45",
         "actions: read",
         "contents: read",
     ]:
@@ -1198,7 +1198,7 @@ def trusted_candidate_gate_violations(
         "trusted-main-ci-proof/scripts/release-promotion.py verify-main-ci",
         '--repository "$GITHUB_REPOSITORY"',
         '--sha "${{ github.event.pull_request.base.sha }}"',
-        "--wait-seconds 1080",
+        "--wait-seconds 2400",
     ]:
         if marker not in proof_run:
             violations.append(f"trusted candidate base CI proof omits {marker!r}")


### PR DESCRIPTION
## Problem

The v0.15.9 release PR (#518) is red, and so were the three release PRs before it. The single failing check is `release base main CI proof`, and it fails the same way every time:

```
timed out waiting for main CI: ... is in_progress
```

The job is not finding a *bad* base. It is giving up before the base's own CI finishes.

## Root cause

`release-base-proof` proves that the release PR's exact base SHA has its own green **push** CI before the release PR is allowed to skip the duplicate lanes. release-please pushes the release branch seconds after the main merge, so the proof starts while that push CI is still running. It waited `--wait-seconds 1080` (18 min) inside a `timeout-minutes: 20` job.

Recent main push CI runs take **18 to 27 minutes**. The proof was racing a job it structurally cannot beat.

Measured on the current base of #518 (`febfbceb`):

| event | time (UTC) |
|---|---|
| main push CI started | 06:35:10 |
| proof gave up (1080s) | 06:54:43 |
| **main push CI succeeded** | **06:57:20** |

The proof lost by 2m37s against a base that was healthy all along. Failed runs: 31412979414, 31419341364, 31469137046, 31674413681.

## Fix

Widen the bounded wait to `2400` seconds and the job cap to `45` minutes: enough to outlast a slow-but-healthy main run with headroom over the 27-minute worst case observed.

**The verification itself is unchanged.** Still the exact base SHA, still the push-event CI run, still fail-closed on anything that is not `success`. Only the bounded wait grew; a base whose CI actually fails still fails the proof, and a base with no CI at all still times out.

The constant is pinned in three places by design (workflow YAML, the Python contract test, the Rust `drift_guard` teeth). All three move together in this commit.

## Verification

- `python scripts/release-workflow-contract.test.py` gives `PASS: release promotion, Homebrew, and Node 24 action contracts`
- `python scripts/release-promotion.test.py` gives `Ran 29 tests ... OK`
- `cargo test -p wenlan-core --lib drift_guard` gives `157 passed; 0 failed`

Run on Windows 11 (x86_64-pc-windows-msvc), Python 3.13.
