### PR TITLE
ci(hooks): run the reader-inventory and route-catalog drift gates first

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,6 +19,23 @@ if [ "$HAS_RUST" = "yes" ]; then
 
 fi
 
+if echo "$STAGED_FILES" | grep -Eq '^crates/(wenlan-core|wenlan-server)/|^scripts/m5-reader-sweep\.py$'; then
+    if command -v python3 >/dev/null 2>&1; then
+        PYTHON_BIN=python3
+    elif command -v python >/dev/null 2>&1; then
+        PYTHON_BIN=python
+    else
+        echo "FAIL: Python is required for the M5 reader inventory check." >&2
+        exit 1
+    fi
+
+    echo "  Checking M5 reader inventory..."
+    "$PYTHON_BIN" scripts/m5-reader-sweep.py --check || {
+        echo "FAIL: the M5 reader inventory is stale. Run python3 scripts/m5-reader-sweep.py --update-inventory, review the diff, and stage crates/wenlan-core/contracts/m5-reader-manifest-inventory.md."
+        exit 1
+    }
+fi
+
 if [ "$HAS_RUST_INPUT" = "yes" ]; then
     # Detect direct owners only; the pre-push hook expands the reverse closure.
     TOUCHED_CRATES=""

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -43,6 +43,28 @@ else
     exit 1
 fi
 
+if printf '%s' "$all_changed" | grep -Eq '^crates/(wenlan-core|wenlan-server)/|^scripts/m5-reader-sweep\.py$'; then
+    "$PYTHON_BIN" scripts/m5-reader-sweep.py --check || {
+        echo "FAIL: the M5 reader inventory is stale. Run python3 scripts/m5-reader-sweep.py --update-inventory, review the diff, and stage crates/wenlan-core/contracts/m5-reader-manifest-inventory.md."
+        exit 1
+    }
+
+    route_catalog_test='lint::serving::tests::review_tests::route_catalog_freezes_exact_global_and_scoped_keys'
+    route_catalog_out=$(cargo test -p wenlan-core --lib -- "$route_catalog_test" 2>&1) && route_catalog_rc=0 || route_catalog_rc=$?
+    echo "$route_catalog_out"
+    if [ "$route_catalog_rc" -eq 0 ] && printf '%s' "$route_catalog_out" | grep -Fq 'test result: ok. 1 passed'; then
+        :
+    elif printf '%s' "$route_catalog_out" | grep -Fq 'running 0 tests'; then
+        echo "FAIL: the route-catalog gate matched no test; the test was renamed or moved. Update the filter in .githooks/pre-push and scripts/git-hooks.test.sh."
+        exit 1
+    else
+        echo "FAIL: the sensitive-read route catalog changed. Add or move the route in SCOPED/GLOBAL and update the count in crates/wenlan-core/src/lint/serving_review_test.rs (see crates/wenlan-server/AGENTS.md, \"Adding or rescoping a route\")."
+        exit 1
+    fi
+
+    echo "Pre-push: fast drift gates passed."
+fi
+
 changed_json=$(printf '%s\n' "$all_changed" | "$PYTHON_BIN" -c \
     'import json, sys; print(json.dumps([line.rstrip("\n") for line in sys.stdin if line.rstrip("\n")]))')
 

--- a/crates/wenlan-server/AGENTS.md
+++ b/crates/wenlan-server/AGENTS.md
@@ -20,6 +20,17 @@ The modules whose job is not evident from the name:
 | `ingest_batcher.rs` | Request-level coalescer for concurrent `/api/memory/store` — folds QualityGate in-line, async classify/extract, passes enrichment + hint through in the response |
 | `scheduler.rs` | Background periodic tasks (distill cycles, distillation, the reconcile/backfill sweeps gated by the `WENLAN_ENABLE_*` flags) |
 
+## Adding or rescoping a route
+
+- If the route reads user data, register it in `crates/wenlan-core/src/lint/serving/routes.rs`.
+- Add it to `SCOPED` or `GLOBAL` and update the count in
+  `crates/wenlan-core/src/lint/serving_review_test.rs`.
+- Run `python3 scripts/m5-reader-sweep.py --update-inventory` and stage the
+  regenerated inventory.
+
+Pre-commit and pre-push run these two checks first, so a missed step fails in
+seconds, not after the full suite.
+
 ## Manual RB-01 profiling flags
 
 These flags control ignored, target-Mac profiling tests; they are not daemon runtime settings and must not be set in normal service configuration.

--- a/scripts/git-hooks.test.sh
+++ b/scripts/git-hooks.test.sh
@@ -11,6 +11,18 @@ if grep -Fq 'cargo check --workspace' .githooks/pre-commit; then
   exit 1
 fi
 
+grep -Fq 'scripts/m5-reader-sweep.py --check' .githooks/pre-commit
+grep -Fq 'scripts/m5-reader-sweep.py --check' .githooks/pre-push
+grep -Fq 'lint::serving::tests::review_tests::route_catalog_freezes_exact_global_and_scoped_keys' .githooks/pre-push
+grep -Fq '1 passed' .githooks/pre-push
+
+fast_gate_line=$(grep -n 'scripts/m5-reader-sweep.py --check' .githooks/pre-push | head -n 1 | cut -d: -f1)
+planner_line=$(grep -n 'scripts/ci_test_plan.py local' .githooks/pre-push | head -n 1 | cut -d: -f1)
+if [ "$fast_gate_line" -ge "$planner_line" ]; then
+  echo 'pre-push must run the fast drift gates before the ci_test_plan.py planner' >&2
+  exit 1
+fi
+
 grep -Fq 'scripts/ci_test_plan.py local' .githooks/pre-push
 if grep -Eq 'cargo (check|clippy|test) --workspace' .githooks/pre-push; then
   echo 'pre-push must delegate changed-owner routing to the fail-closed planner' >&2


### PR DESCRIPTION
## Problem

Two drift gates take seconds but only ran inside the full `wenlan-core` lib suite, which the pre-push planner runs last. A forgotten inventory refresh or route-catalog entry therefore surfaced after the ~30-minute pre-push run and read as a random hook failure. Since 2026-07-27, seven merges needed one or both lists updated, so this recurs on nearly every daemon-route change.

## Change

- `.githooks/pre-commit`: when files under `crates/wenlan-core/`, `crates/wenlan-server/`, or `scripts/m5-reader-sweep.py` are staged, run `scripts/m5-reader-sweep.py --check` (about 3 s) before Clippy. On failure it prints the exact command to run and the file to stage; nothing is auto-staged.
- `.githooks/pre-push`: run the same inventory check plus the single route-catalog test (`lint::serving::tests::review_tests::route_catalog_freezes_exact_global_and_scoped_keys`) before the planner. The gate fails closed if the filter matches no test (a renamed test would otherwise pass silently, because `cargo test` exits 0 on zero matches) and names the file and section to fix.
- `scripts/git-hooks.test.sh`: contract greps for both gates, the `1 passed` check, and an ordering assertion that the gates run before the planner.
- `crates/wenlan-server/AGENTS.md`: a short "Adding or rescoping a route" section with the three steps, where the agent adding a route reads it.

No existing check is weakened or removed. Interpreter detection uses the same `python3`, then `python` probe as the existing pre-push hook, so it stays Windows-safe.

## Verification

- `bash scripts/git-hooks.test.sh` -> `git hook routing contracts: PASS`; `bash -n` on both hooks clean.
- Positive control: a bogus row in the inventory plus a staged core file makes pre-commit fail in seconds with the inventory message, before Clippy compiles.
- Route-catalog gate: wrong filter -> `running 0 tests` -> FAIL (zero-match message); real filter -> `1 passed` -> pass; mutated count (64 -> 63) -> FAIL (catalog message).
- This branch's own push exercised the new hook: `Pre-push: fast drift gates passed.` then the planner.

## Relation to #534

No file overlap. #534 makes the planner skip the local suite when a change widens to the whole workspace; this PR front-loads the two gates on the core/server path, which #534 leaves as slow as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCsZFCHXHjZhHKwsUTDmU6