### PR TITLE
docs(harness): fix stale post-merge instruction files, dedupe rules, add nested CLAUDE.md shims

### DIFF
--- a/.claude/agents/doc-drift-auditor.md
+++ b/.claude/agents/doc-drift-auditor.md
@@ -13,7 +13,7 @@ Check these four surfaces. For each finding give `file:line` (or the artifact) +
 
 1. **Eval-number staleness.** Find numbers cited in `README.md`, `docs/**`, and crate docs that carry an env-stamp (a `comparable_env_hash` / `fixture_revision_hash` / dated baseline). Recompute the *current* hash from code/config — the `ReportEnv` fields in `crates/wenlan-core/src/eval/` (fixture revision, embedder revision, LLM provider class/model, schema versions, similarity fn, sorted flags). Flag any cited number whose stamp no longer matches. Recompute from code — do **not** depend on the gitignored `~/.cache/origin-eval/baselines/` artifacts.
 
-2. **Design-doc / decision rot.** Read `docs/plans/**` (untracked local scratch since 2026-08-09 — skip this leg entirely if the directory is absent, it is not an error), `crates/wenlan-core/contracts/**` (tracked test fixtures, so rot here breaks tests), and the decision memories under `/Users/lucian/.claude/projects/-Users-lucian-Repos-origin/memory/`. Spot-check load-bearing claims (file paths, function names, flag defaults, "X is at db.rs:NNNN") against current code. Flag claims the code contradicts.
+2. **Design-doc / decision rot.** Read `docs/plans/**` (untracked local scratch since 2026-08-09 — skip this leg entirely if the directory is absent, it is not an error), `crates/wenlan-core/contracts/**` (tracked test fixtures, so rot here breaks tests), and the decision memories under `/Users/lucian/.claude/projects/-Users-lucian-Repos/memory/`. Spot-check load-bearing claims (file paths, function names, flag defaults, "X is at db.rs:NNNN") against current code. Flag claims the code contradicts.
 
 3. **Memory → repo dangling pointers.** Read the memory dir above; for every reference to a repo path or `docs/...` file, check it resolves in the current `main` working tree. Flag dangling references. (This is the class the CI teeth structurally cannot own, because memory lives outside the repo.)
 
@@ -21,6 +21,6 @@ Check these four surfaces. For each finding give `file:line` (or the artifact) +
 
 Also surface the **known drift backlog** the CI teeth grandfathered, so it gets burned down rather than forgotten:
 - The `BASELINE_UNDOCUMENTED` list in `drift_guard.rs` (flags undocumented at contract-introduction) — report how many remain.
-- `crates/wenlan-types/AUDIT.md` is a known-stale historical audit (references `app/src/*` code extracted to the wenlan-app repo); recommend updating or removing it.
+- `crates/wenlan-types/AUDIT.md` is a known-stale historical audit (stale by date, 2026-04-12; the app code it discusses is back in-repo); recommend updating or removing it.
 
 Do not open a PR yourself unless explicitly asked; print the report.

--- a/.claude/agents/eval-skew-reviewer.md
+++ b/.claude/agents/eval-skew-reviewer.md
@@ -1,0 +1,83 @@
+---
+name: eval-skew-reviewer
+description: Reviews diffs that add or change a write-time enrichment feature / retrieval channel for training-serving skew — verifies the feature is wired into the ONE canonical ingest path AND the eval seed AND the seed liveness contract, so it can't ship "merged-but-inert". Use after changes touching ingest enrichment, a new RRF channel/substrate, or the eval seed/contract. Read-only — produces findings, does not edit.
+tools: Read, Grep, Glob, LSP, Bash
+model: opus
+---
+
+# Eval-Skew Reviewer
+
+You audit wenlan diffs for **training-serving skew**: a write-time feature added to one consumer but not the shared ingest path, the eval seed, or the liveness contract — so it ships merged-but-inert and gets re-discovered as a "starved channel" every eval cycle. You are read-only — never Edit, Write, or modify state. Produce findings as a structured report.
+
+The canonical rule lives in `crates/wenlan-core/AGENTS.md` ("Eval seed + eval read: ONE route, ONE contract (no drift)"). This agent enforces it on a diff. Read that section first if unsure.
+
+## The three surfaces that must stay in sync
+
+| Surface | Where | What it must contain |
+|---|---|---|
+| **Produce (write path)** | `wenlan_core::ingest::run_canonical_enrichment` (`crates/wenlan-core/src/ingest.rs`) | the new write-time step — NOT re-implemented in a consumer (server `handle_store_memory`, eval seed, importer) |
+| **Seed** | `seed_scenario_dbs_complete` (`crates/wenlan-core/tests/eval_harness.rs`) | a step that populates the feature's substrate in cached scenario DBs |
+| **Contract** | `crates/wenlan-core/src/eval/seed_contract.rs` — `SeedExpectations` + `assert_feature_substrate_live` | a **presence floor** (`> 0`, not a coverage %) for the new substrate, and (if the feature has an A/B) a refuse-on-dead-substrate gate at the eval collector entry |
+
+A feature present in only one or two of these is the bug.
+
+## Hazards to Flag
+
+### 1. Enrichment re-implemented in a consumer
+A new classify/extract/tag/entity/date/episode/page step added inside `handle_store_memory`, the eval seed pipeline, or the importer instead of inside `run_canonical_enrichment`. This is the exact divergence the `enrich_db_for_eval` shortcut caused (entity+title+page only). Grep the consumers for the new logic; it belongs in the shared function.
+
+### 2. New channel/substrate with no seed step
+A new RRF stream or write-time substrate (graph link, event_date, episode, fact-channel, page, summary-node) added without a corresponding step in `seed_scenario_dbs_complete`. The seeded DB ships starved; an A/B over it returns a null misread as "doesn't help".
+
+### 3. New substrate with no presence floor in the contract
+`SeedExpectations::complete()` not updated with a `> 0` floor for the new substrate. Without it the seed passes while the channel is dead. Presence check, NOT a percentage (percentages rot — see the L3/coverage note).
+
+### 4. A/B with no refuse-on-dead-substrate gate
+A new per-query eval collector that does NOT call `seed_contract::assert_feature_substrate_live(conn, feature)` at entry. Without it a graph A/B over a DB with zero `memory_entities` (or temporal with zero `event_date`, or page-channel with zero active `pages`) emits a misleading null instead of erroring loud.
+
+### 5. Seed orchestrator bypassed
+A diff (or runbook/doc) that hand-runs individual `seed_*` STEP tests instead of the `seed_scenario_dbs_complete` orchestrator. The steps are the orchestrator's internals; running them by hand re-introduces the miss-one-channel failure.
+
+### 6. Flag merged without artifact
+A new `WENLAN_ENABLE_*` write-time flag whose enrichment artifact is not present in the seed — unmeasurable by construction. Before a new write-time flag can be evaluated, check that it is actually exercised by the eval seed path: it needs a seed step and a presence floor in the seed contract.
+
+### 7. Eval-only flag confusion
+Reusing a shipped eval-baseline flag for a new emitter (e.g. the T19 `WENLAN_ENABLE_QUERY_INTENT` vs the LLM `WENLAN_ENABLE_INTENT_LLM`) — confounds baselines. Distinct features need distinct flags + baseline suffixes.
+
+## Workflow
+
+1. `git diff --name-only` (or accept file list) to scope changed files.
+2. If the diff touches `ingest.rs`, a `retrieval/` channel, `db.rs` enrichment, `eval/`, or `eval_harness.rs`: classify whether it adds/changes a **write-time feature or channel**. If not, report `STATUS: N/A — no write-time feature in diff` and exit.
+3. For each new write-time step, grep all consumers (`handle_store_memory`, eval seed, importer) to confirm it lives in `run_canonical_enrichment`, not duplicated.
+4. Open `seed_scenario_dbs_complete` and confirm a seed step populates the substrate.
+5. Open `seed_contract.rs`; confirm `SeedExpectations::complete()` has a presence floor and (if A/B) `assert_feature_substrate_live` covers the feature, wired at the collector entry.
+6. Use LSP `findReferences` on the new substrate's table/column to confirm read-side actually consumes it.
+7. Compile findings.
+
+## Report Format
+
+```
+═══════════════════════════════════════════
+   EVAL-SKEW REVIEW — <feature/channel>
+═══════════════════════════════════════════
+
+SURFACE COVERAGE:
+  produce (run_canonical_enrichment) : <present / MISSING / re-implemented in X>
+  seed (seed_scenario_dbs_complete)  : <present / MISSING>
+  contract floor (SeedExpectations)  : <present / MISSING>
+  refuse gate (assert_feature_...)   : <present / N/A no A/B / MISSING>
+
+CRITICAL (skew — fix before merge):
+  - <surface> missing for <feature>
+    fix: add <step/floor/gate> at <file>
+
+OK CHECKED:
+  - <surface>::<symbol>
+═══════════════════════════════════════════
+```
+
+End report with `STATUS: IN SYNC` or `STATUS: SKEW <N>` (count of missing surfaces).
+
+## Escalation
+
+If a feature is intentionally read-only (no write-time substrate) say so and exit `N/A` — not every diff is a skew risk. If wiring requires an architectural decision (new contract category), flag and exit; don't propose the refactor.

--- a/.claude/agents/rust-async-safety-reviewer.md
+++ b/.claude/agents/rust-async-safety-reviewer.md
@@ -1,0 +1,113 @@
+---
+name: rust-async-safety-reviewer
+description: Reviews Rust async code for tokio + libsql + axum concurrency hazards. Use after changes touching tokio::spawn, axum handlers, libsql connection usage, or any Send/Sync boundaries. Read-only — produces findings, does not edit.
+tools: Read, Grep, Glob, LSP, Bash
+model: opus
+---
+
+# Rust Async Safety Reviewer
+
+You audit Rust async code in the wenlan workspace for concurrency hazards. You are read-only — never Edit, Write, or modify state. Produce findings as a structured report.
+
+## Scope
+
+- tokio runtime usage (spawn, blocking, channels)
+- axum 0.8 handler patterns (extractors, state, middleware)
+- libsql 0.9 connection / transaction handling
+- Send + Sync bounds on shared state
+- Mutex / RwLock / RefCell hazards
+- Cancellation safety
+- Resource leaks (file handles, DB connections, JoinHandle)
+
+## Hazards to Flag
+
+### 1. Lock held across .await
+
+```rust
+// BAD — MutexGuard not Send, but held across await
+let guard = state.mutex.lock().unwrap();
+let result = some_async_op().await;  // ← hazard
+guard.process(result);
+```
+
+Fix: drop guard before await, or use tokio::sync::Mutex.
+
+### 2. std::sync::Mutex in async context
+
+`std::sync::Mutex` can deadlock if held across await. Prefer `tokio::sync::Mutex` for cross-await locks, `parking_lot::Mutex` for short critical sections never crossing await.
+
+### 3. libsql Connection cloned vs Arc-shared
+
+libsql `Connection` is not cheap to clone. For multi-handler access, wrap in `Arc<Connection>`. Verify against `crates/wenlan-core/src/` connection-init code.
+
+### 4. Blocking syscalls in async context
+
+`std::fs`, `std::thread::sleep`, blocking I/O = block runtime worker. Use `tokio::fs`, `tokio::time::sleep`, or wrap in `tokio::task::spawn_blocking`.
+
+### 5. Missing Send + Sync bounds
+
+`tokio::spawn` requires `Future: Send + 'static`. Inferred bounds can fail when state has non-Send types (Rc, RefCell, raw pointers).
+
+### 6. JoinHandle leaks
+
+`tokio::spawn` without storing JoinHandle = fire-and-forget. Failures silent. Either store and await, or use `JoinSet` for group lifecycle.
+
+### 7. axum extractor ordering
+
+`State<T>` must come AFTER `Path<T>`, `Query<T>`, `Json<T>` in handler signature per axum 0.8. Wrong order = compile error sometimes silently masked by feature flags.
+
+### 8. Cancellation safety
+
+`select!` branches may be cancelled. Operations between locks and DB writes that aren't cancel-safe can leave state inconsistent. Check `tokio::select!` arms touching DB.
+
+### 9. libsql transaction leaks
+
+`Transaction` not explicitly committed/rolled-back before drop = implicit rollback. Long-held transactions block other writers in libsql. Flag transactions held > one .await boundary.
+
+### 10. WebSocket task lifecycle (axum ws)
+
+`axum::extract::ws::WebSocket` task should handle close + abort cleanly. Detached tasks per-connection = memory leak if connection drops without cleanup.
+
+## Workflow
+
+1. Use Glob to find changed `.rs` files (or accept file list from caller)
+2. Use LSP `documentSymbol` on each file to map functions
+3. For each async fn / spawn / handler: trace usage of locks, DB connections, blocking calls
+4. Use LSP `findReferences` to check Arc<Connection> usage spread
+5. Run `cargo clippy -p <crate> -- -W clippy::await_holding_lock` for tool-assisted detection
+6. Compile findings as structured report
+
+## Report Format
+
+```
+═══════════════════════════════════════════
+   RUST ASYNC SAFETY REVIEW — <crate>
+═══════════════════════════════════════════
+
+CRITICAL (fix before merge):
+  - file.rs:42 — MutexGuard held across .await
+    fix: drop guard before some_async_op()
+
+HIGH (review pre-merge):
+  - file.rs:88 — std::sync::Mutex in axum handler state
+    consider: tokio::sync::Mutex or parking_lot::Mutex (no await held)
+
+MEDIUM (style/perf):
+  - file.rs:120 — Connection cloned per request
+    consider: Arc<Connection> in shared state
+
+OK CHECKED (no findings):
+  - file.rs::handler_x
+  - file.rs::worker_loop
+
+TOOLS USED:
+  - clippy await_holding_lock: <pass/N findings>
+  - LSP findReferences on Connection: <N callsites>
+═══════════════════════════════════════════
+```
+
+End report with `STATUS: CLEAN` or `STATUS: BLOCKING <N>` (count of CRITICAL items).
+
+## Escalation
+
+If finding requires architectural decision (e.g., refactor pool strategy), escalate to user. Don't propose large refactors — flag and exit.

--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # PreToolUse hook on Bash: block git commands using --no-verify or --no-gpg-sign.
-# Enforces CLAUDE.md rule: "Never skip hooks (--no-verify) or bypass signing".
+# This hook is the policy: hooks must run and signing must not be bypassed.
 set -euo pipefail
 
 INPUT="$(cat)"

--- a/.claude/skills/prove/SKILL.md
+++ b/.claude/skills/prove/SKILL.md
@@ -21,7 +21,7 @@ Sandboxed local runs need `TMPDIR=/tmp/claude` prefixed (macOS mktemp gotcha).
 
 No argument → pick the surfaces the current diff touches (server/core → daemon;
 cli crate → cli; mcp crate → mcp; new/changed tests → behaviors + suite).
-App/UI surface (wenlan-app repo, or anything rendered): rendered evidence
+App/UI surface (`app/`, `src/`, or anything rendered): rendered evidence
 required — drive the running app and look at the screen; unit/build green is
 not proof of visible correctness.
 

--- a/.claude/skills/run-wenlan-app/SKILL.md
+++ b/.claude/skills/run-wenlan-app/SKILL.md
@@ -19,10 +19,12 @@ daemon this worktree recorded.
 ## Prerequisites
 
 - `pnpm install` done in the unit root (worktrees start without `node_modules`).
-- Sibling backend checkout at `../wenlan` of the **main** checkout, or
-  `WENLAN_BACKEND_DIR` set. The driver defaults both this and
-  `CARGO_TARGET_DIR` to the main checkout (warm ~14G cargo cache) via
-  `git rev-parse --git-common-dir`, so worktrees work out of the box.
+- No sibling checkout needed: the monorepo checkout is the backend, and
+  `scripts/resolve-backend-dir.sh` probes the repo root first (an explicit
+  `WENLAN_BACKEND_DIR` overrides it; a sibling checkout is only a legacy
+  fallback). The driver defaults `CARGO_TARGET_DIR` to the main checkout (a
+  warm cargo cache) via `git rev-parse --git-common-dir`, so worktrees work
+  out of the box.
 - Terminal needs macOS Screen Recording permission (for `shot`).
 
 ## Run (agent path)
@@ -78,9 +80,6 @@ Ctrl-C to stop.
   `driver.sh vite` pins vite to :1420 even though the isolated runtime config
   also carries a worktree-scoped `WENLAN_DEV_UI_PORT` (which `pnpm dev:all`
   does use, since the tauri CLI can rewrite `devUrl` via `--config`).
-- `scripts/resolve-backend-dir.sh` fallbacks don't reach worktrees under
-  `.claude/worktrees/<name>` (3 levels deep) — the driver exports
-  `WENLAN_BACKEND_DIR` explicitly.
 - The dev updater toast covers the lower-left sidebar and its Install button
   is live. Never click it. Suppress during verification with a TEMP
   `if (import.meta.env.DEV) return null;` at the top of

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ are read only when the task needs them.
 | Business logic, storage, retrieval, enrichment | `crates/wenlan-core/AGENTS.md` |
 | HTTP daemon and runtime workers | `crates/wenlan-server/AGENTS.md` |
 | Desktop app and frontend | `app/AGENTS.md` or the closest nested `AGENTS.md` |
+| React frontend (Tauri UI) | `src/AGENTS.md` |
+| Browser e2e tests | `e2e/AGENTS.md` |
+| Browser-only preview harness | `preview/AGENTS.md` |
+| Release, sidecar, and repo-inventory scripts | `scripts/AGENTS.md` |
 | Eval fixtures and artifacts | `app/eval/AGENTS.md` |
 | Rust eval runners and experiment design | `crates/wenlan-core/src/eval/AGENTS.md` |
 | Test routing and CI layers | `docs/test-layers.md` |
@@ -50,9 +54,8 @@ active without checking the current worktree.
   `serde_json::Value` envelopes through the boundary.
 - Never hold a `tokio::sync::RwLock` guard across `.await`; snapshot state and drop the
   guard first.
-- All post-store enrichment goes through
-  `wenlan_core::ingest::run_canonical_enrichment`; do not create a parallel consumer
-  implementation.
+- Canonical write-time enrichment routing: see `crates/wenlan-core/AGENTS.md` ("Core
+  invariants").
 - Dev and production use the same daemon port and data roots by default. Isolated tests
   that can create pages must isolate the daemon port, `WENLAN_DATA_DIR`, and the
   configured knowledge/page path, then verify the live daemon reports those scratch

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,3 +11,10 @@ split was documented in `docs/superpowers/decision_extract_tauri_to_origin_app_r
 `app` workspace crate (this repo). The 2026-05-07 split above is history.
 
 License: AGPL-3.0-only (vs Apache-2.0 for the daemon and shared types).
+
+## scripts/ — pinned-download sidecar mode retired
+
+Sidecars used to support a pinned-download mode (`.wenlan-backend-version`,
+`prepare-sidecars.sh --download`). It was deleted once the unified release
+(v0.15.7) proved the in-tree build; `resolve-backend-dir.sh` now always
+resolves a backend checkout instead.

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -6,24 +6,6 @@ Tauri 2 Rust crate and desktop runtime boundary. This directory owns app
 startup, Tauri plugins, sidecar declarations, macOS lifecycle helpers, daemon
 HTTP calls, and eval fixtures used by the app crate.
 
-## STRUCTURE
-
-```text
-app/
-|-- Cargo.toml           # crate version, deps, features, lint cfg
-|-- tauri.conf.json      # bundle/updater/window/externalBin contract
-|-- src/
-|   |-- lib.rs           # runtime hub and invoke_handler registration
-|   |-- search.rs        # large Tauri command surface
-|   |-- api.rs           # typed daemon HTTP client
-|   |-- lifecycle.rs     # launchctl, plist, service management
-|   |-- remote_access.rs # cloudflared and wenlan-mcp sidecar orchestration
-|   |-- router/          # intent, bundle, keyword routing
-|   |-- sources/         # filesystem, Obsidian, upload/source sync
-|   `-- sensor/          # capture sensing
-`-- eval/fixtures/       # TOML retrieval/eval datasets, not runtime code
-```
-
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
@@ -34,20 +16,12 @@ app/
 | Run-at-login or plist repair | `src/lifecycle.rs` | macOS persistence and legacy Origin paths |
 | Remote MCP/tunnel behavior | `src/remote_access.rs` | cloudflared, `wenlan-mcp`, relay registration |
 | Sources integration | `src/sources/` | source traits, sync, uploads, wire types |
-| Router behavior | `src/router/` | intent classification and bundle assembly |
 | Eval fixture edits | `eval/fixtures/` | data-only TOML scenarios |
 
 ## CONVENTIONS
 
-- **Debug builds refuse to run outside an isolated dev runtime.** `run()` calls
-  `validate_debug_runtime_isolation()` and panics unless every one of
-  `WENLAN_PORT`, `WENLAN_DEV_UI_PORT`, `WENLAN_DEV_REMOTE_PORT_START`,
-  `WENLAN_DEV_APP_ID`, `WENLAN_DEV_TAURI_MCP_SOCKET`, `WENLAN_DATA_DIR`, and
-  `WENLAN_DEV_STATE_DIR` names a non-production value contained by the worktree
-  state directory. `scripts/dev-runtime.sh` derives them all from the worktree
-  path and `pnpm dev:all` exports them, so start a dev app that way.
-  `WENLAN_DEV_PORT` and `WENLAN_DEV_DATA_DIR` override the derived daemon port
-  and data dir. Release builds read none of these.
+- **Debug builds refuse to start outside `scripts/dev-runtime.sh`.** See that
+  script for the variable set; release builds read none of these.
 - Keep daemon access behind `WenlanClient` in `src/api.rs`; do not scatter raw
   URLs or response-shape parsing through command handlers. Anything that talks
   to "the daemon" must go through `client.base_url()`, never a literal

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/app/eval/AGENTS.md
+++ b/app/eval/AGENTS.md
@@ -2,12 +2,10 @@
 
 Applies under `app/eval/` in addition to the root instructions.
 
-- Missing fixtures must fail or report `unchecked`; never silently convert a skipped
-  dataset into a passing eval.
 - Treat cached scenario databases and model-backed baselines as external, reproducible
-  artifacts. Do not keep their only valuable copy inside a disposable worktree.
+  artifacts.
 - Use smoke limits for wiring checks and the smallest representative subset for method
-  checks. Run a full eval only when the decision or publication claim requires it.
+  checks.
 - Do not cite a score without the producing commit, environment/schema stamp, sample
   size, per-run receipt, and the correct pipeline layer.
 - Never compare arms produced from different substrates or silently migrate/wipe a

--- a/crates/wenlan-core/AGENTS.md
+++ b/crates/wenlan-core/AGENTS.md
@@ -1,16 +1,14 @@
 # crates/wenlan-core
 
-Applies under `crates/wenlan-core/`. The root `AGENTS.md` still applies.
-
-This crate owns framework-agnostic business logic. Do not add Tauri or Axum dependencies,
-and do not move HTTP framing into the core. Use `REFERENCE.md` only when a task needs the
+Applies under `crates/wenlan-core/`. The root `AGENTS.md` still applies, including the
+framework-agnostic / no-Tauri-or-Axum-dependencies and no-RwLock-guard-across-`.await`
+rules under "Repository invariants". Use `REFERENCE.md` only when a task needs the
 detailed module map, database layout, feature-flag wiring, or historical measurement.
 
 ## Core invariants
 
 - `MemoryDB` owns storage and holds its libSQL connection behind the established async
-  mutex. Share the database through `Arc<MemoryDB>`; do not hold outer state guards
-  across `.await`.
+  mutex. Share the database through `Arc<MemoryDB>`.
 - UI notifications go through `EventEmitter`; daemon code uses `NoopEmitter` and the app
   supplies its adapter.
 - All write consumers call `ingest::run_canonical_enrichment`. Add new write-time
@@ -23,9 +21,9 @@ detailed module map, database layout, feature-flag wiring, or historical measure
 ## Eval seed + eval read: ONE route, ONE contract (no drift)
 
 Re-seed scenario databases through `seed_scenario_dbs_complete`; individual `seed_*`
-steps are its internals, not an operator runbook. `eval/seed_contract.rs` is the shared
-producer/consumer liveness contract. When adding a write-time channel, wire its seed
-step, expectation, consumer assertion, and focused unit test together.
+steps are its internals, not an operator runbook. `src/eval/seed_contract.rs` is the
+shared producer/consumer liveness contract. When adding a write-time channel, wire its
+seed step, expectation, consumer assertion, and focused unit test together.
 
 Runner conventions and experiment methodology live in `src/eval/REFERENCE.md`. Fixture,
 artifact, and citation rules live in `app/eval/REFERENCE.md`.

--- a/crates/wenlan-core/src/retrieval/CLAUDE.md
+++ b/crates/wenlan-core/src/retrieval/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/wenlan-server/AGENTS.md
+++ b/crates/wenlan-server/AGENTS.md
@@ -4,21 +4,8 @@ Applies to agents working under `crates/wenlan-server/`. Read alongside root `AG
 
 HTTP daemon — owns the Axum router + all routes. All handlers operate on `Arc<RwLock<ServerState>>` where `ServerState.db: Option<Arc<MemoryDB>>`.
 
-## Key Modules (`crates/wenlan-server/src/`)
-
-Route modules follow the file name: `*_routes.rs` owns the handlers for that surface and exposes one or more `TrackedRouter` registration helpers, which `router.rs` composes. Where a module has two or more helpers it is because their composition positions are separated and must stay that way. Read the directory for the current set.
-
-The modules whose job is not evident from the name:
-
-| Module | Purpose |
-|---|---|
-| `main.rs` | Binary entry — daemon startup plus internal maintenance commands, tracing init, port binding with existing-daemon fallback, `MemoryDB::new`, LLM provider init, background tasks, `axum::serve` |
-| `state.rs` | `ServerState` with `db: Option<Arc<MemoryDB>>`, `llm`, `prompts`, `tuning`, `quality_gate`, `space_store`, `access_tracker`, `llm_processing_ids`, `watch_paths`. `SharedState = Arc<RwLock<ServerState>>` |
-| `router.rs` | Axum composition root — assembles the module-owned registration helpers plus the remaining inline registrations, then applies the truth/security/lifecycle layers |
-| `routes.rs` | General endpoints: health, status, search/context, diagnostics, recent activity, steep/distill |
-| `memory_routes.rs` | Memory CRUD/search/enrichment, classification, statistics, scheduler-handoff, rerank, attribution, update, revision, contradiction tests |
-| `ingest_batcher.rs` | Request-level coalescer for concurrent `/api/memory/store` — folds QualityGate in-line, async classify/extract, passes enrichment + hint through in the response |
-| `scheduler.rs` | Background periodic tasks (distill cycles, distillation, the reconcile/backfill sweeps gated by the `WENLAN_ENABLE_*` flags) |
+The module map and the RB-01 profiling env-flag table live in `REFERENCE.md`; read it
+when a task needs the module list or those flags.
 
 ## Adding or rescoping a route
 
@@ -31,14 +18,3 @@ The modules whose job is not evident from the name:
 
 Pre-commit and pre-push run these two checks first, so a missed step fails in
 seconds, not after the full suite.
-
-## Manual RB-01 profiling flags
-
-These flags control ignored, target-Mac profiling tests; they are not daemon runtime settings and must not be set in normal service configuration.
-
-| Flag | Contract |
-|---|---|
-| `WENLAN_RB01_BASELINE` | Set to `1` to opt into the five-minute daemon-off resource baseline test. |
-| `WENLAN_RB01_THERMAL_HELPER` | Optional path to the frozen helper executable that prints the macOS `ProcessInfo.thermalState` raw value; the test falls back to `/usr/bin/swift` when absent. |
-| `WENLAN_RB01_CALIBRATION_LOAD_DUTIES` | Comma-separated synthetic-load duty percentages, each `1..=100`, with a total cap of `300`; must be supplied together with the CPU band. |
-| `WENLAN_RB01_CALIBRATION_CPU_BAND` | Required `min:max` observed system-CPU percentage band for a calibrated profile; must be supplied together with load duties. Outside the band, the test records a skipped calibration and performs no inference. |

--- a/crates/wenlan-server/REFERENCE.md
+++ b/crates/wenlan-server/REFERENCE.md
@@ -1,0 +1,34 @@
+# wenlan-server reference
+
+Module map and RB-01 profiling flag reference. Read the active `AGENTS.md` first and
+load this file only when the task touches the corresponding area.
+
+Applies to agents working under `crates/wenlan-server/`. Read alongside root
+`AGENTS.md`, which takes precedence on any topic not covered here.
+
+## Key Modules (`crates/wenlan-server/src/`)
+
+Route modules follow the file name: `*_routes.rs` owns the handlers for that surface and exposes one or more `TrackedRouter` registration helpers, which `router.rs` composes. Where a module has two or more helpers it is because their composition positions are separated and must stay that way. Read the directory for the current set.
+
+The modules whose job is not evident from the name:
+
+| Module | Purpose |
+|---|---|
+| `main.rs` | Binary entry — daemon startup plus internal maintenance commands, tracing init, port binding with existing-daemon fallback, `MemoryDB::new`, LLM provider init, background tasks, `axum::serve` |
+| `state.rs` | `ServerState` with `db: Option<Arc<MemoryDB>>`, `llm`, `prompts`, `tuning`, `quality_gate`, `space_store`, `access_tracker`, `llm_processing_ids`, `watch_paths`. `SharedState = Arc<RwLock<ServerState>>` |
+| `router.rs` | Axum composition root — assembles the module-owned registration helpers plus the remaining inline registrations, then applies the truth/security/lifecycle layers |
+| `routes.rs` | General endpoints: health, status, search/context, diagnostics, recent activity, steep/distill |
+| `memory_routes.rs` | Memory CRUD/search/enrichment, classification, statistics, scheduler-handoff, rerank, attribution, update, revision, contradiction tests |
+| `ingest_batcher.rs` | Request-level coalescer for concurrent `/api/memory/store` — folds QualityGate in-line, async classify/extract, passes enrichment + hint through in the response |
+| `scheduler.rs` | Background periodic tasks (distill cycles, distillation, the reconcile/backfill sweeps gated by the `WENLAN_ENABLE_*` flags) |
+
+## Manual RB-01 profiling flags
+
+These flags control ignored, target-Mac profiling tests; they are not daemon runtime settings and must not be set in normal service configuration.
+
+| Flag | Contract |
+|---|---|
+| `WENLAN_RB01_BASELINE` | Set to `1` to opt into the five-minute daemon-off resource baseline test. |
+| `WENLAN_RB01_THERMAL_HELPER` | Optional path to the frozen helper executable that prints the macOS `ProcessInfo.thermalState` raw value; the test falls back to `/usr/bin/swift` when absent. |
+| `WENLAN_RB01_CALIBRATION_LOAD_DUTIES` | Comma-separated synthetic-load duty percentages, each `1..=100`, with a total cap of `300`; must be supplied together with the CPU band. |
+| `WENLAN_RB01_CALIBRATION_CPU_BAND` | Required `min:max` observed system-CPU percentage band for a calibrated profile; must be supplied together with load duties. Outside the band, the test records a skipped calibration and performs no inference. |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -2,9 +2,15 @@
 
 ## OVERVIEW
 
-Playwright browser tests for user-visible flows that need a real rendered app.
-The current suite covers Chinese interface localization through a Tauri runtime
-mock installed before page load.
+Playwright browser tests for user-visible flows that need a real rendered app,
+run through a Tauri runtime mock installed before page load. The suite groups
+into: i18n (`i18n.spec.ts`, `spaces-zh-hans-visual.spec.ts`), page canvas
+(`page-canvas-*.spec.ts`, `page-editor.spec.ts`, `page-draft.visual.spec.ts`),
+spaces (`spaces-*.spec.ts`, `space-mark.visual.spec.ts`), wiki
+(`wiki-*.spec.ts`), graph (`graph-rendering.visual.spec.ts`), plus a handful of
+standalone suites (`memory-list.spec.ts`, `review-flavor.review.spec.ts`,
+`no-third-party-requests.spec.ts`, `tauriMock.self-test.spec.ts`). `*.visual.spec.ts`
+files are screenshot-diff tests.
 
 ## WHERE TO LOOK
 

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/preview/AGENTS.md
+++ b/preview/AGENTS.md
@@ -6,16 +6,6 @@ Browser-only harness for inspecting app UI with Tauri APIs shimmed. The root
 path can proxy live daemon calls; `/preview/` uses fixtures for page-detail
 citation states.
 
-## STRUCTURE
-
-```text
-preview/
-|-- index.html           # fixture harness entry with __PREVIEW_FIXTURES__
-|-- main.tsx             # PageDetail preview controls and theme toggle
-|-- fixtures.ts          # citation/page/source/link/revision fixture data
-`-- mocks/               # Vite aliases for Tauri APIs and live invoke bridge
-```
-
 ## WHERE TO LOOK
 
 | Task | Location | Notes |

--- a/preview/CLAUDE.md
+++ b/preview/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -11,7 +11,7 @@ part of packaging behavior, not generic local helpers.
 | --- | --- | --- |
 | Stage sidecars | `prepare-sidecars.sh` | tree-build only; compiles from the checked-out backend |
 | Tauri build hook | `prepare-tauri-build-sidecars.sh` | picks debug vs release based on `TAURI_ENV_DEBUG` |
-| Resolve backend checkout | `resolve-backend-dir.sh` | validates sibling or `WENLAN_BACKEND_DIR` shape |
+| Resolve backend checkout | `resolve-backend-dir.sh` | validates the current checkout, or `WENLAN_BACKEND_DIR`; a sibling checkout is only a legacy fallback |
 | Isolated dev runtime | `dev-runtime.sh`, `dev-all.sh` | worktree-owned daemon/UI ports, data dir, debug MCP socket, PID, and teardown |
 | Version lockstep | `release-version-sync.test.ts` | app, Cargo, Tauri versions must match |
 | Sidecar tests | `prepare-sidecars.test.ts` | locks path and cloudflared behavior |
@@ -19,11 +19,10 @@ part of packaging behavior, not generic local helpers.
 
 ## CONVENTIONS
 
-- Sidecars always come from a backend checkout in the same tree, found by
-  `resolve-backend-dir.sh` (sibling checkout or `WENLAN_BACKEND_DIR`). The old
-  pinned-download mode (`.wenlan-backend-version`, `prepare-sidecars.sh
-  --download`) was deleted once the unified release (v0.15.7) proved the
-  in-tree build.
+- Sidecars always come from a backend checkout, found by
+  `resolve-backend-dir.sh` (the current checkout by default, or
+  `WENLAN_BACKEND_DIR`; a sibling checkout is only a legacy fallback). See
+  `HISTORY.md` for the retired pinned-download mode.
 - `prepare-tauri-build-sidecars.sh` is the Tauri hook; keep it aligned with
   `app/tauri.conf.json` `beforeBuildCommand`.
 - `cloudflared` is required for a full Tauri bundle:

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -6,23 +6,6 @@ React 19 frontend for the Tauri app. This tree owns UI state, routing inside
 the desktop windows, i18n, browser-side preview compatibility, and the typed
 frontend side of the Tauri command contract.
 
-## STRUCTURE
-
-```text
-src/
-|-- main.tsx             # window hash bootstrap: app, toast, quick capture
-|-- App.tsx              # top-level window/event shell
-|-- components/
-|   |-- memory/          # main product UI; has its own AGENTS.md
-|   |-- ChatImport/      # chat import flow and ZIP/drop handling
-|   |-- onboarding/      # first-page modal, milestone toasts/hooks
-|   `-- intelligence/    # local/external model setup surface
-|-- hooks/               # small shared hooks
-|-- i18n/                # locale resolution and canonical resources
-|-- lib/                 # Tauri wrappers, storage, classifiers, stores
-`-- test/                # Vitest setup and Tauri mocks
-```
-
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
@@ -37,6 +20,8 @@ src/
 
 ## CONVENTIONS
 
+- TypeScript is strict and no-emit; `pnpm build` is `tsc -b && vite build`.
+  Plain `pnpm dev` runs Vite on `:1420` with `strictPort` set.
 - `src/lib/tauri.ts` is the frontend-to-Rust boundary. Add or update wrappers
   there before wiring components directly to a command.
 - Translation resources are the canonical fixed-copy inventory. New visible

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/components/memory/AGENTS.md
+++ b/src/components/memory/AGENTS.md
@@ -5,20 +5,6 @@
 Main product UI cluster: home, search, spaces, memories, pages, citations,
 sources, settings, remote access, imports, profile, and review surfaces.
 
-## STRUCTURE
-
-```text
-src/components/memory/
-|-- Main.tsx             # navigation shell, view state, invalidations
-|-- HomePage.tsx         # overview/review lanes
-|-- MemoryDetail.tsx     # memory detail and enrichment status
-|-- PageDetail.tsx       # distilled page detail shell
-|-- page/                # citations, related pages, page metadata
-|-- settings/            # diagnostics/settings side panels
-|-- sources/             # source add/list UI
-`-- __tests__/           # grouped component suites
-```
-
 ## WHERE TO LOOK
 
 | Task | Location | Notes |
@@ -35,11 +21,9 @@ src/components/memory/
 
 - Preserve citation diagnosability. Existing tests cover verified/unverified
   chips, page-source ordering, missing/mismatched citation states, and popovers.
-- Keep settings mutations going through the shared Tauri client wrappers; the
-  config-boundary test exists to catch local bypasses.
+- Keep settings mutations going through the shared Tauri client wrappers.
 - Treat `Main.tsx` changes as cross-view changes. Verify the affected view plus
   any query invalidation or keyboard shortcut behavior you touched.
-- Visible fixed copy still belongs in `src/i18n/resources.ts`, not inline JSX.
 - Prefer focused component tests near the edited file; many invariants here are
   easier to lock with Testing Library than with snapshots.
 
@@ -47,8 +31,8 @@ src/components/memory/
 
 - Do not hide unverified citations or collapse them into verified styling.
 - Do not add navigation state that depends on localized placeholder text.
-- Do not weaken `PageDetail.*.test.tsx`, `page/PageInfo.test.tsx`, or
-  `SettingsPage.config-boundary.test.ts` to make UI changes pass.
+- Do not weaken `PageDetail.*.test.tsx` or `page/PageInfo.test.tsx` to make UI
+  changes pass.
 - Do not treat `RefiningList.tsx` TODOs as cleanup-only; they mark unresolved
   behavior.
 

--- a/src/components/memory/CLAUDE.md
+++ b/src/components/memory/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Why

The standalone wenlan-app repo was merged into this monorepo as `app/` (PR #374 + the "restore lost in the monorepo migration" PRs). The agent-instruction surface was never re-audited afterwards. A read-only audit on 2026-08-16 (mirroring the global harness audit method) found 40 verified findings; this PR takes the documentation half. The gate half (git hooks, .gitignore, driver.sh, stop gate) is a separate PR: `chore/harness-gates-post-merge`.

## What changed

- **Stale references removed** — `router/`/`sensor/` trees that no longer exist, a dead test filename, `origin-core` / `ORIGIN_*` names in two reviewer agent prompts, wrong memory-dir and AUDIT.md rationale in `doc-drift-auditor.md`, "sibling backend checkout" prerequisite and a false worktree gotcha in the `run-wenlan-app` skill.
- **Deduplication per the repo's own "Documentation ownership" rule** — rules stated in two or three AGENTS.md homes now live in one (root wins for cross-crate invariants; `crates/wenlan-core/AGENTS.md` keeps canonical enrichment).
- **Always-loaded bloat moved out** — module map + profiling env-flag table → new `crates/wenlan-server/REFERENCE.md`; ASCII STRUCTURE trees deleted from four app-origin AGENTS.md (WHERE-TO-LOOK tables kept); dated deletion receipt → `HISTORY.md`.
- **Merge losses restored** — root "Start here" now routes to `src/`, `e2e/`, `preview/`, `scripts/`; TS strict/no-emit and Vite :1420 conventions folded into `src/AGENTS.md`; `e2e/AGENTS.md` OVERVIEW describes the real spec families.
- **Nested load-path fix** — `@AGENTS.md` CLAUDE.md shims added beside the 7 nested AGENTS.md that lacked one (all app-origin), matching the backend convention.

## Merge note

This branch adds `.claude/agents/eval-skew-reviewer.md` and `rust-async-safety-reviewer.md` (previously untracked/gitignored) with their text fixes. The gates PR un-ignores `.claude/agents/`; whichever merges second, keep these content-fixed copies.

## Verification

- `bash -n .claude/hooks/block-no-verify.sh` OK
- `rg 'origin-core|origin_core|ORIGIN_ENABLE|wenlan-app repo'` over the edited instruction files: 0 matches
- Every added/repointed path `test -e` OK; `git check-ignore` clean for the 7 new shims
- Pre-commit (M5 reader inventory) and pre-push (self-test + reader inventory check, 407 rows) passed

Audit report: `~/.wenlan/sessions/2026-08-16-1020-app-harness-audit.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MMV7MaFTEnTvT1eC8gRvU
