### PR TITLE
chore(harness): fix worktree sidecar source, honest pre-commit message, TS-aware stop gate, track agent files

### DIFF
--- a/.claude/hooks/pre-stop-gate.sh
+++ b/.claude/hooks/pre-stop-gate.sh
@@ -11,11 +11,11 @@ cd "$REPO"
 
 [ -f "$REPO/Cargo.toml" ] || exit 0
 
-# Collect changed source files (staged + unstaged + untracked, .rs only)
+# Collect changed source files (staged + unstaged + untracked, Rust and TypeScript)
 FILES_LIST=$({
-  git diff --name-only --diff-filter=ACMR -- '*.rs' 2>/dev/null
-  git diff --name-only --cached --diff-filter=ACMR -- '*.rs' 2>/dev/null
-  git ls-files --others --exclude-standard -- '*.rs' 2>/dev/null
+  git diff --name-only --diff-filter=ACMR -- '*.rs' '*.ts' '*.tsx' 2>/dev/null
+  git diff --name-only --cached --diff-filter=ACMR -- '*.rs' '*.ts' '*.tsx' 2>/dev/null
+  git ls-files --others --exclude-standard -- '*.rs' '*.ts' '*.tsx' 2>/dev/null
 } | sort -u)
 
 PROBLEMS=()
@@ -37,6 +37,10 @@ if [ "${#FILES[@]}" -gt 0 ]; then
     'todo!\s*\('
     'unimplemented!\s*\('
     '^\s*//.*FIXME'
+    'assert[[:space:]]*\([[:space:]]*true[[:space:]]*\)'
+    'expect[[:space:]]*\([[:space:]]*true[[:space:]]*\)[[:space:]]*\.toBe[[:space:]]*\([[:space:]]*true[[:space:]]*\)'
+    '(^|[^[:alnum:]_])(it|test)\.skip[[:space:]]*\('
+    '(^|[^[:alnum:]_])xit[[:space:]]*\('
   )
 
   # Added lines from both unstaged and staged changes. Untracked files are counted
@@ -45,7 +49,7 @@ if [ "${#FILES[@]}" -gt 0 ]; then
     git diff --unified=0 -- "${FILES[@]}" 2>/dev/null
     git diff --cached --unified=0 -- "${FILES[@]}" 2>/dev/null
   } | grep -E '^\+[^+]' || true)"
-  # For untracked .rs files, include all lines
+  # For untracked source files, include all lines
   for f in "${FILES[@]}"; do
     if git ls-files --error-unmatch "$f" >/dev/null 2>&1; then continue; fi
     [ -f "$f" ] && ADDED_LINES+=$'\n'"$(sed 's/^/+ /' "$f")"
@@ -88,7 +92,7 @@ STAGED="$(git diff --cached --shortstat 2>/dev/null | sed 's/^ *//')"
   echo "[$TS] branch=$BRANCH head=$HEAD_SHA"
   [ -n "$CHANGED" ] && echo "  unstaged: $CHANGED"
   [ -n "$STAGED" ]  && echo "  staged:   $STAGED"
-  echo "  files: ${#FILES[@]} .rs touched, pattern scan clear"
+  echo "  files: ${#FILES[@]} source files touched, pattern scan clear"
 } >> "$PROGRESS"
 
 exit 0

--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Hook canary — verify-the-verifier for the repo's Claude Code gates.
-# Feeds synthetic tool-input JSON through each protection hook and asserts
+# Feeds synthetic tool input or repository fixtures through each protection hook and asserts
 # BOTH directions: the block path fires (exit 2) and the allow path stays
 # quiet (exit 0). A gate nobody has ever seen fire is indistinguishable from
 # a dead one — this is the durable evidence (audit 2026-07-02, PR #324).
@@ -28,6 +28,43 @@ t "release-please: block CHANGELOG.md"     block-release-please-files.sh '{"tool
 t "release-please: allow normal file"      block-release-please-files.sh '{"tool_input":{"file_path":"/x/src/main.rs"}}' 0
 t "release-please: allow no file_path"     block-release-please-files.sh '{"tool_input":{}}' 0
 t "release-please: malformed JSON fails closed" block-release-please-files.sh '{{{' 2
+
+stop_t() { # desc fixture want-exit
+  local tmp got filename
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/wenlan-stop-hook.XXXXXX")
+  mkdir -p "$tmp/.claude"
+  printf '[workspace]\n' > "$tmp/Cargo.toml"
+  git -C "$tmp" init -q
+  filename=""
+  case "$2" in
+    rust-todo)
+      filename=canary.rs
+      printf 'fn main() { todo!(); }\n' > "$tmp/$filename"
+      ;;
+    ts-skip)
+      filename=canary.ts
+      printf 'it.skip("pending", () => {});\n' > "$tmp/$filename"
+      ;;
+    clean)
+      ;;
+  esac
+  if [ -n "$filename" ]; then
+    git -C "$tmp" add -- "$filename"
+  fi
+  CLAUDE_PROJECT_DIR="$tmp" bash "$PWD/pre-stop-gate.sh" >/dev/null 2>&1
+  got=$?
+  rm -rf "$tmp"
+  if [ "$got" -eq "$3" ]; then
+    echo "PASS  $1"
+  else
+    echo "FAIL  $1 (want exit $3, got $got)"
+    fails=$((fails + 1))
+  fi
+}
+
+stop_t "pre-stop: block staged todo!" rust-todo 2
+stop_t "pre-stop: block staged TS skip" ts-skip 2
+stop_t "pre-stop: allow clean tree" clean 0
 echo "----"
 if [ "$fails" -eq 0 ]; then
   echo "hook canary: ALL PASS"

--- a/.claude/skills/run-wenlan-app/driver.sh
+++ b/.claude/skills/run-wenlan-app/driver.sh
@@ -4,11 +4,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)" # unit root (repo or worktree)
-# Reuse the main checkout's warm cargo cache and sibling backend even from
-# a linked worktree (resolve-backend-dir.sh fallbacks don't reach
-# .claude/worktrees/<name>, which is 3 levels deep).
 MAIN="$(cd "$(git -C "$ROOT" rev-parse --git-common-dir)/.." && pwd)"
-export WENLAN_BACKEND_DIR="${WENLAN_BACKEND_DIR:-$MAIN/../wenlan}"
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$MAIN/target}"
 BIN="$CARGO_TARGET_DIR/debug/wenlan-app"
 LOG="${TMPDIR:-/tmp}"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,6 +9,8 @@ echo "Pre-commit: running fast checks..."
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACMRD)
 HAS_RUST=$(echo "$STAGED_FILES" | grep -q '\.rs$' && echo "yes" || echo "no")
 HAS_RUST_INPUT=$(echo "$STAGED_FILES" | grep -Eq '(\.rs$|(^|/)Cargo\.toml$|^Cargo\.lock$|^rust-toolchain\.toml$|^clippy\.toml$)' && echo "yes" || echo "no")
+HAS_APP_RUST=$(echo "$STAGED_FILES" | grep -Eq '^app/.*\.rs$' && echo "yes" || echo "no")
+HAS_SHARED_RUST_CONFIG=$(echo "$STAGED_FILES" | grep -Eq '(^|/)Cargo\.toml$|^Cargo\.lock$|^rust-toolchain\.toml$|^clippy\.toml$' && echo "yes" || echo "no")
 
 if [ "$HAS_RUST" = "yes" ]; then
     echo "  Checking Rust formatting..."
@@ -73,8 +75,14 @@ if [ "$HAS_RUST_INPUT" = "yes" ]; then
                 echo "FAIL: Cargo metadata is invalid. Fix before committing."
                 exit 1
             }
+        elif [ "$HAS_APP_RUST" = "yes" ] && [ "$HAS_SHARED_RUST_CONFIG" = "yes" ]; then
+            echo "  CI app-check lane owns app/ Rust checks; shared Rust configuration gets full graph checks pre-push."
+        elif [ "$HAS_APP_RUST" = "yes" ]; then
+            echo "  CI app-check lane owns app/ Rust checks; heavy app compiles stay out of local hooks."
+        elif [ "$HAS_SHARED_RUST_CONFIG" = "yes" ]; then
+            echo "  Shared Rust configuration changed; full graph checks run pre-push."
         else
-            echo "  Shared Rust configuration changed; full checks run pre-push."
+            echo "  No direct local crate owner; remaining Rust checks stay in CI/pre-push routing."
         fi
     fi
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,14 @@ crates/*/.fastembed_cache
 .claude/*
 !.claude/settings.json
 !.claude/hooks/
+!.claude/agents/
 # Skills are tracked selectively: verification skills ship with the repo,
 # personal/local skills stay local.
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/prove/
 !.claude/skills/run-wenlan/
+!.claude/skills/run-wenlan-app/
 !.claude/skills/verify/
 .mcp.json
 
@@ -68,7 +70,7 @@ app/binaries/
 
 # Git worktrees
 .worktrees/
-# Top-level sibling clone of origin-mcp (legacy; crates/origin-mcp/ is the in-repo crate)
+# Top-level sibling clone of wenlan-mcp (legacy; crates/wenlan-mcp/ is the in-repo crate)
 /origin-mcp/
 .autopilot-task.md
 


### PR DESCRIPTION
## Why

Companion to the docs PR (`chore/harness-docs-post-merge`, #541). Same 2026-08-16 post-merge harness audit; this PR takes the findings that change gate behavior, kept deliberately small — no new heavy compiles in local hooks (CI owns app/ and TS checks).

## What changed

- **`.claude/skills/run-wenlan-app/driver.sh`** — removed the `WENLAN_BACKEND_DIR=$MAIN/../wenlan` default. It overrode `scripts/resolve-backend-dir.sh`, so a `driver.sh build` inside a worktree compiled sidecars from the *main* checkout's backend, not the worktree's changed code. An explicit user-set `WENLAN_BACKEND_DIR` still wins.
- **`.githooks/pre-commit`** — the message for non-crate Rust changes was false for `app/` files ("full checks run pre-push" — the planner excludes `wenlan-app` on purpose). Now says the CI app-check lane owns `app/` Rust, and only claims pre-push graph checks when shared Rust config actually changed.
- **`.claude/hooks/pre-stop-gate.sh`** — the fake/unfinished-test grep scanned `*.rs` only; post-merge the repo carries a large TS tree. Now also scans `*.ts`/`*.tsx` with a small TS-safe pattern set.
- **`.claude/hooks/test-hooks.sh`** — canary now covers all three configured hooks: block/allow cases for `pre-stop-gate.sh` (Rust `todo!(` and one TS pattern), not just the two it had.
- **`.gitignore`** — un-ignore `.claude/agents/` and `.claude/skills/run-wenlan-app/` so harness files go through PR review (two agent files had rotted untracked); fix the `origin-mcp` comment.

## Merge note

The docs PR adds the two `.claude/agents/*.md` reviewer files with content fixes; this PR does not add them. Merge in either order; keep the docs PR's copies.

## Verification

- `bash -n` on every edited shell file
- `bash .claude/hooks/test-hooks.sh` PASS (including new cases)
- `bash scripts/git-hooks.test.sh` PASS
- `git check-ignore -v .claude/agents/NEWAGENT.md .claude/skills/run-wenlan-app/NEWFILE.md` → nothing (exit 1)
- `bash scripts/resolve-backend-dir.sh "$PWD"` prints the worktree path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MMV7MaFTEnTvT1eC8gRvU
