### PR TITLE
feat(cli): auto-start the registered daemon service on connect failure; add memories --pending

### DIFF
--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -51,6 +51,10 @@ Set `WENLAN_HOST` to point at a remote daemon:
 export WENLAN_HOST=http://127.0.0.1:7878  # default
 ```
 
+When a request cannot connect, the CLI automatically starts the registered
+background service (`com.wenlan.server`) and waits for its health endpoint. Set
+`WENLAN_NO_AUTOSTART=1` to opt out and report the connection failure directly.
+
 ## Subcommands
 
 ### `wenlan status`
@@ -178,7 +182,7 @@ wenlan capture --file notes.md --type page
 echo "stdin pipe content" | wenlan capture --type quick_thought
 ```
 
-### `wenlan memories [--limit N] [--type X]`
+### `wenlan memories [--limit N] [--type X] [--pending]`
 
 List recent memories.
 
@@ -186,6 +190,7 @@ List recent memories.
 wenlan memories
 wenlan memories --limit 5
 wenlan memories --type fact --format json
+wenlan memories --pending
 ```
 
 ### `wenlan agents list/show/edit`

--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -51,9 +51,11 @@ Set `WENLAN_HOST` to point at a remote daemon:
 export WENLAN_HOST=http://127.0.0.1:7878  # default
 ```
 
-When a request cannot connect, the CLI automatically starts the registered
-background service (`com.wenlan.server`) and waits for its health endpoint. Set
-`WENLAN_NO_AUTOSTART=1` to opt out and report the connection failure directly.
+When a request to a loopback daemon cannot connect, the CLI automatically starts
+the registered background service (`com.wenlan.server`) and waits for its health
+endpoint. Remote or invalid `WENLAN_HOST` values keep the original connection
+error. `status`, `background`, and `restart` skip autostart; set
+`WENLAN_NO_AUTOSTART=1` to opt out for other commands.
 
 ## Subcommands
 
@@ -79,7 +81,7 @@ wenlan setup --anthropic-api-key-env ANTHROPIC_API_KEY
 
 ### `wenlan background <on|off>`
 
-Start or stop the per-user background runtime. `wenlan background off` stops the current daemon while preserving its login registration; run `wenlan background on` to start it again. Most users run `wenlan background on` once after setup and `wenlan restart` after upgrades installed outside `wenlan setup`.
+Start or stop the per-user background runtime. `wenlan background off` stops the current daemon while preserving its login registration and writes `<data root>/autostart.off`, so recovery will not start it again. Run `wenlan background on` to remove the marker and start it again. Most users run `wenlan background on` once after setup and `wenlan restart` after upgrades installed outside `wenlan setup`.
 
 ```bash
 wenlan background on

--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -125,7 +125,10 @@ impl WenlanClient {
     pub async fn health(&self) -> Result<HealthResponse> {
         let url = format!("{}/api/health", self.base_url);
         let resp = self
-            .send(self.http.get(&url), &format!("GET {} failed", url))
+            .send(
+                self.http.get(&url),
+                &format!("GET {} failed (is the daemon running?)", url),
+            )
             .await?;
         let resp = resp
             .error_for_status()
@@ -381,10 +384,7 @@ impl WenlanClient {
     pub async fn list_spaces(&self) -> Result<Vec<wenlan_types::Space>> {
         let url = format!("{}/api/spaces", self.base_url);
         let resp = self
-            .send(
-                self.http.get(&url),
-                &format!("GET {} failed (is the daemon running?)", url),
-            )
+            .send(self.http.get(&url), &format!("GET {} failed", url))
             .await?;
         let resp = resp
             .error_for_status()

--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -97,7 +97,9 @@ impl WenlanClient {
     }
 
     async fn send(&self, req: reqwest::RequestBuilder, what: &str) -> Result<reqwest::Response> {
-        let retry = if recovery::autostart_allowed_from_env(self.recovery_enabled) {
+        let retry = if recovery::autostart_allowed_from_env(self.recovery_enabled)
+            && recovery::is_local_daemon_url(&self.base_url)
+        {
             req.try_clone()
         } else {
             None
@@ -111,7 +113,7 @@ impl WenlanClient {
                 };
                 let original = anyhow::Error::new(error).context(what.to_owned());
                 if let Err(recovery_error) = recovery::recover(&self.base_url).await {
-                    return Err(original.context(recovery_error.to_string()));
+                    return Err(original.context(format!("{recovery_error:#}")));
                 }
                 retry.send().await.with_context(|| what.to_owned())
             }
@@ -123,10 +125,7 @@ impl WenlanClient {
     pub async fn health(&self) -> Result<HealthResponse> {
         let url = format!("{}/api/health", self.base_url);
         let resp = self
-            .send(
-                self.http.get(&url),
-                &format!("GET {} failed (is the daemon running?)", url),
-            )
+            .send(self.http.get(&url), &format!("GET {} failed", url))
             .await?;
         let resp = resp
             .error_for_status()

--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -27,6 +27,7 @@ use wenlan_types::{
 };
 
 mod lint;
+mod recovery;
 pub use lint::origin_host_from_env;
 
 const DEFAULT_HOST: &str = "http://127.0.0.1:7878";
@@ -50,6 +51,7 @@ pub struct SyncStats {
 pub struct WenlanClient {
     base_url: String,
     http: reqwest::Client,
+    recovery_enabled: bool,
 }
 
 impl WenlanClient {
@@ -82,18 +84,50 @@ impl WenlanClient {
                 .default_headers(headers)
                 .build()
                 .context("building Wenlan HTTP client")?,
+            recovery_enabled: true,
         })
+    }
+
+    /// Enable or disable recovery by starting the registered daemon service
+    /// after a connection failure. Environment opt-out still applies when
+    /// recovery is enabled here.
+    pub fn with_recovery(mut self, enabled: bool) -> Self {
+        self.recovery_enabled = enabled;
+        self
+    }
+
+    async fn send(&self, req: reqwest::RequestBuilder, what: &str) -> Result<reqwest::Response> {
+        let retry = if recovery::autostart_allowed_from_env(self.recovery_enabled) {
+            req.try_clone()
+        } else {
+            None
+        };
+        let response = req.send().await;
+        match response {
+            Ok(response) => Ok(response),
+            Err(error) if error.is_connect() => {
+                let Some(retry) = retry else {
+                    return Err(error).with_context(|| what.to_owned());
+                };
+                let original = anyhow::Error::new(error).context(what.to_owned());
+                if let Err(recovery_error) = recovery::recover(&self.base_url).await {
+                    return Err(original.context(recovery_error.to_string()));
+                }
+                retry.send().await.with_context(|| what.to_owned())
+            }
+            Err(error) => Err(error).with_context(|| what.to_owned()),
+        }
     }
 
     /// GET /api/health — daemon liveness + version.
     pub async fn health(&self) -> Result<HealthResponse> {
         let url = format!("{}/api/health", self.base_url);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed (is the daemon running?)", url))?;
+            .send(
+                self.http.get(&url),
+                &format!("GET {} failed (is the daemon running?)", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -110,12 +144,11 @@ impl WenlanClient {
             space: None,
         };
         let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(
+                self.http.post(&url).json(&req),
+                &format!("POST {} failed", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -134,12 +167,11 @@ impl WenlanClient {
             rerank: false,
         };
         let response = self
-            .http
-            .post(&url)
-            .json(&request)
-            .send()
-            .await
-            .with_context(|| format!("POST {url} failed"))?
+            .send(
+                self.http.post(&url).json(&request),
+                &format!("POST {url} failed"),
+            )
+            .await?
             .error_for_status()
             .with_context(|| format!("daemon returned error for {url}"))?;
         response
@@ -152,12 +184,11 @@ impl WenlanClient {
     pub async fn brief(&self, request: &BriefReadRequest) -> Result<BriefReadResponse> {
         let url = format!("{}/api/brief", self.base_url);
         let response = self
-            .http
-            .post(&url)
-            .json(request)
-            .send()
-            .await
-            .with_context(|| format!("POST {url} failed"))?
+            .send(
+                self.http.post(&url).json(request),
+                &format!("POST {url} failed"),
+            )
+            .await?
             .error_for_status()
             .with_context(|| format!("daemon returned error for {url}"))?;
         response.json().await.context("parsing /api/brief response")
@@ -167,12 +198,11 @@ impl WenlanClient {
     pub async fn update_brief(&self, request: &BriefUpdateRequest) -> Result<BriefUpdateReceipt> {
         let url = format!("{}/api/brief", self.base_url);
         let response = self
-            .http
-            .patch(&url)
-            .json(request)
-            .send()
-            .await
-            .with_context(|| format!("PATCH {url} failed"))?
+            .send(
+                self.http.patch(&url).json(request),
+                &format!("PATCH {url} failed"),
+            )
+            .await?
             .error_for_status()
             .with_context(|| format!("daemon returned error for {url}"))?;
         response
@@ -202,12 +232,11 @@ impl WenlanClient {
             retrieval_cue: None,
         };
         let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(
+                self.http.post(&url).json(&req),
+                &format!("POST {} failed", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -220,11 +249,11 @@ impl WenlanClient {
     pub async fn list_sources(&self) -> Result<Vec<Source>> {
         let url = format!("{}/api/sources", self.base_url);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed (is the daemon running?)", url))?;
+            .send(
+                self.http.get(&url),
+                &format!("GET {} failed (is the daemon running?)", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -236,12 +265,11 @@ impl WenlanClient {
         let url = format!("{}/api/sources", self.base_url);
         let req = serde_json::json!({ "source_type": source_type, "path": path });
         let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(
+                self.http.post(&url).json(&req),
+                &format!("POST {} failed", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -254,11 +282,8 @@ impl WenlanClient {
     pub async fn sync_source(&self, id: &str) -> Result<SyncStats> {
         let url = format!("{}/api/sources/{}/sync", self.base_url, id);
         let resp = self
-            .http
-            .post(&url)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(self.http.post(&url), &format!("POST {} failed", url))
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -272,21 +297,16 @@ impl WenlanClient {
         &self,
         limit: Option<usize>,
         memory_type: Option<String>,
+        confirmed: Option<bool>,
     ) -> Result<ListMemoriesResponse> {
         let url = format!("{}/api/memory/list", self.base_url);
-        let req = ListMemoriesRequest {
-            memory_type,
-            space: None,
-            limit: limit.unwrap_or(100),
-            confirmed: None,
-        };
+        let req = build_list_request(limit, memory_type, confirmed);
         let resp = self
-            .http
-            .post(&url)
-            .json(&req)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(
+                self.http.post(&url).json(&req),
+                &format!("POST {} failed", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -299,11 +319,8 @@ impl WenlanClient {
     pub async fn list_agents(&self) -> Result<Vec<AgentResponse>> {
         let url = format!("{}/api/agents", self.base_url);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed", url))?;
+            .send(self.http.get(&url), &format!("GET {} failed", url))
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -314,11 +331,8 @@ impl WenlanClient {
     pub async fn get_agent(&self, name: &str) -> Result<AgentResponse> {
         let url = format!("{}/api/agents/{}", self.base_url, name);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed", url))?;
+            .send(self.http.get(&url), &format!("GET {} failed", url))
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -330,14 +344,15 @@ impl WenlanClient {
     /// POST /api/spaces — register a new space.
     pub async fn create_space(&self, name: &str) -> Result<()> {
         let url = format!("{}/api/spaces", self.base_url);
-        self.http
-            .post(&url)
-            .json(&serde_json::json!({"name": name}))
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?
-            .error_for_status()
-            .with_context(|| format!("daemon returned error for {}", url))?;
+        self.send(
+            self.http
+                .post(&url)
+                .json(&serde_json::json!({"name": name})),
+            &format!("POST {} failed", url),
+        )
+        .await?
+        .error_for_status()
+        .with_context(|| format!("daemon returned error for {}", url))?;
         Ok(())
     }
 
@@ -345,11 +360,8 @@ impl WenlanClient {
     pub async fn move_space(&self, from: &str, to: &str) -> Result<usize> {
         let url = format!("{}/api/spaces/{}/move-to/{}", self.base_url, from, to);
         let resp = self
-            .http
-            .post(&url)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(self.http.post(&url), &format!("POST {} failed", url))
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -370,11 +382,11 @@ impl WenlanClient {
     pub async fn list_spaces(&self) -> Result<Vec<wenlan_types::Space>> {
         let url = format!("{}/api/spaces", self.base_url);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed", url))?;
+            .send(
+                self.http.get(&url),
+                &format!("GET {} failed (is the daemon running?)", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -385,11 +397,8 @@ impl WenlanClient {
     pub async fn get_default_space(&self) -> Result<DefaultSpaceResponse> {
         let url = format!("{}/api/spaces/default", self.base_url);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed", url))?
+            .send(self.http.get(&url), &format!("GET {} failed", url))
+            .await?
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
         resp.json()
@@ -401,12 +410,13 @@ impl WenlanClient {
     pub async fn set_default_space(&self, space_id: String) -> Result<DefaultSpaceResponse> {
         let url = format!("{}/api/spaces/default", self.base_url);
         let resp = self
-            .http
-            .put(&url)
-            .json(&SetDefaultSpaceRequest { space_id })
-            .send()
-            .await
-            .with_context(|| format!("PUT {} failed", url))?
+            .send(
+                self.http
+                    .put(&url)
+                    .json(&SetDefaultSpaceRequest { space_id }),
+                &format!("PUT {} failed", url),
+            )
+            .await?
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
         resp.json()
@@ -417,11 +427,8 @@ impl WenlanClient {
     /// DELETE /api/spaces/default — clear the daemon-owned default save Space.
     pub async fn clear_default_space(&self) -> Result<()> {
         let url = format!("{}/api/spaces/default", self.base_url);
-        self.http
-            .delete(&url)
-            .send()
-            .await
-            .with_context(|| format!("DELETE {} failed", url))?
+        self.send(self.http.delete(&url), &format!("DELETE {} failed", url))
+            .await?
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
         Ok(())
@@ -431,12 +438,11 @@ impl WenlanClient {
     pub async fn update_agent(&self, name: &str, req: UpdateAgentRequest) -> Result<AgentResponse> {
         let url = format!("{}/api/agents/{}", self.base_url, name);
         let resp = self
-            .http
-            .put(&url)
-            .json(&req)
-            .send()
-            .await
-            .with_context(|| format!("PUT {} failed", url))?;
+            .send(
+                self.http.put(&url).json(&req),
+                &format!("PUT {} failed", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -452,11 +458,11 @@ impl WenlanClient {
             self.base_url, limit
         );
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed (is the daemon running?)", url))?;
+            .send(
+                self.http.get(&url),
+                &format!("GET {} failed (is the daemon running?)", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -470,11 +476,8 @@ impl WenlanClient {
     pub async fn accept_revision(&self, id: &str) -> Result<RevisionAcceptResponse> {
         let url = format!("{}/api/memory/revision/{}/accept", self.base_url, id);
         let resp = self
-            .http
-            .post(&url)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(self.http.post(&url), &format!("POST {} failed", url))
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -488,11 +491,8 @@ impl WenlanClient {
     pub async fn dismiss_revision(&self, id: &str) -> Result<RevisionDismissResponse> {
         let url = format!("{}/api/memory/revision/{}/dismiss", self.base_url, id);
         let resp = self
-            .http
-            .post(&url)
-            .send()
-            .await
-            .with_context(|| format!("POST {} failed", url))?;
+            .send(self.http.post(&url), &format!("POST {} failed", url))
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
@@ -507,16 +507,48 @@ impl WenlanClient {
     pub async fn get_memory_detail(&self, source_id: &str) -> Result<MemoryDetailResponse> {
         let url = format!("{}/api/memory/{}/detail", self.base_url, source_id);
         let resp = self
-            .http
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("GET {} failed (is the daemon running?)", url))?;
+            .send(
+                self.http.get(&url),
+                &format!("GET {} failed (is the daemon running?)", url),
+            )
+            .await?;
         let resp = resp
             .error_for_status()
             .with_context(|| format!("daemon returned error for {}", url))?;
         resp.json()
             .await
             .context("parsing /api/memory/{id}/detail response")
+    }
+}
+
+fn build_list_request(
+    limit: Option<usize>,
+    memory_type: Option<String>,
+    confirmed: Option<bool>,
+) -> ListMemoriesRequest {
+    ListMemoriesRequest {
+        memory_type,
+        space: None,
+        limit: limit.unwrap_or(100),
+        confirmed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_list_request;
+
+    #[test]
+    fn list_request_can_filter_unconfirmed_memories() {
+        let request = build_list_request(Some(20), None, Some(false));
+        let json = serde_json::to_value(request).expect("serialize list request");
+        assert_eq!(json["confirmed"], false);
+    }
+
+    #[test]
+    fn list_request_omits_confirmation_filter_by_default() {
+        let request = build_list_request(Some(20), None, None);
+        let json = serde_json::to_value(request).expect("serialize list request");
+        assert!(json.get("confirmed").is_none());
     }
 }

--- a/crates/wenlan-cli/src/client/lint.rs
+++ b/crates/wenlan-cli/src/client/lint.rs
@@ -33,12 +33,15 @@ impl WenlanClient {
             Some(submission) => self.http.post(&url).query(&query).json(submission),
             None => self.http.get(&url).query(&query),
         };
-        let response = request.send().await.with_context(|| {
-            format!(
-                "{} {url} failed",
-                if submission.is_some() { "POST" } else { "GET" }
+        let response = self
+            .send(
+                request,
+                &format!(
+                    "{} {url} failed",
+                    if submission.is_some() { "POST" } else { "GET" }
+                ),
             )
-        })?;
+            .await?;
         let status = response.status();
         let body = read_lint_body(response, &url).await?;
         if !status.is_success() {

--- a/crates/wenlan-cli/src/client/recovery.rs
+++ b/crates/wenlan-cli/src/client/recovery.rs
@@ -20,7 +20,25 @@ pub(crate) fn autostart_allowed_from_env(recovery_enabled: bool) -> bool {
     autostart_allowed(env_no_autostart, recovery_enabled)
 }
 
+pub(crate) fn is_local_daemon_url(base_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(base_url) else {
+        return false;
+    };
+    matches!(
+        url.host_str(),
+        Some("127.0.0.1" | "localhost" | "::1" | "[::1]")
+    )
+}
+
 pub(crate) async fn recover(base_url: &str) -> Result<()> {
+    if !is_local_daemon_url(base_url) {
+        anyhow::bail!("recovery is only supported for a loopback daemon");
+    }
+    if service::autostart_off_marker_exists() {
+        anyhow::bail!(
+            "daemon stopped by `wenlan background off` — run `wenlan background on` to enable it again"
+        );
+    }
     if !service::is_installed() {
         anyhow::bail!(NO_SERVICE_HINT);
     }
@@ -29,33 +47,45 @@ pub(crate) async fn recover(base_url: &str) -> Result<()> {
         "wenlan: daemon not reachable — starting {}…",
         service::SERVICE_LABEL
     );
-    service::start_registered().context("start registered daemon service")?;
+    service::start_registered(false).context("start registered daemon service")?;
 
     let health_url = format!("{base_url}/api/health");
+    poll_health(&health_url, Duration::from_secs(10)).await
+}
+
+pub(crate) async fn poll_health(url: &str, deadline: Duration) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(1))
         .build()
         .context("building daemon recovery client")?;
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline_at = Instant::now() + deadline;
     loop {
-        if let Ok(response) = client.get(&health_url).send().await {
+        if let Ok(response) = client.get(url).send().await {
             if response.status().is_success() {
                 return Ok(());
             }
         }
         let now = Instant::now();
-        if now >= deadline {
+        if now >= deadline_at {
             break;
         }
-        tokio::time::sleep((deadline - now).min(Duration::from_millis(500))).await;
+        tokio::time::sleep((deadline_at - now).min(Duration::from_millis(500))).await;
     }
 
-    anyhow::bail!("daemon did not become healthy within 10s after start");
+    anyhow::bail!("daemon did not become healthy within {deadline:?} after start");
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{autostart_allowed, NO_SERVICE_HINT};
+    use super::{autostart_allowed, is_local_daemon_url, poll_health, NO_SERVICE_HINT};
+    use std::io::Write;
+    use std::net::TcpListener;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn autostart_requires_recovery_and_no_non_empty_opt_out() {
@@ -70,6 +100,60 @@ mod tests {
         assert_eq!(
             NO_SERVICE_HINT,
             "daemon not reachable and no background service is registered — run `wenlan background on`"
+        );
+    }
+
+    #[test]
+    fn local_daemon_url_accepts_only_loopback_hosts() {
+        assert!(is_local_daemon_url("http://127.0.0.1:7878"));
+        assert!(is_local_daemon_url("https://localhost/api/health"));
+        assert!(is_local_daemon_url("http://[::1]:7878"));
+        assert!(!is_local_daemon_url("http://example.com:7878"));
+        assert!(!is_local_daemon_url("http://127.0.0.1.example.com:7878"));
+        assert!(!is_local_daemon_url("not a URL"));
+    }
+
+    #[tokio::test]
+    async fn poll_health_respects_deadline_for_unhealthy_server() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind health stub");
+        listener
+            .set_nonblocking(true)
+            .expect("make health stub nonblocking");
+        let url = format!(
+            "http://{}/api/health",
+            listener.local_addr().expect("health stub address")
+        );
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_server = Arc::clone(&stop);
+        let server = thread::spawn(move || {
+            while !stop_server.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .write_all(
+                                b"HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            )
+                            .expect("write unhealthy response");
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("health stub accept failed: {error}"),
+                }
+            }
+        });
+
+        let deadline = Duration::from_secs(1);
+        let started = Instant::now();
+        let result = poll_health(&url, deadline).await;
+        let elapsed = started.elapsed();
+        stop.store(true, Ordering::Relaxed);
+        server.join().expect("health stub thread");
+
+        assert!(result.is_err(), "503 health responses must not pass");
+        assert!(
+            elapsed < deadline + Duration::from_secs(1),
+            "poll_health exceeded its bound: {elapsed:?}"
         );
     }
 }

--- a/crates/wenlan-cli/src/client/recovery.rs
+++ b/crates/wenlan-cli/src/client/recovery.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Connection recovery for the CLI's registered daemon service.
+
+use anyhow::{Context, Result};
+use std::time::{Duration, Instant};
+
+use crate::commands::service;
+
+pub(crate) const NO_SERVICE_HINT: &str =
+    "daemon not reachable and no background service is registered — run `wenlan background on`";
+
+pub(crate) fn autostart_allowed(env_no_autostart: Option<&str>, recovery_enabled: bool) -> bool {
+    recovery_enabled && matches!(env_no_autostart, None | Some(""))
+}
+
+pub(crate) fn autostart_allowed_from_env(recovery_enabled: bool) -> bool {
+    let env_no_autostart = std::env::var_os("WENLAN_NO_AUTOSTART")
+        .filter(|value| !value.is_empty())
+        .map(|_| "set");
+    autostart_allowed(env_no_autostart, recovery_enabled)
+}
+
+pub(crate) async fn recover(base_url: &str) -> Result<()> {
+    if !service::is_installed() {
+        anyhow::bail!(NO_SERVICE_HINT);
+    }
+
+    eprintln!(
+        "wenlan: daemon not reachable — starting {}…",
+        service::SERVICE_LABEL
+    );
+    service::start_registered().context("start registered daemon service")?;
+
+    let health_url = format!("{base_url}/api/health");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(1))
+        .build()
+        .context("building daemon recovery client")?;
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(response) = client.get(&health_url).send().await {
+            if response.status().is_success() {
+                return Ok(());
+            }
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            break;
+        }
+        tokio::time::sleep((deadline - now).min(Duration::from_millis(500))).await;
+    }
+
+    anyhow::bail!("daemon did not become healthy within 10s after start");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{autostart_allowed, NO_SERVICE_HINT};
+
+    #[test]
+    fn autostart_requires_recovery_and_no_non_empty_opt_out() {
+        assert!(autostart_allowed(None, true));
+        assert!(autostart_allowed(Some(""), true));
+        assert!(!autostart_allowed(Some("1"), true));
+        assert!(!autostart_allowed(None, false));
+    }
+
+    #[test]
+    fn no_service_hint_is_actionable() {
+        assert_eq!(
+            NO_SERVICE_HINT,
+            "daemon not reachable and no background service is registered — run `wenlan background on`"
+        );
+    }
+}

--- a/crates/wenlan-cli/src/commands/list.rs
+++ b/crates/wenlan-cli/src/commands/list.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! `wenlan memories [--limit N] [--type X]` — POST /api/memory/list.
+//! `wenlan memories [--limit N] [--type X] [--pending]` — POST /api/memory/list.
 
 use anyhow::Result;
 use wenlan_types::responses::ListMemoriesResponse;
@@ -13,8 +13,11 @@ pub async fn run(
     quiet: bool,
     limit: usize,
     memory_type: Option<String>,
+    pending: bool,
 ) -> Result<()> {
-    let resp = client.list(Some(limit), memory_type).await?;
+    let resp = client
+        .list(Some(limit), memory_type, pending.then_some(false))
+        .await?;
     if quiet {
         return Ok(());
     }

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -23,6 +23,7 @@ const SHUTDOWN_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_mi
 const SHUTDOWN_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from_secs(1);
 const SHUTDOWN_VERIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
 const DAEMON_PROCESS_ID_HEADER: &str = "x-wenlan-process-id";
+const AUTOSTART_OFF_MARKER: &str = "autostart.off";
 
 #[derive(Clone, Copy, Debug)]
 struct DaemonProcessIdentity {
@@ -163,17 +164,51 @@ fn current_server_path() -> Result<PathBuf> {
 
 /// Resolves the data root the daemon will use at runtime. Mirrors
 /// `crates/wenlan-server/src/main.rs` so launchd log paths line up with the
-/// on-disk layout the daemon owns. macOS-only because launchd is the only
-/// service backend that consumes pre-rendered log paths today.
-#[cfg(target_os = "macos")]
-fn origin_data_root() -> PathBuf {
-    std::env::var_os("WENLAN_DATA_DIR")
+/// on-disk layout the daemon owns.
+// TODO(PR 3): replace this local mirror with wenlan_core::config::data_root().
+fn data_root() -> PathBuf {
+    wenlan_core::env_compat::var_compat("WENLAN_DATA_DIR")
         .map(PathBuf::from)
         .unwrap_or_else(|| {
             dirs::data_local_dir()
                 .unwrap_or_else(|| PathBuf::from("."))
                 .join("wenlan")
         })
+}
+
+fn autostart_off_marker_path() -> PathBuf {
+    data_root().join(AUTOSTART_OFF_MARKER)
+}
+
+pub(crate) fn autostart_off_marker_exists() -> bool {
+    autostart_off_marker_path().is_file()
+}
+
+fn write_autostart_off_marker() -> Result<PathBuf> {
+    let path = autostart_off_marker_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create Wenlan data root for {}", parent.display()))?;
+    }
+    std::fs::write(&path, b"")
+        .with_context(|| format!("write autostart marker {}", path.display()))?;
+    Ok(path)
+}
+
+fn remove_autostart_off_marker() -> Result<()> {
+    let path = autostart_off_marker_path();
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(error).with_context(|| format!("remove autostart marker {}", path.display()))
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn origin_data_root() -> PathBuf {
+    data_root()
 }
 
 /// Builds a launchd plist that mirrors `service-manager`'s default output for
@@ -273,6 +308,7 @@ pub fn install() -> Result<()> {
             "create scheduled task",
         )?;
         run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
+        remove_autostart_off_marker()?;
         println!(
             "Installed and started Windows scheduled task '{}' (wenlan-server).",
             WINDOWS_TASK_NAME
@@ -340,6 +376,7 @@ pub fn install() -> Result<()> {
 
     m.start(ServiceStartCtx { label: label_value })
         .context("start service")?;
+    remove_autostart_off_marker()?;
     println!("Installed and started {}.", SERVICE_LABEL);
     Ok(())
 }
@@ -635,15 +672,24 @@ async fn stop() -> Result<()> {
         }
         Err(error) => return Err(error),
     };
+    let marker = write_autostart_off_marker()?;
     if registration_present {
-        println!("Stopped {}. Background registration kept.", SERVICE_LABEL);
+        println!(
+            "Stopped {}. Background registration kept. Autostart disabled via {}.",
+            SERVICE_LABEL,
+            marker.display()
+        );
     } else if shutdown_requested {
         println!(
-            "Stopped {}. No background registration found.",
-            SERVICE_LABEL
+            "Stopped {}. No background registration found. Autostart disabled via {}.",
+            SERVICE_LABEL,
+            marker.display()
         );
     } else {
-        println!("Wenlan background process is already stopped; no registration found.");
+        println!(
+            "Wenlan background process is already stopped; no registration found. Autostart disabled via {}.",
+            marker.display()
+        );
     }
     Ok(())
 }
@@ -665,6 +711,7 @@ pub fn restart() -> Result<()> {
             .args(["/end", "/tn", WINDOWS_TASK_NAME])
             .output();
         run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
+        remove_autostart_off_marker()?;
         println!("Restarted Windows scheduled task '{}'.", WINDOWS_TASK_NAME);
         return Ok(());
     }
@@ -678,12 +725,13 @@ pub fn restart() -> Result<()> {
     });
     m.start(ServiceStartCtx { label: label_value })
         .context("start service")?;
+    remove_autostart_off_marker()?;
     println!("Restarted {}.", SERVICE_LABEL);
     Ok(())
 }
 
 /// Start the already-registered Wenlan service without stopping or replacing it.
-pub fn start_registered() -> Result<()> {
+pub fn start_registered(explicit_user_command: bool) -> Result<()> {
     if !is_installed() {
         anyhow::bail!("Wenlan background process is not set up. Run `wenlan background on` first.");
     }
@@ -691,14 +739,21 @@ pub fn start_registered() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
         run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
+        if explicit_user_command {
+            remove_autostart_off_marker()?;
+        }
         return Ok(());
     }
 
     #[cfg_attr(target_os = "windows", allow(unreachable_code))]
     let label_value = label()?;
     let m = manager()?;
+    // The service manager may unload/load when the plist carries Disabled: true.
     m.start(ServiceStartCtx { label: label_value })
         .context("start service")?;
+    if explicit_user_command {
+        remove_autostart_off_marker()?;
+    }
     Ok(())
 }
 

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -682,6 +682,26 @@ pub fn restart() -> Result<()> {
     Ok(())
 }
 
+/// Start the already-registered Wenlan service without stopping or replacing it.
+pub fn start_registered() -> Result<()> {
+    if !is_installed() {
+        anyhow::bail!("Wenlan background process is not set up. Run `wenlan background on` first.");
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
+        return Ok(());
+    }
+
+    #[cfg_attr(target_os = "windows", allow(unreachable_code))]
+    let label_value = label()?;
+    let m = manager()?;
+    m.start(ServiceStartCtx { label: label_value })
+        .context("start service")?;
+    Ok(())
+}
+
 pub fn is_installed() -> bool {
     #[cfg(target_os = "windows")]
     {

--- a/crates/wenlan-cli/src/main.rs
+++ b/crates/wenlan-cli/src/main.rs
@@ -150,6 +150,9 @@ enum Commands {
         /// Filter by memory type.
         #[arg(short = 't', long = "type")]
         memory_type: Option<String>,
+        /// Only unconfirmed memories (what the MCP list_pending tool returns).
+        #[arg(long)]
+        pending: bool,
     },
     /// Walk pending revisions (conflicts / merges) awaiting your accept or dismiss.
     Curate {
@@ -176,7 +179,12 @@ async fn main() -> anyhow::Result<ExitCode> {
     }
     let environment_agent = std::env::var("WENLAN_AGENT_NAME").ok();
     let agent_name = resolve_agent_name(cli.agent_name.as_deref(), environment_agent.as_deref());
-    let base_client = client::WenlanClient::from_env_with_context(agent_name.as_deref(), None)?;
+    let recovery_enabled = !matches!(
+        &cli.command,
+        Commands::Status | Commands::Background { .. } | Commands::Restart
+    );
+    let base_client = client::WenlanClient::from_env_with_context(agent_name.as_deref(), None)?
+        .with_recovery(recovery_enabled);
     let is_brief_update = matches!(
         &cli.command,
         Commands::Brief(args) if args.command.is_some()
@@ -210,6 +218,7 @@ async fn main() -> anyhow::Result<ExitCode> {
             agent_name.as_deref(),
             context.space.as_deref(),
         )?
+        .with_recovery(recovery_enabled)
     } else if is_brief_update {
         let strict_space = std::env::var("WENLAN_SPACE").ok();
         effective_cli_space =
@@ -218,6 +227,7 @@ async fn main() -> anyhow::Result<ExitCode> {
             agent_name.as_deref(),
             effective_cli_space.as_deref(),
         )?
+        .with_recovery(recovery_enabled)
     } else if is_lint {
         let strict_space = std::env::var("WENLAN_SPACE").ok();
         effective_cli_space = resolve_native_read_space(
@@ -297,9 +307,11 @@ async fn main() -> anyhow::Result<ExitCode> {
             file,
             memory_type,
         } => commands::store::run(&client, format, cli.quiet, text, file, memory_type).await?,
-        Commands::Memories { limit, memory_type } => {
-            commands::list::run(&client, format, cli.quiet, limit, memory_type).await?
-        }
+        Commands::Memories {
+            limit,
+            memory_type,
+            pending,
+        } => commands::list::run(&client, format, cli.quiet, limit, memory_type, pending).await?,
         Commands::Curate { action } => {
             commands::curate::run(&client, format, cli.quiet, action).await?
         }

--- a/crates/wenlan-cli/tests/brief_cli.rs
+++ b/crates/wenlan-cli/tests/brief_cli.rs
@@ -17,7 +17,9 @@ struct Recorded {
 }
 
 fn cli() -> Command {
-    Command::cargo_bin("wenlan").unwrap()
+    let mut command = Command::cargo_bin("wenlan").unwrap();
+    command.env("WENLAN_NO_AUTOSTART", "1");
+    command
 }
 
 fn response(body: &str) -> String {

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -8,7 +8,9 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 fn cli() -> Command {
-    Command::cargo_bin("wenlan").expect("origin binary built")
+    let mut command = Command::cargo_bin("wenlan").expect("origin binary built");
+    command.env("WENLAN_NO_AUTOSTART", "1");
+    command
 }
 
 fn cli_with_isolated_runtime(runtime: &IsolatedRuntime) -> Command {
@@ -778,6 +780,69 @@ fn memories_reports_existing_connection_error_without_autostart() {
         .stderr(predicate::str::contains("starting com.wenlan.server").not());
 }
 
+#[cfg(unix)]
+#[test]
+fn autostart_reports_missing_service_without_starting_it() {
+    let home = tempfile::tempdir().expect("temp home");
+    let data = tempfile::tempdir().expect("temp data");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
+    let host = format!(
+        "http://{}",
+        listener.local_addr().expect("loopback address")
+    );
+    drop(listener);
+
+    let started = std::time::Instant::now();
+    cli()
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("WENLAN_DATA_DIR", data.path())
+        .env("WENLAN_HOST", &host)
+        .env_remove("WENLAN_NO_AUTOSTART")
+        .arg("memories")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "no background service is registered",
+        ))
+        .stderr(predicate::str::contains("starting com.wenlan.server").not());
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(3),
+        "missing-service recovery stalled: {:?}",
+        started.elapsed()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn autostart_honours_background_off_marker_without_starting_it() {
+    let home = tempfile::tempdir().expect("temp home");
+    let data = tempfile::tempdir().expect("temp data");
+    fs::write(data.path().join("autostart.off"), b"").expect("write autostart marker");
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
+    let host = format!(
+        "http://{}",
+        listener.local_addr().expect("loopback address")
+    );
+    drop(listener);
+
+    cli()
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env("XDG_CONFIG_HOME", home.path().join(".config"))
+        .env("WENLAN_DATA_DIR", data.path())
+        .env("WENLAN_HOST", &host)
+        .env_remove("WENLAN_NO_AUTOSTART")
+        .arg("memories")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "daemon stopped by `wenlan background off` — run `wenlan background on` to enable it again",
+        ))
+        .stderr(predicate::str::contains("starting com.wenlan.server").not());
+}
+
 #[test]
 fn status_table_uses_origin_host_for_health_probe() {
     let runtime = IsolatedRuntime::new();
@@ -937,6 +1002,7 @@ fn setup_background_status_roundtrip_isolated() {
         .stdout(predicate::str::contains(
             "Installed and started com.wenlan.server",
         ));
+    assert!(!runtime.data.path().join("autostart.off").exists());
 
     let plist = fs::read_to_string(runtime.service_unit_path()).expect("plist written");
     assert!(plist.contains("<string>com.wenlan.server</string>"));
@@ -995,8 +1061,10 @@ fn setup_background_status_roundtrip_isolated() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Stopped com.wenlan.server"))
+        .stdout(predicate::str::contains("autostart.off"))
         .stdout(predicate::str::contains("Uninstalled").not());
 
+    assert!(runtime.data.path().join("autostart.off").is_file());
     assert!(
         runtime.service_unit_path().exists(),
         "background off preserves the launchd plist"

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -23,6 +23,7 @@ fn cli_with_isolated_runtime(runtime: &IsolatedRuntime) -> Command {
         .env("USERPROFILE", runtime.home.path())
         .env("WENLAN_DATA_DIR", runtime.data.path())
         .env("WENLAN_HOST", "http://127.0.0.1:9")
+        .env("WENLAN_NO_AUTOSTART", "1")
         .env("WENLAN_BIND_ADDR", "127.0.0.1:9")
         .env("PATH", &joined);
     cmd
@@ -481,6 +482,15 @@ fn each_subcommand_has_help() {
 }
 
 #[test]
+fn memories_help_shows_pending_filter() {
+    cli()
+        .args(["memories", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--pending"));
+}
+
+#[test]
 fn removed_top_level_commands_are_not_advertised() {
     let output = cli()
         .arg("--help")
@@ -749,10 +759,23 @@ fn agents_edit_no_flags_bails() {
 fn status_json_succeeds_when_daemon_is_unreachable() {
     cli()
         .env("WENLAN_HOST", "http://127.0.0.1:9")
+        .env("WENLAN_NO_AUTOSTART", "1")
         .args(["status", "--format", "json"])
         .assert()
         .success()
         .stdout(predicate::str::contains("\"status\": \"unreachable\""));
+}
+
+#[test]
+fn memories_reports_existing_connection_error_without_autostart() {
+    cli()
+        .env("WENLAN_HOST", "http://127.0.0.1:9")
+        .env("WENLAN_NO_AUTOSTART", "1")
+        .args(["memories"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("(is the daemon running?)"))
+        .stderr(predicate::str::contains("starting com.wenlan.server").not());
 }
 
 #[test]

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -776,7 +776,9 @@ fn memories_reports_existing_connection_error_without_autostart() {
         .args(["memories"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("(is the daemon running?)"))
+        .stderr(predicate::str::contains(
+            "GET http://127.0.0.1:9/api/spaces failed",
+        ))
         .stderr(predicate::str::contains("starting com.wenlan.server").not());
 }
 

--- a/crates/wenlan-cli/tests/enrichment_cli.rs
+++ b/crates/wenlan-cli/tests/enrichment_cli.rs
@@ -10,6 +10,7 @@ use std::thread;
 
 fn cli(base: &str) -> Command {
     let mut cmd = Command::cargo_bin("wenlan").expect("wenlan binary built");
+    cmd.env("WENLAN_NO_AUTOSTART", "1");
     cmd.env("WENLAN_HOST", base);
     cmd
 }

--- a/crates/wenlan-cli/tests/ingest_cli.rs
+++ b/crates/wenlan-cli/tests/ingest_cli.rs
@@ -15,7 +15,9 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 fn cli() -> Command {
-    Command::cargo_bin("wenlan").expect("wenlan binary built")
+    let mut command = Command::cargo_bin("wenlan").expect("wenlan binary built");
+    command.env("WENLAN_NO_AUTOSTART", "1");
+    command
 }
 
 #[derive(Clone, Debug)]

--- a/crates/wenlan-cli/tests/lint_cli.rs
+++ b/crates/wenlan-cli/tests/lint_cli.rs
@@ -15,7 +15,9 @@ use support::{
 };
 
 fn cli() -> Command {
-    Command::cargo_bin("wenlan").expect("wenlan binary built")
+    let mut command = Command::cargo_bin("wenlan").expect("wenlan binary built");
+    command.env("WENLAN_NO_AUTOSTART", "1");
+    command
 }
 
 #[test]

--- a/crates/wenlan-cli/tests/pages_cli.rs
+++ b/crates/wenlan-cli/tests/pages_cli.rs
@@ -3,7 +3,9 @@ use assert_cmd::Command;
 use serde_json::json;
 
 fn cli() -> Command {
-    Command::cargo_bin("wenlan").expect("wenlan binary built")
+    let mut command = Command::cargo_bin("wenlan").expect("wenlan binary built");
+    command.env("WENLAN_NO_AUTOSTART", "1");
+    command
 }
 
 #[test]

--- a/crates/wenlan-cli/tests/space_cli.rs
+++ b/crates/wenlan-cli/tests/space_cli.rs
@@ -8,7 +8,9 @@
 use assert_cmd::Command;
 
 fn cli() -> Command {
-    Command::cargo_bin("wenlan").expect("origin binary built")
+    let mut command = Command::cargo_bin("wenlan").expect("origin binary built");
+    command.env("WENLAN_NO_AUTOSTART", "1");
+    command
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

When the daemon is down, every `wenlan` command failed with `GET … failed (is the daemon running?)` and nothing tried to bring it back — the end-of-session handoff then failed too. Part of the handoff-durability plan (`~/.wenlan/specs/wenlan/2026-08-16-handoff-durability.md`, PR 2 of 4; PR 1 = #543).

## What

- **Connection recovery in the CLI client** (`crates/wenlan-cli/src/client.rs`, new `client/recovery.rs`): all requests go through one `send()`. On a connect error to a **loopback** daemon it starts the *registered* background service (`service::start_registered`, start only — never stop/restart, never spawns `wenlan-server` directly), polls `/api/health` for up to 10 s, then retries the request once. Skipped when `WENLAN_NO_AUTOSTART` is set, when `WENLAN_HOST` is not loopback, for `status` / `background` / `restart`, and when `wenlan background off` left its `autostart.off` marker in the data root (`background on` / `restart` clear it). No registered service → clear hint: `daemon not reachable and no background service is registered — run \`wenlan background on\``.
- **`wenlan memories --pending`**: unconfirmed memories only (what the MCP `list_pending` tool returns); `WenlanClient::list()` gained `confirmed: Option<bool>`.
- README: troubleshooting notes for both.

## Proof (real binary, real surfaces; the live service was never started)

- Closed loopback port + `WENLAN_NO_AUTOSTART=1` → original error text, no start line.
- Remote host (`WENLAN_HOST=http://10.255.255.1:1`) → plain error in ~1 s, no start.
- Scratch `HOME` without a plist → the "no background service is registered" hint.
- Scratch `HOME` with a plist + `autostart.off` marker → the "stopped by `wenlan background off`" hint.
- `wenlan status --format json` on a closed port → `unreachable` with the unchanged health error text.
- `wenlan --space wenlan memories --pending` against the live daemon → only `confirmed: false` items.
- Gates: `cargo fmt --check`, `cargo clippy -p wenlan --all-targets -D warnings`, `cargo test -p wenlan` (all green; new tests: loopback predicate, `poll_health` deadline against a 503 stub, no-service hint path, marker path; every test helper sets `WENLAN_NO_AUTOSTART=1`).

## Review

One independent review (fix-first): remote-host recovery bug → fixed with the loopback gate; `background off` undone by the next command → marker file; test helpers could reach the real service → opt-out in every helper; recovery had no coverage → tests above; minor items applied (`{:#}` error chain, README, comment on service-manager unload/load). Skipped by choice: turning `send()`'s message argument into a closure (churn, no behaviour change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MMV7MaFTEnTvT1eC8gRvU
