### PR TITLE
feat(plugin): handoff skill runs CLI-only and survives a down daemon; SessionStart hook reports outbox counts

### DIFF
--- a/plugin-codex/skills/handoff/SKILL.md
+++ b/plugin-codex/skills/handoff/SKILL.md
@@ -4,7 +4,7 @@ description: >
   End a Codex work session. Stores durable captures, writes a narrative session
   log, and automatically applies typed item-level deltas to the current Space
   Brief. Invoked as /handoff.
-allowed-tools: ["Bash", "mcp__wenlan__capture", "mcp__wenlan__list_pending"]
+allowed-tools: ["Bash"]
 user-invocable: true
 ---
 
@@ -33,7 +33,8 @@ if [ -n "$repo" ]; then
 else
   project=""
 fi
-resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" 2>/dev/null)"
+handoff_arg="<the Space name passed to /handoff, empty when none>"
+resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" --arg "$handoff_arg" 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 if [ -z "$space" ] && [ -n "$project" ]; then
@@ -41,6 +42,9 @@ if [ -z "$space" ] && [ -n "$project" ]; then
   source_layer="cwd-repo-new"
 fi
 ```
+
+If the user passed a Space name (`/wenlan:handoff <space>`), pass it as
+`--arg <space>` to resolve-space.sh.
 
 Print `space` and `source_layer`. Explicit pins, defaults, and mappings still
 win. `cwd-repo-new` is the approved first-handoff fallback: use the canonical
@@ -50,7 +54,9 @@ Do not invent any other Space name.
 Outside a Git repository, do not derive a new Space from the directory
 basename. If resolution still leaves `space` empty, skip the Brief read and
 typed update, do not issue Space-scoped captures, and continue with the
-unscoped session log and any unscoped durable captures.
+unscoped session log and any unscoped durable captures. Outside a Git
+repository, a pin, explicit argument, default, or mapping still resolves a
+Space, and the Brief update and captures still run.
 
 ## 2. Read the Brief before composing deltas
 
@@ -58,6 +64,7 @@ unscoped session log and any unscoped durable captures.
 W="$(command -v wenlan || echo "$HOME/.wenlan/bin/wenlan")"
 brief_before=""
 brief_absent=0
+daemon_down=0
 if [ -n "$space" ]; then
   if [ "$source_layer" = "cwd-repo-new" ]; then
     space_probe_status=0
@@ -67,12 +74,27 @@ if [ -n "$space" ]; then
       source_layer="cwd-repo"
     elif [ "$space_probe" = "Error: space '$space' not found" ]; then
       brief_absent=1
+    elif printf '%s' "$space_probe" | grep -qE 'tcp connect error|daemon not reachable'; then
+      daemon_down=1
+      brief_before=""
+      echo "wenlan daemon unreachable — this handoff will queue its writes"
     else
       printf "%s\n" "$space_probe" >&2
       exit "$space_probe_status"
     fi
   else
-    brief_before="$("$W" --format json --space "$space" brief)"
+    brief_status=0
+    brief_output="$("$W" --format json --space "$space" brief 2>&1)" || brief_status=$?
+    if [ "$brief_status" -eq 0 ]; then
+      brief_before="$brief_output"
+    elif printf '%s' "$brief_output" | grep -qE 'tcp connect error|daemon not reachable'; then
+      daemon_down=1
+      brief_before=""
+      echo "wenlan daemon unreachable — this handoff will queue its writes"
+    else
+      printf "%s\n" "$brief_output" >&2
+      exit "$brief_status"
+    fi
   fi
 fi
 ```
@@ -92,16 +114,32 @@ typed update may then create the Space and Brief.
 
 ## 3. Preview pending captures and gather evidence
 
-Call `mcp__wenlan__list_pending(limit=50)`. Filter by
-`created_at >= last_handoff_at`, or 12 hours ago when absent. Show at most three
-when any match, then continue automatically; `/curate captures` remains opt-in.
+Best-effort; skip silently when `daemon_down=1` or the command fails:
+
+```bash
+"$W" --format json --space "$space" memories --pending -l 50
+```
+
+Filter by `created_at >= last_handoff_at`, or 12 hours ago when absent. Show
+at most three when any match, then continue automatically; `/curate captures`
+remains opt-in.
 
 For a repository, inspect a bounded recent log, short status, diff stat, and
 worktree list. Combine that evidence with the conversation. Draft atomic
 captures only for durable decisions, lessons, gotchas, corrections,
 preferences, and facts. Skip transient or git-recoverable state.
 
-## 4. Build and apply one typed Brief update
+## 4. Write the session log
+
+Write `~/.wenlan/sessions/<YYYY-MM-DD-HHmm>-<slug>.md` with Accomplished,
+Decisions, Lessons & Gotchas, Open Threads, Captures stored, and Git summary.
+This is narrative history, not current-work authority. It is a plain file and
+must never depend on the daemon, so write it before the Brief update.
+
+Best-effort commit the logical `~/.wenlan/` file batch; do not fail if no
+repository is configured or a commit races.
+
+## 5. Build and apply one typed Brief update
 
 Compare the session outcome with `brief_before` and write one
 `BriefUpdateRequest` JSON file:
@@ -119,7 +157,11 @@ Compare the session outcome with `brief_before` and write one
 }
 ```
 
-Use the existing Brief version instead of `0` when present.
+Use the existing Brief version instead of `0` when present. When
+`daemon_down=1`, use `expected_version: 0` — the daemon reconciles the
+summary version when it replays the queued file — and author only `add`
+mutations; do not author `edit`, `move`, `set_gate`, or `complete` without a
+Brief snapshot.
 If `space` is empty, skip this typed update entirely.
 
 - `add`: genuinely new open work, in `active` or `backlog`, with an optional
@@ -139,38 +181,34 @@ Apply exactly once:
 ```
 
 Do not ask approval for this normal handoff update. Interpret `applied`,
-`conflicts`, `projection_path`, and `warnings` independently. Non-overlapping
-changes may commit while a stale same-item delta conflicts. Re-read before any
-safe mechanical reconciliation; never guess.
+`conflicts`, `projection_path`, and `warnings` independently. A `"status":
+"queued"` result is success-queued: record the outbox path and report it as
+queued, not applied. Non-overlapping changes may commit while a stale
+same-item delta conflicts. Re-read before any safe mechanical reconciliation;
+never guess.
 
 Apply the Brief update before Space-scoped captures when this fallback is new.
 That creates the basename Space through the typed handoff path without making a
 read or a capture create state. If this first update fails, stop Space-scoped
-captures and report the exact failure.
+captures and report the exact failure. A queued result is not a failure.
 
-## 5. Store durable captures
+## 6. Store durable captures
 
-For each drafted durable item, call:
+For each drafted durable item, run one command:
 
-```text
-mcp__wenlan__capture(
-  content="<self-contained statement with why>",
-  memory_type="<decision|lesson|gotcha|preference|fact>",
-  space="<resolved Space>"
-)
+```bash
+"$W" --format json --space "$space" capture -t <type> "<content>"
 ```
 
-Use one atomic item per call. Do not ask about ordinary captures. Pause only
-for a contradiction, critical incident, irreversible production action, or
-genuine durability ambiguity.
+Use one atomic item per call. A `"status": "queued"` result counts as
+queued, not failed — record the path. Do not ask about ordinary captures.
+Pause only for a contradiction, critical incident, irreversible production
+action, or genuine durability ambiguity.
 
-## 6. Write the session log and report
+## 7. Report
 
-Write `~/.wenlan/sessions/<YYYY-MM-DD-HHmm>-<slug>.md` with Accomplished,
-Decisions, Lessons & Gotchas, Open Threads, Captures stored, and Git summary.
-This is narrative history, not current-work authority.
-
-Best-effort commit the logical `~/.wenlan/` file batch; do not fail if no
-repository is configured or a commit races. Report capture counts, session-log
-path, applied/conflicted Brief deltas, Brief version, and projection path or
-warning.
+Report capture counts (stored vs queued), session-log path,
+applied/conflicted/queued Brief deltas, Brief version or outbox path, and
+projection path or warning. When anything queued, add: `N handoff write(s)
+queued in the outbox — they apply when the daemon is back (`wenlan outbox
+status`).`

--- a/plugin/.claude-plugin/README.md
+++ b/plugin/.claude-plugin/README.md
@@ -60,7 +60,7 @@ Reload the plugin (`/reload-plugins`) and the wrapper picks the local binary on 
 /handoff    end-of-session debrief
 ```
 
-A `SessionStart` hook (`hooks/check-daemon.sh`) probes the local runtime at `127.0.0.1:7878`. If down, it prints a single line: `local runtime not running. Run /wenlan:setup to set up.` The skill owns the install logic — the hook is just a nudge. Hook never blocks the session.
+A `SessionStart` hook (`hooks/check-daemon.sh`) probes the local runtime at `127.0.0.1:7878`. If down, it prints a single line: `local runtime not running. Handoff writes will queue in the outbox; run /wenlan:setup or \`wenlan background on\`.` The skill owns the install logic — the hook is just a nudge. Hook never blocks the session.
 
 ## Where your data lives
 

--- a/plugin/hooks/check-daemon.sh
+++ b/plugin/hooks/check-daemon.sh
@@ -6,8 +6,27 @@
 # Hook never blocks (always exit 0) and never prints command soup.
 set -u
 
-URL="http://127.0.0.1:7878/api/health"
+URL="${WENLAN_HEALTH_URL:-http://127.0.0.1:7878/api/health}"
+W="${WENLAN_CLI:-$(command -v wenlan || echo "$HOME/.wenlan/bin/wenlan")}"
 PLUGIN_JSON="${CLAUDE_PLUGIN_ROOT:-}/.claude-plugin/plugin.json"
+
+# Print a one-line outbox report when queued or failed writes exist. Silent
+# on any error (old CLI without the subcommand, no python3, bad JSON).
+report_outbox() {
+  [ -x "$W" ] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  status=$("$W" --format json outbox status 2>/dev/null) || return 0
+  printf '%s' "$status" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    q, f = d.get("queued", 0), d.get("failed", 0)
+    if q > 0 or f > 0:
+        print(f"[wenlan] outbox: {q} queued handoff write(s), {f} failed — run \`wenlan outbox status\`.")
+except Exception:
+    pass
+' 2>/dev/null
+}
 
 RESP=""
 for i in 1 2 3; do
@@ -17,10 +36,13 @@ done
 
 if [ -z "$RESP" ]; then
   cat <<MSG
-[wenlan] local runtime not running. Run /wenlan:setup to set up.
+[wenlan] local runtime not running. Handoff writes will queue in the outbox; run /wenlan:setup or \`wenlan background on\`.
 MSG
+  report_outbox
   exit 0
 fi
+
+report_outbox
 
 # Compare daemon version vs plugin manifest version. Silent unless mismatch.
 [ -r "$PLUGIN_JSON" ] || exit 0

--- a/plugin/hooks/test-check-daemon.sh
+++ b/plugin/hooks/test-check-daemon.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Bash tests for check-daemon.sh outbox reporting. No network reachable: a
+# closed port always drives the not-running branch.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/check-daemon.sh"
+tmpbase="$(mktemp -d)"
+trap 'rm -rf "$tmpbase"' EXIT
+
+pass=0
+fail=0
+
+check() {
+    name="$1"; expect="$2"; shift 2
+    case "$1" in
+        contains)
+            case "$2" in *"$expect"*) ok=1 ;; *) ok=0 ;; esac ;;
+        missing)
+            case "$2" in *"$expect"*) ok=0 ;; *) ok=1 ;; esac ;;
+    esac
+    if [ "$ok" -eq 1 ]; then
+        printf 'PASS  %s\n' "$name"; pass=$((pass + 1))
+    else
+        printf 'FAIL  %s\n  needle: %s\n  got:    %s\n' "$name" "$expect" "$2" >&2
+        fail=$((fail + 1))
+    fi
+}
+
+stub="$tmpbase/wenlan"
+cat > "$stub" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "--format" ] && [ "$2" = "json" ] && [ "$3" = "outbox" ] && [ "$4" = "status" ]; then
+    printf '%s\n' "$OUTBOX_JSON"
+    exit 0
+fi
+exit 1
+EOF
+chmod +x "$stub"
+
+HEALTH='http://127.0.0.1:1/api/health'
+
+out=$(OUTBOX_JSON='{"queued":2,"failed":1}' WENLAN_HEALTH_URL="$HEALTH" WENLAN_CLI="$stub" bash "$HOOK" 2>&1)
+rc=$?
+check 'not-running line present' 'local runtime not running' contains "$out"
+check 'outbox counts reported' '2 queued handoff write(s), 1 failed' contains "$out"
+[ "$rc" -eq 0 ] || { echo "FAIL exit 0 with queued+failed (got $rc)" >&2; fail=$((fail + 1)); }
+
+out=$(OUTBOX_JSON='{"queued":0,"failed":0}' WENLAN_HEALTH_URL="$HEALTH" WENLAN_CLI="$stub" bash "$HOOK" 2>&1)
+rc=$?
+check 'no outbox line when empty' 'outbox:' missing "$out"
+[ "$rc" -eq 0 ] || { echo "FAIL exit 0 with empty outbox (got $rc)" >&2; fail=$((fail + 1)); }
+
+out=$(WENLAN_HEALTH_URL="$HEALTH" WENLAN_CLI='/nonexistent' bash "$HOOK" 2>&1)
+rc=$?
+check 'no outbox line when CLI missing' 'outbox:' missing "$out"
+[ "$rc" -eq 0 ] || { echo "FAIL exit 0 with missing CLI (got $rc)" >&2; fail=$((fail + 1)); }
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/plugin/skills/handoff/SKILL.md
+++ b/plugin/skills/handoff/SKILL.md
@@ -4,7 +4,7 @@ description: >
   End a work session. Stores durable captures, writes a narrative session log,
   and automatically applies typed item-level deltas to the current Space Brief.
   Invoked as `/handoff`.
-allowed-tools: ["Bash", "mcp__plugin_wenlan_wenlan__capture", "mcp__plugin_wenlan_wenlan__list_pending"]
+allowed-tools: ["Bash"]
 ---
 
 # /handoff
@@ -32,7 +32,8 @@ if [ -n "$repo" ]; then
 else
   project=""
 fi
-resolved="$("$CLAUDE_PLUGIN_ROOT/bin/resolve-space.sh" --cwd "$PWD" 2>/dev/null)"
+handoff_arg="<the Space name passed to /handoff, empty when none>"
+resolved="$("$CLAUDE_PLUGIN_ROOT/bin/resolve-space.sh" --cwd "$PWD" --arg "$handoff_arg" 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 if [ -z "$space" ] && [ -n "$project" ]; then
@@ -40,6 +41,9 @@ if [ -z "$space" ] && [ -n "$project" ]; then
   source_layer="cwd-repo-new"
 fi
 ```
+
+If the user passed a Space name (`/wenlan:handoff <space>`), pass it as
+`--arg <space>` to resolve-space.sh.
 
 Print `space` and `source_layer`. Explicit pins, defaults, and mappings still
 win. `cwd-repo-new` is the approved first-handoff fallback: use the canonical
@@ -49,7 +53,9 @@ Do not invent any other Space name.
 Outside a Git repository, do not derive a new Space from the directory
 basename. If resolution still leaves `space` empty, skip the Brief read and
 typed update, do not issue Space-scoped captures, and continue with the
-unscoped session log and any unscoped durable captures.
+unscoped session log and any unscoped durable captures. Outside a Git
+repository, a pin, explicit argument, default, or mapping still resolves a
+Space, and the Brief update and captures still run.
 
 ## 2. Read the Brief before composing deltas
 
@@ -57,6 +63,7 @@ unscoped session log and any unscoped durable captures.
 W="$(command -v wenlan || echo "$HOME/.wenlan/bin/wenlan")"
 brief_before=""
 brief_absent=0
+daemon_down=0
 if [ -n "$space" ]; then
   if [ "$source_layer" = "cwd-repo-new" ]; then
     space_probe_status=0
@@ -66,12 +73,27 @@ if [ -n "$space" ]; then
       source_layer="cwd-repo"
     elif [ "$space_probe" = "Error: space '$space' not found" ]; then
       brief_absent=1
+    elif printf '%s' "$space_probe" | grep -qE 'tcp connect error|daemon not reachable'; then
+      daemon_down=1
+      brief_before=""
+      echo "wenlan daemon unreachable — this handoff will queue its writes"
     else
       printf "%s\n" "$space_probe" >&2
       exit "$space_probe_status"
     fi
   else
-    brief_before="$("$W" --format json --space "$space" brief)"
+    brief_status=0
+    brief_output="$("$W" --format json --space "$space" brief 2>&1)" || brief_status=$?
+    if [ "$brief_status" -eq 0 ]; then
+      brief_before="$brief_output"
+    elif printf '%s' "$brief_output" | grep -qE 'tcp connect error|daemon not reachable'; then
+      daemon_down=1
+      brief_before=""
+      echo "wenlan daemon unreachable — this handoff will queue its writes"
+    else
+      printf "%s\n" "$brief_output" >&2
+      exit "$brief_status"
+    fi
   fi
 fi
 ```
@@ -91,16 +113,32 @@ typed update may then create the Space and Brief.
 
 ## 3. Preview pending captures and gather evidence
 
-Call `mcp__plugin_wenlan_wenlan__list_pending(limit=50)`. Filter by
-`created_at >= last_handoff_at`, or 12 hours ago when absent. Show at most three
-when any match, then continue automatically; `/curate captures` remains opt-in.
+Best-effort; skip silently when `daemon_down=1` or the command fails:
+
+```bash
+"$W" --format json --space "$space" memories --pending -l 50
+```
+
+Filter by `created_at >= last_handoff_at`, or 12 hours ago when absent. Show
+at most three when any match, then continue automatically; `/curate captures`
+remains opt-in.
 
 For a repository, inspect a bounded recent log, short status, diff stat, and
 worktree list. Combine that evidence with the conversation. Draft atomic
 captures only for durable decisions, lessons, gotchas, corrections,
 preferences, and facts. Skip transient or git-recoverable state.
 
-## 4. Build and apply one typed Brief update
+## 4. Write the session log
+
+Write `~/.wenlan/sessions/<YYYY-MM-DD-HHmm>-<slug>.md` with Accomplished,
+Decisions, Lessons & Gotchas, Open Threads, Captures stored, and Git summary.
+This is narrative history, not current-work authority. It is a plain file and
+must never depend on the daemon, so write it before the Brief update.
+
+Best-effort commit the logical `~/.wenlan/` file batch; do not fail if no
+repository is configured or a commit races.
+
+## 5. Build and apply one typed Brief update
 
 Compare the session outcome with `brief_before` and write one
 `BriefUpdateRequest` JSON file:
@@ -118,7 +156,11 @@ Compare the session outcome with `brief_before` and write one
 }
 ```
 
-Use the existing Brief version instead of `0` when present.
+Use the existing Brief version instead of `0` when present. When
+`daemon_down=1`, use `expected_version: 0` — the daemon reconciles the
+summary version when it replays the queued file — and author only `add`
+mutations; do not author `edit`, `move`, `set_gate`, or `complete` without a
+Brief snapshot.
 If `space` is empty, skip this typed update entirely.
 
 - `add`: genuinely new open work, in `active` or `backlog`, with an optional
@@ -138,38 +180,34 @@ Apply exactly once:
 ```
 
 Do not ask approval for this normal handoff update. Interpret `applied`,
-`conflicts`, `projection_path`, and `warnings` independently. Non-overlapping
-changes may commit while a stale same-item delta conflicts. Re-read before any
-safe mechanical reconciliation; never guess.
+`conflicts`, `projection_path`, and `warnings` independently. A `"status":
+"queued"` result is success-queued: record the outbox path and report it as
+queued, not applied. Non-overlapping changes may commit while a stale
+same-item delta conflicts. Re-read before any safe mechanical reconciliation;
+never guess.
 
 Apply the Brief update before Space-scoped captures when this fallback is new.
 That creates the basename Space through the typed handoff path without making a
 read or a capture create state. If this first update fails, stop Space-scoped
-captures and report the exact failure.
+captures and report the exact failure. A queued result is not a failure.
 
-## 5. Store durable captures
+## 6. Store durable captures
 
-For each drafted durable item, call:
+For each drafted durable item, run one command:
 
-```text
-mcp__plugin_wenlan_wenlan__capture(
-  content="<self-contained statement with why>",
-  memory_type="<decision|lesson|gotcha|preference|fact>",
-  space="<resolved Space>"
-)
+```bash
+"$W" --format json --space "$space" capture -t <type> "<content>"
 ```
 
-Use one atomic item per call. Do not ask about ordinary captures. Pause only
-for a contradiction, critical incident, irreversible production action, or
-genuine durability ambiguity.
+Use one atomic item per call. A `"status": "queued"` result counts as
+queued, not failed — record the path. Do not ask about ordinary captures.
+Pause only for a contradiction, critical incident, irreversible production
+action, or genuine durability ambiguity.
 
-## 6. Write the session log and report
+## 7. Report
 
-Write `~/.wenlan/sessions/<YYYY-MM-DD-HHmm>-<slug>.md` with Accomplished,
-Decisions, Lessons & Gotchas, Open Threads, Captures stored, and Git summary.
-This is narrative history, not current-work authority.
-
-Best-effort commit the logical `~/.wenlan/` file batch; do not fail if no
-repository is configured or a commit races. Report capture counts, session-log
-path, applied/conflicted Brief deltas, Brief version, and projection path or
-warning.
+Report capture counts (stored vs queued), session-log path,
+applied/conflicted/queued Brief deltas, Brief version or outbox path, and
+projection path or warning. When anything queued, add: `N handoff write(s)
+queued in the outbox — they apply when the daemon is back (`wenlan outbox
+status`).`

--- a/scripts/validate-codex-plugin-slice.py
+++ b/scripts/validate-codex-plugin-slice.py
@@ -60,7 +60,7 @@ REQUIRED_SKILL_INTERFACE = {
         "short_description": "Set up and verify the local Wenlan runtime and MCP bridge",
     },
 }
-SKILLS_WITHOUT_MCP_REFERENCE = {"help", "pages"}
+SKILLS_WITHOUT_MCP_REFERENCE = {"handoff", "help", "pages"}
 SKILLS_USING_RESOLVER = {"brief", "capture", "distill", "handoff", "lint", "recall"}
 REQUIRED_GUARDRAILS = {
     "forget": [

--- a/scripts/validate-plugin-contract.py
+++ b/scripts/validate-plugin-contract.py
@@ -18,7 +18,7 @@ from typing import Any
 
 DEFAULT_ROOT = Path(__file__).resolve().parents[1]
 ALLOWED_SKILL_STATUSES = {"shared_now", "claude_only_until_ported"}
-CODEX_SKILLS_WITHOUT_MCP_REFERENCE = {"help", "pages"}
+CODEX_SKILLS_WITHOUT_MCP_REFERENCE = {"handoff", "help", "pages"}
 CODEX_SKILLS_USING_RESOLVER = {
     "brief",
     "capture",


### PR DESCRIPTION
## Why

`/wenlan:handoff` used to depend on the plugin's MCP tools and on a reachable daemon. In a background job (no MCP tools) or with the daemon down it failed and the session's work was not saved. With #544 (auto-start) and the outbox PR (`feat/handoff-outbox`), the CLI already survives a down daemon — this PR makes the skill use only the CLI and follow that flow.

Plan: `~/.wenlan/specs/wenlan/2026-08-16-handoff-durability.md` (PR 4).

## What

- `plugin/skills/handoff/SKILL.md` and the Codex twin `plugin-codex/skills/handoff/SKILL.md`: `allowed-tools: ["Bash"]`; explicit Space argument (`/wenlan:handoff <space>` → `resolve-space.sh --arg`); daemon-down detection on the Brief read/probe (`tcp connect error` / `daemon not reachable`) → continue with `expected_version: 0`, `add`-only mutations, and treat `"status": "queued"` as success-queued; pending preview via `wenlan memories --pending -l 50` (best-effort); captures via `wenlan capture -t <type> "..."`; the session log is written before the Brief update (plain file, never depends on the daemon); report shows stored vs queued.
- `plugin/hooks/check-daemon.sh`: prints `[wenlan] outbox: N queued handoff write(s), M failed — run \`wenlan outbox status\`.` when the outbox is non-empty (daemon up or down); not-running line now says writes will queue. `WENLAN_HEALTH_URL` / `WENLAN_CLI` overrides for tests; new `plugin/hooks/test-check-daemon.sh` (4 cases).
- Validators: `handoff` added to the "no MCP reference required" sets in `scripts/validate-plugin-contract.py` and `scripts/validate-codex-plugin-slice.py`. README not-running text synced.
- No plugin version bump: release-please (`scripts/bump-version.sh`) owns `plugin.json`.

## Proof

- `python3 scripts/validate-plugin-contract.py` → `Plugin contract validation passed`
- `python3 scripts/validate-codex-plugin-slice.py` → `Codex plugin slice validation passed`
- `bash plugin/bin/test/test-resolve-space.sh` → `8 passed, 0 failed`
- `bash plugin/hooks/test-check-daemon.sh` → `4 passed, 0 failed`
- `bash scripts/validate-plugin-contract.test.sh` → all PASS (100 lines)
- CLI-side flow proven on the outbox branch with a scratch daemon on port 17955 and a scratch `WENLAN_DATA_DIR`: `brief update` and `capture` print `"status": "queued"` while down; on daemon start the Brief applied (v1, summary version reconciled) and the capture landed; a quality-gate-rejected capture moved to `outbox/failed/` with a 422 receipt.

## Notes

- Merge after `feat/handoff-outbox` and update the installed CLI/plugin locally before relying on the daemon-down path (`outbox status`, `memories --pending`, `capture` queueing all need the new binary).
- Files are disjoint from the outbox PR (plugin/ + scripts/ only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MMV7MaFTEnTvT1eC8gRvU
