### PR TITLE
fix(kg): core data-integrity repairs and migration 124 (m113/m114 columns, cross-space edge fence, orphan edges on archive/delete, claim locator and inventory retirement)

### DIFF
--- a/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
+++ b/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
@@ -1014,7 +1014,7 @@ carrying the authority of agreement.
 | `core/db.rs::replace_source_page_inner` | `private` | no | no | — | `core/db.rs::append_page_history` |
 | `core/db.rs::resolve_or_create_entity` | `pub` | no | no | — | `core/db.rs::search_entities_by_name`, `core/db.rs::search_entities_by_vector` |
 | `core/db.rs::resolve_orphan_page_links` | `pub` | no | **yes** | `server/routes.rs::handle_distill` | `core/db.rs::find_unique_active_page_id_by_title_scoped` |
-| `core/db.rs::restore_entity` | `pub` | no | no | — | `core/db.rs::append_page_history` |
+| `core/db.rs::restore_entity` | `pub` | no | **yes** | `server/cmd_prune_junk_entities.rs::restore` | `core/db.rs::append_page_history` |
 | `core/db.rs::run_entity_enrichment_slice_inner` | `private` | no | no | — | `core/db.rs::commit_entity_enrichment_at_version`, `core/db.rs::search_entities_by_vector` |
 | `core/db.rs::run_migrations` | `pub` | no | no | — | `core/db.rs::run_migrations_up_to` |
 | `core/db.rs::search_memory` | `pub` | no | **yes** | `server/brief_routes.rs::handle_read_brief`, `server/memory_routes.rs::handle_search_memory`, `server/routes.rs::handle_search` | `core/db.rs::search_memory_with_cue` |
@@ -1214,6 +1214,7 @@ carrying the authority of agreement.
 | `core/truth_adapter.rs::page_write_permit` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_page`, `server/page_routes.rs::handle_export_pages` | `core/db/truth_exposure.rs::page_visibility` |
 | `server/brief_routes.rs::handle_read_brief` | `pub` | no | **yes** | `server/routes.rs::handle_context` | `core/db.rs::search_memory` |
 | `server/cmd_cutover.rs::run` | `pub` | yes | no | — | `core/export/knowledge.rs::plan_truth_cutover` |
+| `server/cmd_prune_junk_entities.rs::restore` | `pub` | yes | no | — | `core/db.rs::restore_entity` |
 | `server/cmd_prune_junk_entities.rs::run` | `pub` | yes | no | — | `core/db.rs::archive_entity`, `server/cmd_prune_junk_entities.rs::collect_candidates` |
 | `server/main/runtime.rs::register_optional_runtime_workers` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db/claim_derivation.rs::reconcile_supported_pages` |
 | `server/main/startup.rs::prepare_startup_state` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db.rs::list_pages` |

--- a/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
+++ b/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
@@ -934,7 +934,7 @@ carrying the authority of agreement.
 | `core/db.rs::query_distillation_staging_pool` | `private` | no | no | — | — |
 | `core/db.rs::rebind_source_page_in_transaction` | `private` | no | no | — | — |
 | `core/db.rs::resolve_entity_by_name` | `pub` | no | **yes** | `server/memory_routes.rs::handle_store_memory` | — |
-| `core/db.rs::run_migrations` | `pub` | no | no | — | — |
+| `core/db.rs::run_migrations_up_to` | `pub(crate)` | no | no | — | — |
 | `core/db.rs::search_entities_by_name` | `pub` | no | no | — | — |
 | `core/db.rs::search_entities_by_vector` | `pub` | no | no | — | — |
 | `core/db.rs::search_memory_with_cue` | `private` | no | no | — | — |
@@ -1010,13 +1010,13 @@ carrying the authority of agreement.
 | `core/db.rs::list_pages_browse` | `pub` | no | no | — | `core/db.rs::list_pages_inner` |
 | `core/db.rs::list_stale_pages` | `pub` | no | no | — | `core/db.rs::list_stale_pages_scoped` |
 | `core/db.rs::minhash_resolve_candidate` | `pub` | no | no | — | `core/db.rs::get_entity_name_type` |
-| `core/db.rs::new` | `pub` | yes | no | — | `core/db.rs::run_migrations` |
-| `core/db.rs::new_with_shared_embedder` | `pub` | no | no | — | `core/db.rs::run_migrations` |
 | `core/db.rs::rebind_source_id_inner` | `private` | no | no | — | `core/db.rs::rebind_source_page_in_transaction` |
 | `core/db.rs::replace_source_page_inner` | `private` | no | no | — | `core/db.rs::append_page_history` |
 | `core/db.rs::resolve_or_create_entity` | `pub` | no | no | — | `core/db.rs::search_entities_by_name`, `core/db.rs::search_entities_by_vector` |
 | `core/db.rs::resolve_orphan_page_links` | `pub` | no | **yes** | `server/routes.rs::handle_distill` | `core/db.rs::find_unique_active_page_id_by_title_scoped` |
+| `core/db.rs::restore_entity` | `pub` | no | no | — | `core/db.rs::append_page_history` |
 | `core/db.rs::run_entity_enrichment_slice_inner` | `private` | no | no | — | `core/db.rs::commit_entity_enrichment_at_version`, `core/db.rs::search_entities_by_vector` |
+| `core/db.rs::run_migrations` | `pub` | no | no | — | `core/db.rs::run_migrations_up_to` |
 | `core/db.rs::search_memory` | `pub` | no | **yes** | `server/brief_routes.rs::handle_read_brief`, `server/memory_routes.rs::handle_search_memory`, `server/routes.rs::handle_search` | `core/db.rs::search_memory_with_cue` |
 | `core/db.rs::search_memory_cross_rerank_cued` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
 | `core/db.rs::search_memory_expanded` | `pub` | no | no | — | `core/db.rs::search_memory_with_cue` |
@@ -1099,6 +1099,8 @@ carrying the authority of agreement.
 | `core/db.rs::first_active_page` | `pub` | no | no | — | `core/db.rs::list_pages` |
 | `core/db.rs::insert_page` | `pub(crate)` | yes | no | — | `core/db.rs::insert_page_with_kind` |
 | `core/db.rs::max_page_overlap` | `pub` | no | no | — | `core/db.rs::find_best_overlapping_page` |
+| `core/db.rs::new` | `pub` | yes | no | — | `core/db.rs::run_migrations` |
+| `core/db.rs::new_with_shared_embedder` | `pub` | no | no | — | `core/db.rs::run_migrations` |
 | `core/db.rs::rebind_source_id` | `pub` | no | no | — | `core/db.rs::rebind_source_id_inner` |
 | `core/db.rs::rebind_source_id_with_source_page` | `pub` | no | **yes** | `server/source_routes.rs::sync_directory_source` | `core/db.rs::rebind_source_id_inner` |
 | `core/db.rs::refresh_page_wikilinks` | `pub` | no | no | — | `core/db.rs::get_page`, `core/synthesis/wikilinks.rs::resolve_against_pages` |
@@ -1126,13 +1128,10 @@ carrying the authority of agreement.
 | `core/document_enrichment.rs::write_document_source_page` | `private` | no | no | — | `core/db.rs::get_page` |
 | `core/eval/answer_quality.rs::build_structured_context` | `private` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/answer_quality.rs::generate_e2e_answers_for_question` | `private` | no | no | — | `core/db.rs::search_memory` |
-| `core/eval/answer_quality.rs::run_e2e_answer_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/answer_quality.rs::run_e2e_context_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/answer_quality.rs::run_e2e_context_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/answer_quality.rs::run_e2e_locomo_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/answer_quality.rs::run_fullpipeline_lme` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/context_path.rs::run_context_path_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/context_path.rs::run_context_path_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/answer_quality.rs::run_e2e_answer_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/answer_quality.rs::run_e2e_locomo_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/context_path.rs::run_context_path_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/context_path.rs::run_context_path_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/lifecycle.rs::measure_phase` | `private` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/lifecycle.rs::run_lifecycle_fixture` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/lifecycle.rs::run_lifecycle_phases` | `private` | no | no | — | `core/db.rs::search_memory`, `core/post_ingest.rs::run_post_ingest_enrichment` |
@@ -1154,24 +1153,21 @@ carrying the authority of agreement.
 | `core/eval/longmemeval.rs::run_longmemeval_eval_with_gate` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/longmemeval.rs::run_longmemeval_headroom_probe_from_db` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/longmemeval.rs::run_longmemeval_headroom_probe_per_question` | `pub` | no | no | — | `core/db.rs::search_memory` |
-| `core/eval/longmemeval.rs::run_longmemeval_rerank_pool_probe` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory_cross_rerank_cued` |
-| `core/eval/pipeline.rs::run_locomo_pipeline_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
-| `core/eval/pipeline.rs::run_longmemeval_pipeline_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
+| `core/eval/longmemeval.rs::run_longmemeval_rerank_pool_probe` | `pub` | no | no | — | `core/db.rs::search_memory_cross_rerank_cued` |
 | `core/eval/pipeline.rs::run_strategy_search` | `private` | no | no | — | `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_memory_layer_comparison` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_multi_turn_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_native_memory_augmentation` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_pipeline_token_eval_simulated` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_quality_at_scale_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_quality_cost_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval.rs::run_scaling_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
-| `core/eval/retrieval_drift.rs::capture_rankings` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_memory_layer_comparison` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_multi_turn_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_native_memory_augmentation` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_pipeline_token_eval_simulated` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_quality_at_scale_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_quality_cost_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval.rs::run_scaling_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
+| `core/eval/retrieval_drift.rs::capture_rankings` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/runner.rs::run_eval` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `core/eval/shared.rs::base_channel_touched` | `pub` | no | no | — | `core/db.rs::graph_stream_touches` |
 | `core/eval/shared.rs::ce_channel_touched` | `pub` | no | no | — | `core/db.rs::graph_stream_touches` |
 | `core/eval/shared.rs::enrich_db_for_eval_local` | `pub` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
 | `core/eval/shared.rs::enrich_post_ingest_batched` | `pub(crate)` | no | no | — | `core/post_ingest.rs::run_post_ingest_enrichment` |
-| `core/eval/shared.rs::open_or_seed_scenario_db` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
 | `core/export/knowledge.rs::enforce_projection_directory_invariant#1` | `pub` | yes | no | — | `core/db/truth_exposure.rs::page_visibility` |
 | `core/export/knowledge.rs::run_truth_cutover` | `pub` | no | **yes** | `server/cmd_cutover.rs::run` | `core/export/knowledge.rs::plan_truth_cutover` |
 | `core/importer.rs::resolve_entity_bulk` | `pub(crate)` | no | no | — | `core/db.rs::resolve_or_create_entity` |
@@ -1249,8 +1245,11 @@ carrying the authority of agreement.
 | `core/db/scoped_pages.rs::list_pages_scoped` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_pages` | `core/db/scoped_pages.rs::list_pages_scoped_inner` |
 | `core/db/scoped_pages.rs::list_pages_scoped_browse` | `pub` | no | **yes** | `server/page_routes.rs::handle_list_pages` | `core/db/scoped_pages.rs::list_pages_scoped_inner` |
 | `core/document_enrichment.rs::run_document_enrichment_with_request_budget` | `private` | no | no | — | `core/document_enrichment.rs::write_document_source_page` |
-| `core/eval/answer_quality.rs::run_fullpipeline_lme_batch` | `pub` | no | no | — | `core/eval/answer_quality.rs::build_structured_context`, `core/eval/shared.rs::open_or_seed_scenario_db` |
-| `core/eval/answer_quality.rs::run_fullpipeline_locomo_batch` | `pub` | no | no | — | `core/eval/answer_quality.rs::build_structured_context`, `core/eval/shared.rs::open_or_seed_scenario_db` |
+| `core/eval/answer_quality.rs::run_e2e_context_eval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/eval/answer_quality.rs::generate_e2e_answers_for_question` |
+| `core/eval/answer_quality.rs::run_e2e_context_eval_longmemeval` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/eval/answer_quality.rs::generate_e2e_answers_for_question` |
+| `core/eval/answer_quality.rs::run_fullpipeline_lme` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder`, `core/eval/answer_quality.rs::build_structured_context` |
+| `core/eval/answer_quality.rs::run_fullpipeline_lme_batch` | `pub` | no | no | — | `core/eval/answer_quality.rs::build_structured_context` |
+| `core/eval/answer_quality.rs::run_fullpipeline_locomo_batch` | `pub` | no | no | — | `core/eval/answer_quality.rs::build_structured_context` |
 | `core/eval/lifecycle.rs::run_lifecycle_locomo` | `pub` | no | no | — | `core/eval/lifecycle.rs::run_lifecycle_phases` |
 | `core/eval/lifecycle.rs::run_lifecycle_longmemeval` | `pub` | no | no | — | `core/eval/lifecycle.rs::run_lifecycle_phases` |
 | `core/eval/locomo.rs::run_locomo_eval` | `pub` | no | no | — | `core/eval/locomo.rs::run_locomo_eval_core` |
@@ -1264,8 +1263,11 @@ carrying the authority of agreement.
 | `core/eval/longmemeval.rs::run_longmemeval_eval_cross_rerank_from_db_collect` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect_core` |
 | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect` | `pub` | no | no | — | `core/eval/longmemeval.rs::run_longmemeval_eval_from_db_collect_core` |
 | `core/eval/pipeline.rs::evaluate_condition` | `private` | no | no | — | `core/eval/pipeline.rs::run_strategy_search` |
+| `core/eval/pipeline.rs::run_locomo_pipeline_eval` | `pub` | no | no | — | `core/db.rs::find_distillation_clusters`, `core/db.rs::new_with_shared_embedder` |
+| `core/eval/pipeline.rs::run_longmemeval_pipeline_eval` | `pub` | no | no | — | `core/db.rs::find_distillation_clusters`, `core/db.rs::new_with_shared_embedder` |
 | `core/eval/retrieval.rs::run_native_memory_comparison` | `pub` | no | no | — | `core/eval/retrieval.rs::run_native_memory_augmentation` |
 | `core/eval/shared.rs::enrich_db_for_eval` | `pub` | no | no | — | `core/eval/shared.rs::enrich_db_for_eval_local` |
+| `core/eval/shared.rs::open_or_seed_scenario_db` | `pub` | no | no | — | `core/db.rs::new_with_shared_embedder` |
 | `core/eval/shared.rs::run_concept_distillation_batch_api` | `pub` | no | no | — | `core/db.rs::find_distillation_clusters`, `core/db.rs::max_page_overlap` |
 | `core/eval/shared.rs::run_enrichment_batch_api` | `pub` | no | no | — | `core/importer.rs::resolve_entity_bulk` |
 | `core/eval/shared.rs::run_entity_extraction_for_eval_cli` | `pub` | no | no | — | `core/importer.rs::resolve_entity_bulk` |

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -15988,7 +15988,12 @@ impl MemoryDB {
         let result: Result<(u64, u64, u64, Vec<CommunityGenerationUpdate>), WenlanError> = async {
             // (a) Orphan entity edges. The stamp resolves to the archived
             // endpoint's entity id (source side first), NULL when the
-            // orphaned endpoint has no shadow page at all.
+            // orphaned endpoint has no shadow page at all. Legacy-lineage
+            // rows are skipped on purpose: the fence never fires on them
+            // (its WHEN excludes `lineage='legacy'`) and typed readers do
+            // not load them, so they cannot cause the aborts this step
+            // repairs. The live archive path retracts every lineage; that
+            // is a stricter policy for new archives, not a repair target.
             let mut rows = conn
                 .query(
                     "SELECT e.edge_id, \
@@ -35646,13 +35651,15 @@ impl MemoryDB {
     }
 
     /// Un-archive an entity: flip its `kind='entity'` shadow page back to
-    /// `active` and re-activate the edges [`Self::archive_entity`] retired
-    /// for it (the rows stamped `payload.$.retired_by_archive = <entity
-    /// id>`). Reversibility is the archive lane's contract, so this is the
-    /// other half of the same operation. An edge whose OTHER endpoint has
-    /// since moved to another space (or gone) would trip the space fence on
-    /// re-activation; that row is logged and left retired rather than
-    /// failing the restore -- the fence is right that it must not come back.
+    /// `active` and re-activate the archive-retired edges incident to it
+    /// (rows stamped `payload.$.retired_by_archive`, whichever endpoint's
+    /// archive stamped them). Reversibility is the archive lane's contract,
+    /// so this is the other half of the same operation. An edge whose OTHER
+    /// endpoint is still archived, has moved to another space, or is gone
+    /// trips the space fence on re-activation; that row is logged and left
+    /// retired (still stamped) rather than failing the restore -- the fence
+    /// is right that it must not come back yet, and restoring the other
+    /// endpoint later picks it up. Any other per-row error propagates.
     ///
     /// Returns true when a page moved from archived to active, false when the
     /// entity has no shadow page or was not archived.
@@ -35688,7 +35695,9 @@ impl MemoryDB {
                 .query(
                     "SELECT edge_id FROM edges \
                      WHERE valid_until IS NOT NULL AND superseded_by IS NULL \
-                       AND json_extract(payload, '$.retired_by_archive') = ?1 \
+                       AND json_extract(payload, '$.retired_by_archive') IS NOT NULL \
+                       AND ((src_kind = 'entity' AND src_id = ?1) \
+                            OR (dst_kind = 'entity' AND dst_id = ?1)) \
                      ORDER BY edge_id",
                     libsql::params![entity_id],
                 )
@@ -35720,12 +35729,17 @@ impl MemoryDB {
                     .await
                 {
                     Ok(_) => {}
-                    Err(e) => {
+                    Err(e) if e.to_string().contains("edges_space_fence") => {
                         log::warn!(
                             "[restore_entity] edge {edge_id} left retired: re-activation refused \
                              ({e})"
                         );
                         continue;
+                    }
+                    Err(e) => {
+                        return Err(WenlanError::VectorDb(format!(
+                            "restore_entity edge {edge_id}: {e}"
+                        )));
                     }
                 }
                 let mut rows = conn

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -923,7 +923,7 @@ pub const EMBEDDING_DIM: usize = 768;
 /// `entities` table, skip every `version < N` branch, and quietly operate
 /// against a schema it cannot see. Refusing to open is recoverable; writing is
 /// not.
-pub const SCHEMA_VERSION: u32 = 123;
+pub const SCHEMA_VERSION: u32 = 124;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -4360,6 +4360,26 @@ impl MemoryDB {
     /// Apply incremental migrations based on PRAGMA user_version.
     /// Idempotent: checks column existence before ALTER TABLE.
     pub async fn run_migrations(&self, emitter: &dyn EventEmitter) -> Result<(), WenlanError> {
+        self.run_migrations_up_to(emitter, i64::MAX).await
+    }
+
+    /// [`Self::run_migrations`] with a stopping point: the chain runs in
+    /// order and returns as soon as the next migration would exceed
+    /// `ceiling`, leaving `user_version` at the highest applied number.
+    /// This is how a test gets a database at a GENUINE historical schema
+    /// state -- the pages shape at 112, say -- instead of hand-dropping the
+    /// columns later migrations add, which is exactly the fixture gap that
+    /// let migrations 113/114 ship UPDATEs against columns 117 creates.
+    /// Only the checkpoints a test needs exist: a ceiling below 113 stops
+    /// before migration 113, a ceiling of 113 or 114 stops before 115, and
+    /// anything higher runs the whole chain. The post-chain repairs
+    /// (community substrate/cutover, embedding recovery) are skipped on an
+    /// early return -- they belong to a fully migrated database.
+    pub(crate) async fn run_migrations_up_to(
+        &self,
+        emitter: &dyn EventEmitter,
+        ceiling: i64,
+    ) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
 
         // Read current user_version
@@ -9068,6 +9088,9 @@ impl MemoryDB {
             // fixed the edge half of this path but missed the entity half).
             // Backfills a shadow page + `entity_page_map` row for every entity
             // that has none. See migrate_113_entity_shadow_page_repair.
+            if ceiling < 113 {
+                return Ok(());
+            }
             if version < 113 {
                 self.migrate_113_entity_shadow_page_repair(version).await?;
             }
@@ -9087,6 +9110,9 @@ impl MemoryDB {
             // confidence, explanation, source_agent) from the live legacy
             // rows, so the blocked readers can migrate onto the edge. See
             // migrate_115_edge_semantic_payload.
+            if ceiling < 115 {
+                return Ok(());
+            }
             if version < 115 {
                 self.migrate_115_edge_semantic_payload(version).await?;
             }
@@ -9183,6 +9209,18 @@ impl MemoryDB {
             if version < 123 {
                 self.migrate_123_retire_legacy_entity_tables(version)
                     .await?;
+            }
+
+            // Migration 124 (KG review 2026-08-16, PR A1): repair the data
+            // the frozen-replay fixes in this same PR cannot reach on an
+            // already-migrated database -- retire active edges stranded on
+            // archived/deleted entity endpoints, requeue derivation jobs
+            // parked by the two now-fixed conflicts, and downgrade
+            // moved-endpoint active edges to legacy so live in-place edge
+            // UPDATEs stop tripping the space fence. See
+            // migrate_124_kg_integrity_repair.
+            if version < 124 {
+                self.migrate_124_kg_integrity_repair(version).await?;
             }
         }
 
@@ -13970,6 +14008,15 @@ impl MemoryDB {
     // A repaired entity is byte-identical in shape to a correctly created
     // one, aliases folded in. Idempotent: scoped to entities with no
     // `entity_page_map` row at all.
+    //
+    // Frozen-replay fix (KG review 2026-08-16 #1): the resync UPDATE once
+    // also SET `source_agent`/`entity_created_at`/`entity_updated_at`/
+    // `community_id`/`embedding_updated_at` -- five `pages` columns that
+    // migration 117 ADDs later in the chain, so on any real database
+    // upgrading from <=112 with an unmapped entity the statement failed at
+    // prepare with `no such column: source_agent` and the daemon could not
+    // open the store. They are gone from this body: 117's own backfill
+    // populates them for every mapped entity once the columns exist.
     async fn migrate_113_entity_shadow_page_repair(
         &self,
         prior_version: i64,
@@ -14040,11 +14087,6 @@ impl MemoryDB {
                         aliases = (SELECT json_group_array(alias_name)
                                    FROM (SELECT alias_name FROM entity_aliases
                                          WHERE canonical_entity_id = ?1 ORDER BY alias_name)),
-                        source_agent = (SELECT source_agent FROM entities WHERE id = ?1),
-                        entity_created_at = (SELECT created_at FROM entities WHERE id = ?1),
-                        entity_updated_at = (SELECT updated_at FROM entities WHERE id = ?1),
-                        community_id = (SELECT community_id FROM entities WHERE id = ?1),
-                        embedding_updated_at = (SELECT embedding_updated_at FROM entities WHERE id = ?1),
                         last_modified = ?3
                      WHERE kind = 'entity'
                        AND id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
@@ -14092,6 +14134,11 @@ impl MemoryDB {
     // `entities` IS authoritative, so re-deriving the shadow from it here
     // remains correct forever, unlike a live writer), is idempotent and
     // repairs every stale mirrored column.
+    //
+    // Frozen-replay fix (KG review 2026-08-16 #1): same as migration 113 --
+    // the five columns migration 117 adds to `pages` are no longer SET
+    // here, because at user_version 113 they do not exist yet and every
+    // mapped entity made the UPDATE fail at prepare.
     async fn migrate_114_entity_shadow_resync(
         &self,
         prior_version: i64,
@@ -14132,11 +14179,6 @@ impl MemoryDB {
                         aliases = (SELECT json_group_array(alias_name)
                                    FROM (SELECT alias_name FROM entity_aliases
                                          WHERE canonical_entity_id = ?1 ORDER BY alias_name)),
-                        source_agent = (SELECT source_agent FROM entities WHERE id = ?1),
-                        entity_created_at = (SELECT created_at FROM entities WHERE id = ?1),
-                        entity_updated_at = (SELECT updated_at FROM entities WHERE id = ?1),
-                        community_id = (SELECT community_id FROM entities WHERE id = ?1),
-                        embedding_updated_at = (SELECT embedding_updated_at FROM entities WHERE id = ?1),
                         last_modified = ?3
                      WHERE kind = 'entity'
                        AND id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
@@ -14167,6 +14209,83 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("m114 bump: {e}")))?;
         log::info!("[migration] Migration 114 applied: {resynced} entity shadow pages re-synced");
         Ok(())
+    }
+
+    /// Downgrade every ACTIVE, non-legacy edge whose endpoint has drifted out
+    /// of the edge's space to `lineage='legacy'`, so a later in-place UPDATE
+    /// of that row cannot trip `edges_space_fence_update` (KG review
+    /// 2026-08-16 #5). The fence's UPDATE twin fires on any column update of
+    /// an active typed edge and RAISE(ABORT)s when either endpoint's resolved
+    /// space `IS NOT` the edge's space -- and a live memory/entity move only
+    /// retracts `supports` edges, so a `cites`/`relates` row can sit active
+    /// with a moved endpoint indefinitely. Migrations 115/116/119 bulk-UPDATE
+    /// active edges inside one transaction with `?` propagation, so one such
+    /// row rolled the whole migration back and the daemon could not open the
+    /// store. `lineage='legacy'` is the same reconciliation
+    /// `dual_write_edge`'s ON CONFLICT applies to a cross-space re-write, and
+    /// it makes the fence's `WHEN NEW.lineage != 'legacy'` false, so this
+    /// pre-pass is itself fence-safe.
+    ///
+    /// The endpoint predicate is the fence body of the migration this runs
+    /// under, arm for arm (including the `attests`-from-root and
+    /// `cites`-to-external exemptions), so exactly the rows the fence would
+    /// abort on are downgraded and no others. `arm` selects where an
+    /// `entity` endpoint's space is read: the historical `entities` table
+    /// (migrations 81/98's fence, live during 115/116/119) or the
+    /// `kind='entity'` shadow page (migration 121's fence, live from 121
+    /// on). Migrations 115/116/119 call it first thing with
+    /// [`EntityArm::installed`] (frozen-replay fix, no new number: on a chain
+    /// replay `entities` is stood up and the 81/98 fence is live; a direct
+    /// re-run on a post-123 store has neither, so the shadow-page arm mirrors
+    /// the fence that is actually installed), and migration 124 calls it with
+    /// `ShadowPages` for live databases already past them.
+    async fn downgrade_cross_space_active_edges(
+        conn: &libsql::Connection,
+        arm: EntityArm,
+    ) -> Result<u64, WenlanError> {
+        let entity_space = |endpoint: &str| match arm {
+            EntityArm::Entities => {
+                format!("(SELECT space FROM entities WHERE id = {endpoint})")
+            }
+            EntityArm::ShadowPages => format!(
+                "(SELECT p.space FROM entity_page_map epm \
+                   JOIN pages p ON p.id = epm.page_id \
+                  WHERE epm.entity_id = {endpoint} \
+                    AND p.kind = 'entity' AND p.status = 'active')"
+            ),
+        };
+        let endpoint_space = |kind: &str, endpoint: &str| {
+            format!(
+                "CASE {kind} \
+                    WHEN 'page' THEN (SELECT space FROM pages WHERE id = {endpoint}) \
+                    WHEN 'memory' THEN (SELECT space FROM memories WHERE source_id = {endpoint}) \
+                    WHEN 'entity' THEN {entity} \
+                    WHEN 'claim_revision' THEN ( \
+                        SELECT p.space FROM claim_revisions cr \
+                          JOIN claims c ON c.claim_id = cr.claim_id \
+                          JOIN pages p ON p.id = c.page_id \
+                         WHERE cr.claim_revision_id = {endpoint}) \
+                    ELSE NULL \
+                 END",
+                entity = entity_space(endpoint)
+            )
+        };
+        let sql = format!(
+            "UPDATE edges SET lineage = 'legacy' \
+             WHERE valid_until IS NULL AND lineage != 'legacy' \
+               AND ( \
+                 (NOT (edge_type = 'attests' AND src_kind = 'root') \
+                  AND ({src}) IS NOT space) \
+                 OR \
+                 (NOT (edge_type = 'cites' AND dst_kind = 'external') \
+                  AND ({dst}) IS NOT space) \
+               )",
+            src = endpoint_space("src_kind", "src_id"),
+            dst = endpoint_space("dst_kind", "dst_id"),
+        );
+        conn.execute(&sql, ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("cross-space edge downgrade: {e}")))
     }
 
     // Migration 115 (KG close plan G6, Stage 1 "one source of truth" — spec
@@ -14201,6 +14320,19 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("m115 begin: {e}")))?;
 
         let result: Result<(u64, u64, u64), WenlanError> = async {
+            // Frozen-replay fix (KG review 2026-08-16 #5): every pass below
+            // UPDATEs active edges in place, and a moved-endpoint row would
+            // make `edges_space_fence_update` abort the whole migration.
+            // Downgrade those rows first; see the helper.
+            let downgraded =
+                Self::downgrade_cross_space_active_edges(&conn, EntityArm::installed(&conn).await?)
+                    .await?;
+            if downgraded > 0 {
+                log::info!(
+                    "[migration] m115: {downgraded} cross-space active edge(s) downgraded to legacy"
+                );
+            }
+
             // Each pass collects (edge_id, patch) pairs first, then updates —
             // the single connection cannot interleave an UPDATE with a
             // streaming SELECT.
@@ -14494,6 +14626,17 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("m116 begin: {e}")))?;
 
         let result: Result<u64, WenlanError> = async {
+            // Frozen-replay fix (KG review 2026-08-16 #5): same fence
+            // hazard as migration 115 -- see
+            // `downgrade_cross_space_active_edges`.
+            let downgraded =
+                Self::downgrade_cross_space_active_edges(&conn, EntityArm::installed(&conn).await?)
+                    .await?;
+            if downgraded > 0 {
+                log::info!(
+                    "[migration] m116: {downgraded} cross-space active edge(s) downgraded to legacy"
+                );
+            }
             #[allow(clippy::type_complexity)]
             let mut pending: Vec<(String, i64, Option<String>)> = Vec::new();
             let mut rows = conn
@@ -14940,6 +15083,20 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("m119 begin: {e}")))?;
 
         let result: Result<u64, WenlanError> = async {
+            // Frozen-replay fix (KG review 2026-08-16 #5): same fence
+            // hazard as migration 115 for the active rows -- see
+            // `downgrade_cross_space_active_edges`. Retired rows are not
+            // downgraded (they cannot trip the fence while retired), so the
+            // reactivation UPDATE below additionally guards that both
+            // endpoints still resolve to the edge's space.
+            let downgraded =
+                Self::downgrade_cross_space_active_edges(&conn, EntityArm::installed(&conn).await?)
+                    .await?;
+            if downgraded > 0 {
+                log::info!(
+                    "[migration] m119: {downgraded} cross-space active edge(s) downgraded to legacy"
+                );
+            }
             let mut rows = conn
                 .query(
                     "SELECT page_id, source_kind, locator FROM page_evidence \
@@ -14972,12 +15129,22 @@ impl MemoryDB {
                 let edge_id = crate::provenance::compute_edge_id(
                     "cites", "page", &page_id, dst_kind, &locator, &locator,
                 );
+                // Reactivating a row makes it active-and-typed again, so the
+                // fence's UPDATE twin re-checks its endpoints: a page or
+                // memory endpoint that has since moved to another space (or
+                // been deleted) would RAISE(ABORT) and roll the migration
+                // back -- and a cross-space or endpoint-less reactivation is
+                // wrong anyway. Only rows whose endpoints still resolve to
+                // the edge's space come back.
                 let affected = conn
                     .execute(
                         "UPDATE edges SET valid_until = NULL \
                          WHERE edge_id = ?1 AND valid_until IS NOT NULL \
-                           AND superseded_by IS NULL",
-                        libsql::params![edge_id],
+                           AND superseded_by IS NULL \
+                           AND space IS (SELECT space FROM pages WHERE id = ?2) \
+                           AND (?3 = 'external' \
+                                OR (SELECT space FROM memories WHERE source_id = ?4) IS space)",
+                        libsql::params![edge_id, page_id.as_str(), dst_kind, locator.as_str()],
                     )
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m119 reactivate: {e}")))?;
@@ -15778,6 +15945,147 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Migration 124 (KG review 2026-08-16, PR A1 data repair). Three
+    /// repairs for state the forward fixes in this PR only prevent going
+    /// forward:
+    ///
+    /// (a) **Orphan entity edges.** `archive_entity`/`delete_entity` used to
+    ///     leave the entity's ACTIVE edges alive; migration 121's fence
+    ///     resolves an `entity` endpoint only through an ACTIVE shadow page,
+    ///     so every later in-place UPDATE of those rows (space rename, source
+    ///     rebind) aborted. Same pattern as migration 111's orphan pass:
+    ///     active, non-legacy edges with an entity endpoint that has no
+    ///     active shadow page are soft-retired (`dual_write_invalidate_edge`)
+    ///     and the community graph generations bumped. A row whose orphaned
+    ///     endpoint is an ARCHIVED shadow page is stamped
+    ///     `payload.$.retired_by_archive = <entity id>` so
+    ///     `restore_entity` can bring it back, exactly as a live archive now
+    ///     stamps it; a deleted endpoint gets no stamp.
+    /// (b) **Parked derivation jobs.** `write_support_edge` refused a
+    ///     version-only re-judgment (`support_verdict_supersedes_existing`)
+    ///     and `evaluate_support_on` refused to publish over a stale edge
+    ///     from a prior run (`M5 finalization refused ...`); both burned the
+    ///     job's attempts and parked it with no self-heal. Both are fixed
+    ///     forward in this PR, so jobs parked with either error are requeued
+    ///     once (the same reset the judge-activation requeue applies).
+    /// (c) **Moved-endpoint active edges** are downgraded to
+    ///     `lineage='legacy'` under the pages-reading fence
+    ///     (`downgrade_cross_space_active_edges(ShadowPages)`), so live
+    ///     renames stop aborting on a `cites`/`relates` row whose memory or
+    ///     entity moved after the edge was minted. Runs AFTER (a): an orphan
+    ///     edge is retired, not downgraded.
+    ///
+    /// Data repair that retracts rows: takes the restore point first.
+    /// Idempotent -- a second run finds no orphan, no matching parked job,
+    /// and no cross-space active row.
+    async fn migrate_124_kg_integrity_repair(&self, prior_version: i64) -> Result<(), WenlanError> {
+        self.backup_before_migration(124, prior_version).await?;
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m124 begin: {e}")))?;
+
+        let result: Result<(u64, u64, u64, Vec<CommunityGenerationUpdate>), WenlanError> = async {
+            // (a) Orphan entity edges. The stamp resolves to the archived
+            // endpoint's entity id (source side first), NULL when the
+            // orphaned endpoint has no shadow page at all.
+            let mut rows = conn
+                .query(
+                    "SELECT e.edge_id, \
+                                COALESCE( \
+                                  (SELECT epm.entity_id FROM entity_page_map epm \
+                                     JOIN pages p ON p.id = epm.page_id \
+                                    WHERE e.src_kind = 'entity' AND epm.entity_id = e.src_id \
+                                      AND p.kind = 'entity' AND p.status = 'archived'), \
+                                  (SELECT epm.entity_id FROM entity_page_map epm \
+                                     JOIN pages p ON p.id = epm.page_id \
+                                    WHERE e.dst_kind = 'entity' AND epm.entity_id = e.dst_id \
+                                      AND p.kind = 'entity' AND p.status = 'archived')) \
+                         FROM edges e \
+                         WHERE e.valid_until IS NULL AND e.lineage != 'legacy' \
+                           AND ((e.src_kind = 'entity' AND NOT EXISTS ( \
+                                    SELECT 1 FROM entity_page_map epm \
+                                      JOIN pages p ON p.id = epm.page_id \
+                                     WHERE epm.entity_id = e.src_id \
+                                       AND p.kind = 'entity' AND p.status = 'active')) \
+                             OR (e.dst_kind = 'entity' AND NOT EXISTS ( \
+                                    SELECT 1 FROM entity_page_map epm \
+                                      JOIN pages p ON p.id = epm.page_id \
+                                     WHERE epm.entity_id = e.dst_id \
+                                       AND p.kind = 'entity' AND p.status = 'active'))) \
+                         ORDER BY e.edge_id",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m124 orphan scan: {e}")))?;
+            let mut orphans: Vec<(String, Option<String>)> = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m124 orphan row: {e}")))?
+            {
+                orphans.push((
+                    row.get::<String>(0).unwrap_or_default(),
+                    row.get::<Option<String>>(1).unwrap_or(None),
+                ));
+            }
+            drop(rows);
+            let retired = orphans.len() as u64;
+            let graph_changes = Self::retire_edges_tagged(&conn, orphans)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m124 retire orphan: {e}")))?;
+            let generation_updates = Self::bump_community_graph_generations(&conn, graph_changes)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m124 generation: {e}")))?;
+
+            // (b) Parked derivation jobs.
+            let now = chrono::Utc::now().timestamp();
+            let requeued = conn
+                .execute(
+                    "UPDATE claim_derivation_jobs \
+                            SET status = 'pending', attempts = 0, last_error = NULL, \
+                                lease_owner = NULL, lease_expires_at = NULL, updated_at = ?1 \
+                          WHERE status = 'parked' \
+                            AND (last_error LIKE '%support_verdict_supersedes_existing%' \
+                                 OR last_error LIKE '%M5 finalization refused%')",
+                    libsql::params![now],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m124 requeue parked: {e}")))?;
+
+            // (c) Moved-endpoint active edges, pages-reading fence.
+            let downgraded =
+                Self::downgrade_cross_space_active_edges(&conn, EntityArm::ShadowPages).await?;
+
+            Ok((retired, requeued, downgraded, generation_updates))
+        }
+        .await;
+
+        let (retired, requeued, downgraded, generation_updates) = match result {
+            Ok(value) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m124 commit: {e}")))?;
+                value
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+        self.record_community_dirty_nodes(generation_updates);
+
+        conn.execute("PRAGMA user_version = 124", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m124 bump: {e}")))?;
+        log::info!(
+            "[migration] Migration 124 applied: {retired} orphan entity edge(s) retired, \
+             {requeued} parked derivation job(s) requeued, \
+             {downgraded} cross-space active edge(s) downgraded to legacy"
+        );
+        Ok(())
+    }
+
     async fn repair_community_cutover(&self) -> Result<(), WenlanError> {
         let conn = self.conn.lock().await;
         let tx = conn
@@ -16412,6 +16720,29 @@ struct CommunityGraphChange {
     dst_id: String,
 }
 
+/// Where an `entity` edge endpoint's space is read from, for
+/// [`MemoryDB::downgrade_cross_space_active_edges`]: the legacy `entities`
+/// table (the fence body migrations 81/98 install) or the `kind='entity'`
+/// shadow page (the fence body migration 121 installs).
+#[derive(Debug, Clone, Copy)]
+enum EntityArm {
+    Entities,
+    ShadowPages,
+}
+
+impl EntityArm {
+    /// The arm matching the fence body installed on `conn`: `entities` while
+    /// the legacy table exists (chain replay through migrations 81..122),
+    /// shadow pages once migration 123 has dropped it.
+    async fn installed(conn: &libsql::Connection) -> Result<Self, WenlanError> {
+        Ok(if legacy_table_present(conn, "entities").await? {
+            EntityArm::Entities
+        } else {
+            EntityArm::ShadowPages
+        })
+    }
+}
+
 #[derive(Debug)]
 struct EntityMergeEdgePlan {
     old_edge_id: String,
@@ -16956,6 +17287,35 @@ impl MemoryDB {
         )
         .await?;
         Ok((affected > 0).then_some(graph_change).flatten())
+    }
+
+    /// Soft-retire a batch of edges, optionally stamping each with the
+    /// entity whose archive retired it (`payload.$.retired_by_archive`), so
+    /// [`Self::restore_entity`] can find and re-activate exactly those rows.
+    /// The stamp lands after the retraction, on a row that is no longer
+    /// active, so `edges_space_fence_update` (which only re-fences rows that
+    /// stay active and typed) never fires for it. Returns the community
+    /// graph changes the retractions imply, for the caller's generation bump.
+    async fn retire_edges_tagged(
+        conn: &libsql::Connection,
+        edges: Vec<(String, Option<String>)>,
+    ) -> Result<Vec<CommunityGraphChange>, libsql::Error> {
+        let mut graph_changes = Vec::new();
+        for (edge_id, archived_entity) in edges {
+            if let Some(change) = Self::dual_write_invalidate_edge(conn, &edge_id, None).await? {
+                graph_changes.push(change);
+            }
+            if let Some(entity_id) = archived_entity {
+                conn.execute(
+                    "UPDATE edges \
+                     SET payload = json_set(COALESCE(payload, '{}'), '$.retired_by_archive', ?1) \
+                     WHERE edge_id = ?2 AND valid_until IS NOT NULL",
+                    libsql::params![entity_id, edge_id],
+                )
+                .await?;
+            }
+        }
+        Ok(graph_changes)
     }
 
     /// Re-address every canonical edge touching a renamed identity (G6
@@ -31454,6 +31814,46 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Retract every ACTIVE edge incident on an entity, in the caller's
+    /// transaction (KG review 2026-08-16 #2). `archive_entity` and
+    /// `delete_entity` used to leave the entity's `relates` edges alive;
+    /// migration 121's fence resolves an `entity` endpoint only through an
+    /// ACTIVE shadow page, so any later in-place UPDATE of those rows -- a
+    /// space rename's `UPDATE edges SET space`, `rebind_source_id`'s payload
+    /// rewrite -- RAISE(ABORT)ed with an opaque cross-space error, and the
+    /// community loaders kept feeding the orphan edges into grouping. Same
+    /// soft retraction `supersede_relation` and migration 111 apply; `tag`
+    /// (the archiving entity's id) marks the rows an un-archive may bring
+    /// back, see [`Self::retire_edges_tagged`] / [`Self::restore_entity`].
+    async fn retract_entity_incident_edges_in_transaction(
+        &self,
+        conn: &libsql::Connection,
+        entity_id: &str,
+        tag: Option<&str>,
+    ) -> Result<u64, libsql::Error> {
+        let mut rows = conn
+            .query(
+                "SELECT edge_id FROM edges \
+                 WHERE valid_until IS NULL \
+                   AND ((src_kind = 'entity' AND src_id = ?1) \
+                     OR (dst_kind = 'entity' AND dst_id = ?1)) \
+                 ORDER BY edge_id",
+                libsql::params![entity_id],
+            )
+            .await?;
+        let mut edges = Vec::new();
+        while let Some(row) = rows.next().await? {
+            edges.push((row.get::<String>(0)?, tag.map(str::to_string)));
+        }
+        drop(rows);
+        let retired = edges.len() as u64;
+        let graph_changes = Self::retire_edges_tagged(conn, edges).await?;
+        let generation_updates =
+            Self::bump_community_graph_generations(conn, graph_changes).await?;
+        self.record_community_dirty_nodes(generation_updates);
+        Ok(retired)
+    }
+
     async fn invalidate_memory_entity_projection_in_transaction(
         &self,
         conn: &libsql::Connection,
@@ -35189,7 +35589,12 @@ impl MemoryDB {
     /// G6 every entity reader joins `pages ... AND p.status='active'`, so an
     /// archived entity disappears from search, listing, and the graph while
     /// its row, its `entity_page_map` link, its observations, and its memory
-    /// links all stay put and can be restored by flipping `status` back.
+    /// links all stay put. Its ACTIVE edges are soft-retired in the same
+    /// transaction and stamped `payload.$.retired_by_archive = <entity id>`
+    /// (KG review 2026-08-16 #2: an archived endpoint no longer resolves to
+    /// the space fence, so a live orphan edge would abort every later space
+    /// rename / source rebind); [`Self::restore_entity`] brings the page and
+    /// those edges back.
     ///
     /// Returns true when a page moved from active to archived, false when the
     /// entity has no shadow page or was already archived.
@@ -35201,21 +35606,168 @@ impl MemoryDB {
         let Some(page_id) = entity_page_adapter::page_id_for_entity(&conn, entity_id).await? else {
             return Ok(false);
         };
-        let affected = conn
-            .execute(
-                "UPDATE pages
-                 SET status = 'archived', version = version + 1, last_modified = ?1
-                 WHERE id = ?2 AND kind = 'entity' AND status = 'active'",
-                libsql::params![now_rfc3339, page_id.clone()],
-            )
+        conn.execute("BEGIN", ())
             .await
-            .map_err(|e| WenlanError::VectorDb(format!("archive_entity: {e}")))?;
-        if affected == 1 {
+            .map_err(|e| WenlanError::VectorDb(format!("archive_entity begin: {e}")))?;
+        let result: Result<bool, WenlanError> = async {
+            let affected = conn
+                .execute(
+                    "UPDATE pages
+                     SET status = 'archived', version = version + 1, last_modified = ?1
+                     WHERE id = ?2 AND kind = 'entity' AND status = 'active'",
+                    libsql::params![now_rfc3339, page_id.clone()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("archive_entity: {e}")))?;
+            if affected != 1 {
+                return Ok(false);
+            }
             Self::append_page_history(&conn, &page_id, "archive", now_ts)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("archive_entity history: {e}")))?;
+            self.retract_entity_incident_edges_in_transaction(&conn, entity_id, Some(entity_id))
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("archive_entity edges: {e}")))?;
+            Ok(true)
         }
-        Ok(affected == 1)
+        .await;
+        match result {
+            Ok(archived) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("archive_entity commit: {e}")))?;
+                Ok(archived)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Un-archive an entity: flip its `kind='entity'` shadow page back to
+    /// `active` and re-activate the edges [`Self::archive_entity`] retired
+    /// for it (the rows stamped `payload.$.retired_by_archive = <entity
+    /// id>`). Reversibility is the archive lane's contract, so this is the
+    /// other half of the same operation. An edge whose OTHER endpoint has
+    /// since moved to another space (or gone) would trip the space fence on
+    /// re-activation; that row is logged and left retired rather than
+    /// failing the restore -- the fence is right that it must not come back.
+    ///
+    /// Returns true when a page moved from archived to active, false when the
+    /// entity has no shadow page or was not archived.
+    pub async fn restore_entity(&self, entity_id: &str) -> Result<bool, WenlanError> {
+        let now = chrono::Utc::now();
+        let now_rfc3339 = now.to_rfc3339();
+        let now_ts = now.timestamp();
+        let conn = self.conn.lock().await;
+        let Some(page_id) = entity_page_adapter::page_id_for_entity(&conn, entity_id).await? else {
+            return Ok(false);
+        };
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("restore_entity begin: {e}")))?;
+        let result: Result<bool, WenlanError> = async {
+            let affected = conn
+                .execute(
+                    "UPDATE pages
+                     SET status = 'active', version = version + 1, last_modified = ?1
+                     WHERE id = ?2 AND kind = 'entity' AND status = 'archived'",
+                    libsql::params![now_rfc3339, page_id.clone()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("restore_entity: {e}")))?;
+            if affected != 1 {
+                return Ok(false);
+            }
+            Self::append_page_history(&conn, &page_id, "restore", now_ts)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("restore_entity history: {e}")))?;
+
+            let mut rows = conn
+                .query(
+                    "SELECT edge_id FROM edges \
+                     WHERE valid_until IS NOT NULL AND superseded_by IS NULL \
+                       AND json_extract(payload, '$.retired_by_archive') = ?1 \
+                     ORDER BY edge_id",
+                    libsql::params![entity_id],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("restore_entity edge scan: {e}")))?;
+            let mut edge_ids = Vec::new();
+            while let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("restore_entity edge row: {e}")))?
+            {
+                edge_ids.push(row.get::<String>(0).unwrap_or_default());
+            }
+            drop(rows);
+
+            let mut graph_changes = Vec::new();
+            for edge_id in edge_ids {
+                // Re-activating makes the row active-and-typed again, so the
+                // fence's UPDATE twin re-checks both endpoints; a RAISE(ABORT)
+                // here rolls back this one statement only.
+                match conn
+                    .execute(
+                        "UPDATE edges \
+                         SET valid_until = NULL, \
+                             payload = json_remove(payload, '$.retired_by_archive') \
+                         WHERE edge_id = ?1 AND valid_until IS NOT NULL",
+                        libsql::params![edge_id.clone()],
+                    )
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::warn!(
+                            "[restore_entity] edge {edge_id} left retired: re-activation refused \
+                             ({e})"
+                        );
+                        continue;
+                    }
+                }
+                let mut rows = conn
+                    .query(
+                        "SELECT space, src_id, dst_id FROM edges \
+                         WHERE edge_id = ?1 AND edge_type = 'relates' \
+                           AND grounded = 1 AND lineage = 'assertion'",
+                        libsql::params![edge_id.clone()],
+                    )
+                    .await
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("restore_entity edge reread: {e}"))
+                    })?;
+                if let Some(row) = rows.next().await.map_err(|e| {
+                    WenlanError::VectorDb(format!("restore_entity edge reread row: {e}"))
+                })? {
+                    graph_changes.push(CommunityGraphChange {
+                        space: row.get::<String>(0).unwrap_or_default(),
+                        src_id: row.get::<String>(1).unwrap_or_default(),
+                        dst_id: row.get::<String>(2).unwrap_or_default(),
+                    });
+                }
+            }
+            let generation_updates = Self::bump_community_graph_generations(&conn, graph_changes)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("restore_entity generation: {e}")))?;
+            self.record_community_dirty_nodes(generation_updates);
+            Ok(true)
+        }
+        .await;
+        match result {
+            Ok(restored) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("restore_entity commit: {e}")))?;
+                Ok(restored)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
     }
 
     /// What an entity is currently carrying: linked memories, observations,
@@ -35317,6 +35869,15 @@ impl MemoryDB {
             .map_err(|e| {
                 WenlanError::VectorDb(format!("delete_entity entity_minhash_bands: {e}"))
             })?;
+
+            // KG review 2026-08-16 #2: retract the entity's active edges in
+            // this same transaction. Once the shadow page is gone the fence
+            // cannot resolve the endpoint, and any later in-place UPDATE of
+            // a still-active row (space rename, source rebind) would abort.
+            // Permanent delete, so no restore tag.
+            self.retract_entity_incident_edges_in_transaction(&conn, entity_id, None)
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("delete_entity edges: {e}")))?;
 
             // Delete the entity's shadow page (M3 PR-1 item C) -- since G6
             // Stage 3 this IS the entity delete, not a mirror of one. The
@@ -35738,6 +36299,13 @@ impl MemoryDB {
                 embeddings.len()
             )));
         }
+        // KG review 2026-08-16 #7: this lane resolves-or-creates entities
+        // too, so it takes the same in-process lock the agent/import lane
+        // (`resolve_or_create_entity`) holds across its lookup->insert
+        // sequence -- and in the same order, resolution lock then `conn` --
+        // otherwise the two creators can each miss the other's insert and
+        // leave two active shadow pages with one lowercase title.
+        let _resolution_guard = self.entity_resolution_lock.lock().await;
         let minhash_enabled = entity_minhash_enabled();
         let mut prepared_entities = Vec::with_capacity(entities.len());
         for ((lower, name, entity_type), embedding) in entities.into_iter().zip(embeddings) {

--- a/crates/wenlan-core/src/db/claim_derivation.rs
+++ b/crates/wenlan-core/src/db/claim_derivation.rs
@@ -2346,6 +2346,62 @@ impl MemoryDB {
                 .await
                 .map_err(|error| WenlanError::VectorDb(format!("M5 attempt write: {error}")))?;
             }
+
+            // Retire the evidence this run no longer weighs (KG review
+            // 2026-08-16 #4). `evaluate_support_on` reads EVERY active support
+            // edge on the page's claim revisions and refuses to publish when
+            // one of them has no attempt row in this run -- but a run's
+            // attempts cover only the locators ranked from the CURRENT linked
+            // chunks, so an edge from a memory that was since edited (offsets
+            // shifted), unlinked, or ranked out of the top-N stayed active
+            // forever and forced NoPublish on every re-run until the job
+            // parked. Inside this lease-checked transaction, soft-retire every
+            // active support edge on this page/version's claim revisions whose
+            // (source, chunk, span, digest) is outside the sealed inventory of
+            // THIS run generation. Same-locator rows are left for
+            // `write_support_edge`'s explicit supersede.
+            let retired = tx
+                .execute(
+                    "UPDATE edges
+                        SET valid_until = ?4, superseded_by = NULL
+                      WHERE edge_type = 'supports' AND src_kind = 'claim_revision'
+                        AND valid_until IS NULL
+                        AND src_id IN (SELECT claim_revision_id FROM page_version_claims
+                                        WHERE page_id = ?1 AND page_version = ?2)
+                        AND NOT EXISTS (
+                            SELECT 1 FROM claim_run_candidates c
+                             WHERE c.page_id = ?1 AND c.page_version = ?2
+                               AND c.run_generation = ?3
+                               AND c.claim_revision_id = edges.src_id
+                               AND c.candidate_source_id = edges.dst_id
+                               AND c.candidate_chunk_index
+                                   = json_extract(edges.payload, '$.chunk_index')
+                               AND c.candidate_span_start
+                                   = json_extract(edges.payload, '$.span_start')
+                               AND c.candidate_span_end
+                                   = json_extract(edges.payload, '$.span_end')
+                               AND c.candidate_digest
+                                   = json_extract(edges.payload, '$.span_digest'))",
+                    libsql::params![
+                        job.page_id.as_str(),
+                        job.page_version,
+                        job.run_generation,
+                        now
+                    ],
+                )
+                .await
+                .map_err(|error| {
+                    WenlanError::VectorDb(format!("M5 stale support retire: {error}"))
+                })?;
+            if retired > 0 {
+                log::info!(
+                    "[claim_derivation] {}:{} run {} retired {retired} support edge(s) outside \
+                     the sealed inventory",
+                    job.page_id,
+                    job.page_version,
+                    job.run_generation
+                );
+            }
             Ok(true)
         }
         .await;

--- a/crates/wenlan-core/src/db/claim_derivation_test.rs
+++ b/crates/wenlan-core/src/db/claim_derivation_test.rs
@@ -5832,3 +5832,166 @@ async fn producer_rolling_judge_upgrade_replaces_edge_without_losing_supported_s
     );
     assert!(rows.next().await.unwrap().is_none());
 }
+
+/// Every `supports` edge into `source_id`, oldest first: (active, source_version).
+async fn support_edges_into(db: &MemoryDB, source_id: &str) -> Vec<(bool, i64)> {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT valid_until IS NULL, json_extract(payload, '$.source_version')
+               FROM edges
+              WHERE edge_type = 'supports' AND dst_id = ?1
+              ORDER BY json_extract(payload, '$.source_version'), created_at, edge_id",
+            libsql::params![source_id],
+        )
+        .await
+        .unwrap();
+    let mut edges = Vec::new();
+    while let Some(row) = rows.next().await.unwrap() {
+        edges.push((row.get::<i64>(0).unwrap() == 1, row.get::<i64>(1).unwrap()));
+    }
+    edges
+}
+
+/// KG review 2026-08-16 #3 / #28: the demote -> re-derive -> re-support loop
+/// after a version bump that leaves the text alone. A space rename bumps
+/// `memories.version`, the move trigger retracts the support edge and demotes
+/// the page; the re-run used to collide on the same edge id with a payload
+/// differing only in `source_version` and park the job forever. With the
+/// version in the locator the re-judgment is a new edge, the old one stays
+/// retracted, and the page is supported again.
+#[tokio::test]
+async fn producer_re_supports_after_a_space_rename_bumps_the_source_version() {
+    let (db, _temp) = db_with_queue().await;
+    authorize_producer_judge(&db).await;
+    db.create_space("space-a", None, false).await.unwrap();
+    let evidence = "Alpha launched successfully.";
+    add_producer_memory(&db, "rename-source", evidence, "space-a", "folder").await;
+    add_producer_page(&db, "rename-page", evidence, "space-a").await;
+    link_page_evidence(&db, "rename-page", "rename-source").await;
+    let judge = ProducerJudge::pinned(&db);
+    assert!(matches!(
+        db.run_page_linked_truth_promotion_turn(&judge, "producer-worker")
+            .await
+            .unwrap(),
+        PromotionTurn::Completed { .. }
+    ));
+    assert_eq!(truth_row(&db, "rename-page").await.unwrap().0, "supported");
+    assert_eq!(
+        support_edges_into(&db, "rename-source").await,
+        vec![(true, 1)]
+    );
+
+    db.update_space("space-a", "space-b", None).await.unwrap();
+    assert_eq!(
+        truth_row(&db, "rename-page").await.unwrap().0,
+        "provisional"
+    );
+    assert_eq!(
+        job_for(&db, "rename-page")
+            .await
+            .map(|(_, status, _)| status),
+        Some("pending".to_string()),
+        "the move trigger demotes and requeues"
+    );
+    assert_eq!(
+        support_edges_into(&db, "rename-source").await,
+        vec![(false, 1)],
+        "the move trigger retracts the old edge"
+    );
+
+    assert!(matches!(
+        db.run_page_linked_truth_promotion_turn(&judge, "producer-worker")
+            .await
+            .unwrap(),
+        PromotionTurn::Completed { .. }
+    ));
+    assert_eq!(truth_row(&db, "rename-page").await.unwrap().0, "supported");
+    assert_eq!(
+        support_edges_into(&db, "rename-source").await,
+        vec![(false, 1), (true, 2)],
+        "the re-run mints a new edge at the live version and leaves the old one retracted"
+    );
+    assert_eq!(
+        job_for(&db, "rename-page")
+            .await
+            .map(|(_, status, _)| status),
+        Some("done".to_string())
+    );
+}
+
+/// KG review 2026-08-16 #4 / #28: the loop after a content edit. Rewriting the
+/// cited chunk demotes and requeues the page but leaves the old support edge
+/// active; the re-run ranks the NEW chunk's spans, so the old locator is not
+/// in its inventory and evaluation used to refuse to publish (`unregistered`)
+/// until the job parked. The run now retires the edges outside its sealed
+/// inventory, so the page is supported again and nothing parks.
+#[tokio::test]
+async fn producer_retires_stale_support_edges_after_the_cited_chunk_is_rewritten() {
+    let (db, _temp) = db_with_queue().await;
+    authorize_producer_judge(&db).await;
+    add_producer_memory(
+        &db,
+        "edit-source",
+        "Alpha launched successfully.",
+        "space-a",
+        "folder",
+    )
+    .await;
+    add_producer_page(&db, "edit-page", "Alpha launched successfully.", "space-a").await;
+    link_page_evidence(&db, "edit-page", "edit-source").await;
+    let judge = ProducerJudge::pinned(&db);
+    assert!(matches!(
+        db.run_page_linked_truth_promotion_turn(&judge, "producer-worker")
+            .await
+            .unwrap(),
+        PromotionTurn::Completed { .. }
+    ));
+    assert_eq!(truth_row(&db, "edit-page").await.unwrap().0, "supported");
+    assert_eq!(
+        support_edges_into(&db, "edit-source").await,
+        vec![(true, 1)]
+    );
+
+    // A typo fix ahead of the cited sentence shifts every offset in chunk 0.
+    db.update_memory(
+        "edit-source",
+        "Preface added by an edit. Alpha launched successfully.",
+    )
+    .await
+    .unwrap();
+    assert_eq!(truth_row(&db, "edit-page").await.unwrap().0, "provisional");
+    assert_eq!(
+        job_for(&db, "edit-page").await.map(|(_, status, _)| status),
+        Some("pending".to_string()),
+        "the chunk-edit trigger demotes and requeues"
+    );
+    assert_eq!(
+        support_edges_into(&db, "edit-source").await,
+        vec![(true, 1)],
+        "the chunk-edit trigger does not retract the old edge"
+    );
+
+    assert!(matches!(
+        db.run_page_linked_truth_promotion_turn(&judge, "producer-worker")
+            .await
+            .unwrap(),
+        PromotionTurn::Completed { .. }
+    ));
+    assert_eq!(truth_row(&db, "edit-page").await.unwrap().0, "supported");
+    // The edited memory has two sentences and the pinned judge scores every
+    // span, so the re-run may publish more than one edge; what matters is
+    // that the pre-edit edge is the only retired one and every live edge
+    // names the live version.
+    let edges = support_edges_into(&db, "edit-source").await;
+    assert_eq!(edges[0], (false, 1), "the stale edge is retired by the run");
+    assert!(
+        edges.len() >= 2 && edges[1..].iter().all(|(active, v)| *active && *v > 1),
+        "the re-run's edges are active at the live version: {edges:?}"
+    );
+    assert_eq!(
+        job_for(&db, "edit-page").await.map(|(_, status, _)| status),
+        Some("done".to_string()),
+        "nothing parks"
+    );
+}

--- a/crates/wenlan-core/src/db/claim_identity.rs
+++ b/crates/wenlan-core/src/db/claim_identity.rs
@@ -1279,9 +1279,26 @@ impl MemoryDB {
         // genuinely distinct citations in chunks 0 and 1 would otherwise collide
         // on one edge id and the second would be refused as a superseding
         // re-judgment of the first.
+        //
+        // The source version is in the locator too (KG review 2026-08-16 #3).
+        // It was only in the payload, and every version bump that leaves the
+        // text alone -- a space rename or move bumps `memories.version` and
+        // the space-move trigger retracts the edge -- made the re-run's write
+        // land on the same edge id with a payload differing only in
+        // `source_version`: neither the byte-equal reactivation nor a
+        // legitimate supersede, so a hard `support_verdict_supersedes_existing`
+        // conflict that parked the page's derivation job for good. With the
+        // version in the id a re-judgment of the same place at a newer version
+        // is a NEW edge; the supersede UPDATE below still retires an active
+        // same-span row (any version), the retracted old row keeps its id and
+        // its audit record, and no payload is ever rewritten in place.
         let span_locator = format!(
-            "{}:{}:{}:{}",
-            verdict.chunk_index, verdict.span_start, verdict.span_end, verdict.span_digest
+            "{}:{}:{}:{}:{}",
+            verdict.chunk_index,
+            verdict.source_version,
+            verdict.span_start,
+            verdict.span_end,
+            verdict.span_digest
         );
         let judgment_locator = serde_json::json!([
             span_locator,

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -46685,6 +46685,60 @@ async fn archive_entity_retracts_its_edges_so_rename_and_rebind_succeed_and_rest
     );
 }
 
+/// Restore is order-independent when both endpoints were archived. The
+/// stamp names the entity whose archive retired the edge (A); B's archive
+/// finds the edge already retired and stamps nothing. Restoring A first must
+/// leave the edge retired (B is still archived, the fence says no) but keep
+/// the stamp; restoring B then brings it back. Restoring in the other order
+/// works the same way.
+#[tokio::test]
+async fn restore_entity_reactivates_shared_edge_regardless_of_restore_order() {
+    let (db, _dir) = test_db().await;
+    let edge_id = seed_linked_entity_pair(&db, "ord", "work").await;
+
+    assert!(db.archive_entity("ord-a").await.unwrap());
+    assert!(db.archive_entity("ord-b").await.unwrap());
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &edge_id).await;
+    assert!(valid_until.is_some());
+    assert_eq!(
+        tag.as_deref(),
+        Some("ord-a"),
+        "first archive stamps the edge"
+    );
+
+    // A first: the other endpoint is still archived, so the fence refuses the
+    // re-activation and the row stays retired *and stamped*.
+    assert!(db.restore_entity("ord-a").await.unwrap());
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &edge_id).await;
+    assert!(
+        valid_until.is_some(),
+        "an edge whose other endpoint is still archived must stay retired"
+    );
+    assert_eq!(
+        tag.as_deref(),
+        Some("ord-a"),
+        "the stamp survives a refused restore"
+    );
+
+    // B second: the edge is incident to B, so B's restore picks it up even
+    // though the stamp names A.
+    assert!(db.restore_entity("ord-b").await.unwrap());
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &edge_id).await;
+    assert!(
+        valid_until.is_none(),
+        "restoring the second endpoint re-activates the shared edge"
+    );
+    assert!(tag.is_none());
+    assert_eq!(
+        db.entity_link_summary("ord-a").await.unwrap().active_edges,
+        1
+    );
+    assert_eq!(
+        db.entity_link_summary("ord-b").await.unwrap().active_edges,
+        1
+    );
+}
+
 /// KG review 2026-08-16 #2, the permanent half: delete retracts the edges too
 /// (untagged -- there is nothing to restore), and a rename still succeeds.
 #[tokio::test]

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -509,6 +509,71 @@ pub async fn test_db() -> (MemoryDB, tempfile::TempDir) {
     (memory_db, dir)
 }
 
+/// [`test_db`] stopped at a historical schema state: the migration chain
+/// runs only up to `ceiling` (see `run_migrations_up_to` for the exact
+/// checkpoints), so a test gets the GENUINE `pages`/`edges` shape of that
+/// version instead of a fully migrated schema with columns dropped by
+/// hand. Everything else -- embedder, chunker, caches -- is `test_db`'s.
+pub async fn test_db_at(ceiling: i64) -> (MemoryDB, tempfile::TempDir) {
+    let dir = tempdir().expect("failed to create temp dir");
+    let db_path = dir.path();
+    std::fs::create_dir_all(db_path).unwrap();
+    let db_file = db_path.join("origin_memory.db");
+
+    let db = libsql::Builder::new_local(db_file.to_str().unwrap())
+        .build()
+        .await
+        .expect("libsql open");
+    let conn = db.connect().expect("libsql connect");
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+        .await
+        .unwrap();
+    conn.execute_batch(SCHEMA).await.unwrap();
+    let _ = conn.execute_batch(FTS_SCHEMA).await;
+    let _ = conn.execute_batch(FTS_TRIGGERS).await;
+    let _ = conn
+        .execute(
+            "CREATE INDEX IF NOT EXISTS memories_vec_idx ON memories (
+                libsql_vector_idx(embedding, 'metric=cosine', 'compress_neighbors=float8', 'max_neighbors=32')
+            )",
+            (),
+        )
+        .await;
+    let _ = conn
+        .execute(
+            "CREATE INDEX IF NOT EXISTS child_vectors_vec_idx ON child_vectors (
+                libsql_vector_idx(embedding, 'metric=cosine', 'compress_neighbors=float8', 'max_neighbors=32')
+            )",
+            (),
+        )
+        .await;
+
+    let lint_freshness = Arc::new(
+        crate::lint::snapshot::LintFreshnessClock::new(&db).expect("lint freshness observer"),
+    );
+    let memory_db = MemoryDB {
+        _db: db,
+        conn: Arc::new(tokio::sync::Mutex::new(conn)),
+        entity_resolution_lock: tokio::sync::Mutex::new(()),
+        space_write_lock: tokio::sync::Mutex::new(()),
+        lint_freshness,
+        page_projection_tracker: crate::page_projection_tracker::PageProjectionTracker::new(),
+        derived_artifact_state: crate::derived_artifact_state::DerivedArtifactState::new(),
+        embedder: Some(shared_embedder()),
+        chunker: build_chunker(std::path::Path::new(".nonexistent")),
+        embedding_cache: std::sync::Mutex::new(EmbeddingCache::new(200)),
+        community_dirty_nodes: std::sync::Mutex::new(BTreeMap::new()),
+        community_grouping_runtime: std::sync::Mutex::new(
+            crate::community_grouping::CommunityGroupingRuntime::default(),
+        ),
+    };
+    memory_db
+        .run_migrations_up_to(&crate::events::NoopEmitter, ceiling)
+        .await
+        .unwrap();
+    (memory_db, dir)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn cancelling_m4_finalize_rolls_back_and_restores_lease_connection_and_runtime() {
     const SPACE: &str = "m4-cancel-space";
@@ -31688,6 +31753,268 @@ async fn ambient_entity_sweep_dual_writes_shadow_pages() {
     }
 }
 
+async fn user_version(db: &MemoryDB) -> i64 {
+    let conn = db.conn.lock().await;
+    let mut rows = conn.query("PRAGMA user_version", ()).await.unwrap();
+    rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+}
+
+async fn pages_has_column(db: &MemoryDB, column: &str) -> bool {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM pragma_table_info('pages') WHERE name = ?1",
+            libsql::params![column],
+        )
+        .await
+        .unwrap();
+    rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap() > 0
+}
+
+/// KG review 2026-08-16 #1: the frozen bodies of migrations 113 and 114
+/// UPDATEd five `pages` columns that only migration 117 adds, so a real
+/// database at user_version <= 112 holding any entity could not open on the
+/// current build. The fixture is a GENUINE schema-112 store (the chain
+/// stopped before 113 -- no hand-dropped columns), with one unmapped entity
+/// for 113's repair loop and one mapped entity for 114's resync loop.
+#[tokio::test]
+async fn migration_113_and_114_replay_against_a_genuine_schema_112_pages_shape() {
+    let (db, _dir) = test_db_at(112).await;
+    assert_eq!(user_version(&db).await, 112);
+    // Tripwire: the fixture really is pre-117.
+    assert!(
+        !pages_has_column(&db, "source_agent").await,
+        "a schema-112 pages table must not carry migration 117's columns"
+    );
+
+    let mapped_page = crate::pages::new_page_id();
+    {
+        let conn = db.conn.lock().await;
+        // A: unmapped -- migration 113 backfills its shadow, then resyncs it.
+        conn.execute(
+            "INSERT INTO entities \
+                 (id, name, entity_type, space, source_agent, confidence, confirmed, \
+                  created_at, updated_at, community_id, embedding_updated_at) \
+             VALUES ('m112-unmapped', 'Unmapped', 'concept', 'work', 'claude', NULL, 0, \
+                     11, 12, NULL, NULL)",
+            (),
+        )
+        .await
+        .unwrap();
+        // B: mapped -- migration 114 resyncs every mapped shadow.
+        conn.execute(
+            "INSERT INTO entities \
+                 (id, name, entity_type, space, source_agent, confidence, confirmed, \
+                  created_at, updated_at, community_id, embedding_updated_at) \
+             VALUES ('m112-mapped', 'Mapped', 'concept', 'work', 'codex', NULL, 0, \
+                     21, 22, NULL, NULL)",
+            (),
+        )
+        .await
+        .unwrap();
+        // Same column list migration 113 uses for a shadow at this version.
+        conn.execute(
+            "INSERT INTO pages (
+                id, title, summary, content, kind, entity_type, confidence, entity_confirmed,
+                embedding, space, workspace, source_memory_ids, version, status,
+                created_at, last_compiled, last_modified, creation_kind, review_status
+             ) VALUES (?1, 'Mapped', NULL, '', 'entity', 'concept', NULL, 0,
+                       NULL, 'work', 'work', '[]', 1, 'active',
+                       '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z',
+                       'entity', 'unconfirmed')",
+            libsql::params![mapped_page.as_str()],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO entity_page_map (entity_id, page_id, created_at) \
+             VALUES ('m112-mapped', ?1, '2026-08-01T00:00:00Z')",
+            libsql::params![mapped_page.as_str()],
+        )
+        .await
+        .unwrap();
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("a schema-112 database with entities must open on the current build");
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
+    assert_eq!(user_version(&db).await, 124);
+
+    let conn = db.conn.lock().await;
+    for (entity_id, source_agent, created_at) in [
+        ("m112-unmapped", "claude", 11i64),
+        ("m112-mapped", "codex", 21i64),
+    ] {
+        let mut rows = conn
+            .query(
+                "SELECT p.source_agent, p.entity_created_at, p.status \
+                 FROM entity_page_map epm JOIN pages p ON p.id = epm.page_id \
+                 WHERE epm.entity_id = ?1 AND p.kind = 'entity'",
+                libsql::params![entity_id],
+            )
+            .await
+            .unwrap();
+        let row = rows
+            .next()
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("{entity_id} must have a shadow page after the chain"));
+        assert_eq!(
+            row.get::<Option<String>>(0).unwrap().as_deref(),
+            Some(source_agent),
+            "{entity_id}: migration 117's backfill must populate source_agent"
+        );
+        assert_eq!(
+            row.get::<Option<i64>>(1).unwrap(),
+            Some(created_at),
+            "{entity_id}: migration 117's backfill must populate entity_created_at"
+        );
+        assert_eq!(row.get::<String>(2).unwrap(), "active");
+    }
+}
+
+/// Seed a page P and a memory M in one space with an active `cites` edge
+/// between them (the id migration 115/119 derive from `page_evidence`), on a
+/// database whose chain stopped before 115. Returns the edge id.
+async fn seed_cites_edge_at_114(
+    db: &MemoryDB,
+    page_id: &str,
+    source_id: &str,
+    space: &str,
+    valid_until: Option<i64>,
+) -> String {
+    let edge_id = crate::provenance::compute_edge_id(
+        "cites", "page", page_id, "memory", source_id, source_id,
+    );
+    let conn = db.conn.lock().await;
+    conn.execute(
+        "INSERT INTO pages (id, title, content, space, workspace, version, status, \
+                            created_at, last_compiled, last_modified) \
+         VALUES (?1, ?1, 'body', ?2, ?2, 1, 'active', \
+                 '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z')",
+        libsql::params![page_id, space],
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO memories \
+             (id, content, source, source_id, title, chunk_index, last_modified, \
+              chunk_type, source_agent, space, pending_revision, version) \
+         VALUES (?1, 'evidence body', 'memory', ?2, ?2, 0, 0, 'text', 'folder', ?3, 0, 1)",
+        libsql::params![format!("row_{source_id}"), source_id, space],
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO page_evidence (page_id, source_kind, locator, title, linked_at, link_reason) \
+         VALUES (?1, 'memory', ?2, 'Evidence', 5, 'test')",
+        libsql::params![page_id, source_id],
+    )
+    .await
+    .unwrap();
+    conn.execute(
+        "INSERT INTO edges \
+             (edge_id, src_id, src_kind, dst_id, dst_kind, edge_type, lineage, \
+              grounded, root_id, space, created_at, superseded_by, valid_until) \
+         VALUES (?1, ?2, 'page', ?3, 'memory', 'cites', 'evidence', \
+                 0, NULL, ?4, 0, NULL, ?5)",
+        libsql::params![edge_id.as_str(), page_id, source_id, space, valid_until],
+    )
+    .await
+    .unwrap();
+    edge_id
+}
+
+async fn edge_state(db: &MemoryDB, edge_id: &str) -> (String, Option<i64>, Option<String>) {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT lineage, valid_until, json_extract(payload, '$.source_kind') \
+             FROM edges WHERE edge_id = ?1",
+            libsql::params![edge_id],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("edge row");
+    (
+        row.get::<String>(0).unwrap(),
+        row.get::<Option<i64>>(1).unwrap(),
+        row.get::<Option<String>>(2).unwrap(),
+    )
+}
+
+/// KG review 2026-08-16 #5: an active `cites` edge whose memory endpoint
+/// moved to another space made migration 115's payload UPDATE trip the space
+/// fence and roll the whole migration back. The pre-pass downgrades it to
+/// legacy first, so the chain completes and the payload still gets patched.
+#[tokio::test]
+async fn migration_115_downgrades_a_moved_endpoint_cites_edge_before_patching() {
+    let (db, _dir) = test_db_at(114).await;
+    assert_eq!(user_version(&db).await, 114);
+    let edge_id = seed_cites_edge_at_114(&db, "m114-page", "m114-mem", "space-a", None).await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET space = 'space-b' WHERE source_id = 'm114-mem'",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("a moved-endpoint cites edge must not abort migrations 115/116/119");
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
+
+    let (lineage, valid_until, source_kind) = edge_state(&db, &edge_id).await;
+    assert_eq!(
+        lineage, "legacy",
+        "the cross-space row is downgraded, not left typed"
+    );
+    assert!(valid_until.is_none(), "downgrade keeps the row active");
+    assert_eq!(
+        source_kind.as_deref(),
+        Some("memory"),
+        "migration 115 still patches the downgraded row's payload"
+    );
+}
+
+/// KG review 2026-08-16 #5, migration 119's half: a RETIRED cites edge is
+/// not downgraded (it cannot trip the fence while retired), so 119's
+/// reactivation must skip it when its memory endpoint has moved -- bringing
+/// it back would either abort under the fence or resurrect a cross-space
+/// typed row.
+#[tokio::test]
+async fn migration_119_leaves_a_retired_cites_edge_with_a_moved_memory_retired() {
+    let (db, _dir) = test_db_at(114).await;
+    let edge_id =
+        seed_cites_edge_at_114(&db, "m119-page", "m119-mem", "space-a", Some(1_700_000_000)).await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET space = 'space-b' WHERE source_id = 'm119-mem'",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("chain must complete");
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
+
+    let (lineage, valid_until, _) = edge_state(&db, &edge_id).await;
+    assert_eq!(
+        valid_until,
+        Some(1_700_000_000),
+        "migration 119 must not reactivate a cites edge whose memory moved"
+    );
+    assert_eq!(lineage, "evidence", "a retired row is not downgraded");
+}
+
 /// KG close plan G5: migration 113 repairs the entities #473's sweep already
 /// wrote without shadow pages. Simulate the damage (a mapped-page-less
 /// entity, the live drift shape), run the migration, and the parity sweep
@@ -46241,6 +46568,147 @@ async fn delete_entity_deletes_shadow_page() {
     );
 }
 
+/// Two same-space entities joined by an active `relates` edge, plus the memory
+/// the edge cites (so `rebind_source_id` has a live source to rename).
+async fn seed_linked_entity_pair(db: &MemoryDB, prefix: &str, space: &str) -> String {
+    db.create_space(space, None, false).await.unwrap();
+    db.upsert_documents(vec![make_memory_doc(
+        &format!("{prefix}-src"),
+        "The two entities relate.",
+        "fact",
+        space,
+        "folder",
+    )])
+    .await
+    .unwrap();
+    db.test_seed_entity_shadow_page(
+        TestEntity::new(&format!("{prefix}-a"), "Left", "concept").space(space),
+    )
+    .await
+    .unwrap();
+    db.test_seed_entity_shadow_page(
+        TestEntity::new(&format!("{prefix}-b"), "Right", "concept").space(space),
+    )
+    .await
+    .unwrap();
+    db.create_relation(
+        &format!("{prefix}-a"),
+        &format!("{prefix}-b"),
+        "related_to",
+        None,
+        None,
+        None,
+        Some(&format!("{prefix}-src")),
+    )
+    .await
+    .unwrap()
+}
+
+async fn relates_edge_state(
+    db: &MemoryDB,
+    edge_id: &str,
+) -> (Option<i64>, String, Option<String>, Option<String>) {
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT valid_until, space, json_extract(payload, '$.retired_by_archive'), \
+                    json_extract(payload, '$.source_memory_id') \
+             FROM edges WHERE edge_id = ?1",
+            libsql::params![edge_id],
+        )
+        .await
+        .unwrap();
+    let row = rows.next().await.unwrap().expect("edge row");
+    (
+        row.get::<Option<i64>>(0).unwrap(),
+        row.get::<String>(1).unwrap(),
+        row.get::<Option<String>>(2).unwrap(),
+        row.get::<Option<String>>(3).unwrap(),
+    )
+}
+
+/// KG review 2026-08-16 #2: archiving an entity used to leave its active
+/// edges alive with an endpoint the space fence can no longer resolve, so the
+/// next space rename or source rebind aborted. Archive retracts them (tagged),
+/// both writers succeed, and restore brings the entity and its edges back.
+#[tokio::test]
+async fn archive_entity_retracts_its_edges_so_rename_and_rebind_succeed_and_restore_reverts() {
+    let (db, _dir) = test_db().await;
+    let edge_id = seed_linked_entity_pair(&db, "arch", "work").await;
+    assert_eq!(
+        db.entity_link_summary("arch-a").await.unwrap().active_edges,
+        1
+    );
+
+    assert!(db.archive_entity("arch-a").await.unwrap());
+    assert_eq!(
+        db.entity_link_summary("arch-a").await.unwrap().active_edges,
+        0,
+        "archive must retract the entity's active edges"
+    );
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &edge_id).await;
+    assert!(
+        valid_until.is_some(),
+        "the edge is soft-retired, not deleted"
+    );
+    assert_eq!(
+        tag.as_deref(),
+        Some("arch-a"),
+        "an archive-retired edge is stamped with the archiving entity"
+    );
+
+    // Both in-place edge writers the fence used to abort on.
+    db.update_space("work", "career", None)
+        .await
+        .expect("a space rename must survive an archived entity's edges");
+    db.rebind_source_id("memory", "arch-src", "arch-src-renamed")
+        .await
+        .expect("a source rebind must survive an archived entity's edges");
+    let (_, space, _, source_memory_id) = relates_edge_state(&db, &edge_id).await;
+    assert_eq!(space, "career");
+    assert_eq!(source_memory_id.as_deref(), Some("arch-src-renamed"));
+
+    assert!(db.restore_entity("arch-a").await.unwrap());
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &edge_id).await;
+    assert!(
+        valid_until.is_none(),
+        "restore re-activates the archive-retired edge"
+    );
+    assert!(tag.is_none(), "restore removes the archive stamp");
+    assert_eq!(
+        db.entity_link_summary("arch-a").await.unwrap().active_edges,
+        1
+    );
+    assert!(
+        !db.restore_entity("arch-a").await.unwrap(),
+        "restoring an active entity is a no-op"
+    );
+}
+
+/// KG review 2026-08-16 #2, the permanent half: delete retracts the edges too
+/// (untagged -- there is nothing to restore), and a rename still succeeds.
+#[tokio::test]
+async fn delete_entity_retracts_its_edges_so_rename_succeeds() {
+    let (db, _dir) = test_db().await;
+    let edge_id = seed_linked_entity_pair(&db, "del", "work").await;
+
+    db.delete_entity("del-a").await.unwrap();
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &edge_id).await;
+    assert!(
+        valid_until.is_some(),
+        "delete must retract the entity's active edges"
+    );
+    assert!(tag.is_none(), "a permanent delete leaves no restore stamp");
+    assert_eq!(
+        db.entity_link_summary("del-b").await.unwrap().active_edges,
+        0
+    );
+
+    db.update_space("work", "career", None)
+        .await
+        .expect("a space rename must survive a deleted entity's edges");
+}
+
 #[tokio::test]
 async fn merge_entities_deletes_loser_shadow_and_resyncs_canonical() {
     let (db, _dir) = test_db().await;
@@ -52694,6 +53162,114 @@ async fn migration_123_shadow_page_write_bumps_each_generation_exactly_once() {
 /// retirement had left any of the three reading a table that no longer exists,
 /// or writing one nothing reads, this fails rather than silently producing an
 /// empty community set.
+/// KG review 2026-08-16, migration 124: the repair for databases already past
+/// the frozen-replay fixes. (a) An active edge stranded on an archived shadow
+/// page (archived by a raw status flip, i.e. before `archive_entity` learned
+/// to retract) is retired and stamped; (b) a job parked by either now-fixed
+/// conflict is requeued; (c) an active cites edge whose memory moved is
+/// downgraded to legacy under the pages-reading fence.
+#[tokio::test]
+async fn migration_124_retires_orphan_edges_requeues_parked_jobs_and_downgrades_moved_edges() {
+    let (db, _dir) = test_db().await;
+    let orphan_edge = seed_linked_entity_pair(&db, "m124", "work").await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "m124-page",
+        "M124 page",
+        None,
+        "cites a memory",
+        None,
+        Some("work"),
+        &["m124-src"],
+        &now,
+    )
+    .await
+    .unwrap();
+    let cites_edge = crate::provenance::compute_edge_id(
+        "cites",
+        "page",
+        "m124-page",
+        "memory",
+        "m124-src",
+        "m124-src",
+    );
+    {
+        let conn = db.conn.lock().await;
+        // (a) the pre-fix archive shape: status flipped, edges untouched.
+        conn.execute(
+            "UPDATE pages SET status = 'archived' \
+             WHERE id = (SELECT page_id FROM entity_page_map WHERE entity_id = 'm124-a')",
+            (),
+        )
+        .await
+        .unwrap();
+        // (b) a job parked by the version-only conflict.
+        conn.execute(
+            "INSERT INTO claim_derivation_jobs \
+                 (job_id, page_id, page_version, status, attempts, last_error, \
+                  created_at, updated_at) \
+             VALUES ('m124-page:1', 'm124-page', 1, 'parked', 5, \
+                     'Conflict: support_verdict_supersedes_existing: cr already has a support \
+                      edge for this span naming a different verdict', 1, 1) \
+             ON CONFLICT(job_id) DO UPDATE SET status = 'parked', attempts = 5, \
+                 last_error = excluded.last_error",
+            (),
+        )
+        .await
+        .unwrap();
+        // (c) `insert_page` dual-wrote the same-space cites edge; now the
+        // memory moves (the live move path leaves cites edges active).
+        conn.execute(
+            "UPDATE memories SET space = 'elsewhere' WHERE source_id = 'm124-src'",
+            (),
+        )
+        .await
+        .unwrap();
+        // Rewind to the pre-repair boundary.
+        conn.execute("PRAGMA user_version = 123", ()).await.unwrap();
+    }
+
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("migration 124 must apply");
+    assert_eq!(user_version(&db).await, 124);
+
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &orphan_edge).await;
+    assert!(valid_until.is_some(), "the orphan edge is retired");
+    assert_eq!(
+        tag.as_deref(),
+        Some("m124-a"),
+        "an edge orphaned by an ARCHIVED shadow is stamped for restore"
+    );
+    let (lineage, cites_valid_until, _) = edge_state(&db, &cites_edge).await;
+    assert_eq!(
+        lineage, "legacy",
+        "the moved-endpoint cites edge is downgraded"
+    );
+    assert!(cites_valid_until.is_none());
+    {
+        let conn = db.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT status, attempts, last_error FROM claim_derivation_jobs \
+                 WHERE job_id = 'm124-page:1'",
+                (),
+            )
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
+        assert_eq!(row.get::<String>(0).unwrap(), "pending");
+        assert_eq!(row.get::<i64>(1).unwrap(), 0);
+        assert!(row.get::<Option<String>>(2).unwrap().is_none());
+    }
+
+    // The restore lane picks the stamped edge back up.
+    assert!(db.restore_entity("m124-a").await.unwrap());
+    let (valid_until, _, tag, _) = relates_edge_state(&db, &orphan_edge).await;
+    assert!(valid_until.is_none());
+    assert!(tag.is_none());
+}
+
 #[tokio::test]
 async fn community_pipeline_survives_entity_retirement_end_to_end() {
     const SPACE: &str = "g6s3-community-space";

--- a/crates/wenlan-server/src/cmd_prune_junk_entities.rs
+++ b/crates/wenlan-server/src/cmd_prune_junk_entities.rs
@@ -17,7 +17,10 @@
 //! Dry run is the default, and `--apply` archives rather than deletes: the
 //! shadow page flips to `status='archived'`, which hides the entity from every
 //! reader while leaving the row, its observations, its aliases, and its memory
-//! links in place and restorable.
+//! links in place; its live edges are retracted alongside it, stamped so they
+//! come back. `--restore <ENTITY_ID>` is the way back: it un-archives the
+//! entity and re-activates those edges (a bare `UPDATE pages SET status`
+//! would bring the entity back with none of its relations).
 //!
 //! Like the other one-off commands here, it refuses to run while the daemon is
 //! up, so it never writes to a live WAL.
@@ -40,7 +43,9 @@ struct Candidate {
     links: EntityLinkSummary,
 }
 
-pub async fn run(apply: bool, include_review: bool) -> Result<()> {
+/// Open the store the way every one-off command here does: daemon down,
+/// data-root lock held for the life of the returned guard.
+async fn open_store() -> Result<(MemoryDB, super::DaemonDataLock)> {
     super::cmd_backfill::check_service_unloaded()?;
     super::cmd_backfill::check_daemon_not_running().await?;
 
@@ -52,11 +57,52 @@ pub async fn run(apply: bool, include_review: bool) -> Result<()> {
                 .join("wenlan")
         });
     let data_dir = wenlan_root.join("memorydb");
-    let _data_root_lock = super::DaemonDataLock::acquire(&wenlan_root, true)?;
+    let data_root_lock = super::DaemonDataLock::acquire(&wenlan_root, true)?;
 
     let db = MemoryDB::new(&data_dir, Arc::new(NoopEmitter))
         .await
         .with_context(|| format!("opening MemoryDB at {}", data_dir.display()))?;
+    Ok((db, data_root_lock))
+}
+
+/// `--restore <ENTITY_ID>`: un-archive each entity and re-activate the edges
+/// its archive retracted. Reports per id; an id that is not archived (or does
+/// not exist) is a no-op, not an error.
+pub async fn restore(entity_ids: &[String]) -> Result<()> {
+    let (db, _data_root_lock) = open_store().await?;
+    let mut restored = 0usize;
+    for id in entity_ids {
+        let before = db
+            .entity_link_summary(id)
+            .await
+            .with_context(|| format!("link summary for {id}"))?;
+        if db
+            .restore_entity(id)
+            .await
+            .with_context(|| format!("restoring entity {id}"))?
+        {
+            let after = db
+                .entity_link_summary(id)
+                .await
+                .with_context(|| format!("link summary for {id}"))?;
+            println!(
+                "restored {id}: active edges {} -> {}",
+                before.active_edges, after.active_edges
+            );
+            restored += 1;
+        } else {
+            println!("skipped {id}: no archived entity page with that id");
+        }
+    }
+    println!(
+        "Restored {restored} of {} entity page(s).",
+        entity_ids.len()
+    );
+    Ok(())
+}
+
+pub async fn run(apply: bool, include_review: bool) -> Result<()> {
+    let (db, _data_root_lock) = open_store().await?;
 
     let candidates = collect_candidates(&db).await?;
     if candidates.is_empty() {
@@ -120,7 +166,8 @@ pub async fn run(apply: bool, include_review: bool) -> Result<()> {
 
     print!(
         "Archive {} entity page(s)? Observations, aliases, and memory links are kept; live \
-         edges are retracted and come back on restore. (y/N): ",
+         edges are retracted and come back with `prune-junk-entities --restore <ENTITY_ID>`. \
+         (y/N): ",
         targets.len()
     );
     io::stdout().flush().ok();
@@ -145,7 +192,8 @@ pub async fn run(apply: bool, include_review: bool) -> Result<()> {
     }
     println!(
         "Archived {archived} entity page(s). Nothing was deleted; each entity's live edges were \
-         retracted alongside it, and restoring the entity re-activates them."
+         retracted alongside it. To bring one back with its edges: \
+         `prune-junk-entities --restore <ENTITY_ID>`."
     );
     Ok(())
 }

--- a/crates/wenlan-server/src/cmd_prune_junk_entities.rs
+++ b/crates/wenlan-server/src/cmd_prune_junk_entities.rs
@@ -119,7 +119,8 @@ pub async fn run(apply: bool, include_review: bool) -> Result<()> {
     }
 
     print!(
-        "Archive {} entity page(s)? Observations, aliases, edges, and memory links are kept. (y/N): ",
+        "Archive {} entity page(s)? Observations, aliases, and memory links are kept; live \
+         edges are retracted and come back on restore. (y/N): ",
         targets.len()
     );
     io::stdout().flush().ok();
@@ -143,8 +144,8 @@ pub async fn run(apply: bool, include_review: bool) -> Result<()> {
         }
     }
     println!(
-        "Archived {archived} entity page(s). Nothing was deleted; flip `pages.status` back to \
-         'active' on a page to restore it with all of its links intact."
+        "Archived {archived} entity page(s). Nothing was deleted; each entity's live edges were \
+         retracted alongside it, and restoring the entity re-activates them."
     );
     Ok(())
 }

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -624,6 +624,8 @@ enum Command {
     /// Internal maintenance: archive entity pages whose names the admission
     /// gate refuses (quantities, paths, filenames, shas, test residue).
     /// Daemon must be stopped first. Dry run unless `--apply`.
+    /// `--restore <ENTITY_ID>` un-archives one entity (repeatable) and
+    /// re-activates the edges the archive retracted.
     #[command(name = "prune-junk-entities", hide = true)]
     PruneJunkEntities {
         /// Archive the listed pages. Without it this only prints them.
@@ -633,6 +635,10 @@ enum Command {
         /// names, URLs). Off by default: those are ambiguous, not junk.
         #[arg(long)]
         include_review: bool,
+        /// Un-archive this entity id (repeatable) instead of scanning; the
+        /// edges its archive retracted come back with it.
+        #[arg(long, value_name = "ENTITY_ID", conflicts_with_all = ["apply", "include_review"])]
+        restore: Vec<String>,
     },
 }
 
@@ -956,7 +962,14 @@ async fn main() -> anyhow::Result<()> {
             Some(Command::PruneJunkEntities {
                 apply,
                 include_review,
-            }) => cmd_prune_junk_entities::run(apply, include_review).await,
+                restore,
+            }) => {
+                if restore.is_empty() {
+                    cmd_prune_junk_entities::run(apply, include_review).await
+                } else {
+                    cmd_prune_junk_entities::restore(&restore).await
+                }
+            }
             None => run_daemon(startup_repair_claim).await,
         }
     }


### PR DESCRIPTION
## What this PR does
Core data-integrity repairs for the knowledge graph (review findings 1, 5, 2, 7, 3, 4, 28 from the 2026-08-16 KG subsystem review), plus migration 124 (`SCHEMA_VERSION` 123 → 124):

- **#1** frozen migrations 113/114 no longer `SET` five `pages` columns that migration 117 adds later, so a DB captured at schema 112 with mapped entities upgrades again (was an upgrade blocker).
- **#5** `downgrade_cross_space_active_edges` runs first inside migrations 115/116/119 so the edge space fence cannot abort on cross-space edges; m119 reactivation checks the memory's live space.
- **#2** `archive_entity` / `delete_entity` retract the entity's incident edges inside a transaction (archive tags them `retired_by_archive`); new `restore_entity` reverses an archive. Fixes space renames and source rebinds failing on orphan edges.
- **#7** `commit_entity_enrichment_at_version` takes the entity resolution lock (same order as `store_entity`).
- **#3** claim span locator includes `source_version`, so a moved/edited memory re-supports cleanly instead of `Conflict`.
- **#4** `persist_run_judgments` retires active `supports` edges outside the sealed run inventory (lease-checked transaction), so a chunk edit no longer parks the page's derivation job.
- **#28** producer test: demote → re-derive → re-support.
- **m124** repair: retire orphan edges (tagging archived-shadow ones), requeue jobs parked on `support_verdict_supersedes_existing` / `M5 finalization refused`, downgrade cross-space edges against shadow pages.

## How to test
- `cargo test -p wenlan-core --lib -- claim_identity_test claim_derivation_test archive_entity delete_entity restore_entity merge_entities prune migration` → 348 passed, 0 failed (after rebase on main).
- Full `wenlan-core` lib suite before rebase: 4161 passed, 0 failed.
- Real surface: built `wenlan-server` from this branch and booted it on an isolated port against a `.backup` copy of the live DB (schema 123, 8461 active edges, 108 parked jobs): `/api/health` ok in 5 s, `user_version` 123 → 124, 5 orphan edges retired and tagged, 89 parked jobs requeued to `pending` (19 remain parked on other errors), `/api/memory/graph` → 200.

## Checklist
- [x] Tests pass (focused suites above; full core lib suite green pre-rebase; CI runs the rest)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

Independent review (2026-08-17): one important finding, fixed in the follow-up commit — reversibility now has a real user path: `wenlan-server prune-junk-entities --restore <ENTITY_ID>` un-archives an entity and re-activates the edges its archive retracted (the CLI messages point at it). `restore_entity` also scans by endpoint (not only by stamp), so restoring two mutually-linked archived entities works in either order (new test), and it propagates non-fence errors instead of swallowing them. Reviewer's note on m124 (c) quantified on the live-DB copy: 0 lineage flips (1219 legacy-lineage active edges before and after), 5 orphan edges retired, 89 jobs requeued.

Known limits: the resolution-lock race has no race test (reviewed one-liner). The `source_version` locator makes each supported page grow one retired row per support edge on its next run (one-time, auditable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
