### PR TITLE
fix(kg): count live relates edges instead of the frozen relations table in count_relations, stale-source diagnostics, and the quality pipeline test

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -39187,11 +39187,19 @@ impl MemoryDB {
             .map_err(|e| WenlanError::VectorDb(format!("count_entities get: {}", e)))
     }
 
-    /// Count rows in the `relations` table (knowledge-graph edges).
+    /// Count live knowledge-graph relations. Reads the active
+    /// entity->entity `relates` edges (the same predicate as
+    /// `list_relations_between`), not the frozen legacy `relations` table,
+    /// which has had no writer since G6 Stage 2 PR 2b.
     pub async fn count_relations(&self) -> Result<i64, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
-            .query("SELECT COUNT(*) FROM relations", ())
+            .query(
+                "SELECT COUNT(*) FROM edges \
+                 WHERE edge_type = 'relates' AND src_kind = 'entity' AND dst_kind = 'entity' \
+                   AND valid_until IS NULL",
+                (),
+            )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("count_relations query: {}", e)))?;
         let row = rows

--- a/crates/wenlan-core/src/db/entity_clean_readers_test.rs
+++ b/crates/wenlan-core/src/db/entity_clean_readers_test.rs
@@ -173,3 +173,45 @@ async fn shadow_page_title_type_and_confidence_track_store_entity_updates() {
         "confidence must still track the entities row after the re-sync"
     );
 }
+
+/// `count_relations` reads live `relates` edges, not the frozen legacy
+/// `relations` table (which `create_relation` stopped writing at G6 Stage 2
+/// PR 2b). Five entities plus one live relation is exactly the shape the
+/// GraphAlive onboarding gate (`onboarding.rs`) needs to fire.
+#[tokio::test]
+async fn count_relations_counts_live_relates_edges() {
+    let (db, _tmp) = crate::db::tests::test_db().await;
+
+    let mut ids = Vec::new();
+    for name in ["Ent One", "Ent Two", "Ent Three", "Ent Four", "Ent Five"] {
+        ids.push(
+            db.store_entity(name, "concept", None, None, Some(0.5))
+                .await
+                .unwrap(),
+        );
+    }
+    assert_eq!(db.count_entities().await.unwrap(), 5);
+    assert_eq!(
+        db.count_relations().await.unwrap(),
+        0,
+        "entities alone must count as zero relations"
+    );
+
+    db.create_relation(
+        &ids[0],
+        &ids[1],
+        "related_to",
+        Some("test"),
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        db.count_relations().await.unwrap(),
+        1,
+        "one live relation created through the writer must be counted"
+    );
+}

--- a/crates/wenlan-core/src/db/kg_quality_diagnostics.rs
+++ b/crates/wenlan-core/src/db/kg_quality_diagnostics.rs
@@ -10,21 +10,18 @@ pub(crate) struct ContradictionObservationCount {
 }
 
 impl MemoryDB {
-    // G6 Stage 2 PR 2b sweep classification (2026-08-06): Tripwire, not a
-    // live bug -- `detect_stale_relations` (kg_quality.rs), the only caller,
-    // is pure `log::warn!` for visibility with no behavioral effect (its own
-    // doc comment: "actual pruning is deferred"). Left on `relations` on
-    // purpose, same disposition as the Q3-ruled entity-store lint audits
-    // (frozen-store tripwire; a CONSTANT post-cutover count is itself the
-    // signal that no writer regressed back onto `relations`). Retires with
-    // the store in Stage 3, not migrated onto `edges` in Stage 2.
+    /// Count live `relates` edges whose payload `source_memory_id` no longer
+    /// resolves to a memory row. Reads `edges` (the sole live producer of
+    /// relations since G6 Stage 2 PR 2b), not the frozen legacy `relations`
+    /// table.
     pub(crate) async fn count_stale_relation_sources(&self) -> Result<usize, WenlanError> {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT COUNT(*) FROM relations
-                 WHERE source_memory_id IS NOT NULL
-                 AND source_memory_id NOT IN (SELECT DISTINCT source_id FROM memories WHERE source_id IS NOT NULL)",
+                "SELECT COUNT(*) FROM edges
+                 WHERE edge_type = 'relates' AND valid_until IS NULL
+                 AND json_extract(payload, '$.source_memory_id') IS NOT NULL
+                 AND json_extract(payload, '$.source_memory_id') NOT IN (SELECT DISTINCT source_id FROM memories WHERE source_id IS NOT NULL)",
                 (),
             )
             .await

--- a/crates/wenlan-core/src/db/kg_quality_diagnostics_test.rs
+++ b/crates/wenlan-core/src/db/kg_quality_diagnostics_test.rs
@@ -31,12 +31,16 @@ async fn insert_relation(
     to_entity: &str,
     source_memory_id: Option<&str>,
 ) {
+    // Live `relates` edge; `source_memory_id` lives in the payload JSON.
+    let payload = match source_memory_id {
+        Some(source) => serde_json::json!({ "source_memory_id": source }).to_string(),
+        None => "{}".to_string(),
+    };
     let conn = db.conn.lock().await;
     conn.execute(
-        "INSERT INTO relations (
-             id, from_entity, to_entity, relation_type, source_memory_id, created_at
-         ) VALUES (?1, ?2, ?3, 'related_to', ?4, 1)",
-        libsql::params![id, from_entity, to_entity, source_memory_id],
+        "INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,payload,created_at,semantic_type)
+         VALUES (?1,?2,'entity',?3,'entity','relates','legacy',0,'00000000-0000-4000-8000-000000000001',?4,1,'related_to')",
+        libsql::params![id, from_entity, to_entity, payload],
     )
     .await
     .unwrap();

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -734,23 +734,28 @@ mod tests {
             .await
             .unwrap();
 
-        // Verify normalization happened at insert time
+        // Verify normalization happened at insert time. `relations` is
+        // frozen; the live relation is the `relates` edge's `semantic_type`.
         {
             let conn = db.test_primary_session().await;
             let mut rows = conn
                 .query(
-                    "SELECT relation_type FROM relations WHERE from_entity = ?1",
+                    "SELECT semantic_type FROM edges \
+                     WHERE edge_type = 'relates' AND src_id = ?1 AND valid_until IS NULL",
                     libsql::params![id1.clone()],
                 )
                 .await
                 .unwrap();
+            let mut seen = 0;
             while let Some(row) = rows.next().await.unwrap() {
                 let rt: String = row.get::<String>(0).unwrap();
                 assert_eq!(
                     rt, "works_on",
                     "expected all relations normalized to 'works_on'"
                 );
+                seen += 1;
             }
+            assert_eq!(seen, 2, "both live relates edges must be visible");
         }
 
         // 5. Entity self-retrieval passes


### PR DESCRIPTION
## What this PR does
Three leftovers that still read the frozen legacy `relations` table (KG review findings 6, 23, 29):

- **#6** `count_relations` now counts active entity→entity `relates` edges (same predicate as `list_relations_between`), so the GraphAlive onboarding milestone can fire on post-cutover installs.
- **#29** `count_stale_relation_sources` reads `json_extract(payload,'$.source_memory_id')` from active `relates` edges instead of the frozen table; the "Retires with the store in Stage 3" comment is gone. `RethinkReport.stale_relations_flagged` keeps its shape.
- **#23** `test_full_kg_quality_pipeline` asserts over live edges (`semantic_type`) and requires exactly 2 rows, so its loop actually runs.

## How to test
- `cargo test -p wenlan-core --lib -- entity_clean_readers_test kg_quality_diagnostics_test test_full_kg_quality_pipeline count_relations` → 8 passed, 0 failed (after rebase on main).
- Reader inventory check ok (`scripts/m5-reader-sweep.py --check`).

## Checklist
- [x] Tests pass (focused suite above; CI runs the rest)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
