### PR TITLE
fix(kg): principled short-sha name rule, reject self-loop relations, drop the dead fresh-DB backup guard, make the eval harness compile in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1546,6 +1546,11 @@ jobs:
         env:
           CI_TEST_PLAN: ${{ needs.detect-changes.outputs.test-plan }}
         run: python3 scripts/ci_test_plan.py run --suite core-integration --plan-json "$CI_TEST_PLAN"
+      - name: Check eval_harness compiles (Linux)
+        if: needs.detect-changes.outputs.core-integration-required == 'true'
+        # Check-only: the target is manual-only to run, but it must keep
+        # building or the eval scripts that invoke it rot silently.
+        run: cargo check -p wenlan-core --features eval-harness --test eval_harness
       - name: E2E wenlan background on/off (Linux user-systemd)
         if: needs.detect-changes.outputs.canonical-smokes-required == 'true'
         run: |

--- a/app/eval/REFERENCE.md
+++ b/app/eval/REFERENCE.md
@@ -224,7 +224,7 @@ Cache directories accumulate fast (1GB+ per full LoCoMo+LME run) and snapshots s
 
 > Moved from root `AGENTS.md` (index-and-pointer refactor); co-located with its `kg_fixtures/` fixtures.
 
-`app/eval/kg_fixtures/*.toml` hold hand-curated entity + relation ground-truth per source_text case. The `eval::kg_faithfulness` module's smoke test (`#[ignore]`d, runs in L6 main canary) extracts KG from each case and scores entity + relation precision/recall/F1 against the expected ground truth. No LLM judge in this bench — string-match faithfulness only. LLM-judge variant is a follow-up plan.
+`app/eval/kg_fixtures/*.toml` hold hand-curated entity + relation ground-truth per source_text case. `eval::kg_faithfulness::run_kg_faithfulness_eval` scores entity + relation precision/recall/F1 against that ground truth (string-match only, no LLM judge). Its smoke test in `crates/wenlan-core/tests/eval_harness.rs` (`run_kg_faithfulness_smoke`, `#[ignore]`d) is currently a stub: it locates the fixture dir and prints SKIP without constructing an extractor, so nothing scores these fixtures yet. CI only checks that the `eval_harness` target compiles (`cargo check -p wenlan-core --features eval-harness --test eval_harness`). Wiring the extractor and the LLM-judge variant are follow-up work.
 
 ---
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -9971,18 +9971,15 @@ impl MemoryDB {
     /// §6.9 pre-migration backup: take an online snapshot + integrity receipt
     /// BEFORE a migration's DDL so a botched migration has a restore point, and
     /// record the receipt in `app_metadata` (key `backup_before_migration_<n>`)
-    /// so an operator can find it. Skips a fresh DB (`prior_version == 0`:
-    /// nothing to protect -- the first-ever open runs every migration from
-    /// scratch). The snapshot lands beside the live db as
-    /// `pre_migration_<n>_backup.db`.
+    /// so an operator can find it. Runs on every open that reaches the
+    /// migration, including a fresh DB (`prior_version` is the `user_version`
+    /// the dispatch re-read after the early migrations, never 0 here). The
+    /// snapshot lands beside the live db as `pre_migration_<n>_backup.db`.
     async fn backup_before_migration(
         &self,
         migration: i64,
         prior_version: i64,
     ) -> Result<(), WenlanError> {
-        if prior_version == 0 {
-            return Ok(());
-        }
         let source_path = {
             let conn = self.conn.lock().await;
             Self::main_db_path(&conn).await?
@@ -10019,7 +10016,8 @@ impl MemoryDB {
         )
         .await?;
         log::info!(
-            "[migration] pre-migration {migration} backup: {} ({} pages, integrity ok)",
+            "[migration] pre-migration {migration} backup (from user_version {prior_version}): {} \
+             ({} pages, integrity ok)",
             receipt.dest,
             receipt.backup_pages
         );
@@ -10074,7 +10072,7 @@ impl MemoryDB {
         // §6.9: pre-migration online backup + integrity receipt BEFORE any DDL,
         // so a botched cutover migration has a restore point. Taken here (not
         // inside the BEGIN) because `online_backup` checkpoints + copies under
-        // its own conn lock; skips a fresh DB (prior_version == 0).
+        // its own conn lock.
         self.backup_before_migration(82, prior_version).await?;
 
         let conn = self.conn.lock().await;
@@ -35058,6 +35056,13 @@ impl MemoryDB {
         model_version: Option<&str>,
         prompt_version: Option<&str>,
     ) -> Result<String, WenlanError> {
+        // A self-loop carries no information and would only draw a loop on
+        // the map; refuse it before any vocabulary side effect.
+        if from_entity == to_entity {
+            return Err(WenlanError::Validation(
+                "from_entity and to_entity must differ".to_string(),
+            ));
+        }
         // Normalize relation type against vocabulary.
         // NOTE: resolve_relation_type acquires the conn lock, so we must not hold it here.
         let canonical = match self.resolve_relation_type(relation_type).await? {
@@ -36708,6 +36713,12 @@ impl MemoryDB {
                     let Some(to_id) = entity_ids.get(&relation.to.to_lowercase()) else {
                         continue;
                     };
+                    // Resolution can collapse two extractor names onto one
+                    // entity ("Rust" / "Rust lang"); a self-loop is not a
+                    // relation.
+                    if from_id == to_id {
+                        continue;
+                    }
 
                     let mut canonical = None;
                     let mut canonical_rows = conn

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -24088,6 +24088,107 @@ async fn create_relation_captures_coerced_type_as_promote_candidate() {
 }
 
 #[tokio::test]
+async fn create_relation_rejects_self_loop_before_vocabulary_side_effects() {
+    let (db, _tmp) = test_db().await;
+    let e1 = db.create_entity("Rust", "concept", None).await.unwrap();
+
+    // An unknown type would normally queue a promote proposal; the self-loop
+    // must be refused before that side effect fires.
+    let err = db
+        .create_relation(&e1, &e1, "is_same_as", None, Some(0.9), None, None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, WenlanError::Validation(ref msg) if msg == "from_entity and to_entity must differ"),
+        "expected Validation error, got {err:?}"
+    );
+
+    let pending = db.get_pending_refinements().await.unwrap();
+    assert!(
+        !pending.iter().any(|p| p.action == "vocab_promote"
+            && p.payload.as_deref().unwrap_or("").contains("is_same_as")),
+        "a refused self-loop must not queue a promote candidate"
+    );
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM edges \
+             WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?1",
+            libsql::params![e1.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        0,
+        "no self-loop edge may be written"
+    );
+}
+
+#[tokio::test]
+async fn ambient_enrichment_skips_self_loop_relation_after_resolution() {
+    let (db, _dir) = test_db().await;
+    // "Rust" and "Rust Lang" both resolve to the same entity (exact title +
+    // alias), so the extractor's triple collapses onto a self-loop.
+    let rust = db
+        .store_entity("Rust", "concept", Some("work"), Some("test"), Some(1.0))
+        .await
+        .unwrap();
+    db.add_entity_alias("rust lang", &rust, "test")
+        .await
+        .unwrap();
+    db.upsert_documents(vec![make_memory_doc(
+        "mem_self_loop_relation",
+        "Rust is also called Rust Lang.",
+        "fact",
+        "work",
+        "agent",
+    )])
+    .await
+    .unwrap();
+
+    let mut extracted = extracted_graph("Rust", "Rust Lang", "Rust is a language");
+    extracted[0].relations[0].relation_type = "also_known_as".to_string();
+    assert!(db
+        .commit_entity_enrichment_at_version(
+            "mem_self_loop_relation",
+            1,
+            &extracted,
+            "Rust is also called Rust Lang.",
+        )
+        .await
+        .unwrap());
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM edges \
+             WHERE edge_type = 'relates' AND src_id = dst_id AND src_id = ?1",
+            libsql::params![rust.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        0,
+        "the ambient lane must skip a relation whose endpoints collapse to one entity"
+    );
+    drop(rows);
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM memory_entities WHERE memory_id = 'mem_self_loop_relation' AND entity_id = ?1",
+            libsql::params![rust.clone()],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+        1,
+        "skipping the self-loop must not drop the entity link itself"
+    );
+}
+
+#[tokio::test]
 async fn entity_type_vocabulary_seeded_and_resolves() {
     let (db, _tmp) = test_db().await;
     // Canonical resolves to itself.

--- a/crates/wenlan-core/src/db/scoped_entities.rs
+++ b/crates/wenlan-core/src/db/scoped_entities.rs
@@ -945,7 +945,11 @@ impl MemoryDB {
             let to_entity: String = row.get(2).map_err(|error| {
                 WenlanError::VectorDb(format!("get_knowledge_graph_scoped relation dst: {error}"))
             })?;
-            if !entity_ids.contains(from_entity.as_str())
+            // A self-loop is not a relationship between two things (mirrors
+            // the page->page self-link drop below); older rows written before
+            // the writers refused them must not draw a loop on the map.
+            if from_entity == to_entity
+                || !entity_ids.contains(from_entity.as_str())
                 || !entity_ids.contains(to_entity.as_str())
             {
                 continue;

--- a/crates/wenlan-core/src/db/scoped_entities_test.rs
+++ b/crates/wenlan-core/src/db/scoped_entities_test.rs
@@ -1073,6 +1073,43 @@ async fn get_knowledge_graph_scoped_returns_whole_scope_and_drops_out_of_scope_r
     }
 }
 
+/// A self-loop `relates` row stored before the writers refused them must not
+/// be drawn (mirrors the page->page self-link drop).
+#[tokio::test]
+async fn get_knowledge_graph_scoped_drops_stored_self_loop_relations() {
+    let (db, _tmp) = test_db().await;
+    let a = db
+        .store_entity("Self loop A", "topic", Some("work"), None, Some(0.9))
+        .await
+        .unwrap();
+    let b = db
+        .store_entity("Self loop B", "topic", Some("work"), None, Some(0.9))
+        .await
+        .unwrap();
+    db.create_relation(&a, &b, "related_to", None, None, None, None)
+        .await
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO edges (edge_id,src_id,src_kind,dst_id,dst_kind,edge_type,lineage,grounded,space,created_at,semantic_type)
+             VALUES ('self-loop-edge',?1,'entity',?1,'entity','relates','assertion',0,'work',1,'related_to')",
+            libsql::params![a.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    let graph = db
+        .get_knowledge_graph_scoped(&ReadScope::Space("work".to_string()))
+        .await
+        .unwrap();
+    assert_eq!(graph.entities.len(), 2);
+    assert_eq!(graph.relations.len(), 1);
+    assert_eq!(graph.relations[0].from_entity, a);
+    assert_eq!(graph.relations[0].to_entity, b);
+}
+
 /// The same seed read unscoped: the cross-space relation is a real relation
 /// between two visible entities, so Global keeps it (and the other space's
 /// memory too). Pins that the drops above come from scoping, not from the

--- a/crates/wenlan-core/src/kg/entity_name_quality.rs
+++ b/crates/wenlan-core/src/kg/entity_name_quality.rs
@@ -348,16 +348,46 @@ fn is_quantity(name: &str) -> bool {
     suffix == "%" || digit_count >= 2
 }
 
+/// Real names spelled only with hex letters and digits, in the single-case
+/// short-sha shape. `feb`/`dec` followed by digits (month + year) are handled
+/// as a pattern in `is_hex_word`.
+const HEX_WORDS: &[&str] = &["ed25519"];
+
+fn is_hex_word(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    HEX_WORDS.contains(&lower.as_str())
+        || ["feb", "dec"].iter().any(|month| {
+            lower
+                .strip_prefix(month)
+                .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()))
+        })
+}
+
 fn is_hex_or_uuid(name: &str) -> bool {
     let hex_run = |s: &str| !s.is_empty() && s.chars().all(|c| c.is_ascii_hexdigit());
     // Short git sha: 7-40 hex characters carrying at least one digit and one
-    // letter, which keeps real words like "decade" and "facade" out.
+    // letter, which keeps real words like "decade" and "facade" out. Words
+    // spelled only with a-f and digits ("Ed25519", "Face2Face", "Feb2024") also
+    // fit that shape, so a short candidate counts as a sha only when it looks
+    // like one: single-case letters, no alphabetic run of four or more, and not
+    // a known hex-spelled word. At 12+ characters the odds of a real word
+    // vanish and the shape alone decides.
     if (7..=40).contains(&name.len())
         && hex_run(name)
         && name.chars().any(|c| c.is_ascii_digit())
         && name.chars().any(|c| c.is_ascii_alphabetic())
     {
-        return true;
+        if name.len() >= 12 {
+            return true;
+        }
+        let single_case = !(name.chars().any(|c| c.is_ascii_lowercase())
+            && name.chars().any(|c| c.is_ascii_uppercase()));
+        let longest_alpha_run = name
+            .split(|c: char| !c.is_ascii_alphabetic())
+            .map(str::len)
+            .max()
+            .unwrap_or(0);
+        return single_case && longest_alpha_run < 4 && !is_hex_word(name);
     }
     let groups: Vec<&str> = name.split('-').collect();
     groups.len() == 5
@@ -573,6 +603,11 @@ mod tests {
             ("bd691cc", Reason::HexOrUuid),
             ("9f97751", Reason::HexOrUuid),
             ("a310415", Reason::HexOrUuid),
+            ("7a8287fe", Reason::HexOrUuid),
+            ("231794f4", Reason::HexOrUuid),
+            ("ba894341", Reason::HexOrUuid),
+            ("deadbeefcafe0123", Reason::HexOrUuid),
+            ("ABCDEF1234567", Reason::HexOrUuid),
             ("3f444117-ef36-4205-b00b-2c0dc830683e", Reason::HexOrUuid),
             ("~/.claude/CLAUDE.md", Reason::FilesystemPath),
             ("~/.claude/skills", Reason::FilesystemPath),
@@ -731,6 +766,12 @@ mod tests {
             // words that brush the hex rule
             "decade",
             "facade",
+            "Ed25519",
+            "ED25519",
+            "Face2Face",
+            "Feb2024",
+            "Cafe2024",
+            "Deadbeef1",
             // names containing "test" that are real
             "Convergence Test Entity",
             "A/B test memory pool",

--- a/crates/wenlan-core/tests/eval_harness.rs
+++ b/crates/wenlan-core/tests/eval_harness.rs
@@ -5,6 +5,7 @@
 //! Tests needing external data (locomo10.json, longmemeval) or real GPU LLM stay `#[ignore]`.
 
 use wenlan_core::eval::runner::{run_eval, GateMode};
+use wenlan_core::read_scope::ReadScope;
 
 /// Stderr logger so distill's per-cluster `log::warn!`/`log::info!` skip reasons
 /// (thin cluster / LLM error / hallucination sim / garbage title) are visible in
@@ -2281,7 +2282,6 @@ async fn seed_scenario_dbs_complete() {
     use wenlan_core::eval::seed_contract::{assert_seed_contract, SeedExpectations};
     use wenlan_core::eval::shared::run_classification_for_eval_concurrent;
     use wenlan_core::prompts::PromptRegistry;
-    use wenlan_core::read_scope::ReadScope;
     use wenlan_core::tuning::DistillationConfig;
 
     // Route distill's per-cluster log::warn!/info! skip reasons to stderr so the
@@ -7903,6 +7903,7 @@ async fn kg_faithfulness_llm_judge_smoke() {
             relation_type: "is_a".into(),
             confidence: None,
             explanation: None,
+            span: None,
         }],
     };
     let judged = judge_kg_case_with_llm(&case, &extracted, "claude-haiku-4-5-20251001")
@@ -9736,6 +9737,7 @@ async fn enrichment_parity_contract() {
             structured_fields: None,
             retrieval_cue: None,
             source_text: None,
+            content_hash: None,
         }
     }
 


### PR DESCRIPTION
## What this PR does
Four small isolated fixes from the 2026-08-16 KG review (findings 8, 22, 24, 15):

- **#8** `entity_name_quality`: a 7–40 char hex-shaped name with digit+letter is treated as a sha only when it is 12+ chars, or single-case with no alphabetic run of 4+ and not a hex-spelled word (`ed25519`, `feb`/`dec` + digits). `Ed25519`, `ED25519`, `Face2Face`, `Feb2024`, `Cafe2024`, `Deadbeef1` now accept; `7a8287fe`, `231794f4`, `ba894341`, `deadbeefcafe0123`, `ABCDEF1234567` still reject.
- **#24** self-loop relations: `create_relation_with_span` returns `Validation("from_entity and to_entity must differ")` before any vocabulary side effect; the ambient enrichment loop skips a relation whose endpoints resolve to one entity; `get_knowledge_graph_scoped` drops stored self-loops (mirrors the page→page self-link drop).
- **#22** `backup_before_migration`: the `prior_version == 0` guard that could never fire and the "skips a fresh DB" wording are gone; the value is logged with the receipt. Restore-point drills for m92/m97/m123 unchanged.
- **#15** `tests/eval_harness.rs` compiles again (span, content_hash, `ReadScope` import); `app/eval/REFERENCE.md` says the KG faithfulness smoke is a stub; CI gains a check-only step so the target keeps building.

## How to test
- `cargo test -p wenlan-core --lib -- entity_name_quality create_relation self_loop scoped_entities_test migration_92 migration_97 migration_123` → 61 passed, 0 failed (after rebase on main).
- `cargo check -p wenlan-core --features eval-harness --test eval_harness` → ok.

## Checklist
- [x] Tests pass (focused suite above; CI runs the rest)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
