### PR TITLE
docs: document the CLI WENLAN_NO_AUTOSTART opt-out so the flag-doc drift gate passes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,10 @@ active without checking the current worktree.
 - Request defaults: `WENLAN_AGENT_NAME` supplies the CLI identity when no explicit
   agent name is given; `WENLAN_DEFAULT_SPACE` is an overridable CLI/MCP fallback, while
   the strict `WENLAN_SPACE` lock wins over both explicit and default values.
+- CLI autostart: when a request to a loopback daemon cannot connect, the CLI starts the
+  registered background service and waits for its health endpoint; `status`,
+  `background`, and `restart` skip this, and `WENLAN_NO_AUTOSTART=1` opts out for the
+  other commands.
 - Preserve cross-platform behavior on macOS arm64, Linux x86_64/aarch64, and Windows
   x86_64. Read `docs/cross-platform.md` before changing platform conditionals or release
   matrices.


### PR DESCRIPTION
## What this PR does
Unblocks PR CI on `main`. PR #544 added the `WENLAN_NO_AUTOSTART` opt-out (read in `crates/wenlan-cli/src/client/recovery.rs`) but documented it only in the CLI README, which the flag-doc drift contract does not count. Every PR CI run since fails `drift_guard::behavioral_flags_are_documented` with `NEW undocumented behavioral WENLAN_* flag(s): WENLAN_NO_AUTOSTART` (seen on #547 and #543). This adds one behavior bullet to the root `AGENTS.md` (the CLI crate has no `AGENTS.md` of its own).

## How to test
`cargo test -p wenlan-core --lib -- drift_guard::behavioral_flags_are_documented` — fails on `main`, passes with this line (checked both ways locally).

## Checklist
- [x] Tests pass (the drift test above)
- [x] `cargo clippy` and `cargo fmt` pass (docs only)
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
