### PR TITLE
fix(kg): keep provenance on folded edges, sentinel-aware uncategorized lint scope, decodable minhash merge proposals that stay dismissed, re-type entities when their vocabulary is accepted

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -529,7 +529,8 @@ impl MemoryDB {
                     "SELECT edge_id, src_id, dst_id, json_extract(payload,'$.confidence'), \
                             json_extract(payload,'$.explanation'), \
                             json_extract(payload,'$.source_memory_id'), \
-                            json_extract(payload,'$.source_agent'), created_at \
+                            json_extract(payload,'$.source_agent'), created_at, \
+                            payload, grounded \
                      FROM edges \
                      WHERE edge_type = 'relates' AND src_kind = 'entity' AND dst_kind = 'entity' \
                        AND valid_until IS NULL AND semantic_type = ?1",
@@ -548,6 +549,7 @@ impl MemoryDB {
                 Option<String>,
                 Option<String>,
                 Option<i64>,
+                Option<String>,
             )> = Vec::new();
             while let Some(r) = rows
                 .next()
@@ -562,22 +564,30 @@ impl MemoryDB {
                 let smid: Option<String> = r.get(5).ok();
                 let sagent: Option<String> = r.get(6).ok();
                 let created: Option<i64> = r.get(7).ok();
+                let payload: Option<String> = r.get(8).ok();
+                let grounded: i64 = r.get(9).unwrap_or(0);
                 pre_image.push(serde_json::json!({
                     "edge_id": id, "from_entity": from, "to_entity": to, "relation_type": old_type,
                     "confidence": conf, "explanation": expl, "source_memory_id": smid,
-                    "source_agent": sagent, "created_at": created,
+                    "source_agent": sagent, "created_at": created, "grounded": grounded,
                 }));
                 // G6 Stage 2 PR 2b: sagent/created ride along too now — the
                 // relations-side fold write stops below, so the edge's
                 // semantic patch is built from this pre-image instead of a
-                // post-write re-read.
-                ids.push((id, from, to, conf, expl, smid, sagent, created));
+                // post-write re-read. The full `payload` rides along so the
+                // canonical-type edge minted below keeps the loser's
+                // `source_memory_id`/`span`/`model_version`/`prompt_version`
+                // (memory-delete invalidation and the M3g grounding scan key
+                // on `payload.source_memory_id`). Grounding itself resets on
+                // the new edge by design: the M3g candidate scan re-promotes
+                // it because `source_memory_id` survives.
+                ids.push((id, from, to, conf, expl, smid, sagent, created, payload));
             }
             drop(rows);
 
             let mut folded = 0usize;
             let mut graph_changes: Vec<CommunityGraphChange> = Vec::new();
-            for (_id, from, to, conf, expl, _smid, sagent, created) in &ids {
+            for (_id, from, to, conf, expl, _smid, sagent, created, payload) in &ids {
                 // Set in each branch below; feeds the edge's semantic patch
                 // once the relations-side fold write stops (G6 Stage 2 PR 2b).
                 let fold_semantic_patch: Option<String>;
@@ -706,7 +716,7 @@ impl MemoryDB {
                     &space,
                     cross_space_downgrade,
                     None,
-                    None,
+                    payload.as_deref(),
                     Some(canonical),
                     fold_semantic_patch.as_deref(),
                 )
@@ -874,6 +884,99 @@ impl MemoryDB {
                 conn.execute("COMMIT", ())
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("fold_entity commit: {e}")))?;
+                Ok(n)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
+    /// Re-type the entities that were stored under the default type
+    /// (`concept`) only because their extracted type was not yet in the
+    /// vocabulary, once that type has been accepted as a canonical. Called by
+    /// the `vocab_promote` accept path with the proposal's `source_ids` (the
+    /// affected entity ids recorded by [`Self::append_vocab_promote_affected`])
+    /// and the freshly promoted canonical. Only shadow pages still typed
+    /// `concept` move -- an entity a human already re-typed is left alone.
+    /// Ledgered exactly like [`Self::fold_entity_type`] so it is reversible.
+    /// Returns the number of entities re-typed.
+    pub async fn retype_entities_after_promote(
+        &self,
+        entity_ids: &[String],
+        canonical: &str,
+    ) -> Result<usize, WenlanError> {
+        let default_type = crate::vocab::entity_type::DEFAULT_ENTITY_TYPE;
+        if entity_ids.is_empty() || canonical == default_type {
+            return Ok(0);
+        }
+        let ids_json = serde_json::to_string(entity_ids)
+            .map_err(|e| WenlanError::VectorDb(format!("retype ids: {e}")))?;
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("retype begin: {e}")))?;
+
+        let result: Result<usize, WenlanError> = async {
+            let mut rows = conn
+                .query(
+                    "SELECT epm.entity_id FROM entity_page_map epm \
+                     JOIN pages p ON p.id = epm.page_id \
+                     WHERE p.kind = 'entity' AND p.status = 'active' \
+                       AND p.entity_type = ?1 \
+                       AND epm.entity_id IN (SELECT CAST(value AS TEXT) FROM json_each(?2))",
+                    libsql::params![default_type, ids_json.clone()],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
+            let mut ids = Vec::new();
+            while let Some(r) = rows
+                .next()
+                .await
+                .map_err(|e| WenlanError::VectorDb(e.to_string()))?
+            {
+                ids.push(r.get::<String>(0).unwrap_or_default());
+            }
+            drop(rows);
+            if ids.is_empty() {
+                return Ok(0);
+            }
+            let pre: Vec<serde_json::Value> = ids
+                .iter()
+                .map(|id| serde_json::json!({"id": id, "entity_type": default_type}))
+                .collect();
+            let pre_json = serde_json::to_string(&pre).unwrap_or_else(|_| "[]".into());
+
+            let now_iso = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "UPDATE pages SET entity_type = ?1, last_modified = ?2 \
+                 WHERE kind = 'entity' AND status = 'active' AND entity_type = ?3 \
+                   AND id IN (SELECT page_id FROM entity_page_map \
+                              WHERE entity_id IN (SELECT CAST(value AS TEXT) FROM json_each(?4)))",
+                libsql::params![canonical.to_string(), now_iso, default_type, ids_json],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("retype_entities shadow: {e}")))?;
+
+            let ledger_id = format!("vheal-{}", uuid::Uuid::new_v4());
+            let now = chrono::Utc::now().timestamp();
+            conn.execute(
+                "INSERT INTO vocab_heal_ledger (id, kind, old_value, new_value, pre_image, created_at) VALUES (?1, 'entity', ?2, ?3, ?4, ?5)",
+                libsql::params![ledger_id, default_type, canonical, pre_json, now],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("insert_vocab_ledger: {e}")))?;
+
+            Ok(ids.len())
+        }
+        .await;
+
+        match result {
+            Ok(n) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("retype commit: {e}")))?;
                 Ok(n)
             }
             Err(e) => {
@@ -33737,6 +33840,13 @@ impl MemoryDB {
                 log::warn!("[resolve_or_create_entity] minhash band index failed for {id}: {e}");
             }
         }
+        // A freshly created entity stored under the default type is recorded
+        // on its vocab proposal so accepting the type can re-type it.
+        if let Some(raw) = admitted.unrecognized_type.as_deref() {
+            if let Err(e) = self.append_vocab_promote_affected("entity", raw, &id).await {
+                log::warn!("[resolve_or_create_entity] vocab promote affected append failed: {e}");
+            }
+        }
         Ok((id, true))
     }
 
@@ -36297,12 +36407,19 @@ impl MemoryDB {
                 if !seen_names.insert(lower.clone()) {
                     continue;
                 }
-                if let Some(raw) = admitted.unrecognized_type {
-                    if !unrecognized_types.contains(&raw) {
-                        unrecognized_types.push(raw);
+                if let Some(raw) = admitted.unrecognized_type.as_deref() {
+                    if !unrecognized_types.iter().any(|t| t == raw) {
+                        unrecognized_types.push(raw.to_string());
                     }
                 }
-                entities.push((lower, admitted.name, admitted.entity_type));
+                // The raw type rides along so a created entity can be
+                // recorded on its vocab proposal after COMMIT.
+                entities.push((
+                    lower,
+                    admitted.name,
+                    admitted.entity_type,
+                    admitted.unrecognized_type,
+                ));
             }
         }
         // Outside the connection lock by construction: the preflight guard's
@@ -36319,7 +36436,10 @@ impl MemoryDB {
 
         // Embedding is CPU work and must not hold the SQLite connection lock.
         // Batch it once for the selected memory instead of once per entity.
-        let entity_names: Vec<String> = entities.iter().map(|(_, name, _)| name.clone()).collect();
+        let entity_names: Vec<String> = entities
+            .iter()
+            .map(|(_, name, _, _)| name.clone())
+            .collect();
         let embeddings = if entity_names.is_empty() {
             Vec::new()
         } else {
@@ -36341,7 +36461,9 @@ impl MemoryDB {
         let _resolution_guard = self.entity_resolution_lock.lock().await;
         let minhash_enabled = entity_minhash_enabled();
         let mut prepared_entities = Vec::with_capacity(entities.len());
-        for ((lower, name, entity_type), embedding) in entities.into_iter().zip(embeddings) {
+        for ((lower, name, entity_type, raw_type), embedding) in
+            entities.into_iter().zip(embeddings)
+        {
             let minhash_candidate = if minhash_enabled {
                 self.minhash_resolve_candidate(&name, &entity_type).await?
             } else {
@@ -36353,6 +36475,7 @@ impl MemoryDB {
                 entity_type,
                 Self::vec_to_sql(&embedding),
                 minhash_candidate,
+                raw_type,
             ));
         }
 
@@ -36363,7 +36486,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("entity enrichment begin: {e}")))?;
 
-        let mut created_entities: Vec<(String, String)> = Vec::new();
+        let mut created_entities: Vec<(String, String, Option<String>)> = Vec::new();
         let mut generation_updates: Vec<CommunityGenerationUpdate> = Vec::new();
         let result: Result<bool, WenlanError> = async {
             let mut current_rows = conn
@@ -36439,7 +36562,9 @@ impl MemoryDB {
 
             let mut entity_ids: HashMap<String, String> = HashMap::new();
             let mut first_entity_id: Option<String> = None;
-            for (lower, name, entity_type, embedding, minhash_candidate) in &prepared_entities {
+            for (lower, name, entity_type, embedding, minhash_candidate, raw_type) in
+                &prepared_entities
+            {
                 let mut resolved: Option<String> = None;
 
                 // G6 Stage 2 PR 2c sub-step 3 item 4: page-payload lookup,
@@ -36611,7 +36736,7 @@ impl MemoryDB {
                             now,
                         )
                         .await?;
-                        created_entities.push((id.clone(), name.clone()));
+                        created_entities.push((id.clone(), name.clone(), raw_type.clone()));
                         id
                     }
                 };
@@ -37067,14 +37192,27 @@ impl MemoryDB {
                     .map_err(|e| WenlanError::VectorDb(format!("entity enrichment commit: {e}")))?;
                 self.record_community_dirty_nodes(generation_updates);
                 drop(conn);
-                if minhash_enabled {
-                    for (entity_id, name) in created_entities {
+                for (entity_id, name, raw_type) in created_entities {
+                    if minhash_enabled {
                         if let Err(error) = self
                             .index_entity_minhash_if_eligible(&entity_id, &name)
                             .await
                         {
                             log::warn!(
                                 "[entity_enrichment_slice] minhash index failed for {entity_id}: {error}"
+                            );
+                        }
+                    }
+                    // Same rule as `resolve_or_create_entity`: a created
+                    // entity stored under the default type is recorded on
+                    // its vocab proposal so accepting the type re-types it.
+                    if let Some(raw) = raw_type.as_deref() {
+                        if let Err(error) = self
+                            .append_vocab_promote_affected("entity", raw, &entity_id)
+                            .await
+                        {
+                            log::warn!(
+                                "[entity_enrichment_slice] vocab promote affected append failed for {entity_id}: {error}"
                             );
                         }
                     }
@@ -42263,6 +42401,40 @@ impl MemoryDB {
         Ok(())
     }
 
+    /// Insert a refinement proposal only when no row with `id` exists yet.
+    /// Returns true iff a new row was created. Unlike
+    /// [`Self::insert_refinement_proposal`] (`INSERT OR REPLACE`), the
+    /// `ON CONFLICT(id) DO NOTHING` guard keeps an existing
+    /// dismissed/resolved row intact, so a producer that recomputes the same
+    /// deterministic id every pass (the MinHash merge sweep) cannot resurrect
+    /// a human dismissal -- same contract as `insert_vocab_promote_proposal`.
+    pub async fn insert_refinement_proposal_if_absent(
+        &self,
+        id: &str,
+        action: &str,
+        source_ids: &[String],
+        payload: Option<&str>,
+        confidence: f64,
+    ) -> Result<bool, WenlanError> {
+        if action == "lint_repair_review" {
+            return Err(WenlanError::Validation(
+                "lint repair reviews require the canonical insert_lint_review_if_absent writer"
+                    .to_string(),
+            ));
+        }
+        let conn = self.conn.lock().await;
+        let source_ids_json = serde_json::to_string(source_ids).unwrap_or_default();
+        let affected = conn
+            .execute(
+                "INSERT INTO refinement_queue (id, action, source_ids, payload, confidence) \
+                 VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(id) DO NOTHING",
+                libsql::params![id, action, source_ids_json, payload, confidence],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("insert_refinement_if_absent: {e}")))?;
+        Ok(affected > 0)
+    }
+
     /// Persist one stable lint Review Item without overwriting an existing
     /// open or terminal decision. The deterministic id is the dedupe key;
     /// `INSERT OR IGNORE` deliberately never resurrects a dismissed item.
@@ -42380,6 +42552,35 @@ impl MemoryDB {
             )
             .await
             .map_err(|e| WenlanError::VectorDb(format!("insert_vocab_promote: {e}")))?;
+        Ok(affected > 0)
+    }
+
+    /// Record `entity_id` on the open `vocab_promote` proposal for
+    /// `(kind, old_value)` so that accepting the proposal can re-type the
+    /// entities that were stored under the default type because of it (see
+    /// [`Self::retype_entities_after_promote`]). Appends to `source_ids` only
+    /// while the proposal is still open and only if the id is not already
+    /// listed; a missing, dismissed or resolved proposal is left untouched.
+    /// Returns true iff a row was updated.
+    pub async fn append_vocab_promote_affected(
+        &self,
+        kind: &str,
+        old_value: &str,
+        entity_id: &str,
+    ) -> Result<bool, WenlanError> {
+        let id = Self::vocab_proposal_fingerprint(kind, old_value);
+        let conn = self.conn.lock().await;
+        let affected = conn
+            .execute(
+                "UPDATE refinement_queue \
+                 SET source_ids = json_insert(COALESCE(source_ids, '[]'), '$[#]', ?2) \
+                 WHERE id = ?1 AND status IN ('pending', 'awaiting_review') \
+                   AND NOT EXISTS (SELECT 1 FROM json_each(COALESCE(source_ids, '[]')) \
+                                    WHERE value = ?2)",
+                libsql::params![id, entity_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("append_vocab_promote_affected: {e}")))?;
         Ok(affected > 0)
     }
 

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -51309,10 +51309,19 @@ async fn fold_relation_type_dual_writes_edges() {
         .await
         .unwrap();
 
-    // Simple rename: a->c carries only the old type (both are vocabulary canonicals).
-    db.create_relation(&a, &c, "works_on", Some("test"), None, None, None)
-        .await
-        .unwrap();
+    // Simple rename: a->c carries only the old type (both are vocabulary
+    // canonicals) and a source memory whose id must survive the fold.
+    db.create_relation(
+        &a,
+        &c,
+        "works_on",
+        Some("test"),
+        None,
+        None,
+        Some("mem_fold_ac"),
+    )
+    .await
+    .unwrap();
     // Collision merge: a->b carries BOTH the old and the canonical type.
     db.create_relation(&a, &b, "works_on", Some("test"), None, None, None)
         .await
@@ -51350,6 +51359,27 @@ async fn fold_relation_type_dual_writes_edges() {
             "old-type edge points at its canonical successor"
         );
     }
+    // Review finding #11: the simple-rename branch mints the canonical-type
+    // edge WITH the retired edge's payload, so `source_memory_id` survives.
+    let new_ac = crate::provenance::compute_edge_id("relates", "entity", &a, "entity", &c, "leads");
+    let mut rows = conn
+        .query(
+            "SELECT json_extract(payload,'$.source_memory_id') FROM edges \
+             WHERE edge_id = ?1 AND valid_until IS NULL",
+            libsql::params![new_ac.as_str()],
+        )
+        .await
+        .unwrap();
+    let row = rows
+        .next()
+        .await
+        .unwrap()
+        .expect("canonical a->c edge exists");
+    assert_eq!(
+        row.get::<Option<String>>(0).unwrap().as_deref(),
+        Some("mem_fold_ac"),
+        "folded edge keeps the retired edge's source_memory_id"
+    );
 }
 
 /// `replace_page_sources` prunes `page_sources` + memory-kind `page_evidence`

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -707,6 +707,7 @@ crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_typ
 crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_merges_provenance_and_ledgers_the_loser|TestDbSession::query|1
 crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_merges_provenance_and_ledgers_the_loser|TestDbSession::query|2
 crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_merges_provenance_and_ledgers_the_loser|test_primary_session|1
+crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_merges_provenance_and_ledgers_the_loser|TestDbRow::get|5
 crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_rolls_back_when_ledger_insert_fails|TestDbRow::get|1
 crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_rolls_back_when_ledger_insert_fails|TestDbRow::get|2
 crates/wenlan-core/src/kg_quality.rs|crate::kg_quality::tests::fold_relation_type_rolls_back_when_ledger_insert_fails|TestDbRow::get|3
@@ -1013,3 +1014,7 @@ crates/wenlan-core/src/truth_adapter_test.rs|crate::truth_adapter::tests::db_wit
 crates/wenlan-core/src/truth_adapter_test.rs|crate::truth_adapter::tests::db_with_truth_rows|TestDbSession::execute|10
 crates/wenlan-core/src/truth_adapter_test.rs|crate::truth_adapter::tests::db_with_truth_rows|TestDbSession::execute|11
 crates/wenlan-core/src/truth_adapter_test.rs|crate::truth_adapter::tests::db_with_truth_rows|test_primary_session|1
+crates/wenlan-core/src/synthesis/refinement_queue.rs|crate::synthesis::refinement_queue::tests::apply_refinement_vocab_promote_retypes_proposing_entities|TestDbRow::get|1
+crates/wenlan-core/src/synthesis/refinement_queue.rs|crate::synthesis::refinement_queue::tests::apply_refinement_vocab_promote_retypes_proposing_entities|TestDbRows::next|1
+crates/wenlan-core/src/synthesis/refinement_queue.rs|crate::synthesis::refinement_queue::tests::apply_refinement_vocab_promote_retypes_proposing_entities|TestDbSession::query|1
+crates/wenlan-core/src/synthesis/refinement_queue.rs|crate::synthesis::refinement_queue::tests::apply_refinement_vocab_promote_retypes_proposing_entities|test_primary_session|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,7 +3229,7 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        1015,
+        1020,
         "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
          the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, \
          the 7 G6 BindPageLink repair-test calls (G6 Stage 2 PR 2b, item 3: \
@@ -3310,7 +3310,14 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
          carries the behavior on its own; +4 calls added for the new \
          alias_collision lint check's own fixtures, lint/deep_test.rs's \
          alias_collision_inventory_flags_the_same_alias_on_two_active_pages and \
-         alias_collision_inventory_is_silent_on_a_clean_store"
+         alias_collision_inventory_is_silent_on_a_clean_store; plus the net +5 KG-review \
+         2026-08-16 PR D calls: kg_quality.rs's \
+         fold_relation_type_merges_provenance_and_ledgers_the_loser gains one TestDbRow::get \
+         (finding #11: it now reads json_extract(payload,'$.source_memory_id') off the canonical \
+         edge to prove provenance survives the fold), and the new vocab re-type acceptance test \
+         synthesis/refinement_queue.rs::apply_refinement_vocab_promote_retypes_proposing_entities \
+         contributes a test_primary_session / TestDbSession::query / TestDbRows::next / \
+         TestDbRow::get chain reading the shadow page's entity_type after the promote"
     );
 }
 

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -234,24 +234,34 @@ async fn surface_minhash_merge_candidates(db: &MemoryDB) -> Result<usize, Wenlan
                 let i_len = id_i.len().min(8);
                 let j_len = id_j.len().min(8);
                 let proposal_id = format!("minhash_{}_{}", &id_i[..i_len], &id_j[..j_len]);
+                // `similarity` is the key `RefinementPayload::EntityMerge`
+                // decodes on the wire; `jaccard` stays as the provenance-
+                // specific extra. `source_ids` follows the accept path's
+                // `[new, existing]` convention (`apply_refinement` folds
+                // `source_ids[0]` into `source_ids[1]`), so `existing_id`
+                // (id_i) is the survivor it declares.
                 let payload = serde_json::json!({
                     "existing_id": id_i,
                     "new_id": id_j,
+                    "similarity": jac,
                     "jaccard": jac,
                     "same_type": same_type,
                     "provenance": "minhash_jaccard",
                 })
                 .to_string();
+                // If-absent insert: the id is deterministic per pair, so a
+                // dismissed proposal must stay dismissed across rethink
+                // passes; only a genuinely new row counts as enqueued.
                 if db
-                    .insert_refinement_proposal(
+                    .insert_refinement_proposal_if_absent(
                         &proposal_id,
                         "entity_merge",
-                        &[id_i.clone(), id_j.clone()],
+                        &[id_j.clone(), id_i.clone()],
                         Some(&payload),
                         jac,
                     )
                     .await
-                    .is_ok()
+                    .unwrap_or(false)
                 {
                     enqueued += 1;
                 }
@@ -910,7 +920,7 @@ mod tests {
         db.create_relation(&e1, &e2, "works_on", Some("test"), Some(0.9), None, None)
             .await
             .unwrap();
-        // Loser: leads, confidence 0.5, has an explanation.
+        // Loser: leads, confidence 0.5, has an explanation and a source memory.
         db.create_relation(
             &e1,
             &e2,
@@ -918,7 +928,7 @@ mod tests {
             Some("test"),
             Some(0.5),
             Some("employed since 2020"),
-            None,
+            Some("mem_fold_loser"),
         )
         .await
         .unwrap();
@@ -932,7 +942,8 @@ mod tests {
         // (survivor had none).
         let mut rows = conn
             .query(
-                "SELECT COUNT(*), MAX(json_extract(payload,'$.confidence')) FROM edges \
+                "SELECT COUNT(*), MAX(json_extract(payload,'$.confidence')), \
+                        MAX(json_extract(payload,'$.source_memory_id')) FROM edges \
                  WHERE edge_type = 'relates' AND src_id = ?1 AND dst_id = ?2 AND valid_until IS NULL",
                 libsql::params![e1.clone(), e2.clone()],
             )
@@ -941,10 +952,19 @@ mod tests {
         let row = rows.next().await.unwrap().unwrap();
         let cnt: i64 = row.get(0).unwrap();
         let conf: f64 = row.get(1).unwrap();
+        let smid: Option<String> = row.get(2).unwrap();
         assert_eq!(cnt, 1, "collision must not leave two rows");
         assert!(
             (conf - 0.9).abs() < 1e-6,
             "survivor keeps the higher confidence"
+        );
+        // Review finding #11: the loser's `source_memory_id` is COALESCE-merged
+        // into the survivor (fill-if-absent), so memory-delete invalidation and
+        // the grounding scan still see this relation after the fold.
+        assert_eq!(
+            smid.as_deref(),
+            Some("mem_fold_loser"),
+            "survivor must inherit the loser's source_memory_id"
         );
         drop(rows);
         // The absorbed edge's pre-image is in the ledger (undo is possible),
@@ -1288,6 +1308,84 @@ mod tests {
             assert!(
                 payload.contains("minhash_jaccard"),
                 "proposal must carry minhash_jaccard provenance, got: {payload}"
+            );
+            // Review finding #13: the payload must decode as the wire type
+            // (the server tags the raw map with `action` before decoding,
+            // mirrored here) and `source_ids` must follow the accept path's
+            // `[new, existing]` order so `existing_id` really is the survivor.
+            let mut tagged: serde_json::Map<String, serde_json::Value> =
+                serde_json::from_str(payload).expect("payload is a JSON object");
+            tagged.insert("action".into(), serde_json::json!("entity_merge"));
+            let decoded: wenlan_types::RefinementPayload =
+                serde_json::from_value(serde_json::Value::Object(tagged))
+                    .expect("minhash payload must decode as RefinementPayload::EntityMerge");
+            match decoded {
+                wenlan_types::RefinementPayload::EntityMerge {
+                    existing_id,
+                    new_id,
+                    similarity,
+                } => {
+                    assert_eq!(proposal.source_ids.len(), 2);
+                    assert_eq!(
+                        proposal.source_ids[1], existing_id,
+                        "source_ids[1] is the survivor apply_refinement keeps"
+                    );
+                    assert_eq!(proposal.source_ids[0], new_id);
+                    assert!((similarity - jac).abs() < 1e-9);
+                }
+                other => panic!("expected EntityMerge, got {other:?}"),
+            }
+        })
+        .await;
+    }
+
+    // Review finding #14: the proposal id is deterministic per pair, so a
+    // second rethink pass must not resurrect a dismissed proposal (nor count
+    // it as enqueued again).
+    #[tokio::test]
+    async fn find_merge_candidates_keeps_dismissed_minhash_proposals_dismissed() {
+        temp_env::async_with_vars([("WENLAN_ENABLE_ENTITY_MINHASH", Some("1"))], async {
+            let (db, _dir) = test_db().await;
+            db.store_entity("Glorptech", "project", None, Some("t"), None)
+                .await
+                .unwrap();
+            db.store_entity("Glorptechs", "project", None, Some("t"), None)
+                .await
+                .unwrap();
+
+            let first = find_merge_candidates(&db).await.unwrap();
+            assert_eq!(first, 1, "first pass enqueues the pair once");
+            let pending = db.get_pending_refinements().await.unwrap();
+            let proposal = pending
+                .iter()
+                .find(|p| p.action == "entity_merge" && p.id.starts_with("minhash_"))
+                .expect("a minhash entity_merge proposal must be queued");
+            let id = proposal.id.clone();
+            assert_eq!(
+                db.resolve_refinement_if_open(&id, "dismissed")
+                    .await
+                    .unwrap(),
+                1
+            );
+
+            let second = find_merge_candidates(&db).await.unwrap();
+            assert_eq!(
+                second, 0,
+                "second pass must not re-enqueue a dismissed pair"
+            );
+            let row = db
+                .get_refinement_proposal(&id)
+                .await
+                .unwrap()
+                .expect("dismissed row still exists");
+            assert_eq!(row.status, "dismissed", "dismissal must stay permanent");
+            assert!(
+                !db.get_pending_refinements()
+                    .await
+                    .unwrap()
+                    .iter()
+                    .any(|p| p.id == id),
+                "dismissed proposal must not reappear in the pending queue"
             );
         })
         .await;

--- a/crates/wenlan-core/src/kg_quality.rs
+++ b/crates/wenlan-core/src/kg_quality.rs
@@ -199,6 +199,12 @@ async fn surface_minhash_merge_candidates(db: &MemoryDB) -> Result<usize, Wenlan
             }
         })
         .collect();
+    // Canonical pair orientation: the proposal id (`minhash_{i}_{j}`) and the
+    // survivor (`existing_id = id_i`) derive from index order, and the reader
+    // has no ORDER BY, so sort by id here or a plan change would mint a new id
+    // for a pair a human already dismissed.
+    let mut entities = entities;
+    entities.sort_by(|a, b| a.0.cmp(&b.0));
 
     // Bucket entity indices by band key.
     let mut buckets: HashMap<u64, Vec<usize>> = HashMap::new();

--- a/crates/wenlan-core/src/lint/deep.rs
+++ b/crates/wenlan-core/src/lint/deep.rs
@@ -99,7 +99,7 @@ pub(super) async fn run(
 // pre-Stage-3). Scans every active `kind='entity'` shadow page's `aliases`
 // JSON array directly; no `entities`/`entity_aliases` read at all.
 async fn alias_collisions(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (scope, params) = scope_clause_folded(context.scope().filter(), "p.space", false);
+    let (scope, params) = scope_clause(context.scope().filter(), "p.space", false);
     rows(
         context,
         &format!(
@@ -229,7 +229,7 @@ async fn structured_conflicts(context: &LintContext<'_, '_>) -> Result<RowCheck,
 }
 
 // G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
-// space-sentinel fold: `e.space` now uses `scope_clause_folded`,
+// space-sentinel fold: `e.space` now uses `scope_clause`,
 // sentinel-aware (entity-existence side only -- observation content itself
 // is out of scope for this stage regardless, see the spec's 1.5b
 // observations ruling). G6 Stage 3 retirement lint track: the prior
@@ -243,7 +243,7 @@ async fn structured_conflicts(context: &LintContext<'_, '_>) -> Result<RowCheck,
 // canonical-only entity (no `entities` row) no longer silently drops its
 // observations out of this scope filter.
 async fn observation_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (scope, params) = scope_clause_folded(context.scope().filter(), "e.space", true);
+    let (scope, params) = scope_clause(context.scope().filter(), "e.space", true);
     rows(
         context,
         &format!(
@@ -292,7 +292,7 @@ async fn page_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> 
 
 // G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
 // space-sentinel fold: `f.space` (the src-entity alias) now uses
-// `scope_clause_folded`, sentinel-aware. G6 Stage 3 retirement lint track:
+// `scope_clause`, sentinel-aware. G6 Stage 3 retirement lint track:
 // the prior disposition here ("audits the legacy entities store's own data
 // quality") was wrong -- the `entities` join exists ONLY to resolve
 // `f.space` for scope filtering; the actual subject is whether a relation
@@ -302,7 +302,7 @@ async fn page_duplicates(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> 
 // fix round finding 3): a canonical-only src entity no longer silently
 // drops its relates edges out of this scope filter.
 async fn relation_vocabulary(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (scope, params) = scope_clause_folded(context.scope().filter(), "f.space", true);
+    let (scope, params) = scope_clause(context.scope().filter(), "f.space", true);
     rows(
         context,
         &format!(
@@ -621,38 +621,11 @@ fn population_basis(context: &LintContext<'_, '_>, id: &str) -> PopulationBasis 
     }
 }
 
+/// Scope predicate for a space column folded by the 1.5b space-sentinel
+/// migration (`memories.space`, `entities.space`, `pages.workspace`): an
+/// unfiled row stores `UNFILED_SPACE_ID`, not SQL NULL, so `Uncategorized`
+/// must match either. Mirrors `push_read_scope_filter_folded` (db.rs).
 fn scope_clause(
-    scope: &ScopeFilter,
-    column: &str,
-    exclude_missing_owner: bool,
-) -> (String, libsql::params::Params) {
-    match scope {
-        ScopeFilter::Global => (String::new(), libsql::params::Params::None),
-        ScopeFilter::Registered(value) => (
-            format!(" AND {column}=?1"),
-            libsql::params::Params::Positional(vec![libsql::Value::Text(value.clone())]),
-        ),
-        ScopeFilter::Uncategorized => (
-            format!(
-                " AND {column} IS NULL{}",
-                if exclude_missing_owner {
-                    format!(
-                        " AND {} IS NOT NULL",
-                        column.trim_end_matches(".space").to_owned() + ".id"
-                    )
-                } else {
-                    String::new()
-                }
-            ),
-            libsql::params::Params::None,
-        ),
-    }
-}
-
-/// Same as `scope_clause`, but for an `entities.space` column folded by the
-/// 1.5b space-sentinel migration: an unfiled row stores `UNFILED_SPACE_ID`,
-/// not SQL NULL, so `Uncategorized` must match either.
-fn scope_clause_folded(
     scope: &ScopeFilter,
     column: &str,
     exclude_missing_owner: bool,

--- a/crates/wenlan-core/src/lint/kg/query.rs
+++ b/crates/wenlan-core/src/lint/kg/query.rs
@@ -46,7 +46,7 @@ pub(super) async fn load(context: &LintContext<'_, '_>, hub_cap: u64) -> Result<
 }
 
 // G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
-// space-sentinel fold: the scope clause now uses `scope_clause_folded`, and
+// space-sentinel fold: the scope clause now uses `scope_clause`, and
 // the integrity predicate excludes the `UNFILED_SPACE_ID` sentinel itself
 // (never a registered `spaces.name`) so a folded unfiled entity no longer
 // vacuously flags as an integrity violation. G6 Stage 3 retirement lint
@@ -60,7 +60,7 @@ pub(super) async fn load(context: &LintContext<'_, '_>, hub_cap: u64) -> Result<
 // `e.name`/`e.entity_type`/`e.confirmed`/`e.confidence`/`e.space`/`e.id`
 // reference is unchanged.
 async fn entity_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (clause, params) = scope_clause_folded(context.scope().filter(), "e", false);
+    let (clause, params) = scope_clause(context.scope().filter(), "e", false);
     row_check(
         context,
         &format!(
@@ -83,7 +83,7 @@ async fn entity_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()>
 }
 
 // G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
-// space-sentinel fold: `e.space`/`e.id` now uses `scope_clause_folded`,
+// space-sentinel fold: `e.space`/`e.id` now uses `scope_clause`,
 // sentinel-aware (entity-existence side only -- observation content itself
 // is out of scope for this stage regardless, see the spec's 1.5b
 // observations ruling). G6 Stage 3 retirement lint track: the prior
@@ -96,7 +96,7 @@ async fn entity_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()>
 // `link_integrity` above: a canonical-only entity's observations no longer
 // read as orphaned just because it never got an `entities` row.
 async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (clause, params) = scope_clause_folded(context.scope().filter(), "e", true);
+    let (clause, params) = scope_clause(context.scope().filter(), "e", true);
     row_check(
         context,
         &format!(
@@ -118,7 +118,7 @@ async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck
 
 // G6 Stage 1.5a carryover (2026-08-05), resolved by the 1.5b Part 2
 // space-sentinel fold: `f.space`/`f.id` (the src-entity alias) now uses
-// `scope_clause_folded`, sentinel-aware. G6 Stage 3 retirement lint track:
+// `scope_clause`, sentinel-aware. G6 Stage 3 retirement lint track:
 // the prior disposition here ("audits the legacy entities store's own data
 // quality") was only half right -- `TRIM(r.semantic_type)=''` has nothing to
 // do with `entities`, and `f.id`/`t.id IS NULL` are real orphan-relation
@@ -127,7 +127,7 @@ async fn observation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck
 // projected subquery, same pattern as `link_integrity` above; two separate
 // subquery instances since `f` and `t` each need their own derived table.
 async fn relation_integrity(context: &LintContext<'_, '_>) -> Result<RowCheck, ()> {
-    let (clause, params) = scope_clause_folded(context.scope().filter(), "f", true);
+    let (clause, params) = scope_clause(context.scope().filter(), "f", true);
     row_check(
         context,
         &format!(
@@ -203,35 +203,11 @@ async fn row_check(
     })
 }
 
+/// Scope predicate for a space column folded by the 1.5b space-sentinel
+/// migration (`memories.space`, `entities.space`, `pages.workspace`): an
+/// unfiled row stores `UNFILED_SPACE_ID`, not SQL NULL, so `Uncategorized`
+/// must match either. Mirrors `push_read_scope_filter_folded` (db.rs).
 pub(super) fn scope_clause(
-    scope: &ScopeFilter,
-    alias: &str,
-    exclude_missing_owner: bool,
-) -> (String, libsql::params::Params) {
-    match scope {
-        ScopeFilter::Global => (String::new(), libsql::params::Params::None),
-        ScopeFilter::Registered(space) => (
-            format!(" WHERE {alias}.space=?1"),
-            libsql::params::Params::Positional(vec![libsql::Value::Text(space.clone())]),
-        ),
-        ScopeFilter::Uncategorized => (
-            format!(
-                " WHERE {alias}.space IS NULL{}",
-                if exclude_missing_owner {
-                    format!(" AND {alias}.id IS NOT NULL")
-                } else {
-                    String::new()
-                }
-            ),
-            libsql::params::Params::None,
-        ),
-    }
-}
-
-/// Same as `scope_clause`, but for an `entities.space` alias folded by the
-/// 1.5b space-sentinel migration: an unfiled row stores `UNFILED_SPACE_ID`,
-/// not SQL NULL, so `Uncategorized` must match either.
-pub(super) fn scope_clause_folded(
     scope: &ScopeFilter,
     alias: &str,
     exclude_missing_owner: bool,

--- a/crates/wenlan-core/src/lint/kg/query/aggregate.rs
+++ b/crates/wenlan-core/src/lint/kg/query/aggregate.rs
@@ -1,4 +1,4 @@
-use super::{scope_clause, scope_clause_folded};
+use super::scope_clause;
 use crate::lint::context::LintContext;
 use wenlan_types::lint::{LintMetric, LintMetricCode, LintMetricValue};
 
@@ -42,7 +42,7 @@ impl AggregateCounts {
 pub(super) async fn entity_partitions(
     context: &LintContext<'_, '_>,
 ) -> Result<Vec<LintMetric>, ()> {
-    let (clause, params) = scope_clause_folded(context.scope().filter(), "e", false);
+    let (clause, params) = scope_clause(context.scope().filter(), "e", false);
     let values = scalar_row(
         context,
         &format!(

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -100,6 +100,25 @@ async fn scoped_rows_follow_memory_or_entity_ownership_but_aggregates_stay_globa
     assert_eq!(metric(aggregates, LintMetricCode::KgMemoryEntityLinks), 3);
 }
 
+// Review finding #12: `memories.space` stores the `UNFILED_SPACE_ID` sentinel
+// (never NULL) since migration 91, so the memory-side scope clause must be
+// sentinel-aware or the Uncategorized scope silently sees zero rows.
+#[tokio::test]
+async fn uncategorized_scope_sees_sentinel_space_memory_rows() {
+    let (db, _tmp) = test_db().await;
+    seed_valid_scoped_graph(&db).await;
+
+    let report = run(&db, Some("uncategorized"), test_config(true)).await;
+
+    // mem-none -> ent-a is the one link owned by an unfiled memory.
+    assert_eq!(check(&report, LINKS).coverage().denominator(), 1);
+    // mem-none is the one unfiled memory eligible for serving.
+    assert_eq!(
+        metric(check(&report, LIVENESS), LintMetricCode::EligibleRecords),
+        1
+    );
+}
+
 #[tokio::test]
 async fn configured_off_is_expected_empty_and_enabled_empty_substrate_is_actionable() {
     let (db, _tmp) = test_db().await;

--- a/crates/wenlan-core/src/lint/semantic_candidates.rs
+++ b/crates/wenlan-core/src/lint/semantic_candidates.rs
@@ -877,9 +877,9 @@ async fn load_memory_entity_links(
 // repairs for relations that already existed. Ported to the same canonical
 // projected subquery `entity_scope_clause` above already uses for its
 // `source`-aliased edges joins; `source.space` still resolves the same way,
-// so `scope_clause_folded` needs no change.
+// so `scope_clause` needs no change.
 async fn load_relations(context: &LintContext<'_, '_>) -> Result<Vec<Relation>, ()> {
-    let (scope, params) = scope_clause_folded(context.scope().filter(), "source.space");
+    let (scope, params) = scope_clause(context.scope().filter(), "source.space");
     let mut rows = context
         .snapshot()
         .query(
@@ -956,25 +956,11 @@ async fn load_page_evidence(context: &LintContext<'_, '_>) -> Result<Vec<PageEvi
     Ok(output)
 }
 
+/// Scope predicate for a space column folded by the 1.5b space-sentinel
+/// migration (`memories.space`, `entities.space`, `pages.workspace`): an
+/// unfiled row stores `UNFILED_SPACE_ID`, not SQL NULL, so `Uncategorized`
+/// must match either. Mirrors `push_read_scope_filter_folded` (db.rs).
 fn scope_clause(scope: &ScopeFilter, column: &str) -> (String, libsql::params::Params) {
-    match scope {
-        ScopeFilter::Global => (String::new(), libsql::params::Params::None),
-        ScopeFilter::Registered(value) => (
-            format!(" AND {column}=?1"),
-            libsql::params::Params::Positional(vec![libsql::Value::Text(value.clone())]),
-        ),
-        ScopeFilter::Uncategorized => (
-            format!(" AND {column} IS NULL"),
-            libsql::params::Params::None,
-        ),
-    }
-}
-
-/// Same as `scope_clause`, but for an `entities.space` column folded by the
-/// 1.5b space-sentinel migration: an unfiled row stores `UNFILED_SPACE_ID`,
-/// not SQL NULL, so `Uncategorized` must match either. Mirrors
-/// `push_read_scope_filter_folded` (db.rs).
-fn scope_clause_folded(scope: &ScopeFilter, column: &str) -> (String, libsql::params::Params) {
     match scope {
         ScopeFilter::Global => (String::new(), libsql::params::Params::None),
         ScopeFilter::Registered(value) => (

--- a/crates/wenlan-core/src/synthesis/refinement_queue.rs
+++ b/crates/wenlan-core/src/synthesis/refinement_queue.rs
@@ -236,6 +236,14 @@ pub async fn apply_refinement_with_decision(
             let category = v["category"].as_str();
             db.promote_vocabulary_canonical(kind, old_value, category)
                 .await?;
+            // The entities that proposed this type were stored under the
+            // default `concept` (their ids are the proposal's `source_ids`);
+            // now that the type is canonical, move them onto it.
+            if kind == "entity" {
+                let canonical = old_value.to_lowercase();
+                db.retype_entities_after_promote(&prop.source_ids, &canonical)
+                    .await?;
+            }
         }
         other => {
             return Err(WenlanError::Validation(format!("unknown action: {other}")));
@@ -860,6 +868,56 @@ mod tests {
                 .unwrap(),
             Some("design_inspiration".into())
         );
+    }
+
+    // Appendix E miss: an entity whose extracted type was unknown is stored
+    // as `concept` and its id recorded on the vocab proposal; accepting the
+    // proposal must re-type that entity onto the new canonical.
+    #[tokio::test]
+    async fn apply_refinement_vocab_promote_retypes_proposing_entities() {
+        let (db, _tmp) = test_db().await;
+        // "widget" is not a canonical, alias, or safe transform of one.
+        let (id, created) = db
+            .resolve_or_create_entity("Sprocket Widget", "widget", None, Some("test"), None)
+            .await
+            .unwrap();
+        assert!(created);
+        let stored = db.get_entity_name_type(&id).await.unwrap().unwrap();
+        assert_eq!(stored.1, "concept", "unknown type is stored as the default");
+
+        let proposal_id = crate::db::MemoryDB::vocab_proposal_fingerprint("entity", "widget");
+        let prop = db
+            .get_refinement_proposal(&proposal_id)
+            .await
+            .unwrap()
+            .expect("vocab_promote proposal was queued");
+        assert_eq!(
+            prop.source_ids,
+            vec![id.clone()],
+            "the created entity is recorded on the proposal"
+        );
+
+        apply_refinement(&db, &proposal_id, "test").await.unwrap();
+        assert_eq!(
+            db.resolve_entity_type("widget").await.unwrap(),
+            Some("widget".into())
+        );
+        let retyped = db.get_entity_name_type(&id).await.unwrap().unwrap();
+        assert_eq!(
+            retyped.1, "widget",
+            "accepting the vocabulary re-types the entity that proposed it"
+        );
+        // Ledgered like fold_entity_type so the re-type is reversible.
+        let conn = db.test_primary_session().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM vocab_heal_ledger WHERE kind='entity' AND old_value='concept' AND new_value='widget'",
+                (),
+            )
+            .await
+            .unwrap();
+        let n: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+        assert_eq!(n, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What this PR does
KG quality / rethink correctness (2026-08-16 KG review findings 11, 12, 13, 14, plus the vocabulary re-type gap Codex flagged):

- **#11** `fold_relation_type` carries the loser edge's payload (`source_memory_id`, span, model/prompt versions) into the canonical edge, so folded edges keep provenance. Grounding resets on purpose; the M3g scan re-promotes since `source_memory_id` survives.
- **#12** the lint `scope_clause` is sentinel-aware for the `uncategorized` space (`IS NULL OR = sentinel`) and the `_folded` split is deleted in `lint/kg/query.rs`, `lint/deep.rs`, `lint/semantic_candidates.rs`, so uncategorized link-integrity and liveness see their rows.
- **#13** minhash merge proposals decode on the wire as `RefinementPayload::EntityMerge` (`similarity`, `source_ids = [new, existing]`).
- **#14** new `MemoryDB::insert_refinement_proposal_if_absent` (`ON CONFLICT(id) DO NOTHING`); a dismissed merge proposal stays dismissed across rethink passes and is not counted as enqueued.
- **vocab re-type** `append_vocab_promote_affected` records entities that proposed an unrecognized type on the pending vocab proposal; accepting the proposal calls `retype_entities_after_promote`, which moves those entities' shadow pages from `concept` to the accepted type, ledgered like `fold_entity_type`.

## How to test
- `cargo test -p wenlan-core --lib -- kg_quality lint::kg fold_relation_type refinement_queue lint::deep lint::semantic entity_enrichment resolve_or_create_entity vocab` → 155 passed, 0 failed (after rebase on main).
- Each fix has a mutation control: reverting it makes its new/extended test fail.

Notes: the vocab re-type is forward-only — proposals already sitting in a queue before this PR have empty `source_ids`, so accepting them re-types nothing (no backfill). Independent review (2026-08-17) asked for one fix, landed as a follow-up commit: the minhash sweep sorts entities by id so the proposal id and survivor are stable across passes and a dismissed pair stays dismissed. The re-type test uses type `widget` (not the plan's `framework`, which is already a seeded alias and never counts as unrecognized).

## Checklist
- [x] Tests pass (focused suites above; CI runs the rest)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
