### PR TITLE
fix(communities): count generation bumps only for assertion relates edges, supersede stale community proposals on republish, cover 422 paths in community routes

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -17978,10 +17978,18 @@ impl MemoryDB {
                     })?;
                 flipped += affected as usize;
                 if affected > 0 {
+                    // Only rows the m4_grouping_edge_update trigger fires for
+                    // (entity-entity assertion relates) count toward the
+                    // trigger compensation below; a legacy-lineage promotion
+                    // fires no trigger and must contribute nothing here, or
+                    // the batch's real advance cancels out. Mirrors
+                    // `dual_write_invalidate_edge`.
                     let mut rows = conn
                         .query(
                             "SELECT space, src_id, dst_id FROM edges \
-                             WHERE edge_id = ?1 AND edge_type = 'relates'",
+                             WHERE edge_id = ?1 AND edge_type = 'relates' \
+                               AND src_kind = 'entity' AND dst_kind = 'entity' \
+                               AND lineage = 'assertion'",
                             libsql::params![promotion.edge_id.clone()],
                         )
                         .await
@@ -18814,6 +18822,25 @@ impl MemoryDB {
                         "finalize publication receipt: {error}"
                     ))
                 })?;
+                // Open identity proposals from earlier generations can no
+                // longer pass accept/reject's generation CAS once this
+                // generation publishes; mark them superseded so they leave
+                // the review list instead of crowding it forever.
+                tx.execute(
+                    "UPDATE refinement_queue
+                        SET status='superseded', resolved_at=datetime('now')
+                      WHERE action IN ('community_split','community_merge','community_rename')
+                        AND status IN ('pending','awaiting_review')
+                        AND json_extract(payload,'$.space')=?1
+                        AND json_extract(payload,'$.source_generation')<?2",
+                    libsql::params![attempt.space.clone(), attempt.input_generation],
+                )
+                .await
+                .map_err(|error| {
+                    CommunityGroupingError::Database(format!(
+                        "finalize supersede stale community proposals: {error}"
+                    ))
+                })?;
                 for event in &identity_events {
                     let mut source_ids = event.old_community_ids.clone();
                     source_ids.extend(event.new_community_ids.iter().cloned());
@@ -18966,6 +18993,23 @@ impl MemoryDB {
             "space": row.get::<String>(9).ok(),
             "payload": row.get::<Option<String>>(10).ok().flatten(),
         }))
+    }
+
+    /// Test-only: read a space's `space_graph_state.graph_generation`, so the
+    /// `edge_grounding` tests (which cannot reach the private `conn`) can pin
+    /// the promotion batch's trigger compensation. `None` when the space has
+    /// no graph-state row yet.
+    #[cfg(test)]
+    pub(crate) async fn space_graph_generation_for_test(&self, space: &str) -> Option<i64> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT graph_generation FROM space_graph_state WHERE space = ?1",
+                libsql::params![space],
+            )
+            .await
+            .ok()?;
+        rows.next().await.ok()??.get::<i64>(0).ok()
     }
 
     /// Test-only: count rows in the now-frozen `relations` table. Lets the M3g

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -5155,6 +5155,151 @@ async fn finalizing_a_split_queues_review_without_overwriting_curated_names() {
 }
 
 #[tokio::test]
+async fn community_republish_supersedes_open_proposals_from_earlier_generations() {
+    // KG review #10: accept/reject CAS on the proposal's `source_generation`
+    // against the live published generation, so a proposal left open across a
+    // republish can never be actioned again -- yet it stayed `awaiting_review`
+    // and crowded the review list. Finalize now marks such rows `superseded`.
+    use crate::community_grouping::{
+        CommunityGroupingComputeMode, CommunityGroupingComputed, CommunityGroupingFullReason,
+        CommunityGroupingOutcome, ComputedCommunityMember,
+    };
+    use wenlan_types::{CommunityProposalAction, CommunityProposalPayload};
+
+    const SPACE: &str = "m96-republish-space";
+    const OLD_COMMUNITY: &str = "m96-republish-old";
+    const NEW_COMMUNITY: &str = "m96-republish-new";
+    let (db, _dir) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO communities
+                (community_id, space, display_name, algo_version, projection_version,
+                 created_at, updated_at, retired_at)
+             VALUES (?1, ?2, NULL, 'leiden-m4-v1', 'grounded-relates-v1', 1, 1, NULL)",
+            libsql::params![OLD_COMMUNITY, SPACE],
+        )
+        .await
+        .unwrap();
+        for node_id in ["m96-republish-node-a", "m96-republish-node-b"] {
+            conn.execute(
+                "INSERT INTO community_members
+                    (space, node_id, node_kind, community_id,
+                     published_generation, attachment)
+                 VALUES (?1, ?2, 'entity', ?3, 1, 'core')",
+                libsql::params![SPACE, node_id, OLD_COMMUNITY],
+            )
+            .await
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO space_graph_state
+                (space, graph_generation, grouping_generation, published_generation, dirty)
+             VALUES (?1, 2, 2, 1, 1)",
+            libsql::params![SPACE],
+        )
+        .await
+        .unwrap();
+    }
+    let computed = |members: Vec<(&str, &str)>| CommunityGroupingComputed {
+        members: members
+            .into_iter()
+            .map(|(node_id, community_id)| ComputedCommunityMember {
+                node_id: node_id.to_string(),
+                community_id: community_id.to_string(),
+                attachment: "core",
+            })
+            .collect(),
+        held_below_floor: false,
+        projected_edge_count: 0,
+        compute_mode: CommunityGroupingComputeMode::Full {
+            reason: CommunityGroupingFullReason::RuntimeStateMissing,
+        },
+    };
+
+    // Generation 2: node-b leaves OLD -> one split proposal.
+    let attempt = db.prepare_community_grouping(SPACE).await.unwrap();
+    let outcome = db
+        .finalize_community_grouping(
+            attempt,
+            computed(vec![
+                ("m96-republish-node-a", OLD_COMMUNITY),
+                ("m96-republish-node-b", NEW_COMMUNITY),
+            ]),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(outcome, CommunityGroupingOutcome::Published(_)));
+    let proposals = db
+        .list_community_proposals(&crate::read_scope::ReadScope::Global, 10)
+        .await
+        .unwrap();
+    assert_eq!(proposals.proposals.len(), 1);
+    let split_id = proposals.proposals[0].id.clone();
+    assert_eq!(
+        proposals.proposals[0].action,
+        CommunityProposalAction::CommunitySplit
+    );
+
+    // Generation 3 (left unreviewed): node-b comes back -> one merge proposal.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE space_graph_state
+                SET graph_generation=3, grouping_generation=3, dirty=1
+              WHERE space=?1",
+            libsql::params![SPACE],
+        )
+        .await
+        .unwrap();
+    }
+    let attempt = db.prepare_community_grouping(SPACE).await.unwrap();
+    let outcome = db
+        .finalize_community_grouping(
+            attempt,
+            computed(vec![
+                ("m96-republish-node-a", OLD_COMMUNITY),
+                ("m96-republish-node-b", OLD_COMMUNITY),
+            ]),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(outcome, CommunityGroupingOutcome::Published(_)));
+
+    let proposals = db
+        .list_community_proposals(&crate::read_scope::ReadScope::Global, 10)
+        .await
+        .unwrap();
+    assert_eq!(
+        proposals.proposals.len(),
+        1,
+        "the generation-2 split must leave the review list after generation 3 publishes"
+    );
+    assert_eq!(
+        proposals.proposals[0].action,
+        CommunityProposalAction::CommunityMerge
+    );
+    match &proposals.proposals[0].payload {
+        CommunityProposalPayload::CommunityMerge {
+            source_generation, ..
+        } => assert_eq!(*source_generation, 3),
+        other => panic!("expected merge payload, got {other:?}"),
+    }
+
+    let conn = db.conn.lock().await;
+    let mut rows = conn
+        .query(
+            "SELECT status, resolved_at IS NOT NULL FROM refinement_queue WHERE id=?1",
+            libsql::params![split_id],
+        )
+        .await
+        .unwrap();
+    let stale = rows.next().await.unwrap().unwrap();
+    assert_eq!(stale.get::<String>(0).unwrap(), "superseded");
+    assert_eq!(stale.get::<i64>(1).unwrap(), 1);
+}
+
+#[tokio::test]
 async fn community_consistency_detects_a_missing_connected_participant() {
     use crate::community_grouping::{
         run_community_grouping_cycle, CommunityGroupingOutcome, CommunityGroupingRuntime,

--- a/crates/wenlan-core/src/edge_grounding.rs
+++ b/crates/wenlan-core/src/edge_grounding.rs
@@ -994,6 +994,129 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mixed_lineage_promotion_batch_advances_graph_generation_once() {
+        // KG review #9: `promote_edges_grounded` compensates the m4 grouping
+        // trigger with `graph_generation = MAX(graph_generation - N + 1, 1)`,
+        // where N must count only the promoted rows that actually FIRED the
+        // trigger (entity-entity `lineage='assertion'` relates). A cross-space
+        // legacy edge promoted in the same batch fires no trigger; counting it
+        // used to cancel the batch's real +1 advance.
+        let (db, _dir) = crate::db::tests::test_db().await;
+        let content = "Alice works on ProjectX. Bob works on ProjectY. Carol works on ProjectZ.";
+        seed_folder_memory(&db, "doc_mixed", content, "space_a").await;
+        // A first grounded assertion edge so `space_a` has a graph-state row;
+        // at a fresh row the `MAX(.., 1)` floor would mask the miscount.
+        let baseline_edge = seed_edge(
+            &db,
+            "Alice",
+            "ProjectX",
+            "works_on",
+            "space_a",
+            "doc_mixed",
+            Some("Alice works on ProjectX"),
+            content,
+        )
+        .await;
+        let assertion_edge = seed_edge(
+            &db,
+            "Bob",
+            "ProjectY",
+            "works_on",
+            "space_a",
+            "doc_mixed",
+            Some("Bob works on ProjectY"),
+            content,
+        )
+        .await;
+        // Cross-space endpoints stamp `lineage='legacy'` in the source
+        // entity's space (`space_a`), so both batch rows share one graph state.
+        let carol = db
+            .create_entity("Carol", "concept", Some("space_a"))
+            .await
+            .unwrap();
+        let project_z = db
+            .create_entity("ProjectZ", "concept", Some("space_b"))
+            .await
+            .unwrap();
+        db.create_relation_with_span(
+            &carol,
+            &project_z,
+            "works_on",
+            Some("post_ingest"),
+            None,
+            None,
+            Some("doc_mixed"),
+            Some("Carol works on ProjectZ"),
+            Some(content),
+            Some("extract-model"),
+            Some("extract-prompt-v1"),
+        )
+        .await
+        .unwrap();
+        let canonical = db
+            .resolve_relation_type("works_on")
+            .await
+            .unwrap()
+            .unwrap_or_else(|| "related_to".to_string());
+        let legacy_edge = crate::provenance::compute_edge_id(
+            "relates", "entity", &carol, "entity", &project_z, &canonical,
+        );
+        let legacy = db.edge_snapshot_for_test(&legacy_edge).await.unwrap();
+        assert_eq!(legacy["lineage"], "legacy");
+        assert_eq!(legacy["space"], "space_a");
+
+        let root_id = db
+            .acquire_provenance_root(
+                "document_ingest",
+                content,
+                &IndependenceSignals {
+                    source_identity: Some("file:///doc_mixed"),
+                    agent_turn: None,
+                    import_batch: None,
+                },
+            )
+            .await
+            .unwrap();
+        let promotion = |edge_id: &str| EdgePromotion {
+            edge_id: edge_id.to_string(),
+            root_id: root_id.clone(),
+            payload: build_grounding_payload("span+entailment", 0.95, "test-model", 1),
+            source_memory_id: "doc_mixed".to_string(),
+            judged_content: content.to_string(),
+        };
+
+        assert_eq!(
+            db.promote_edges_grounded(&[promotion(&baseline_edge)])
+                .await
+                .unwrap(),
+            1
+        );
+        let before = db
+            .space_graph_generation_for_test("space_a")
+            .await
+            .expect("a grounded assertion edge creates the graph-state row");
+
+        assert_eq!(
+            db.promote_edges_grounded(&[promotion(&assertion_edge), promotion(&legacy_edge)])
+                .await
+                .unwrap(),
+            2,
+            "both the assertion and the legacy edge flip"
+        );
+        let after = db.space_graph_generation_for_test("space_a").await.unwrap();
+        assert_eq!(
+            after,
+            before + 1,
+            "one batch with one trigger-firing change advances graph_generation by exactly \
+             one; the legacy promotion fired no trigger and must not be compensated"
+        );
+        assert_eq!(
+            db.edge_snapshot_for_test(&legacy_edge).await.unwrap()["grounded"],
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn canonical_only_edge_with_no_relations_row_is_scanned_and_promoted() {
         // G6 Stage 2 PR 2b regression. The M3g candidate scan used to select
         // from `relations`, documented there as "the sole producer of every

--- a/crates/wenlan-server/src/community_routes.rs
+++ b/crates/wenlan-server/src/community_routes.rs
@@ -137,4 +137,51 @@ mod tests {
             );
         }
     }
+
+    #[tokio::test]
+    async fn communities_routes_reject_unknown_space_and_half_cursors_with_422() {
+        // KG review #26: the query -> scope -> ServerError -> 422 translation
+        // is what the app keys its unregistered-space fallback on, and the
+        // members cursor must be all-or-nothing.
+        let root = tempfile::tempdir().unwrap();
+        let db = Arc::new(
+            wenlan_core::db::MemoryDB::new(root.path(), Arc::new(wenlan_core::events::NoopEmitter))
+                .await
+                .unwrap(),
+        );
+        let state = crate::state::ServerState {
+            db: Some(db),
+            ..Default::default()
+        };
+        let router = crate::router::build_router(Arc::new(RwLock::new(state)));
+        for (uri, expected) in [
+            (
+                "/api/communities?space=missing",
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                "/api/communities/members?space=missing",
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                "/api/communities/members?cursor_node_id=node-1",
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                "/api/communities/members?cursor_space=space-a",
+                axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+            ),
+            (
+                "/api/communities/members?cursor_space=space-a&cursor_node_id=node-1",
+                axum::http::StatusCode::OK,
+            ),
+        ] {
+            let response = router
+                .clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), expected, "{uri}");
+        }
+    }
 }


### PR DESCRIPTION
## What this PR does
Community layer fixes (2026-08-16 KG review findings 9, 10, 26):

- **#9** `promote_edges_grounded` counts a graph-generation bump only for `entity→entity` `relates` edges with `lineage='assertion'` (mirrors `dual_write_invalidate_edge`), so promoting a legacy or cross-space edge no longer inflates `space_graph_state.graph_generation` and forces needless regrouping.
- **#10** `finalize_community_grouping` marks open `community_split` / `community_merge` / `community_rename` proposals from earlier generations of the same space as `superseded` (with `resolved_at`) before inserting the new ones, so stale proposals disappear after a republish.
- **#26** `community_routes` tests cover the 422 paths: `?space=missing`, and a lone `cursor_node_id` / `cursor_space` on the members route; the full cursor pair returns 200.

## How to test
- `cargo test -p wenlan-core --lib -- edge_grounding community` → 81 passed, 0 failed, 3 ignored (after rebase on main).
- `cargo test -p wenlan-server --lib community_routes` → 2 passed.
- Mutation controls: reverting #9 makes `mixed_lineage_promotion_batch_advances_graph_generation_once` fail (`left: 1 right: 2`); reverting #10 makes `community_republish_supersedes_open_proposals_from_earlier_generations` fail.

Notes: the #9 test adds a `#[cfg(test)]` reader `space_graph_generation_for_test`; the 100k-row `m4_community_gates` integration test was not run locally (CI runs it) — its promotion paths use same-space assertion edges, so they still count.

## Checklist
- [x] Tests pass (focused suites above; CI runs the rest)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
