### PR TITLE
fix(kg): cascade the community/genesis substrate on space move and merge

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -23415,6 +23415,10 @@ impl MemoryDB {
                 .map_err(|e| {
                     WenlanError::VectorDb(format!("delete_space move pages scope: {}", e))
                 })?;
+                // Fold the community/genesis substrate into the target too, so
+                // the moved entities keep their `relates` edges for grouping and
+                // no control row keeps naming the space deleted below.
+                space_rename::cascade_space_merge(&tx, name, target).await?;
                 #[cfg(test)]
                 page_drafts_test::transaction_test_hooks::after_space_cascade(&format!(
                     "delete_space:{name}"
@@ -23539,6 +23543,10 @@ impl MemoryDB {
         )
         .await
         .map_err(|e| WenlanError::VectorDb(format!("reassign pages scope: {}", e)))?;
+        // Fold the community/genesis substrate into the target too, so the
+        // moved entities keep their `relates` edges for grouping and the
+        // source's community rows do not outlive its content.
+        space_rename::cascade_space_merge(&tx, from, to).await?;
         #[cfg(test)]
         page_drafts_test::transaction_test_hooks::after_space_cascade(&format!(
             "reassign_memories_space:{from}"

--- a/crates/wenlan-core/src/db/space_rename.rs
+++ b/crates/wenlan-core/src/db/space_rename.rs
@@ -123,6 +123,16 @@ const PERMANENT_GENESIS_TABLES: &[&str] = &[
 /// space rename creates that name.
 const DESTINATION_ORPHANS_TO_RETIRE: &[&str] = &["genesis_refresh_jobs"];
 
+/// Permanent M6 rows whose identity is `spaces.id`, not the name. Migration
+/// 109's identity triggers (`m6/remaining_substrate.rs`) refuse an `UPDATE …
+/// SET space` to a name whose `spaces.id` differs from the row's `space_id`,
+/// and refuse every `DELETE`, so a merge into a live space can neither move
+/// nor retire them. A rename keeps the id and passes; a merge leaves them
+/// under the source name — the retained-proof posture `delete_space(_,
+/// "keep")` already has, locked by
+/// `delete_keep_cannot_authorize_proof_parking_and_zero_reset`.
+const SPACE_ID_BOUND_TABLES: &[&str] = &["genesis_coverage_state", "m6_counters"];
+
 /// Rewrite every space-keyed row from `old_name` to `new_name` inside the
 /// caller's transaction. The caller must already have renamed the `spaces` row
 /// and cascaded `memories`, `entities`, and `pages` (see the `edges` fence
@@ -197,6 +207,118 @@ pub(super) async fn cascade_space_rename(
     Ok(())
 }
 
+/// Fold every space-keyed row from `old_name` into the LIVE space
+/// `target_name` inside the caller's transaction, after the memories/pages
+/// cascade (see the `edges` fence above). This is a merge, not a rename: the
+/// destination has rows of its own that must survive, so nothing under
+/// `target_name` is retired. Over the same `CLOSURE`, per table: `edges` are
+/// re-keyed to the target; `communities` are retired the way
+/// `finalize_community_grouping` retires a superseded generation; re-derivable
+/// community/genesis control rows are dropped; permanent genesis rows move
+/// only when the target holds none (a merge must not splice two spaces'
+/// histories, so both sides carrying rows refuses the whole operation before
+/// anything is written); `SPACE_ID_BOUND_TABLES` stay put. Finally the target
+/// is marked dirty so grouping re-runs over the merged input.
+pub(super) async fn cascade_space_merge(
+    tx: &libsql::Transaction,
+    old_name: &str,
+    target_name: &str,
+) -> Result<(), WenlanError> {
+    for table in PERMANENT_GENESIS_TABLES {
+        if SPACE_ID_BOUND_TABLES.contains(table) {
+            continue;
+        }
+        if has_rows_naming(tx, table, old_name).await?
+            && has_rows_naming(tx, table, target_name).await?
+        {
+            return Err(WenlanError::Validation(format!(
+                "both {old_name:?} and {target_name:?} carry permanent genesis rows in {table}; \
+                 refusing to merge their histories"
+            )));
+        }
+    }
+
+    // `edges` goes first, out of CLOSURE order: `m4_grouping_edge_update`
+    // (db.rs `m4_grouping_edge_update`) re-materialises the `space_graph_state`
+    // row of OLD.space when a grounded edge changes space, so that row can only
+    // be retired once the edge rewrite is done.
+    tx.execute(
+        "UPDATE edges SET space = ?1 WHERE space = ?2",
+        libsql::params![target_name, old_name],
+    )
+    .await
+    .map_err(|e| WenlanError::VectorDb(format!("space merge cascade edges: {e}")))?;
+
+    let now = chrono::Utc::now().timestamp();
+    for (table, _) in CLOSURE {
+        match *table {
+            "edges" => {}
+            "communities" => {
+                tx.execute(
+                    "UPDATE communities SET retired_at = ?2, updated_at = ?2 \
+                     WHERE space = ?1 AND retired_at IS NULL",
+                    libsql::params![old_name, now],
+                )
+                .await
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("space merge retire communities: {e}"))
+                })?;
+            }
+            table if SPACE_ID_BOUND_TABLES.contains(&table) => {}
+            table if PERMANENT_GENESIS_TABLES.contains(&table) => {
+                tx.execute(
+                    &format!("UPDATE {table} SET space = ?1 WHERE space = ?2"),
+                    libsql::params![target_name, old_name],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("space merge cascade {table}: {e}")))?;
+            }
+            table => {
+                tx.execute(
+                    &format!("DELETE FROM {table} WHERE space = ?1"),
+                    libsql::params![old_name],
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("space merge retire {table}: {e}")))?;
+            }
+        }
+    }
+
+    // Same shape as `m4_grouping_entity_update`'s destination upsert, so a
+    // merge that moved no entity page still invalidates the target's grouping.
+    tx.execute(
+        "INSERT INTO space_graph_state
+             (space, graph_generation, grouping_generation, published_generation, dirty)
+         VALUES (?1, 0, 1, NULL, 1)
+         ON CONFLICT(space) DO UPDATE SET
+             grouping_generation = grouping_generation + 1,
+             dirty = 1",
+        libsql::params![target_name],
+    )
+    .await
+    .map_err(|e| WenlanError::VectorDb(format!("space merge dirty target: {e}")))?;
+    Ok(())
+}
+
+async fn has_rows_naming(
+    tx: &libsql::Transaction,
+    table: &str,
+    space: &str,
+) -> Result<bool, WenlanError> {
+    let mut rows = tx
+        .query(
+            &format!("SELECT 1 FROM {table} WHERE space = ?1 LIMIT 1"),
+            libsql::params![space],
+        )
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("space merge inspect {table}: {e}")))?;
+    Ok(rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("space merge inspect {table}: {e}")))?
+        .is_some())
+}
+
 /// Every table the closure covers, for the teeth.
 #[cfg(test)]
 pub(super) fn closed_tables() -> Vec<&'static str> {
@@ -208,4 +330,10 @@ pub(super) fn closed_tables() -> Vec<&'static str> {
 #[cfg(test)]
 pub(super) fn permanent_tables() -> Vec<&'static str> {
     PERMANENT_GENESIS_TABLES.to_vec()
+}
+
+/// Permanent M6 rows a merge leaves under the source name.
+#[cfg(test)]
+pub(super) fn space_id_bound_tables() -> Vec<&'static str> {
+    SPACE_ID_BOUND_TABLES.to_vec()
 }

--- a/crates/wenlan-core/src/db/space_rename.rs
+++ b/crates/wenlan-core/src/db/space_rename.rs
@@ -123,15 +123,27 @@ const PERMANENT_GENESIS_TABLES: &[&str] = &[
 /// space rename creates that name.
 const DESTINATION_ORPHANS_TO_RETIRE: &[&str] = &["genesis_refresh_jobs"];
 
-/// Permanent M6 rows whose identity is `spaces.id`, not the name. Migration
-/// 109's identity triggers (`m6/remaining_substrate.rs`) refuse an `UPDATE …
-/// SET space` to a name whose `spaces.id` differs from the row's `space_id`,
-/// and refuse every `DELETE`, so a merge into a live space can neither move
-/// nor retire them. A rename keeps the id and passes; a merge leaves them
-/// under the source name — the retained-proof posture `delete_space(_,
-/// "keep")` already has, locked by
+/// Permanent M6 rows a merge leaves under the source name (a rename still
+/// moves them). `genesis_coverage_state` and `m6_counters` carry `spaces.id`:
+/// migration 109's identity triggers (`m6/remaining_substrate.rs`) refuse an
+/// `UPDATE … SET space` to a name whose `spaces.id` differs from the row's
+/// `space_id`, and refuse every `DELETE`, so a merge into a live space can
+/// neither move nor retire them. `m6_readiness` and its soak receipts are
+/// per-space operational phase, not history: the genesis shadow loop stamps
+/// an epoch-0 `off` readiness row on every space it visits
+/// (`m6/evidence.rs` `note_shadow_readiness`), so refusing on it would refuse
+/// nearly every merge, and moving the source's phase onto a target that
+/// already runs its own would be wrong either way (the soak-receipt fence in
+/// `m6/refresh_readiness.rs` keys receipts to their readiness row, so both
+/// stay together). Leaving them is the retained-proof posture
+/// `delete_space(_, "keep")` already has, locked by
 /// `delete_keep_cannot_authorize_proof_parking_and_zero_reset`.
-const SPACE_ID_BOUND_TABLES: &[&str] = &["genesis_coverage_state", "m6_counters"];
+const MERGE_RETAINED_TABLES: &[&str] = &[
+    "genesis_coverage_state",
+    "m6_counters",
+    "m6_readiness",
+    "m6_readiness_soak_receipts",
+];
 
 /// Rewrite every space-keyed row from `old_name` to `new_name` inside the
 /// caller's transaction. The caller must already have renamed the `spaces` row
@@ -217,7 +229,8 @@ pub(super) async fn cascade_space_rename(
 /// community/genesis control rows are dropped; permanent genesis rows move
 /// only when the target holds none (a merge must not splice two spaces'
 /// histories, so both sides carrying rows refuses the whole operation before
-/// anything is written); `SPACE_ID_BOUND_TABLES` stay put. Finally the target
+/// anything is written); `MERGE_RETAINED_TABLES` stay under the source name.
+/// Finally the target
 /// is marked dirty so grouping re-runs over the merged input.
 pub(super) async fn cascade_space_merge(
     tx: &libsql::Transaction,
@@ -225,7 +238,7 @@ pub(super) async fn cascade_space_merge(
     target_name: &str,
 ) -> Result<(), WenlanError> {
     for table in PERMANENT_GENESIS_TABLES {
-        if SPACE_ID_BOUND_TABLES.contains(table) {
+        if MERGE_RETAINED_TABLES.contains(table) {
             continue;
         }
         if has_rows_naming(tx, table, old_name).await?
@@ -264,7 +277,7 @@ pub(super) async fn cascade_space_merge(
                     WenlanError::VectorDb(format!("space merge retire communities: {e}"))
                 })?;
             }
-            table if SPACE_ID_BOUND_TABLES.contains(&table) => {}
+            table if MERGE_RETAINED_TABLES.contains(&table) => {}
             table if PERMANENT_GENESIS_TABLES.contains(&table) => {
                 tx.execute(
                     &format!("UPDATE {table} SET space = ?1 WHERE space = ?2"),
@@ -273,6 +286,13 @@ pub(super) async fn cascade_space_merge(
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("space merge cascade {table}: {e}")))?;
             }
+            // Everything else in CLOSURE is re-derivable control state
+            // (memberships, route inputs, leases, receipts, pair stats, jobs):
+            // dropped, and rebuilt by the target's next grouping pass. A new
+            // CLOSURE table that must survive a merge belongs in
+            // `PERMANENT_GENESIS_TABLES` (or `MERGE_RETAINED_TABLES`), which
+            // `permanent_destination_fence_covers_retained_migration_109_history`
+            // pins.
             table => {
                 tx.execute(
                     &format!("DELETE FROM {table} WHERE space = ?1"),
@@ -334,6 +354,6 @@ pub(super) fn permanent_tables() -> Vec<&'static str> {
 
 /// Permanent M6 rows a merge leaves under the source name.
 #[cfg(test)]
-pub(super) fn space_id_bound_tables() -> Vec<&'static str> {
-    SPACE_ID_BOUND_TABLES.to_vec()
+pub(super) fn merge_retained_tables() -> Vec<&'static str> {
+    MERGE_RETAINED_TABLES.to_vec()
 }

--- a/crates/wenlan-core/src/db/space_rename_test.rs
+++ b/crates/wenlan-core/src/db/space_rename_test.rs
@@ -4,7 +4,7 @@
 //! and genesis substrate, then check that identity is unchanged, that the new
 //! name resolves, and that no row still names the old space.
 
-use super::space_rename::{closed_tables, permanent_tables, space_id_bound_tables};
+use super::space_rename::{closed_tables, merge_retained_tables, permanent_tables};
 use crate::db::tests::test_db;
 use crate::db::MemoryDB;
 
@@ -847,7 +847,7 @@ async fn assert_substrate_merged_into_target(db: &MemoryDB) {
         if table == "communities" || table == "edges" {
             continue;
         }
-        let expected = if space_id_bound_tables().contains(&table) {
+        let expected = if merge_retained_tables().contains(&table) {
             1
         } else {
             0
@@ -859,7 +859,7 @@ async fn assert_substrate_merged_into_target(db: &MemoryDB) {
         );
     }
     for table in permanent_tables() {
-        if space_id_bound_tables().contains(&table) {
+        if merge_retained_tables().contains(&table) {
             continue;
         }
         assert_eq!(

--- a/crates/wenlan-core/src/db/space_rename_test.rs
+++ b/crates/wenlan-core/src/db/space_rename_test.rs
@@ -4,7 +4,7 @@
 //! and genesis substrate, then check that identity is unchanged, that the new
 //! name resolves, and that no row still names the old space.
 
-use super::space_rename::{closed_tables, permanent_tables};
+use super::space_rename::{closed_tables, permanent_tables, space_id_bound_tables};
 use crate::db::tests::test_db;
 use crate::db::MemoryDB;
 
@@ -800,6 +800,151 @@ async fn every_space_keyed_table_is_accounted_for() {
         assert!(
             space_keyed.iter().any(|t| t == table),
             "{table} is in the closure but carries no `space` column"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Merge cascade (`reassign_memories_space`, `delete_space(_, "move:…")`).
+//
+// The same seeded substrate, folded into a LIVE second space rather than
+// renamed: edges follow the moved entities, the source's communities retire,
+// its re-derivable control rows go, and the target's grouping input sees the
+// moved edge.
+// ---------------------------------------------------------------------------
+
+async fn seeded_db_with_live_target() -> (MemoryDB, tempfile::TempDir) {
+    let (db, dir) = seeded_db().await;
+    db.create_space(NEW, None, false).await.unwrap();
+    (db, dir)
+}
+
+async fn assert_substrate_merged_into_target(db: &MemoryDB) {
+    let conn = db.conn.lock().await;
+    assert_eq!(
+        rows_naming(&conn, "edges", OLD).await,
+        0,
+        "an edge still names the source space after the merge"
+    );
+    assert_eq!(rows_naming(&conn, "edges", NEW).await, 1);
+
+    let mut rows = conn
+        .query(
+            "SELECT space, retired_at FROM communities WHERE community_id = 'com-1'",
+            (),
+        )
+        .await
+        .unwrap();
+    let community = rows.next().await.unwrap().unwrap();
+    assert_eq!(community.get::<String>(0).unwrap(), OLD);
+    assert!(
+        community.get::<Option<i64>>(1).unwrap().is_some(),
+        "the source community must be retired, not left live under the old name"
+    );
+    drop(rows);
+
+    for table in closed_tables() {
+        if table == "communities" || table == "edges" {
+            continue;
+        }
+        let expected = if space_id_bound_tables().contains(&table) {
+            1
+        } else {
+            0
+        };
+        assert_eq!(
+            rows_naming(&conn, table, OLD).await,
+            expected,
+            "{table} rows naming the source space after the merge"
+        );
+    }
+    for table in permanent_tables() {
+        if space_id_bound_tables().contains(&table) {
+            continue;
+        }
+        assert_eq!(
+            rows_naming(&conn, table, NEW).await,
+            1,
+            "permanent {table} row did not follow the merge"
+        );
+    }
+
+    let mut rows = conn
+        .query(
+            "SELECT dirty FROM space_graph_state WHERE space = ?1",
+            libsql::params![NEW],
+        )
+        .await
+        .unwrap();
+    let dirty: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(
+        dirty, 1,
+        "the target must be re-grouped over the merged input"
+    );
+    drop(rows);
+    drop(conn);
+
+    let (edges, _) = db.load_community_ungrounded_edges_paged(NEW).await.unwrap();
+    let ids: Vec<&str> = edges.iter().map(|e| e.edge_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        ["edge-1"],
+        "the target's grouping input must see the moved edge"
+    );
+}
+
+#[tokio::test]
+async fn reassigning_memories_merges_the_substrate_into_the_target() {
+    let (db, _dir) = seeded_db_with_live_target().await;
+    db.reassign_memories_space(OLD, NEW).await.unwrap();
+    assert!(db.get_space(OLD).await.unwrap().is_some());
+    assert_substrate_merged_into_target(&db).await;
+}
+
+#[tokio::test]
+async fn deleting_a_space_with_move_merges_the_substrate_into_the_target() {
+    let (db, _dir) = seeded_db_with_live_target().await;
+    db.delete_space(OLD, &format!("move:{NEW}")).await.unwrap();
+    assert!(db.get_space(OLD).await.unwrap().is_none());
+    assert_substrate_merged_into_target(&db).await;
+}
+
+#[tokio::test]
+async fn permanent_genesis_rows_on_both_sides_refuse_the_merge_without_mutating_either() {
+    let (db, _dir) = seeded_db_with_live_target().await;
+    {
+        let conn = db.conn.lock().await;
+        seed_destination_genesis(&conn).await;
+    }
+
+    let error = db
+        .reassign_memories_space(OLD, NEW)
+        .await
+        .expect_err("two genesis histories must not be spliced");
+    assert!(
+        error.to_string().contains("permanent genesis rows"),
+        "merge was refused for the wrong reason: {error}"
+    );
+
+    let conn = db.conn.lock().await;
+    for table in closed_tables() {
+        assert_eq!(
+            rows_naming(&conn, table, OLD).await,
+            1,
+            "source row in {table} was not rolled back"
+        );
+    }
+    assert_eq!(rows_naming(&conn, "pages", OLD).await, 2);
+    for table in [
+        "genesis_candidates",
+        "genesis_coverage_state",
+        "genesis_group_coverage",
+        "genesis_frontier",
+    ] {
+        assert_eq!(
+            rows_naming(&conn, table, NEW).await,
+            1,
+            "destination row in {table} changed during the refused merge"
         );
     }
 }

--- a/crates/wenlan-server/src/spaces_routes.rs
+++ b/crates/wenlan-server/src/spaces_routes.rs
@@ -175,10 +175,8 @@ pub async fn handle_move_space(
         let s = state.read().await;
         s.db.clone().ok_or(ServerError::DbNotInitialized)?
     };
-    let affected = db
-        .reassign_memories_space(&from, &to)
-        .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+    // `From<WenlanError>` keeps `Validation` (a refused merge) a 400, not a 500.
+    let affected = db.reassign_memories_space(&from, &to).await?;
     Ok(Json(serde_json::json!({"affected": affected})))
 }
 


### PR DESCRIPTION
## What this PR does
Space move / merge cascade (2026-08-16 KG review finding 21). `reassign_memories_space` (`POST /api/spaces/{from}/move-to/{to}`) and `delete_space(old, "move:<target>")` moved memories and pages but left `edges.space`, communities, community members, `space_graph_state`, grouping leases, receipts and the M6 tables under the old name, so moved entities arrived in the target space with none of their relates edges and the old name kept publishing communities for content it no longer had.

`space_rename::cascade_space_merge(tx, old, target)` sits beside the rename cascade and iterates the same `CLOSURE` (so the accounting/teeth test covers it):
- `edges` re-keyed to the target after the memories/pages cascade (the endpoint fence resolves) and before `space_graph_state` (the m4 edge trigger cannot re-materialise the source row);
- `communities` retired the way `finalize_community_grouping` does; re-derivable control rows (`community_members`, `page_community_assignments`, `page_community_route_inputs`, `community_route_space_inputs`, `space_graph_state`, `grouping_leases`, `community_reader_space_proof`, `community_publication_receipts`, `m6_pair_stats`, `m6_adjacency`, `genesis_refresh_jobs`) deleted for the source;
- permanent genesis rows moved only when the target holds none; both sides carrying rows refuses the whole merge before anything is written (surfaced as 400 on `move-to`, not 500);
- `genesis_coverage_state`, `m6_counters` (m109 identity triggers refuse both a move and a delete), `m6_readiness` and `m6_readiness_soak_receipts` (per-space operational phase; the genesis shadow loop stamps an epoch-0 `off` row on every space, so counting them as history would refuse nearly every merge) stay under the source name;
- the target's `space_graph_state` is upserted dirty.

Depends on #547 (migration 124 retires the orphan edges whose fence aborts this cascade would otherwise hit).

Independent review (Fable, read-only): cascade ordering, atomicity/rollback, both call sites, m4 trigger interaction and test teeth checked clean; the one important finding (readiness rows tripping the refusal) is fixed above, plus the 400 mapping and a comment on the default delete arm. Not changed: `prepared` genesis candidates follow the merge when the target has none (design note; leaving them behind for pages that moved away is worse).

## How to test
- `cargo test -p wenlan-core --lib -- db::space_rename_test::` → 16 passed, 0 failed (after rebase); `cargo clippy -p wenlan-core -- -D warnings` and `cargo fmt --check` clean.
- Real surface: branch daemon (`0.15.8+g606836eb`) on an isolated port against a copy of the live DB at schema 124; `POST /api/spaces/ruru/move-to/engineering` → `{"affected":233}` 200. Before: 291 `edges.space='ruru'` rows (9 active relates), 24 ruru entities, 1 `space_graph_state` row. After: 0 ruru edge rows, engineering active relates 3 → 12, ruru entities 0 (engineering 11 → 35), ruru `space_graph_state` row gone, engineering `dirty=1`, no active ruru communities/members. `GET /api/memory/graph` with `x-wenlan-space: engineering` → 200 with 35 entity nodes and the moved relations; under `ruru` → 200 with 0 nodes. Server log clean.

## Checklist
- [x] Tests pass (focused suite above; CI runs the rest)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
