### PR TITLE
chore: steer next release to 0.16.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "simple",
       "always-update": true,
-      "versioning": "always-bump-patch"
+      "versioning": "always-bump-patch",
+      "release-as": "0.16.0"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/scripts/validate-release-candidate.test.py
+++ b/scripts/validate-release-candidate.test.py
@@ -1513,7 +1513,11 @@ class ValidateReleaseCandidateTests(unittest.TestCase):
         config_text = (repo_root / "release-please-config.json").read_text()
         version_txt = (repo_root / "version.txt").read_text().strip()
         major, minor, patch = (int(part) for part in version_txt.split("."))
-        next_version = f"{major}.{minor}.{patch + 1}"
+        # A deliberate minor/major is steered by a `release-as` override in the
+        # real config (RELEASING.md, version-steering policy); while one is in
+        # place the candidate must carry exactly that version, not next patch.
+        release_as = json.loads(config_text)["packages"]["."].get("release-as")
+        next_version = release_as or f"{major}.{minor}.{patch + 1}"
         VALIDATOR._release_version_policy(config_text, version_txt, next_version)
 
     def test_artifact_record_rejects_expiry_digest_and_fork_identity(self) -> None:


### PR DESCRIPTION
Adds the documented release-please `release-as` override (RELEASING.md, version-steering policy) so the eight knowledge-graph fix PRs (#547 #548 #549 #551 #552 #553 #554 #555) and everything else since 0.15.8 ship as **0.16.0** instead of 0.15.9. release-please will retitle Release PR #518 after this merges. A follow-up PR removes the override once 0.16.0 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA