### PR TITLE
chore: drop the release-as override now that 0.16.0 is cut

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
     ".": {
       "release-type": "simple",
       "always-update": true,
-      "versioning": "always-bump-patch",
-      "release-as": "0.16.0"
+      "versioning": "always-bump-patch"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Removes `"release-as": "0.16.0"` from `release-please-config.json` (added in #557) so the next release goes back to a plain patch bump (0.16.1), per the RELEASING.md version-steering policy. Merge after the v0.16.0 Release workflow has finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA