### PR TITLE
fix(release): stop Git Bash path conversion breaking the Windows bundle tag check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -583,6 +583,12 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: read
+    env:
+      # Git Bash on Windows rewrites arguments that look like absolute POSIX
+      # paths ("/repos/...") into filesystem paths, which broke the `gh api`
+      # tag check in the v0.16.0 release run. Disable that conversion for
+      # every bash step in this job.
+      MSYS_NO_PATHCONV: "1"
     outputs:
       setup_filename: ${{ steps.stage.outputs.setup_filename }}
       sig_filename: ${{ steps.stage.outputs.sig_filename }}


### PR DESCRIPTION
The v0.16.0 Release run (https://github.com/7xuanlu/wenlan/actions/runs/32213972069) failed only in "Build Windows desktop app bundle" → "Verify release checkout":

```
invalid API endpoint: "C:/Program Files/Git/repos/7xuanlu/wenlan/git/ref/tags/v0.16.0". Your shell might be rewriting URL paths as filesystem paths.
```

Git Bash on `windows-2022` converts the `/repos/...` `gh api` endpoint into a filesystem path. This sets `MSYS_NO_PATHCONV: "1"` on that job so every bash step keeps its arguments verbatim. Everything else in the run succeeded (crates.io, npm, Homebrew, GHCR, macOS bundle); the release is still a prerelease and #518 is still `autorelease: pending`, so the documented `workflow_dispatch` recovery can finish it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA