### PR TITLE
fix(release): make the recovery dispatch rerun-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,6 +463,12 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          # Git Bash on Windows rewrites arguments that look like absolute POSIX
+          # paths ("/repos/...") into filesystem paths, which broke this `gh api`
+          # tag check in the v0.16.0 release run. Scoped to this step only:
+          # job-wide it also breaks the pnpm shim, which relies on that
+          # conversion to find its own install path.
+          MSYS_NO_PATHCONV: "1"
         run: |
           set -euo pipefail
           checkout_sha="$(git rev-parse HEAD)"
@@ -583,12 +589,6 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: read
-    env:
-      # Git Bash on Windows rewrites arguments that look like absolute POSIX
-      # paths ("/repos/...") into filesystem paths, which broke the `gh api`
-      # tag check in the v0.16.0 release run. Disable that conversion for
-      # every bash step in this job.
-      MSYS_NO_PATHCONV: "1"
     outputs:
       setup_filename: ${{ steps.stage.outputs.setup_filename }}
       sig_filename: ${{ steps.stage.outputs.sig_filename }}
@@ -1072,7 +1072,39 @@ jobs:
           name: docker-runtime-inputs
           path: ${{ runner.temp }}/docker-runtime-inputs
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      # Runtime image builds are not byte-reproducible, so a recovery dispatch
+      # that rebuilt the images would produce new digests and docker-manifest
+      # would then refuse to touch the already-published `$IMG:$TAG` (which is
+      # exactly what happened on the second v0.16.0 recovery run). If the
+      # release tag image already exists it was created only by this same
+      # fail-closed job, so reuse its per-architecture digest as this run's
+      # receipt and skip the rebuild/push. Anonymous inspect: no credential is
+      # involved before the tag check below.
+      - name: Reuse an already-published release image for this architecture
+        id: existing
+        env:
+          IMG: ghcr.io/7xuanlu/wenlan-server
+          ARCH: ${{ matrix.tag-suffix }}
+          DIGEST_FILE: ${{ runner.temp }}/docker-image-digest-${{ matrix.tag-suffix }}.txt
+          EVIDENCE_FILE: ${{ runner.temp }}/runtime-image-evidence-${{ matrix.tag-suffix }}.json
+        run: |
+          set -euo pipefail
+          if ! raw="$(docker buildx imagetools inspect "$IMG:$RELEASE_TAG" --raw 2>/dev/null)"; then
+            echo "reuse=false" >> "$GITHUB_OUTPUT"
+            echo "$IMG:$RELEASE_TAG is not published yet; building."
+            exit 0
+          fi
+          digest="$(jq -er --arg arch "$ARCH" \
+            '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == $arch) | .digest]
+             | if length == 1 then .[0] else error("expected one manifest for " + $arch) end' <<<"$raw")"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          printf '%s@%s\n' "$IMG" "$digest" > "$DIGEST_FILE"
+          jq -n --arg image "$IMG:$RELEASE_TAG" --arg digest "$digest" --arg run "$GITHUB_RUN_ID" \
+            '{reused_published_image: $image, digest: $digest, run_id: $run}' > "$EVIDENCE_FILE"
+          echo "reuse=true" >> "$GITHUB_OUTPUT"
+          echo "Reusing published $IMG:$RELEASE_TAG ($ARCH) at $digest; skipping rebuild."
       - name: Revalidate bytes, build runtime-only image, and smoke
+        if: steps.existing.outputs.reuse != 'true'
         env:
           LOCAL_IMAGE: ghcr.io/7xuanlu/wenlan-server:staging-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.tag-suffix }}
         run: |
@@ -1102,11 +1134,13 @@ jobs:
           fi
       # No untrusted binary runs after this point.
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        if: steps.existing.outputs.reuse != 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push content-scoped staging image and record registry digest
+        if: steps.existing.outputs.reuse != 'true'
         env:
           LOCAL_IMAGE: ghcr.io/7xuanlu/wenlan-server:staging-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.tag-suffix }}
           DIGEST_FILE: ${{ runner.temp }}/docker-image-digest-${{ matrix.tag-suffix }}.txt


### PR DESCRIPTION
Two problems surfaced by the v0.16.0 recovery runs (https://github.com/7xuanlu/wenlan/actions/runs/32226770079):

1. **Windows bundle**: `MSYS_NO_PATHCONV` set job-wide in #559 also disabled the path conversion the pnpm shim relies on, so `pnpm tauri build` failed with `Cannot find module 'D:\c\Users\runneradmin\setup-pnpm\...\pnpm.cjs'`. It is now scoped to the single `gh api` tag-check step.
2. **Docker manifest**: runtime image builds are not byte-reproducible. The recovery run rebuilt both platform images, and `docker-manifest` then refused the already-published `ghcr.io/7xuanlu/wenlan-server:v0.16.0` ("Existing ... differs from validated platform digests"). When the release-tag image already exists, the `docker` job now reuses its per-architecture digest as the run's receipt and skips rebuild/login/push, so `docker-manifest` verifies the published manifest instead of fighting it.

`actionlint` clean. After merge, a third `workflow_dispatch` recovery for v0.16.0 should finish the release (Windows bundle → desktop assets → promote prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA