### PR TITLE
fix(release): put MSYS_NO_PATHCONV on the Windows tag-check step, not the macOS one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -463,12 +463,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          # Git Bash on Windows rewrites arguments that look like absolute POSIX
-          # paths ("/repos/...") into filesystem paths, which broke this `gh api`
-          # tag check in the v0.16.0 release run. Scoped to this step only:
-          # job-wide it also breaks the pnpm shim, which relies on that
-          # conversion to find its own install path.
-          MSYS_NO_PATHCONV: "1"
         run: |
           set -euo pipefail
           checkout_sha="$(git rev-parse HEAD)"
@@ -607,6 +601,12 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          # Git Bash on Windows rewrites arguments that look like absolute POSIX
+          # paths ("/repos/...") into filesystem paths, which broke this `gh api`
+          # tag check in the v0.16.0 release run. Scoped to this step only:
+          # job-wide it also breaks the pnpm shim, which relies on that
+          # conversion to find its own install path.
+          MSYS_NO_PATHCONV: "1"
         run: |
           set -euo pipefail
           checkout_sha="$(git rev-parse HEAD)"


### PR DESCRIPTION
#560 attached the step-scoped `MSYS_NO_PATHCONV: "1"` to the macOS bundle job's identical "Verify release checkout" step instead of the Windows one, so the third v0.16.0 recovery run (https://github.com/7xuanlu/wenlan/actions/runs/32230410638) failed on Windows with the same `invalid API endpoint: "C:/Program Files/Git/repos/..."` error. Everything else in that run passed, including the Docker reuse path. This moves the env to the Windows step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA