### PR TITLE
fix(release): read Windows bundle checksums via stdin so sha256sum does not escape them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -756,8 +756,14 @@ jobs:
           cp "$setup" "$staged/$setup_name"
           cp "$sig" "$staged/$sig_name"
 
-          setup_sha256="$(sha256sum "$staged/$setup_name" | awk '{print $1}')"
-          sig_sha256="$(sha256sum "$staged/$sig_name" | awk '{print $1}')"
+          # Read via stdin: $RUNNER_TEMP is a backslash path on Windows, and
+          # GNU sha256sum escapes such filenames by prefixing the digest with
+          # a backslash ("\30c5..."), which then fails the byte-exact match in
+          # promote-app-assets (seen on the fourth v0.16.0 recovery run).
+          setup_sha256="$(sha256sum < "$staged/$setup_name" | awk '{print $1}')"
+          sig_sha256="$(sha256sum < "$staged/$sig_name" | awk '{print $1}')"
+          [[ "$setup_sha256" =~ ^[0-9a-f]{64}$ && "$sig_sha256" =~ ^[0-9a-f]{64}$ ]] || {
+            echo "ERROR: staged checksums are not canonical hex: $setup_sha256 $sig_sha256"; exit 1; }
           echo "Tauri NSIS installer: $setup"
           echo "Tauri updater signature: $sig"
           echo "Staged checksums: $setup_sha256 $sig_sha256"


### PR DESCRIPTION
Fourth v0.16.0 recovery run (https://github.com/7xuanlu/wenlan/actions/runs/32234097457): the Windows bundle finally built, but "Promote the desktop app assets" failed with

```
ERROR: app bundle asset Wenlan_0.16.0_x64-setup.exe SHA-256 mismatch: expected \30c540...26f8, got 30c540...26f8.
```

`$RUNNER_TEMP` is a backslash path on Windows and GNU `sha256sum` escapes such filenames by prefixing the digest with `\`. The staging step now hashes via stdin and asserts the result is canonical 64-hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA