### PR TITLE
fix: use the shared superseder predicates in the community parity gate and summary buckets

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -19453,15 +19453,15 @@ impl MemoryDB {
                 })?;
             drop(generation_rows);
 
-            let mut candidate_rows = snapshot_conn
-                .query(
-                    // G6 Stage 3: the "legacy" side of this comparator used to
-                    // read `entities.community_id` directly. `detect_communities`
-                    // dual-wrote that column and the entity's shadow page; the
-                    // retirement migration leaves only the shadow, which is the
-                    // same value by the same writer, read through the same join
-                    // shape `search_summary_buckets` already uses.
-                    "SELECT m.source_id, m.space, CAST(p.community_id AS TEXT),
+            let live = not_self_archived("m");
+            let candidate_sql = format!(
+                // G6 Stage 3: the "legacy" side of this comparator used to
+                // read `entities.community_id` directly. `detect_communities`
+                // dual-wrote that column and the entity's shadow page; the
+                // retirement migration leaves only the shadow, which is the
+                // same value by the same writer, read through the same join
+                // shape `search_summary_buckets` already uses.
+                "SELECT m.source_id, m.space, CAST(p.community_id AS TEXT),
                                 raw_member.community_id,
                                 CASE WHEN current_community.community_id IS NOT NULL
                                      THEN raw_member.community_id END
@@ -19496,13 +19496,14 @@ impl MemoryDB {
                                 )
                             )
                             AND m.is_recap=0
-                            AND m.supersede_mode<>'archive'
+                            AND {live}
                             AND m.source_id NOT LIKE 'merged_%'
                             AND m.source_id NOT LIKE 'recap_%'
                             AND m.embedding IS NOT NULL
-                          ORDER BY m.source_id",
-                    libsql::params![consumer],
-                )
+                          ORDER BY m.source_id"
+            );
+            let mut candidate_rows = snapshot_conn
+                .query(&candidate_sql, libsql::params![consumer])
                 .await
                 .map_err(|error| {
                     WenlanError::VectorDb(format!("community parity candidates: {error}"))
@@ -29548,18 +29549,14 @@ impl MemoryDB {
             )
         };
         let live = not_self_archived("m");
+        let superseded = distillation_not_superseded("m");
         let sql = format!(
             "SELECT m.source_id, m.title, m.content, {community_expr}
                FROM memories m
                {community_join}
               WHERE m.source = 'memory' AND m.chunk_index = 0
                 AND COALESCE(m.pending_revision, 0) = 0
-                AND NOT EXISTS (
-                    SELECT 1 FROM memories superseder
-                     WHERE superseder.supersedes = m.source_id
-                       AND COALESCE(superseder.pending_revision, 0) = 0
-                       AND superseder.source = 'memory'
-                )
+                AND {superseded}
                 AND m.is_recap = 0
                 AND {live}
                 AND m.source_id NOT LIKE 'merged_%'

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -17058,6 +17058,78 @@ async fn load_summary_buckets_includes_decisions_but_not_merged_originals() {
     assert_eq!(source_ids, vec!["summary_decision".to_string()]);
 }
 
+/// The half neither companion above covers. Those two exercise a memory's *own*
+/// `supersede_mode`; this one exercises the mode of the memory that supersedes
+/// it, which is what `distillation_not_superseded` reads.
+///
+/// `load_summary_buckets` used to hand-roll a mode-blind superseder test, so any
+/// non-pending superseder removed its predecessor. `'archive'` is supposed to
+/// leave the predecessor visible — that is how search and the distillation pool
+/// already behave — and every decision is auto-stamped `'archive'` at store
+/// time, so the mode-blind test silently dropped a memory from summaries the
+/// moment a decision referenced it.
+#[tokio::test]
+async fn load_summary_buckets_keeps_memories_an_archive_superseder_replaced() {
+    let (db, _dir) = test_db().await;
+    let entity_id = db
+        .store_entity("Scheduler", "concept", None, None, None)
+        .await
+        .unwrap();
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE pages SET community_id = 7 \
+             WHERE id = (SELECT page_id FROM entity_page_map WHERE entity_id = ?1)",
+            libsql::params![entity_id.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    let mut kept = make_memory_doc(
+        "summary_kept",
+        "An archive-mode superseder leaves this memory visible.",
+        "fact",
+        "work",
+        "agent",
+    );
+    kept.entity_id = Some(entity_id.clone());
+    let mut archiver = make_memory_doc(
+        "summary_archiver",
+        "We chose libSQL over sqlite for the graph store.",
+        "decision",
+        "work",
+        "agent",
+    );
+    archiver.entity_id = Some(entity_id);
+    archiver.supersedes = Some("summary_kept".to_string());
+    archiver.pending_revision = false;
+    db.upsert_documents(vec![kept, archiver]).await.unwrap();
+
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE memories SET supersede_mode = 'archive' \
+             WHERE source_id = 'summary_archiver' AND source = 'memory'",
+            (),
+        )
+        .await
+        .unwrap();
+    }
+
+    let buckets = db.load_summary_buckets().await.unwrap();
+    let mut source_ids: Vec<String> = buckets
+        .into_iter()
+        .flat_map(|(_, members)| members.into_iter().map(|member| member.source_id))
+        .collect();
+    source_ids.sort();
+    assert_eq!(
+        source_ids,
+        vec!["summary_archiver".to_string(), "summary_kept".to_string()],
+        "an 'archive'-mode superseder must leave its predecessor in summary buckets"
+    );
+}
+
 // ==================== Space CRUD ====================
 
 #[tokio::test]


### PR DESCRIPTION
Two stale predicates that PR #539 replaced elsewhere and missed here. Neither is
visible to a user on its own; both leave a reader disagreeing with the readers it
is supposed to match.

## The parity gate was certifying less than its own subject

`reconcile_community_reader_parity` filtered its candidate universe with a
hardcoded `m.supersede_mode <> 'archive'`.

Since #539 admitted decisions to summary buckets — and every decision is stamped
`'archive'` automatically at store time — that gate was checking a strictly
smaller set of rows than the thing it certifies. A verifier that cannot see part
of its subject reports a pass it did not earn.

It now filters with `not_self_archived`, the shared helper whose whole purpose is
that an archive-stamped *decision* is still live content. The raw query string
becomes a `format!` so the helper can be interpolated; the SQL is otherwise
unchanged.

## Summary buckets disagreed with the distillation pool

`load_summary_buckets` hand-rolled a mode-blind superseder `NOT EXISTS` while
using `not_self_archived` for its self-state half, so it disagreed with
`query_distillation_staging_pool` about the same rows.

It now calls `distillation_not_superseded`, the helper those pool readers already
share. This is a real behaviour change: a memory replaced by an `'archive'`-mode
superseder stays in summary buckets, matching search and the distillation pool,
where before any non-pending superseder removed it regardless of mode.

## Verification, and one honest gap

The three existing tests around `load_summary_buckets` **all stayed green with
the fix reverted**, so they proved no regression and nothing more. Two of them
exercise a memory's own `supersede_mode`; none exercised the mode of the memory
that supersedes it, which is the column `distillation_not_superseded` actually
reads.

The new test seeds a fact plus a decision that supersedes it with
`supersede_mode='archive'`, and asserts both stay in the buckets. Reverting the
predicate to the old mode-blind `NOT EXISTS` fails it with:

```
left:  ["summary_archiver"]
right: ["summary_archiver", "summary_kept"]
```

while both existing bucket tests correctly stay green. Restored, 5/5 pass.

`cargo nextest run -p wenlan-core load_summary_buckets community_reader_parity distillation`
→ `22 tests run: 22 passed` against this branch rebased onto `56b3f6c7`.

**The parity-gate change has no test.** Building one means constructing a
community assignment that drifts only for an archive-stamped decision, and the
receipt exposes drift counts rather than its candidate set, so the fixture is
disproportionate to a predicate swap. It is verified by reading instead: after
the change the gate filters candidates with `not_self_archived`, the same helper
its subject `load_summary_buckets` already uses, so the two sets now match by
construction.

## Relationship to #564

#564 rewrites `distillation_not_superseded` to delegate to a new shared
`not_hidden_by_superseder`. That delegation is meant to be behaviour-neutral, so
these two branches should compose — but whichever merges second should re-run the
tests above against the merged result rather than trusting either branch's own
green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EknrjYbYHh8scrrjtZDMAN
