### PR TITLE
fix(app): keep atlas shelf clusters live under drag physics

### DIFF
--- a/src/components/memory/AtlasView.test.tsx
+++ b/src/components/memory/AtlasView.test.tsx
@@ -453,11 +453,11 @@ describe("AtlasView", () => {
     expect(refreshSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps a pinned node pinned after its drag, and releases an unpinned one", async () => {
-    // shelveComponents parks every node outside the biggest component on the
-    // shelf and the sim pins it there. Clearing that pin on mouseup would hand
-    // the node back to charge + forceCenter, which would drag the shelf up
-    // into the core on the first drag.
+  it("releases fx/fy for every node on mouseup, pinned or not", async () => {
+    // Every component is live now (see atlas.ts's groupCenterForce): its own
+    // anchor holds it at its shelf slot, so mouseup no longer has to leave a
+    // shelved node pinned to keep the shelf out of the core — it always
+    // clears fx/fy, the same as a core drag always did.
     mockConnectedPair();
 
     renderWithQuery(<AtlasView />);
@@ -472,8 +472,8 @@ describe("AtlasView", () => {
     instance.handlers.get("downNode")?.({ node: "e1" });
     mouseCaptor.handlers.get("mousemovebody")?.(dragEvent(300, 300));
     mouseCaptor.handlers.get("mouseup")?.({});
-    expect(pinned.fx).toBe(300);
-    expect(pinned.fy).toBe(300);
+    expect(pinned.fx).toBeNull();
+    expect(pinned.fy).toBeNull();
 
     const free = sim.nodes().find((n: { id: string }) => n.id === "e2");
     instance.handlers.get("downNode")?.({ node: "e2" });

--- a/src/components/memory/AtlasView.test.tsx
+++ b/src/components/memory/AtlasView.test.tsx
@@ -761,6 +761,7 @@ describe("AtlasView", () => {
       const mouseCaptor = instance.getMouseCaptor();
       const sim = (window as any).__ATLAS_SIM;
       const stopSpy = vi.spyOn(sim, "stop");
+      const settleSpy = vi.spyOn(sim, "settleShelf");
 
       const before = { x: graph.getNodeAttribute("e1", "x"), y: graph.getNodeAttribute("e1", "y") };
 
@@ -776,6 +777,10 @@ describe("AtlasView", () => {
 
       expect(matchMediaMock).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)");
       expect(stopSpy).toHaveBeenCalledTimes(1);
+      // Stopping outright skips the tail that walks a released shelf component
+      // back onto its slot, so the same correction has to be applied in one
+      // step here or the component stays where the drag left it.
+      expect(settleSpy).toHaveBeenCalledTimes(1);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/src/components/memory/AtlasView.tsx
+++ b/src/components/memory/AtlasView.tsx
@@ -838,8 +838,13 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       sim.setDraggingId(null);
       container.style.cursor = hoverStateRef.current.hovered ? "pointer" : "default";
       // Natural decay is the inertia tail; reduced motion skips it outright.
-      if (prefersReducedMotion()) sim.stop();
-      else sim.alphaTarget(0);
+      // That tail is also what walks a released shelf component back onto its
+      // slot, so skipping it needs the same correction applied in one step —
+      // otherwise a component dragged toward the core just stays there.
+      if (prefersReducedMotion()) {
+        sim.settleShelf();
+        sim.stop();
+      } else sim.alphaTarget(0);
     });
 
     // Direct wheel zoom. Sigma's default quantizes the gesture into 1.7x

--- a/src/components/memory/AtlasView.tsx
+++ b/src/components/memory/AtlasView.tsx
@@ -178,9 +178,6 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
   // pointer actually moved during the current press — the latter gates
   // clickNode so a drag-release doesn't also fire entity navigation.
   const draggedNodeRef = useRef<string | null>(null);
-  /** Was the node under the pointer already pinned before this drag? A packed
-   *  island node is, and must stay pinned when the pointer lets go. */
-  const draggedNodeWasPinnedRef = useRef(false);
   const movedDuringPressRef = useRef(false);
   // Cached cartography (hulls + graticule). Recomputing every hull on every
   // afterRender meant a plain camera pan or a hover re-hulled all 66 regions;
@@ -777,11 +774,6 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       // its orbit on the next tick unless the sim knows a hand is on it.
       sim.setDraggingId(node);
       const simNode = sim.nodes().find((n) => n.id === node);
-      // Nodes outside the biggest component are parked on the shelf by
-      // shelveComponents and pinned there; a drag moves the pin, and release
-      // leaves it at the new spot rather than handing it back to charge +
-      // forceCenter, which would fling it into the core.
-      draggedNodeWasPinnedRef.current = simNode?.fx != null;
       // Leaf memories aren't sim members (see nonSimulatedIds) — dragging one
       // is pure direct manipulation via mousemovebody's graphology writes, so
       // there's nothing here to pin or reheat; setDraggingId above is what
@@ -834,12 +826,14 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       if (draggedNode) {
         graph.setNodeAttribute(draggedNode, "highlighted", false);
         const simNode = sim.nodes().find((n) => n.id === draggedNode);
-        if (simNode && !draggedNodeWasPinnedRef.current) {
+        // Every component is live now (see atlas.ts's groupCenterForce) — its
+        // own anchor holds it at its shelf slot, so releasing fx/fy here
+        // never hands a shelved node back to unconstrained charge/forceCenter.
+        if (simNode) {
           simNode.fx = null;
           simNode.fy = null;
         }
         draggedNodeRef.current = null;
-        draggedNodeWasPinnedRef.current = false;
       }
       sim.setDraggingId(null);
       container.style.cursor = hoverStateRef.current.hovered ? "pointer" : "default";

--- a/src/lib/graph/atlas.test.ts
+++ b/src/lib/graph/atlas.test.ts
@@ -434,16 +434,17 @@ describe("createAtlasSimulation", () => {
     expect(after).not.toEqual(before);
   });
 
-  it("invokes onTick after every writeback — settle, then the pack pass, then once per manual tick", () => {
+  it("invokes onTick after every writeback — settle, the relax pass, the pack pass, then once per manual tick", () => {
     const graph = starGraph();
     const onTick = vi.fn();
     const sim = createAtlasSimulation(graph, onTick);
-    // The settle runs as a single wrapped tick(220) call → one writeback;
-    // round 4's component packing runs the same writeback path afterwards so
-    // satellites follow their moved anchors → a second.
-    expect(onTick).toHaveBeenCalledTimes(2);
-    sim.tick(1);
+    // The settle runs as a single wrapped tick(settleTicks) call → one
+    // writeback; the live shelf's relax pass runs the same wrapped tick →
+    // a second; the final pack-and-anchor pass writes back explicitly so
+    // satellites follow their moved anchors → a third.
     expect(onTick).toHaveBeenCalledTimes(3);
+    sim.tick(1);
+    expect(onTick).toHaveBeenCalledTimes(4);
   });
 });
 
@@ -1149,15 +1150,23 @@ describe("shelveComponents", () => {
     expect(shelveComponents(graph)).toEqual([]);
   });
 
-  it("holds the shelved components still through a drag reheat", () => {
+  it("holds each shelved component's centroid still through a drag reheat", () => {
     const graph = buildAtlasGraph(componentsModel([9, 6, 5]), PALETTE);
     runAtlasLayout(graph);
     const sim = createAtlasSimulation(graph);
-    const placement = [
+    const groups = [
       ["c1n0", "c1n1", "c1n2", "c1n3", "c1n4", "c1n5"],
       ["c2n0", "c2n1", "c2n2", "c2n3", "c2n4"],
     ];
-    const before = placement.map((ids) => box(graph, ids));
+    const centroidOf = (ids: string[]) => {
+      const xs = ids.map((id) => graph.getNodeAttribute(id, "x") as number);
+      const ys = ids.map((id) => graph.getNodeAttribute(id, "y") as number);
+      return {
+        x: xs.reduce((a, b) => a + b, 0) / xs.length,
+        y: ys.reduce((a, b) => a + b, 0) / ys.length,
+      };
+    };
+    const before = groups.map(centroidOf);
     // Exactly AtlasView's downNode: pin the pressed core node, jump alpha to
     // 0.3 and reheat.
     const pressed = sim.nodes().find((n) => n.id === "c0n0") as {
@@ -1170,22 +1179,45 @@ describe("shelveComponents", () => {
     pressed.fy = pressed.y;
     sim.alpha(0.3).alphaTarget(0.3);
     sim.tick(60);
-    placement.forEach((ids, i) => {
-      expect(box(graph, ids)).toEqual(before[i]);
+
+    // Every component is live now (see groupCenterForce) — collide and link
+    // can still shuffle nodes WITHIN a shelved component on a core reheat,
+    // that is the fix — but each component's own rigid anchor has to hold
+    // its CENTROID in place, an exact-box freeze no longer applies. The
+    // anchor corrects the centroid to target BEFORE d3's own velocity
+    // integration runs each tick (same as the original core-only force), so
+    // a small residual carries forward every tick rather than zeroing out —
+    // measured ~2.2 units over 60 ticks here, well short of drifting.
+    groups.forEach((ids, i) => {
+      const after = centroidOf(ids);
+      const b = before[i] as { x: number; y: number };
+      expect(Math.hypot(after.x - b.x, after.y - b.y)).toBeLessThan(3);
     });
+    // The two shelved components still keep clear of each other.
+    const [b1, b2] = groups.map((ids) => box(graph, ids)) as [
+      { minX: number; maxX: number; minY: number; maxY: number },
+      { minX: number; maxX: number; minY: number; maxY: number },
+    ];
+    const overlaps = b1.minX < b2.maxX && b2.minX < b1.maxX && b1.minY < b2.maxY && b2.minY < b1.maxY;
+    expect(overlaps).toBe(false);
   });
 
   it("holds the core in place through a reheat instead of chasing the shelf's mass", () => {
     const graph = buildAtlasGraph(componentsModel([24, 6, 6, 6, 6]), PALETTE);
     runAtlasLayout(graph);
     const sim = createAtlasSimulation(graph);
-    const pressed = sim.nodes().find((n) => n.fx == null) as {
+    // Every component is live now (see groupCenterForce), so fx == null no
+    // longer picks out the core — every node's fx is null right after
+    // creation. c0 is the core by construction (24 of 48 nodes, by far the
+    // largest), so select it by id instead.
+    const core = sim.nodes().filter((n) => n.id.startsWith("c0n"));
+    const pressed = core[0] as {
       fx?: number | null;
       fy?: number | null;
       x?: number;
       y?: number;
     };
-    const rest = sim.nodes().filter((n) => n.fx == null && n !== pressed);
+    const rest = core.filter((n) => n !== pressed);
     const centroid = () => ({
       x: rest.reduce((sum, n) => sum + (n.x ?? 0), 0) / rest.length,
       y: rest.reduce((sum, n) => sum + (n.y ?? 0), 0) / rest.length,
@@ -1199,13 +1231,94 @@ describe("shelveComponents", () => {
     sim.tick(60);
 
     const after = centroid();
-    // The shelf is pinned BELOW the core, so a centre force that averaged
-    // every node would see a centroid below the origin every tick and walk
-    // the core upward to compensate — the two zones would drift apart.
-    // 18 units on a 430-unit span as written. d3's own forceCenter, which
-    // averages the pinned shelf in too, gives 268; averaging only the free
-    // nodes but pulling them to a centroid of (0,0) rather than to where the
-    // shelf pass left them gives 54.
+    // The shelf sits BELOW the core, so a centre force that averaged every
+    // node would see a centroid below the origin every tick and walk the
+    // core upward to compensate — the two zones would drift apart. Each
+    // component holding its OWN centroid (not a shared one across the whole
+    // graph) is what keeps the core from chasing the shelf's mass.
     expect(Math.hypot(after.x - before.x, after.y - before.y)).toBeLessThan(span * 0.08);
+  });
+
+  it("pulls a shelved component's neighbor toward a dragged node in it, while other components hold still", () => {
+    const graph = buildAtlasGraph(componentsModel([9, 5, 5]), PALETTE);
+    runAtlasLayout(graph);
+    const sim = createAtlasSimulation(graph);
+    const byId = new Map(sim.nodes().map((n) => [n.id, n]));
+    const dragged = byId.get("c1n0") as { fx?: number | null; fy?: number | null; x?: number; y?: number };
+    const neighbor = byId.get("c1n1") as { x?: number; y?: number };
+    const otherIds = ["c2n0", "c2n1", "c2n2", "c2n3", "c2n4"];
+    const centroidOf = (ids: string[]) => {
+      const pts = ids.map((id) => byId.get(id) as { x?: number; y?: number });
+      return {
+        x: pts.reduce((sum, n) => sum + (n.x ?? 0), 0) / pts.length,
+        y: pts.reduce((sum, n) => sum + (n.y ?? 0), 0) / pts.length,
+      };
+    };
+    const otherBefore = centroidOf(otherIds);
+
+    // Exactly AtlasView's downNode + mousemovebody on a SHELF node: pin it
+    // 50 units off from where it sits and reheat, same as a live core drag.
+    dragged.fx = (dragged.x ?? 0) + 50;
+    dragged.fy = dragged.y ?? 0;
+    const targetX = dragged.fx;
+    const targetY = dragged.fy;
+    const distBefore = Math.hypot((neighbor.x ?? 0) - targetX, (neighbor.y ?? 0) - targetY);
+    sim.alpha(0.3).alphaTarget(0.3);
+    sim.tick(60);
+
+    // The neighbor is pulled toward the drag target by the link force —
+    // the whole point of never freezing a shelved component with fx/fy.
+    const distAfter = Math.hypot((neighbor.x ?? 0) - targetX, (neighbor.y ?? 0) - targetY);
+    expect(distAfter).toBeLessThan(distBefore - 10);
+    // The OTHER shelved component never had a hand on it — its anchor holds
+    // its centroid exactly as the core-drag case above does.
+    const otherAfter = centroidOf(otherIds);
+    expect(Math.hypot(otherAfter.x - otherBefore.x, otherAfter.y - otherBefore.y)).toBeLessThan(2);
+  });
+
+  it("opens a knot: an overlapping dense cluster clears every pair of discs once settled", () => {
+    const spokeCount = 20;
+    const nodes: GraphNode[] = [node({ id: "hub", entityType: "page", degree: spokeCount })];
+    const edges: GraphEdge[] = [];
+    for (let i = 0; i < spokeCount; i += 1) {
+      const id = `p${i}`;
+      // Ring neighbor plus the hub spoke gives every page node degree 2+, so
+      // none of them is a satellite (see nonSimulatedIds) — the whole
+      // cluster stays in the sim, discs and all.
+      nodes.push(node({ id, entityType: "page", degree: 2 }));
+      edges.push(edge({ id: `h${i}`, source: "hub", target: id, type: "about" }));
+    }
+    for (let i = 0; i < spokeCount; i += 1) {
+      edges.push(
+        edge({ id: `ring${i}`, source: `p${i}`, target: `p${(i + 1) % spokeCount}`, type: "wikilink" }),
+      );
+    }
+    const graph = buildAtlasGraph(makeModel(nodes, edges), PALETTE);
+    // Seeded overlapping — every node on the same point, standing in for the
+    // real capture's "Lucian Threads" cluster, which froze mid-settle as a
+    // collapsed knot under the old fx/fy-pin design (see the round 5 spec).
+    graph.forEachNode((id) => {
+      graph.setNodeAttribute(id, "x", 0);
+      graph.setNodeAttribute(id, "y", 0);
+    });
+
+    const sim = createAtlasSimulation(graph);
+    const simNodes = sim.nodes();
+    let minClearance = Infinity;
+    for (let i = 0; i < simNodes.length; i += 1) {
+      for (let j = i + 1; j < simNodes.length; j += 1) {
+        const a = simNodes[i] as AtlasSimNode;
+        const b = simNodes[j] as AtlasSimNode;
+        const dist = Math.hypot((a.x ?? 0) - (b.x ?? 0), (a.y ?? 0) - (b.y ?? 0));
+        minClearance = Math.min(minClearance, dist - (a.radius + b.radius));
+      }
+    }
+    // Every pair of discs cleared, not just ring neighbors — the knot opened
+    // rather than merely stretching along one axis. Collide runs at strength
+    // 0.7 (not 1), so a linked pair settles right at its two radii's shared
+    // boundary rather than genuinely apart — measured clearance here is
+    // -0.00007, float noise around exactly touching, not real overlap; the
+    // knot started at clearance ~-16 (every node stacked on (0,0)).
+    expect(minClearance).toBeGreaterThan(-0.01);
   });
 });

--- a/src/lib/graph/atlas.test.ts
+++ b/src/lib/graph/atlas.test.ts
@@ -8,6 +8,7 @@ import {
   buildAtlasGraph,
   runAtlasLayout,
   createAtlasSimulation,
+  relaxShelf,
   nonSimulatedIds,
   satellitePlan,
   placeSatellites,
@@ -21,7 +22,7 @@ import {
   drawPageRings,
   drawRadialNodeLabel,
 } from "./atlas";
-import type { HoverState, AtlasSimNode } from "./atlas";
+import type { HoverState, AtlasSimNode, AtlasSimLink } from "./atlas";
 
 const PALETTE: GraphPalette = {
   project: "#111111",
@@ -434,17 +435,61 @@ describe("createAtlasSimulation", () => {
     expect(after).not.toEqual(before);
   });
 
-  it("invokes onTick after every writeback — settle, the relax pass, the pack pass, then once per manual tick", () => {
+  it("invokes onTick after every writeback — settle, the pack pass, then once per manual tick", () => {
     const graph = starGraph();
     const onTick = vi.fn();
     const sim = createAtlasSimulation(graph, onTick);
     // The settle runs as a single wrapped tick(settleTicks) call → one
-    // writeback; the live shelf's relax pass runs the same wrapped tick →
-    // a second; the final pack-and-anchor pass writes back explicitly so
-    // satellites follow their moved anchors → a third.
-    expect(onTick).toHaveBeenCalledTimes(3);
+    // writeback; the final pack-and-anchor pass writes back explicitly so
+    // satellites follow their moved anchors → a second. The knot relax in
+    // between is exactly TWO, not three: it runs on relaxShelf's scratch
+    // simulation, which never touches this graph or this callback.
+    expect(onTick).toHaveBeenCalledTimes(2);
     sim.tick(1);
-    expect(onTick).toHaveBeenCalledTimes(4);
+    expect(onTick).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("relaxShelf", () => {
+  it("owns the shelved nodes and only them, opens them, and leaves the core exactly where it was", () => {
+    const nodes: AtlasSimNode[] = [
+      { id: "core0", x: 0, y: 0, radius: 5 },
+      { id: "core1", x: 40, y: 0, radius: 5 },
+      // Two shelved nodes dropped on nearly the same point: the knot this
+      // pass exists to open.
+      { id: "s0", x: 0, y: -200, radius: 5 },
+      { id: "s1", x: 1, y: -200, radius: 5 },
+    ];
+    const links: AtlasSimLink[] = [
+      { source: "core0", target: "core1", type: "knows" },
+      { source: "s0", target: "s1", type: "knows" },
+    ];
+    const placement = [
+      ["core0", "core1"],
+      ["s0", "s1"],
+    ];
+    const degree = new Map([
+      ["core0", 1],
+      ["core1", 1],
+      ["s0", 1],
+      ["s1", 1],
+    ]);
+
+    const sim = relaxShelf(nodes, links, placement, degree);
+
+    // The perf guard, asserted structurally rather than on a stopwatch: the
+    // core is already settled, so relaxing it again would only buy back the
+    // whole O(core) charge cost this scratch pass was split out to avoid.
+    expect(sim.nodes().map((n) => n.id).sort()).toEqual(["s0", "s1"]);
+    // Core positions come back byte-identical — it was never simulated.
+    expect(nodes[0]).toMatchObject({ x: 0, y: 0 });
+    expect(nodes[1]).toMatchObject({ x: 40, y: 0 });
+    // The shelved pair opened to its link's rest length...
+    const [s0, s1] = [nodes[2] as AtlasSimNode, nodes[3] as AtlasSimNode];
+    expect(Math.hypot((s0.x ?? 0) - (s1.x ?? 0), (s0.y ?? 0) - (s1.y ?? 0))).toBeGreaterThan(10);
+    // ...around the centroid it started on, held there by its own group anchor.
+    expect(((s0.x ?? 0) + (s1.x ?? 0)) / 2).toBeCloseTo(0.5, 1);
+    expect(((s0.y ?? 0) + (s1.y ?? 0)) / 2).toBeCloseTo(-200, 1);
   });
 });
 
@@ -1180,18 +1225,21 @@ describe("shelveComponents", () => {
     sim.alpha(0.3).alphaTarget(0.3);
     sim.tick(60);
 
-    // Every component is live now (see groupCenterForce) — collide and link
+    // Every component is live now (see shelfAnchorForce) — collide and link
     // can still shuffle nodes WITHIN a shelved component on a core reheat,
-    // that is the fix — but each component's own rigid anchor has to hold
-    // its CENTROID in place, an exact-box freeze no longer applies. The
-    // anchor corrects the centroid to target BEFORE d3's own velocity
-    // integration runs each tick (same as the original core-only force), so
-    // a small residual carries forward every tick rather than zeroing out —
-    // measured ~2.2 units over 60 ticks here, well short of drifting.
+    // that is the fix — but the component as a whole has to stay on its
+    // slot; an exact-box freeze no longer applies.
+    //
+    // The bound is tight on purpose. A hold that only corrects POSITION
+    // leaves each tick's velocity to carry the component a little further,
+    // every tick, forever: ~2.2 units here, and 27 units on the real capture
+    // where the core's mass sits 3,000 units away and pushes that much
+    // harder. Cancelling the component's bulk velocity is what makes the
+    // residual vanish rather than merely look small at fixture scale.
     groups.forEach((ids, i) => {
       const after = centroidOf(ids);
       const b = before[i] as { x: number; y: number };
-      expect(Math.hypot(after.x - b.x, after.y - b.y)).toBeLessThan(3);
+      expect(Math.hypot(after.x - b.x, after.y - b.y)).toBeLessThan(0.5);
     });
     // The two shelved components still keep clear of each other.
     const [b1, b2] = groups.map((ids) => box(graph, ids)) as [
@@ -1239,41 +1287,149 @@ describe("shelveComponents", () => {
     expect(Math.hypot(after.x - before.x, after.y - before.y)).toBeLessThan(span * 0.08);
   });
 
-  it("pulls a shelved component's neighbor toward a dragged node in it, while other components hold still", () => {
+  /** Runs AtlasView's gesture — pin `dragged` 50 units away, jump alpha to
+   *  0.3, reheat — once per compass direction, and returns the MEAN distance
+   *  its chain neighbor travelled.
+   *
+   *  Two measurement traps this avoids. Distance from the neighbor to the
+   *  drag target is not the quantity: the link holds the pair at its rest
+   *  length, so a neighbor that follows perfectly still stops ~30 units short
+   *  and that gap can grow while it is doing exactly the right thing. And a
+   *  single direction is not enough: how far a neighbor gets depends on what
+   *  is in the way (a shelved component dragged sideways runs into the one
+   *  beside it on its row and stops at 7 units, while the same drag downward
+   *  covers 44), so one axis measures collide, not the anchor. */
+  function meanNeighborTravel(sizes: number[], dragged: string) {
+    const neighbor = dragged.replace("n0", "n1");
+    const travels = ([
+      [50, 0],
+      [-50, 0],
+      [0, 50],
+      [0, -50],
+    ] as const).map(([dx, dy]) => {
+      const graph = buildAtlasGraph(componentsModel(sizes), PALETTE);
+      runAtlasLayout(graph);
+      const sim = createAtlasSimulation(graph);
+      const byId = new Map(sim.nodes().map((n) => [n.id, n]));
+      const pressed = byId.get(dragged) as { fx?: number | null; fy?: number | null; x?: number; y?: number };
+      const follower = byId.get(neighbor) as { x?: number; y?: number };
+      const from = { x: follower.x ?? 0, y: follower.y ?? 0 };
+      pressed.fx = (pressed.x ?? 0) + dx;
+      pressed.fy = (pressed.y ?? 0) + dy;
+      sim.alpha(0.3).alphaTarget(0.3);
+      sim.tick(120);
+      sim.stop();
+      return Math.hypot((follower.x ?? 0) - from.x, (follower.y ?? 0) - from.y);
+    });
+    return travels.reduce((a, b) => a + b, 0) / travels.length;
+  }
+
+  it("pulls a shelved component's neighbor along about as readily as a core one", () => {
+    const core = meanNeighborTravel([9, 5], "c0n0");
+    const shelf = meanNeighborTravel([9, 5], "c1n0");
+    // The bug this round exists to fix: under the old fx/fy freeze a shelved
+    // neighbor travelled exactly 0, in every direction.
+    expect(shelf).toBeGreaterThan(10);
+    // "Dragging should feel the same everywhere" — the shelf anchor is a
+    // tenth of a link's strength precisely so a hand still wins.
+    expect(shelf).toBeGreaterThan(0.5 * core);
+  });
+
+  it("holds an untouched component's centroid while a NEIGHBORING shelf component is dragged", () => {
     const graph = buildAtlasGraph(componentsModel([9, 5, 5]), PALETTE);
+    runAtlasLayout(graph);
+    const sim = createAtlasSimulation(graph);
+    const byId = new Map(sim.nodes().map((n) => [n.id, n]));
+    const untouched = ["c2n0", "c2n1", "c2n2", "c2n3", "c2n4"].map(
+      (id) => byId.get(id) as { x?: number; y?: number },
+    );
+    const centroid = () => ({
+      x: untouched.reduce((sum, n) => sum + (n.x ?? 0), 0) / untouched.length,
+      y: untouched.reduce((sum, n) => sum + (n.y ?? 0), 0) / untouched.length,
+    });
+    const before = centroid();
+
+    const dragged = byId.get("c1n0") as { fx?: number | null; fy?: number | null; x?: number; y?: number };
+    dragged.fx = (dragged.x ?? 0) + 50;
+    dragged.fy = dragged.y ?? 0;
+    sim.alpha(0.3).alphaTarget(0.3);
+    sim.tick(60);
+
+    const after = centroid();
+    expect(Math.hypot(after.x - before.x, after.y - before.y)).toBeLessThan(0.5);
+  });
+
+  it("lets a TWO-node shelf component follow a drag instead of clamping its one free node to the anchor", () => {
+    const graph = buildAtlasGraph(componentsModel([9, 2]), PALETTE);
     runAtlasLayout(graph);
     const sim = createAtlasSimulation(graph);
     const byId = new Map(sim.nodes().map((n) => [n.id, n]));
     const dragged = byId.get("c1n0") as { fx?: number | null; fy?: number | null; x?: number; y?: number };
     const neighbor = byId.get("c1n1") as { x?: number; y?: number };
-    const otherIds = ["c2n0", "c2n1", "c2n2", "c2n3", "c2n4"];
-    const centroidOf = (ids: string[]) => {
-      const pts = ids.map((id) => byId.get(id) as { x?: number; y?: number });
-      return {
-        x: pts.reduce((sum, n) => sum + (n.x ?? 0), 0) / pts.length,
-        y: pts.reduce((sum, n) => sum + (n.y ?? 0), 0) / pts.length,
-      };
-    };
-    const otherBefore = centroidOf(otherIds);
+    const from = { x: neighbor.x ?? 0, y: neighbor.y ?? 0 };
 
-    // Exactly AtlasView's downNode + mousemovebody on a SHELF node: pin it
-    // 50 units off from where it sits and reheat, same as a live core drag.
-    dragged.fx = (dragged.x ?? 0) + 50;
+    // A pair is the worst case for any group-centroid hold: pin one node and
+    // the other is the group's ENTIRE free set, so "hold the free centroid at
+    // the group target" degenerates into "teleport the neighbor to the middle
+    // of the slot", away from the hand. Drag far enough that following and
+    // clamping cannot be confused — a clamped neighbor stays put whatever the
+    // drag distance, a following one tracks it.
+    dragged.fx = (dragged.x ?? 0) + 200;
     dragged.fy = dragged.y ?? 0;
-    const targetX = dragged.fx;
-    const targetY = dragged.fy;
-    const distBefore = Math.hypot((neighbor.x ?? 0) - targetX, (neighbor.y ?? 0) - targetY);
     sim.alpha(0.3).alphaTarget(0.3);
     sim.tick(60);
 
-    // The neighbor is pulled toward the drag target by the link force —
-    // the whole point of never freezing a shelved component with fx/fy.
-    const distAfter = Math.hypot((neighbor.x ?? 0) - targetX, (neighbor.y ?? 0) - targetY);
-    expect(distAfter).toBeLessThan(distBefore - 10);
-    // The OTHER shelved component never had a hand on it — its anchor holds
-    // its centroid exactly as the core-drag case above does.
-    const otherAfter = centroidOf(otherIds);
-    expect(Math.hypot(otherAfter.x - otherBefore.x, otherAfter.y - otherBefore.y)).toBeLessThan(2);
+    const travel = Math.hypot((neighbor.x ?? 0) - from.x, (neighbor.y ?? 0) - from.y);
+    expect(travel).toBeGreaterThan(100);
+    // And it went WITH the drag, not to the group's own centre.
+    expect((neighbor.x ?? 0) - from.x).toBeGreaterThan(100);
+  });
+
+  it("keeps a long shelf component from swinging its far end up into the core over a long reheat", () => {
+    // Chains this long are the case a centroid hold cannot catch: holding the
+    // CENTRE says nothing about which way a body points, and an elongated
+    // component in the core's repulsion field pivots to point at the core —
+    // its top edge rises even though its centroid has barely moved. Under the
+    // centroid-only hold this fixture's five-node chain rose 9.1 units toward
+    // the core in 120 ticks and its centroid drifted 1.8; both are near zero
+    // once each node is sprung to its own slot.
+    const graph = buildAtlasGraph(componentsModel([24, 6, 5]), PALETTE);
+    runAtlasLayout(graph);
+    const sim = createAtlasSimulation(graph);
+    const ids = [24, 6, 5].map((size, c) => Array.from({ length: size }, (_, i) => `c${c}n${i}`));
+    const centroidOf = (group: string[]) => {
+      const xs = group.map((id) => graph.getNodeAttribute(id, "x") as number);
+      const ys = group.map((id) => graph.getNodeAttribute(id, "y") as number);
+      return { x: xs.reduce((a, b) => a + b, 0) / xs.length, y: ys.reduce((a, b) => a + b, 0) / ys.length };
+    };
+    const before = ids.map(centroidOf);
+    const boxBefore = ids.map((group) => box(graph, group));
+
+    const pressed = sim.nodes().find((n) => n.id === "c0n0") as {
+      fx?: number | null;
+      fy?: number | null;
+      x?: number;
+      y?: number;
+    };
+    pressed.fx = pressed.x;
+    pressed.fy = pressed.y;
+    sim.alpha(0.3).alphaTarget(0.3);
+    sim.tick(120);
+
+    const core = box(graph, ids[0] as string[]);
+    for (let i = 1; i < ids.length; i += 1) {
+      const shelf = box(graph, ids[i] as string[]);
+      const overlaps =
+        shelf.minX < core.maxX && core.minX < shelf.maxX && shelf.minY < core.maxY && core.minY < shelf.maxY;
+      expect(overlaps).toBe(false);
+      // The shelf is BELOW the core, so "rising toward the core" is maxY
+      // climbing. Bounded well inside the SHELF_GAP the packing left.
+      const rise = shelf.maxY - (boxBefore[i] as { maxY: number }).maxY;
+      expect(rise).toBeLessThan(5);
+      const after = centroidOf(ids[i] as string[]);
+      const b = before[i] as { x: number; y: number };
+      expect(Math.hypot(after.x - b.x, after.y - b.y)).toBeLessThan(0.5);
+    }
   });
 
   it("opens a knot: an overlapping dense cluster clears every pair of discs once settled", () => {

--- a/src/lib/graph/atlas.test.ts
+++ b/src/lib/graph/atlas.test.ts
@@ -441,8 +441,8 @@ describe("createAtlasSimulation", () => {
     const sim = createAtlasSimulation(graph, onTick);
     // The settle runs as a single wrapped tick(settleTicks) call → one
     // writeback; the final pack-and-anchor pass writes back explicitly so
-    // satellites follow their moved anchors → a second. The knot relax in
-    // between is exactly TWO, not three: it runs on relaxShelf's scratch
+    // satellites follow their moved anchors → a second. TWO in total, not
+    // three: the knot relax in between runs on relaxShelf's scratch
     // simulation, which never touches this graph or this callback.
     expect(onTick).toHaveBeenCalledTimes(2);
     sim.tick(1);
@@ -1254,10 +1254,11 @@ describe("shelveComponents", () => {
     const graph = buildAtlasGraph(componentsModel([24, 6, 6, 6, 6]), PALETTE);
     runAtlasLayout(graph);
     const sim = createAtlasSimulation(graph);
-    // Every component is live now (see groupCenterForce), so fx == null no
-    // longer picks out the core — every node's fx is null right after
-    // creation. c0 is the core by construction (24 of 48 nodes, by far the
-    // largest), so select it by id instead.
+    // Every component is live now — the core under groupCenterForce, the
+    // shelved ones under shelfAnchorForce — so fx == null no longer picks out
+    // the core; every node's fx is null right after creation. c0 is the core
+    // by construction (24 of 48 nodes, by far the largest), so select it by
+    // id instead.
     const core = sim.nodes().filter((n) => n.id.startsWith("c0n"));
     const pressed = core[0] as {
       fx?: number | null;
@@ -1383,6 +1384,82 @@ describe("shelveComponents", () => {
     expect(travel).toBeGreaterThan(100);
     // And it went WITH the drag, not to the group's own centre.
     expect((neighbor.x ?? 0) - from.x).toBeGreaterThan(100);
+  });
+
+  /** The real mouseup path: pin a shelved node, haul the component `distance`
+   *  units toward the core (the shelf is below it, so +y), then let go the way
+   *  AtlasView does — clear fx/fy, alphaTarget(0), and let the simulation cool
+   *  to alphaMin. Returns where the component ended up relative to its slot. */
+  function dragAndRelease(distance: number, reducedMotion = false) {
+    const graph = buildAtlasGraph(componentsModel([9, 2]), PALETTE);
+    runAtlasLayout(graph);
+    const sim = createAtlasSimulation(graph);
+    const core = Array.from({ length: 9 }, (_, i) => `c0n${i}`);
+    const shelf = ["c1n0", "c1n1"];
+    const centroidOf = (group: string[]) => ({
+      x: group.reduce((sum, id) => sum + (graph.getNodeAttribute(id, "x") as number), 0) / group.length,
+      y: group.reduce((sum, id) => sum + (graph.getNodeAttribute(id, "y") as number), 0) / group.length,
+    });
+    const slot = centroidOf(shelf);
+
+    const dragged = sim.nodes().find((n) => n.id === "c1n0") as {
+      fx?: number | null;
+      fy?: number | null;
+      x?: number;
+      y?: number;
+    };
+    dragged.fx = dragged.x;
+    dragged.fy = (dragged.y ?? 0) + distance;
+    sim.alpha(0.3).alphaTarget(0.3);
+    sim.tick(60);
+
+    dragged.fx = null;
+    dragged.fy = null;
+    if (reducedMotion) {
+      sim.settleShelf();
+      sim.stop();
+    } else {
+      sim.alphaTarget(0);
+      // alphaDecay 0.03 from 0.3 reaches alphaMin in ~190; the cap only keeps
+      // a regression here from hanging the suite.
+      for (let i = 0; i < 400 && sim.alpha() >= sim.alphaMin(); i += 1) sim.tick(1);
+      sim.stop();
+    }
+
+    const after = centroidOf(shelf);
+    const c = box(graph, core);
+    const s = box(graph, shelf);
+    return {
+      offset: Math.hypot(after.x - slot.x, after.y - slot.y),
+      overlapsCore: s.minX < c.maxX && c.minX < s.maxX && s.minY < c.maxY && c.minY < s.maxY,
+    };
+  }
+
+  it("walks a RELEASED component all the way back to its slot, not part of the way", () => {
+    // The failure this catches: hold a component's bulk velocity at zero and
+    // the spring's own return velocity is cancelled again every tick, leaving
+    // one alpha-scaled impulse per tick to do the whole journey — and alpha is
+    // a finite budget. Measured that way, this 200-unit drag settled 77.5
+    // units from its slot with its box 13 units inside the core's; the
+    // 100-unit drag settled 33.4 out, past the 24-unit SHELF_GAP that is
+    // supposed to separate the zones. Steering the bulk velocity home instead
+    // (SHELF_RETURN_RATE) is not alpha-scaled, so the return completes.
+    const far = dragAndRelease(200);
+    expect(far.offset).toBeLessThan(2);
+    expect(far.overlapsCore).toBe(false);
+    const near = dragAndRelease(100);
+    expect(near.offset).toBeLessThan(2);
+    expect(near.overlapsCore).toBe(false);
+  });
+
+  it("puts a released component back on its slot in ONE step when reduced motion skips the cooling tail", () => {
+    // AtlasView's mouseup stops the simulation outright under reduced motion,
+    // so there is no tail to walk the component home — without settleShelf it
+    // simply stays where the drag left it, 61 units off slot and overlapping
+    // the core.
+    const settled = dragAndRelease(200, true);
+    expect(settled.offset).toBeLessThan(0.5);
+    expect(settled.overlapsCore).toBe(false);
   });
 
   it("keeps a long shelf component from swinging its far end up into the core over a long reheat", () => {

--- a/src/lib/graph/atlas.ts
+++ b/src/lib/graph/atlas.ts
@@ -445,7 +445,8 @@ function shelfRows(boxes: ComponentBox[], maxWidth: number): ComponentBox[][] {
  * grasp first.
  *
  * Returns the node ids of each component in placement order — the core first,
- * so the caller can tell it from the shelved ones and pin the rest.
+ * so the caller can tell it from the shelved ones and hold each kind the way
+ * it needs (rigid centroid for the core, springs for the shelf).
  *
  * Pure in the sense that matters here: it reads x/y/size off the graph and
  * writes x/y back, touching nothing else and consulting no clock or random.
@@ -504,6 +505,10 @@ export function shelveComponents(graph: Graph): string[][] {
  *  to be told to leave the dragged one alone (see placeSatellites). */
 export interface AtlasSimulation extends Simulation<AtlasSimNode, undefined> {
   setDraggingId(id: string | null): void;
+  /** Put every unheld shelf component back on its slot right now, instead of
+   *  over the cooling tail. The release path uses it when there will be no
+   *  cooling tail (see shelfAnchorForce's `settle`). */
+  settleShelf(): void;
 }
 
 export interface AtlasSimNode extends SimulationNodeDatum {
@@ -693,6 +698,18 @@ function groupCenterForce(): {
  *  instead of snapping. */
 const SHELF_ANCHOR_STRENGTH = 0.1;
 
+/** What fraction of a component's remaining centroid offset is closed per
+ *  tick while no hand is on it. Deliberately NOT scaled by alpha, unlike every
+ *  other force here: alpha is a finite budget (it decays 3%/tick toward
+ *  alphaMin, so the whole cooling tail after a release sums to about 10), and
+ *  an alpha-scaled return of this shape completes only ~53% of the journey
+ *  before the simulation goes to sleep — measured as a 77.5-unit residual
+ *  offset, enough for a released pair to sit inside the core's box. Unscaled,
+ *  0.1 closes the offset geometrically (0.925 per tick after velocity decay)
+ *  and is done long before alphaMin. It is the same rate as the springs, so a
+ *  release reads as one motion rather than two. */
+const SHELF_RETURN_RATE = 0.1;
+
 /** One shelved node's slot, and which component it belongs to. */
 interface ShelfAnchor {
   x: number;
@@ -714,34 +731,55 @@ interface ShelfAnchor {
  *   even see it — on the 24/6/5 fixture a five-node chain raised its top edge
  *   9.1 units toward the core over 120 ticks under a centroid-only hold, and
  *   0.75 with these springs. Soft, so a drag still wins locally.
- * - Removal of each component's BULK velocity, for components with no hand on
- *   them. A spring this soft cannot balance the core's charge on its own: at
+ * - Control of each component's BULK velocity, for components with no hand on
+ *   them: whatever link and charge just handed the component as a whole is
+ *   replaced by exactly the velocity that carries its centroid back to the
+ *   slot, `offset * SHELF_RETURN_RATE`. Only the uniform part is touched — the
+ *   part that translates a component without changing its shape — so every
+ *   relative motion (a drag pulling a neighbor, collide opening a knot) is
+ *   left alone. This is what a spring this soft cannot do on its own: at
  *   capture scale the core's mass accelerates a distant component by roughly
  *   11 units per tick, which a 0.1 spring only cancels hundreds of units away
- *   from the slot. Subtracting the group's mean velocity — computed AFTER
- *   link and charge, before the spring — cancels exactly the uniform part of
- *   that field, the part that translates a component without changing its
- *   shape, and leaves every relative motion (a drag pulling a neighbor,
- *   collide opening a knot) untouched. Measured together at capture scale:
- *   28.5 units of drift under the centroid hold, 0.65 under these two.
+ *   from the slot. Measured together at capture scale: 28.5 units of drift
+ *   under the centroid hold, 0.65 under these two.
  *
- * A component the pointer is holding keeps its velocity: with one node pinned,
- * "the group's mean velocity" is mostly the drag response itself, and removing
- * it would clamp the very neighbors that are supposed to follow. The hand is
- * the constraint while it is down; the springs take over on release.
+ *   Steering home rather than simply zeroing the bulk velocity is what makes a
+ *   RELEASE land. Zeroing removes the spring's own return velocity again on
+ *   the following tick, leaving only one alpha-scaled impulse per tick to do
+ *   the whole journey — and alpha runs out first: a 200-unit drag on a shelved
+ *   pair used to settle 77.5 units from its slot, overlapping the core's box
+ *   by 13. With the bulk velocity steered home it lands within a unit.
+ *
+ * A component the pointer is holding is left entirely alone: with one node
+ * pinned, "the group's bulk velocity" is mostly the drag response itself, and
+ * overriding it would clamp the very neighbors that are supposed to follow.
+ * The hand is the constraint while it is down; this force takes over on
+ * release. When the release skips the cooling tail altogether (reduced
+ * motion), `settle` does the same correction in one step.
  */
 function shelfAnchorForce(): {
   (alpha: number): void;
   initialize(nodes: AtlasSimNode[]): void;
   setPlacement(shelf: string[][]): void;
+  settle(): void;
 } {
   let nodes: AtlasSimNode[] = [];
   let anchorOf = new Map<string, ShelfAnchor>();
   let groupCount = 0;
 
-  const force = (alpha: number) => {
-    if (anchorOf.size === 0) return;
-    const drift = Array.from({ length: groupCount }, () => ({ vx: 0, vy: 0, free: 0 }));
+  interface Bulk {
+    /** Summed velocity and summed offset-to-anchor over the group's free members. */
+    vx: number;
+    vy: number;
+    dx: number;
+    dy: number;
+    free: number;
+  }
+
+  /** Per group: how its free members are moving, how far they are from their
+   *  slots, and whether the pointer is holding one of them. */
+  const measure = (): { bulk: Bulk[]; handOn: boolean[] } => {
+    const bulk = Array.from({ length: groupCount }, () => ({ vx: 0, vy: 0, dx: 0, dy: 0, free: 0 }));
     const handOn = new Array<boolean>(groupCount).fill(false);
     for (const node of nodes) {
       const anchor = anchorOf.get(node.id);
@@ -750,19 +788,29 @@ function shelfAnchorForce(): {
         handOn[anchor.group] = true;
         continue;
       }
-      const entry = drift[anchor.group] as { vx: number; vy: number; free: number };
+      const entry = bulk[anchor.group] as Bulk;
       entry.vx += node.vx ?? 0;
       entry.vy += node.vy ?? 0;
+      entry.dx += anchor.x - (node.x ?? 0);
+      entry.dy += anchor.y - (node.y ?? 0);
       entry.free += 1;
     }
+    return { bulk, handOn };
+  };
+
+  const force = (alpha: number) => {
+    if (anchorOf.size === 0) return;
+    const { bulk, handOn } = measure();
     for (const node of nodes) {
       const anchor = anchorOf.get(node.id);
       if (!anchor) continue;
       if (node.fx != null || node.fy != null) continue;
-      const entry = drift[anchor.group] as { vx: number; vy: number; free: number };
+      const entry = bulk[anchor.group] as Bulk;
       if (!handOn[anchor.group] && entry.free > 0) {
-        node.vx = (node.vx ?? 0) - entry.vx / entry.free;
-        node.vy = (node.vy ?? 0) - entry.vy / entry.free;
+        // Shift every member by (wanted bulk velocity - current bulk velocity),
+        // both means over the group's free set.
+        node.vx = (node.vx ?? 0) + (entry.dx * SHELF_RETURN_RATE - entry.vx) / entry.free;
+        node.vy = (node.vy ?? 0) + (entry.dy * SHELF_RETURN_RATE - entry.vy) / entry.free;
       }
       node.vx = (node.vx ?? 0) + (anchor.x - (node.x ?? 0)) * SHELF_ANCHOR_STRENGTH * alpha;
       node.vy = (node.vy ?? 0) + (anchor.y - (node.y ?? 0)) * SHELF_ANCHOR_STRENGTH * alpha;
@@ -784,6 +832,28 @@ function shelfAnchorForce(): {
         anchorOf.set(id, { x: node.x ?? 0, y: node.y ?? 0, group });
       }
     });
+  };
+  /** The cooling tail's whole job, done in one step: rigidly translate every
+   *  unheld component back onto its slot and stop it dead. For the release
+   *  path under reduced motion, where there IS no cooling tail — the
+   *  simulation is stopped on mouseup, so a component would otherwise keep
+   *  whatever displacement the drag gave it, up to and including sitting on
+   *  top of the core. Rigid, so the shape the drag produced survives; only the
+   *  offset that breaks the two zones apart is undone. */
+  force.settle = () => {
+    if (anchorOf.size === 0) return;
+    const { bulk, handOn } = measure();
+    for (const node of nodes) {
+      const anchor = anchorOf.get(node.id);
+      if (!anchor) continue;
+      if (node.fx != null || node.fy != null) continue;
+      const entry = bulk[anchor.group] as Bulk;
+      if (handOn[anchor.group] || entry.free === 0) continue;
+      node.x = (node.x ?? 0) + entry.dx / entry.free;
+      node.y = (node.y ?? 0) + entry.dy / entry.free;
+      node.vx = 0;
+      node.vy = 0;
+    }
   };
   return force;
 }
@@ -1043,6 +1113,10 @@ export function createAtlasSimulation(
   const atlasSim = sim as AtlasSimulation;
   atlasSim.setDraggingId = (id: string | null) => {
     draggingId = id;
+  };
+  atlasSim.settleShelf = () => {
+    shelfAnchor.settle();
+    writeBack();
   };
   return atlasSim;
 }

--- a/src/lib/graph/atlas.ts
+++ b/src/lib/graph/atlas.ts
@@ -512,12 +512,21 @@ export interface AtlasSimNode extends SimulationNodeDatum {
   radius: number;
 }
 
-interface AtlasSimLink {
-  source: string;
-  target: string;
+export interface AtlasSimLink {
+  source: string | AtlasSimNode;
+  target: string | AtlasSimNode;
   /** The graph edge's verb, which sets this link's rest length and pull. */
   type: string;
 }
+
+/** Node-to-node repulsion, matching the retired ConstellationMap feel. Named
+ *  because the shelf relax pass (relaxShelf) has to run the same charge over
+ *  its scratch copy or a component would relax to a different shape there
+ *  than it holds in the live simulation. */
+const CHARGE_STRENGTH = -40;
+/** Collide runs at 0.7 rather than 1 so a collision resolves over a few ticks
+ *  instead of snapping, which reads calmer. */
+const COLLIDE_STRENGTH = 0.7;
 
 /** Breathing room between two discs that are not otherwise pushed apart. Two
  *  px is enough to stop the overlap that made page clusters read as one blob
@@ -549,6 +558,24 @@ function linkEndId(end: string | AtlasSimNode): string {
   return typeof end === "string" ? end : end.id;
 }
 
+/** Rest length for one link's verb — LINK_LAYOUT's, or d3's own 30. */
+function linkDistanceFor(link: AtlasSimLink): number {
+  return LINK_LAYOUT[link.type]?.distance ?? 30;
+}
+
+/** Pull for one link's verb. d3's default strength is 1/min(degree) over the
+ *  LINK graph, computed privately inside forceLink — overriding .strength()
+ *  would throw that away for every verb, so the same formula is rebuilt here
+ *  from a precomputed degree map and used for anything LINK_LAYOUT does not
+ *  name. */
+function linkStrengthFor(link: AtlasSimLink, degree: Map<string, number>): number {
+  const named = LINK_LAYOUT[link.type];
+  if (named) return named.strength;
+  const source = degree.get(linkEndId(link.source)) ?? 1;
+  const target = degree.get(linkEndId(link.target)) ?? 1;
+  return 1 / Math.min(source, target);
+}
+
 /** One shelf group's rigid centroid anchor: every free (non-fx/fy) member is
  *  shifted uniformly so the group's own centroid sits at `targetX/targetY`. */
 interface CenterGroup {
@@ -574,13 +601,20 @@ interface CenterGroup {
  * force to hold each component exactly where the composition put it, which
  * leaves only the small amount a component genuinely relaxes by.
  *
- * Round 5's live shelf generalizes this from one group (the core) to one per
- * shelved component (see `setGroups`): every component gets its own rigid
- * hold at its shelf slot instead of the old fx/fy freeze, so charge/collide/
- * link can still act on it — a knot has room to open, and a drag on a
- * shelved node pulls its neighbors along. Before `setGroups` is ever called
- * (the pre-shelf settle), every node falls into one implicit group targeting
- * the origin — exactly today's single-group behavior.
+ * Round 5's live shelf generalizes this from one group to many (see
+ * `setGroups`). On the live simulation only the CORE is held this way: a
+ * rigid hold corrects position but not velocity, so a group carries whatever
+ * momentum the external field gave it into the next tick — negligible across
+ * the core's thousands of free nodes, but the dominant error on a handful of
+ * nodes sitting thousands of units from the core's mass (measured at capture
+ * scale: 28 units of centroid drift over a 60-tick drag reheat). Shelved
+ * components are held by `shelfAnchorForce` instead. The many-group form is
+ * still what `relaxShelf`'s scratch simulation uses, where every group is a
+ * shelf component and there is no distant core to be pushed by.
+ *
+ * Before `setGroups` is ever called (the pre-shelf settle), every node falls
+ * into one implicit group targeting the origin — exactly the old single-group
+ * behavior. After it is called, a node no group names is left alone.
  */
 function groupCenterForce(): {
   (alpha: number): void;
@@ -589,11 +623,13 @@ function groupCenterForce(): {
   retarget(): void;
 } {
   let nodes: AtlasSimNode[] = [];
-  // Populated by setGroups; a node absent from this map (the pre-shelf state,
-  // or an id setGroups never named) falls back to defaultGroup.
-  let groupOf = new Map<string, CenterGroup>();
+  // Null until setGroups runs: every node is then in one implicit group at the
+  // origin. Once groups are installed, an id no group names is skipped — on
+  // the live simulation that is every shelved node, held by shelfAnchorForce.
+  let groupOf: Map<string, CenterGroup> | null = null;
   const defaultGroup: CenterGroup = { targetX: 0, targetY: 0 };
-  const groupFor = (id: string): CenterGroup => groupOf.get(id) ?? defaultGroup;
+  const groupFor = (id: string): CenterGroup | undefined =>
+    groupOf === null ? defaultGroup : groupOf.get(id);
 
   // One pass over all nodes, bucketed by group — O(nodes) regardless of how
   // many components are on the shelf, rather than O(nodes * groups).
@@ -602,6 +638,7 @@ function groupCenterForce(): {
     for (const node of nodes) {
       if (node.fx != null || node.fy != null) continue;
       const group = groupFor(node.id);
+      if (!group) continue;
       const entry = sums.get(group) ?? { x: 0, y: 0, free: 0 };
       entry.x += node.x ?? 0;
       entry.y += node.y ?? 0;
@@ -620,6 +657,7 @@ function groupCenterForce(): {
     for (const node of nodes) {
       if (node.fx != null || node.fy != null) continue;
       const group = groupFor(node.id);
+      if (!group) continue;
       const centroid = sums.get(group);
       if (!centroid) continue;
       node.x = (node.x ?? 0) - (centroid.x - group.targetX);
@@ -629,14 +667,14 @@ function groupCenterForce(): {
   force.initialize = (ns: AtlasSimNode[]) => {
     nodes = ns;
   };
-  // Installs one group per placement entry (shelveComponents' return, core
-  // first) — an id shelveComponents didn't mention (there is none) would just
-  // fall back to defaultGroup.
+  // Installs one group per placement entry. An id no entry names is left to
+  // whatever else holds it — on the live simulation, the shelf springs.
   force.setGroups = (placement: string[][]) => {
-    groupOf = new Map();
+    const installed = new Map<string, CenterGroup>();
+    groupOf = installed;
     for (const ids of placement) {
       const group: CenterGroup = { targetX: 0, targetY: 0 };
-      for (const id of ids) groupOf.set(id, group);
+      for (const id of ids) installed.set(id, group);
     }
   };
   force.retarget = () => {
@@ -646,6 +684,189 @@ function groupCenterForce(): {
     }
   };
   return force;
+}
+
+/** How hard a shelved node is pulled back to the slot the packing gave it.
+ *  0.1 is d3's own forceX/forceY default: an order of magnitude weaker than a
+ *  link (strength 1), so a hand on one node still drags its neighbors along
+ *  instead of fighting the anchor, and a released node eases back to its slot
+ *  instead of snapping. */
+const SHELF_ANCHOR_STRENGTH = 0.1;
+
+/** One shelved node's slot, and which component it belongs to. */
+interface ShelfAnchor {
+  x: number;
+  y: number;
+  group: number;
+}
+
+/**
+ * What holds the shelf together once no component is frozen with fx/fy.
+ *
+ * Two parts, and both are needed:
+ *
+ * - A per-node SPRING toward the exact position the packing gave that node.
+ *   Unlike a centroid hold this resists rotation and shear as well as
+ *   translation, which is what the packed rows actually need: an elongated
+ *   component in the core's repulsion field is a body in a radial field, and
+ *   it swings to point at the core unless something pulls each end back. Its
+ *   centroid barely moves while it does that, so a centroid hold does not
+ *   even see it — on the 24/6/5 fixture a five-node chain raised its top edge
+ *   9.1 units toward the core over 120 ticks under a centroid-only hold, and
+ *   0.75 with these springs. Soft, so a drag still wins locally.
+ * - Removal of each component's BULK velocity, for components with no hand on
+ *   them. A spring this soft cannot balance the core's charge on its own: at
+ *   capture scale the core's mass accelerates a distant component by roughly
+ *   11 units per tick, which a 0.1 spring only cancels hundreds of units away
+ *   from the slot. Subtracting the group's mean velocity — computed AFTER
+ *   link and charge, before the spring — cancels exactly the uniform part of
+ *   that field, the part that translates a component without changing its
+ *   shape, and leaves every relative motion (a drag pulling a neighbor,
+ *   collide opening a knot) untouched. Measured together at capture scale:
+ *   28.5 units of drift under the centroid hold, 0.65 under these two.
+ *
+ * A component the pointer is holding keeps its velocity: with one node pinned,
+ * "the group's mean velocity" is mostly the drag response itself, and removing
+ * it would clamp the very neighbors that are supposed to follow. The hand is
+ * the constraint while it is down; the springs take over on release.
+ */
+function shelfAnchorForce(): {
+  (alpha: number): void;
+  initialize(nodes: AtlasSimNode[]): void;
+  setPlacement(shelf: string[][]): void;
+} {
+  let nodes: AtlasSimNode[] = [];
+  let anchorOf = new Map<string, ShelfAnchor>();
+  let groupCount = 0;
+
+  const force = (alpha: number) => {
+    if (anchorOf.size === 0) return;
+    const drift = Array.from({ length: groupCount }, () => ({ vx: 0, vy: 0, free: 0 }));
+    const handOn = new Array<boolean>(groupCount).fill(false);
+    for (const node of nodes) {
+      const anchor = anchorOf.get(node.id);
+      if (!anchor) continue;
+      if (node.fx != null || node.fy != null) {
+        handOn[anchor.group] = true;
+        continue;
+      }
+      const entry = drift[anchor.group] as { vx: number; vy: number; free: number };
+      entry.vx += node.vx ?? 0;
+      entry.vy += node.vy ?? 0;
+      entry.free += 1;
+    }
+    for (const node of nodes) {
+      const anchor = anchorOf.get(node.id);
+      if (!anchor) continue;
+      if (node.fx != null || node.fy != null) continue;
+      const entry = drift[anchor.group] as { vx: number; vy: number; free: number };
+      if (!handOn[anchor.group] && entry.free > 0) {
+        node.vx = (node.vx ?? 0) - entry.vx / entry.free;
+        node.vy = (node.vy ?? 0) - entry.vy / entry.free;
+      }
+      node.vx = (node.vx ?? 0) + (anchor.x - (node.x ?? 0)) * SHELF_ANCHOR_STRENGTH * alpha;
+      node.vy = (node.vy ?? 0) + (anchor.y - (node.y ?? 0)) * SHELF_ANCHOR_STRENGTH * alpha;
+    }
+  };
+  force.initialize = (ns: AtlasSimNode[]) => {
+    nodes = ns;
+  };
+  /** Anchor every named node where it stands right now — call it straight
+   *  after the pack, whose output IS the arrangement to hold. */
+  force.setPlacement = (shelf: string[][]) => {
+    const byId = new Map(nodes.map((node) => [node.id, node]));
+    anchorOf = new Map();
+    groupCount = shelf.length;
+    shelf.forEach((ids, group) => {
+      for (const id of ids) {
+        const node = byId.get(id);
+        if (!node) continue;
+        anchorOf.set(id, { x: node.x ?? 0, y: node.y ?? 0, group });
+      }
+    });
+  };
+  return force;
+}
+
+/**
+ * The knot-opening relax pass, run on a scratch simulation that owns the
+ * SHELVED nodes only.
+ *
+ * Every component keeps its own rigid centroid hold here (groupCenterForce
+ * over the shelf placement), so charge, collide and links can spread a
+ * component that settled into a tangle without any of them wandering off its
+ * slot. Relaxed positions are copied back onto `nodes` — the caller re-packs
+ * afterwards, because a component that opened up no longer fits its old row.
+ *
+ * Scratch rather than the live simulation for two reasons: the core is
+ * already settled, so re-running it buys nothing and costs the whole O(core)
+ * charge (the live-sim version of this pass doubled Atlas's synchronous load
+ * time, 543 ms to ~1,000 ms on the real capture); and with the core absent
+ * there is no distant mass to push the shelf around while it relaxes.
+ *
+ * Returns the scratch simulation, which is stopped and whose only remaining
+ * use is to show a caller (or a test) exactly which nodes it owned.
+ */
+export function relaxShelf(
+  nodes: AtlasSimNode[],
+  links: AtlasSimLink[],
+  placement: string[][],
+  linkDegree: Map<string, number>,
+): Simulation<AtlasSimNode, undefined> {
+  const shelfPlacement = placement.slice(1);
+  const shelfIds = new Set(shelfPlacement.flat());
+  // Fresh node and link objects: d3 stamps `index` onto every node it
+  // simulates and rewrites a link's endpoints from id to node reference, so
+  // handing it the live simulation's own objects would corrupt the live
+  // collide and link forces.
+  const scratch: AtlasSimNode[] = [];
+  const relaxed = new Map<string, AtlasSimNode>();
+  for (const node of nodes) {
+    if (!shelfIds.has(node.id)) continue;
+    const copy: AtlasSimNode = { id: node.id, x: node.x, y: node.y, radius: node.radius };
+    scratch.push(copy);
+    relaxed.set(node.id, copy);
+  }
+  const scratchLinks: AtlasSimLink[] = [];
+  for (const link of links) {
+    const source = linkEndId(link.source);
+    const target = linkEndId(link.target);
+    if (!shelfIds.has(source) || !shelfIds.has(target)) continue;
+    scratchLinks.push({ source, target, type: link.type });
+  }
+
+  const center = groupCenterForce();
+  const sim = forceSimulation(scratch)
+    .force(
+      "link",
+      forceLink<AtlasSimNode, AtlasSimLink>(scratchLinks)
+        .id((d) => d.id)
+        .distance(linkDistanceFor)
+        .strength((link) => linkStrengthFor(link, linkDegree)),
+    )
+    .force("charge", forceManyBody<AtlasSimNode>().strength(CHARGE_STRENGTH))
+    .force("center", center)
+    .force(
+      "collide",
+      forceCollide<AtlasSimNode>().radius((d) => d.radius).strength(COLLIDE_STRENGTH).iterations(1),
+    )
+    .alphaDecay(0.03)
+    .velocityDecay(0.25)
+    // forceSimulation starts its own animation frame loop on construction;
+    // this pass is synchronous and ticks by hand.
+    .stop();
+  center.setGroups(shelfPlacement);
+  center.retarget();
+  sim.alpha(0.3);
+  sim.tick(settleTicks(scratch.length));
+
+  for (const node of nodes) {
+    const copy = relaxed.get(node.id);
+    if (!copy) continue;
+    node.x = copy.x;
+    node.y = copy.y;
+  }
+  return sim;
 }
 
 /** d3-force simulation over the live graphology graph — the interaction engine.
@@ -699,36 +920,37 @@ export function createAtlasSimulation(
   });
   const links = [...linkByPair.values()];
 
-  // d3's default link strength is 1/min(degree) over the LINK graph, computed
-  // privately inside forceLink — overriding .strength() would throw that away
-  // for every verb, so the same formula is rebuilt here and used for anything
-  // LINK_LAYOUT does not name.
+  // Degrees over the LINK graph, which is what d3's own 1/min(degree) default
+  // strength is computed from (see linkStrengthFor).
   const linkDegree = new Map<string, number>();
   for (const link of links) {
-    linkDegree.set(link.source, (linkDegree.get(link.source) ?? 0) + 1);
-    linkDegree.set(link.target, (linkDegree.get(link.target) ?? 0) + 1);
+    const source = linkEndId(link.source);
+    const target = linkEndId(link.target);
+    linkDegree.set(source, (linkDegree.get(source) ?? 0) + 1);
+    linkDegree.set(target, (linkDegree.get(target) ?? 0) + 1);
   }
 
   const center = groupCenterForce();
+  const shelfAnchor = shelfAnchorForce();
   const sim = forceSimulation(nodes)
     .force(
       "link",
       forceLink<AtlasSimNode, AtlasSimLink>(links)
         .id((d) => d.id)
-        .distance((link) => LINK_LAYOUT[link.type]?.distance ?? 30)
-        .strength((link) => {
-          const named = LINK_LAYOUT[link.type];
-          if (named) return named.strength;
-          const source = linkDegree.get(linkEndId(link.source)) ?? 1;
-          const target = linkDegree.get(linkEndId(link.target)) ?? 1;
-          return 1 / Math.min(source, target);
-        }),
+        .distance(linkDistanceFor)
+        .strength((link) => linkStrengthFor(link, linkDegree)),
     )
-    .force("charge", forceManyBody<AtlasSimNode>().strength(-40))
+    .force("charge", forceManyBody<AtlasSimNode>().strength(CHARGE_STRENGTH))
     .force("center", center)
-    // Keeps discs off each other. Strength 0.7 (not 1) so the collision
-    // resolves over a few ticks instead of snapping, which reads calmer.
-    .force("collide", forceCollide<AtlasSimNode>().radius((d) => d.radius).strength(0.7).iterations(1))
+    // After link and charge, before collide: the shelf springs cancel the
+    // bulk velocity those two just handed a shelved component, and collide
+    // then gets the last word on discs that would otherwise overlap.
+    .force("shelf", shelfAnchor)
+    // Keeps discs off each other.
+    .force(
+      "collide",
+      forceCollide<AtlasSimNode>().radius((d) => d.radius).strength(COLLIDE_STRENGTH).iterations(1),
+    )
     .alphaDecay(0.03)
     .velocityDecay(0.25);
 
@@ -779,35 +1001,37 @@ export function createAtlasSimulation(
     node.x = graph.getNodeAttribute(node.id, "x") as number;
     node.y = graph.getNodeAttribute(node.id, "y") as number;
   }
-  // Every component — not just the core — gets its own rigid centroid anchor
-  // at the shelf slot shelveComponents just gave it, and holds THERE on every
-  // later reheat rather than being pulled toward a centroid of (0,0).
-  center.setGroups(placement);
-  center.retarget();
 
-  // Live shelf: relax the WHOLE simulation against those anchors instead of
-  // freezing every component with fx/fy. A component with no edge into the
-  // core has nothing to flex toward the rest of the graph, but charge and
-  // collide still act inside it — this is what opens a component that
-  // settled into a tangled knot before the shelf pass, and what makes a drag
-  // on a shelved node pull its neighbors along afterward. Each anchor's rigid
-  // hold keeps this from just re-exploding the shelf back into a ring.
-  const relaxTicks = settleTicks(graph.order);
-  sim.alpha(0.3);
-  sim.tick(relaxTicks);
+  // Live shelf: instead of freezing every shelved component with fx/fy, open
+  // the ones that settled into a tangled knot. Charge and collide inside a
+  // component are what spread it; the core is already settled and would only
+  // make the pass cost more, so this runs on a shelf-only scratch simulation
+  // (see relaxShelf) whose results are copied back onto the sim nodes.
+  relaxShelf(nodes, links, placement, linkDegree);
+  for (const node of nodes) {
+    graph.setNodeAttribute(node.id, "x", node.x);
+    graph.setNodeAttribute(node.id, "y", node.y);
+  }
 
-  // Relaxing changes every component's bbox (that is the point — a knot
-  // spreading out grows its own box), so the row packing above is stale.
-  // Re-shelve: rigid translation preserves the shape the relax pass just
-  // found, it only restores which row and how much space each component
-  // gets. Anchors move to the fresh slots the same way as above.
+  // Relaxing changes a component's bbox (that is the point — a knot spreading
+  // out grows its own box), so the row packing above is stale. Re-shelve:
+  // rigid translation preserves the shape the relax pass just found, it only
+  // restores which row and how much space each component gets.
   placement = shelveComponents(graph);
   for (const node of nodes) {
     node.x = graph.getNodeAttribute(node.id, "x") as number;
     node.y = graph.getNodeAttribute(node.id, "y") as number;
+    // The settle and the relax both left velocity behind, and the pack just
+    // teleported everything anyway — a later reheat must start from rest
+    // rather than resume momentum aimed at positions that no longer exist.
+    node.vx = 0;
+    node.vy = 0;
   }
-  center.setGroups(placement);
+  // The core keeps the rigid centroid hold it has always had; every shelved
+  // component is held at the slot this pack just gave it by its own springs.
+  center.setGroups(placement.slice(0, 1));
   center.retarget();
+  shelfAnchor.setPlacement(placement.slice(1));
 
   // Same writeback path as a tick, so satellites re-place around their moved
   // anchors and the caller's onTick marks the cartography scene dirty.

--- a/src/lib/graph/atlas.ts
+++ b/src/lib/graph/atlas.ts
@@ -549,9 +549,16 @@ function linkEndId(end: string | AtlasSimNode): string {
   return typeof end === "string" ? end : end.id;
 }
 
+/** One shelf group's rigid centroid anchor: every free (non-fx/fy) member is
+ *  shifted uniformly so the group's own centroid sits at `targetX/targetY`. */
+interface CenterGroup {
+  targetX: number;
+  targetY: number;
+}
+
 /**
- * `forceCenter(0, 0)`, but blind to pinned nodes — and able to hold a target
- * other than the origin.
+ * `forceCenter(0, 0)`, but blind to pinned nodes, PER GROUP, and able to hold
+ * a target other than the origin.
  *
  * d3's own centre force averages EVERY node and shifts them all by the
  * offset. Pinned nodes snap straight back to fx/fy afterwards, so with a
@@ -560,52 +567,83 @@ function linkEndId(end: string | AtlasSimNode): string {
  * drag-reheat slid the core 776 units up a 3,939-unit span, pulling the two
  * zones apart. Averaging the FREE nodes only cuts that to 371.
  *
- * `retarget()` removes the rest. shelveComponents centres the core by its
- * BOUNDING BOX, which is not where its centroid is; asking the force for a
- * centroid of exactly (0,0) therefore slides the core by the difference on
- * the first reheat. Retargeting after the shelf is laid out tells the force
- * to hold the core exactly where the composition put it, which leaves only
- * the ~154 units the core genuinely relaxes by.
+ * `retarget()` removes the rest. shelveComponents centres each component by
+ * its BOUNDING BOX, which is not where its centroid is; asking the force for
+ * a centroid of exactly (0,0) therefore slides a component by the difference
+ * on the first reheat. Retargeting after the shelf is laid out tells the
+ * force to hold each component exactly where the composition put it, which
+ * leaves only the small amount a component genuinely relaxes by.
+ *
+ * Round 5's live shelf generalizes this from one group (the core) to one per
+ * shelved component (see `setGroups`): every component gets its own rigid
+ * hold at its shelf slot instead of the old fx/fy freeze, so charge/collide/
+ * link can still act on it — a knot has room to open, and a drag on a
+ * shelved node pulls its neighbors along. Before `setGroups` is ever called
+ * (the pre-shelf settle), every node falls into one implicit group targeting
+ * the origin — exactly today's single-group behavior.
  */
-function coreCenterForce(): {
+function groupCenterForce(): {
   (alpha: number): void;
   initialize(nodes: AtlasSimNode[]): void;
+  setGroups(placement: string[][]): void;
   retarget(): void;
 } {
   let nodes: AtlasSimNode[] = [];
-  let targetX = 0;
-  let targetY = 0;
-  const centroid = (): { x: number; y: number; free: number } => {
-    let sx = 0;
-    let sy = 0;
-    let free = 0;
+  // Populated by setGroups; a node absent from this map (the pre-shelf state,
+  // or an id setGroups never named) falls back to defaultGroup.
+  let groupOf = new Map<string, CenterGroup>();
+  const defaultGroup: CenterGroup = { targetX: 0, targetY: 0 };
+  const groupFor = (id: string): CenterGroup => groupOf.get(id) ?? defaultGroup;
+
+  // One pass over all nodes, bucketed by group — O(nodes) regardless of how
+  // many components are on the shelf, rather than O(nodes * groups).
+  const centroids = (): Map<CenterGroup, { x: number; y: number; free: number }> => {
+    const sums = new Map<CenterGroup, { x: number; y: number; free: number }>();
     for (const node of nodes) {
       if (node.fx != null || node.fy != null) continue;
-      sx += node.x ?? 0;
-      sy += node.y ?? 0;
-      free += 1;
+      const group = groupFor(node.id);
+      const entry = sums.get(group) ?? { x: 0, y: 0, free: 0 };
+      entry.x += node.x ?? 0;
+      entry.y += node.y ?? 0;
+      entry.free += 1;
+      sums.set(group, entry);
     }
-    return free === 0 ? { x: 0, y: 0, free } : { x: sx / free, y: sy / free, free };
+    for (const entry of sums.values()) {
+      entry.x /= entry.free;
+      entry.y /= entry.free;
+    }
+    return sums;
   };
+
   const force = () => {
-    const { x, y, free } = centroid();
-    if (free === 0) return;
-    const dx = x - targetX;
-    const dy = y - targetY;
+    const sums = centroids();
     for (const node of nodes) {
       if (node.fx != null || node.fy != null) continue;
-      node.x = (node.x ?? 0) - dx;
-      node.y = (node.y ?? 0) - dy;
+      const group = groupFor(node.id);
+      const centroid = sums.get(group);
+      if (!centroid) continue;
+      node.x = (node.x ?? 0) - (centroid.x - group.targetX);
+      node.y = (node.y ?? 0) - (centroid.y - group.targetY);
     }
   };
   force.initialize = (ns: AtlasSimNode[]) => {
     nodes = ns;
   };
+  // Installs one group per placement entry (shelveComponents' return, core
+  // first) — an id shelveComponents didn't mention (there is none) would just
+  // fall back to defaultGroup.
+  force.setGroups = (placement: string[][]) => {
+    groupOf = new Map();
+    for (const ids of placement) {
+      const group: CenterGroup = { targetX: 0, targetY: 0 };
+      for (const id of ids) groupOf.set(id, group);
+    }
+  };
   force.retarget = () => {
-    const { x, y, free } = centroid();
-    if (free === 0) return;
-    targetX = x;
-    targetY = y;
+    for (const [group, centroid] of centroids()) {
+      group.targetX = centroid.x;
+      group.targetY = centroid.y;
+    }
   };
   return force;
 }
@@ -616,7 +654,7 @@ function coreCenterForce(): {
  *  isolates are not drawn at all once drawableModel drops components under
  *  MIN_COMPONENT_SIZE, and a leaf memory rides its anchor as a satellite.
  *  Matches the retired ConstellationMap feel: charge -40,
- *  centre-on-origin (coreCenterForce), alphaDecay 0.03, velocityDecay 0.25, d3-default link
+ *  centre-on-origin (groupCenterForce), alphaDecay 0.03, velocityDecay 0.25, d3-default link
  *  force. Parallel edges collapse to one link per undirected pair (d3 sums
  *  pull per link; sigma still RENDERS every parallel edge). Settles
  *  synchronously to its own equilibrium before returning — a FA2 seed handed
@@ -671,7 +709,7 @@ export function createAtlasSimulation(
     linkDegree.set(link.target, (linkDegree.get(link.target) ?? 0) + 1);
   }
 
-  const center = coreCenterForce();
+  const center = groupCenterForce();
   const sim = forceSimulation(nodes)
     .force(
       "link",
@@ -736,25 +774,41 @@ export function createAtlasSimulation(
   // balance at about the same radius for all of them). Move them onto a shelf
   // below the core instead, then copy those positions back INTO the sim so a
   // later drag flexes the real layout rather than snapping to the ring.
-  const placement = shelveComponents(graph);
-  // Everything outside the core is PINNED where the shelf put it. Without
-  // this the first drag undoes the whole arrangement: downNode reheats the
-  // sim to alpha 0.3 and charge plus forceCenter push the shelved components
-  // straight back out into a ring, and nothing re-shelves them. A shelved
-  // component has no edge into the core, so it has nothing to flex toward
-  // anyway — holding it still costs the layout nothing.
-  const core = new Set(placement[0] ?? []);
+  let placement = shelveComponents(graph);
   for (const node of nodes) {
     node.x = graph.getNodeAttribute(node.id, "x") as number;
     node.y = graph.getNodeAttribute(node.id, "y") as number;
-    if (!core.has(node.id)) {
-      node.fx = node.x;
-      node.fy = node.y;
-    }
   }
-  // The core is now where the composition wants it — hold it THERE on every
-  // later reheat rather than dragging it back to a centroid of (0,0).
+  // Every component — not just the core — gets its own rigid centroid anchor
+  // at the shelf slot shelveComponents just gave it, and holds THERE on every
+  // later reheat rather than being pulled toward a centroid of (0,0).
+  center.setGroups(placement);
   center.retarget();
+
+  // Live shelf: relax the WHOLE simulation against those anchors instead of
+  // freezing every component with fx/fy. A component with no edge into the
+  // core has nothing to flex toward the rest of the graph, but charge and
+  // collide still act inside it — this is what opens a component that
+  // settled into a tangled knot before the shelf pass, and what makes a drag
+  // on a shelved node pull its neighbors along afterward. Each anchor's rigid
+  // hold keeps this from just re-exploding the shelf back into a ring.
+  const relaxTicks = settleTicks(graph.order);
+  sim.alpha(0.3);
+  sim.tick(relaxTicks);
+
+  // Relaxing changes every component's bbox (that is the point — a knot
+  // spreading out grows its own box), so the row packing above is stale.
+  // Re-shelve: rigid translation preserves the shape the relax pass just
+  // found, it only restores which row and how much space each component
+  // gets. Anchors move to the fresh slots the same way as above.
+  placement = shelveComponents(graph);
+  for (const node of nodes) {
+    node.x = graph.getNodeAttribute(node.id, "x") as number;
+    node.y = graph.getNodeAttribute(node.id, "y") as number;
+  }
+  center.setGroups(placement);
+  center.retarget();
+
   // Same writeback path as a tick, so satellites re-place around their moved
   // anchors and the caller's onTick marks the cartography scene dirty.
   writeBack();


### PR DESCRIPTION
## What

The Atlas graph froze every non-core component after packing it onto the shelf (`fx`/`fy` pins), so dragging a node in a shelved cluster moved only that node, and an under-settled cluster stayed a collapsed knot forever (found during manual prod review of the Lucian Threads cluster, 2026-08-19).

Now every component stays live in the one d3 simulation:

- The core keeps its rigid centroid hold (unchanged feel).
- Shelf components get per-node anchor springs toward their packed slots (`SHELF_ANCHOR_STRENGTH` 0.1) plus bulk-velocity steering home (`SHELF_RETURN_RATE` 0.1, not alpha-scaled so release always completes).
- The knot-opening relax runs on a shelf-only scratch simulation, then rows re-pack; load layout is ~1.1x the frozen parent (v1 of this fix was 1.9x).
- `settleShelf()` lands components on their slots for the reduced-motion mouseup path, which stops the sim outright.
- Mouseup always releases the drag pin (`draggedNodeWasPinnedRef` deleted).

Community-aligned design: one live simulation with positional anchoring (d3's disjoint-graph guidance) on top of the existing component packing.

## Evidence

- 3 adversarial Codex (gpt-5.6-sol) review rounds; final verdict **no blocker**, with independent probes: release offset 0.000031 after a 200-unit drag, reduced motion exactly 0, no core/shelf overlap, steering stable over 1,000 ticks.
- Capture-scale probe (2,951 nodes): shelf drift during a 60-tick reheat 28.49 → 0.11 units; rotation bounded ~23°; two-node cluster follows a drag (travel 122 units, previously clamped).
- `pnpm vitest run src/lib/graph` 205 pass; `AtlasView.test.tsx` 66 pass; `tsc -b` clean — re-run on the rebased head.
- New tests red-controlled against both the frozen parent and intermediate versions.
- Spec: `~/.wenlan/specs/wenlan/2026-08-19-atlas-live-shelf.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA