### PR TITLE
fix(app): count only knowledge pages in the Home pages metric

### DIFF
--- a/crates/wenlan-types/src/pages.rs
+++ b/crates/wenlan-types/src/pages.rs
@@ -52,7 +52,9 @@ pub struct Page {
     #[serde(default)]
     pub workspace: Option<String>,
     /// Routing metadata: which mechanism created this page.
-    /// One of: "distilled" | "authored" | "research" | "imported".
+    /// One of: "distilled" | "authored" | "research" | "imported" | "source"
+    /// | "entity" (the dual-write shadow page behind an entity; `kind` never
+    /// serializes, so this is the wire-visible shadow marker).
     /// NOT a trust signal (see `review_status` for that).
     #[serde(default = "default_creation_kind")]
     pub creation_kind: String,

--- a/src/components/memory/HomePage.redesign.test.tsx
+++ b/src/components/memory/HomePage.redesign.test.tsx
@@ -257,6 +257,26 @@ describe("HomePage redesign", () => {
     expect(screen.queryByTestId("what-happens-next")).toBeNull();
   });
 
+  it("counts only knowledge pages in the pages metric, never entity shadow pages", async () => {
+    // Given two knowledge pages (one updated today) and one entity shadow page
+    // updated today — the daemon's browse list returns all three by contract
+    const lastWeek = new Date(Date.now() - 7 * 86_400_000).toISOString();
+    vi.mocked(tauri.listPages).mockResolvedValue([
+      page({ id: "page-architecture", title: "Wenlan app architecture", creation_kind: "distilled" }),
+      page({ id: "page-policy", title: "Codex workflow policy", last_modified: lastWeek }),
+      page({ id: "shadow-lucian", title: "Lucian", creation_kind: "entity", entity_id: "ent-1" }),
+    ]);
+
+    // When Home renders its overview metrics
+    renderHome();
+    await screen.findByTestId("wiki-context-rail");
+
+    // Then the pages total and its updated-today chip exclude the shadow page
+    expect(screen.getByTestId("wiki-context-pages")).toHaveTextContent("2");
+    expect(screen.getByTestId("wiki-context-pages")).not.toHaveTextContent("3");
+    expect(screen.getByTestId("wiki-context-updated-today")).toHaveTextContent(/^1 updated today$/);
+  });
+
   it("keeps today, index, articles, and review items in the expected reading order", async () => {
     const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
       bottom: 0,

--- a/src/components/memory/HomePage.tsx
+++ b/src/components/memory/HomePage.tsx
@@ -11,7 +11,7 @@ import {
   type MemoryStats,
   type Page,
 } from "../../lib/tauri";
-import { listAllActivePages } from "./pages/listAllPages";
+import { isKnowledgePage, listAllActivePages } from "./pages/listAllPages";
 import { Greeting } from "./Greeting";
 import { useReviewQueue, reviewItemId, type ReviewItem } from "./useReviewQueue";
 import ReviewDialog, {
@@ -642,7 +642,11 @@ function HomeContextRail({
     queryFn: () => listEntities(),
     staleTime: 60_000,
   });
-  const pagesUpdatedToday = updatedTodayCount(pages);
+  // The browse list includes entity shadow pages by daemon contract; entities
+  // already have their own metric below, so the Pages number and its
+  // updated-today chip count knowledge pages only.
+  const knowledgePages = useMemo(() => pages.filter(isKnowledgePage), [pages]);
+  const pagesUpdatedToday = updatedTodayCount(knowledgePages);
 
   return (
     <div
@@ -661,7 +665,7 @@ function HomeContextRail({
           <ContextMetric
             testId="pages"
             label={t("home.pages")}
-            total={String(pages.length)}
+            total={String(knowledgePages.length)}
             deltas={
               pagesUpdatedToday > 0
                 ? [

--- a/src/components/memory/pages/listAllPages.test.ts
+++ b/src/components/memory/pages/listAllPages.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { listPages, listPagesExplicitBrowse, type Page } from "../../../lib/tauri";
 import {
+  isKnowledgePage,
   listAllActivePages,
   listAllActivePagesExplicitBrowse,
   listAllDraftPages,
@@ -109,5 +110,16 @@ describe("listAllDraftPages", () => {
 
     expect(result).toHaveLength(500);
     expect(listPages).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("isKnowledgePage", () => {
+  it("excludes entity shadow pages and keeps every other creation kind", () => {
+    expect(isKnowledgePage({ ...page("shadow"), creation_kind: "entity" })).toBe(false);
+    for (const kind of ["distilled", "authored", "research", "imported", "source"]) {
+      expect(isKnowledgePage({ ...page(kind), creation_kind: kind })).toBe(true);
+    }
+    expect(isKnowledgePage(page("no-kind"))).toBe(true);
+    expect(isKnowledgePage({ ...page("null-kind"), creation_kind: null })).toBe(true);
   });
 });

--- a/src/components/memory/pages/listAllPages.ts
+++ b/src/components/memory/pages/listAllPages.ts
@@ -37,6 +37,21 @@ async function listAllPagesWithStatus(
   }
 }
 
+/**
+ * True for a page a person wrote, distilled, imported, or researched; false
+ * for an entity "shadow" page (the auto-made page behind every entity).
+ *
+ * `pages.kind` never serializes, but every shadow page carries
+ * `creation_kind = "entity"` — the same invariant the daemon's knowledge-graph
+ * query relies on (`crates/wenlan-core/src/db/scoped_entities.rs`,
+ * `get_knowledge_graph_scoped`). A missing `creation_kind` (older daemons)
+ * counts as a knowledge page. Browse lists still include shadow pages by
+ * contract; this is for counts that should not double-count entities.
+ */
+export function isKnowledgePage(page: Page): boolean {
+  return page.creation_kind !== "entity";
+}
+
 export function listAllActivePages(): Promise<Page[]> {
   return listAllPagesWithStatus("active", listPages);
 }


### PR DESCRIPTION
## Why

Home's overview strip said "1939 Pages". On the live database that is every active `pages` row the browse list returns, including the entity shadow page behind each entity (1803 of 1939). Entities already have their own metric on the same strip, so Pages double-counted them. Only 136 rows are pages a person wrote, distilled, imported, or researched.

## What

- `src/components/memory/pages/listAllPages.ts`: new `isKnowledgePage(page)` = `creation_kind !== "entity"`. `pages.kind` never serializes; `creation_kind = "entity"` is the wire-visible shadow marker the knowledge-graph query (`scoped_entities.rs` `get_knowledge_graph_scoped`) already relies on. Missing `creation_kind` (older daemons) counts as a knowledge page.
- `src/components/memory/HomePage.tsx` (`HomeContextRail`): the Pages total and its "N updated today" chip count `pages.filter(isKnowledgePage)`. The browse fetch is untouched — `GET /api/pages` keeps returning shadow pages by contract (`page_browse_entity_shadow_e2e.rs`), and the recent-pages list, `TodayHeader`, and the alive/gathering state still see the full list (not part of this fix).
- `crates/wenlan-types/src/pages.rs`: doc comment lists the real `creation_kind` values (adds "source" and "entity"). No behavior change.

## Proof

- New Home test seeds 2 knowledge pages + 1 shadow page → Pages reads "2", chip "1 updated today". Red control on main: read "3".
- New `isKnowledgePage` unit test (entity false; distilled/authored/research/imported/source/missing/null true).
- `pnpm vitest run src/components/memory/HomePage.redesign.test.tsx src/components/memory/pages/listAllPages.test.ts` → 44 pass, 1 pre-existing skip; `pnpm exec tsc -b` clean; `cargo fmt --check -p wenlan-types` clean.
- Live: prod build from this branch against the :7878 daemon — Pages should read 136 (1939 − 1803) with Entities unchanged; user confirms on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA