### PR TITLE
fix(cli): make wenlan restart wait for the old daemon and verify health

### DIFF
--- a/.claude/skills/run-wenlan/SKILL.md
+++ b/.claude/skills/run-wenlan/SKILL.md
@@ -47,7 +47,8 @@ desktop app share it — never kill it casually.
 - **Upgrading requires a restart** — installing a new binary never replaces a running
   daemon: the new process detects the healthy incumbent on :7878 and exits
   (`crates/wenlan-server/src/main.rs`). `wenlan background on` stops the running service
-  before reinstalling; `wenlan restart` (stop then start) reloads it explicitly. The MCP
+  before reinstalling; `wenlan restart` (graceful stop, wait for exit, start, health
+  check) reloads it explicitly. The MCP
   version handshake surfaces a stale daemon (`VersionStatus::DaemonOutdated`) and points
   users at `wenlan restart`.
 - **Reranker startup** — enabling the cross-encoder (`WENLAN_RERANKER_ENABLED=1`) blocks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1659,6 +1659,29 @@ jobs:
             exit 1
           fi
 
+          pre_restart_pid="$(systemctl --user show wenlan-server -p MainPID --value)"
+          run_bounded restart 60s "$STAGE/wenlan" restart
+
+          if ! run_bounded restart-health 90s bash -c '
+            until curl --connect-timeout 1 --max-time 2 -sf \
+              http://127.0.0.1:7878/api/health >/dev/null; do
+              sleep 1
+            done
+          '; then
+            echo "FAIL: daemon did not become healthy after wenlan restart" >&2
+            timeout --signal=TERM --kill-after=5s 20s \
+              journalctl --user -u wenlan-server --no-pager -n 50 >&2 || true
+            exit 1
+          fi
+
+          post_restart_pid="$(systemctl --user show wenlan-server -p MainPID --value)"
+          if [ "$post_restart_pid" = "$pre_restart_pid" ]; then
+            echo "FAIL: wenlan restart did not replace the daemon process (MainPID stayed $pre_restart_pid)" >&2
+            timeout --signal=TERM --kill-after=5s 20s \
+              journalctl --user -u wenlan-server --no-pager -n 50 >&2 || true
+            exit 1
+          fi
+
           run_bounded stop 45s "$STAGE/wenlan" background off
           receipt probe-persistence start 20s
           test -f "$UNIT_PATH"

--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -30,7 +30,7 @@ use wenlan_types::{
 };
 
 mod lint;
-mod recovery;
+pub(crate) mod recovery;
 pub use lint::origin_host_from_env;
 
 const DEFAULT_HOST: &str = "http://127.0.0.1:7878";

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -15,6 +15,7 @@ use service_manager::{
 use std::path::{Path, PathBuf};
 
 use crate::client::origin_host_from_env;
+use crate::client::recovery::poll_health;
 
 pub const SERVICE_LABEL: &str = "com.wenlan.server";
 const DEFAULT_LOCAL_BIND_ADDR: &str = "127.0.0.1:7878";
@@ -74,7 +75,7 @@ pub enum BackgroundCommand {
 
 pub async fn run_background(command: BackgroundCommand) -> Result<()> {
     match command {
-        BackgroundCommand::On => install(),
+        BackgroundCommand::On => install().await,
         BackgroundCommand::Off => stop().await,
     }
 }
@@ -265,7 +266,7 @@ fn build_launchd_plist(
     buf
 }
 
-pub fn install() -> Result<()> {
+pub async fn install() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
         // wenlan-server is a plain console app and does not speak the Windows
@@ -307,10 +308,27 @@ pub fn install() -> Result<()> {
     let program = current_server_path()?;
     let m = manager()?;
 
-    // Stop any daemon already running under this label so the reinstall swaps
+    // Gracefully stop any daemon that is currently answering, and wait for it
+    // to fully exit, before reinstalling. Swapping the binary under a live
+    // process would otherwise leave the OLD daemon running until something
+    // else kills it (see restart()'s doc comment for the full story).
+    match request_daemon_shutdown().await {
+        Ok(DaemonShutdownRequest::Requested(process)) => {
+            verify_local_daemon_shutdown(process)
+                .await
+                .context("graceful daemon shutdown before reinstall did not complete")?;
+        }
+        Ok(DaemonShutdownRequest::NotRunning) => {}
+        Err(error) => {
+            return Err(error).context("request graceful daemon shutdown before reinstall")
+        }
+    }
+
+    // Stop any daemon still running under this label so the reinstall swaps
     // the binary. Without this, the freshly-installed binary detects the
     // healthy incumbent on port 7878 and exits, leaving the OLD daemon running
-    // (wenlan-server/src/main.rs:582-615). Best-effort: errors if not running.
+    // (wenlan-server/src/main.rs:582-615). Best-effort: errors if not running
+    // (e.g. the graceful shutdown above already stopped it).
     let _ = m.stop(ServiceStopCtx {
         label: label_value.clone(),
     });
@@ -385,6 +403,51 @@ fn current_user_id() -> Result<String> {
     Ok(uid.to_owned())
 }
 
+#[cfg(target_os = "macos")]
+fn kickstart_registered_service() -> Result<()> {
+    let uid = current_user_id()?;
+    let target = format!("gui/{uid}/{SERVICE_LABEL}");
+    let output = std::process::Command::new("launchctl")
+        .args(["kickstart", "-k", &target])
+        .output()
+        .context("spawn launchctl kickstart")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let details = if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        };
+        anyhow::bail!(
+            "launchctl kickstart failed (exit {}): {}",
+            output.status.code().unwrap_or(-1),
+            details
+        );
+    }
+    Ok(())
+}
+
+/// Best-effort `launchctl print` dump for the restart failure path, so a
+/// timed-out health poll leaves the user something to look at besides the URL
+/// that never answered.
+#[cfg(target_os = "macos")]
+fn print_service_diagnostics() {
+    let Ok(uid) = current_user_id() else {
+        return;
+    };
+    let target = format!("gui/{uid}/{SERVICE_LABEL}");
+    if let Ok(output) = std::process::Command::new("launchctl")
+        .args(["print", &target])
+        .output()
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if !stdout.trim().is_empty() {
+            eprintln!("{}", stdout.trim());
+        }
+    }
+}
+
 fn stop_registered_service() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
@@ -442,6 +505,56 @@ fn stop_registered_service() -> Result<()> {
             .context("stop service")?;
         Ok(())
     }
+}
+
+// restart() starts the daemon back up after its graceful stop using whatever
+// fallback each platform's service manager needs, so each platform gets its
+// own definition rather than one function with unused parameters in the
+// branches that do not need them (macOS's `kickstart -k` folds its fallback
+// into the start itself and ignores both arguments).
+#[cfg(target_os = "macos")]
+async fn start_after_graceful_stop(
+    _graceful_failed: bool,
+    _expected_process: Option<DaemonProcessIdentity>,
+) -> Result<()> {
+    kickstart_registered_service()
+        .context("if you ran `wenlan background off`, run `wenlan background on`")
+}
+
+#[cfg(target_os = "linux")]
+async fn start_after_graceful_stop(
+    graceful_failed: bool,
+    expected_process: Option<DaemonProcessIdentity>,
+) -> Result<()> {
+    if graceful_failed {
+        stop_registered_service()
+            .context("graceful daemon shutdown failed; service fallback failed")?;
+        verify_local_daemon_shutdown(expected_process)
+            .await
+            .context("service fallback did not stop the daemon before restart")?;
+    }
+    let label_value = label()?;
+    let m = manager()?;
+    m.start(ServiceStartCtx { label: label_value })
+        .context("start service; if you ran `wenlan background off`, run `wenlan background on`")
+}
+
+#[cfg(target_os = "windows")]
+async fn start_after_graceful_stop(
+    graceful_failed: bool,
+    expected_process: Option<DaemonProcessIdentity>,
+) -> Result<()> {
+    if graceful_failed {
+        let _ = std::process::Command::new("schtasks.exe")
+            .args(["/end", "/tn", WINDOWS_TASK_NAME])
+            .output();
+        verify_local_daemon_shutdown(expected_process)
+            .await
+            .context("service fallback did not stop the daemon before restart")?;
+    }
+    run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")
+        .context("if you ran `wenlan background off`, run `wenlan background on`")?;
+    Ok(())
 }
 
 async fn request_daemon_shutdown() -> Result<DaemonShutdownRequest> {
@@ -680,39 +793,51 @@ async fn stop() -> Result<()> {
     Ok(())
 }
 
-/// Restart the Wenlan daemon: stop the running process, then start the freshly
-/// registered binary. Required after an upgrade — installing a new binary does
-/// not replace an already-running daemon (the new process detects the healthy
+/// Restart the Wenlan daemon: gracefully stop the running process, wait for
+/// it to fully exit, then start the freshly registered binary and verify
+/// `/api/health` answers before returning. A bare stop-then-start with no
+/// wait races the old process's exit: launchd's `KeepAlive
+/// {SuccessfulExit=false}` never relaunches an exit-0 process, so `start`
+/// issued while the old process is still alive is a silent no-op. Restarting
+/// is also required after an upgrade — installing a new binary does not
+/// replace an already-running daemon (the new process detects the healthy
 /// incumbent on port 7878 and exits). See wenlan-server/src/main.rs:582-615.
-pub fn restart() -> Result<()> {
+pub async fn restart() -> Result<()> {
     if !is_installed() {
         anyhow::bail!("Wenlan background process is not set up. Run `wenlan background on` first.");
     }
 
-    #[cfg(target_os = "windows")]
-    {
-        // No service-manager on Windows: drive Task Scheduler directly,
-        // mirroring stop()'s /end and install()'s /run.
-        let _ = std::process::Command::new("schtasks.exe")
-            .args(["/end", "/tn", WINDOWS_TASK_NAME])
-            .output();
-        run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
-        remove_autostart_off_marker()?;
-        println!("Restarted Windows scheduled task '{}'.", WINDOWS_TASK_NAME);
-        return Ok(());
+    // Ask the daemon to shut down cooperatively and wait for it to actually
+    // exit — the same graceful path stop() uses. A failure here does not
+    // abort restart(); the OS-specific start step below force-stops as a
+    // fallback where one is needed.
+    let mut expected_process = None;
+    let graceful_failed = match request_daemon_shutdown().await {
+        Ok(DaemonShutdownRequest::Requested(process)) => {
+            expected_process = process;
+            verify_local_daemon_shutdown(process).await.is_err()
+        }
+        Ok(DaemonShutdownRequest::NotRunning) => false,
+        Err(_) => true,
+    };
+
+    start_after_graceful_stop(graceful_failed, expected_process).await?;
+
+    let base_url = local_daemon_base_url()?;
+    let health_url = format!("{base_url}/api/health");
+    if let Err(error) = poll_health(&health_url, std::time::Duration::from_secs(30)).await {
+        #[cfg(target_os = "macos")]
+        print_service_diagnostics();
+        anyhow::bail!(
+            "daemon at {health_url} did not become healthy after restart ({error:#}); the daemon may still be starting; re-check with `wenlan status`"
+        );
     }
 
-    #[cfg_attr(target_os = "windows", allow(unreachable_code))]
-    let label_value = label()?;
-    let m = manager()?;
-    // Best-effort stop: errors if not currently running, which is fine.
-    let _ = m.stop(ServiceStopCtx {
-        label: label_value.clone(),
-    });
-    m.start(ServiceStartCtx { label: label_value })
-        .context("start service")?;
     remove_autostart_off_marker()?;
-    println!("Restarted {}.", SERVICE_LABEL);
+    println!(
+        "Restarted {}; daemon healthy at {}.",
+        SERVICE_LABEL, base_url
+    );
     Ok(())
 }
 

--- a/crates/wenlan-cli/src/main.rs
+++ b/crates/wenlan-cli/src/main.rs
@@ -297,7 +297,7 @@ async fn main() -> anyhow::Result<ExitCode> {
             .await?
         }
         Commands::Background { command } => commands::service::run_background(command).await?,
-        Commands::Restart => commands::service::restart()?,
+        Commands::Restart => commands::service::restart().await?,
         Commands::Doctor => commands::setup::run_doctor().await?,
         Commands::Lint {
             profile,

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -343,6 +343,104 @@ fn spawn_shutdown_stub_response(
     (base, received)
 }
 
+// A restart-cycle daemon models launchd across `wenlan restart`: it answers the
+// shutdown POST, closes its listener, and only re-listens once a start/kickstart
+// verb lands in the fake launchctl log after that close -- the same "does not
+// come back until told to" behavior a real KeepAlive job has.
+#[cfg(target_os = "macos")]
+fn spawn_restart_cycle_daemon(log_path: PathBuf) -> String {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind restart cycle daemon");
+    let address = listener.local_addr().expect("restart cycle daemon address");
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept shutdown request");
+        let mut reader = BufReader::new(stream);
+        let mut request_line = String::new();
+        reader
+            .read_line(&mut request_line)
+            .expect("read shutdown request line");
+        assert!(
+            request_line.starts_with("POST /api/shutdown"),
+            "expected a shutdown request, got {request_line:?}"
+        );
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).expect("read shutdown header");
+            if line == "\r\n" || line.is_empty() {
+                break;
+            }
+        }
+        reader
+            .get_mut()
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 13\r\nConnection: close\r\n\r\nshutting down",
+            )
+            .expect("write shutdown response");
+        // Mark how much of the launchctl log exists right now: everything after
+        // this point is what restart()'s start step produces, so the daemon
+        // must not come back before that.
+        let offset = fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+        drop(reader);
+        drop(listener);
+
+        loop {
+            let contents = fs::read_to_string(&log_path).unwrap_or_default();
+            if contents.len() as u64 > offset {
+                let started = contents[offset as usize..]
+                    .lines()
+                    .any(|line| line.starts_with("start ") || line.starts_with("kickstart "));
+                if started {
+                    break;
+                }
+            }
+            thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let restarted = TcpListener::bind(address).expect("rebind restart cycle daemon");
+        while let Ok((health, _)) = restarted.accept() {
+            let mut health_reader = BufReader::new(health);
+            let mut request_line = String::new();
+            if health_reader.read_line(&mut request_line).is_err() {
+                continue;
+            }
+            loop {
+                let mut line = String::new();
+                if health_reader.read_line(&mut line).is_err() || line == "\r\n" || line.is_empty()
+                {
+                    break;
+                }
+            }
+            let _ = health_reader.get_mut().write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Length: 15\r\nConnection: close\r\n\r\n{\"status\":\"ok\"}",
+            );
+        }
+    });
+    format!("http://{address}")
+}
+
+#[cfg(target_os = "macos")]
+fn restart_health_probe_ok(base_url: &str) -> bool {
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+
+    let host = bind_addr_from_stub_host(base_url);
+    let Ok(mut stream) = TcpStream::connect(host) else {
+        return false;
+    };
+    let request = format!("GET /api/health HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+    if stream.write_all(request.as_bytes()).is_err() {
+        return false;
+    }
+    let mut response = String::new();
+    if stream.read_to_string(&mut response).is_err() {
+        return false;
+    }
+    response.starts_with("HTTP/1.1 200")
+}
+
 // Every caller is a launchd/unix background-lifecycle test, so on Windows this
 // is dead code and `-D warnings` fails the whole `cli_integration` target. CI's
 // lint job runs on Linux, so nothing caught it: `cargo clippy --workspace
@@ -1011,12 +1109,69 @@ fn restart_after_install_succeeds_isolated() {
         .assert()
         .success();
 
-    // Installed → restart stops then starts the service and reports it.
+    let log = runtime.data.path().join("restart_launchctl.log");
+    let base_url = spawn_restart_cycle_daemon(log.clone());
+    let bind_addr = bind_addr_from_stub_host(&base_url);
+
+    // Installed → restart gracefully stops the daemon, waits for it to exit,
+    // starts it, and only reports success once health answers again.
     cli_with_isolated_runtime(&runtime)
+        .env("WENLAN_BIND_ADDR", bind_addr)
+        .env("WENLAN_TEST_LAUNCHCTL_LOG", &log)
         .arg("restart")
         .assert()
         .success()
         .stdout(predicate::str::contains("Restarted com.wenlan.server"));
+
+    let calls = fs::read_to_string(&log).unwrap_or_default();
+    assert!(
+        !calls.lines().any(|l| l.starts_with("stop ")),
+        "restart must use the graceful HTTP shutdown, not `launchctl stop`; launchctl calls were:\n{calls}"
+    );
+    assert!(
+        calls
+            .lines()
+            .any(|l| l.starts_with("start ") || l.starts_with("kickstart ")),
+        "restart must start the service after the graceful stop; launchctl calls were:\n{calls}"
+    );
+
+    assert!(
+        restart_health_probe_ok(&base_url),
+        "daemon must answer /api/health after `wenlan restart` returns"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn restart_without_a_daemon_fails_loud_after_starting_the_service() {
+    let runtime = IsolatedRuntime::new();
+
+    cli_with_isolated_runtime(&runtime)
+        .args(["background", "on"])
+        .assert()
+        .success();
+
+    let log = runtime.data.path().join("restart_no_daemon_launchctl.log");
+
+    // Nothing answers on the isolated port: restart must still issue the start
+    // (loud failure, no racy stop) and only fail once its 30s health deadline
+    // elapses.
+    cli_with_isolated_runtime(&runtime)
+        .env("WENLAN_TEST_LAUNCHCTL_LOG", &log)
+        .arg("restart")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("did not become healthy"))
+        .stderr(predicate::str::contains("http://127.0.0.1:9/api/health"))
+        .stderr(predicate::str::contains("wenlan status"));
+
+    let calls = fs::read_to_string(&log).unwrap_or_default();
+    assert!(
+        calls
+            .lines()
+            .any(|l| l.starts_with("start ") || l.starts_with("kickstart ")),
+        "restart must still attempt to start the service even when health never answers; launchctl calls were:\n{calls}"
+    );
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
Closes #577.

## What

`wenlan restart` on macOS ran `launchctl stop` immediately followed by `launchctl start` and printed `Restarted com.wenlan.server.` unconditionally. When the start landed while the old process was still exiting, launchd treated it as a no-op; the job's `KeepAlive {SuccessfulExit=false}` never relaunches an exit-0 process, so the daemon stayed down while the command reported success (observed during the 2026-08-23 prod upgrade).

`restart` now:

1. Requests a graceful daemon shutdown over HTTP and waits (≤8 s) until the process is confirmed gone.
2. Starts the service — on macOS via `launchctl kickstart -k gui/<uid>/com.wenlan.server`, which kills any straggler and starts in one launchd operation; Linux/Windows keep stop-verify-start. A start failure is wrapped with a hint for the booted-out state after `wenlan background off`.
3. Polls `/api/health` for 30 s and exits non-zero with the health URL and recovery hints (`wenlan status`, `launchctl print`) if the daemon never answers.

`wenlan background on` gains the same graceful pre-stop before reinstalling (no health poll — isolated tests run without a daemon).

## Tests

- `restart_after_install_succeeds_isolated` rewritten around an in-test daemon that models launchd: it only re-listens once a `start`/`kickstart` line lands in the fake-launchctl log **after** its listener closed, so the old racy stop-then-start flow fails this test.
- New `restart_without_a_daemon_fails_loud_after_starting_the_service`: nothing listening → non-zero exit naming the health URL, after having issued the start.
- Linux systemd CI smoke now runs `wenlan restart` between the health pass and `background off`, asserting health again and that `MainPID` changed.

macOS real-launchd verification is deliberately left to the production machine (tracked as unchecked; the unit + systemd evidence carries the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CYCdM1rkwed1VEwPiYiUKA
