### PR TITLE
fix: accept the steered candidate tree in the release-config self-check

### DIFF
--- a/scripts/validate-release-candidate.test.py
+++ b/scripts/validate-release-candidate.test.py
@@ -1528,7 +1528,17 @@ class ValidateReleaseCandidateTests(unittest.TestCase):
         # place the candidate must carry exactly that version, not next patch.
         release_as = json.loads(config_text)["packages"]["."].get("release-as")
         next_version = release_as or f"{major}.{minor}.{patch + 1}"
-        VALIDATOR._release_version_policy(config_text, version_txt, next_version)
+        base_version = version_txt
+        if release_as == version_txt:
+            # This tree is the steered release candidate itself: the version
+            # sync already wrote the release-as version into version.txt, and
+            # the released base (main's version.txt) is strictly lower but not
+            # recorded in this tree. Real candidate validation always takes the
+            # base from main, so any strictly lower base exercises the same
+            # closed-schema and release-as checks without misreading the
+            # candidate's own bumped version.txt as the released base.
+            base_version = "0.0.0"
+        VALIDATOR._release_version_policy(config_text, base_version, next_version)
 
     def test_artifact_record_rejects_expiry_digest_and_fork_identity(self) -> None:
         name = "release-candidate-1-1-x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Why

Release PR #581 (0.17.0) failed CI (run 32674176302) in `detect-changes` → "Test release target inventory": `test_release_version_policy_accepts_the_real_repo_config` errored with `release-as override '0.17.0' is stale: it does not advance past the released base version '0.17.0'`.

The test (added in #510) reads the real `release-please-config.json` and `version.txt` and requires the version policy to accept them. On a release-please candidate branch with a `release-as` override in place, the version sync has already written the override version into `version.txt`, so the test calls the policy with base == release-as and trips the stale-override guard. Real candidate validation takes the base from main and accepts the candidate — only this self-check misreads the candidate's own bumped `version.txt` as the released base. Any steered (minor/major) release would hit this on its release PR CI.

## What

When the tree's `version.txt` already equals the `release-as` override, the test substitutes a strictly lower base version. The closed-schema and release-as checks the test exists for (its documented regression target) still run against the real config file.

Verified: `python3 scripts/validate-release-candidate.test.py` — all 40 tests pass on this tree; the candidate-tree state was reproduced directly (`_release_version_policy(config, "0.17.0", "0.17.0")` raises, `("0.0.0", "0.17.0")` passes).

## After merge

The release-PR maintenance synchronizer merges main into `release-please--branches--main`, re-running #581's CI with the fixed test; the observer should then validate 0.17.0 and the normal merge → tag → publish chain proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
