### PR TITLE
feat(server,cli): manual ambient sweep, status route, and quiet-tick drain

### DIFF
--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -51,6 +51,25 @@ pub struct SyncStats {
     pub paused: Option<String>,
 }
 
+/// Local mirror of the daemon's `AmbientSweepReport`/`AmbientJobSweepResult`
+/// (defined in `wenlan-server`, which the CLI must not depend on). Typed so
+/// envelope drift fails loud rather than silently deserializing into
+/// `serde_json::Value`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AmbientSweepReport {
+    pub phases: Vec<AmbientJobSweepResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AmbientJobSweepResult {
+    pub job: String,
+    pub attempted: bool,
+    pub selected: bool,
+    pub llm_calls: usize,
+    pub panicked: bool,
+    pub elapsed_ms: u128,
+}
+
 pub struct WenlanClient {
     base_url: String,
     http: reqwest::Client,
@@ -331,6 +350,28 @@ impl WenlanClient {
     /// POST /api/outbox/drain — ask the daemon to replay queued envelopes.
     pub async fn drain_outbox(&self) -> Result<OutboxDrainReport> {
         self.post_empty_json("/api/outbox/drain").await
+    }
+
+    /// POST /api/ambient/sweep — force one bounded pass over every ambient
+    /// job type, bypassing the idle/resource gate (each job's own per-call
+    /// slice bound is unchanged). Document and Citation phases can call the
+    /// on-device LLM, so a full lap can legitimately take minutes; this
+    /// request gets its own generous timeout rather than the client's
+    /// default, which is sized for ordinary sub-second daemon calls.
+    pub async fn sweep_ambient(&self) -> Result<AmbientSweepReport> {
+        const SWEEP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+        let url = format!("{}/api/ambient/sweep", self.base_url);
+        let resp = self
+            .send(
+                self.http.post(&url).timeout(SWEEP_TIMEOUT),
+                &format!("POST {url} failed"),
+            )
+            .await?
+            .error_for_status()
+            .with_context(|| format!("daemon returned error for {url}"))?;
+        resp.json()
+            .await
+            .context("parsing /api/ambient/sweep response")
     }
 
     /// GET /api/sources — list registered sources.

--- a/crates/wenlan-cli/src/commands/mod.rs
+++ b/crates/wenlan-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod setup;
 pub mod space;
 pub mod status;
 pub mod store;
+pub mod sweep;
 
 #[cfg(not(target_os = "windows"))]
 pub use service::service_unit_path;

--- a/crates/wenlan-cli/src/commands/sweep.rs
+++ b/crates/wenlan-cli/src/commands/sweep.rs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `wenlan sweep` — force one bounded pass over every due ambient job
+//! (chunking, citation backfill, relations/communities, ...), bypassing the
+//! daemon's idle gate. Each job's own per-call slice bound is unchanged; only
+//! the wait for a quiet turn is skipped.
+
+use anyhow::Result;
+
+use crate::client::WenlanClient;
+use crate::output::{print_json, ResolvedFormat};
+
+/// We still hit the daemon under `quiet` so a connection failure still
+/// surfaces via exit code, matching `commands::status::run`.
+pub async fn run(client: &WenlanClient, format: ResolvedFormat, quiet: bool) -> Result<()> {
+    let report = client.sweep_ambient().await?;
+    if quiet {
+        return Ok(());
+    }
+    match format {
+        ResolvedFormat::Json => print_json(&report)?,
+        ResolvedFormat::Table => {
+            for phase in &report.phases {
+                if !phase.attempted {
+                    println!("{}: skipped (not available)", phase.job);
+                    continue;
+                }
+                let outcome = if phase.panicked {
+                    "panicked"
+                } else if phase.selected {
+                    "ran"
+                } else {
+                    "nothing due"
+                };
+                println!(
+                    "{}: {} (llm_calls={}, elapsed_ms={})",
+                    phase.job, outcome, phase.llm_calls, phase.elapsed_ms
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/wenlan-cli/src/main.rs
+++ b/crates/wenlan-cli/src/main.rs
@@ -180,6 +180,9 @@ enum Commands {
         #[command(subcommand)]
         cmd: commands::entities::EntitiesCmd,
     },
+    /// Force one bounded pass over every due ambient job now, instead of
+    /// waiting for a quiet turn.
+    Sweep,
 }
 
 #[tokio::main]
@@ -379,6 +382,7 @@ async fn main() -> anyhow::Result<ExitCode> {
         Commands::Entities { cmd } => {
             commands::entities::run(&client, format, cli.quiet, cmd).await?
         }
+        Commands::Sweep => commands::sweep::run(&client, format, cli.quiet).await?,
     }
     Ok(ExitCode::SUCCESS)
 }

--- a/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
+++ b/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
@@ -522,9 +522,9 @@ A surface that transmits anyway is a failing test on that surface. That gate is
 soft, and saying so plainly is what cooperative-tier means. It is also no longer
 load-bearing: the shape gate holds even when this one is bypassed.
 
-## HTTP — all 167 registered `(method, path, handler)` triples
+## HTTP — all 166 registered `(method, path, handler)` triples
 
-60 page-bearing, 107 not.
+59 page-bearing, 107 not.
 
 | Method | Path | Builder | Page-bearing | Class | Marker-shape | Adapter | Evidence |
 |---|---|---|---|---|---|---|---|
@@ -533,6 +533,8 @@ load-bearing: the shape gate holds even when this one is bypassed.
 | `DELETE` | `/api/agents/{name}` | main | yes | automatic | `none` | `handle_delete_agent` | opaque response type — fail-closed |
 | `GET` | `/api/agents/{name}` | main | no | not_applicable | `none` | — | DEMOTED — proof in the inventory doc |
 | `PUT` | `/api/agents/{name}` | main | no | not_applicable | `none` | — | DEMOTED — proof in the inventory doc |
+| `GET` | `/api/ambient/status` | main | no | not_applicable | `none` | — | no prose fields |
+| `POST` | `/api/ambient/sweep` | main | no | not_applicable | `none` | — | no prose fields |
 | `PATCH` | `/api/brief` | main | no | not_applicable | `none` | — | BriefUpdateReceipt carries no page prose |
 | `POST` | `/api/brief` | main | yes | automatic | `none` | `handle_read_brief` | Brief.last_session_summary, BriefItem.text, SearchResult.content |
 | `GET` | `/api/briefing` | main | yes | automatic | `none` | `handle_get_briefing` | BriefingResponse.content = revision-card titles |
@@ -1311,7 +1313,7 @@ carrying the authority of agreement.
 | `server/routes.rs::handle_context` | `pub` | no | no | — | `server/brief_routes.rs::handle_read_brief` |
 | `server/scheduler.rs::fire_steep_phase` | `private` | no | no | `server/scheduler.rs::fire_steep_phase_safe` | `core/refinery/mod.rs::run_periodic_steep_phase_with_api` |
 | `server/scheduler.rs::spawn_scheduler` | `pub` | no | **yes** | `server/main.rs::run_daemon` | `server/scheduler.rs::fire_maintenance_stage_safe` |
-| `server/scheduler/ambient.rs::run_ambient_job_safe` | `pub(super)` | no | no | `server/scheduler.rs::spawn_scheduler` | `server/scheduler/ambient.rs::run_ambient_job` |
+| `server/scheduler/ambient.rs::run_ambient_job_safe` | `pub(super)` | no | no | `server/scheduler.rs::spawn_scheduler`, `server/scheduler/ambient_admin.rs::force_ambient_sweep` | `server/scheduler/ambient.rs::run_ambient_job` |
 | `server/source_routes.rs::sync_directory_source` | `pub(crate)` | no | no | `server/scheduler.rs::sync_directory_sources`, `server/source_routes.rs::handle_sync_source` | `core/db.rs::rebind_source_id_with_source_page` |
 
 <!-- m5-reader-sweep:end -->

--- a/crates/wenlan-core/src/truth_manifest.rs
+++ b/crates/wenlan-core/src/truth_manifest.rs
@@ -172,10 +172,10 @@ pub struct CliReader {
     pub adapter: &'static str,
 }
 
-/// All 167 registered `(method, path, handler)` triples.
+/// All 166 registered `(method, path, handler)` triples.
 ///
-/// 59 page-bearing, 108 not. Expands to 171 `(builder, method, path)`
-/// runtime entries: 165 in `main`, 6 in `repair`.
+/// 59 page-bearing, 107 not. Expands to 170 `(builder, method, path)`
+/// runtime entries: 164 in `main`, 6 in `repair`.
 #[rustfmt::skip]
 pub const HTTP_READERS: &[HttpReader] = &[
     HttpReader { method: ReaderMethod::Get, path: "/api/activities", builder: Builder::Main, page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "handle_list_activities", evidence: "AgentActivityRow.detail = title={page.title}" },
@@ -183,6 +183,8 @@ pub const HTTP_READERS: &[HttpReader] = &[
     HttpReader { method: ReaderMethod::Delete, path: "/api/agents/{name}", builder: Builder::Main, page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "handle_delete_agent", evidence: "opaque response type — fail-closed" },
     HttpReader { method: ReaderMethod::Get, path: "/api/agents/{name}", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "DEMOTED — proof in the inventory doc" },
     HttpReader { method: ReaderMethod::Put, path: "/api/agents/{name}", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "DEMOTED — proof in the inventory doc" },
+    HttpReader { method: ReaderMethod::Get, path: "/api/ambient/status", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "no prose fields" },
+    HttpReader { method: ReaderMethod::Post, path: "/api/ambient/sweep", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "no prose fields" },
     HttpReader { method: ReaderMethod::Patch, path: "/api/brief", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "BriefUpdateReceipt carries no page prose" },
     HttpReader { method: ReaderMethod::Post, path: "/api/brief", builder: Builder::Main, page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "handle_read_brief", evidence: "Brief.last_session_summary, BriefItem.text, SearchResult.content" },
     HttpReader { method: ReaderMethod::Get, path: "/api/briefing", builder: Builder::Main, page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "handle_get_briefing", evidence: "BriefingResponse.content = revision-card titles" },

--- a/crates/wenlan-core/src/truth_manifest_test.rs
+++ b/crates/wenlan-core/src/truth_manifest_test.rs
@@ -204,10 +204,12 @@ fn manifest_counts_match_the_spec() {
     // `/api/config/skip-apps` pair were deleted (audit 2026-08-22), then 164
     // after the entity merge/alias surface added POST
     // `/api/memory/entities/{id}/merge` and POST
-    // `/api/memory/entities/{id}/aliases` (2026-08-22).
+    // `/api/memory/entities/{id}/aliases` (2026-08-22). Then 166 after GET
+    // `/api/ambient/status` and POST `/api/ambient/sweep` were added
+    // (force-sweep + status surface for the ambient scheduler).
     assert_eq!(
         HTTP_READERS.len(),
-        164,
+        166,
         "registered (method, path, handler) triples"
     );
     assert_eq!(MCP_READERS.len(), 29, "#[tool( declarations");
@@ -218,7 +220,7 @@ fn manifest_counts_match_the_spec() {
     let entries: Vec<_> = runtime_entries().collect();
     assert_eq!(
         entries.len(),
-        168,
+        170,
         "(builder, method, path) runtime entries"
     );
     assert_eq!(
@@ -226,7 +228,7 @@ fn manifest_counts_match_the_spec() {
             .iter()
             .filter(|(b, _, _)| *b == Builder::Main)
             .count(),
-        162,
+        164,
         "main builder entries"
     );
     assert_eq!(
@@ -402,7 +404,7 @@ fn marker_shape_allowlist_is_fail_closed() {
             .iter()
             .filter(|r| r.marker_shape == MarkerShape::None)
             .count(),
-        158
+        160
     );
 }
 

--- a/crates/wenlan-server/src/ambient_routes.rs
+++ b/crates/wenlan-server/src/ambient_routes.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Operator-facing HTTP surface for the ambient enrichment scheduler:
+//! `POST /api/ambient/sweep` forces one bounded, synchronous pass over every
+//! ambient job type, bypassing the idle/resource gate (not each job's own
+//! per-call slice bound); `GET /api/ambient/status` reports pending-work
+//! counts, per-phase last-run timestamps, and whether the passive scheduler's
+//! idle gate currently admits work. Business logic for both lives in
+//! `crate::scheduler` (via the `ambient_admin` submodule) — this file only
+//! owns HTTP framing.
+
+use axum::{extract::State, Json};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::error::ServerError;
+use crate::route_registry::{get, post, TrackedRouter};
+use crate::scheduler::{AmbientStatusReport, AmbientSweepReport};
+use crate::state::{ServerState, SharedState};
+
+pub(crate) fn register(router: TrackedRouter<SharedState>) -> TrackedRouter<SharedState> {
+    router
+        .route("/api/ambient/status", get(handle_ambient_status))
+        .route("/api/ambient/sweep", post(handle_ambient_sweep))
+}
+
+/// POST /api/ambient/sweep
+pub async fn handle_ambient_sweep(
+    State(state): State<Arc<RwLock<ServerState>>>,
+) -> Result<Json<AmbientSweepReport>, ServerError> {
+    let (db, llm, api_llm, external_llm, prompts, refinery_cfg, distillation_cfg, ambient_run_lock) = {
+        let s = state.read().await;
+        (
+            s.db.clone().ok_or(ServerError::DbNotInitialized)?,
+            s.llm.clone(),
+            s.api_llm.clone(),
+            s.external_llm.clone(),
+            s.prompts.clone(),
+            s.tuning.refinery.clone(),
+            s.tuning.distillation.clone(),
+            s.ambient_run_lock.clone(),
+        )
+    };
+    // Routing consent and the knowledge root are read fresh from config, same
+    // as the passive scheduler tick and `handle_sync_source` — neither is
+    // cached in `ServerState`.
+    let runtime_config = wenlan_core::config::load_config();
+    let everyday_pin =
+        wenlan_core::refinery::EverydaySource::parse(runtime_config.everyday_source.as_deref());
+    let knowledge_path = runtime_config.knowledge_path_or_default();
+
+    // Hold the ambient-run lock for the whole lap so this force-sweep and
+    // the passive scheduler's own ambient tick can never execute jobs at the
+    // same time (doubled LLM contention, possible double-claiming of the
+    // same document/page). Unlike the scheduler tick, which only
+    // `try_lock`s and skips its turn, the endpoint *waits* here: a caller
+    // that explicitly asked for a sweep wants the work done, not a fast
+    // failure to retry later, and this is exactly the trade the CLI's
+    // generous request timeout is sized for. Holding a `tokio::sync::Mutex`
+    // guard across `.await` is fine — the repo's no-guard-across-await
+    // invariant is specific to `RwLock`.
+    let _ambient_run_guard = ambient_run_lock.lock().await;
+
+    let report = crate::scheduler::force_ambient_sweep(
+        &db,
+        llm.as_ref(),
+        api_llm.as_ref(),
+        external_llm.as_ref(),
+        everyday_pin,
+        &prompts,
+        &refinery_cfg,
+        &distillation_cfg,
+        Some(knowledge_path.as_path()),
+    )
+    .await;
+    Ok(Json(report))
+}
+
+/// GET /api/ambient/status
+pub async fn handle_ambient_status(
+    State(state): State<Arc<RwLock<ServerState>>>,
+) -> Result<Json<AmbientStatusReport>, ServerError> {
+    let (db, gate) = {
+        let s = state.read().await;
+        let db = s.db.clone().ok_or(ServerError::DbNotInitialized)?;
+        // A `std::sync::Mutex` lock is synchronous and released before this
+        // statement ends — never held across an `.await`. Bound to its own
+        // `let` (rather than inlined into the tuple below) so the guard
+        // drops here, before `s` itself drops at the end of this block.
+        let gate = s.ambient_gate.lock().unwrap().clone();
+        (db, gate)
+    };
+    let report = crate::scheduler::ambient_status(&db, gate)
+        .await
+        .map_err(ServerError::from)?;
+    Ok(Json(report))
+}

--- a/crates/wenlan-server/src/daemon_structure_test.rs
+++ b/crates/wenlan-server/src/daemon_structure_test.rs
@@ -1257,6 +1257,7 @@ fn structure_violations_with_children(
     let expected_scheduler_files: BTreeSet<String> = [
         phase.external_tests().then_some("scheduler_tests.rs"),
         phase.ambient_child().then_some("ambient.rs"),
+        phase.ambient_child().then_some("ambient_admin.rs"),
     ]
     .into_iter()
     .flatten()

--- a/crates/wenlan-server/src/lib.rs
+++ b/crates/wenlan-server/src/lib.rs
@@ -5,6 +5,7 @@
 //! entry-point (`main.rs`) continues to own the daemon lifecycle.
 
 pub mod activity_tag_routes;
+pub mod ambient_routes;
 pub mod brief_files;
 pub mod brief_routes;
 pub mod briefing_routes;

--- a/crates/wenlan-server/src/route_registry.rs
+++ b/crates/wenlan-server/src/route_registry.rs
@@ -374,6 +374,7 @@ where
 #[rustfmt::skip]
 const NON_SENSITIVE_PATHS: &[&str] = &[
     "/api/health", "/api/status", "/api/lint", "/api/repairs/plan", "/api/repairs/plan/entries", "/api/repairs/prepare", "/api/repairs/apply", "/api/repairs/verify", "/api/llm/test", "/api/shutdown", "/api/debug/pipeline",
+    "/api/ambient/status", "/api/ambient/sweep",
     "/api/steep", "/api/distill", "/api/distill/{page_id}",
     "/api/ingest/text", "/api/ingest/webpage", "/api/ingest/memory", "/api/documents/{source}/{source_id}",
     "/api/import/memories", "/api/import/chat-export", "/api/memory/store", "/api/memory/confirm/{source_id}",

--- a/crates/wenlan-server/src/route_registry/handler_manifest.txt
+++ b/crates/wenlan-server/src/route_registry/handler_manifest.txt
@@ -2,6 +2,7 @@
 main|get|/api/activities|wenlan_server::activity_tag_routes::handle_list_activities
 main|get|/api/agents|wenlan_server::profile_agents_routes::handle_list_agents
 main|get|/api/agents/{name}|wenlan_server::profile_agents_routes::handle_get_agent
+main|get|/api/ambient/status|wenlan_server::ambient_routes::handle_ambient_status
 main|get|/api/briefing|wenlan_server::briefing_routes::handle_get_briefing
 main|get|/api/capture-stats|wenlan_server::memory_detail_routes::handle_capture_stats
 main|get|/api/chunks/{source_id}|wenlan_server::indexed_files_routes::handle_get_chunks
@@ -60,6 +61,7 @@ main|get|/api/status|wenlan_server::routes::handle_status
 main|get|/api/suggest-tags|wenlan_server::activity_tag_routes::handle_suggest_tags
 main|get|/api/tags|wenlan_server::activity_tag_routes::handle_list_tags
 main|get|/ws/updates|wenlan_server::websocket::handle_ws_upgrade
+main|post|/api/ambient/sweep|wenlan_server::ambient_routes::handle_ambient_sweep
 main|post|/api/brief|wenlan_server::brief_routes::handle_read_brief
 main|post|/api/chunks/delete-bulk|wenlan_server::indexed_files_routes::handle_delete_bulk
 main|post|/api/context|wenlan_server::routes::handle_context

--- a/crates/wenlan-server/src/router.rs
+++ b/crates/wenlan-server/src/router.rs
@@ -6,12 +6,13 @@ pub use crate::route_registry::AppRouter;
 use crate::route_registry::{get, TrackedRouter};
 use crate::state::SharedState;
 use crate::{
-    activity_tag_routes, brief_routes, briefing_routes, community_routes, config_routes,
-    decisions_routes, entity_graph_routes, import_routes, indexed_files_routes, ingest_routes,
-    knowledge_routes, lint_routes, memory_detail_routes, memory_revision_routes, memory_routes,
-    onboarding_routes, outbox_routes, page_map_routes, page_routes, pinned_memory_routes,
-    profile_agents_routes, profile_narrative_routes, refinery_routes, repair_routes, routes,
-    security, snapshot_routes, source_routes, spaces_routes, truth_guard, websocket,
+    activity_tag_routes, ambient_routes, brief_routes, briefing_routes, community_routes,
+    config_routes, decisions_routes, entity_graph_routes, import_routes, indexed_files_routes,
+    ingest_routes, knowledge_routes, lint_routes, memory_detail_routes, memory_revision_routes,
+    memory_routes, onboarding_routes, outbox_routes, page_map_routes, page_routes,
+    pinned_memory_routes, profile_agents_routes, profile_narrative_routes, refinery_routes,
+    repair_routes, routes, security, snapshot_routes, source_routes, spaces_routes, truth_guard,
+    websocket,
 };
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use wenlan_core::truth_manifest::Builder;
@@ -48,6 +49,7 @@ pub fn build_router_with_shutdown(state: SharedState, shutdown: ShutdownHandle) 
 
     let router = repair_routes::register(lint_routes::register(TrackedRouter::new(Builder::Main)));
     let router = routes::register(router);
+    let router = ambient_routes::register(router);
     let router = brief_routes::register(router);
     let router = outbox_routes::register(router);
     let router = community_routes::register(router);

--- a/crates/wenlan-server/src/scheduler.rs
+++ b/crates/wenlan-server/src/scheduler.rs
@@ -15,6 +15,11 @@ use crate::state::SharedState;
 
 mod ambient;
 use ambient::*;
+mod ambient_admin;
+pub(crate) use ambient_admin::{
+    ambient_status, force_ambient_sweep, AmbientGateSnapshot, AmbientStatusReport,
+    AmbientSweepReport,
+};
 
 /// 30-minute ceiling for adaptive gap — matches ACTIVITY_GAP_SECS in wenlan-core.
 const BURST_GAP_CEILING: Duration = Duration::from_secs(1800);
@@ -445,6 +450,33 @@ fn refresh_last_write_activity(write_signal: &WriteSignal, last_write_activity: 
 
 fn automatic_work_consumes_thermal_turn(selected: bool, llm_calls: usize, panicked: bool) -> bool {
     selected || llm_calls > 0 || panicked
+}
+
+/// Charge the shared thermal cooldown for one drained ambient lap, if any
+/// job in it consumed a thermal turn — against the lap's FULL elapsed wall
+/// time (`lap_completed - lap_started`), never a single job's own slice.
+///
+/// A lap can now run several due jobs back to back (see `drain_due`).
+/// Charging only the last thermal-consuming job's elapsed time — the
+/// previous, single-job-per-tick behavior — would silently discard every
+/// earlier job's wall time and undershoot the 5%-duty-cycle budget more and
+/// more as laps grow longer. Charging the lap's total elapsed time once,
+/// after every due job has run, preserves the invariant regardless of how
+/// many jobs a lap drains.
+fn charge_lap_thermal_cooldown(
+    schedule: &mut AmbientSchedule,
+    lap_started: Instant,
+    lap_completed: Instant,
+    any_job_consumed_thermal_turn: bool,
+    policy: ThermalPolicy,
+) {
+    if any_job_consumed_thermal_turn {
+        schedule.note_thermal_work_completion(
+            lap_completed,
+            lap_completed.saturating_duration_since(lap_started),
+            policy,
+        );
+    }
 }
 
 /// Ambient-only provider facade that fails closed after forwarding one LLM
@@ -1277,6 +1309,23 @@ pub fn spawn_scheduler(
                 sample_host_activity(),
             );
 
+            // Publish the gate state this tick actually observed so
+            // `/api/ambient/status` can report it without re-sampling
+            // CPU/host-activity independently (see `AmbientGateSnapshot`).
+            {
+                let ambient_gate = {
+                    let state = shared.read().await;
+                    state.ambient_gate.clone()
+                };
+                *ambient_gate.lock().unwrap() = Some(AmbientGateSnapshot {
+                    admitted: resource_status.admitted,
+                    blocked_reason: resource_status
+                        .block_reason
+                        .map(|reason| format!("{reason:?}")),
+                    sampled_at_epoch: chrono::Utc::now().timestamp(),
+                });
+            }
+
             // All automatic heavy work shares the same resource and cooldown
             // gate as the ambient lanes. The Idle recap trigger additionally
             // keeps its Wenlan-write batching window in trigger selection.
@@ -1556,8 +1605,17 @@ pub fn spawn_scheduler(
                 break;
             }
 
-            // --- 5. Ambient enrichment: one due job, one durable slice, one
-            //        LLM request maximum. Never detached. ---
+            // --- 5. Ambient enrichment: drain every currently-due job once
+            //        per quiet tick — at most one full round-robin lap
+            //        (`AmbientJob::ALL.len()` attempts) — each still capped
+            //        at one durable slice / one LLM request maximum. Never
+            //        detached. Looping here (instead of firing only the
+            //        first due job) is what lets a later-cursor job such as
+            //        Citation run in the same quiet window as an
+            //        always-due earlier one such as Document; the resource
+            //        gate is still checked once on entry, not per job, so a
+            //        long drain cannot be interrupted mid-lap by its own
+            //        thermal cooldown. ---
             refresh_last_write_activity(&write_signal, &mut last_write_activity);
             let ambient_now = Instant::now();
             if !automatic_work_ran
@@ -1574,84 +1632,135 @@ pub fn spawn_scheduler(
                     ambient_schedule.next_allowed_at,
                 )
             {
-                let ambient_provider_available = resolve_ambient_provider(
-                    everyday_pin,
-                    api_llm.as_ref(),
-                    external_llm.as_ref(),
-                    llm.as_ref(),
-                )
-                .is_some();
-                let availability = AmbientAvailability::for_provider(ambient_provider_available);
-                if let Some(job) = ambient_schedule.select_due(ambient_now, availability) {
-                    // Availability/selection is intentionally cheap, but may
-                    // still race with shutdown. Do not start another ambient
-                    // item after the stop signal became sticky.
-                    if crate::lifecycle::shutdown_requested(&shutdown) {
-                        break;
-                    }
-                    tracing::info!(
-                        "[scheduler] ambient turn started job={:?} cpu_percent={:?} available_memory_mb={:?}",
-                        job,
-                        resource_status
-                            .snapshot
-                            .map(|snapshot| snapshot.cpu_usage_percent),
-                        resource_status
-                            .snapshot
-                            .map(|snapshot| snapshot.available_memory_bytes / (1024 * 1024)),
-                    );
-                    let report = run_ambient_job_safe(
-                        job,
-                        &db,
-                        llm.as_ref(),
-                        api_llm.as_ref(),
-                        external_llm.as_ref(),
-                        everyday_pin,
-                        &prompts,
-                        &refinery_cfg,
-                        &distillation_cfg,
-                        Some(knowledge_path.as_path()),
-                    )
-                    .await;
-                    let completion = Instant::now();
-                    ambient_schedule.note_job_result(
-                        report.job,
-                        completion,
-                        !should_backoff_ambient_lane(report.selected, report.llm_calls),
-                    );
-                    // Fresh-document preparation can be CPU-heavy even before
-                    // an LLM call, so a selected document also consumes the
-                    // conservative thermal turn budget.
-                    if report.panicked
-                        || ambient_work_consumes_thermal_turn(
-                            report.job,
-                            report.selected,
-                            report.llm_calls,
-                            report.page_growth_terminal_no_match_committed,
-                        )
-                    {
-                        ambient_schedule.note_thermal_work_completion(
-                            completion,
-                            report.elapsed,
-                            thermal_policy,
+                // A force-sweep request (`POST /api/ambient/sweep`) and this
+                // tick's own ambient section must never run concurrently: two
+                // ambient jobs in flight at once means doubled on-device LLM
+                // contention and a real risk of the same document/page being
+                // claimed twice. `try_lock` (never `.lock().await`) because
+                // the scheduler must keep servicing its OTHER duties every
+                // poll — it must not block behind a force-sweep lap that can
+                // run for minutes. `ambient_turn_owed` is deliberately left
+                // untouched when the lock is contended: the ambient lane did
+                // not get its turn this tick, so it must not be marked as
+                // having received one (that would starve it behind a
+                // long-running sweep).
+                let ambient_run_lock = {
+                    let state = shared.read().await;
+                    state.ambient_run_lock.clone()
+                };
+                match ambient_run_lock.try_lock() {
+                    Err(_) => {
+                        tracing::debug!(
+                            "[scheduler] ambient tick skipped: force-sweep holds the ambient-run lock"
                         );
                     }
-                    tracing::info!(
-                        "[scheduler] ambient job={:?} selected={} llm_calls={} panicked={} elapsed_ms={} next_eligible_ms={}",
-                        report.job,
-                        report.selected,
-                        report.llm_calls,
-                        report.panicked,
-                        report.elapsed.as_millis(),
-                        ambient_schedule
-                            .next_allowed_at
-                            .saturating_duration_since(completion)
-                            .as_millis(),
-                    );
-                }
-                // The ambient lane received its admission opportunity. Empty
-                // work is enough to release the debt; known selected work owns
-                // the shared cooldown through `note_thermal_work_completion`.
-                ambient_turn_owed = false;
+                    Ok(_ambient_run_guard) => {
+                        let ambient_provider_available = resolve_ambient_provider(
+                            everyday_pin,
+                            api_llm.as_ref(),
+                            external_llm.as_ref(),
+                            llm.as_ref(),
+                        )
+                        .is_some();
+                        let availability =
+                            AmbientAvailability::for_provider(ambient_provider_available);
+                        // Post-lap thermal accounting: the cooldown must
+                        // reflect the FULL lap's wall time, not just the last
+                        // job run. `note_thermal_work_completion` used to be
+                        // called once per job inside this loop with that
+                        // job's own `report.elapsed` — harmless when a tick
+                        // could only ever run one job, but now that
+                        // `drain_due` can return several jobs in one lap,
+                        // only the LAST thermal-consuming job's (typically
+                        // much smaller) elapsed time would size the cooldown,
+                        // silently discarding every earlier job's wall time
+                        // and undershooting the 5%-duty-cycle budget.
+                        // Accumulate a lap-consumed flag instead and charge
+                        // the cooldown once after the loop, against the
+                        // whole lap's elapsed time.
+                        let mut lap_consumed_thermal_turn = false;
+                        for job in ambient_schedule.drain_due(ambient_now, availability) {
+                            // Availability/selection is intentionally cheap,
+                            // but may still race with shutdown. Do not start
+                            // another ambient item after the stop signal
+                            // became sticky.
+                            if crate::lifecycle::shutdown_requested(&shutdown) {
+                                break;
+                            }
+                            tracing::info!(
+                                "[scheduler] ambient turn started job={:?} cpu_percent={:?} available_memory_mb={:?}",
+                                job,
+                                resource_status
+                                    .snapshot
+                                    .map(|snapshot| snapshot.cpu_usage_percent),
+                                resource_status
+                                    .snapshot
+                                    .map(|snapshot| snapshot.available_memory_bytes / (1024 * 1024)),
+                            );
+                            let report = run_ambient_job_safe(
+                                job,
+                                &db,
+                                llm.as_ref(),
+                                api_llm.as_ref(),
+                                external_llm.as_ref(),
+                                everyday_pin,
+                                &prompts,
+                                &refinery_cfg,
+                                &distillation_cfg,
+                                Some(knowledge_path.as_path()),
+                            )
+                            .await;
+                            let completion = Instant::now();
+                            ambient_schedule.note_job_result(
+                                report.job,
+                                completion,
+                                !should_backoff_ambient_lane(report.selected, report.llm_calls),
+                            );
+                            // Fresh-document preparation can be CPU-heavy
+                            // even before an LLM call, so a selected document
+                            // also consumes the conservative thermal turn
+                            // budget.
+                            if report.panicked
+                                || ambient_work_consumes_thermal_turn(
+                                    report.job,
+                                    report.selected,
+                                    report.llm_calls,
+                                    report.page_growth_terminal_no_match_committed,
+                                )
+                            {
+                                lap_consumed_thermal_turn = true;
+                            }
+                            tracing::info!(
+                                "[scheduler] ambient job={:?} selected={} llm_calls={} panicked={} elapsed_ms={}",
+                                report.job,
+                                report.selected,
+                                report.llm_calls,
+                                report.panicked,
+                                report.elapsed.as_millis(),
+                            );
+                        }
+                        let lap_completed = Instant::now();
+                        charge_lap_thermal_cooldown(
+                            &mut ambient_schedule,
+                            ambient_now,
+                            lap_completed,
+                            lap_consumed_thermal_turn,
+                            thermal_policy,
+                        );
+                        tracing::info!(
+                            "[scheduler] ambient lap complete next_eligible_ms={}",
+                            ambient_schedule
+                                .next_allowed_at
+                                .saturating_duration_since(lap_completed)
+                                .as_millis(),
+                        );
+                        // The ambient lane received its admission opportunity
+                        // for this tick. Empty work is enough to release the
+                        // debt; known selected work owns the shared cooldown
+                        // through `note_thermal_work_completion`.
+                        ambient_turn_owed = false;
+                    }
+                };
             }
             if crate::lifecycle::shutdown_requested(&shutdown) {
                 break;

--- a/crates/wenlan-server/src/scheduler/ambient.rs
+++ b/crates/wenlan-server/src/scheduler/ambient.rs
@@ -14,7 +14,7 @@ pub(super) enum AmbientJob {
 }
 
 impl AmbientJob {
-    const ALL: [Self; 9] = [
+    pub(super) const ALL: [Self; 9] = [
         Self::Document,
         Self::Classification,
         Self::StructuredExtract,
@@ -25,6 +25,43 @@ impl AmbientJob {
         Self::Citation,
         Self::EdgeGroundingPromote,
     ];
+
+    /// Stable key for this job, used for the `app_metadata` last-run record
+    /// and the `/api/ambient/status` wire response. Never renamed once
+    /// shipped — it is a persisted key, not just a debug label.
+    pub(super) const fn as_key(self) -> &'static str {
+        match self {
+            Self::Document => "document",
+            Self::Classification => "classification",
+            Self::StructuredExtract => "structured_extract",
+            Self::Entity => "entity",
+            Self::Title => "title",
+            Self::PageGrowth => "page_growth",
+            Self::Reconcile => "reconcile",
+            Self::Citation => "citation",
+            Self::EdgeGroundingPromote => "edge_grounding_promote",
+        }
+    }
+}
+
+const AMBIENT_LAST_RUN_KEY_PREFIX: &str = "ambient_last_run_v1";
+
+/// `app_metadata` key recording the last time this job was attempted
+/// (selected or not), by either the passive scheduler tick or a forced sweep.
+pub(super) fn ambient_last_run_key(job: AmbientJob) -> String {
+    format!("{AMBIENT_LAST_RUN_KEY_PREFIX}_{}", job.as_key())
+}
+
+async fn persist_ambient_last_run(db: &wenlan_core::db::MemoryDB, job: AmbientJob) {
+    let epoch = chrono::Utc::now().timestamp().to_string();
+    if let Err(error) = db
+        .set_app_metadata(&ambient_last_run_key(job), &epoch)
+        .await
+    {
+        tracing::warn!(
+            "[scheduler] failed to persist ambient last-run timestamp for {job:?}: {error}"
+        );
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -153,6 +190,42 @@ impl AmbientSchedule {
         None
     }
 
+    /// Enumerate every currently-due job for one bounded scheduler tick — at
+    /// most one full round-robin lap.
+    ///
+    /// Without this, a quiet tick only ever fires the single job the cursor
+    /// lands on; an always-due job at an earlier cursor position (Document,
+    /// which has no interval) can starve a job several slots further round
+    /// (e.g. Citation) for many ticks.
+    ///
+    /// The loop bound is "stop the first time `select_due` repeats a job
+    /// already collected this call", not merely "call `select_due` at most
+    /// `ALL.len()` times": collecting due jobs up front does not call
+    /// `note_job_result` in between (that only happens once each job has
+    /// actually run, back in the caller), so a job's due-ness is invariant
+    /// for the whole `drain_due` call. If fewer than `ALL.len()` jobs are
+    /// currently due-and-supported, `select_due`'s own internal scan (itself
+    /// bounded to one lap) can still cross a full circuit within a single
+    /// call and land back on an already-returned job — counting outer
+    /// `select_due` *calls* does not bound total *probes*. Detecting the
+    /// repeat, rather than counting calls, is what actually keeps every job
+    /// in the result at most once.
+    pub(super) fn drain_due(
+        &mut self,
+        now: Instant,
+        availability: AmbientAvailability,
+    ) -> Vec<AmbientJob> {
+        let mut due = Vec::with_capacity(AmbientJob::ALL.len());
+        for _ in 0..AmbientJob::ALL.len() {
+            match self.select_due(now, availability) {
+                Some(job) if due.contains(&job) => break,
+                Some(job) => due.push(job),
+                None => break,
+            }
+        }
+        due
+    }
+
     /// Back off an empty periodic lane, but leave known backlog due. The global
     /// thermal cooldown still limits actual work; this only prevents a second
     /// 30-minute delay from turning catch-up into a multi-week drain.
@@ -258,7 +331,7 @@ pub(super) async fn run_ambient_job_safe(
         distillation,
         knowledge_path,
     ));
-    match futures::FutureExt::catch_unwind(future).await {
+    let report = match futures::FutureExt::catch_unwind(future).await {
         Ok(report) => report,
         Err(error) => {
             let message = if let Some(message) = error.downcast_ref::<&str>() {
@@ -280,7 +353,11 @@ pub(super) async fn run_ambient_job_safe(
                 elapsed: started.elapsed(),
             }
         }
-    }
+    };
+    // Record every attempt (selected or not) so `/api/ambient/status` can
+    // show liveness even for a job that keeps finding nothing to do.
+    persist_ambient_last_run(db, job).await;
+    report
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/wenlan-server/src/scheduler/ambient_admin.rs
+++ b/crates/wenlan-server/src/scheduler/ambient_admin.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Operator-facing entry points into the ambient scheduler: a synchronous
+//! force-sweep trigger and a status snapshot. Both are read/act surfaces for
+//! `crate::ambient_routes`; neither owns any scheduling state of its own —
+//! the passive scheduler tick in `scheduler.rs` remains the only place that
+//! advances `AmbientSchedule`'s round-robin cursor and thermal cooldown.
+
+use super::*;
+
+/// Outcome of one forced attempt at a single ambient job.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AmbientJobSweepResult {
+    pub job: &'static str,
+    /// False when the job's own availability gate (provider health, or an
+    /// opt-in flag like `citation_backfill_enabled`) parked it — the sweep
+    /// still bypasses the idle/resource gate and each job's periodic
+    /// due-check, but never bypasses explicit user consent.
+    pub attempted: bool,
+    pub selected: bool,
+    pub llm_calls: usize,
+    pub panicked: bool,
+    pub elapsed_ms: u128,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AmbientSweepReport {
+    pub phases: Vec<AmbientJobSweepResult>,
+}
+
+/// Force one bounded, synchronous pass over every ambient job type, bypassing
+/// the idle/resource gate and each job's periodic due-check (`ENRICHMENT_
+/// SWEEP_INTERVAL` and friends). Each job's own per-call slice bound is
+/// unchanged — Document still claims one document, Citation still backfills
+/// one page, etc. — only the *scheduling* gate is bypassed, not the batch
+/// size.
+///
+/// This does not touch `AmbientSchedule.next_allowed_at` (the passive
+/// scheduler's thermal cooldown clock): that state lives inside the spawned
+/// scheduler task's local loop variables, not in `SharedState`, so a forced
+/// sweep and the background scheduler are not mutually cooling down — each
+/// side still only throttles its own future runs. That is an accepted,
+/// documented limitation, not an oversight. They *are* mutually exclusive in
+/// time, though: `ServerState::ambient_run_lock` (held by the caller in
+/// `crate::ambient_routes::handle_ambient_sweep`, not by this function)
+/// keeps a forced sweep and a passive scheduler tick from ever executing
+/// ambient jobs concurrently, even though neither one's cooldown clock knows
+/// about the other's completed work.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn force_ambient_sweep(
+    db: &Arc<wenlan_core::db::MemoryDB>,
+    llm: Option<&Arc<dyn wenlan_core::llm_provider::LlmProvider>>,
+    api_llm: Option<&Arc<dyn wenlan_core::llm_provider::LlmProvider>>,
+    external_llm: Option<&Arc<dyn wenlan_core::llm_provider::LlmProvider>>,
+    everyday_pin: Option<wenlan_core::refinery::EverydaySource>,
+    prompts: &wenlan_core::prompts::PromptRegistry,
+    refinery: &wenlan_core::tuning::RefineryConfig,
+    distillation: &wenlan_core::tuning::DistillationConfig,
+    knowledge_path: Option<&std::path::Path>,
+) -> AmbientSweepReport {
+    let provider_available =
+        resolve_ambient_provider(everyday_pin, api_llm, external_llm, llm).is_some();
+    let availability = AmbientAvailability::for_provider(provider_available);
+
+    let mut phases = Vec::with_capacity(AmbientJob::ALL.len());
+    for job in AmbientJob::ALL {
+        if !availability.supports(job) {
+            phases.push(AmbientJobSweepResult {
+                job: job.as_key(),
+                attempted: false,
+                selected: false,
+                llm_calls: 0,
+                panicked: false,
+                elapsed_ms: 0,
+            });
+            continue;
+        }
+        let report = run_ambient_job_safe(
+            job,
+            db,
+            llm,
+            api_llm,
+            external_llm,
+            everyday_pin,
+            prompts,
+            refinery,
+            distillation,
+            knowledge_path,
+        )
+        .await;
+        phases.push(AmbientJobSweepResult {
+            job: job.as_key(),
+            attempted: true,
+            selected: report.selected,
+            llm_calls: report.llm_calls,
+            panicked: report.panicked,
+            elapsed_ms: report.elapsed.as_millis(),
+        });
+    }
+    AmbientSweepReport { phases }
+}
+
+/// Latest resource/host-activity admission observed by the background
+/// scheduler tick. The HTTP status handler reads this instead of sampling
+/// CPU/host-activity itself: a freshly constructed `SystemResourceProbe`
+/// always reports "warming" until its own first real interval passes, so an
+/// independently sampled probe could never agree with the real gate the
+/// scheduler actually enforces — it would just be a second, disagreeing
+/// opinion.
+#[derive(Debug, Clone)]
+pub struct AmbientGateSnapshot {
+    pub admitted: bool,
+    pub blocked_reason: Option<String>,
+    pub sampled_at_epoch: i64,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct AmbientStatusReport {
+    pub unchunked_documents: u64,
+    pub pages_missing_citations: u64,
+    /// `None` only before the scheduler's first post-startup tick has run.
+    pub idle_gate_admitted: Option<bool>,
+    pub idle_gate_blocked_reason: Option<String>,
+    pub idle_gate_sampled_at_epoch: Option<i64>,
+    /// Unix-epoch seconds of the last attempt at each job (selected or not),
+    /// keyed by `AmbientJob::as_key()`. `None` means never attempted.
+    pub phase_last_run_epoch: std::collections::BTreeMap<String, Option<i64>>,
+}
+
+/// A missing-citations count above this cap is reported as the cap, not the
+/// true total — enough to answer "is this queue draining", not an exact
+/// backlog size, and cheap regardless of how large the real backlog is.
+const CITATION_STATUS_COUNT_LIMIT: usize = 5_000;
+
+pub(crate) async fn ambient_status(
+    db: &wenlan_core::db::MemoryDB,
+    gate: Option<AmbientGateSnapshot>,
+) -> Result<AmbientStatusReport, wenlan_core::WenlanError> {
+    let queue = db.document_enrichment_queue_status().await?;
+    let pages_missing_citations = db
+        .get_pages_missing_citations(CITATION_STATUS_COUNT_LIMIT)
+        .await?
+        .len() as u64;
+
+    let mut phase_last_run_epoch = std::collections::BTreeMap::new();
+    for job in AmbientJob::ALL {
+        let last_run = db
+            .get_app_metadata(&ambient_last_run_key(job))
+            .await
+            .ok()
+            .flatten()
+            .and_then(|value| value.parse::<i64>().ok());
+        phase_last_run_epoch.insert(job.as_key().to_string(), last_run);
+    }
+
+    Ok(AmbientStatusReport {
+        unchunked_documents: queue.pending,
+        pages_missing_citations,
+        idle_gate_admitted: gate.as_ref().map(|snapshot| snapshot.admitted),
+        idle_gate_blocked_reason: gate
+            .as_ref()
+            .and_then(|snapshot| snapshot.blocked_reason.clone()),
+        idle_gate_sampled_at_epoch: gate.map(|snapshot| snapshot.sampled_at_epoch),
+        phase_last_run_epoch,
+    })
+}

--- a/crates/wenlan-server/src/scheduler/scheduler_tests.rs
+++ b/crates/wenlan-server/src/scheduler/scheduler_tests.rs
@@ -386,6 +386,84 @@ fn ambient_schedule_round_robins_all_due_jobs() {
 }
 
 #[test]
+fn drain_due_returns_the_full_lap_in_cursor_order_when_everything_is_due() {
+    let now = Instant::now();
+    let mut schedule = AmbientSchedule::new(now);
+    let available = AmbientAvailability {
+        document: true,
+        classification: true,
+        structured_extract: true,
+        entity: true,
+        title: true,
+        page_growth: true,
+        reconcile: true,
+        citation: true,
+        edge_grounding_promote: true,
+    };
+    assert_eq!(
+        schedule.drain_due(now, available),
+        vec![
+            AmbientJob::Document,
+            AmbientJob::Classification,
+            AmbientJob::StructuredExtract,
+            AmbientJob::Entity,
+            AmbientJob::Title,
+            AmbientJob::PageGrowth,
+            AmbientJob::Reconcile,
+            AmbientJob::Citation,
+            AmbientJob::EdgeGroundingPromote,
+        ]
+    );
+}
+
+#[test]
+fn drain_due_lets_a_later_cursor_job_run_alongside_an_always_due_earlier_one() {
+    // Reproduces the reported starvation directly: Document (cursor slot 0)
+    // is unconditionally due every tick, while Citation (slot 7) only
+    // becomes due every `CITATION_SWEEP_INTERVAL`. A single-shot `select_due`
+    // per tick lets Document's always-due status re-claim the tick before
+    // the cursor ever reaches Citation. `drain_due` must surface both in one
+    // quiet turn without repeating either.
+    let now = Instant::now();
+    let mut schedule = AmbientSchedule::new(now);
+    let available = AmbientAvailability {
+        document: true,
+        classification: true,
+        structured_extract: true,
+        entity: true,
+        title: true,
+        page_growth: true,
+        reconcile: true,
+        citation: true,
+        edge_grounding_promote: true,
+    };
+    // Mark every periodic lane except Citation as freshly run-and-empty so it
+    // is not due again this instant. Citation and Document are left alone:
+    // Citation because it never ran (due since `last_citation` is `None`),
+    // Document because nothing ever gates it.
+    for job in [
+        AmbientJob::Classification,
+        AmbientJob::StructuredExtract,
+        AmbientJob::Entity,
+        AmbientJob::Title,
+        AmbientJob::PageGrowth,
+        AmbientJob::Reconcile,
+        AmbientJob::EdgeGroundingPromote,
+    ] {
+        schedule.note_job_result(job, now, false);
+    }
+
+    // Without the fix in `drain_due` (bounding by call count instead of by
+    // "stop at the first repeat"), this returns a 9-element vec alternating
+    // [Document, Citation, Document, Citation, ...] instead of stopping
+    // cleanly after each fires exactly once.
+    assert_eq!(
+        schedule.drain_due(now, available),
+        vec![AmbientJob::Document, AmbientJob::Citation]
+    );
+}
+
+#[test]
 fn selected_backlog_lane_stays_due_after_global_cooldown() {
     let now = Instant::now();
     let mut schedule = AmbientSchedule::new(now);
@@ -1305,6 +1383,65 @@ fn ambient_thermal_work_completion_starts_conservative_cooldown() {
 }
 
 #[test]
+fn charge_lap_thermal_cooldown_uses_the_full_lap_elapsed_time_not_a_single_jobs_slice() {
+    // Simulate a two-job lap: Document ran for 8s, then Citation (the last
+    // thermal-consuming job) ran for only 2s — 10s of real lap time in
+    // total. Charging the cooldown against the *lap's* elapsed time (what
+    // `charge_lap_thermal_cooldown` does) must produce a materially
+    // different, larger cooldown than charging it against only the last
+    // job's own 2s slice (what the pre-fix per-job call site did).
+    let lap_started = Instant::now();
+    let lap_completed = lap_started + Duration::from_secs(10);
+    let mut schedule = AmbientSchedule::new(lap_started);
+
+    charge_lap_thermal_cooldown(
+        &mut schedule,
+        lap_started,
+        lap_completed,
+        true, // some job in the lap consumed a thermal turn
+        ThermalPolicy::conservative(),
+    );
+
+    // cooldown_after(10s) = max(120s, 10 * 19) = 190s.
+    assert_eq!(
+        schedule.next_allowed_at,
+        lap_completed + Duration::from_secs(190),
+        "cooldown must be sized from the full 10s lap, not the last job's 2s slice"
+    );
+    // The bug this guards against: charging only the last job's 2s slice
+    // gives cooldown_after(2s) = max(120s, 2 * 19) = 120s — the floor, and
+    // 70s short of the correct 190s. Pin that the fixed behavior is not
+    // merely "at least the floor" but the specific, larger lap-sized value.
+    assert_ne!(
+        schedule.next_allowed_at,
+        lap_completed + Duration::from_secs(120),
+        "must not fall back to the floor value a single 2s job's slice would produce"
+    );
+}
+
+#[test]
+fn charge_lap_thermal_cooldown_leaves_the_cooldown_untouched_when_no_job_in_the_lap_did_billable_work(
+) {
+    let lap_started = Instant::now();
+    let mut schedule = AmbientSchedule::new(lap_started);
+    let next_allowed_before = schedule.next_allowed_at;
+    let lap_completed = lap_started + Duration::from_secs(10);
+
+    charge_lap_thermal_cooldown(
+        &mut schedule,
+        lap_started,
+        lap_completed,
+        false, // every job in the lap was a no-op skip, nothing panicked
+        ThermalPolicy::conservative(),
+    );
+
+    assert_eq!(
+        schedule.next_allowed_at, next_allowed_before,
+        "an all-empty lap must not arm a cooldown at all"
+    );
+}
+
+#[test]
 fn empty_automatic_scan_does_not_consume_a_thermal_turn() {
     assert!(
         !automatic_work_consumes_thermal_turn(false, 0, false),
@@ -1909,6 +2046,159 @@ async fn document_provider_panic_pauses_claimed_generation() {
         .as_deref()
         .is_some_and(|reason| reason.contains("panicked")));
     assert_eq!(after.last_completed_chunk, before.last_completed_chunk);
+}
+
+#[tokio::test]
+async fn force_ambient_sweep_runs_document_and_reports_unsupported_phases_as_not_attempted() {
+    let _lock = crate::TEST_DATA_DIR_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let _env = DataDirGuard::new();
+
+    let source_root = tempfile::tempdir().unwrap();
+    let file_path = source_root.path().join("sweep-note.txt");
+    std::fs::write(
+        &file_path,
+        "Wenlan should chunk this document during a forced sweep, not wait for a quiet tick.",
+    )
+    .unwrap();
+    register_directory_source("directory-sweep", source_root.path());
+
+    let (db, _db_dir) = new_test_db().await;
+    sync_directory_sources(&db).await;
+
+    // No LLM provider configured at all: only Document (which has no
+    // provider gate) should be attempted. Every provider-gated phase must be
+    // reported as `attempted: false`, not silently dropped from `phases`.
+    let report = force_ambient_sweep(
+        &db,
+        None,
+        None,
+        None,
+        None,
+        &wenlan_core::prompts::PromptRegistry::default(),
+        &wenlan_core::tuning::RefineryConfig::default(),
+        &wenlan_core::tuning::DistillationConfig::default(),
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        report.phases.len(),
+        AmbientJob::ALL.len(),
+        "the sweep must report on every ambient job type, not only the ones that ran"
+    );
+
+    let document = report
+        .phases
+        .iter()
+        .find(|phase| phase.job == "document")
+        .expect("document phase must be present in the report");
+    assert!(
+        document.attempted,
+        "Document has no provider gate and must run even with no LLM configured"
+    );
+    assert!(
+        document.selected,
+        "the freshly-synced document should be claimed and chunked by the forced sweep"
+    );
+
+    for job_key in [
+        "classification",
+        "structured_extract",
+        "title",
+        "page_growth",
+    ] {
+        let phase = report
+            .phases
+            .iter()
+            .find(|phase| phase.job == job_key)
+            .unwrap_or_else(|| panic!("{job_key} phase must be present in the report"));
+        assert!(
+            !phase.attempted,
+            "{job_key} requires an LLM provider and must be reported as not attempted"
+        );
+        assert!(!phase.selected);
+        assert_eq!(phase.llm_calls, 0);
+    }
+}
+
+#[tokio::test]
+async fn ambient_status_reports_pending_queue_and_gate_snapshot() {
+    let _lock = crate::TEST_DATA_DIR_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let _env = DataDirGuard::new();
+
+    let source_root = tempfile::tempdir().unwrap();
+    let file_path = source_root.path().join("status-note.txt");
+    std::fs::write(
+        &file_path,
+        "Wenlan should count this as pending before it is chunked.",
+    )
+    .unwrap();
+    register_directory_source("directory-status", source_root.path());
+
+    let (db, _db_dir) = new_test_db().await;
+    sync_directory_sources(&db).await;
+
+    let gate = Some(AmbientGateSnapshot {
+        admitted: false,
+        blocked_reason: Some("HostActive".to_string()),
+        sampled_at_epoch: 1_700_000_000,
+    });
+
+    let status = ambient_status(&db, gate).await.unwrap();
+    assert_eq!(
+        status.unchunked_documents, 1,
+        "the freshly-synced, not-yet-chunked document must count as pending"
+    );
+    assert_eq!(status.idle_gate_admitted, Some(false));
+    assert_eq!(
+        status.idle_gate_blocked_reason.as_deref(),
+        Some("HostActive")
+    );
+    assert_eq!(status.idle_gate_sampled_at_epoch, Some(1_700_000_000));
+    assert_eq!(status.phase_last_run_epoch.len(), AmbientJob::ALL.len());
+    assert!(
+        status.phase_last_run_epoch.values().all(Option::is_none),
+        "nothing has run yet against a fresh database"
+    );
+}
+
+#[tokio::test]
+async fn ambient_status_records_last_run_after_force_ambient_sweep() {
+    let _lock = crate::TEST_DATA_DIR_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    let _env = DataDirGuard::new();
+    let (db, _db_dir) = new_test_db().await;
+
+    force_ambient_sweep(
+        &db,
+        None,
+        None,
+        None,
+        None,
+        &wenlan_core::prompts::PromptRegistry::default(),
+        &wenlan_core::tuning::RefineryConfig::default(),
+        &wenlan_core::tuning::DistillationConfig::default(),
+        None,
+    )
+    .await;
+
+    let status = ambient_status(&db, None).await.unwrap();
+    assert!(
+        status.phase_last_run_epoch["document"].is_some(),
+        "force_ambient_sweep must persist a last-run timestamp for a phase it actually attempted"
+    );
+    assert!(
+        status.phase_last_run_epoch["classification"].is_none(),
+        "a phase parked by the provider gate must not be recorded as having run"
+    );
 }
 
 struct MaintenanceTestProvider {

--- a/crates/wenlan-server/src/state.rs
+++ b/crates/wenlan-server/src/state.rs
@@ -150,6 +150,22 @@ pub struct ServerState {
     pub optional_runtime_workers_suspended: bool,
     pub lint_config: LintServerConfig,
     pub lint_observer: Arc<dyn LintRunObserver>,
+    /// Latest resource/host-activity admission the background ambient
+    /// scheduler tick observed, published each tick so `GET
+    /// /api/ambient/status` can report the idle gate's current state without
+    /// independently re-sampling CPU/host-activity (a fresh sampler would
+    /// always disagree during its own warm-up window). `None` before the
+    /// scheduler's first post-startup tick.
+    pub ambient_gate: Arc<std::sync::Mutex<Option<crate::scheduler::AmbientGateSnapshot>>>,
+    /// Mutual exclusion between `POST /api/ambient/sweep` and the
+    /// scheduler's own passive ambient-lane execution. Both sides run the
+    /// same nine ambient jobs against the same on-device LLM and DB rows;
+    /// letting them run at once would double LLM contention and risks two
+    /// callers claiming the same document/page. The force-sweep endpoint
+    /// holds this for its entire lap; the scheduler tick only `try_lock`s it
+    /// and skips its whole ambient section for that tick if held — it must
+    /// never block its other duties waiting for a multi-minute sweep.
+    pub ambient_run_lock: Arc<Mutex<()>>,
 }
 
 impl Default for ServerState {
@@ -183,6 +199,8 @@ impl Default for ServerState {
             optional_runtime_workers_suspended: false,
             lint_config: LintServerConfig::default(),
             lint_observer: Arc::new(NoopLintRunObserver),
+            ambient_gate: Arc::new(std::sync::Mutex::new(None)),
+            ambient_run_lock: Arc::new(Mutex::new(())),
         }
     }
 }


### PR DESCRIPTION
## What

Two new daemon routes plus a CLI verb for driving the ambient scheduler by hand, and one behavioral fix to the passive quiet-tick path:

- `POST /api/ambient/sweep` — force one bounded synchronous lap over every ambient job type (all 9 phases), bypassing the idle/resource gate only. Consent/availability gates and each job's own per-call slice bound (e.g. citation backfill stays 1 page per call) are unchanged.
- `GET /api/ambient/status` — unchunked-document and pages-missing-citations counts (capped at 5000), per-job last-run epochs persisted under `app_metadata` keys `ambient_last_run_v1_<job>`, and a snapshot of the idle gate (admitted / blocked reason / sampled-at).
- `wenlan sweep` — CLI wrapper for the sweep route with a 600s request timeout, since a full lap can hit the on-device LLM once per job.
- Quiet-tick drain (`drain_due`): one passive tick now drains every currently-due ambient job exactly once, instead of at most one job per tick.

## Why

On a busy machine the idle gate can stay closed for days, and even when it opens, the old one-job-per-tick round robin let an always-due job starve a rarely-due one. `AmbientSchedule::select_due` advances one slot per call and returns the first due job; Document (no interval, always due) sits ahead of Citation (interval-gated), so Citation could wait indefinitely — observed in production as a citation backlog that never drained. The sweep route gives an operator (or the app) a way to force the work now; the status route makes the queue state visible instead of inferred from logs.

## Design notes

- **Drain is bounded by first-repeat detection**, not a call-count: `drain_due` keeps calling `select_due` until it would return a job already run this lap. One tick never runs a job twice and never loops unboundedly.
- **Thermal accounting is per-lap**: since a tick can now run several jobs back to back, `charge_lap_thermal_cooldown` charges `note_thermal_work_completion` once with the full lap's wall time (`lap_completed.saturating_duration_since(lap_started)`), only if some job consumed a thermal turn. Charging only the last job's slice would undershoot the 5%-duty-cycle budget more as laps grow.
- **Mutual exclusion**: `ServerState.ambient_run_lock: Arc<tokio::sync::Mutex<()>>`. The sweep handler `.lock().await`s across the forced lap (an explicit sweep should wait and do the work, not 409). The passive tick only `try_lock`s and skips its ambient section if held, leaving `ambient_turn_owed` untouched so it retries next tick. Holding a `tokio::sync::Mutex` guard across `.await` is fine; the repo invariant bars `RwLock` guards specifically.
- **Accepted limitation** (documented in `ambient_admin.rs`): the forced sweep and the passive scheduler are mutually exclusive in time via the lock but keep independent thermal-cooldown clocks.

## Verification

- `cargo test -p wenlan-server scheduler::` — includes 2 new `drain_due` tests (one a Document-must-not-starve-Citation regression), 2 lap-thermal numeric tests (190s vs the 120s floor), 2 async admin tests.
- RED controls (mutation receipts): reverting `drain_due` to the old call-count loop fails the starvation test with `[Document, Citation, Document, Citation, …]` vs expected `[Document, Citation]` (RC=101); hardcoding a 2s "last job only" thermal slice fails the lap test with the cooldown short by exactly 70s (120s instead of 190s for a 10s lap). Both restored and reran green.
- `cargo test -p wenlan-core -- drift_guard truth_manifest` (172 passed), `cargo test -p wenlan-server --lib` (381+ passed), `cargo check -p wenlan --tests`, `cargo fmt --all -- --check` — green on the rebased head, and the pre-push affected-package closure passed at push time.

## Route-catalog sync surfaces worth knowing about

Registering the 2 routes in the runtime catalogs was not enough; the full affected-package closure (not the scheduler-filtered runs) caught four more sync points. The newest: `crates/wenlan-server/src/route_registry/handler_manifest.txt` (added by the pre-launch audit) pins exact route-to-handler bindings, and a missing row fails every test that builds the router ("route handler binding drift in Main" — 124 tests at once). The other three: the auto-generated call-graph section of `crates/wenlan-core/contracts/m5-reader-manifest-inventory.md` (regenerated via `python3 scripts/m5-reader-sweep.py --update-inventory`), the hand-maintained HTTP table + header in the same document, and hardcoded count literals in `truth_manifest_test.rs` that assert the spec rather than derive it. The pre-commit hook that normally keeps the first in sync was not installed in this worktree. Integrated counts on this head: 166 HTTP readers (59 page-bearing), 170 runtime entries (164 main + 6 repair), 160 marker-shape-none rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY