### PR TITLE
ci(gauntlet): SIGKILL watchdog for post-mortem daemon replays

### DIFF
--- a/scripts/first-run/lib.sh
+++ b/scripts/first-run/lib.sh
@@ -186,15 +186,10 @@ daemon_postmortem() {
         return 0
     fi
     [ -x "$bin" ] || { info daemon-replay "skipped: $bin is not executable"; return 0; }
-    local replay="$GAUNTLET_OUT/checks/daemon-replay.log" rc=0 timeout_bin
-    timeout_bin="$(command -v timeout || command -v gtimeout || true)"
-    (
-        cd / && env -i HOME="$HOME" USER="${USER:-$(id -un)}" PATH=/usr/bin:/bin:/usr/sbin:/sbin \
-            RUST_LOG=info WENLAN_DATA_DIR="$data_root" WENLAN_BIND_ADDR=127.0.0.1:17917 \
-            ${timeout_bin:+"$timeout_bin" 30} "$bin"
-    ) >"$replay" 2>&1 || rc=$?
-    # 124: still running after 30s, i.e. the binary is fine and the fault is
-    # in how the service runs it. Anything else is the daemon's own exit.
+    local replay="$GAUNTLET_OUT/checks/daemon-replay.log" rc=0
+    _replay_capped "$bin" "$replay" 127.0.0.1:17917 || rc=$?
+    # 124: still running (healthy) at 30s, i.e. the binary is fine and the
+    # fault is in how the service runs it. Anything else is the daemon's exit.
     info daemon-replay "rc=$rc (124 = still running at 30s) $(tail -c 1500 "$replay" | tr '\n' '|')"
 
     # Discriminating replay: identical environment shape, but with an explicit
@@ -203,11 +198,39 @@ daemon_postmortem() {
     # both failing points away from it (network/TLS under the service env).
     local replay2="$GAUNTLET_OUT/checks/daemon-replay-cache-dir.log" rc2=0
     mkdir -p "$data_root/replay-cache"
-    ( cd / && env -i HOME="$HOME" USER="${USER:-$(id -un)}" PATH=/usr/bin:/bin:/usr/sbin:/sbin \
-          RUST_LOG=info WENLAN_DATA_DIR="$data_root" WENLAN_BIND_ADDR=127.0.0.1:17918 \
-          FASTEMBED_CACHE_DIR="$data_root/replay-cache" \
-          ${timeout_bin:+"$timeout_bin" 30} "$bin" ) >"$replay2" 2>&1 || rc2=$?
+    _replay_capped "$bin" "$replay2" 127.0.0.1:17918 \
+        FASTEMBED_CACHE_DIR="$data_root/replay-cache" || rc2=$?
     info daemon-replay-cache-dir "rc=$rc2 (124 = still running at 30s) $(tail -c 1500 "$replay2" | tr '\n' '|')"
+}
+
+# Run the daemon exactly as launchd would (cwd /, minimal env) for at most
+# 30 s, then SIGKILL. `timeout` proved insufficient here: in the from-main
+# gauntlet run a replay whose daemon survived init outlived the cap and hung
+# every macOS job into its timeout-minutes, losing the verdict row. A KILL
+# watchdog cannot be ignored or waited out. Exit 124 = killed while running.
+# Usage: _replay_capped <bin> <logfile> <bind_addr> [EXTRA=env ...]
+# Reads $data_root from the calling daemon_postmortem scope. The cap is
+# GAUNTLET_REPLAY_CAP seconds (default 30; the test shortens it).
+_replay_capped() {
+    local bin="$1" log="$2" bind="$3" cap="${GAUNTLET_REPLAY_CAP:-30}"
+    shift 3
+    (
+        cd / || exit 125
+        env -i HOME="$HOME" USER="${USER:-$(id -un)}" PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+            RUST_LOG=info WENLAN_DATA_DIR="$data_root" WENLAN_BIND_ADDR="$bind" \
+            "$@" "$bin" >"$log" 2>&1 &
+        pid=$!
+        for _ in $(seq "$cap"); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 1
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+            kill -9 "$pid" 2>/dev/null
+            wait "$pid" 2>/dev/null
+            exit 124
+        fi
+        wait "$pid"
+    )
 }
 
 collect() {

--- a/scripts/first-run/lib.test.sh
+++ b/scripts/first-run/lib.test.sh
@@ -119,6 +119,29 @@ empty_rc="$(
 )"
 assert "evaluate returns 1 when no findings were recorded" [ "$empty_rc" = 1 ]
 
+# The post-mortem replay watchdog must SIGKILL a daemon that ignores TERM and
+# report 124: a TERM-only cap let a recovered daemon hang the job past its
+# timeout-minutes and lose the verdict row (from-main run, all macOS legs).
+cat >"$tmp/stubborn.sh" <<'EOS'
+#!/bin/sh
+trap '' TERM
+while :; do sleep 1; done
+EOS
+chmod +x "$tmp/stubborn.sh"
+watchdog_rc="$(
+    GAUNTLET_OUT="$tmp/run/findings-watchdog-macos" GAUNTLET_CHANNEL=watchdog \
+    GAUNTLET_REPLAY_CAP=2 bash -c '
+        . "$1/lib.sh" >/dev/null
+        data_root="$GAUNTLET_OUT"
+        if _replay_capped "$2" "$GAUNTLET_OUT/checks/stubborn.log" 127.0.0.1:17999; then
+            echo 0
+        else
+            echo $?
+        fi
+    ' _ "$here" "$tmp/stubborn.sh"
+)"
+assert "replay watchdog kills a TERM-ignoring daemon with rc 124" [ "$watchdog_rc" = 124 ]
+
 echo "== summary.py"
 summary="$(python3 "$here/summary.py" "$tmp/run")"
 assert "table header"              grep -q '^| Channel | Label | PASS | FAIL | INFO | seconds-to-health | Worst |$' <<<"$summary"


### PR DESCRIPTION
## What

The from-main gauntlet run (32706075944) confirmed F4 via the discriminating replay: with an absolute `FASTEMBED_CACHE_DIR` the daemon printed `WENLAN_LISTENING_ON=127.0.0.1:17918` under the exact launchd environment shape, while the default-cache replay died with the embedder error — same host, same minute, one variable. But the recovered daemon then outlived the replay's 30s cap: all three macOS jobs hung until their own `timeout-minutes`, GitHub reported them (and the run) as **cancelled**, and the `daemon-replay-cache-dir` verdict row was lost.

## Fix

- `scripts/first-run/lib.sh`: replace the `timeout`/`gtimeout` invocation with a shared `_replay_capped` helper — daemon in the background of the replay subshell, poll `GAUNTLET_REPLAY_CAP` seconds (default 30), then SIGKILL. A KILL watchdog cannot be ignored or waited out, so the info row is always written and the job never hangs.
- `scripts/first-run/lib.test.sh`: new case proves a TERM-ignoring daemon is killed with rc 124 (cap shortened to 2s for the test).

## Verification

- `bash scripts/first-run/lib.test.sh`: 38/38 assertions pass (4.5s), including the new watchdog case.
- `shellcheck -x` clean on both files; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh