### PR TITLE
ci(gauntlet): harden two review-flagged evidence gaps

### DIFF
--- a/scripts/first-run/lib.sh
+++ b/scripts/first-run/lib.sh
@@ -187,7 +187,7 @@ daemon_postmortem() {
     fi
     [ -x "$bin" ] || { info daemon-replay "skipped: $bin is not executable"; return 0; }
     local replay="$GAUNTLET_OUT/checks/daemon-replay.log" rc=0
-    _replay_capped "$bin" "$replay" 127.0.0.1:17917 || rc=$?
+    _replay_capped "$bin" "$replay" "$data_root" 127.0.0.1:17917 || rc=$?
     # 124: still running (healthy) at 30s, i.e. the binary is fine and the
     # fault is in how the service runs it. Anything else is the daemon's exit.
     info daemon-replay "rc=$rc (124 = still running at 30s) $(tail -c 1500 "$replay" | tr '\n' '|')"
@@ -198,7 +198,7 @@ daemon_postmortem() {
     # both failing points away from it (network/TLS under the service env).
     local replay2="$GAUNTLET_OUT/checks/daemon-replay-cache-dir.log" rc2=0
     mkdir -p "$data_root/replay-cache"
-    _replay_capped "$bin" "$replay2" 127.0.0.1:17918 \
+    _replay_capped "$bin" "$replay2" "$data_root" 127.0.0.1:17918 \
         FASTEMBED_CACHE_DIR="$data_root/replay-cache" || rc2=$?
     info daemon-replay-cache-dir "rc=$rc2 (124 = still running at 30s) $(tail -c 1500 "$replay2" | tr '\n' '|')"
 }
@@ -208,12 +208,11 @@ daemon_postmortem() {
 # gauntlet run a replay whose daemon survived init outlived the cap and hung
 # every macOS job into its timeout-minutes, losing the verdict row. A KILL
 # watchdog cannot be ignored or waited out. Exit 124 = killed while running.
-# Usage: _replay_capped <bin> <logfile> <bind_addr> [EXTRA=env ...]
-# Reads $data_root from the calling daemon_postmortem scope. The cap is
-# GAUNTLET_REPLAY_CAP seconds (default 30; the test shortens it).
+# Usage: _replay_capped <bin> <logfile> <data_root> <bind_addr> [EXTRA=env ...]
+# The cap is GAUNTLET_REPLAY_CAP seconds (default 30; the test shortens it).
 _replay_capped() {
-    local bin="$1" log="$2" bind="$3" cap="${GAUNTLET_REPLAY_CAP:-30}"
-    shift 3
+    local bin="$1" log="$2" data_root="$3" bind="$4" cap="${GAUNTLET_REPLAY_CAP:-30}"
+    shift 4
     (
         cd / || exit 125
         env -i HOME="$HOME" USER="${USER:-$(id -un)}" PATH=/usr/bin:/bin:/usr/sbin:/sbin \

--- a/scripts/first-run/lib.test.sh
+++ b/scripts/first-run/lib.test.sh
@@ -120,8 +120,9 @@ empty_rc="$(
 assert "evaluate returns 1 when no findings were recorded" [ "$empty_rc" = 1 ]
 
 # The post-mortem replay watchdog must SIGKILL a daemon that ignores TERM and
-# report 124: a TERM-only cap let a recovered daemon hang the job past its
-# timeout-minutes and lose the verdict row (from-main run, all macOS legs).
+# report 124: the macos-15 runner image ships no timeout/gtimeout, so the old
+# optional cap silently did not exist and a recovered daemon hung every macOS
+# job past its timeout-minutes, losing the verdict row (from-main run).
 cat >"$tmp/stubborn.sh" <<'EOS'
 #!/bin/sh
 trap '' TERM
@@ -132,8 +133,7 @@ watchdog_rc="$(
     GAUNTLET_OUT="$tmp/run/findings-watchdog-macos" GAUNTLET_CHANNEL=watchdog \
     GAUNTLET_REPLAY_CAP=2 bash -c '
         . "$1/lib.sh" >/dev/null
-        data_root="$GAUNTLET_OUT"
-        if _replay_capped "$2" "$GAUNTLET_OUT/checks/stubborn.log" 127.0.0.1:17999; then
+        if _replay_capped "$2" "$GAUNTLET_OUT/checks/stubborn.log" "$GAUNTLET_OUT" 127.0.0.1:17999; then
             echo 0
         else
             echo $?

--- a/scripts/first-run/windows-nsis.ps1
+++ b/scripts/first-run/windows-nsis.ps1
@@ -157,6 +157,19 @@ try {
     } catch { Info "screenshot" "skipped: $($_.Exception.Message)" }
 
     if ($App) { Stop-Process -Id $App.Id -Force -ErrorAction SilentlyContinue }
+    # A surviving daemon is only an orphan if the app really died: prove the
+    # kill landed before blaming the sidecar (adversarial review, F13).
+    Check -Name "app-exited-after-kill" -Script {
+        if (-not $App) { throw "no app process handle to kill" }
+        for ($attempt = 0; $attempt -lt 20; $attempt++) {
+            if (-not (Get-Process -Id $App.Id -ErrorAction SilentlyContinue)) {
+                Write-Output "app pid $($App.Id) exited"
+                return
+            }
+            Start-Sleep -Milliseconds 500
+        }
+        throw "app pid $($App.Id) still alive 10s after Stop-Process"
+    }
     Check -Name "sidecar-exits-after-app" -Script {
         $left = $null
         for ($attempt = 0; $attempt -lt 20; $attempt++) {


### PR DESCRIPTION
Follow-ups from adversarial review round 2 (Codex Sol) of the from-main gauntlet run:

- **windows-nsis.ps1**: new `app-exited-after-kill` check proves the app pid actually exited after `Stop-Process` before the orphan-sidecar assertion runs. `Stop-Process` errors were suppressed, so the F13 orphan claim rested on an unverified kill.
- **lib.sh**: `_replay_capped` now takes `data_root` as an argument instead of reading it from the caller's dynamic scope.
- **lib.test.sh**: corrected the watchdog comment — the macos-15 runner image ships no `timeout`/`gtimeout`, so the pre-#588 optional cap silently did not exist (#588's description said a TERM-only cap was outlived; that diagnosis was refuted, the fix stands).

Verification: `bash scripts/first-run/lib.test.sh` 38/38 pass; `shellcheck -x` clean. No local pwsh; the windows CI leg parses the ps1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh