### PR TITLE
fix(cli,mcp): first-hour hints and the real pages path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,9 @@ claim hooks are active without checking the current worktree.
 - Dev and production use the same daemon port and data roots by default. Isolated tests
   that can create pages must isolate the daemon port, `WENLAN_DATA_DIR`, and the
   configured knowledge/page path, then verify the live daemon reports those scratch
-  paths.
+  paths. For a scratch daemon, the CLI reads `WENLAN_HOST` (a full URL such as
+  `http://127.0.0.1:17917`, not a port), `wenlan-mcp` takes `--origin-url`, and the
+  default pages folder follows `HOME`, not `WENLAN_DATA_DIR`.
 - Request defaults: `WENLAN_AGENT_NAME` supplies the CLI identity when no explicit
   agent name is given; `WENLAN_DEFAULT_SPACE` is an overridable CLI/MCP fallback, while
   the strict `WENLAN_SPACE` lock wins over both explicit and default values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,8 @@ claim hooks are active without checking the current worktree.
   configured knowledge/page path, then verify the live daemon reports those scratch
   paths. For a scratch daemon, the CLI reads `WENLAN_HOST` (a full URL such as
   `http://127.0.0.1:17917`, not a port), `wenlan-mcp` takes `--origin-url`, and the
-  default pages folder follows `HOME`, not `WENLAN_DATA_DIR`.
+  default pages folder is `.wenlan/pages` under the OS user-home directory, not under
+  `WENLAN_DATA_DIR` — a portable scratch setup sets `knowledge_path` explicitly.
 - Request defaults: `WENLAN_AGENT_NAME` supplies the CLI identity when no explicit
   agent name is given; `WENLAN_DEFAULT_SPACE` is an overridable CLI/MCP fallback, while
   the strict `WENLAN_SPACE` lock wins over both explicit and default values.

--- a/crates/wenlan-cli/src/commands/pages.rs
+++ b/crates/wenlan-cli/src/commands/pages.rs
@@ -297,7 +297,7 @@ fn print_list(shown: &[(String, usize)], total_titles: usize, total_pages: usize
     if total_pages == 0 {
         println!("(no pages in {})", dir.display());
         println!(
-            "  Pages are written by /distill in the Claude Code plugin once 3 or more related memories exist in a space."
+            "  Pages come from the distill tool (/distill in the Claude Code or Codex plugin, or any MCP client) once a few related memories exist, or from the page editor in the Wenlan app."
         );
         return;
     }

--- a/crates/wenlan-cli/src/commands/pages.rs
+++ b/crates/wenlan-cli/src/commands/pages.rs
@@ -296,6 +296,9 @@ fn render_citations(citations: &[wenlan_types::pages::PageCitation]) -> String {
 fn print_list(shown: &[(String, usize)], total_titles: usize, total_pages: usize, dir: &Path) {
     if total_pages == 0 {
         println!("(no pages in {})", dir.display());
+        println!(
+            "  Pages are written by /distill in the Claude Code plugin once 3 or more related memories exist in a space."
+        );
         return;
     }
     if shown.len() < total_titles {

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -251,25 +251,8 @@ pub async fn run_doctor() -> anyhow::Result<()> {
     print_model_status();
     print_reranker_status().await;
 
-    let cfg = config::load_config();
-    let has_key = cfg
-        .anthropic_api_key
-        .as_deref()
-        .map(|s| !s.trim().is_empty())
-        .unwrap_or(false);
-    let has_cached_model = configured_model()
-        .map(on_device_models::is_cached)
-        .unwrap_or(false);
-
     println!();
-    if has_key || has_cached_model {
-        println!("Model provider: available for explicit foreground use.");
-        println!("  Provider availability does not authorize background inference.");
-    } else {
-        println!("Model provider: none configured.");
-        println!("  Run: wenlan models install");
-        println!("  Or:  wenlan keys set anthropic");
-    }
+    print_model_provider_hint();
     print_enrichment_status().await;
 
     let cwd = std::env::current_dir()?;
@@ -313,6 +296,7 @@ fn print_daemon_log_paths() {
 pub async fn print_runtime_status() -> anyhow::Result<()> {
     print_key_status();
     print_model_status();
+    print_model_provider_hint();
     print_reranker_status().await;
     print_enrichment_status().await;
     Ok(())
@@ -395,6 +379,27 @@ fn print_model_status() {
             "not downloaded"
         }
     );
+}
+
+fn print_model_provider_hint() {
+    let cfg = config::load_config();
+    let has_key = cfg
+        .anthropic_api_key
+        .as_deref()
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+    let has_cached_model = configured_model()
+        .map(on_device_models::is_cached)
+        .unwrap_or(false);
+
+    if has_key || has_cached_model {
+        println!("Model provider: available for explicit foreground use.");
+        println!("  Provider availability does not authorize background inference.");
+    } else {
+        println!("Model provider: none configured.");
+        println!("  Run: wenlan models install");
+        println!("  Or:  wenlan keys set anthropic");
+    }
 }
 
 async fn install_model(model_id: &str, yes: bool) -> anyhow::Result<()> {

--- a/crates/wenlan-cli/src/main.rs
+++ b/crates/wenlan-cli/src/main.rs
@@ -100,7 +100,7 @@ enum Commands {
     },
     /// Connect Wenlan to a supported agent or editor.
     Connect(commands::mcp::ConnectArgs),
-    /// Search memories and pages by query (hybrid vector + keyword); --limit controls the count.
+    /// Search memories and pages by query (hybrid vector + keyword); --limit caps the primary results, plus up to 3 supplemental pages.
     Search {
         /// Search query.
         query: String,
@@ -108,7 +108,7 @@ enum Commands {
         #[arg(short, long, default_value_t = 10)]
         limit: usize,
     },
-    /// Recall the memories most relevant to a query (memories only, scored, top 20).
+    /// Recall scored memories for a query (up to 20; the table shows the top 10, JSON also carries supplemental pages).
     Recall {
         /// Query to recall memories for.
         query: String,

--- a/crates/wenlan-cli/src/main.rs
+++ b/crates/wenlan-cli/src/main.rs
@@ -100,7 +100,7 @@ enum Commands {
     },
     /// Connect Wenlan to a supported agent or editor.
     Connect(commands::mcp::ConnectArgs),
-    /// Search memories by query (vector + FTS hybrid).
+    /// Search memories and pages by query (hybrid vector + keyword); --limit controls the count.
     Search {
         /// Search query.
         query: String,
@@ -108,7 +108,7 @@ enum Commands {
         #[arg(short, long, default_value_t = 10)]
         limit: usize,
     },
-    /// Recall memories relevant to a query.
+    /// Recall the memories most relevant to a query (memories only, scored, top 20).
     Recall {
         /// Query to recall memories for.
         query: String,

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -2528,7 +2528,7 @@ impl WenlanMcpServer {
     }
 
     #[tool(
-        description = "Create or refresh a distilled wiki page. Omit page_id to create a new page (title required); the daemon writes the DB row and the on-disk ~/.wenlan/pages/<slug>.md projection atomically. Pass page_id (from the `stale_pages` block in distill output) to refresh that page in place — replaces content + source_memory_ids + optional summary, clears stale_reason, preserves page_id and created_at, bumps version monotonically so external [[wikilinks]] keep working. Never delete_page + recreate to refresh: that churns ids and loses version history. Refresh is not available over remote HTTP MCP transport (local stdio only).",
+        description = "Create or refresh a distilled wiki page. Omit page_id to create a new page (title required); the daemon writes the DB row and the on-disk <pages dir>/<slug>.md projection atomically (default ~/.wenlan/pages/, slug made unique on collision). Pass page_id (from the `stale_pages` block in distill output) to refresh that page in place — replaces content + source_memory_ids + optional summary, clears stale_reason, preserves page_id and created_at, bumps version monotonically so external [[wikilinks]] keep working. Never delete_page + recreate to refresh: that churns ids and loses version history. Refresh is not available over remote HTTP MCP transport (local stdio only).",
         annotations(
             title = "Write page",
             read_only_hint = false,

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -2520,7 +2520,7 @@ impl WenlanMcpServer {
     }
 
     #[tool(
-        description = "Create or refresh a distilled wiki page. Omit page_id to create a new page (title required); the daemon writes the DB row and the on-disk .origin/pages/<slug>.md projection atomically. Pass page_id (from the `stale_pages` block in distill output) to refresh that page in place — replaces content + source_memory_ids + optional summary, clears stale_reason, preserves page_id and created_at, bumps version monotonically so external [[wikilinks]] keep working. Never delete_page + recreate to refresh: that churns ids and loses version history. Refresh is not available over remote HTTP MCP transport (local stdio only).",
+        description = "Create or refresh a distilled wiki page. Omit page_id to create a new page (title required); the daemon writes the DB row and the on-disk ~/.wenlan/pages/<slug>.md projection atomically. Pass page_id (from the `stale_pages` block in distill output) to refresh that page in place — replaces content + source_memory_ids + optional summary, clears stale_reason, preserves page_id and created_at, bumps version monotonically so external [[wikilinks]] keep working. Never delete_page + recreate to refresh: that churns ids and loses version history. Refresh is not available over remote HTTP MCP transport (local stdio only).",
         annotations(
             title = "Write page",
             read_only_hint = false,

--- a/crates/wenlan-server/src/page_routes.rs
+++ b/crates/wenlan-server/src/page_routes.rs
@@ -204,7 +204,7 @@ pub async fn handle_archive_page(
 
 /// DELETE /api/pages/{id}
 ///
-/// Removes both the DB row and the projected `~/.wenlan/pages/<slug>.md`
+/// Removes both the DB row and the projected `<pages dir>/<slug>.md`
 /// file. DB-first so a transient md removal failure leaves a stale file
 /// (cheap to clean up) rather than a stranded DB row (invisible to the
 /// user). The md side failing is logged but not surfaced as an error —
@@ -270,7 +270,8 @@ pub async fn handle_search_pages(
 
 /// POST /api/pages
 ///
-/// Atomic md-first + DB-index. The `~/.wenlan/pages/<slug>.md` file is the
+/// Atomic md-first + DB-index. The `<pages dir>/<slug>.md` file (default
+/// `~/.wenlan/pages/`, slug made unique on collision) is the
 /// human-readable canonical form; the DB row is the hybrid index over it.
 /// If the DB insert fails after the md write succeeds, the md file is
 /// removed so the two stores stay consistent.

--- a/crates/wenlan-server/src/page_routes.rs
+++ b/crates/wenlan-server/src/page_routes.rs
@@ -204,7 +204,7 @@ pub async fn handle_archive_page(
 
 /// DELETE /api/pages/{id}
 ///
-/// Removes both the DB row and the projected `.origin/pages/<slug>.md`
+/// Removes both the DB row and the projected `~/.wenlan/pages/<slug>.md`
 /// file. DB-first so a transient md removal failure leaves a stale file
 /// (cheap to clean up) rather than a stranded DB row (invisible to the
 /// user). The md side failing is logged but not surfaced as an error —
@@ -270,7 +270,7 @@ pub async fn handle_search_pages(
 
 /// POST /api/pages
 ///
-/// Atomic md-first + DB-index. The `.origin/pages/<slug>.md` file is the
+/// Atomic md-first + DB-index. The `~/.wenlan/pages/<slug>.md` file is the
 /// human-readable canonical form; the DB row is the hybrid index over it.
 /// If the DB insert fails after the md write succeeds, the md file is
 /// removed so the two stores stay consistent.


### PR DESCRIPTION
## Summary

First-hour text fixes found by the usefulness soak (`wenlan-usefulness-soak-2026-08-25.md`, gaps 2, 3, 5, 8). A new user on a modelless install sees no next step in three places and reads a stale path in a fourth.

- `wenlan pages` on an empty store now says where pages come from (the plugin's `/distill`, once 3 or more related memories exist in a space).
- `wenlan status` now prints the same model-provider next step that `wenlan doctor` already prints (`wenlan models install` / `wenlan keys set anthropic`); the block is one shared helper so doctor output is unchanged.
- `wenlan --help` now distinguishes `search` (hybrid vector + keyword, `--limit`, page hits) from `recall` (memories only, scored, top 20).
- The MCP `write_page` description and two `page_routes.rs` doc comments named `.origin/pages/<slug>.md`; the default pages folder is `~/.wenlan/pages/<slug>.md` (`config.rs:142-151`).
- `AGENTS.md`: one sentence on isolating a scratch daemon (`WENLAN_HOST` is a full URL, `wenlan-mcp` takes `--origin-url`, the pages folder follows `HOME`).

## Verification

- `cargo check -p wenlan-cli -p wenlan-mcp -p wenlan-server`, `cargo test -p wenlan-cli`, `git diff --check` — receipts in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
