### PR TITLE
fix(core): split oversized distill clusters in steps instead of dropping them

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -2552,6 +2552,13 @@ fn has_capture_seed_floor(memories: &[ClusterMemRow], cluster: &DistillationClus
         >= MIN_CAPTURE_SEED_MEMBERS
 }
 
+/// Bounded re-split ladder for an oversized cluster (see `cluster_distillation_rows`):
+/// each round tightens the similarity threshold by this much...
+const RESPLIT_STEP: f64 = 0.05;
+/// ...until it hits this ceiling, past which an oversized sub-cluster is dropped
+/// rather than tightened further.
+const RESPLIT_MAX_THRESHOLD: f64 = 0.92;
+
 #[derive(Debug, Clone, Copy)]
 enum DistillationClusterMode {
     SpaceScoped,
@@ -2583,13 +2590,38 @@ fn cluster_distillation_rows(
                           indices: &[usize],
                           cap: usize,
                           clusters: &mut Vec<DistillationCluster>| {
-        let sub = cluster_by_similarity(memories, indices, similarity_threshold);
-        for group in sub {
+        // FIFO queue of (group, threshold-that-produced-it), seeded at
+        // `similarity_threshold`. An oversized group is re-split in
+        // `RESPLIT_STEP` increments (pushed to the back) rather than given a
+        // single re-split attempt, so a stubborn cluster tightens repeatedly
+        // up to `RESPLIT_MAX_THRESHOLD` before it is dropped. Popping from
+        // the front preserves today's output order for groups that never
+        // need a re-split.
+        let mut queue: std::collections::VecDeque<(Vec<usize>, f64)> =
+            cluster_by_similarity(memories, indices, similarity_threshold)
+                .into_iter()
+                .map(|group| (group, similarity_threshold))
+                .collect();
+
+        while let Some((group, threshold)) = queue.pop_front() {
             if group.len() < min_size {
                 continue;
             }
             if group.len() > cap {
-                let tighter = (similarity_threshold + 0.05).min(0.92);
+                if threshold >= RESPLIT_MAX_THRESHOLD {
+                    log::warn!(
+                        "[distill] dropping {} sub-cluster after re-split: \
+                             {} memories still > cap {} at threshold {:.2} -- raise \
+                             max_{}_cluster_size if this is a genuine page",
+                        bucket_label,
+                        group.len(),
+                        cap,
+                        threshold,
+                        bucket_label,
+                    );
+                    continue;
+                }
+                let tighter = (threshold + RESPLIT_STEP).min(RESPLIT_MAX_THRESHOLD);
                 log::info!(
                     "[distill] re-splitting oversized {} cluster: \
                          {} memories at threshold {:.2} (cap = {})",
@@ -2600,23 +2632,7 @@ fn cluster_distillation_rows(
                 );
                 let resplit = cluster_by_similarity(memories, &group, tighter);
                 for sub_group in resplit {
-                    if sub_group.len() < min_size {
-                        continue;
-                    }
-                    if sub_group.len() > cap {
-                        log::warn!(
-                            "[distill] dropping {} sub-cluster after re-split: \
-                                 {} memories still > cap {} -- raise \
-                                 max_{}_cluster_size if this is a genuine page",
-                            bucket_label,
-                            sub_group.len(),
-                            cap,
-                            bucket_label,
-                        );
-                        continue;
-                    }
-                    let cluster = build_distillation_cluster(memories, &sub_group);
-                    emit_split(cluster, clusters);
+                    queue.push_back((sub_group, tighter));
                 }
                 continue;
             }

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -2590,54 +2590,57 @@ fn cluster_distillation_rows(
                           indices: &[usize],
                           cap: usize,
                           clusters: &mut Vec<DistillationCluster>| {
-        // FIFO queue of (group, threshold-that-produced-it), seeded at
-        // `similarity_threshold`. An oversized group is re-split in
-        // `RESPLIT_STEP` increments (pushed to the back) rather than given a
-        // single re-split attempt, so a stubborn cluster tightens repeatedly
-        // up to `RESPLIT_MAX_THRESHOLD` before it is dropped. Popping from
-        // the front preserves today's output order for groups that never
-        // need a re-split.
-        let mut queue: std::collections::VecDeque<(Vec<usize>, f64)> =
-            cluster_by_similarity(memories, indices, similarity_threshold)
-                .into_iter()
-                .map(|group| (group, similarity_threshold))
-                .collect();
-
-        while let Some((group, threshold)) = queue.pop_front() {
-            if group.len() < min_size {
-                continue;
-            }
-            if group.len() > cap {
-                if threshold >= RESPLIT_MAX_THRESHOLD {
-                    log::warn!(
-                        "[distill] dropping {} sub-cluster after re-split: \
-                             {} memories still > cap {} at threshold {:.2} -- raise \
-                             max_{}_cluster_size if this is a genuine page",
-                        bucket_label,
-                        group.len(),
-                        cap,
-                        threshold,
-                        bucket_label,
-                    );
+        // Each base group is drained, together with every re-split
+        // descendant, before the next sibling starts. That keeps the output
+        // order of the one-shot re-split this replaces: a group that never
+        // needs a re-split is emitted exactly where it used to be, and the
+        // stable size sort plus `max_clusters` truncation below break ties
+        // the same way. Within a base group, an oversized group is re-split
+        // in `RESPLIT_STEP` increments (FIFO) rather than given a single
+        // attempt, so a stubborn cluster tightens repeatedly up to
+        // `RESPLIT_MAX_THRESHOLD` before it is dropped.
+        for base_group in cluster_by_similarity(memories, indices, similarity_threshold) {
+            let mut queue: std::collections::VecDeque<(Vec<usize>, f64)> =
+                std::collections::VecDeque::from([(base_group, similarity_threshold)]);
+            while let Some((group, threshold)) = queue.pop_front() {
+                if group.len() < min_size {
                     continue;
                 }
-                let tighter = (threshold + RESPLIT_STEP).min(RESPLIT_MAX_THRESHOLD);
-                log::info!(
-                    "[distill] re-splitting oversized {} cluster: \
+                if group.len() > cap {
+                    let tighter = (threshold + RESPLIT_STEP).min(RESPLIT_MAX_THRESHOLD);
+                    // The tuning loader does not range-check
+                    // `formation_threshold`; a non-finite or huge negative
+                    // value would never advance, so drop instead of looping.
+                    let can_advance = threshold.is_finite() && tighter > threshold;
+                    if threshold >= RESPLIT_MAX_THRESHOLD || !can_advance {
+                        log::warn!(
+                            "[distill] dropping {} sub-cluster after re-split: \
+                             {} memories still > cap {} at threshold {:.2} -- raise \
+                             max_{}_cluster_size if this is a genuine page",
+                            bucket_label,
+                            group.len(),
+                            cap,
+                            threshold,
+                            bucket_label,
+                        );
+                        continue;
+                    }
+                    log::info!(
+                        "[distill] re-splitting oversized {} cluster: \
                          {} memories at threshold {:.2} (cap = {})",
-                    bucket_label,
-                    group.len(),
-                    tighter,
-                    cap,
-                );
-                let resplit = cluster_by_similarity(memories, &group, tighter);
-                for sub_group in resplit {
-                    queue.push_back((sub_group, tighter));
+                        bucket_label,
+                        group.len(),
+                        tighter,
+                        cap,
+                    );
+                    for sub_group in cluster_by_similarity(memories, &group, tighter) {
+                        queue.push_back((sub_group, tighter));
+                    }
+                    continue;
                 }
-                continue;
+                let cluster = build_distillation_cluster(memories, &group);
+                emit_split(cluster, clusters);
             }
-            let cluster = build_distillation_cluster(memories, &group);
-            emit_split(cluster, clusters);
         }
     };
 

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -21683,6 +21683,105 @@ async fn test_sub_cluster_by_tokens() {
 }
 
 #[test]
+fn oversized_space_cluster_resplits_in_steps_instead_of_dropping() {
+    // Regression test: a single space with more memories than the grouped
+    // cluster cap must not be dropped outright when the first re-split step
+    // still leaves it oversized. `cluster_distillation_rows` must keep
+    // tightening in RESPLIT_STEP increments (up to RESPLIT_MAX_THRESHOLD)
+    // instead of giving up after one re-split attempt.
+    //
+    // Fixture: 4 topics x 5 members. Cross-topic cosine ~0.67 sits between
+    // the formation threshold (0.60) and the first re-split step (0.65), so
+    // the first re-split still can't separate the topics; the second
+    // re-split step (0.70) does.
+    const TOPICS: usize = 4;
+    const MEMBERS: usize = 5;
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    for k in 0..TOPICS {
+        for i in 0..MEMBERS {
+            let mut emb = vec![0.0f32; 768];
+            emb[0] = 1.0; // shared component
+            emb[1 + k] = 0.686; // topic component
+            emb[10 + 5 * k + i] = 0.15; // per-member noise
+            memories.push(ClusterMemRow {
+                source_id: format!("t{k}_m{i}"),
+                content: format!("topic {k} note {i}"),
+                entity_id: None,
+                entity_name: None,
+                space: Some("wenlan".to_string()),
+                can_seed_page: true,
+                embedding: emb,
+            });
+        }
+    }
+
+    // Fixture self-check: cross-topic cosine sits in (0.65, 0.70); within-topic
+    // cosine sits well above both re-split thresholds.
+    let cross_topic = cosine_similarity(&memories[0].embedding, &memories[5].embedding);
+    assert!(
+        (cross_topic - 0.675).abs() < 0.02,
+        "cross-topic cosine drifted: {cross_topic}"
+    );
+    let within_topic = cosine_similarity(&memories[0].embedding, &memories[1].embedding);
+    assert!(
+        (within_topic - 0.99).abs() < 0.02,
+        "within-topic cosine drifted: {within_topic}"
+    );
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.60,
+        3,
+        20,
+        16_000,
+        50,
+        12,
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    assert!(
+        clusters.len() >= TOPICS,
+        "expected at least {TOPICS} clusters, got {}: {:?}",
+        clusters.len(),
+        clusters
+            .iter()
+            .map(|c| c.source_ids.clone())
+            .collect::<Vec<_>>()
+    );
+    for cluster in &clusters {
+        assert!(
+            cluster.source_ids.len() >= 3 && cluster.source_ids.len() <= 12,
+            "cluster size {} out of [3, 12]: {:?}",
+            cluster.source_ids.len(),
+            cluster.source_ids
+        );
+    }
+
+    let mut all_ids: Vec<String> = clusters.iter().flat_map(|c| c.source_ids.clone()).collect();
+    all_ids.sort();
+    let mut expected: Vec<String> = memories.iter().map(|m| m.source_id.clone()).collect();
+    expected.sort();
+    assert_eq!(
+        all_ids, expected,
+        "every memory must appear in exactly one cluster"
+    );
+
+    for cluster in &clusters {
+        let prefixes: std::collections::HashSet<&str> = cluster
+            .source_ids
+            .iter()
+            .map(|id| id.split('_').next().unwrap())
+            .collect();
+        assert_eq!(
+            prefixes.len(),
+            1,
+            "cluster mixes topics: {:?}",
+            cluster.source_ids
+        );
+    }
+}
+
+#[test]
 fn sub_cluster_by_tokens_drops_single_member_subclusters_after_split() {
     // A token-split can strand a single memory in its own sub-cluster
     // (the farthest-first orthogonal outlier). The floor re-check (spec

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -21782,6 +21782,137 @@ fn oversized_space_cluster_resplits_in_steps_instead_of_dropping() {
 }
 
 #[test]
+fn resplit_children_keep_their_base_group_position_for_max_clusters_ties() {
+    // Regression test: re-split children must be emitted where their base
+    // group sat, not queued behind every later sibling. The stable size sort
+    // plus `max_clusters` truncation break ties by emission order, so a
+    // FIFO across base groups would silently swap which tied cluster
+    // survives.
+    //
+    // Fixture: topic A = two sub-topics (5 + 8 members) whose cross-sub
+    // cosine ~0.62 sits between the formation threshold (0.60) and the first
+    // re-split step (0.65); topic B = 5 members far from A (~0.30). At 0.60
+    // A forms one 13-member group (over cap 12) and B its own group; A
+    // re-splits into [5, 8] at 0.65. With `max_clusters = 2` the survivors
+    // must be A1 (8) and then A0 (5), never B.
+    let s = 0.30f32.sqrt(); // shared
+    let t = 0.32f32.sqrt(); // topic
+    let u = 0.3575f32.sqrt(); // sub-topic
+    let m = 0.15f32; // per-member noise
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    let mut push = |prefix: &str, topic_dim: usize, sub_dim: usize, count: usize| {
+        for i in 0..count {
+            let mut emb = vec![0.0f32; 768];
+            emb[0] = s;
+            emb[topic_dim] = t;
+            emb[sub_dim] = u;
+            emb[10 + memories.len()] = m;
+            memories.push(ClusterMemRow {
+                source_id: format!("{prefix}_m{i}"),
+                content: format!("{prefix} note {i}"),
+                entity_id: None,
+                entity_name: None,
+                space: Some("wenlan".to_string()),
+                can_seed_page: true,
+                embedding: emb,
+            });
+        }
+    };
+    push("a0", 1, 3, 5);
+    push("a1", 1, 4, 8);
+    push("b", 2, 5, 5);
+
+    // Fixture self-checks.
+    let cross_sub = cosine_similarity(&memories[0].embedding, &memories[5].embedding);
+    assert!(
+        (cross_sub - 0.62).abs() < 0.02,
+        "cross-sub-topic cosine drifted: {cross_sub}"
+    );
+    let cross_topic = cosine_similarity(&memories[0].embedding, &memories[13].embedding);
+    assert!(
+        (cross_topic - 0.30).abs() < 0.03,
+        "cross-topic cosine drifted: {cross_topic}"
+    );
+    let within = cosine_similarity(&memories[0].embedding, &memories[1].embedding);
+    assert!(
+        (within - 0.98).abs() < 0.02,
+        "within-sub cosine drifted: {within}"
+    );
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.60,
+        3,
+        2,
+        16_000,
+        50,
+        12,
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    let shape: Vec<(usize, String)> = clusters
+        .iter()
+        .map(|c| {
+            let prefixes: std::collections::BTreeSet<&str> = c
+                .source_ids
+                .iter()
+                .map(|id| id.split('_').next().unwrap())
+                .collect();
+            (
+                c.source_ids.len(),
+                prefixes.into_iter().collect::<Vec<_>>().join("+"),
+            )
+        })
+        .collect();
+    assert_eq!(
+        shape,
+        vec![(8, "a1".to_string()), (5, "a0".to_string())],
+        "re-split children must keep their base group's position (b must lose the tie)"
+    );
+}
+
+#[test]
+fn a_threshold_that_cannot_advance_drops_instead_of_looping() {
+    // Regression test: a tuned formation threshold the loader never
+    // validated (`-inf`, NaN, or a huge negative) makes `threshold +
+    // RESPLIT_STEP` land on the same value, so a group over cap would be
+    // re-queued forever. The loop must drop such a group instead.
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    for i in 0..20usize {
+        let mut emb = vec![0.0f32; 768];
+        emb[0] = 1.0;
+        emb[10 + i] = 0.15;
+        memories.push(ClusterMemRow {
+            source_id: format!("m{i}"),
+            content: format!("note {i}"),
+            entity_id: None,
+            entity_name: None,
+            space: Some("wenlan".to_string()),
+            can_seed_page: true,
+            embedding: emb,
+        });
+    }
+    for threshold in [f64::NEG_INFINITY, f64::NAN, -1.0e17] {
+        let clusters = cluster_distillation_rows(
+            &memories,
+            threshold,
+            3,
+            20,
+            16_000,
+            50,
+            12,
+            DistillationClusterMode::SpaceScoped,
+        );
+        assert!(
+            clusters.is_empty(),
+            "threshold {threshold}: an oversized group that cannot be re-split must be \
+             dropped, got {} clusters",
+            clusters.len()
+        );
+    }
+}
+
+#[test]
 fn sub_cluster_by_tokens_drops_single_member_subclusters_after_split() {
     // A token-split can strand a single memory in its own sub-cluster
     // (the farthest-first orthogonal outlier). The floor re-check (spec

--- a/crates/wenlan-core/src/tuning.rs
+++ b/crates/wenlan-core/src/tuning.rs
@@ -292,10 +292,11 @@ pub struct DistillationConfig {
     pub max_unlinked_cluster_size: usize,
     /// Hard cap on size of entity- or community-grouped clusters before the
     /// agent's coherence check rejects them as grab-bags. A 12+ prose-memory
-    /// cluster at the default 0.73 similarity is almost always a community
+    /// cluster at the default 0.60 similarity is almost always a community
     /// pile (e.g. cid=16 "Wenlan" sweeping in unrelated sub-topics). When a
-    /// grouped sub-cluster exceeds this, re-split once at threshold +0.05
-    /// (cap 0.92) and drop sub-clusters that still overflow.
+    /// grouped sub-cluster exceeds this, re-split repeatedly in +0.05
+    /// threshold steps up to a ceiling of 0.92; only a sub-cluster still
+    /// over cap at that ceiling is dropped.
     #[serde(default = "d_12_usize")]
     pub max_grouped_cluster_size: usize,
     /// Minimum source-memory overlap required for a page to pass the

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -864,7 +864,7 @@ pub async fn handle_distill(
             map.insert(
                 "hint".into(),
                 serde_json::json!(
-                    "No page-sized cluster formed: a page needs at least 3 related memories in one space. Keep capturing, or run distill again after more memories exist."
+                    "No page-sized cluster formed in this scope: nothing grouped into 3 or more related memories that fit one page. Capture more related memories, or check the daemon log for dropped clusters."
                 ),
             );
         }

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -845,7 +845,11 @@ pub async fn handle_distill(
             .collect()
     };
 
-    Ok(Json(serde_json::json!({
+    // `clusters_found` is the raw cluster count BEFORE the covered-page
+    // filter above drops clusters a page already subsumes -- "found" means
+    // clustering formed them, not that they survived disclosure.
+    let no_clusters_and_no_pages = result.pending.is_empty() && result.created.is_empty();
+    let mut response = serde_json::json!({
         "pages_created": result.created.len(),
         "scoped": scoped,
         "created_ids": result.created,
@@ -853,7 +857,19 @@ pub async fn handle_distill(
         "stale_pages": stale_pages_payload,
         "stale_truncated": stale_truncated,
         "orphan_topics": orphan_topics,
-    })))
+        "clusters_found": result.pending.len(),
+    });
+    if no_clusters_and_no_pages {
+        if let serde_json::Value::Object(ref mut map) = response {
+            map.insert(
+                "hint".into(),
+                serde_json::json!(
+                    "No page-sized cluster formed: a page needs at least 3 related memories in one space. Keep capturing, or run distill again after more memories exist."
+                ),
+            );
+        }
+    }
+    Ok(Json(response))
 }
 
 /// POST /api/distill/{page_id}

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -120,7 +120,8 @@ JSON. Possible shapes:
   "orphan_topics": [
     { "label": "Topic Z", "count": 3 },
     ...
-  ]
+  ],
+  "clusters_found": 0
 }
 ```
 
@@ -129,7 +130,15 @@ when called from this skill; `pending` carries every cluster the
 daemon found. The agent synthesizes them in this session — that's why
 the LLM choice is consistent with how the user invoked the skill.
 
-`unresolved` + `hint`: relay to user verbatim and stop.
+`clusters_found` is the raw cluster count *before* the existing-page
+overlap filter drops fully-covered clusters — it can be nonzero even
+when `pending` ends up empty. A top-level `hint` (string) is present
+only when `clusters_found` is 0 *and* `pages_created` is 0: nothing
+formed at all, and the text explains why.
+
+`unresolved` + `hint`: relay to user verbatim and stop. (Different
+condition, same field name — this one comes from a target-resolution
+failure, not from an empty distillation pass.)
 
 ### 3. Synthesize each `pending` cluster
 
@@ -290,7 +299,13 @@ Skip the section when `orphan_topics` is empty.
 
 Three output shapes. Pick the one that matches what happened.
 
-**If `pending` is empty (every cluster already fully covered):**
+**If `clusters_found` is 0 (no cluster formed at all):**
+
+```
+No page formed yet in `<scope>`: <hint text from the response>
+```
+
+**If `clusters_found` is nonzero but `pending` is empty (every cluster already fully covered):**
 
 ```
 Scope `<scope>` is up to date — no new memories to distill.

--- a/plugin/skills/distill/SKILL.md
+++ b/plugin/skills/distill/SKILL.md
@@ -136,9 +136,10 @@ when `pending` ends up empty. A top-level `hint` (string) is present
 only when `clusters_found` is 0 *and* `pages_created` is 0: nothing
 formed at all, and the text explains why.
 
-`unresolved` + `hint`: relay to user verbatim and stop. (Different
-condition, same field name — this one comes from a target-resolution
-failure, not from an empty distillation pass.)
+`unresolved` + `hint`: a target-resolution failure (different condition,
+same field name as the empty-pass hint). The MCP tool renders it as one
+line of text — ``Could not resolve target `<target>`. <hint>`` — not as
+JSON; relay that line to the user verbatim and stop.
 
 ### 3. Synthesize each `pending` cluster
 


### PR DESCRIPTION
## Summary

Top gap from the usefulness soak (`wenlan-usefulness-soak-2026-08-25.md`, gap 1): on a 28-memory store about one project, `/api/distill` returned no clusters and the plugin reported "up to date". The daemon log shows why:

```
[distill] found 26 eligible memories for clustering (raw excluded)
[distill] re-splitting oversized space cluster: 24 memories at threshold 0.65 (cap = 12)
[distill] dropping space sub-cluster after re-split: 20 memories still > cap 12 -- raise max_space_cluster_size if this is a genuine page
[distill] space_groups=1, unlinked=2, clusters_found=0
```

`cluster_distillation_rows` re-split an oversized group exactly once at `threshold + 0.05` and dropped whatever was still over the cap. A first-hour user who captures ~20 memories about one project never gets a page, and nothing outside the daemon log says so.

## Changes

- **core**: re-split in `+0.05` steps up to `0.92` before dropping (`RESPLIT_STEP`, `RESPLIT_MAX_THRESHOLD`). Only the branch that dropped clusters before is affected; groups that fit the cap today are clustered exactly as before. Tuning doc comment updated (it also described a stale 0.73 default; the code default is 0.60).
- **server**: `/api/distill` returns `clusters_found` (count before the covered-page filter) and a `hint` when nothing formed, so the caller can tell "nothing to cluster yet" from "everything is already covered".
- **plugin**: the distill skill's empty branch reports "No page formed yet" with the hint when `clusters_found` is 0, and keeps "up to date" only when clusters existed and were all covered.
- **test**: `oversized_space_cluster_resplits_in_steps_instead_of_dropping` — 4 topics × 5 memories in one space with cross-topic cosine ≈ 0.675 (survives the first re-split at 0.65, separates at 0.70). Written first: fails on the old code (0 clusters), passes with the fix. Outputs in the first comment.

## Verification

- Red/green run of the new test, the existing cluster tests, `cargo check` on server/mcp/types, clippy — receipts in the first comment.
- Real-surface proof: the fixed daemon run on a copy of the soak store returns page-sized clusters where 0.17.0 returned none — receipt in the first comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
