### PR TITLE
fix(cli,core,mcp): say what to do when the daemon, model, or config is broken

### DIFF
--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -51,6 +51,9 @@ Set `WENLAN_HOST` to point at a remote daemon:
 export WENLAN_HOST=http://127.0.0.1:7878  # default
 ```
 
+A bare port (`17917`) or `host:port` is completed to `http://127.0.0.1:17917` /
+`http://host:port`; a loopback shorthand takes part in autostart like the full URL.
+
 When a request to a loopback daemon cannot connect, the CLI automatically starts
 the registered background service (`com.wenlan.server`) and waits for its health
 endpoint. Remote or invalid `WENLAN_HOST` values keep the original connection

--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -145,9 +145,20 @@ impl WenlanClient {
                 };
                 let original = anyhow::Error::new(error).context(what.to_owned());
                 if let Err(recovery_error) = recovery::recover(&self.base_url).await {
-                    return Err(original.context(format!("{recovery_error:#}")));
+                    return Err(original.context(format!("{recovery_error:#}")).context(
+                        "the daemon did not come up on its own — run `wenlan doctor` to see why",
+                    ));
                 }
-                retry.send().await.with_context(|| what.to_owned())
+                retry
+                    .send()
+                    .await
+                    .with_context(|| what.to_owned())
+                    .with_context(|| {
+                        format!(
+                            "the daemon was started but {} still does not answer — run `wenlan doctor`",
+                            self.base_url
+                        )
+                    })
             }
             Err(error) => Err(error).with_context(|| what.to_owned()),
         }
@@ -658,18 +669,23 @@ mod tests {
 
     #[tokio::test]
     async fn connect_failure_says_what_to_do_next() {
-        let client = client_for("http://127.0.0.1:1").with_recovery(false);
-        let error = client
-            .health()
+        // An ephemeral port that was just released: nothing listens there.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+        let base = format!("http://{addr}");
+        let client = client_for(&base).with_recovery(false);
+        let error = tokio::time::timeout(std::time::Duration::from_secs(10), client.health())
             .await
-            .expect_err("nothing listens on port 1");
+            .expect("connect failure within 10s")
+            .expect_err("nothing listens on the released port");
         let text = format!("{error:#}");
         assert!(
-            text.contains("no Wenlan daemon is listening at http://127.0.0.1:1"),
+            text.contains(&format!("no Wenlan daemon is listening at {base}")),
             "{text}"
         );
         assert!(
-            text.contains("GET http://127.0.0.1:1/api/health failed"),
+            text.contains(&format!("GET {base}/api/health failed")),
             "{text}"
         );
     }

--- a/crates/wenlan-cli/src/client.rs
+++ b/crates/wenlan-cli/src/client.rs
@@ -139,7 +139,9 @@ impl WenlanClient {
             Ok(response) => Ok(response),
             Err(error) if error.is_connect() => {
                 let Some(retry) = retry else {
-                    return Err(error).with_context(|| what.to_owned());
+                    return Err(error)
+                        .with_context(|| what.to_owned())
+                        .with_context(|| recovery::connect_failure_hint(&self.base_url));
                 };
                 let original = anyhow::Error::new(error).context(what.to_owned());
                 if let Err(recovery_error) = recovery::recover(&self.base_url).await {
@@ -652,6 +654,24 @@ mod tests {
         let request = build_list_request(Some(20), None, None);
         let json = serde_json::to_value(request).expect("serialize list request");
         assert!(json.get("confirmed").is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_failure_says_what_to_do_next() {
+        let client = client_for("http://127.0.0.1:1").with_recovery(false);
+        let error = client
+            .health()
+            .await
+            .expect_err("nothing listens on port 1");
+        let text = format!("{error:#}");
+        assert!(
+            text.contains("no Wenlan daemon is listening at http://127.0.0.1:1"),
+            "{text}"
+        );
+        assert!(
+            text.contains("GET http://127.0.0.1:1/api/health failed"),
+            "{text}"
+        );
     }
 
     fn client_for(base_url: &str) -> WenlanClient {

--- a/crates/wenlan-cli/src/client/lint.rs
+++ b/crates/wenlan-cli/src/client/lint.rs
@@ -18,7 +18,9 @@ pub fn origin_host_from_env() -> String {
 /// without a base", which the CLI used to report as "is the daemon
 /// running?". Complete the obvious shorthand instead: digits become a
 /// loopback URL, a schemeless host gets `http://`, and an empty value means
-/// the default. A value with a scheme is only trimmed.
+/// the default. A value with a scheme is only trimmed. A loopback shorthand
+/// takes part in autostart exactly like the full loopback URL would; digits
+/// that are not a valid non-zero port are left alone so the error names them.
 pub fn normalize_origin_host(raw: &str) -> String {
     let value = raw.trim().trim_end_matches('/');
     if value.is_empty() {
@@ -28,7 +30,10 @@ pub fn normalize_origin_host(raw: &str) -> String {
         return value.to_string();
     }
     if value.bytes().all(|b| b.is_ascii_digit()) {
-        return format!("http://127.0.0.1:{value}");
+        return match value.parse::<u16>() {
+            Ok(port) if port > 0 => format!("http://127.0.0.1:{port}"),
+            _ => value.to_string(),
+        };
     }
     format!("http://{value}")
 }
@@ -120,6 +125,8 @@ mod origin_host_tests {
             "http://localhost:7878"
         );
         assert_eq!(normalize_origin_host(""), DEFAULT_HOST);
+        assert_eq!(normalize_origin_host("0"), "0");
+        assert_eq!(normalize_origin_host("70000"), "70000");
         assert_eq!(
             normalize_origin_host("http://127.0.0.1:17917/"),
             "http://127.0.0.1:17917"

--- a/crates/wenlan-cli/src/client/lint.rs
+++ b/crates/wenlan-cli/src/client/lint.rs
@@ -8,10 +8,29 @@ use wenlan_types::lint::{
 const MAX_LINT_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
 
 pub fn origin_host_from_env() -> String {
-    std::env::var("WENLAN_HOST")
-        .unwrap_or_else(|_| DEFAULT_HOST.to_string())
-        .trim_end_matches('/')
-        .to_string()
+    normalize_origin_host(
+        &std::env::var("WENLAN_HOST").unwrap_or_else(|_| DEFAULT_HOST.to_string()),
+    )
+}
+
+/// `WENLAN_HOST` is a full URL, but the first thing people try is a bare
+/// port (`17917`) or `host:port`; reqwest then fails with "relative URL
+/// without a base", which the CLI used to report as "is the daemon
+/// running?". Complete the obvious shorthand instead: digits become a
+/// loopback URL, a schemeless host gets `http://`, and an empty value means
+/// the default. A value with a scheme is only trimmed.
+pub fn normalize_origin_host(raw: &str) -> String {
+    let value = raw.trim().trim_end_matches('/');
+    if value.is_empty() {
+        return DEFAULT_HOST.to_string();
+    }
+    if value.contains("://") {
+        return value.to_string();
+    }
+    if value.bytes().all(|b| b.is_ascii_digit()) {
+        return format!("http://127.0.0.1:{value}");
+    }
+    format!("http://{value}")
 }
 
 impl WenlanClient {
@@ -83,4 +102,31 @@ async fn read_lint_body(mut response: reqwest::Response, url: &str) -> Result<Ve
         body.extend_from_slice(&chunk);
     }
     Ok(body)
+}
+
+#[cfg(test)]
+mod origin_host_tests {
+    use super::{normalize_origin_host, DEFAULT_HOST};
+
+    #[test]
+    fn shorthand_hosts_become_full_urls() {
+        assert_eq!(normalize_origin_host("17917"), "http://127.0.0.1:17917");
+        assert_eq!(
+            normalize_origin_host("127.0.0.1:17917"),
+            "http://127.0.0.1:17917"
+        );
+        assert_eq!(
+            normalize_origin_host("localhost:7878/"),
+            "http://localhost:7878"
+        );
+        assert_eq!(normalize_origin_host(""), DEFAULT_HOST);
+        assert_eq!(
+            normalize_origin_host("http://127.0.0.1:17917/"),
+            "http://127.0.0.1:17917"
+        );
+        assert_eq!(
+            normalize_origin_host("https://wenlan.example:8443"),
+            "https://wenlan.example:8443"
+        );
+    }
 }

--- a/crates/wenlan-cli/src/client/recovery.rs
+++ b/crates/wenlan-cli/src/client/recovery.rs
@@ -30,6 +30,23 @@ pub(crate) fn is_local_daemon_url(base_url: &str) -> bool {
     )
 }
 
+/// The top line of a connect failure when no automatic start was attempted.
+/// The reqwest chain under it ("tcp connect error ... Connection refused")
+/// says what happened; this says what to do.
+pub(crate) fn connect_failure_hint(base_url: &str) -> String {
+    if !is_local_daemon_url(base_url) {
+        return format!("cannot connect to the Wenlan daemon at {base_url} (from WENLAN_HOST)");
+    }
+    let mut hint = format!(
+        "no Wenlan daemon is listening at {base_url} — run `wenlan status`; if Wenlan is \
+         installed, `wenlan background on` starts it"
+    );
+    if std::env::var_os("WENLAN_NO_AUTOSTART").is_some_and(|value| !value.is_empty()) {
+        hint.push_str(" (WENLAN_NO_AUTOSTART is set, so it was not started automatically)");
+    }
+    hint
+}
+
 pub(crate) async fn recover(base_url: &str) -> Result<()> {
     if !is_local_daemon_url(base_url) {
         anyhow::bail!("recovery is only supported for a loopback daemon");
@@ -77,7 +94,22 @@ pub(crate) async fn poll_health(url: &str, deadline: Duration) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{autostart_allowed, is_local_daemon_url, poll_health, NO_SERVICE_HINT};
+    use super::{
+        autostart_allowed, connect_failure_hint, is_local_daemon_url, poll_health, NO_SERVICE_HINT,
+    };
+
+    #[test]
+    fn connect_failure_hint_names_the_next_command_for_a_loopback_daemon() {
+        let hint = connect_failure_hint("http://127.0.0.1:1");
+        assert!(
+            hint.starts_with("no Wenlan daemon is listening at http://127.0.0.1:1"),
+            "{hint}"
+        );
+        assert!(hint.contains("`wenlan background on`"), "{hint}");
+        let remote = connect_failure_hint("http://wenlan.example:7878");
+        assert!(remote.contains("WENLAN_HOST"), "{remote}");
+        assert!(!remote.contains("background on"), "{remote}");
+    }
     use std::io::Write;
     use std::net::TcpListener;
     use std::sync::{

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -263,13 +263,7 @@ pub async fn run_doctor() -> anyhow::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn print_daemon_log_paths() {
-    let data_root = std::env::var_os("WENLAN_DATA_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
-            dirs::data_local_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join("wenlan")
-        });
+    let data_root = daemon_data_root();
     let fallback_root = dirs::home_dir()
         .map(|home| home.join("Library/Logs/com.wenlan.server-fallback"))
         .unwrap_or_else(|| std::env::temp_dir().join("wenlan-server-fallback"));
@@ -676,9 +670,75 @@ async fn print_daemon_health() {
         Ok(resp) => println!("Daemon: unhealthy ({})", resp.status()),
         Err(_) => {
             println!("Daemon: not reachable on {}", url);
-            print_downgrade_barrier_hint();
+            let log_path = daemon_data_root().join("logs/wenlan-server.log");
+            match last_daemon_error(&log_path) {
+                Some(line) => {
+                    println!("  Last daemon error ({}):", log_path.display());
+                    println!("    {line}");
+                    if line.contains("newer than this build supports") {
+                        print_downgrade_barrier_hint();
+                    } else {
+                        println!(
+                            "  Fix the cause above, then run `wenlan background on` (or open the Wenlan app)."
+                        );
+                    }
+                }
+                None => {
+                    println!("  No daemon error recorded in {}.", log_path.display());
+                    println!(
+                        "  Start it with `wenlan background on` (or open the Wenlan app); if it stops again, that log says why."
+                    );
+                }
+            }
         }
     }
+}
+
+/// The data root the daemon writes to: `WENLAN_DATA_DIR`, else the
+/// platform data directory (`~/Library/Application Support/wenlan` on macOS).
+fn daemon_data_root() -> std::path::PathBuf {
+    std::env::var_os("WENLAN_DATA_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::data_local_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join("wenlan")
+        })
+}
+
+/// The last `ERROR` line of the daemon log, colour codes stripped, so a
+/// daemon that exited on purpose (newer schema, missing model, bad data
+/// root) is not reported as merely "not running".
+fn last_daemon_error(log_path: &std::path::Path) -> Option<String> {
+    let contents = std::fs::read_to_string(log_path).ok()?;
+    let line = contents
+        .lines()
+        .map(strip_ansi)
+        .rfind(|line| line.contains("ERROR"))?;
+    let line = line.trim();
+    Some(if line.chars().count() > 400 {
+        format!("{}…", line.chars().take(400).collect::<String>())
+    } else {
+        line.to_string()
+    })
+}
+
+fn strip_ansi(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next();
+            for d in chars.by_ref() {
+                if d.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 /// A daemon that refuses to start because the store was migrated by a newer
@@ -849,4 +909,39 @@ fn prompt_secret(prompt: &str) -> anyhow::Result<String> {
     println!();
     read?;
     Ok(value)
+}
+
+#[cfg(test)]
+mod doctor_tests {
+    use super::{last_daemon_error, strip_ansi};
+
+    #[test]
+    fn last_daemon_error_returns_the_final_error_line_without_colour_codes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = dir.path().join("wenlan-server.log");
+        std::fs::write(
+            &log,
+            concat!(
+                "\x1b[2m2026-08-25T07:01:52Z\x1b[0m \x1b[33m WARN\x1b[0m wenlan_core::db: creating schema...\n",
+                "\x1b[2m2026-08-25T07:01:53Z\x1b[0m \x1b[31mERROR\x1b[0m wenlan_server: first failure\n",
+                "\x1b[2m2026-08-25T07:01:54Z\x1b[0m \x1b[31mERROR\x1b[0m wenlan_server: wenlan-server terminated with an error: Embedding error: could not load the embedding model\n",
+                "\x1b[2m2026-08-25T07:01:55Z\x1b[0m \x1b[32m INFO\x1b[0m wenlan_server: bye\n",
+            ),
+        )
+        .expect("write log");
+        let line = last_daemon_error(&log).expect("an ERROR line");
+        assert!(!line.contains('\x1b'), "{line}");
+        assert!(
+            line.ends_with("could not load the embedding model"),
+            "{line}"
+        );
+        assert!(line.starts_with("2026-08-25T07:01:54Z"), "{line}");
+        assert_eq!(last_daemon_error(&dir.path().join("missing.log")), None);
+    }
+
+    #[test]
+    fn strip_ansi_leaves_plain_text_alone() {
+        assert_eq!(strip_ansi("plain ERROR line"), "plain ERROR line");
+        assert_eq!(strip_ansi("\x1b[31mred\x1b[0m"), "red");
+    }
 }

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -261,12 +261,19 @@ pub async fn run_doctor() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Where the daemon logs when its data root is not writable (mirrors
+/// `fallback_log_root` in wenlan-server).
+#[cfg(target_os = "macos")]
+fn fallback_log_root() -> std::path::PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join("Library/Logs/com.wenlan.server-fallback"))
+        .unwrap_or_else(|| std::env::temp_dir().join("wenlan-server-fallback"))
+}
+
 #[cfg(target_os = "macos")]
 fn print_daemon_log_paths() {
-    let data_root = daemon_data_root();
-    let fallback_root = dirs::home_dir()
-        .map(|home| home.join("Library/Logs/com.wenlan.server-fallback"))
-        .unwrap_or_else(|| std::env::temp_dir().join("wenlan-server-fallback"));
+    let data_root = config::data_root();
+    let fallback_root = fallback_log_root();
     println!(
         "Daemon log: {}",
         data_root.join("logs/wenlan-server.log").display()
@@ -670,59 +677,100 @@ async fn print_daemon_health() {
         Ok(resp) => println!("Daemon: unhealthy ({})", resp.status()),
         Err(_) => {
             println!("Daemon: not reachable on {}", url);
-            let log_path = daemon_data_root().join("logs/wenlan-server.log");
-            match last_daemon_error(&log_path) {
-                Some(line) => {
-                    println!("  Last daemon error ({}):", log_path.display());
-                    println!("    {line}");
-                    if line.contains("newer than this build supports") {
-                        print_downgrade_barrier_hint();
-                    } else {
-                        println!(
-                            "  Fix the cause above, then run `wenlan background on` (or open the Wenlan app)."
-                        );
-                    }
-                }
-                None => {
-                    println!("  No daemon error recorded in {}.", log_path.display());
-                    println!(
-                        "  Start it with `wenlan background on` (or open the Wenlan app); if it stops again, that log says why."
-                    );
-                }
+            if super::service::autostart_off_marker_exists() {
+                println!(
+                    "  The background service is switched off (`wenlan background off`); turn it back on with `wenlan background on`."
+                );
+                return;
             }
+            print_last_daemon_error();
         }
     }
 }
 
-/// The data root the daemon writes to: `WENLAN_DATA_DIR`, else the
-/// platform data directory (`~/Library/Application Support/wenlan` on macOS).
-fn daemon_data_root() -> std::path::PathBuf {
-    std::env::var_os("WENLAN_DATA_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| {
-            dirs::data_local_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join("wenlan")
-        })
+/// macOS: the daemon keeps a rotating file log (primary data root, else the
+/// fallback root), so a daemon that exited on purpose can say why.
+#[cfg(target_os = "macos")]
+fn print_last_daemon_error() {
+    let log_path = config::data_root().join("logs/wenlan-server.log");
+    // The fallback log is consulted only when the primary one does not exist
+    // at all (the daemon could not write its data root), so an old fallback
+    // entry never shadows a healthy primary log.
+    let found = if log_path.exists() {
+        last_daemon_error(&log_path).map(|line| (log_path.clone(), line))
+    } else {
+        let fallback = fallback_log_root().join("logs/wenlan-server.log");
+        last_daemon_error(&fallback).map(|line| (fallback, line))
+    };
+    match found {
+        Some((path, line)) => {
+            println!("  Last daemon error ({}):", path.display());
+            println!("    {line}");
+            if line.contains("newer than this build supports") {
+                print_downgrade_barrier_hint();
+            } else {
+                println!(
+                    "  Fix the cause above, then run `wenlan background on` (or open the Wenlan app)."
+                );
+            }
+        }
+        None => {
+            println!("  No daemon error recorded in {}.", log_path.display());
+            println!(
+                "  Start it with `wenlan background on` (or open the Wenlan app); if it stops again, that log says why."
+            );
+        }
+    }
 }
 
-/// The last `ERROR` line of the daemon log, colour codes stripped, so a
-/// daemon that exited on purpose (newer schema, missing model, bad data
-/// root) is not reported as merely "not running".
+/// Linux and Windows: the daemon logs to the service's console (journal or
+/// Task Scheduler), not to a file this command can read.
+#[cfg(not(target_os = "macos"))]
+fn print_last_daemon_error() {
+    println!("  Start it with `wenlan background on` (or open the Wenlan app).");
+    println!(
+        "  If it stops again, the service log says why (Linux: `journalctl --user -u wenlan-server`); \
+         a store migrated by a NEWER Wenlan is refused on purpose — upgrade Wenlan."
+    );
+}
+
+/// The last `ERROR` line of the daemon's most recent run, colour codes
+/// stripped, so a daemon that exited on purpose (newer schema, missing model,
+/// bad data root) is not reported as merely "not running". Only the lines
+/// after the last startup banner count, and an error that was followed by a
+/// clean shutdown is history rather than the current state.
+#[cfg(any(target_os = "macos", test))]
 fn last_daemon_error(log_path: &std::path::Path) -> Option<String> {
-    let contents = std::fs::read_to_string(log_path).ok()?;
-    let line = contents
+    let bytes = std::fs::read(log_path).ok()?;
+    let lines: Vec<String> = String::from_utf8_lossy(&bytes)
         .lines()
         .map(strip_ansi)
-        .rfind(|line| line.contains("ERROR"))?;
-    let line = line.trim();
-    Some(if line.chars().count() > 400 {
-        format!("{}…", line.chars().take(400).collect::<String>())
+        .collect();
+    let start = lines
+        .iter()
+        .rposition(|line| line.contains("wenlan-server v"))
+        .unwrap_or(0);
+    let run = &lines[start..];
+    let error_at = run.iter().rposition(|line| line.contains("ERROR"))?;
+    if run[error_at..]
+        .iter()
+        .any(|line| line.contains("graceful shutdown complete"))
+    {
+        return None;
+    }
+    let line = run[error_at].trim();
+    let count = line.chars().count();
+    Some(if count > 400 {
+        // Keep both ends: the cause sits at the front, the advice at the back.
+        let head: String = line.chars().take(300).collect();
+        let tail: String = line.chars().skip(count - 80).collect();
+        format!("{head} … {tail}")
     } else {
         line.to_string()
     })
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn strip_ansi(line: &str) -> String {
     let mut out = String::with_capacity(line.len());
     let mut chars = line.chars().peekable();
@@ -745,6 +793,7 @@ fn strip_ansi(line: &str) -> String {
 /// build looks exactly like a daemon that is simply not running. Say the
 /// difference out loud: the refusal is deliberate, it is written to the daemon
 /// log verbatim, and the fix is to upgrade rather than to keep restarting.
+#[cfg(target_os = "macos")]
 fn print_downgrade_barrier_hint() {
     println!(
         "  If the store was migrated by a NEWER Wenlan, this build refuses to open it \
@@ -922,6 +971,7 @@ mod doctor_tests {
         std::fs::write(
             &log,
             concat!(
+                "\x1b[2m2026-08-25T07:01:50Z\x1b[0m \x1b[32m INFO\x1b[0m wenlan_server: wenlan-server v0.17.0\n",
                 "\x1b[2m2026-08-25T07:01:52Z\x1b[0m \x1b[33m WARN\x1b[0m wenlan_core::db: creating schema...\n",
                 "\x1b[2m2026-08-25T07:01:53Z\x1b[0m \x1b[31mERROR\x1b[0m wenlan_server: first failure\n",
                 "\x1b[2m2026-08-25T07:01:54Z\x1b[0m \x1b[31mERROR\x1b[0m wenlan_server: wenlan-server terminated with an error: Embedding error: could not load the embedding model\n",
@@ -937,6 +987,38 @@ mod doctor_tests {
         );
         assert!(line.starts_with("2026-08-25T07:01:54Z"), "{line}");
         assert_eq!(last_daemon_error(&dir.path().join("missing.log")), None);
+    }
+
+    #[test]
+    fn an_error_from_a_previous_run_or_before_a_clean_shutdown_is_not_current() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = dir.path().join("wenlan-server.log");
+        // Run 1 failed, then run 2 came up and shut down cleanly: nothing current.
+        std::fs::write(
+            &log,
+            concat!(
+                "2026-08-24T10:00:00Z  INFO wenlan_server: wenlan-server v0.17.0\n",
+                "2026-08-24T10:00:01Z ERROR wenlan_server: wenlan-server terminated with an error: old failure\n",
+                "2026-08-25T09:00:00Z  INFO wenlan_server: wenlan-server v0.17.0\n",
+                "2026-08-25T09:00:05Z ERROR wenlan_core::scheduler: one job failed\n",
+                "2026-08-25T09:30:00Z  INFO wenlan_server: graceful shutdown complete\n",
+            ),
+        )
+        .expect("write log");
+        assert_eq!(last_daemon_error(&log), None);
+
+        // Run 3 failed again: only that run's error counts, and one bad byte
+        // in the file does not hide it.
+        let mut bytes = std::fs::read(&log).expect("read log");
+        bytes.extend_from_slice(
+            b"2026-08-25T10:00:00Z  INFO wenlan_server: wenlan-server v0.17.0 \xff\n",
+        );
+        bytes.extend_from_slice(
+            b"2026-08-25T10:00:01Z ERROR wenlan_server: wenlan-server terminated with an error: new failure\n",
+        );
+        std::fs::write(&log, bytes).expect("rewrite log");
+        let line = last_daemon_error(&log).expect("the current run's ERROR line");
+        assert!(line.ends_with("new failure"), "{line}");
     }
 
     #[test]

--- a/crates/wenlan-cli/src/commands/status.rs
+++ b/crates/wenlan-cli/src/commands/status.rs
@@ -19,9 +19,11 @@ pub async fn run(client: &WenlanClient, format: ResolvedFormat, quiet: bool) -> 
         ResolvedFormat::Json => match client.health().await {
             Ok(health) => print_json(&health)?,
             Err(err) => {
+                // The whole chain: the hint first, then the endpoint and the
+                // transport cause, so a script reading this field sees both.
                 let status = serde_json::json!({
                     "status": "unreachable",
-                    "error": err.to_string(),
+                    "error": format!("{err:#}"),
                 });
                 print_json(&status)?;
             }

--- a/crates/wenlan-core/src/config.rs
+++ b/crates/wenlan-core/src/config.rs
@@ -235,16 +235,37 @@ pub fn outbox_dir() -> PathBuf {
     data_root().join("outbox")
 }
 
+/// The last reported configuration failure (path and parse error), so a
+/// corrupt file is logged once rather than on every request and scheduler
+/// tick. It is reported again when the error changes or after a successful
+/// parse in between.
+static LAST_CONFIG_WARNING: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// Record the current parse outcome; true when a failure is new.
+fn note_config_parse(failure: Option<&str>) -> bool {
+    let mut last = LAST_CONFIG_WARNING
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let is_new = failure.is_some() && last.as_deref() != failure;
+    *last = failure.map(str::to_owned);
+    is_new
+}
+
 pub fn load_config() -> Config {
     let path = config_path();
     let mut config = match std::fs::read_to_string(&path) {
         Ok(contents) => match serde_json::from_str(&contents) {
-            Ok(config) => config,
+            Ok(config) => {
+                note_config_parse(None);
+                config
+            }
             Err(error) => {
-                log::warn!(
-                    "[config] {} is not valid JSON ({error}); using defaults until it is fixed",
-                    path.display()
-                );
+                if note_config_parse(Some(&format!("{}|{error}", path.display()))) {
+                    log::warn!(
+                        "[config] {} is not valid JSON ({error}); using defaults until it is fixed",
+                        path.display()
+                    );
+                }
                 Config::default()
             }
         },

--- a/crates/wenlan-core/src/config.rs
+++ b/crates/wenlan-core/src/config.rs
@@ -238,7 +238,16 @@ pub fn outbox_dir() -> PathBuf {
 pub fn load_config() -> Config {
     let path = config_path();
     let mut config = match std::fs::read_to_string(&path) {
-        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Ok(contents) => match serde_json::from_str(&contents) {
+            Ok(config) => config,
+            Err(error) => {
+                log::warn!(
+                    "[config] {} is not valid JSON ({error}); using defaults until it is fixed",
+                    path.display()
+                );
+                Config::default()
+            }
+        },
         Err(_) => Config::default(),
     };
     config.migrate();

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1313,13 +1313,39 @@ pub(crate) fn embedder_init_error(
     error: &anyhow::Error,
     cache: Option<&std::path::Path>,
 ) -> WenlanError {
+    // fastembed gives HF_HOME precedence over the configured cache dir, so
+    // name the directory it actually used.
+    let cache = std::env::var_os("HF_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| cache.map(std::path::Path::to_path_buf));
     let location = cache
+        .as_deref()
         .map(|path| format!(" from {}", path.display()))
         .unwrap_or_default();
-    WenlanError::Embedding(format!(
-        "could not load the embedding model (BGE base v1.5, about 140 MB){location}: {error:#}. \
-         The first start downloads it from huggingface.co; check the network or proxy, then \
+    let cause = format!("{error:#}");
+    let lower = cause.to_ascii_lowercase();
+    let is_download = !lower.contains("permission denied")
+        && [
+            "retrieve",
+            "request",
+            "connect",
+            "dns",
+            "timed out",
+            "timeout",
+        ]
+        .iter()
+        .any(|needle| lower.contains(needle));
+    let advice = if is_download {
+        "The first start downloads it from huggingface.co; check the network or proxy, then \
          start Wenlan again"
+    } else {
+        "If the cached files are damaged or unreadable, fix or delete that cache directory and \
+         start Wenlan again to download a fresh copy; an ONNX Runtime error usually means an \
+         unsupported CPU or a broken install"
+    };
+    WenlanError::Embedding(format!(
+        "could not load the embedding model (quantized BGE base en v1.5, about 210 MB){location}. \
+         {advice}. Cause: {cause}"
     ))
 }
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1306,6 +1306,23 @@ pub(crate) fn init_text_embedding(options: InitOptions) -> anyhow::Result<TextEm
     TextEmbedding::try_new(options)
 }
 
+/// The message a user sees when the embedding model cannot be loaded. The raw
+/// fastembed error ("Failed to retrieve model_optimized.onnx") does not say
+/// that this is a one-time download, where it goes, or what to do next.
+pub(crate) fn embedder_init_error(
+    error: &anyhow::Error,
+    cache: Option<&std::path::Path>,
+) -> WenlanError {
+    let location = cache
+        .map(|path| format!(" from {}", path.display()))
+        .unwrap_or_default();
+    WenlanError::Embedding(format!(
+        "could not load the embedding model (BGE base v1.5, about 140 MB){location}: {error:#}. \
+         The first start downloads it from huggingface.co; check the network or proxy, then \
+         start Wenlan again"
+    ))
+}
+
 /// Known-client registry — maps canonical technical IDs (what clients send in
 /// `x-agent-name`) to human-friendly display names (what users see in UI).
 ///
@@ -4331,6 +4348,7 @@ impl MemoryDB {
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "<default>".into())
         );
+        let embed_cache_label = embed_cache_dir.clone();
         let (embed_tx, embed_rx) = tokio::sync::oneshot::channel();
         std::thread::Builder::new()
             .name("embedder-init".into())
@@ -4348,7 +4366,7 @@ impl MemoryDB {
         let embedder = embed_rx
             .await
             .map_err(|_| WenlanError::Embedding("embedder thread panicked".into()))?
-            .map_err(|e| WenlanError::Embedding(format!("init embedder: {}", e)))?;
+            .map_err(|e| embedder_init_error(&e, embed_cache_label.as_deref()))?;
 
         log::info!("[memory_db] initialized at {}", db_file.display());
 
@@ -4486,7 +4504,7 @@ impl MemoryDB {
         let embedder = rx
             .await
             .map_err(|_| WenlanError::Embedding("embedder thread panicked".into()))?
-            .map_err(|e| WenlanError::Embedding(format!("init embedder: {}", e)))?;
+            .map_err(|e| embedder_init_error(&e, None))?;
         Ok(Arc::new(std::sync::Mutex::new(embedder)))
     }
 

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -991,7 +991,9 @@ fn format_capture_success(resp: &StoreMemoryResponse) -> String {
 }
 
 fn daemon_setup_hint() -> &'static str {
-    "Install the local Wenlan runtime and run `wenlan setup`.
+    "If Wenlan is already installed, the daemon may just be stopped: run `wenlan status`, then `wenlan background on`.
+
+Otherwise install the local Wenlan runtime and run `wenlan setup`.
 
 Setup choices:
 - Local Memory: store, search, and recall now. No model download or API key.

--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -991,7 +991,7 @@ fn format_capture_success(resp: &StoreMemoryResponse) -> String {
 }
 
 fn daemon_setup_hint() -> &'static str {
-    "If Wenlan is already installed, the daemon may just be stopped: run `wenlan status`, then `wenlan background on`.
+    "If Wenlan is already installed, the daemon may just be stopped. If you use the Wenlan app, open or restart it; if the `wenlan` CLI is on PATH, run `wenlan status`, then `wenlan background on`. A connector-only install (`wenlan-mcp` from npm, Homebrew, or Cargo) has no daemon of its own and needs the local runtime below.
 
 Otherwise install the local Wenlan runtime and run `wenlan setup`.
 


### PR DESCRIPTION
## Why

Failure-mode sweep of the first hour against the released v0.17.0 binaries (report: `wenlan-failure-sweep-2026-08-25.md`, twelve scenarios in an isolated data root; the developer daemon was never contacted). Four common breakages left the user with no next step; two more were silent or misleading.

| Breakage | v0.17.0 showed | Now |
|---|---|---|
| Daemon down, `wenlan recall`/`search`/`brief` | `Error: GET …/api/spaces failed` + `Caused by: … Connection refused (os error 61)` | First line: *no Wenlan daemon is listening at `<url>` — run `wenlan status`; if Wenlan is installed, `wenlan background on` starts it* (notes when `WENLAN_NO_AUTOSTART` suppressed the automatic start; a remote `WENLAN_HOST` gets *cannot connect to the Wenlan daemon at `<url>` (from WENLAN_HOST)*). The reqwest chain stays underneath. |
| `WENLAN_HOST=17917` or `host:port` | `GET 17917/api/health failed (is the daemon running?)` | The shorthand is completed: digits → `http://127.0.0.1:<port>`, schemeless host → `http://<host>`, empty → default. |
| Daemon exited on purpose (newer schema, missing model, unwritable data root) | `wenlan doctor`: "Daemon: not reachable" + a paragraph about the newer-schema case regardless of cause | Doctor prints the last `ERROR` line of the daemon log (colour codes stripped), shows the schema paragraph only when that is the cause, otherwise says to fix the cause and run `wenlan background on`. |
| First start, no model cached, no network | `Embedding error: init embedder: Failed to retrieve model_optimized.onnx` | *could not load the embedding model (quantized BGE base en v1.5, about 210 MB) from `<cache>`. The first start downloads it from huggingface.co; check the network or proxy, then start Wenlan again. Cause: `<error>`* (cache dir follows `HF_HOME` like fastembed; a damaged cache, permission, or ONNX Runtime failure gets different advice) |
| `config.json` with a JSON typo | Silently replaced by defaults, nothing logged | `[config] <path> is not valid JSON (<error>); using defaults until it is fixed` |
| MCP tool call, daemon down | "Install the local Wenlan runtime…" (assumes not installed) | Leads with *If Wenlan is already installed, the daemon may just be stopped: run `wenlan status`, then `wenlan background on`.* |

Scenarios that were already clear and are unchanged: port taken by a healthy daemon (exit 75 for launchd), port taken by a mute holder, a store migrated by a newer Wenlan (the daemon's refusal text), an unwritable data root, capture while offline (outbox), a stale 0.16.0 CLI.

## Verification

Focused tests (`cargo test -p wenlan --lib -- origin_host_tests connect_failure doctor_tests recovery::tests client::tests`): 14 passed, including a live connect failure against `127.0.0.1:1` asserting the new first line. `cargo test -p wenlan-core --lib -- config::tests`: 30 passed. Clippy clean on `wenlan`, `wenlan-core`, `wenlan-mcp` (`--all-targets`); `cargo check -p wenlan-server` clean; `cargo fmt` clean.

Real-surface proof with the freshly built binaries is in the first comment.

Not run: autostart with no registered service (the recovery path talks to the real launchd session, which this sweep must not touch), disk full, and the desktop app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
