### PR TITLE
fix(core,cli): stop the fresh-install daemon crash-loop under launchd

### DIFF
--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -84,7 +84,7 @@ wenlan setup --anthropic-api-key-env ANTHROPIC_API_KEY
 
 ### `wenlan background <on|off>`
 
-Start or stop the per-user background runtime. `wenlan background off` stops the current daemon while preserving its login registration and writes `<data root>/autostart.off`, so recovery will not start it again. Run `wenlan background on` to remove the marker and start it again; it waits up to 10 s for the daemon to answer and, on macOS, reports the daemon's last logged error instead of a false "started". Most users run `wenlan background on` once after setup and `wenlan restart` after upgrades installed outside `wenlan setup`.
+Start or stop the per-user background runtime. `wenlan background off` stops the current daemon while preserving its login registration and writes `<data root>/autostart.off`, so recovery will not start it again. Run `wenlan background on` to remove the marker and start it again; it waits up to 10 s for the daemon to answer before saying "started" and, on macOS, reports an error the daemon logged during this start (never one left over from an earlier run). Most users run `wenlan background on` once after setup and `wenlan restart` after upgrades installed outside `wenlan setup`.
 
 ```bash
 wenlan background on

--- a/crates/wenlan-cli/README.md
+++ b/crates/wenlan-cli/README.md
@@ -84,7 +84,7 @@ wenlan setup --anthropic-api-key-env ANTHROPIC_API_KEY
 
 ### `wenlan background <on|off>`
 
-Start or stop the per-user background runtime. `wenlan background off` stops the current daemon while preserving its login registration and writes `<data root>/autostart.off`, so recovery will not start it again. Run `wenlan background on` to remove the marker and start it again. Most users run `wenlan background on` once after setup and `wenlan restart` after upgrades installed outside `wenlan setup`.
+Start or stop the per-user background runtime. `wenlan background off` stops the current daemon while preserving its login registration and writes `<data root>/autostart.off`, so recovery will not start it again. Run `wenlan background on` to remove the marker and start it again; it waits up to 10 s for the daemon to answer and, on macOS, reports the daemon's last logged error instead of a false "started". Most users run `wenlan background on` once after setup and `wenlan restart` after upgrades installed outside `wenlan setup`.
 
 ```bash
 wenlan background on

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -25,6 +25,8 @@ const SHUTDOWN_STABILITY_WINDOW: std::time::Duration = std::time::Duration::from
 const SHUTDOWN_VERIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
 const DAEMON_PROCESS_ID_HEADER: &str = "x-wenlan-process-id";
 const AUTOSTART_OFF_MARKER: &str = "autostart.off";
+/// How long `background on` waits for `/api/health` before reporting.
+const FIRST_HEALTH_WAIT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[derive(Clone, Copy, Debug)]
 struct DaemonProcessIdentity {
@@ -203,7 +205,11 @@ fn origin_data_root() -> PathBuf {
 /// embedded `com.wenlan.server.plist` template carried: stdout/stderr routing,
 /// `EnvironmentVariables.RUST_LOG`, and the canonical `WENLAN_DATA_DIR`
 /// ownership marker consumed by the desktop app. The daemon owns bounded file
-/// logging, so launchd routes its raw streams to `/dev/null`.
+/// logging, so launchd's stdout goes to `/dev/null`; stderr goes to
+/// `<data root>/logs/launchd-stderr.log` so a crash before file logging is up
+/// (a missing library, an abort) is never silent. That file stays small: the
+/// daemon writes only bootstrap failures there and download progress bars are
+/// hidden off a terminal.
 ///
 /// `LaunchdInstallConfig` in service-manager 0.11 only exposes `keep_alive`;
 /// stdout/stderr paths must come through `ServiceInstallCtx.contents` as a
@@ -300,7 +306,7 @@ pub async fn install() -> Result<()> {
             "Installed and started Windows scheduled task '{}' (wenlan-server).",
             WINDOWS_TASK_NAME
         );
-        return Ok(());
+        return wait_for_first_health().await;
     }
 
     #[cfg_attr(target_os = "windows", allow(unreachable_code))]
@@ -347,10 +353,16 @@ pub async fn install() -> Result<()> {
         #[cfg(target_os = "macos")]
         {
             let data_root = origin_data_root();
+            let stderr_log = launchd_stderr_log_path(&data_root);
+            if let Some(log_dir) = stderr_log.parent() {
+                std::fs::create_dir_all(log_dir).with_context(|| {
+                    format!("create the daemon log directory {}", log_dir.display())
+                })?;
+            }
             Some(build_launchd_plist(
                 &program,
                 Path::new("/dev/null"),
-                Path::new("/dev/null"),
+                &stderr_log,
                 "info",
                 &data_root,
             ))
@@ -382,7 +394,59 @@ pub async fn install() -> Result<()> {
         .context("start service")?;
     remove_autostart_off_marker()?;
     println!("Installed and started {}.", SERVICE_LABEL);
+    wait_for_first_health().await
+}
+
+/// Where launchd writes the daemon's raw stderr (see `build_launchd_plist`).
+#[cfg(target_os = "macos")]
+pub(crate) fn launchd_stderr_log_path(data_root: &Path) -> PathBuf {
+    data_root.join("logs/launchd-stderr.log")
+}
+
+/// `background on` used to return as soon as the service manager accepted the
+/// job, so a daemon that crash-looped under launchd still printed "Installed
+/// and started" (first-run gauntlet finding F4). Wait for the daemon to
+/// answer; when it does not, tell a first start that is still downloading the
+/// embedding model apart from a daemon that has already failed.
+async fn wait_for_first_health() -> Result<()> {
+    // A routable `WENLAN_BIND_ADDR` has no local URL to poll; the install
+    // itself succeeded, so there is nothing to report.
+    let Ok(base_url) = local_daemon_base_url() else {
+        return Ok(());
+    };
+    let health_url = format!("{base_url}/api/health");
+    if poll_health(&health_url, FIRST_HEALTH_WAIT).await.is_ok() {
+        println!("Daemon healthy at {base_url}.");
+        return Ok(());
+    }
+    #[cfg(target_os = "macos")]
+    if let Some((log_path, line)) = crate::commands::setup::current_daemon_error() {
+        anyhow::bail!(
+            "the daemon started but stopped with an error ({}):\n  {line}\nFix the cause above, then run `wenlan background on` again.",
+            log_path.display()
+        );
+    }
+    println!("{}", first_health_pending_note(&health_url));
     Ok(())
+}
+
+/// The message for a daemon that has not answered yet but has not failed
+/// either, as far as this command can see.
+fn first_health_pending_note(health_url: &str) -> String {
+    let mut note = format!(
+        "Daemon not answering yet at {health_url} after {}s. A first start downloads the 210 MB embedding model; check `wenlan status` in a minute.",
+        FIRST_HEALTH_WAIT.as_secs()
+    );
+    #[cfg(target_os = "macos")]
+    note.push_str(&format!(
+        "\nIf it stays down, `wenlan doctor` shows the daemon's last error (log: {}).",
+        crate::commands::setup::daemon_log_path().display()
+    ));
+    #[cfg(target_os = "linux")]
+    note.push_str("\nIf it stays down, `journalctl --user -u wenlan-server` says why.");
+    #[cfg(target_os = "windows")]
+    note.push_str("\nIf it stays down, run `wenlan doctor`.");
+    note
 }
 
 #[cfg(target_os = "macos")]
@@ -958,6 +1022,40 @@ mod tests {
             );
             std::thread::sleep(std::time::Duration::from_millis(100));
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_keeps_stderr_in_the_data_root() {
+        let data_root = Path::new("/tmp/wenlan-plist-test-root");
+        let stderr_log = launchd_stderr_log_path(data_root);
+        assert_eq!(
+            stderr_log,
+            Path::new("/tmp/wenlan-plist-test-root/logs/launchd-stderr.log")
+        );
+        let plist = build_launchd_plist(
+            Path::new("/opt/wenlan/wenlan-server"),
+            Path::new("/dev/null"),
+            &stderr_log,
+            "info",
+            data_root,
+        );
+        assert!(plist.contains(
+            "<key>StandardErrorPath</key>\n\t<string>/tmp/wenlan-plist-test-root/logs/launchd-stderr.log</string>"
+        ));
+        assert!(plist.contains("<key>StandardOutPath</key>\n\t<string>/dev/null</string>"));
+        assert!(plist.contains(
+            "<key>WENLAN_DATA_DIR</key>\n\t\t<string>/tmp/wenlan-plist-test-root</string>"
+        ));
+    }
+
+    #[test]
+    fn first_health_note_says_how_long_it_waited_and_what_to_do() {
+        let note = first_health_pending_note("http://127.0.0.1:7878/api/health");
+        assert!(note.contains("after 10s"), "{note}");
+        assert!(note.contains("210 MB embedding model"), "{note}");
+        assert!(note.contains("`wenlan status`"), "{note}");
+        assert!(note.contains("If it stays down"), "{note}");
     }
 
     #[test]

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -207,9 +207,10 @@ fn origin_data_root() -> PathBuf {
 /// ownership marker consumed by the desktop app. The daemon owns bounded file
 /// logging, so launchd's stdout goes to `/dev/null`; stderr goes to
 /// `<data root>/logs/launchd-stderr.log` so a crash before file logging is up
-/// (a missing library, an abort) is never silent. That file stays small: the
-/// daemon writes only bootstrap failures there and download progress bars are
-/// hidden off a terminal.
+/// (a missing library, an abort) is never silent. launchd does not rotate
+/// that file: the daemon writes only bootstrap failures there (progress bars
+/// are hidden off a terminal), so it grows a couple of lines per attempt only
+/// while launchd keeps retrying a daemon that cannot start.
 ///
 /// `LaunchdInstallConfig` in service-manager 0.11 only exposes `keep_alive`;
 /// stdout/stderr paths must come through `ServiceInstallCtx.contents` as a
@@ -300,13 +301,14 @@ pub async fn install() -> Result<()> {
             ],
             "create scheduled task",
         )?;
+        let log_marks = DaemonLogMarks::capture();
         run_schtasks(&["/run", "/tn", WINDOWS_TASK_NAME], "run scheduled task")?;
         remove_autostart_off_marker()?;
-        println!(
-            "Installed and started Windows scheduled task '{}' (wenlan-server).",
-            WINDOWS_TASK_NAME
-        );
-        return wait_for_first_health().await;
+        return wait_for_first_health(
+            &format!("Windows scheduled task '{WINDOWS_TASK_NAME}' (wenlan-server)"),
+            &log_marks,
+        )
+        .await;
     }
 
     #[cfg_attr(target_os = "windows", allow(unreachable_code))]
@@ -373,6 +375,7 @@ pub async fn install() -> Result<()> {
         }
     };
 
+    let log_marks = DaemonLogMarks::capture();
     m.install(ServiceInstallCtx {
         label: label_value.clone(),
         program,
@@ -393,8 +396,7 @@ pub async fn install() -> Result<()> {
     m.start(ServiceStartCtx { label: label_value })
         .context("start service")?;
     remove_autostart_off_marker()?;
-    println!("Installed and started {}.", SERVICE_LABEL);
-    wait_for_first_health().await
+    wait_for_first_health(SERVICE_LABEL, &log_marks).await
 }
 
 /// Where launchd writes the daemon's raw stderr (see `build_launchd_plist`).
@@ -403,29 +405,96 @@ pub(crate) fn launchd_stderr_log_path(data_root: &Path) -> PathBuf {
     data_root.join("logs/launchd-stderr.log")
 }
 
+/// Where the daemon's logs ended before this command started the daemon, so
+/// an error reported afterwards is one this start produced and not a stale
+/// line from an earlier run (the logs outlive the daemon).
+struct DaemonLogMarks {
+    #[cfg(target_os = "macos")]
+    daemon_log: (PathBuf, u64),
+    #[cfg(target_os = "macos")]
+    stderr_log: (PathBuf, u64),
+}
+
+impl DaemonLogMarks {
+    fn capture() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self::at(
+                crate::commands::setup::daemon_log_path(),
+                launchd_stderr_log_path(&origin_data_root()),
+            )
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self {}
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn at(daemon_log: PathBuf, stderr_log: PathBuf) -> Self {
+        let len = |path: &Path| std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        Self {
+            daemon_log: (daemon_log.clone(), len(&daemon_log)),
+            stderr_log: (stderr_log.clone(), len(&stderr_log)),
+        }
+    }
+
+    /// The error this start produced, if any: the daemon log's last `ERROR`
+    /// line written after the mark, else the last line launchd captured on
+    /// stderr since then (a crash before file logging is up, such as a
+    /// missing library).
+    #[cfg(target_os = "macos")]
+    fn error_since(&self) -> Option<(PathBuf, String)> {
+        let (daemon_log, daemon_mark) = &self.daemon_log;
+        if let Some(line) =
+            crate::commands::setup::last_daemon_error_since(daemon_log, *daemon_mark)
+        {
+            return Some((daemon_log.clone(), line));
+        }
+        let (stderr_log, stderr_mark) = &self.stderr_log;
+        let bytes = std::fs::read(stderr_log).ok()?;
+        let start = usize::try_from(*stderr_mark)
+            .unwrap_or(usize::MAX)
+            .min(bytes.len());
+        let line = String::from_utf8_lossy(&bytes[start..])
+            .lines()
+            .map(str::trim)
+            .rfind(|line| !line.is_empty())?
+            .chars()
+            .take(400)
+            .collect();
+        Some((stderr_log.clone(), line))
+    }
+}
+
 /// `background on` used to return as soon as the service manager accepted the
 /// job, so a daemon that crash-looped under launchd still printed "Installed
 /// and started" (first-run gauntlet finding F4). Wait for the daemon to
-/// answer; when it does not, tell a first start that is still downloading the
-/// embedding model apart from a daemon that has already failed.
-async fn wait_for_first_health() -> Result<()> {
+/// answer before claiming it started; when it does not, tell a first start
+/// that is still downloading the embedding model apart from a daemon that
+/// failed during this start.
+async fn wait_for_first_health(installed: &str, marks: &DaemonLogMarks) -> Result<()> {
     // A routable `WENLAN_BIND_ADDR` has no local URL to poll; the install
-    // itself succeeded, so there is nothing to report.
+    // itself succeeded, so there is nothing more to report.
     let Ok(base_url) = local_daemon_base_url() else {
+        println!("Installed and started {installed}.");
         return Ok(());
     };
     let health_url = format!("{base_url}/api/health");
     if poll_health(&health_url, FIRST_HEALTH_WAIT).await.is_ok() {
-        println!("Daemon healthy at {base_url}.");
+        println!("Installed and started {installed}; daemon healthy at {base_url}.");
         return Ok(());
     }
     #[cfg(target_os = "macos")]
-    if let Some((log_path, line)) = crate::commands::setup::current_daemon_error() {
+    if let Some((log_path, line)) = marks.error_since() {
         anyhow::bail!(
-            "the daemon started but stopped with an error ({}):\n  {line}\nFix the cause above, then run `wenlan background on` again.",
+            "installed {installed}, but the daemon stopped with an error ({}):\n  {line}\nFix the cause above, then run `wenlan background on` again.",
             log_path.display()
         );
     }
+    #[cfg(not(target_os = "macos"))]
+    let _ = marks;
+    println!("Installed {installed}; the daemon is still starting.");
     println!("{}", first_health_pending_note(&health_url));
     Ok(())
 }
@@ -1047,6 +1116,51 @@ mod tests {
         assert!(plist.contains(
             "<key>WENLAN_DATA_DIR</key>\n\t\t<string>/tmp/wenlan-plist-test-root</string>"
         ));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn install_reports_only_errors_written_after_it_started_the_daemon() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let daemon_log = dir.path().join("wenlan-server.log");
+        let stderr_log = dir.path().join("launchd-stderr.log");
+        std::fs::write(
+            &daemon_log,
+            "INFO wenlan-server v0.17.0\nERROR wenlan_server: stale failure\n",
+        )
+        .expect("write daemon log");
+        let marks = DaemonLogMarks::at(daemon_log.clone(), stderr_log.clone());
+        assert_eq!(
+            marks.error_since(),
+            None,
+            "an error from an earlier run must not be blamed on this start"
+        );
+        std::fs::write(
+            &stderr_log,
+            "dyld[123]: Library not loaded: libonnxruntime.dylib\n",
+        )
+        .expect("write stderr log");
+        assert_eq!(
+            marks.error_since(),
+            Some((
+                stderr_log.clone(),
+                "dyld[123]: Library not loaded: libonnxruntime.dylib".to_string()
+            ))
+        );
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&daemon_log)
+            .expect("open daemon log");
+        std::io::Write::write_all(
+            &mut file,
+            b"INFO wenlan-server v0.17.1\nERROR wenlan_server: fresh failure\n",
+        )
+        .expect("append");
+        assert_eq!(
+            marks.error_since(),
+            Some((daemon_log, "ERROR wenlan_server: fresh failure".to_string())),
+            "the daemon log's own error wins over launchd's stderr"
+        );
     }
 
     #[test]

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -760,8 +760,19 @@ fn print_last_daemon_error() {
 /// clean shutdown is history rather than the current state.
 #[cfg(any(target_os = "macos", test))]
 fn last_daemon_error(log_path: &std::path::Path) -> Option<String> {
+    last_daemon_error_since(log_path, 0)
+}
+
+/// Like [`last_daemon_error`], but only the bytes written after `offset`
+/// count: a caller that noted the log's length before starting the daemon
+/// never blames this start for an error from an earlier run.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn last_daemon_error_since(log_path: &std::path::Path, offset: u64) -> Option<String> {
     let bytes = std::fs::read(log_path).ok()?;
-    let lines: Vec<String> = String::from_utf8_lossy(&bytes)
+    let start = usize::try_from(offset)
+        .unwrap_or(usize::MAX)
+        .min(bytes.len());
+    let lines: Vec<String> = String::from_utf8_lossy(&bytes[start..])
         .lines()
         .map(strip_ansi)
         .collect();
@@ -981,7 +992,37 @@ fn prompt_secret(prompt: &str) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod doctor_tests {
-    use super::{last_daemon_error, strip_ansi};
+    use super::{last_daemon_error, last_daemon_error_since, strip_ansi};
+
+    #[test]
+    fn last_daemon_error_since_ignores_errors_written_before_the_mark() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = dir.path().join("wenlan-server.log");
+        std::fs::write(
+            &log,
+            "INFO wenlan-server v0.17.0\nERROR wenlan_server: stale failure from last week\n",
+        )
+        .expect("write log");
+        let mark = std::fs::metadata(&log).expect("metadata").len();
+        assert_eq!(last_daemon_error_since(&log, mark), None);
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log)
+            .expect("open log");
+        std::io::Write::write_all(
+            &mut file,
+            b"INFO wenlan-server v0.17.1\nERROR wenlan_server: fresh failure\n",
+        )
+        .expect("append");
+        assert_eq!(
+            last_daemon_error_since(&log, mark).as_deref(),
+            Some("ERROR wenlan_server: fresh failure")
+        );
+        assert_eq!(
+            last_daemon_error(&log).as_deref(),
+            Some("ERROR wenlan_server: fresh failure")
+        );
+    }
 
     #[test]
     fn last_daemon_error_returns_the_final_error_line_without_colour_codes() {

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -292,6 +292,10 @@ fn print_daemon_log_paths() {
         "Daemon fallback log: {}",
         fallback_root.join("logs/wenlan-server.log").display()
     );
+    println!(
+        "Launchd stderr log: {}",
+        super::service::launchd_stderr_log_path(&data_root).display()
+    );
 }
 
 pub async fn print_runtime_status() -> anyhow::Result<()> {
@@ -688,21 +692,33 @@ async fn print_daemon_health() {
     }
 }
 
+/// The daemon's rotating file log in the data root (macOS only; Linux and
+/// Windows log to the service console).
+#[cfg(target_os = "macos")]
+pub(crate) fn daemon_log_path() -> std::path::PathBuf {
+    config::data_root().join("logs/wenlan-server.log")
+}
+
+/// The error the daemon's most recent run ended with, and the log it was read
+/// from. The fallback log is consulted only when the primary one does not
+/// exist at all (the daemon could not write its data root), so an old fallback
+/// entry never shadows a healthy primary log.
+#[cfg(target_os = "macos")]
+pub(crate) fn current_daemon_error() -> Option<(std::path::PathBuf, String)> {
+    let log_path = daemon_log_path();
+    if log_path.exists() {
+        last_daemon_error(&log_path).map(|line| (log_path, line))
+    } else {
+        let fallback = fallback_log_root().join("logs/wenlan-server.log");
+        last_daemon_error(&fallback).map(|line| (fallback, line))
+    }
+}
+
 /// macOS: the daemon keeps a rotating file log (primary data root, else the
 /// fallback root), so a daemon that exited on purpose can say why.
 #[cfg(target_os = "macos")]
 fn print_last_daemon_error() {
-    let log_path = config::data_root().join("logs/wenlan-server.log");
-    // The fallback log is consulted only when the primary one does not exist
-    // at all (the daemon could not write its data root), so an old fallback
-    // entry never shadows a healthy primary log.
-    let found = if log_path.exists() {
-        last_daemon_error(&log_path).map(|line| (log_path.clone(), line))
-    } else {
-        let fallback = fallback_log_root().join("logs/wenlan-server.log");
-        last_daemon_error(&fallback).map(|line| (fallback, line))
-    };
-    match found {
+    match current_daemon_error() {
         Some((path, line)) => {
             println!("  Last daemon error ({}):", path.display());
             println!("    {line}");
@@ -715,7 +731,10 @@ fn print_last_daemon_error() {
             }
         }
         None => {
-            println!("  No daemon error recorded in {}.", log_path.display());
+            println!(
+                "  No daemon error recorded in {}.",
+                daemon_log_path().display()
+            );
             println!(
                 "  Start it with `wenlan background on` (or open the Wenlan app); if it stops again, that log says why."
             );

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -1257,13 +1257,18 @@ fn setup_background_status_roundtrip_isolated() {
     assert!(config.contains(r#""on_device_model": null"#));
     assert!(config.contains(r#""anthropic_api_key": null"#));
 
+    // The fake launchctl never starts a daemon, so `background on` must not
+    // claim one started: it reports the install and that the daemon is still
+    // starting, with the health URL it waited on.
     cli_with_isolated_runtime(&runtime)
         .args(["background", "on"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "Installed and started com.wenlan.server",
-        ));
+            "Installed com.wenlan.server; the daemon is still starting.",
+        ))
+        .stdout(predicate::str::contains("Daemon not answering yet at"))
+        .stdout(predicate::str::contains("Installed and started").not());
     assert!(!runtime.data.path().join("autostart.off").exists());
 
     let plist = fs::read_to_string(runtime.service_unit_path()).expect("plist written");

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1243,7 +1243,7 @@ pub type SharedEmbedder = Arc<std::sync::Mutex<TextEmbedding>>;
 
 /// Process-wide lock that serializes FastEmbed (BGE) embedder initialization.
 ///
-/// `TextEmbedding::try_new()` performs filesystem I/O against `~/.fastembed_cache`
+/// `TextEmbedding::try_new()` performs filesystem I/O against the fastembed cache
 /// via the `hf-hub` crate. Concurrent first-time inits race on that cache and
 /// one of them fails with `Failed to retrieve model_optimized.onnx` (verified
 /// against PR #23 CI: same process, same module, two parallel `MemoryDB::new`
@@ -1474,11 +1474,10 @@ mod agent_id_tests {
 ///      matches the production daemon's conventional path on the same
 ///      host, so tests that use a tempdir DB still pick up the already-
 ///      downloaded model instead of re-fetching from HuggingFace.
-///   4. `None` — let FastEmbed use its own default (`~/.fastembed_cache/`)
-///      and download the model if it isn't there. Fine for a dev box
-///      with internet, fails noisily on hosts where the HuggingFace TLS
-///      bundle misbehaves (see the `OSStatus -26276` symptom from
-///      2026-04-16 that blocked ~240 tests from `test_db()`).
+///   4. `None` — no populated cache exists yet. fastembed's own default is
+///      `.fastembed_cache` relative to the process working directory
+///      (`FASTEMBED_CACHE_DIR` overrides it), which is why the daemon never
+///      falls through to it: see [`daemon_fastembed_cache_dir`].
 pub fn resolve_fastembed_cache_dir(db_path: &std::path::Path) -> Option<std::path::PathBuf> {
     // 1. Per-DB cache — production daemon populates this.
     let per_db = db_path.join("fastembed_cache");
@@ -1513,11 +1512,42 @@ pub fn resolve_fastembed_cache_dir(db_path: &std::path::Path) -> Option<std::pat
     None
 }
 
+/// The cache directory the daemon hands to fastembed. Unlike
+/// [`resolve_fastembed_cache_dir`] this never returns `None`: fastembed's own
+/// default is `.fastembed_cache` **relative to the process working directory**
+/// (`FASTEMBED_CACHE_DIR` overrides it), and launchd starts the daemon with
+/// cwd `/`, so a first boot that fell through could never write the model
+/// download and every launchd attempt died with `Failed to retrieve
+/// model_optimized.onnx` (first-run gauntlet finding F4). Order: a populated
+/// cache from the resolver, then `FASTEMBED_CACHE_DIR` (CI pre-populates it),
+/// then `<db_path>/fastembed_cache` next to the store.
+pub fn daemon_fastembed_cache_dir(db_path: &std::path::Path) -> std::path::PathBuf {
+    daemon_fastembed_cache_dir_from(
+        resolve_fastembed_cache_dir(db_path),
+        std::env::var_os("FASTEMBED_CACHE_DIR"),
+        db_path,
+    )
+}
+
+fn daemon_fastembed_cache_dir_from(
+    existing: Option<std::path::PathBuf>,
+    configured: Option<std::ffi::OsString>,
+    db_path: &std::path::Path,
+) -> std::path::PathBuf {
+    if let Some(existing) = existing {
+        return existing;
+    }
+    if let Some(configured) = configured.filter(|value| !value.is_empty()) {
+        return std::path::PathBuf::from(configured);
+    }
+    db_path.join("fastembed_cache")
+}
+
 /// Build the chunking engine for a DB at `db_path`, preferring token-aware
 /// sizing (the BGE tokenizer loaded from the resolved FastEmbed cache) so no
 /// embedded chunk exceeds the model's 512-token limit. Falls back to
-/// character-based sizing when the tokenizer isn't on disk (e.g. FastEmbed's
-/// default `~/.fastembed_cache` with no per-DB/shared cache resolved).
+/// character-based sizing when the tokenizer isn't on disk (no populated
+/// per-DB, env, or shared cache resolved).
 fn build_chunker(db_path: &Path) -> ChunkingEngine {
     resolve_fastembed_cache_dir(db_path)
         .as_deref()
@@ -4366,13 +4396,21 @@ impl MemoryDB {
         // runtime — spawn_blocking still occupies runtime-managed threads and
         // its JoinHandle needs worker threads to poll, which caused deadlocks
         // when combined with block_on calls during startup.
-        let embed_cache_dir = resolve_fastembed_cache_dir(db_path);
+        // Always hand fastembed an explicit directory. Its own default is
+        // `.fastembed_cache` relative to the working directory, and launchd
+        // starts the daemon at `/`, where the first-run download cannot be
+        // written — every launchd attempt died with "Failed to retrieve
+        // model_optimized.onnx" (first-run gauntlet finding F4).
+        let embed_cache_dir = daemon_fastembed_cache_dir(db_path);
+        std::fs::create_dir_all(&embed_cache_dir).map_err(|e| {
+            WenlanError::Embedding(format!(
+                "create the embedding-model cache directory {}: {e}",
+                embed_cache_dir.display()
+            ))
+        })?;
         log::info!(
             "[memory_db] starting embedder init (std::thread), cache={}",
-            embed_cache_dir
-                .as_deref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "<default>".into())
+            embed_cache_dir.display()
         );
         let embed_cache_label = embed_cache_dir.clone();
         let (embed_tx, embed_rx) = tokio::sync::oneshot::channel();
@@ -4380,11 +4418,9 @@ impl MemoryDB {
             .name("embedder-init".into())
             .spawn(move || {
                 log::info!("[memory_db] embedder thread: loading ONNX model...");
-                let mut opts = InitOptions::new(EmbeddingModel::BGEBaseENV15Q)
-                    .with_show_download_progress(true);
-                if let Some(cache) = embed_cache_dir {
-                    opts = opts.with_cache_dir(cache);
-                }
+                let opts = InitOptions::new(EmbeddingModel::BGEBaseENV15Q)
+                    .with_show_download_progress(true)
+                    .with_cache_dir(embed_cache_dir);
                 let result = init_text_embedding(opts);
                 let _ = embed_tx.send(result);
             })
@@ -4392,7 +4428,7 @@ impl MemoryDB {
         let embedder = embed_rx
             .await
             .map_err(|_| WenlanError::Embedding("embedder thread panicked".into()))?
-            .map_err(|e| embedder_init_error(&e, embed_cache_label.as_deref()))?;
+            .map_err(|e| embedder_init_error(&e, Some(embed_cache_label.as_path())))?;
 
         log::info!("[memory_db] initialized at {}", db_file.display());
 

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1512,17 +1512,23 @@ pub fn resolve_fastembed_cache_dir(db_path: &std::path::Path) -> Option<std::pat
     None
 }
 
-/// The cache directory the daemon hands to fastembed. Unlike
-/// [`resolve_fastembed_cache_dir`] this never returns `None`: fastembed's own
-/// default is `.fastembed_cache` **relative to the process working directory**
-/// (`FASTEMBED_CACHE_DIR` overrides it), and launchd starts the daemon with
-/// cwd `/`, so a first boot that fell through could never write the model
-/// download and every launchd attempt died with `Failed to retrieve
-/// model_optimized.onnx` (first-run gauntlet finding F4). Order: a populated
-/// cache from the resolver, then `FASTEMBED_CACHE_DIR` (CI pre-populates it),
+/// The cache directory the daemon hands to fastembed, for the text embedder
+/// and every reranker alike. Unlike [`resolve_fastembed_cache_dir`] this never
+/// returns `None`: fastembed's own default is `.fastembed_cache` **relative to
+/// the process working directory** (`FASTEMBED_CACHE_DIR` overrides it), and
+/// launchd starts the daemon with cwd `/`, so a first boot that fell through
+/// could never write the model download and every launchd attempt died with
+/// `Failed to retrieve model_optimized.onnx` (first-run gauntlet finding F4).
+///
+/// Order: a non-empty `HF_HOME` first — fastembed 5.13 gives it precedence
+/// over the configured directory for text models but ignores it for
+/// rerankers, so naming it here keeps every model, the lock, the log line and
+/// the error message on the directory fastembed really uses; then a populated
+/// cache from the resolver; then `FASTEMBED_CACHE_DIR` (CI pre-populates it);
 /// then `<db_path>/fastembed_cache` next to the store.
 pub fn daemon_fastembed_cache_dir(db_path: &std::path::Path) -> std::path::PathBuf {
     daemon_fastembed_cache_dir_from(
+        std::env::var_os("HF_HOME"),
         resolve_fastembed_cache_dir(db_path),
         std::env::var_os("FASTEMBED_CACHE_DIR"),
         db_path,
@@ -1530,10 +1536,14 @@ pub fn daemon_fastembed_cache_dir(db_path: &std::path::Path) -> std::path::PathB
 }
 
 fn daemon_fastembed_cache_dir_from(
+    hf_home: Option<std::ffi::OsString>,
     existing: Option<std::path::PathBuf>,
     configured: Option<std::ffi::OsString>,
     db_path: &std::path::Path,
 ) -> std::path::PathBuf {
+    if let Some(hf_home) = hf_home.filter(|value| !value.is_empty()) {
+        return std::path::PathBuf::from(hf_home);
+    }
     if let Some(existing) = existing {
         return existing;
     }
@@ -4401,6 +4411,13 @@ impl MemoryDB {
         // starts the daemon at `/`, where the first-run download cannot be
         // written — every launchd attempt died with "Failed to retrieve
         // model_optimized.onnx" (first-run gauntlet finding F4).
+        // fastembed treats an empty HF_HOME as set and resolves it against the
+        // working directory, which is exactly the launchd failure above.
+        if std::env::var_os("HF_HOME").is_some_and(|value| value.is_empty()) {
+            return Err(WenlanError::Embedding(
+                "HF_HOME is set but empty, so the embedding model would download into the working directory; unset it or point it at a writable directory".into(),
+            ));
+        }
         let embed_cache_dir = daemon_fastembed_cache_dir(db_path);
         std::fs::create_dir_all(&embed_cache_dir).map_err(|e| {
             WenlanError::Embedding(format!(

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -55731,3 +55731,35 @@ async fn strict_page_search_fails_on_a_row_the_lenient_path_skips() {
         "lenient search must degrade to the vector arm and still return the page"
     );
 }
+
+/// The daemon must never let fastembed pick its cwd-relative default: under
+/// launchd the cwd is `/` and the first-run download has nowhere to go.
+#[test]
+fn daemon_cache_dir_never_falls_through_to_the_cwd_default() {
+    let dir = tempdir().expect("tempdir");
+    let db_path = dir.path();
+    // Nothing populated, nothing configured: the store's own directory.
+    assert_eq!(
+        daemon_fastembed_cache_dir_from(None, None, db_path),
+        db_path.join("fastembed_cache")
+    );
+    // The CI hook keeps its pre-populated cache.
+    assert_eq!(
+        daemon_fastembed_cache_dir_from(None, Some("/ci/cache".into()), db_path),
+        std::path::PathBuf::from("/ci/cache")
+    );
+    // An empty override is not a directory.
+    assert_eq!(
+        daemon_fastembed_cache_dir_from(None, Some("".into()), db_path),
+        db_path.join("fastembed_cache")
+    );
+    // A populated cache always wins.
+    assert_eq!(
+        daemon_fastembed_cache_dir_from(
+            Some("/populated".into()),
+            Some("/ci/cache".into()),
+            db_path
+        ),
+        std::path::PathBuf::from("/populated")
+    );
+}

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -55740,26 +55740,43 @@ fn daemon_cache_dir_never_falls_through_to_the_cwd_default() {
     let db_path = dir.path();
     // Nothing populated, nothing configured: the store's own directory.
     assert_eq!(
-        daemon_fastembed_cache_dir_from(None, None, db_path),
+        daemon_fastembed_cache_dir_from(None, None, None, db_path),
         db_path.join("fastembed_cache")
     );
     // The CI hook keeps its pre-populated cache.
     assert_eq!(
-        daemon_fastembed_cache_dir_from(None, Some("/ci/cache".into()), db_path),
+        daemon_fastembed_cache_dir_from(None, None, Some("/ci/cache".into()), db_path),
         std::path::PathBuf::from("/ci/cache")
     );
     // An empty override is not a directory.
     assert_eq!(
-        daemon_fastembed_cache_dir_from(None, Some("".into()), db_path),
+        daemon_fastembed_cache_dir_from(None, None, Some("".into()), db_path),
         db_path.join("fastembed_cache")
     );
-    // A populated cache always wins.
+    // A populated cache beats the configured one.
     assert_eq!(
         daemon_fastembed_cache_dir_from(
+            None,
             Some("/populated".into()),
             Some("/ci/cache".into()),
             db_path
         ),
         std::path::PathBuf::from("/populated")
+    );
+    // HF_HOME beats everything: fastembed uses it for the text model whatever
+    // the daemon configures, so the reranker, lock and messages follow it.
+    assert_eq!(
+        daemon_fastembed_cache_dir_from(
+            Some("/hf/home".into()),
+            Some("/populated".into()),
+            Some("/ci/cache".into()),
+            db_path
+        ),
+        std::path::PathBuf::from("/hf/home")
+    );
+    // An empty HF_HOME is not a directory either.
+    assert_eq!(
+        daemon_fastembed_cache_dir_from(Some("".into()), None, None, db_path),
+        db_path.join("fastembed_cache")
     );
 }

--- a/crates/wenlan-server/src/daemon_structure_test.rs
+++ b/crates/wenlan-server/src/daemon_structure_test.rs
@@ -31,7 +31,7 @@ const MAIN_BASELINE_ORDER: &[&str] = &[
     "server_state.api_llm = Some(",
     "server_state.synthesis_llm = Some(",
     "server_state.external_llm = Some(",
-    "let reranker_cache_dir = wenlan_core::db::resolve_fastembed_cache_dir(",
+    "let reranker_cache_dir = Some(wenlan_core::db::daemon_fastembed_cache_dir(",
     "let mut deep_bgebase_pending = false",
     "reranker_mode_resolved(",
     "import_legacy_default_once(",
@@ -101,7 +101,7 @@ const STARTUP_CHILD_ORDER: &[&str] = &[
     "server_state.api_llm = Some(",
     "server_state.synthesis_llm = Some(",
     "server_state.external_llm = Some(",
-    "let reranker_cache_dir = wenlan_core::db::resolve_fastembed_cache_dir(",
+    "let reranker_cache_dir = Some(wenlan_core::db::daemon_fastembed_cache_dir(",
     "let mut deep_bgebase_pending = false",
     "reranker_mode_resolved(",
     "import_legacy_default_once(",
@@ -753,6 +753,7 @@ fn runtime_recompute_violations(source: &str, owner: &str) -> Vec<String> {
     for path in [
         "load_config",
         "resolve_fastembed_cache_dir",
+        "daemon_fastembed_cache_dir",
         "reranker_mode_resolved",
         "resolve_reranker_plan",
     ] {
@@ -1330,7 +1331,7 @@ fn structure_violations_with_children(
     };
     for anchor in [
         "let config = wenlan_core::config::load_config(",
-        "let reranker_cache_dir = wenlan_core::db::resolve_fastembed_cache_dir(",
+        "let reranker_cache_dir = Some(wenlan_core::db::daemon_fastembed_cache_dir(",
         "let mut deep_bgebase_pending = false",
     ] {
         violations.extend(exact_anchor_owner_violations(
@@ -2231,7 +2232,7 @@ fn reviewer_mutations_reject_value_ownership_and_shared_read_drift() {
 
     for anchor in [
         "let config = wenlan_core::config::load_config(",
-        "let reranker_cache_dir = wenlan_core::db::resolve_fastembed_cache_dir(",
+        "let reranker_cache_dir = Some(wenlan_core::db::daemon_fastembed_cache_dir(",
         "let mut deep_bgebase_pending = false",
     ] {
         let duplicated = format!("{main}\nfn hidden_startup_value() {{ {anchor}; }}\n");

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -938,8 +938,9 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Resolving the path is read-only. Before rotating tracing is available,
-    // a bounded bootstrap file keeps launchd failures and panics observable
-    // even though the plist intentionally redirects stdout/stderr to /dev/null.
+    // a bounded bootstrap file keeps launchd failures and panics observable;
+    // the plist sends stdout to /dev/null and stderr to
+    // `<data root>/logs/launchd-stderr.log`.
     let wenlan_root = resolve_wenlan_root();
     install_bootstrap_panic_hook(wenlan_root.clone());
 

--- a/crates/wenlan-server/src/main/startup.rs
+++ b/crates/wenlan-server/src/main/startup.rs
@@ -601,7 +601,10 @@ pub(super) async fn prepare_startup_state(
     // configured model — exactly the pre-mode behavior. First construction downloads
     // weights (turbo ~146MB, bge-base ~1.1GB) into the shared FastEmbed cache;
     // failure is non-fatal (the affected path falls back to embedding+FTS ordering).
-    let reranker_cache_dir = wenlan_core::db::resolve_fastembed_cache_dir(&data_dir);
+    // The same directory `MemoryDB::new` gave the text embedder: fastembed does
+    // not read HF_HOME for rerankers and would otherwise fall back to a cache
+    // relative to the working directory (`/` under launchd).
+    let reranker_cache_dir = Some(wenlan_core::db::daemon_fastembed_cache_dir(&data_dir));
     let mut deep_bgebase_pending = false;
     if optional_runtime_workers_allowed(repair_recovery_pending) {
         use wenlan_core::reranker::{RerankerMode, RerankerPick};

--- a/scripts/first-run/lib.sh
+++ b/scripts/first-run/lib.sh
@@ -165,9 +165,10 @@ stop_process() {
 daemon_postmortem() {
     # Call from teardown, after the service is stopped and before the data
     # root is deleted. The daemon owns its log files (the launchd plist sends
-    # stdout/stderr to /dev/null), so those files plus a foreground replay
-    # under the service's environment shape (cwd /, minimal PATH, the plist
-    # env) are the only way to learn why a managed daemon never got healthy.
+    # stdout to /dev/null and stderr to logs/launchd-stderr.log), so those
+    # files plus a foreground replay under the service's environment shape
+    # (cwd /, minimal PATH, the plist env) are the only way to learn why a
+    # managed daemon never got healthy.
     local bin="$1" data_root="$2" log tail_text
     collect "$data_root/logs" "$HOME/Library/Logs/com.wenlan.server-fallback"
     for log in "$data_root/logs/wenlan-server.log" "$data_root/logs/wenlan-server.bootstrap.log"; do
@@ -192,15 +193,13 @@ daemon_postmortem() {
     # fault is in how the service runs it. Anything else is the daemon's exit.
     info daemon-replay "rc=$rc (124 = still running at 30s) $(tail -c 1500 "$replay" | tr '\n' '|')"
 
-    # Discriminating replay: identical environment shape, but with an explicit
-    # absolute writable embedder cache. Default failing while this one lives
-    # past init pins the crash on the cwd-relative fastembed default cache;
-    # both failing points away from it (network/TLS under the service env).
-    local replay2="$GAUNTLET_OUT/checks/daemon-replay-cache-dir.log" rc2=0
-    mkdir -p "$data_root/replay-cache"
-    _replay_capped "$bin" "$replay2" "$data_root" 127.0.0.1:17918 \
-        FASTEMBED_CACHE_DIR="$data_root/replay-cache" || rc2=$?
-    info daemon-replay-cache-dir "rc=$rc2 (124 = still running at 30s) $(tail -c 1500 "$replay2" | tr '\n' '|')"
+    # Where the replay put the embedding model. The daemon must use the cache
+    # next to its store and never fastembed's default, which is relative to
+    # the working directory (`/` under launchd, finding F4).
+    local per_store=no cwd_relative=no
+    [ -d "$data_root/memorydb/fastembed_cache" ] && per_store=yes
+    [ -e /.fastembed_cache ] && cwd_relative=yes
+    info daemon-replay-cache "per-store=$per_store cwd-relative=$cwd_relative"
 }
 
 # Run the daemon exactly as launchd would (cwd /, minimal env) for at most

--- a/scripts/smoke-cli.sh
+++ b/scripts/smoke-cli.sh
@@ -52,8 +52,11 @@ if lsof -ti ":${PORT}" >/dev/null 2>&1; then
 fi
 
 echo "==> Starting daemon on port ${PORT} (data dir ${DATA_DIR})"
-# cwd = repo root so the daemon finds the shared .fastembed_cache.
+# The daemon no longer reads a cache relative to its working directory, so
+# name the repo's shared .fastembed_cache explicitly instead of downloading
+# 210 MB into every scratch data dir.
 (cd "$ROOT" && WENLAN_PORT="$PORT" WENLAN_DATA_DIR="$DATA_DIR" \
+    FASTEMBED_CACHE_DIR="${FASTEMBED_CACHE_DIR:-$ROOT/.fastembed_cache}" \
     exec "$BIN/wenlan-server" >"$DATA_DIR/daemon.log" 2>&1) &
 DAEMON_PID=$!
 

--- a/scripts/smoke-folder-ingest.sh
+++ b/scripts/smoke-folder-ingest.sh
@@ -44,8 +44,11 @@ if lsof -ti ":${PORT}" >/dev/null 2>&1; then
 fi
 
 echo "==> Starting daemon on port ${PORT} (data dir ${DATA_DIR})"
-# cwd = repo root so the daemon finds the shared .fastembed_cache.
+# The daemon no longer reads a cache relative to its working directory, so
+# name the repo's shared .fastembed_cache explicitly instead of downloading
+# 210 MB into every scratch data dir.
 (cd "$ROOT" && WENLAN_PORT="$PORT" WENLAN_DATA_DIR="$DATA_DIR" \
+    FASTEMBED_CACHE_DIR="${FASTEMBED_CACHE_DIR:-$ROOT/.fastembed_cache}" \
     exec "$BIN/wenlan-server" >"$DATA_DIR/daemon.log" 2>&1) &
 DAEMON_PID=$!
 


### PR DESCRIPTION
Pre-launch tracker row 10 (`wenlan-audit-2026-08-22.md`), first-run gauntlet finding F4 plus the rest of F8.

## What was wrong

Every fresh macOS install in the gauntlet crash-looped: `wenlan background on` printed `Installed and started com.wenlan.server.` while launchd restarted the daemon every 10 s with exit 1 and `stderr path = /dev/null`. The daemon's own log showed each attempt ending in `Failed to retrieve model_optimized.onnx`.

Mechanism (confirmed by the gauntlet's A/B replay): on a fresh account `resolve_fastembed_cache_dir` finds no populated cache and returned `None`, so fastembed used its own default — `.fastembed_cache` **relative to the process working directory** (`FASTEMBED_CACHE_DIR` overrides it; the old comment claiming `~/.fastembed_cache` was wrong). launchd starts the daemon at `/`, where the 210 MB first-run download cannot be written. Channels that start the daemon from a writable cwd (brew archive, systemd, schtasks) worked by accident and left a `.fastembed_cache` wherever the daemon happened to run.

## What changed

| Area | Change |
|---|---|
| `wenlan-core` `db.rs` | `MemoryDB::new` always passes an explicit cache directory: `daemon_fastembed_cache_dir(db_path)` returns a populated cache from the resolver, else `FASTEMBED_CACHE_DIR` (CI pre-populates it), else `<db_path>/fastembed_cache`, created before the embedder thread starts. The log line always names the directory now. |
| `wenlan` CLI `service.rs` | `background on` waits up to 10 s for `/api/health` on every platform. It prints "Installed and started …" only once the daemon answers. On macOS a daemon that stopped during this start fails the command with the error it logged after the command began ("installed …, but the daemon stopped with an error (<log>): …"; daemon log first, then launchd's stderr file; an error left over from an earlier run is never blamed on this start). Otherwise it says the daemon is still starting, that a first start downloads the 210 MB embedding model, and where to look. The launchd plist sends stderr to `<data root>/logs/launchd-stderr.log` instead of `/dev/null`; launchd does not rotate that file, and the daemon writes only bootstrap failures there (progress bars are hidden off a terminal). |
| `wenlan` CLI `setup.rs` | `wenlan doctor` lists the launchd stderr log; the log-reading helpers are shared with `background on`. |
| `crates/wenlan-cli/README.md` | Documents the wait and the error report. |

Not changed on purpose: `resolve_fastembed_cache_dir` itself (tests, the chunker, and the eval runner call it with a sentinel path and must not create directories); the Linux/Windows service paths beyond the shared health wait.

## Tests

- `db::tests::daemon_cache_dir_never_falls_through_to_the_cwd_default` — the three tiers and the empty-override case.
- `service::tests::launchd_plist_keeps_stderr_in_the_data_root` (macOS) and `first_health_note_says_how_long_it_waited_and_what_to_do`.
- `service::tests::install_reports_only_errors_written_after_it_started_the_daemon` (macOS) and `setup::doctor_tests::last_daemon_error_since_ignores_errors_written_before_the_mark`: only errors written after the start marks are reported.

## Receipts

`cargo clippy -p wenlan --all-targets -- -D warnings` clean; `cargo clippy -p wenlan-core --lib -- -D warnings` clean; `cargo test -p wenlan --lib -- service::tests doctor_tests` 7 passed; `cargo test -p wenlan-core --lib -- daemon_cache_dir` 1 passed; `cargo check -p wenlan-server` clean.

Real surface, rebuilt daemon started the way launchd does (cwd `/`, `env -i`, fresh fake `HOME`, fresh `WENLAN_DATA_DIR`, isolated port; the developer daemon on 7878 untouched):

- No network (sandbox denies huggingface.co): exit 1 within a second, `wenlan-server terminated with an error: Embedding error: could not load the embedding model (quantized BGE base en v1.5, about 210 MB) from <root>/memorydb/fastembed_cache. The first start downloads it from huggingface.co; check the network or proxy, then start Wenlan again. Cause: Failed to retrieve model_optimized.onnx: …`; the directory exists; no `/.fastembed_cache`, no `<home>/.fastembed_cache`.
- With network: `WENLAN_LISTENING_ON=127.0.0.1:17935`, healthy after 4 s, `209M <root>/memorydb/fastembed_cache/models--Qdrant--bge-base-en-v1.5-onnx-Q`; again no cwd or home cache.

`background on` against a real launchd session is not exercised here (this machine's registered service must stay untouched); the plist and the messages are unit-tested, and the first-run gauntlet on the next release is the end-to-end check.

## Review follow-up (ad04ad67)

One adversarial Codex Sol pass on 816b6ed1 returned DO NOT MERGE with one P1 and several smaller points. Acted on:

- **HF_HOME (P1).** fastembed 5.13 lets `HF_HOME` override the configured cache for text models but ignores it for rerankers, so the text model, the lock, the log line and the error message could all name different directories, and the reranker still fell back to a cwd-relative `.fastembed_cache`. `daemon_fastembed_cache_dir` now puts a non-empty `HF_HOME` first; startup passes `Some(daemon_fastembed_cache_dir(&data_dir))` to the reranker load (the structure tests anchor on that statement and forbid the runtime child from recomputing either helper); `MemoryDB::new` rejects `HF_HOME=""` with `WenlanError::Embedding` instead of letting fastembed resolve it against the working directory.
- **Stale errors.** `background on` records where the daemon log and `launchd-stderr.log` ended before it starts the daemon, prints "Installed and started …" only after health, and reports only an error written after that mark (daemon log first, then launchd stderr). `last_daemon_error_since(path, offset)` is the shared helper; `wenlan doctor` keeps the whole-file variant.
- **Comments and scripts.** The `/dev/null` stderr claims in `main.rs`, `service.rs` and the gauntlet library are corrected; the gauntlet's replay A/B (which changed two variables at once) is replaced by one line reporting whether the model landed next to the store or under `/.fastembed_cache`; `smoke-cli.sh` and `smoke-folder-ingest.sh` pass `FASTEMBED_CACHE_DIR` explicitly now that the daemon never reads a cwd-relative cache.

Not done, on purpose:

- No rotation for `launchd-stderr.log`: it only receives bootstrap failures, a couple of lines per attempt, and only while launchd keeps retrying a daemon that cannot start. The earlier "bounded" wording above was wrong and is corrected.
- The npm installer, the plugin and the desktop app still do not wait for health after `background on`; the plugin re-probe is a separate pre-launch task.
- `background on` does not inspect launchd's PID or last exit status; the log marks cover the crash-before-logging case the review raised.
- No production-wiring test of the real fastembed download under `HF_HOME` (needs the 210 MB model in CI); the tiering is covered by the pure-function test.

Receipts on ad04ad67: `cargo test -p wenlan-core --lib daemon_cache_dir_never` (1 passed, six tier cases), `cargo test -p wenlan-server --lib daemon_structure` (13 passed), `cargo test -p wenlan --lib` (57 passed, including `last_daemon_error_since_ignores_errors_written_before_the_mark` and `install_reports_only_errors_written_after_it_started_the_daemon`), `cargo clippy -p wenlan -p wenlan-server -p wenlan-core --all-targets -- -D warnings` clean, `cargo fmt --check` clean, shellcheck clean on the three scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh

