### PR TITLE
fix(mcp): pin rmcp-macros beside rmcp so an unlocked cargo install compiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -9162,6 +9162,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.12.28",
  "rmcp",
+ "rmcp-macros",
  "schemars 1.2.1",
  "semver",
  "serde",

--- a/crates/wenlan-mcp/Cargo.toml
+++ b/crates/wenlan-mcp/Cargo.toml
@@ -21,6 +21,11 @@ path = "src/main.rs"
 
 [dependencies]
 rmcp = { version = "~1.5", features = ["server", "transport-io", "transport-streamable-http-server"] }
+# rmcp 1.x only requires `rmcp-macros = "^X.Y.0"`, so an unlocked `cargo install`
+# resolves the newest macros crate, whose `#[tool]` expansion calls helpers the
+# pinned rmcp does not have (`schema_for_input`, first-run gauntlet finding F3).
+# Keep the macros crate on the same minor as rmcp.
+rmcp-macros = "~1.5"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/wenlan-mcp/README.md
+++ b/crates/wenlan-mcp/README.md
@@ -28,14 +28,16 @@ If you only need the raw MCP connector config, add this to your MCP client:
 }
 ```
 
-The npm wrapper auto-detects the host platform and downloads the matching prebuilt binary from the Wenlan release. Supported: macOS (arm64), Linux (x64, arm64; glibc), Windows (x64). Other targets require building the connector from source via `cargo install wenlan-mcp`; macOS Intel does not currently have a supported complete local runtime.
+The npm wrapper auto-detects the host platform and downloads the matching prebuilt binary from the Wenlan release. Supported: macOS (arm64), Linux (x64, arm64; glibc), Windows (x64). Other targets require building the connector from source via `cargo install --locked wenlan-mcp`; macOS Intel does not currently have a supported complete local runtime.
 
 Or install a binary directly:
 
 ```bash
 brew install 7xuanlu/tap/wenlan-mcp
-cargo install wenlan-mcp
+cargo install --locked wenlan-mcp
 ```
+
+`--locked` builds with the dependency versions the release was tested with; a plain `cargo install wenlan-mcp` also works, since the crate pins its proc-macro crate to the same minor as `rmcp`.
 
 Then use:
 


### PR DESCRIPTION
Pre-launch tracker row 11 (`wenlan-audit-2026-08-22.md`), first-run gauntlet finding F3.

## What was wrong

`cargo install wenlan-mcp` on a clean ubuntu-24.04 runner failed after 83 s with `error[E0425]: cannot find function schema_for_input in module rmcp::handler::server::common` (30 errors). `crates/wenlan-mcp/Cargo.toml` pins `rmcp = "~1.5"`, but rmcp 1.5.0 itself only requires `rmcp-macros = "^1.5.0"`; an unlocked install resolved rmcp-macros 1.8.0, whose `#[tool]` expansion calls a helper rmcp 1.5.0 does not have. The workspace `Cargo.lock` held 1.6.0, so CI never saw it.

## What changed

| File | Change |
|---|---|
| `crates/wenlan-mcp/Cargo.toml` | `rmcp-macros = "~1.5"` beside `rmcp = "~1.5"`, with a comment saying why the macros crate must stay on rmcp's minor. |
| `Cargo.lock` | `rmcp-macros` 1.6.0 → 1.5.0 (`cargo update -p rmcp-macros --precise 1.5.0`); nothing else moves. |
| `crates/wenlan-mcp/README.md` | Recommends `cargo install --locked wenlan-mcp` and says a plain install works too. |

Not changed: the gauntlet's `scripts/first-run/cargo-mcp.sh` keeps the plain `cargo install wenlan-mcp` row, so a future drift shows up again. Bumping rmcp instead would only postpone the next break: every rmcp 1.x release declares `rmcp-macros = "^X.Y.0"`.

## Receipts

`cargo build -p wenlan-mcp` clean; `cargo test -p wenlan-mcp --lib` 182 passed; `cargo test -p wenlan-mcp --test type_contract` 40 passed. `cargo tree -p wenlan-mcp -i rmcp-macros --depth 1` shows `rmcp-macros v1.5.0` pulled by both `rmcp v1.5.0` and `wenlan-mcp`; `cargo update -p rmcp-macros --dry-run` (unpinned resolve) reports `Locking 0 packages to latest compatible versions`, so nothing outside the 1.5 series can be chosen. The end-to-end check is the gauntlet's cargo row on the next published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
