### PR TITLE
fix(release): ship wenlan-server in the Homebrew wenlan formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -885,7 +885,7 @@ jobs:
         with:
           name: homebrew-artifacts
           path: |
-            ${{ runner.temp }}/promoted-assets/wenlan-cli-darwin-arm64.tar.gz
+            ${{ runner.temp }}/promoted-assets/wenlan-darwin-arm64.tar.gz
             ${{ runner.temp }}/promoted-assets/wenlan-mcp-darwin-arm64.tar.gz
           retention-days: 1
           if-no-files-found: error
@@ -1499,14 +1499,14 @@ jobs:
           require_event_tag
           VERSION="${RELEASE_TAG#v}"
           SHA_MCP_DARWIN_ARM64=$(shasum -a 256 wenlan-mcp-darwin-arm64.tar.gz | cut -d' ' -f1)
-          SHA_CLI_DARWIN_ARM64=$(shasum -a 256 wenlan-cli-darwin-arm64.tar.gz | cut -d' ' -f1)
+          SHA_DARWIN_ARM64=$(shasum -a 256 wenlan-darwin-arm64.tar.gz | cut -d' ' -f1)
 
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/7xuanlu/homebrew-tap.git" tap
           mkdir -p tap/Formula
 
           cat > tap/Formula/wenlan-mcp.rb << 'FORMULA'
           class WenlanMcp < Formula
-            desc "MCP server for Wenlan â€” personal agent memory layer"
+            desc "MCP server for Wenlan — personal agent memory layer"
             homepage "https://github.com/7xuanlu/wenlan"
             version "VERSION_PLACEHOLDER"
             url "https://github.com/7xuanlu/wenlan/releases/download/vVERSION_PLACEHOLDER/wenlan-mcp-darwin-arm64.tar.gz"
@@ -1540,12 +1540,16 @@ jobs:
             -e 's/VERSION_PLACEHOLDER/$ENV{VERSION}/g; s/SHA_PLACEHOLDER/$ENV{SHA}/g' \
             tap/Formula/wenlan-mcp.rb
 
+          # The formula installs from the full darwin archive, not the CLI-only one:
+          # `wenlan background on` looks for wenlan-server next to the `wenlan`
+          # binary, so a CLI-only install failed at the documented first step
+          # (first-run gauntlet finding F7). wenlan-mcp stays in its own formula.
           cat > tap/Formula/wenlan.rb << 'FORMULA'
           class Wenlan < Formula
-            desc "Wenlan CLI â€” local-first memory + knowledge layer for AI agents"
+            desc "Wenlan CLI and daemon — local-first memory + knowledge layer for AI agents"
             homepage "https://github.com/7xuanlu/wenlan"
             version "VERSION_PLACEHOLDER"
-            url "https://github.com/7xuanlu/wenlan/releases/download/vVERSION_PLACEHOLDER/wenlan-cli-darwin-arm64.tar.gz"
+            url "https://github.com/7xuanlu/wenlan/releases/download/vVERSION_PLACEHOLDER/wenlan-darwin-arm64.tar.gz"
             sha256 "SHA_PLACEHOLDER"
             license "Apache-2.0"
 
@@ -1559,16 +1563,17 @@ jobs:
             end
 
             def install
-              bin.install "wenlan"
+              bin.install "wenlan", "wenlan-server"
             end
 
             test do
               assert_match "wenlan", shell_output("#{bin}/wenlan --help")
+              assert_match "wenlan-server", shell_output("#{bin}/wenlan-server --help")
             end
           end
           FORMULA
 
-          VERSION="$VERSION" SHA="$SHA_CLI_DARWIN_ARM64" perl -pi \
+          VERSION="$VERSION" SHA="$SHA_DARWIN_ARM64" perl -pi \
             -e 's/VERSION_PLACEHOLDER/$ENV{VERSION}/g; s/SHA_PLACEHOLDER/$ENV{SHA}/g' \
             tap/Formula/wenlan.rb
 

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -156,7 +156,9 @@ fn current_server_path() -> Result<PathBuf> {
     }
     if !server.exists() {
         anyhow::bail!(
-            "wenlan-server not found next to origin at {}. Re-run the Wenlan installer.",
+            "wenlan-server not found next to wenlan at {}. If you installed with Homebrew, \
+             run `brew upgrade 7xuanlu/tap/wenlan` (the current formula ships the daemon); \
+             otherwise re-run the installer with `npx wenlan setup`.",
             server.display()
         );
     }

--- a/scripts/first-run/brew.sh
+++ b/scripts/first-run/brew.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # First-run gauntlet: Homebrew tap (macos-15, arm64).
-# `brew install 7xuanlu/tap/wenlan` ships the CLI only, so the documented next
-# step (`wenlan background on`) is expected to fail; that gap is recorded, then
-# a daemon from the release archive stands in for the CLI and MCP loops.
+# `brew install 7xuanlu/tap/wenlan` must ship wenlan-server beside the CLI so the
+# documented next step (`wenlan background on`) registers the daemon. The CLI
+# and MCP loops still run against a daemon from the release archive on a
+# scratch port and data dir, so they never depend on the launchd service.
 # No `set -e`: a failed step records a row and the later steps still run.
 # shellcheck disable=SC2016  # bash -c snippets take $1/$2 positionally on purpose
 set -u -o pipefail
@@ -21,7 +22,7 @@ cleanup() {
     if [ -n "$DAEMON_PID" ]; then
         stop_process "$DAEMON_PID"
     fi
-    # `background on` should fail before registering, but never trust that: unload anyway.
+    # `background on` registers a launchd service in the runner's real HOME: unload it.
     launchctl bootout "gui/$UID_NUM/com.wenlan.server" 2>/dev/null || true
     rm -f "$HOME/Library/LaunchAgents/com.wenlan.server.plist"
     brew uninstall wenlan wenlan-mcp >"$GAUNTLET_OUT/logs/teardown-brew-uninstall.log" 2>&1 || true
@@ -51,13 +52,12 @@ WENLAN_PATH="$(command -v wenlan || true)"
 info brew-wenlan-path "${WENLAN_PATH:-not on PATH}"
 info brew-server-next-to-cli "$(ls -l "$(dirname "${WENLAN_PATH:-/nonexistent}")/wenlan-server" 2>&1 || true)"
 
-# The documented next step. Today it fails because the formula ships no
-# wenlan-server (finding F7) — that is a real user-facing failure, so it is a
-# plain check and stays red until packaging or the docs change. Encoding the
-# known defect as the success condition would hide the breakage and turn the
-# eventual fix into a false red.
+# The documented next step. It failed on every release up to v0.17.0 because
+# the formula shipped no wenlan-server (finding F7); the formula now installs
+# both binaries from the full darwin archive, so this row must be green.
+check brew-server-installed -- test -x "$(dirname "${WENLAN_PATH:-/nonexistent}")/wenlan-server"
 check brew-background-on -- wenlan background on
-info brew-status-without-daemon "$(WENLAN_NO_AUTOSTART=1 wenlan status 2>&1 || true)"
+info brew-status-after-background-on "$(WENLAN_NO_AUTOSTART=1 wenlan status 2>&1 || true)"
 
 # Stand-in daemon from the release archive so the brew CLI and MCP can be exercised.
 DAEMON_LINE="$(TAG="$TAG" PORT="$PORT" DATA_DIR="$DATA_DIR" VERSION="$VERSION" \

--- a/scripts/first-run/brew.sh
+++ b/scripts/first-run/brew.sh
@@ -24,6 +24,13 @@ cleanup() {
     fi
     # `background on` registers a launchd service in the runner's real HOME: unload it.
     launchctl bootout "gui/$UID_NUM/com.wenlan.server" 2>/dev/null || true
+    # bootout returns before the job has exited; uninstalling or deleting
+    # state under a daemon that is still shutting down races it, so wait.
+    local i=0
+    while pgrep -x wenlan-server >/dev/null 2>&1 && [ "$i" -lt 15 ]; do
+        sleep 1
+        i=$((i + 1))
+    done
     rm -f "$HOME/Library/LaunchAgents/com.wenlan.server.plist"
     brew uninstall wenlan wenlan-mcp >"$GAUNTLET_OUT/logs/teardown-brew-uninstall.log" 2>&1 || true
     brew untap 7xuanlu/tap >"$GAUNTLET_OUT/logs/teardown-brew-untap.log" 2>&1 || true

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -58,6 +58,16 @@ def named_step_body(job: str, step_name: str) -> str:
     return match.group("body").strip() if match else ""
 
 
+def heredoc_body(job: str, path: str) -> str:
+    """The body of `cat > <path> << 'TAG'` inside a job, without the delimiters."""
+    match = re.search(
+        rf"^\s*cat > {re.escape(path)} << '(?P<tag>[A-Z_]+)'\n(?P<body>.*?)^\s*(?P=tag)\s*$",
+        job,
+        re.MULTILINE | re.DOTALL,
+    )
+    return match.group("body") if match else ""
+
+
 def contract_violations(
     ci: str,
     release: str,
@@ -548,16 +558,32 @@ def contract_violations(
             violations.append(f"validated asset promotion omits {marker!r}")
     # `wenlan background on` needs wenlan-server next to the brewed CLI, so the
     # `wenlan` formula must install from the full darwin archive and ship both.
+    # The assertions read the formula heredoc's active lines, not the job
+    # text, so a marker moved into a comment cannot satisfy them.
     homebrew = job_body(release, "update-homebrew")
+    formula = heredoc_body(homebrew, "tap/Formula/wenlan.rb")
+    if not formula:
+        violations.append("Homebrew wenlan formula heredoc is missing")
+    active_formula = [
+        line.strip()
+        for line in formula.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
     for marker in [
-        "shasum -a 256 wenlan-darwin-arm64.tar.gz",
+        'url "https://github.com/7xuanlu/wenlan/releases/download/vVERSION_PLACEHOLDER/wenlan-darwin-arm64.tar.gz"',
         'bin.install "wenlan", "wenlan-server"',
-        'shell_output("#{bin}/wenlan-server --help")',
+        'assert_match "wenlan-server", shell_output("#{bin}/wenlan-server --help")',
     ]:
-        if marker not in homebrew:
+        if marker not in active_formula:
             violations.append(f"Homebrew wenlan formula omits {marker!r}")
-    if "wenlan-cli-darwin-arm64.tar.gz" in homebrew:
+    if "wenlan-cli-darwin-arm64.tar.gz" in formula:
         violations.append("Homebrew wenlan formula still installs the CLI-only archive")
+    # The checksum the formula is stamped with must come from the same archive.
+    if "SHA_DARWIN_ARM64=$(shasum -a 256 wenlan-darwin-arm64.tar.gz" not in homebrew:
+        violations.append("Homebrew wenlan formula checksum is not taken from the full darwin archive")
+    after_formula = homebrew.split("cat > tap/Formula/wenlan.rb", 1)[-1]
+    if 'SHA="$SHA_DARWIN_ARM64" perl' not in after_formula:
+        violations.append("Homebrew wenlan formula sha256 is not stamped from SHA_DARWIN_ARM64")
 
     app_bundle = job_body(release, "app-bundle")
     app_bundle_windows = job_body(release, "app-bundle-windows")
@@ -1682,6 +1708,21 @@ def main() -> None:
             "observer reruns are accepted",
             "conflicting release semantics",
             "promotion",
+        ),
+        # The Homebrew formula must ship the daemon: an install line moved
+        # into a comment, or only the URL pointing back at the CLI-only
+        # archive, must each be caught on its own.
+        (
+            '              bin.install "wenlan", "wenlan-server"',
+            '              # bin.install "wenlan", "wenlan-server"\n              bin.install "wenlan"',
+            "Homebrew wenlan formula omits 'bin.install",
+            "release",
+        ),
+        (
+            'vVERSION_PLACEHOLDER/wenlan-darwin-arm64.tar.gz"',
+            'vVERSION_PLACEHOLDER/wenlan-cli-darwin-arm64.tar.gz"',
+            "still installs the CLI-only archive",
+            "release",
         ),
     ]
     for old, new, expected, owner in release_mutations:

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -541,10 +541,23 @@ def contract_violations(
         "Existing release asset $name differs; refusing to clobber.",
         "name: release-promotion-plan-${{ github.run_id }}",
         "name: homebrew-artifacts",
+        "promoted-assets/wenlan-darwin-arm64.tar.gz",
         "name: docker-runtime-inputs",
     ]:
         if marker not in promote:
             violations.append(f"validated asset promotion omits {marker!r}")
+    # `wenlan background on` needs wenlan-server next to the brewed CLI, so the
+    # `wenlan` formula must install from the full darwin archive and ship both.
+    homebrew = job_body(release, "update-homebrew")
+    for marker in [
+        "shasum -a 256 wenlan-darwin-arm64.tar.gz",
+        'bin.install "wenlan", "wenlan-server"',
+        'shell_output("#{bin}/wenlan-server --help")',
+    ]:
+        if marker not in homebrew:
+            violations.append(f"Homebrew wenlan formula omits {marker!r}")
+    if "wenlan-cli-darwin-arm64.tar.gz" in homebrew:
+        violations.append("Homebrew wenlan formula still installs the CLI-only archive")
 
     app_bundle = job_body(release, "app-bundle")
     app_bundle_windows = job_body(release, "app-bundle-windows")


### PR DESCRIPTION
Pre-launch tracker row 12 (`wenlan-audit-2026-08-22.md`), first-run gauntlet finding F7.

## What was wrong

`brew install 7xuanlu/tap/wenlan` installed from `wenlan-cli-darwin-arm64.tar.gz`, which holds only the `wenlan` binary (39 MB). The documented next step, `wenlan background on`, looks for `wenlan-server` beside the CLI (`current_server_path` in `crates/wenlan-cli/src/commands/service.rs`) and failed with `wenlan-server not found next to origin at /opt/homebrew/bin/wenlan-server. Re-run the Wenlan installer.` The gauntlet's `brew-background-on` row was red on v0.17.0. The full `wenlan-darwin-arm64.tar.gz` archive already carries `wenlan`, `wenlan-server` (87 MB), and `wenlan-mcp`.

## What changed

| File | Change |
|---|---|
| `.github/workflows/release.yml` | The `homebrew-artifacts` upload carries `wenlan-darwin-arm64.tar.gz` instead of the CLI-only archive; `update-homebrew` hashes it as `SHA_DARWIN_ARM64`; the `wenlan` formula installs from it with `bin.install "wenlan", "wenlan-server"` and its test also runs `wenlan-server --help`. `wenlan-mcp` keeps its own formula, so installing both stays conflict-free. Both formula descriptions get a real em dash instead of the double-encoded `â€”` that has been shipping in `brew info`. |
| `scripts/release-workflow-contract.test.py` | New markers: the promote job must upload the full archive; the Homebrew job must hash it, install both binaries, and test the server; the CLI-only archive name may not reappear in the Homebrew job. |
| `scripts/first-run/brew.sh` | New `brew-server-installed` row; comments no longer call the `background on` failure expected; the status row after `background on` is renamed. The CLI and MCP loops keep using the scratch daemon from the archive. |
| `crates/wenlan-cli/src/commands/service.rs` | The missing-daemon error says `next to wenlan` and names the fix per install path: `brew upgrade 7xuanlu/tap/wenlan`, otherwise `npx wenlan setup`. |

Not changed: the two darwin archives, `release_targets`, and the asset validator; `wenlan-cli-darwin-arm64.tar.gz` is still published for direct downloads.

## Receipts

- `python3 scripts/release-workflow-contract.test.py`: `PASS: release promotion, Homebrew, and Node 24 action contracts`.
- Mutation control: with the formula edited back to `bin.install "wenlan"`, the same test reports `Homebrew wenlan formula omits 'bin.install "wenlan", "wenlan-server"'`; restored, PASS again.
- `python3 scripts/release_targets.test.py`: OK.
- Rendered `wenlan.rb` (placeholders substituted the way the job does it): `ruby -c` → `Syntax OK`.
- `shellcheck scripts/first-run/brew.sh`: only the pre-existing SC1091 info about sourcing `lib.sh`.
- `cargo check -p wenlan` clean.
- `target/debug/wenlan-server --help` prints `Usage: wenlan-server [OPTIONS]`, so the new formula assertion matches.

End-to-end proof is the formula the next release generates, then the gauntlet's brew rows against that release (tracker row 22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
