### PR TITLE
fix(app): let a newer Wenlan.app take over from a running older one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9070,6 +9070,7 @@ dependencies = [
  "raw-window-handle",
  "regex",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=5e3c459d2b63607afbca51d7c7c6695326138156a9be535bcd02ef675c37a927 -->
+<!-- README_SYNC: source=README.md sha256=c8dbe1b39a702cde2a79dfc1b7f8b7c836fa3ee3efe5a6ac6e77d084ca31e413 -->
 
 <p align="center">
   <picture>
@@ -55,7 +55,7 @@ Wenlan funciona como un único daemon local. La aplicación de escritorio lo lle
 
 No hay nada más que instalar. La aplicación incluye el daemon, la CLI y el conector MCP, arranca el daemon al abrirse y ofrece conectar los clientes de IA que detecta: el plugin para Claude Code y Codex, una entrada MCP para el resto. A partir de ahí lees Páginas, inspeccionas la Fuente detrás de cualquier cita y gestionas el sistema de conocimiento.
 
-Esta vista previa aún no está notarizada, así que macOS bloquea el primer arranque con "Apple no ha podido verificar que Wenlan no contenga software malicioso". Pulsa Listo y luego permítelo una vez en Ajustes del Sistema, Privacidad y seguridad, "Abrir de todos modos". Un comando se salta ese paso: comprueba la descarga contra el SHA-256 publicado en GitHub, elimina la cuarentena solo para esta aplicación y no cambia ninguna configuración de seguridad de macOS.
+Esta vista previa está firmada ad hoc y no notarizada, así que macOS bloquea el primer arranque: puede decir que Wenlan "no se puede abrir" o que no ha podido comprobar si contiene software malicioso. Cierra ese aviso y luego permite la aplicación una vez en Ajustes del Sistema, Privacidad y seguridad, "Abrir de todos modos". Un comando se salta ese paso: comprueba la descarga contra el SHA-256 publicado en GitHub, elimina la cuarentena solo para esta aplicación y no cambia ninguna configuración de seguridad de macOS.
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=c4e73e02e9e5607b16b7e0d2282e1bc5cc3aff927b0e5acb7bbdfb038a688fc5 -->
+<!-- README_SYNC: source=README.md sha256=5e3c459d2b63607afbca51d7c7c6695326138156a9be535bcd02ef675c37a927 -->
 
 <p align="center">
   <picture>
@@ -51,11 +51,11 @@ Wenlan funciona como un único daemon local. La aplicación de escritorio lo lle
 
 ### Aplicación de escritorio
 
-**[Descarga Wenlan para macOS](https://github.com/7xuanlu/wenlan/releases/latest)** (Apple Silicon), abre el `.dmg` y arrastra la aplicación a Aplicaciones.
+**[Descarga Wenlan para macOS](https://github.com/7xuanlu/wenlan/releases/latest)** (Apple Silicon), abre el `.dmg` y arrastra la aplicación a Aplicaciones. Para actualizar, arrastra la aplicación nueva sobre la antigua y ábrela: si Wenlan está en ejecución se cierra y arranca la versión nueva (Wenlan 0.17.0 y anteriores hay que cerrarlos a mano antes).
 
 No hay nada más que instalar. La aplicación incluye el daemon, la CLI y el conector MCP, arranca el daemon al abrirse y ofrece conectar los clientes de IA que detecta: el plugin para Claude Code y Codex, una entrada MCP para el resto. A partir de ahí lees Páginas, inspeccionas la Fuente detrás de cualquier cita y gestionas el sistema de conocimiento.
 
-Esta vista previa aún no está notarizada, así que macOS bloquea el primer arranque. Permítelo una vez en Ajustes del Sistema, Privacidad y seguridad, "Abrir de todos modos". Un comando se salta ese paso: comprueba la descarga contra el SHA-256 publicado en GitHub, elimina la cuarentena solo para esta aplicación y no cambia ninguna configuración de seguridad de macOS.
+Esta vista previa aún no está notarizada, así que macOS bloquea el primer arranque con "Apple no ha podido verificar que Wenlan no contenga software malicioso". Pulsa Listo y luego permítelo una vez en Ajustes del Sistema, Privacidad y seguridad, "Abrir de todos modos". Un comando se salta ese paso: comprueba la descarga contra el SHA-256 publicado en GitHub, elimina la cuarentena solo para esta aplicación y no cambia ninguna configuración de seguridad de macOS.
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Wenlan runs as one local daemon. The desktop app carries that daemon inside it; 
 
 Nothing else to install. The app bundles the daemon, CLI, and MCP connector, starts the daemon on launch, and offers to connect the AI clients it detects: the plugin for Claude Code and Codex, an MCP entry for the rest. From there you read Pages, inspect the Source behind any citation, and curate the knowledge system.
 
-This preview is not notarized yet, so macOS blocks the first launch with "Apple could not verify Wenlan is free of malware". Click Done, then allow it once under System Settings, Privacy & Security, "Open Anyway". One command skips that step: it verifies the download against GitHub's published SHA-256, clears quarantine for this app alone, and changes no macOS security settings.
+This preview is ad-hoc signed and not notarized, so macOS blocks the first launch: it may say Wenlan "cannot be opened" or that it could not check it for malicious software. Close that dialog, then allow the app once under System Settings, Privacy & Security, "Open Anyway". One command skips that step: it verifies the download against GitHub's published SHA-256, clears quarantine for this app alone, and changes no macOS security settings.
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Wenlan runs as one local daemon. The desktop app carries that daemon inside it; 
 
 ### Desktop app
 
-**[Download Wenlan for macOS](https://github.com/7xuanlu/wenlan/releases/latest)** (Apple Silicon), open the `.dmg`, and drag the app to Applications.
+**[Download Wenlan for macOS](https://github.com/7xuanlu/wenlan/releases/latest)** (Apple Silicon), open the `.dmg`, and drag the app to Applications. To upgrade, drag the new app over the old one and open it: a running Wenlan quits and the new version starts (Wenlan 0.17.0 and older must be quit by hand first).
 
 Nothing else to install. The app bundles the daemon, CLI, and MCP connector, starts the daemon on launch, and offers to connect the AI clients it detects: the plugin for Claude Code and Codex, an MCP entry for the rest. From there you read Pages, inspect the Source behind any citation, and curate the knowledge system.
 
-This preview is not notarized yet, so macOS blocks the first launch. Allow it once under System Settings, Privacy & Security, "Open Anyway". One command skips that step: it verifies the download against GitHub's published SHA-256, clears quarantine for this app alone, and changes no macOS security settings.
+This preview is not notarized yet, so macOS blocks the first launch with "Apple could not verify Wenlan is free of malware". Click Done, then allow it once under System Settings, Privacy & Security, "Open Anyway". One command skips that step: it verifies the download against GitHub's published SHA-256, clears quarantine for this app alone, and changes no macOS security settings.
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=c4e73e02e9e5607b16b7e0d2282e1bc5cc3aff927b0e5acb7bbdfb038a688fc5 -->
+<!-- README_SYNC: source=README.md sha256=5e3c459d2b63607afbca51d7c7c6695326138156a9be535bcd02ef675c37a927 -->
 
 <p align="center">
   <picture>
@@ -51,11 +51,11 @@ Wenlan 以单个本地 daemon 运行。桌面 app 内置这个 daemon；无 GUI 
 
 ### 桌面 app
 
-**[下载 macOS 版 Wenlan](https://github.com/7xuanlu/wenlan/releases/latest)**（Apple Silicon），打开 `.dmg`，把 app 拖进「应用程序」。
+**[下载 macOS 版 Wenlan](https://github.com/7xuanlu/wenlan/releases/latest)**（Apple Silicon），打开 `.dmg`，把 app 拖进「应用程序」。升级时把新 app 拖到旧 app 上覆盖，再打开它：正在运行的 Wenlan 会自动退出，新版本随即启动（Wenlan 0.17.0 及更早的版本需要先手动退出）。
 
 不需要再安装别的东西。App 内已打包 daemon、CLI 与 MCP 连接器，启动时会自动运行 daemon，并会为检测到的 AI 客户端提供接入：Claude Code 与 Codex 安装 plugin，其余客户端写入 MCP 配置。之后你就可以阅读 Page、检查任一引用背后的 Source，并整理整个知识体系。
 
-这个预览版尚未经过 Apple notarization，首次启动会被 macOS 拦下，在「系统设置」的「隐私与安全性」里点一次「仍要打开」即可。一条命令可以跳过这一步：它会用 GitHub 发布的 SHA-256 核对下载文件，只为这一个 app 清除 quarantine，不会更改任何 macOS 安全设置。
+这个预览版尚未经过 Apple notarization，首次启动会被 macOS 拦下，提示「Apple 无法验证 Wenlan 是否包含恶意软件」。点「完成」，再到「系统设置」的「隐私与安全性」里点一次「仍要打开」即可。一条命令可以跳过这一步：它会用 GitHub 发布的 SHA-256 核对下载文件，只为这一个 app 清除 quarantine，不会更改任何 macOS 安全设置。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=5e3c459d2b63607afbca51d7c7c6695326138156a9be535bcd02ef675c37a927 -->
+<!-- README_SYNC: source=README.md sha256=c8dbe1b39a702cde2a79dfc1b7f8b7c836fa3ee3efe5a6ac6e77d084ca31e413 -->
 
 <p align="center">
   <picture>
@@ -55,7 +55,7 @@ Wenlan 以单个本地 daemon 运行。桌面 app 内置这个 daemon；无 GUI 
 
 不需要再安装别的东西。App 内已打包 daemon、CLI 与 MCP 连接器，启动时会自动运行 daemon，并会为检测到的 AI 客户端提供接入：Claude Code 与 Codex 安装 plugin，其余客户端写入 MCP 配置。之后你就可以阅读 Page、检查任一引用背后的 Source，并整理整个知识体系。
 
-这个预览版尚未经过 Apple notarization，首次启动会被 macOS 拦下，提示「Apple 无法验证 Wenlan 是否包含恶意软件」。点「完成」，再到「系统设置」的「隐私与安全性」里点一次「仍要打开」即可。一条命令可以跳过这一步：它会用 GitHub 发布的 SHA-256 核对下载文件，只为这一个 app 清除 quarantine，不会更改任何 macOS 安全设置。
+这个预览版只做了 ad-hoc 签名、未经 Apple notarization，首次启动会被 macOS 拦下：可能提示 Wenlan「无法打开」，或者无法检查它是否包含恶意软件。关掉这个提示，再到「系统设置」的「隐私与安全性」里点一次「仍要打开」即可。一条命令可以跳过这一步：它会用 GitHub 发布的 SHA-256 核对下载文件，只为这一个 app 清除 quarantine，不会更改任何 macOS 安全设置。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=c4e73e02e9e5607b16b7e0d2282e1bc5cc3aff927b0e5acb7bbdfb038a688fc5 -->
+<!-- README_SYNC: source=README.md sha256=5e3c459d2b63607afbca51d7c7c6695326138156a9be535bcd02ef675c37a927 -->
 
 <p align="center">
   <picture>
@@ -51,11 +51,11 @@ Wenlan 以單一本地 daemon 運行。桌面 app 內建這個 daemon；無 GUI 
 
 ### 桌面 app
 
-**[下載 macOS 版 Wenlan](https://github.com/7xuanlu/wenlan/releases/latest)**（Apple Silicon），打開 `.dmg`，把 app 拖進「應用程式」。
+**[下載 macOS 版 Wenlan](https://github.com/7xuanlu/wenlan/releases/latest)**（Apple Silicon），打開 `.dmg`，把 app 拖進「應用程式」。升級時把新 app 拖到舊 app 上覆蓋，再打開它：正在執行的 Wenlan 會自動結束，新版本隨即啟動（Wenlan 0.17.0 及更早的版本需要先手動結束）。
 
 不需要再安裝其他東西。App 內已打包 daemon、CLI 與 MCP 連接器，啟動時會自動執行 daemon，並會為偵測到的 AI 用戶端提供接入：Claude Code 與 Codex 安裝 plugin，其餘用戶端寫入 MCP 設定。之後你就可以閱讀 Page、檢查任一引用背後的 Source，並整理整個知識體系。
 
-這個預覽版尚未經 Apple notarization，首次啟動會被 macOS 擋下，在「系統設定」的「隱私權與安全性」裡點一次「仍要打開」即可。一條指令可以跳過這一步：它會用 GitHub 發布的 SHA-256 核對下載檔案，只為這一個 app 清除 quarantine，不會變更任何 macOS 安全設定。
+這個預覽版尚未經 Apple notarization，首次啟動會被 macOS 擋下，提示「Apple 無法驗證 Wenlan 是否含有惡意軟體」。點「完成」，再到「系統設定」的「隱私權與安全性」裡點一次「仍要打開」即可。一條指令可以跳過這一步：它會用 GitHub 發布的 SHA-256 核對下載檔案，只為這一個 app 清除 quarantine，不會變更任何 macOS 安全設定。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=5e3c459d2b63607afbca51d7c7c6695326138156a9be535bcd02ef675c37a927 -->
+<!-- README_SYNC: source=README.md sha256=c8dbe1b39a702cde2a79dfc1b7f8b7c836fa3ee3efe5a6ac6e77d084ca31e413 -->
 
 <p align="center">
   <picture>
@@ -55,7 +55,7 @@ Wenlan 以單一本地 daemon 運行。桌面 app 內建這個 daemon；無 GUI 
 
 不需要再安裝其他東西。App 內已打包 daemon、CLI 與 MCP 連接器，啟動時會自動執行 daemon，並會為偵測到的 AI 用戶端提供接入：Claude Code 與 Codex 安裝 plugin，其餘用戶端寫入 MCP 設定。之後你就可以閱讀 Page、檢查任一引用背後的 Source，並整理整個知識體系。
 
-這個預覽版尚未經 Apple notarization，首次啟動會被 macOS 擋下，提示「Apple 無法驗證 Wenlan 是否含有惡意軟體」。點「完成」，再到「系統設定」的「隱私權與安全性」裡點一次「仍要打開」即可。一條指令可以跳過這一步：它會用 GitHub 發布的 SHA-256 核對下載檔案，只為這一個 app 清除 quarantine，不會變更任何 macOS 安全設定。
+這個預覽版只做了 ad-hoc 簽署、未經 Apple notarization，首次啟動會被 macOS 擋下：可能提示 Wenlan「無法打開」，或者無法檢查它是否含有惡意軟體。關掉這個提示，再到「系統設定」的「隱私權與安全性」裡點一次「仍要打開」即可。一條指令可以跳過這一步：它會用 GitHub 發布的 SHA-256 核對下載檔案，只為這一個 app 清除 quarantine，不會變更任何 macOS 安全設定。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1"
 toml = "0.8"
 toml_edit = "0.22"
 plist = "1"
+semver = "1"
 base64 = "0.22"
 
 # File watching

--- a/app/src/handover.rs
+++ b/app/src/handover.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Hand the running app over to a newer bundle that was just launched.
+//!
+//! The single-instance plugin makes every second launch exit right after it
+//! hands its argv to the running instance. When that second launch is a newer
+//! Wenlan — the installer replaced the bundle, or the user dragged a new one
+//! into Applications — focusing the old window is wrong: the user asked for
+//! the new version and nothing told them the old one is still on screen
+//! (first-run gauntlet finding F2). The running app instead quits the way
+//! "Quit Wenlan" does and reopens the newer bundle once its own process is
+//! gone, so the single-instance socket is free by the time the newcomer
+//! claims it.
+
+use std::path::{Path, PathBuf};
+
+/// A newer app bundle that just tried to launch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NewerBundle {
+    pub bundle: PathBuf,
+    pub version: semver::Version,
+}
+
+/// The newer bundle behind a second launch, if that is what `argv` describes.
+///
+/// `argv[0]` of a bundle launched through LaunchServices is the executable
+/// inside `<name>.app/Contents/MacOS/`; the bundle's `Info.plist` carries the
+/// version. Anything else — a dev binary, an unreadable plist, the same or an
+/// older version — yields `None` and the caller keeps the focus behavior.
+pub fn newer_bundle_from_launch(argv: &[String], running: &semver::Version) -> Option<NewerBundle> {
+    let bundle = bundle_root(Path::new(argv.first()?))?;
+    let version = bundle_version(&bundle)?;
+    (version > *running).then_some(NewerBundle { bundle, version })
+}
+
+fn bundle_root(exe: &Path) -> Option<PathBuf> {
+    let macos = exe.parent()?;
+    let contents = macos.parent()?;
+    let bundle = contents.parent()?;
+    let is_bundle = macos.file_name()? == "MacOS"
+        && contents.file_name()? == "Contents"
+        && bundle.extension()? == "app";
+    is_bundle.then(|| bundle.to_path_buf())
+}
+
+fn bundle_version(bundle: &Path) -> Option<semver::Version> {
+    let info = plist::Value::from_file(bundle.join("Contents/Info.plist")).ok()?;
+    let version = info
+        .as_dictionary()?
+        .get("CFBundleShortVersionString")?
+        .as_string()?;
+    semver::Version::parse(version).ok()
+}
+
+/// Shell script that reopens the bundle passed as `$0` once process `pid`
+/// has exited.
+///
+/// The old app cannot `open` the newcomer itself: while it is alive,
+/// LaunchServices would only activate it, and its single-instance socket
+/// would send the newcomer straight back to exit. A detached shell waits the
+/// old process out instead.
+pub fn relaunch_script(pid: u32) -> String {
+    format!("while kill -0 {pid} 2>/dev/null; do sleep 0.1; done; exec open \"$0\"")
+}
+
+/// Spawn the detached helper that reopens `bundle` after this process exits.
+pub fn relaunch_after_exit(bundle: &Path) {
+    let spawned = std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(relaunch_script(std::process::id()))
+        .arg(bundle)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+    match spawned {
+        Ok(_) => log::info!(
+            "[handover] will reopen {} once this process exits",
+            bundle.display()
+        ),
+        Err(e) => log::error!(
+            "[handover] could not schedule the reopen of {}: {e}",
+            bundle.display()
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scratch_bundle(version: Option<&str>) -> (PathBuf, PathBuf) {
+        let root = std::env::temp_dir().join(format!(
+            "wenlan-handover-{}-{}",
+            std::process::id(),
+            version.unwrap_or("none").replace('.', "_")
+        ));
+        let bundle = root.join("Wenlan.app");
+        let macos = bundle.join("Contents/MacOS");
+        std::fs::create_dir_all(&macos).unwrap();
+        let exe = macos.join("wenlan-app");
+        std::fs::write(&exe, b"").unwrap();
+        if let Some(version) = version {
+            std::fs::write(
+                bundle.join("Contents/Info.plist"),
+                format!(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                     <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+                     \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+                     <plist version=\"1.0\"><dict>\
+                     <key>CFBundleIdentifier</key><string>com.wenlan.desktop</string>\
+                     <key>CFBundleShortVersionString</key><string>{version}</string>\
+                     </dict></plist>\n"
+                ),
+            )
+            .unwrap();
+        }
+        (bundle, exe)
+    }
+
+    fn argv(exe: &Path) -> Vec<String> {
+        vec![exe.to_string_lossy().into_owned()]
+    }
+
+    #[test]
+    fn a_newer_bundle_is_recognized_and_an_equal_or_older_one_is_not() {
+        let (bundle, exe) = scratch_bundle(Some("0.18.0"));
+        let newer = newer_bundle_from_launch(&argv(&exe), &semver::Version::new(0, 17, 0));
+        assert_eq!(
+            newer,
+            Some(NewerBundle {
+                bundle: bundle.clone(),
+                version: semver::Version::new(0, 18, 0),
+            })
+        );
+        assert_eq!(
+            newer_bundle_from_launch(&argv(&exe), &semver::Version::new(0, 18, 0)),
+            None,
+            "the same version must keep the focus behavior"
+        );
+        assert_eq!(
+            newer_bundle_from_launch(&argv(&exe), &semver::Version::new(0, 19, 0)),
+            None,
+            "an older newcomer must never take over"
+        );
+        std::fs::remove_dir_all(bundle.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn anything_that_is_not_a_readable_app_bundle_keeps_the_focus_behavior() {
+        let running = semver::Version::new(0, 17, 0);
+        assert_eq!(newer_bundle_from_launch(&[], &running), None);
+        assert_eq!(
+            newer_bundle_from_launch(&["target/debug/wenlan-app".to_string()], &running),
+            None,
+            "a dev binary outside a bundle has no version to compare"
+        );
+        let (bundle, exe) = scratch_bundle(None);
+        assert_eq!(
+            newer_bundle_from_launch(&argv(&exe), &running),
+            None,
+            "a bundle without Info.plist has no version to compare"
+        );
+        std::fs::remove_dir_all(bundle.parent().unwrap()).unwrap();
+        let (bundle, exe) = scratch_bundle(Some("not-a-version"));
+        assert_eq!(newer_bundle_from_launch(&argv(&exe), &running), None);
+        std::fs::remove_dir_all(bundle.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn the_relaunch_script_waits_for_the_old_process_then_opens_the_bundle() {
+        let script = relaunch_script(4242);
+        assert_eq!(
+            script,
+            "while kill -0 4242 2>/dev/null; do sleep 0.1; done; exec open \"$0\""
+        );
+    }
+}

--- a/app/src/handover.rs
+++ b/app/src/handover.rs
@@ -13,6 +13,12 @@
 
 use std::path::{Path, PathBuf};
 
+/// How long the old app may take to finish its guarded quit once a newer
+/// bundle asked for the handover. The frontend normally acknowledges within
+/// 2 s and persists in well under a second; past this the old app is hidden
+/// and the user sees nothing at all, so the quit is forced.
+pub const QUIT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(15);
+
 /// A newer app bundle that just tried to launch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NewerBundle {
@@ -29,7 +35,9 @@ pub struct NewerBundle {
 pub fn newer_bundle_from_launch(argv: &[String], running: &semver::Version) -> Option<NewerBundle> {
     let bundle = bundle_root(Path::new(argv.first()?))?;
     let version = bundle_version(&bundle)?;
-    (version > *running).then_some(NewerBundle { bundle, version })
+    // Precedence only: build metadata (`0.18.0+abc`) never decides an upgrade.
+    (version.cmp_precedence(running) == std::cmp::Ordering::Greater)
+        .then_some(NewerBundle { bundle, version })
 }
 
 fn bundle_root(exe: &Path) -> Option<PathBuf> {
@@ -141,6 +149,27 @@ mod tests {
             newer_bundle_from_launch(&argv(&exe), &semver::Version::new(0, 19, 0)),
             None,
             "an older newcomer must never take over"
+        );
+        std::fs::remove_dir_all(bundle.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn build_metadata_never_decides_an_upgrade() {
+        let (bundle, exe) = scratch_bundle(Some("0.18.0+build.1"));
+        let running = semver::Version::parse("0.18.0+build.2").unwrap();
+        assert_eq!(
+            newer_bundle_from_launch(&argv(&exe), &running),
+            None,
+            "a lower build tag on the same release is not an upgrade"
+        );
+        assert_eq!(
+            newer_bundle_from_launch(&argv(&exe), &semver::Version::new(0, 18, 0)),
+            None,
+            "a build tag alone does not make the same release newer"
+        );
+        assert!(
+            newer_bundle_from_launch(&argv(&exe), &semver::Version::new(0, 17, 9)).is_some(),
+            "a higher release with a build tag is still an upgrade"
         );
         std::fs::remove_dir_all(bundle.parent().unwrap()).unwrap();
     }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -15,6 +15,8 @@ pub mod config;
 mod daemon_start;
 pub mod error;
 pub mod events;
+#[cfg(target_os = "macos")]
+mod handover;
 mod identity_paths;
 mod indexer;
 mod lifecycle;
@@ -539,8 +541,29 @@ pub fn run() {
     let app_state = AppState::new();
 
     let builder =
-        tauri::Builder::default().plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+        tauri::Builder::default().plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
             use tauri::Manager;
+            // A second launch of a *newer* bundle means the user upgraded and
+            // wants the new version, not the old window brought to the front.
+            #[cfg(target_os = "macos")]
+            {
+                let running = app.package_info().version.clone();
+                if let Some(newer) = handover::newer_bundle_from_launch(&argv, &running) {
+                    log::info!(
+                        "[handover] Wenlan {} was launched while {running} is running; quitting so {} can take over",
+                        newer.version,
+                        newer.bundle.display()
+                    );
+                    lifecycle::set_handover_bundle(newer.bundle);
+                    if let Err(e) = request_full_quit(app) {
+                        log::error!("[handover] failed to request guarded quit: {e}");
+                        force_full_quit(app.clone());
+                    }
+                    return;
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            let _ = &argv;
             if let Some(window) = app.get_webview_window("main") {
                 set_main_window_dock_visibility(app, true);
                 let _ = window.show();

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -420,7 +420,14 @@ fn acknowledge_guarded_quit_request(request_id: u64, delivery_id: u64) -> bool {
 #[cfg(not(feature = "review-fixtures"))]
 #[tauri::command]
 fn cancel_guarded_quit_request(request_id: u64, delivery_id: u64) -> bool {
-    with_guarded_quit(|guard| guard.cancel(request_id, delivery_id))
+    let cancelled = with_guarded_quit(|guard| guard.cancel(request_id, delivery_id));
+    // A refused quit ends a pending handover too: the user keeps this app to
+    // fix the save, and a later quit must not reopen the newer bundle.
+    #[cfg(target_os = "macos")]
+    if cancelled {
+        lifecycle::clear_handover_bundle();
+    }
+    cancelled
 }
 
 #[cfg(not(feature = "review-fixtures"))]
@@ -428,7 +435,30 @@ fn force_full_quit(app: tauri::AppHandle) {
     tauri::async_runtime::spawn(async move {
         if let Err(e) = crate::lifecycle::quit_origin(&app).await {
             log::error!("[app] forced quit failed: {e}");
-            app.exit(1);
+            crate::lifecycle::exit_after_quit(&app, 1);
+        }
+    });
+}
+
+/// The guarded quit's own timer only covers the acknowledgement. Once the
+/// frontend has acknowledged, nothing bounds how long it takes to call the
+/// full quit, and a hung persist would leave the old app hidden with the user
+/// staring at nothing. A handover therefore carries a hard deadline: a quit
+/// still in flight when it passes is forced. A guard the frontend refused (it
+/// could not save) has already dropped the handover and is left alone.
+#[cfg(all(target_os = "macos", not(feature = "review-fixtures")))]
+fn arm_handover_deadline(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(handover::QUIT_DEADLINE).await;
+        if lifecycle::handover_pending()
+            && !lifecycle::is_quitting()
+            && with_guarded_quit(GuardedQuitCoordinator::force_if_in_flight)
+        {
+            log::warn!(
+                "[handover] the guarded quit did not finish within {:?}; forcing shutdown",
+                handover::QUIT_DEADLINE
+            );
+            force_full_quit(app);
         }
     });
 }
@@ -555,9 +585,12 @@ pub fn run() {
                         newer.bundle.display()
                     );
                     lifecycle::set_handover_bundle(newer.bundle);
-                    if let Err(e) = request_full_quit(app) {
-                        log::error!("[handover] failed to request guarded quit: {e}");
-                        force_full_quit(app.clone());
+                    match request_full_quit(app) {
+                        Ok(()) => arm_handover_deadline(app.clone()),
+                        Err(e) => {
+                            log::error!("[handover] failed to request guarded quit: {e}");
+                            force_full_quit(app.clone());
+                        }
                     }
                     return;
                 }
@@ -1690,6 +1723,32 @@ mod platform_tests {
                 request_id: 3,
                 delivery_id: 1,
             }
+        );
+    }
+
+    #[test]
+    fn an_acknowledged_guard_that_never_resolves_is_still_in_flight_for_the_handover_deadline() {
+        let mut guard = GuardedQuitCoordinator::new();
+        assert!(matches!(
+            guard.request(),
+            GuardedQuitAction::RequestFrontendGuard { .. }
+        ));
+        assert!(guard.acknowledge(1, 1));
+        assert!(
+            guard.force_if_in_flight(),
+            "acknowledged but never resolved: the deadline may force"
+        );
+        assert!(!guard.force_if_in_flight(), "forcing once is enough");
+
+        let mut guard = GuardedQuitCoordinator::new();
+        assert!(matches!(
+            guard.request(),
+            GuardedQuitAction::RequestFrontendGuard { .. }
+        ));
+        assert!(guard.cancel(1, 1));
+        assert!(
+            !guard.force_if_in_flight(),
+            "a refused quit is not in flight; the deadline leaves it alone"
         );
     }
 

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -27,6 +27,14 @@ pub fn set_handover_bundle(bundle: PathBuf) {
         .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(bundle);
 }
 
+/// Drop a pending handover: the frontend refused the quit (it could not
+/// save), so the user keeps this app and a later, unrelated quit must not
+/// reopen the newer bundle.
+#[cfg(target_os = "macos")]
+pub fn clear_handover_bundle() {
+    take_handover_bundle();
+}
+
 #[cfg(target_os = "macos")]
 fn take_handover_bundle() -> Option<PathBuf> {
     HANDOVER_BUNDLE
@@ -35,13 +43,15 @@ fn take_handover_bundle() -> Option<PathBuf> {
         .take()
 }
 
-/// Finish a quit: schedule the handover reopen when one is pending, then exit.
-fn exit_after_quit(app_handle: &AppHandle) {
+/// Finish a quit: schedule the handover reopen when one is pending, then exit
+/// with `code`. A failed teardown exits non-zero but still hands over, so the
+/// newer bundle opens either way.
+pub(crate) fn exit_after_quit(app_handle: &AppHandle, code: i32) {
     #[cfg(target_os = "macos")]
     if let Some(bundle) = take_handover_bundle() {
         crate::handover::relaunch_after_exit(&bundle);
     }
-    app_handle.exit(0);
+    app_handle.exit(code);
 }
 
 struct QuitAttemptGuard<'a> {
@@ -806,28 +816,49 @@ pub async fn set_run_at_login(enabled: bool, launchctl: &dyn LaunchctlExec) -> R
 }
 
 #[cfg(target_os = "macos")]
-fn handover_pending() -> bool {
+pub fn handover_pending() -> bool {
     HANDOVER_BUNDLE
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .is_some()
 }
 
-/// Poll the daemon's health route until it stops answering or `limit` passes.
+/// Wait until the daemon stops answering its health route *and* its listener
+/// is closed, or `limit` passes. The limit is a hard ceiling: it bounds the
+/// health calls themselves, not only the gaps between them. The closed port
+/// is the fact the reopened app needs; health can stop answering while the
+/// listener lingers.
 #[cfg(target_os = "macos")]
 async fn wait_for_daemon_to_stop(limit: Duration) {
     let client = crate::api::WenlanClient::new();
-    let deadline = std::time::Instant::now() + limit;
-    while client.health().await.is_ok() {
-        if std::time::Instant::now() >= deadline {
-            log::warn!(
-                "[handover] daemon still answering at {} after {limit:?}; the new app will retry",
-                client.base_url()
-            );
-            return;
+    let listener = listener_addr(client.base_url());
+    let released = tokio::time::timeout(limit, async {
+        while client.health().await.is_ok() {
+            tokio::time::sleep(Duration::from_millis(200)).await;
         }
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        if let Some(addr) = listener.as_deref() {
+            while tokio::net::TcpStream::connect(addr).await.is_ok() {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    })
+    .await;
+    if released.is_err() {
+        log::warn!(
+            "[handover] daemon still holding {} after {limit:?}; the new app will retry",
+            client.base_url()
+        );
     }
+}
+
+/// `host:port` of the daemon listener behind a base URL, for a raw TCP probe.
+#[cfg(target_os = "macos")]
+fn listener_addr(base_url: &str) -> Option<String> {
+    let rest = base_url
+        .strip_prefix("http://")
+        .or_else(|| base_url.strip_prefix("https://"))?;
+    let authority = rest.split('/').next()?;
+    (!authority.is_empty()).then(|| authority.to_string())
 }
 
 fn shutdown_url_for(client: &crate::api::WenlanClient) -> String {
@@ -844,7 +875,7 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
 
     if data_dir_env_overridden() {
         log::info!("[lifecycle] skipping quit teardown: isolated run (data-dir env override)");
-        exit_after_quit(app_handle);
+        exit_after_quit(app_handle, 0);
         attempt.commit();
         return Ok(());
     }
@@ -895,7 +926,7 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
     }
 
     if quit_plan.exit_app {
-        exit_after_quit(app_handle);
+        exit_after_quit(app_handle, 0);
         attempt.commit();
     }
     Ok(())
@@ -1431,6 +1462,25 @@ mod tests {
             !is_run_at_login_enabled(&staging_only),
             ".staging suffixed labels must not satisfy exact-label match"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn listener_addr_is_the_authority_of_the_base_url() {
+        assert_eq!(
+            listener_addr("http://127.0.0.1:7878").as_deref(),
+            Some("127.0.0.1:7878")
+        );
+        assert_eq!(
+            listener_addr("http://127.0.0.1:7878/").as_deref(),
+            Some("127.0.0.1:7878")
+        );
+        assert_eq!(
+            listener_addr("https://localhost:7878/api").as_deref(),
+            Some("localhost:7878")
+        );
+        assert_eq!(listener_addr("127.0.0.1:7878"), None);
+        assert_eq!(listener_addr("http://"), None);
     }
 
     #[test]

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -14,6 +14,36 @@ use tauri::AppHandle;
 /// teardown releases it so the recovered app can guard a later retry.
 static QUITTING: AtomicBool = AtomicBool::new(false);
 
+/// The newer app bundle to reopen once this quit has finished, set by the
+/// single-instance handover (see `handover.rs`). Only ever read on macOS.
+#[cfg(target_os = "macos")]
+static HANDOVER_BUNDLE: std::sync::Mutex<Option<PathBuf>> = std::sync::Mutex::new(None);
+
+/// Remember the newer bundle that the running quit must hand over to.
+#[cfg(target_os = "macos")]
+pub fn set_handover_bundle(bundle: PathBuf) {
+    *HANDOVER_BUNDLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(bundle);
+}
+
+#[cfg(target_os = "macos")]
+fn take_handover_bundle() -> Option<PathBuf> {
+    HANDOVER_BUNDLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+}
+
+/// Finish a quit: schedule the handover reopen when one is pending, then exit.
+fn exit_after_quit(app_handle: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    if let Some(bundle) = take_handover_bundle() {
+        crate::handover::relaunch_after_exit(&bundle);
+    }
+    app_handle.exit(0);
+}
+
 struct QuitAttemptGuard<'a> {
     flag: &'a AtomicBool,
     committed: bool,
@@ -775,6 +805,31 @@ pub async fn set_run_at_login(enabled: bool, launchctl: &dyn LaunchctlExec) -> R
     Ok(())
 }
 
+#[cfg(target_os = "macos")]
+fn handover_pending() -> bool {
+    HANDOVER_BUNDLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .is_some()
+}
+
+/// Poll the daemon's health route until it stops answering or `limit` passes.
+#[cfg(target_os = "macos")]
+async fn wait_for_daemon_to_stop(limit: Duration) {
+    let client = crate::api::WenlanClient::new();
+    let deadline = std::time::Instant::now() + limit;
+    while client.health().await.is_ok() {
+        if std::time::Instant::now() >= deadline {
+            log::warn!(
+                "[handover] daemon still answering at {} after {limit:?}; the new app will retry",
+                client.base_url()
+            );
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
 fn shutdown_url_for(client: &crate::api::WenlanClient) -> String {
     format!("{}/api/shutdown", client.base_url())
 }
@@ -789,7 +844,7 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
 
     if data_dir_env_overridden() {
         log::info!("[lifecycle] skipping quit teardown: isolated run (data-dir env override)");
-        app_handle.exit(0);
+        exit_after_quit(app_handle);
         attempt.commit();
         return Ok(());
     }
@@ -830,10 +885,17 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
 
         // Wait briefly for the daemon to flush.
         tokio::time::sleep(Duration::from_millis(500)).await;
+        // A handover reopens a newer app right after this one exits, and
+        // that app starts its own daemon on the same port: give the old
+        // daemon a bounded moment to release it.
+        #[cfg(target_os = "macos")]
+        if handover_pending() {
+            wait_for_daemon_to_stop(Duration::from_secs(5)).await;
+        }
     }
 
     if quit_plan.exit_app {
-        app_handle.exit(0);
+        exit_after_quit(app_handle);
         attempt.commit();
     }
     Ok(())

--- a/scripts/install-macos-app.sh
+++ b/scripts/install-macos-app.sh
@@ -107,6 +107,23 @@ fi
 
 rm -rf "$backup"
 
+# A Wenlan that is still running from the replaced bundle would only come to
+# the front when the new one is opened (its single-instance socket sends the
+# newcomer straight back to exit), so ask it to quit first. Apps from 0.18.0 on
+# hand over by themselves; this covers upgrades from 0.17.0 and older.
+app_exe="$target/Contents/MacOS/wenlan-app"
+if pgrep -f "$app_exe" >/dev/null 2>&1; then
+  echo "Asking the running Wenlan to quit so the new version can start..."
+  osascript -e 'tell application id "com.wenlan.desktop" to quit' >/dev/null 2>&1 || true
+  for _ in $(seq 1 100); do
+    pgrep -f "$app_exe" >/dev/null 2>&1 || break
+    sleep 0.1
+  done
+  if pgrep -f "$app_exe" >/dev/null 2>&1; then
+    echo "Wenlan app install warning: the previous Wenlan is still running. Quit it, then open Wenlan again." >&2
+  fi
+fi
+
 echo "Installed Wenlan at $target"
 if [[ ${WENLAN_APP_NO_LAUNCH:-0} != 1 ]]; then
   open "$target"

--- a/scripts/install-macos-app.sh
+++ b/scripts/install-macos-app.sh
@@ -94,6 +94,31 @@ xattr -dr com.apple.quarantine "$source_app" 2>/dev/null || true
 ditto "$source_app" "$incoming"
 xattr -dr com.apple.quarantine "$incoming" 2>/dev/null || true
 
+# A Wenlan that is still running would only come to the front when the new one
+# is opened (its single-instance socket sends the newcomer straight back to
+# exit), so ask it to quit before its bundle is replaced. Apps from 0.18.0 on
+# hand over by themselves; this covers upgrades from 0.17.0 and older, wherever
+# the running bundle lives. The Apple event is bounded, so a stuck or
+# unanswered permission prompt cannot hold the install, and a Wenlan that will
+# not quit is an error rather than a success message.
+running_wenlan() {
+  pgrep -f '\.app/Contents/MacOS/wenlan-app$' >/dev/null 2>&1
+}
+if running_wenlan; then
+  echo "Asking the running Wenlan to quit so the new version can start..."
+  osascript -e 'tell application id "com.wenlan.desktop" to quit' >/dev/null 2>&1 &
+  quit_request=$!
+  for _ in $(seq 1 100); do
+    running_wenlan || break
+    sleep 0.1
+  done
+  kill "$quit_request" 2>/dev/null || true
+  wait "$quit_request" 2>/dev/null || true
+  if running_wenlan; then
+    die "the running Wenlan did not quit within 10 s. Quit it from its menu bar icon, then run this command again."
+  fi
+fi
+
 if [[ -e $target ]]; then
   mv "$target" "$backup"
 fi
@@ -106,23 +131,6 @@ if ! mv "$incoming" "$target"; then
 fi
 
 rm -rf "$backup"
-
-# A Wenlan that is still running from the replaced bundle would only come to
-# the front when the new one is opened (its single-instance socket sends the
-# newcomer straight back to exit), so ask it to quit first. Apps from 0.18.0 on
-# hand over by themselves; this covers upgrades from 0.17.0 and older.
-app_exe="$target/Contents/MacOS/wenlan-app"
-if pgrep -f "$app_exe" >/dev/null 2>&1; then
-  echo "Asking the running Wenlan to quit so the new version can start..."
-  osascript -e 'tell application id "com.wenlan.desktop" to quit' >/dev/null 2>&1 || true
-  for _ in $(seq 1 100); do
-    pgrep -f "$app_exe" >/dev/null 2>&1 || break
-    sleep 0.1
-  done
-  if pgrep -f "$app_exe" >/dev/null 2>&1; then
-    echo "Wenlan app install warning: the previous Wenlan is still running. Quit it, then open Wenlan again." >&2
-  fi
-fi
 
 echo "Installed Wenlan at $target"
 if [[ ${WENLAN_APP_NO_LAUNCH:-0} != 1 ]]; then

--- a/scripts/test-install-macos-app.sh
+++ b/scripts/test-install-macos-app.sh
@@ -113,7 +113,91 @@ SH
   fi
 }
 
+
+# The quit path runs against a stubbed `pgrep` and `osascript`: the stub `pgrep`
+# reports a running Wenlan until the stub `osascript` has been asked to quit it.
+make_quit_stubs() {
+  local fake_bin=$1
+  local quit_marker=$2
+  local quits=$3
+
+  mkdir -p "$fake_bin"
+  cat > "$fake_bin/pgrep" <<SH
+#!/usr/bin/env bash
+[[ -e "$quit_marker" ]] && exit 1
+exit 0
+SH
+  cat > "$fake_bin/osascript" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > "$quit_marker.request"
+if [[ "$quits" == yes ]]; then
+  sleep 0.3
+  : > "$quit_marker"
+fi
+sleep 30
+SH
+  chmod +x "$fake_bin/pgrep" "$fake_bin/osascript"
+}
+
+test_quits_running_app_before_replacing_it() {
+  local fixture_dir="$TMP_DIR/quits"
+  local install_dir="$fixture_dir/Applications"
+  local fake_bin="$fixture_dir/fake-bin"
+  local quit_marker="$fixture_dir/quit"
+  mkdir -p "$fixture_dir" "$install_dir/Wenlan.app"
+  printf 'keep me\n' > "$install_dir/Wenlan.app/existing-marker"
+  make_fixture "$fixture_dir" actual
+  make_quit_stubs "$fake_bin" "$quit_marker" yes
+
+  PATH="$fake_bin:$PATH" \
+    WENLAN_APP_RELEASE_JSON_URL="file://$fixture_dir/release.json" \
+    WENLAN_APP_INSTALL_DIR="$install_dir" \
+    WENLAN_APP_NO_LAUNCH=1 \
+    WENLAN_APP_SKIP_PLATFORM_CHECK=1 \
+    bash "$INSTALLER"
+
+  if ! grep -q 'tell application id "com.wenlan.desktop" to quit' "$quit_marker.request"; then
+    echo "installer did not ask the running Wenlan to quit" >&2
+    return 1
+  fi
+  test -x "$install_dir/Wenlan.app/Contents/MacOS/wenlan-app"
+  if [[ -f "$install_dir/Wenlan.app/existing-marker" ]]; then
+    echo "installer kept the old app after the running Wenlan quit" >&2
+    return 1
+  fi
+}
+
+test_fails_when_running_app_does_not_quit() {
+  local fixture_dir="$TMP_DIR/never-quits"
+  local install_dir="$fixture_dir/Applications"
+  local fake_bin="$fixture_dir/fake-bin"
+  local quit_marker="$fixture_dir/quit"
+  mkdir -p "$fixture_dir" "$install_dir/Wenlan.app"
+  printf 'keep me\n' > "$install_dir/Wenlan.app/existing-marker"
+  make_fixture "$fixture_dir" actual
+  make_quit_stubs "$fake_bin" "$quit_marker" no
+
+  if PATH="$fake_bin:$PATH" \
+    WENLAN_APP_RELEASE_JSON_URL="file://$fixture_dir/release.json" \
+    WENLAN_APP_INSTALL_DIR="$install_dir" \
+    WENLAN_APP_NO_LAUNCH=1 \
+    WENLAN_APP_SKIP_PLATFORM_CHECK=1 \
+    bash "$INSTALLER" > "$fixture_dir/installer.log" 2>&1; then
+    echo "installer replaced an app that never quit" >&2
+    return 1
+  fi
+
+  if ! grep -q 'did not quit within 10 s' "$fixture_dir/installer.log"; then
+    echo "installer failed without naming the app that would not quit:" >&2
+    cat "$fixture_dir/installer.log" >&2
+    return 1
+  fi
+  test -f "$install_dir/Wenlan.app/existing-marker"
+}
+
 test_installs_verified_app_without_quarantine
 test_rejects_bad_digest_before_replacing_existing_app
 test_restores_existing_app_when_interrupted_after_backup
+test_quits_running_app_before_replacing_it
+test_fails_when_running_app_does_not_quit
 echo "install-macos-app tests passed"


### PR DESCRIPTION
Pre-launch tracker row 13 (`wenlan-audit-2026-08-22.md`), first-run gauntlet findings F2 and F11.

## What was wrong

`tauri-plugin-single-instance` keys its socket by bundle id only, so opening a freshly installed 0.17.0 bundle while 0.16.0 ran made the newcomer exit after ~1 s and brought the old window to the front. Nothing told the user the old version was still what they were looking at; the README's upgrade story ("re-run the installer or open the new app") was false.

## What changed

| File | Change |
|---|---|
| `app/src/handover.rs` (new) | `newer_bundle_from_launch(argv, running)` reads the newcomer's `Info.plist` (argv[0] of a LaunchServices launch is `<bundle>.app/Contents/MacOS/<exe>`) and returns it only when `CFBundleShortVersionString` is strictly newer; anything else — a dev binary, missing or unparsable plist, same or older version — keeps the focus behavior. `relaunch_after_exit(bundle)` spawns a detached `/bin/sh` that waits for this pid to disappear, then `open`s the bundle: the old app cannot `open` the newcomer itself (LaunchServices would only activate it, and its socket would send the newcomer back to exit). |
| `app/src/lib.rs` | The single-instance callback checks for a newer bundle first (macOS only), records it, and runs the same guarded quit as the tray's "Quit Wenlan" (`request_full_quit`, falling back to `force_full_quit`). |
| `app/src/lifecycle.rs` | `set_handover_bundle`; `quit_origin` waits up to 5 s for the daemon to stop answering when a handover is pending (the new app starts its own daemon on the same port), then `exit_after_quit` schedules the reopen right before `app.exit(0)` on both exit paths. |
| `app/Cargo.toml`, `Cargo.lock` | `semver = "1"` (already in the tree through Tauri) for the version comparison. |
| `scripts/install-macos-app.sh` | Apps up to 0.17.0 have no handover, so the installer asks a Wenlan still running from the replaced bundle to quit (`osascript … quit`), waits up to 10 s, and warns if it is still there before `open`. |
| `README.md` | Says how to upgrade by drag and drop (and that 0.17.0 and older must be quit by hand), and names the Gatekeeper dialog a first launch shows before pointing at "Open Anyway" (F11 — the notarization itself stays a known gap). |

Why a full quit rather than a plain exit: "Quit Wenlan" already shuts the daemon down and unloads the LaunchAgents, and the new app's startup preflight installs them again — so the handover is the manual "quit, then open the new one" made automatic, on the app's most-exercised exit path.

## Receipts

- `cargo test -p wenlan-app --lib`: 438 passed, 0 failed, 1 ignored (3 new `handover` tests: newer/equal/older bundle, non-bundle argv and missing or bad plist, relaunch script shape).
- `cargo clippy -p wenlan-app --all-targets -- -D warnings` clean; `cargo fmt --check -p wenlan-app` clean.
- `bash scripts/test-install-macos-app.sh`: `install-macos-app tests passed`; `shellcheck scripts/install-macos-app.sh` clean.

Unchecked: the live handover between two signed bundles. It needs two built versions on a Mac; the next release's gauntlet upgrade walk (tracker row 22) is where that runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
