### PR TITLE
fix(app): stop the sidecar the app spawned and install outside the data root on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9097,6 +9097,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wenlan-types",
+ "windows-sys 0.59.0",
  "zip 2.4.2",
 ]
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -81,8 +81,8 @@ sysinfo = { workspace = true }
 pdf-extract = "0.10"
 zip = { version = "2.2", default-features = false, features = ["deflate"] }
 
-# Keep this table LAST. A TOML table runs until the next header, so any
-# dependency written below it silently becomes macOS-only. That is how
+# Keep the target tables LAST. A TOML table runs until the next header, so any
+# dependency written below one silently becomes platform-specific. That is how
 # wenlan-types, sysinfo, pdf-extract, and zip stopped existing off macOS and
 # left the app crate uncompilable on Windows (15 unresolved-import errors,
 # unnoticed because app-check only runs on macOS).
@@ -90,6 +90,10 @@ zip = { version = "2.2", default-features = false, features = ["deflate"] }
 cocoa = "0.26"
 objc = "0.2"
 raw-window-handle = "0.6"
+
+# Job object that ends the sidecar daemon with the app (daemon_start::job).
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading"] }
 
 [dev-dependencies]
 serial_test = "3"

--- a/app/src/daemon_start.rs
+++ b/app/src/daemon_start.rs
@@ -14,8 +14,9 @@
 //! and [`stop_sidecar`] ends it on quit, and on Windows the process is bound
 //! to a kill-on-close job object so a hard kill of the app takes it too.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tauri_plugin_shell::process::CommandChild;
 use tokio::sync::RwLock;
 
@@ -40,38 +41,62 @@ fn startup_preflight_ok() -> bool {
 /// handle used to be dropped at spawn, so the daemon outlived the app on
 /// every exit path (first-run gauntlet finding F14); the shell plugin only
 /// kills children spawned through its JS `execute` command.
-static SIDECAR: Mutex<Option<CommandChild>> = Mutex::new(None);
+static SIDECAR: Mutex<Option<(u64, CommandChild)>> = Mutex::new(None);
 
-/// How long [`stop_sidecar`] waits for a SIGTERM to be honored before it
-/// kills: the daemon drains and exits in about a second.
-#[cfg(unix)]
-const SIDECAR_STOP_POLLS: usize = 30;
-#[cfg(unix)]
-const SIDECAR_STOP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+/// Counts spawns. The shell plugin's own wait thread reaps a child that exits
+/// on its own, and a later spawn can reuse its PID, so a termination event
+/// clears the slot only when it names the same spawn.
+static SIDECAR_GENERATION: AtomicU64 = AtomicU64::new(0);
 
-fn remember_sidecar(child: CommandChild) {
-    *SIDECAR
+/// How long [`stop_sidecar`] waits for the daemon to release its port after
+/// the shutdown request before it kills the child: the daemon drains and
+/// exits in about a second.
+const SIDECAR_STOP_LIMIT: Duration = Duration::from_secs(3);
+
+/// Remember a freshly spawned sidecar; returns its spawn generation. A child
+/// still in the slot is killed first: two sidecars would race for one port,
+/// and the first would be left unowned.
+fn remember_sidecar(child: CommandChild) -> u64 {
+    let generation = SIDECAR_GENERATION.fetch_add(1, Ordering::Relaxed) + 1;
+    let previous = SIDECAR
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(child);
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .replace((generation, child));
+    if let Some((old_generation, old)) = previous {
+        log::warn!(
+            "[daemon-start] sidecar {} (spawn {old_generation}) was still in the slot; killing it",
+            old.pid()
+        );
+        if let Err(e) = old.kill() {
+            log::warn!("[daemon-start] could not kill the earlier sidecar: {e}");
+        }
+    }
+    generation
 }
 
-fn forget_sidecar(pid: u32) {
+fn forget_sidecar(generation: u64) {
     let mut slot = SIDECAR
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if slot.as_ref().is_some_and(|child| child.pid() == pid) {
+    if slot
+        .as_ref()
+        .is_some_and(|(spawned, _)| *spawned == generation)
+    {
         *slot = None;
     }
 }
 
-/// Stop the sidecar this app spawned, if any. On Unix it asks first (SIGTERM)
-/// and kills only after a bounded wait; on Windows the daemon was already
-/// asked over HTTP by the quit flow, so what is left is killed. A daemon
-/// owned by launchd or the Task Scheduler is never in the slot and is never
-/// touched. Without this a quit left the daemon holding the port, and the
-/// next launch adopted the stale one (the upgrade shape of finding F2).
+/// Stop the sidecar this app spawned, if any: ask the daemon to shut down
+/// over HTTP (its own clean path, the one the quit flow uses), wait a bounded
+/// time for it to release the port, and kill it only if it has not. The kill
+/// goes through the child handle, which is a no-op once the child was reaped,
+/// so it can never reach a process that reused the PID; a raw signal to the
+/// numeric PID could. A daemon owned by launchd or the Task Scheduler is never
+/// in the slot and is never touched. Without this a quit left the daemon
+/// holding the port, and the next launch adopted the stale one (the upgrade
+/// shape of finding F2).
 pub async fn stop_sidecar() {
-    let Some(child) = SIDECAR
+    let Some((_, child)) = SIDECAR
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
         .take()
@@ -79,28 +104,23 @@ pub async fn stop_sidecar() {
         return;
     };
     let pid = child.pid();
-    #[cfg(unix)]
+    let client = crate::api::WenlanClient::new();
+    if let Ok(http) = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
     {
-        let sys_pid = sysinfo::Pid::from_u32(pid);
-        let mut system = sysinfo::System::new();
-        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
-        if let Some(process) = system.process(sys_pid) {
-            process.kill_with(sysinfo::Signal::Term);
-        }
-        for _ in 0..SIDECAR_STOP_POLLS {
-            tokio::time::sleep(SIDECAR_STOP_POLL_INTERVAL).await;
-            system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
-            let gone = match system.process(sys_pid) {
-                None => true,
-                Some(process) => process.status() == sysinfo::ProcessStatus::Zombie,
-            };
-            if gone {
-                log::info!("[daemon-start] sidecar {pid} exited after SIGTERM");
-                return;
-            }
-        }
-        log::warn!("[daemon-start] sidecar {pid} still running after SIGTERM; killing it");
+        let _ = http
+            .post(crate::lifecycle::shutdown_url_for(&client))
+            .send()
+            .await;
     }
+    if crate::lifecycle::wait_for_daemon_to_stop(SIDECAR_STOP_LIMIT).await {
+        log::info!("[daemon-start] sidecar {pid} released the port after the shutdown request");
+        return;
+    }
+    log::warn!(
+        "[daemon-start] sidecar {pid} still holds the port after {SIDECAR_STOP_LIMIT:?}; killing it"
+    );
     match child.kill() {
         Ok(()) => log::info!("[daemon-start] killed sidecar {pid}"),
         Err(e) => log::warn!("[daemon-start] could not kill sidecar {pid}: {e}"),
@@ -254,7 +274,7 @@ pub fn spawn_daemon_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
     if let Err(e) = job::bind(pid) {
         log::warn!("[daemon-start] sidecar {pid} is not bound to the app's job object: {e}");
     }
-    remember_sidecar(child);
+    let generation = remember_sidecar(child);
     tauri::async_runtime::spawn(async move {
         use tauri_plugin_shell::process::CommandEvent;
         while let Some(event) = rx.recv().await {
@@ -267,7 +287,7 @@ pub fn spawn_daemon_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
                 }
                 CommandEvent::Terminated(status) => {
                     log::warn!("[daemon] exited: {:?}", status);
-                    forget_sidecar(pid);
+                    forget_sidecar(generation);
                     break;
                 }
                 _ => {}

--- a/app/src/daemon_start.rs
+++ b/app/src/daemon_start.rs
@@ -9,9 +9,14 @@
 //!
 //! It does NOT manage the launchd plist: when launchd owns the daemon we defer
 //! to it rather than fighting it with a second process.
+//!
+//! A sidecar this app spawned is this app's to stop: the child handle is kept
+//! and [`stop_sidecar`] ends it on quit, and on Windows the process is bound
+//! to a kill-on-close job object so a hard kill of the app takes it too.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use tauri_plugin_shell::process::CommandChild;
 use tokio::sync::RwLock;
 
 use crate::state::AppState;
@@ -28,6 +33,155 @@ pub fn set_startup_preflight_ok(ok: bool) {
 
 fn startup_preflight_ok() -> bool {
     STARTUP_PREFLIGHT_OK.load(Ordering::Relaxed)
+}
+
+/// The sidecar this app spawned, so quitting can stop it. Empty when launchd
+/// or the Task Scheduler owns the daemon, or once the sidecar exited. The
+/// handle used to be dropped at spawn, so the daemon outlived the app on
+/// every exit path (first-run gauntlet finding F14); the shell plugin only
+/// kills children spawned through its JS `execute` command.
+static SIDECAR: Mutex<Option<CommandChild>> = Mutex::new(None);
+
+/// How long [`stop_sidecar`] waits for a SIGTERM to be honored before it
+/// kills: the daemon drains and exits in about a second.
+#[cfg(unix)]
+const SIDECAR_STOP_POLLS: usize = 30;
+#[cfg(unix)]
+const SIDECAR_STOP_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+fn remember_sidecar(child: CommandChild) {
+    *SIDECAR
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(child);
+}
+
+fn forget_sidecar(pid: u32) {
+    let mut slot = SIDECAR
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if slot.as_ref().is_some_and(|child| child.pid() == pid) {
+        *slot = None;
+    }
+}
+
+/// Stop the sidecar this app spawned, if any. On Unix it asks first (SIGTERM)
+/// and kills only after a bounded wait; on Windows the daemon was already
+/// asked over HTTP by the quit flow, so what is left is killed. A daemon
+/// owned by launchd or the Task Scheduler is never in the slot and is never
+/// touched. Without this a quit left the daemon holding the port, and the
+/// next launch adopted the stale one (the upgrade shape of finding F2).
+pub async fn stop_sidecar() {
+    let Some(child) = SIDECAR
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take()
+    else {
+        return;
+    };
+    let pid = child.pid();
+    #[cfg(unix)]
+    {
+        let sys_pid = sysinfo::Pid::from_u32(pid);
+        let mut system = sysinfo::System::new();
+        system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
+        if let Some(process) = system.process(sys_pid) {
+            process.kill_with(sysinfo::Signal::Term);
+        }
+        for _ in 0..SIDECAR_STOP_POLLS {
+            tokio::time::sleep(SIDECAR_STOP_POLL_INTERVAL).await;
+            system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[sys_pid]), true);
+            let gone = match system.process(sys_pid) {
+                None => true,
+                Some(process) => process.status() == sysinfo::ProcessStatus::Zombie,
+            };
+            if gone {
+                log::info!("[daemon-start] sidecar {pid} exited after SIGTERM");
+                return;
+            }
+        }
+        log::warn!("[daemon-start] sidecar {pid} still running after SIGTERM; killing it");
+    }
+    match child.kill() {
+        Ok(()) => log::info!("[daemon-start] killed sidecar {pid}"),
+        Err(e) => log::warn!("[daemon-start] could not kill sidecar {pid}: {e}"),
+    }
+}
+
+/// Windows has no parent-death signal. A job object with
+/// `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` ends every member when its last
+/// handle closes, which the OS does when the app process ends for any
+/// reason (Task Manager, a crash, `Stop-Process`). The app is the daemon's
+/// only owner in sidecar mode, and an orphan kept the port and blocked the
+/// next launch's daemon (first-run gauntlet finding F13).
+#[cfg(windows)]
+mod job {
+    use std::sync::OnceLock;
+    use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+    };
+
+    /// One job for the app's lifetime. Its handle is never closed on
+    /// purpose: closing it is what kills the members, and the OS closes it
+    /// when the app ends. Zero means creating it failed.
+    static JOB: OnceLock<usize> = OnceLock::new();
+
+    fn create_job() -> usize {
+        // SAFETY: plain Win32 calls with valid arguments; the handle is
+        // checked before use and closed on the failure path.
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                log::warn!("[daemon-start] CreateJobObjectW failed: {}", GetLastError());
+                return 0;
+            }
+            let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            let ok = SetInformationJobObject(
+                job,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(limits).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if ok == 0 {
+                log::warn!(
+                    "[daemon-start] SetInformationJobObject failed: {}",
+                    GetLastError()
+                );
+                CloseHandle(job);
+                return 0;
+            }
+            job as usize
+        }
+    }
+
+    /// Put `pid` in the app's kill-on-close job.
+    pub fn bind(pid: u32) -> Result<(), String> {
+        let job = *JOB.get_or_init(create_job) as HANDLE;
+        if job.is_null() {
+            return Err("the kill-on-close job object could not be created".into());
+        }
+        // SAFETY: the process handle is checked and closed here; the job
+        // handle stays open by design (see `JOB`).
+        unsafe {
+            let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+            if process.is_null() {
+                return Err(format!("OpenProcess({pid}) failed: {}", GetLastError()));
+            }
+            let ok = AssignProcessToJobObject(job, process);
+            let error = GetLastError();
+            CloseHandle(process);
+            if ok == 0 {
+                return Err(format!("AssignProcessToJobObject({pid}) failed: {error}"));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// What the guards decided. Pure output of [`decide_daemon_start`].
@@ -76,8 +230,9 @@ pub enum DaemonStartResult {
 
 /// Spawn the wenlan-server sidecar with the app-selected data root and pipe its
 /// logs. Factored from `setup()` so the startup path and the on-demand command
-/// spawn identically. Returns `Err(msg)` when the sidecar command can't be
-/// created or spawned; the caller decides how to surface it.
+/// spawn identically. The child is remembered for [`stop_sidecar`] (and bound
+/// to the app's job object on Windows). Returns `Err(msg)` when the sidecar
+/// command can't be created or spawned; the caller decides how to surface it.
 pub fn spawn_daemon_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
     use tauri_plugin_shell::ShellExt;
     let (data_dir_env, data_dir) = crate::identity_paths::sidecar_data_dir_env();
@@ -89,12 +244,17 @@ pub fn spawn_daemon_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
         .env(data_dir_env, data_dir.as_os_str())
         .spawn()
         .map_err(|e| format!("Failed to spawn wenlan-server sidecar: {e}"))?;
+    let pid = child.pid();
     log::info!(
-        "[daemon-start] Spawned wenlan-server daemon (pid {}, {}={})",
-        child.pid(),
+        "[daemon-start] Spawned wenlan-server daemon (pid {pid}, {}={})",
         data_dir_env,
         data_dir.display()
     );
+    #[cfg(windows)]
+    if let Err(e) = job::bind(pid) {
+        log::warn!("[daemon-start] sidecar {pid} is not bound to the app's job object: {e}");
+    }
+    remember_sidecar(child);
     tauri::async_runtime::spawn(async move {
         use tauri_plugin_shell::process::CommandEvent;
         while let Some(event) = rx.recv().await {
@@ -107,6 +267,7 @@ pub fn spawn_daemon_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
                 }
                 CommandEvent::Terminated(status) => {
                     log::warn!("[daemon] exited: {:?}", status);
+                    forget_sidecar(pid);
                     break;
                 }
                 _ => {}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1084,7 +1084,8 @@ pub fn run() {
 
             // Launch wenlan-server daemon as a sidecar process.
             // If a daemon is already running on the port, the sidecar exits cleanly.
-            // The shell plugin kills the child when the Tauri app exits.
+            // The quit flow stops it (`daemon_start::stop_sidecar`); the shell
+            // plugin only kills children spawned from its JS `execute` command.
             //
             // Skip the sidecar only when the current Wenlan launchd service
             // already targets this app-selected data root. A stale launchd
@@ -1104,6 +1105,27 @@ pub fn run() {
                 } else if let Err(e) = crate::daemon_start::spawn_daemon_sidecar(app.handle()) {
                     log::error!("[init] {e}. Run: xattr -cr /Applications/Origin.app or /Applications/Wenlan.app");
                 }
+            }
+
+            // SIGTERM (`kill`, logout, a supervisor) ends the process without any
+            // Tauri exit event, which orphaned the sidecar. Stop the sidecar we
+            // spawned and exit; nothing else: LaunchAgents and a launchd-owned
+            // daemon are not ours to remove on a signal.
+            #[cfg(unix)]
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    use tokio::signal::unix::{signal, SignalKind};
+                    match signal(SignalKind::terminate()) {
+                        Ok(mut sigterm) => {
+                            sigterm.recv().await;
+                            log::info!("[app] SIGTERM received; stopping the sidecar and exiting");
+                            crate::daemon_start::stop_sidecar().await;
+                            handle.exit(0);
+                        }
+                        Err(e) => log::warn!("[app] cannot listen for SIGTERM: {e}"),
+                    }
+                });
             }
 
             // Wait for daemon health, then initialize local state + file watcher

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1116,11 +1116,32 @@ pub fn run() {
                 let handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     use tokio::signal::unix::{signal, SignalKind};
+                    // A second SIGTERM, or a stop that hangs, must still end the
+                    // process: `kill <pid>` has to mean exit.
+                    const SIGTERM_STOP_LIMIT: std::time::Duration =
+                        std::time::Duration::from_secs(10);
                     match signal(SignalKind::terminate()) {
                         Ok(mut sigterm) => {
                             sigterm.recv().await;
                             log::info!("[app] SIGTERM received; stopping the sidecar and exiting");
-                            crate::daemon_start::stop_sidecar().await;
+                            tauri::async_runtime::spawn(async move {
+                                sigterm.recv().await;
+                                log::warn!(
+                                    "[app] second SIGTERM; exiting without waiting for the sidecar"
+                                );
+                                std::process::exit(1);
+                            });
+                            if tokio::time::timeout(
+                                SIGTERM_STOP_LIMIT,
+                                crate::daemon_start::stop_sidecar(),
+                            )
+                            .await
+                            .is_err()
+                            {
+                                log::warn!(
+                                    "[app] sidecar stop did not finish within {SIGTERM_STOP_LIMIT:?}; exiting anyway"
+                                );
+                            }
                             handle.exit(0);
                         }
                         Err(e) => log::warn!("[app] cannot listen for SIGTERM: {e}"),

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -827,9 +827,8 @@ pub fn handover_pending() -> bool {
 /// is closed, or `limit` passes. The limit is a hard ceiling: it bounds the
 /// health calls themselves, not only the gaps between them. The closed port
 /// is the fact the reopened app needs; health can stop answering while the
-/// listener lingers.
-#[cfg(target_os = "macos")]
-async fn wait_for_daemon_to_stop(limit: Duration) {
+/// listener lingers. Returns whether the port was released within `limit`.
+pub(crate) async fn wait_for_daemon_to_stop(limit: Duration) -> bool {
     let client = crate::api::WenlanClient::new();
     let listener = listener_addr(client.base_url());
     let released = tokio::time::timeout(limit, async {
@@ -845,14 +844,14 @@ async fn wait_for_daemon_to_stop(limit: Duration) {
     .await;
     if released.is_err() {
         log::warn!(
-            "[handover] daemon still holding {} after {limit:?}; the new app will retry",
+            "[lifecycle] daemon still holding {} after {limit:?}",
             client.base_url()
         );
     }
+    released.is_ok()
 }
 
 /// `host:port` of the daemon listener behind a base URL, for a raw TCP probe.
-#[cfg(target_os = "macos")]
 fn listener_addr(base_url: &str) -> Option<String> {
     let rest = base_url
         .strip_prefix("http://")
@@ -861,7 +860,7 @@ fn listener_addr(base_url: &str) -> Option<String> {
     (!authority.is_empty()).then(|| authority.to_string())
 }
 
-fn shutdown_url_for(client: &crate::api::WenlanClient) -> String {
+pub(crate) fn shutdown_url_for(client: &crate::api::WenlanClient) -> String {
     format!("{}/api/shutdown", client.base_url())
 }
 
@@ -1469,7 +1468,6 @@ mod tests {
         );
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn listener_addr_is_the_authority_of_the_base_url() {
         assert_eq!(

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -875,6 +875,8 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
 
     if data_dir_env_overridden() {
         log::info!("[lifecycle] skipping quit teardown: isolated run (data-dir env override)");
+        // The isolated run has no launchd job: the daemon is our sidecar.
+        crate::daemon_start::stop_sidecar().await;
         exit_after_quit(app_handle, 0);
         attempt.commit();
         return Ok(());
@@ -926,6 +928,9 @@ pub async fn quit_origin(app_handle: &AppHandle) -> Result<()> {
     }
 
     if quit_plan.exit_app {
+        // A sidecar we spawned (no launchd job, or a respawn from Diagnostics)
+        // must not outlive the app: the next launch would adopt it.
+        crate::daemon_start::stop_sidecar().await;
         exit_after_quit(app_handle, 0);
         attempt.commit();
     }

--- a/app/tauri.windows.conf.json
+++ b/app/tauri.windows.conf.json
@@ -4,6 +4,11 @@
       "binaries/onnxruntime.dll": "onnxruntime.dll",
       "binaries/vulkan-1.dll": "vulkan-1.dll",
       "binaries/VulkanRT-License.txt": "VulkanRT-License.txt"
+    },
+    "windows": {
+      "nsis": {
+        "installerHooks": "./windows/installer-hooks.nsh"
+      }
     }
   }
 }

--- a/app/windows/installer-hooks.nsh
+++ b/app/windows/installer-hooks.nsh
@@ -6,8 +6,15 @@
 ; the uninstaller could never remove its directory, and a future "delete my
 ; data" flow could take the app with it. Move only that default under
 ; Programs; a directory the user picked in the installer is kept.
+;
+; Not on an in-app update (`/UPDATE`, the Tauri updater): that run skips the
+; previous uninstaller and leaves existing shortcuts alone, so moving $INSTDIR
+; there would leave two copies with the shortcuts on the old one. An install
+; that predates the move stays where it is until the user runs the full
+; installer.
 !macro NSIS_HOOK_PREINSTALL
-  ${If} $INSTDIR == "$LOCALAPPDATA\${PRODUCTNAME}"
+  ${If} $UpdateMode <> 1
+  ${AndIf} $INSTDIR == "$LOCALAPPDATA\${PRODUCTNAME}"
     StrCpy $INSTDIR "$LOCALAPPDATA\Programs\${PRODUCTNAME}"
     SetOutPath $INSTDIR
   ${EndIf}

--- a/app/windows/installer-hooks.nsh
+++ b/app/windows/installer-hooks.nsh
@@ -1,0 +1,14 @@
+; Wenlan NSIS installer hooks (tauri.windows.conf.json, bundle.windows.nsis.installerHooks).
+;
+; Tauri's per-user default install directory is %LOCALAPPDATA%\Wenlan. The CLI
+; data root is %LOCALAPPDATA%\wenlan, and Windows paths are case-insensitive,
+; so the app was installed inside its own data (first-run gauntlet finding F6):
+; the uninstaller could never remove its directory, and a future "delete my
+; data" flow could take the app with it. Move only that default under
+; Programs; a directory the user picked in the installer is kept.
+!macro NSIS_HOOK_PREINSTALL
+  ${If} $INSTDIR == "$LOCALAPPDATA\${PRODUCTNAME}"
+    StrCpy $INSTDIR "$LOCALAPPDATA\Programs\${PRODUCTNAME}"
+    SetOutPath $INSTDIR
+  ${EndIf}
+!macroend

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -16,9 +16,17 @@ Supported builds and prebuilt releases cover macOS arm64, Linux x86_64/aarch64 w
 The Windows desktop app installs to `%LOCALAPPDATA%\Programs\Wenlan`:
 `app/windows/installer-hooks.nsh` moves the NSIS per-user default off
 `%LOCALAPPDATA%\Wenlan`, which is the CLI data root above on a case-insensitive
-filesystem. A directory the user picks in the installer is kept. In sidecar mode
-(no service registration) the app binds the daemon to a kill-on-close job object on
-Windows and sends it SIGTERM on quit elsewhere, so the daemon never outlives the app.
+filesystem. A directory the user picks in the installer is kept, and so is the
+directory of an install that predates the move when the in-app updater runs (that
+path skips the old uninstaller and keeps the existing shortcuts); running the full
+installer moves it.
+
+In sidecar mode (no service registration) a quit or SIGTERM asks the daemon to shut
+down over HTTP and kills it through the child handle if it has not released the port
+within 3 s. On Windows the sidecar is also bound to a kill-on-close job object, so an
+app crash takes it down too; when that binding fails the app logs it and keeps the
+daemon running, and the crash case is then not covered. A launchd, systemd, or Task
+Scheduler daemon is service-owned and outlives the app by design.
 
 ## llama-cpp-2 backend
 

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -13,6 +13,13 @@ Supported builds and prebuilt releases cover macOS arm64, Linux x86_64/aarch64 w
 
 `wenlan background on` / `wenlan background off` work on macOS, Linux, and Windows. macOS + Linux go through the `service-manager` crate (launchd / systemd-user); Windows takes the schtasks path described above so the daemon does not need a service dispatcher.
 
+The Windows desktop app installs to `%LOCALAPPDATA%\Programs\Wenlan`:
+`app/windows/installer-hooks.nsh` moves the NSIS per-user default off
+`%LOCALAPPDATA%\Wenlan`, which is the CLI data root above on a case-insensitive
+filesystem. A directory the user picks in the installer is kept. In sidecar mode
+(no service registration) the app binds the daemon to a kill-on-close job object on
+Windows and sends it SIGTERM on quit elsewhere, so the daemon never outlives the app.
+
 ## llama-cpp-2 backend
 
 macOS builds use Metal, Windows x86_64 builds use Vulkan with observable CPU/OpenMP fallback, and Linux builds remain CPU/OpenMP. Windows setup, device selection, CI/release prerequisites, and physical Qwen live-smoke commands are in [`windows-vulkan.md`](windows-vulkan.md).

--- a/scripts/first-run/windows-nsis.ps1
+++ b/scripts/first-run/windows-nsis.ps1
@@ -60,7 +60,10 @@ try {
     # main binary after the crate's default-run, not the productName). The
     # display name Wenlan.exe resolves case-insensitively to the CLI sidecar
     # wenlan.exe — launching that was this script's own bug in the first runs.
-    $candidate = Join-Path $env:LOCALAPPDATA "Wenlan\wenlan-app.exe"
+    # The installer hook moves the per-user default off the data root
+    # (%LOCALAPPDATA%\Wenlan is %LOCALAPPDATA%\wenlan on a case-insensitive
+    # filesystem); the search below still finds an older layout.
+    $candidate = Join-Path $env:LOCALAPPDATA "Programs\Wenlan\wenlan-app.exe"
     if (Test-Path $candidate) { $AppExe = $candidate }
     else {
         foreach ($root in @($env:LOCALAPPDATA, $env:ProgramFiles, ${env:ProgramFiles(x86)})) {
@@ -72,6 +75,11 @@ try {
     Check -Name "app-exe-found" -Script { if (-not $AppExe) { throw "wenlan-app.exe not found under LOCALAPPDATA or Program Files" }; Write-Output $AppExe }
     if ($AppExe) { $Install = Split-Path -Parent $AppExe }
     Info "install-dir" "$Install"
+    Check -Name "install-dir-outside-data-root" -Script {
+        if (-not $Install) { throw "no install dir was discovered" }
+        if ($Install.TrimEnd('\') -ieq $DataDir.TrimEnd('\')) { throw "app installed into the CLI data root $DataDir (finding F6)" }
+        Write-Output "$Install is not $DataDir"
+    }
     if ($Install) {
         Info "install-dir-exes" ((Get-ChildItem -Path $Install -Filter *.exe -File -ErrorAction SilentlyContinue | ForEach-Object { "$($_.Name) $($_.Length)" }) -join "; ")
     }


### PR DESCRIPTION
## What

The `wenlan-server` sidecar this app spawns is now the app's to stop, and the Windows installer no longer installs into the daemon's data root. Stacked on #603 (base is its branch until it merges).

First-run gauntlet findings: the sidecar outlived the app on macOS quit and Windows kill, and the NSIS default install dir collided with `%LOCALAPPDATA%\Wenlan`.

## How

- `app/src/daemon_start.rs`: the spawned `CommandChild` is remembered in a process-wide slot; `stop_sidecar()` takes it and, on Unix, sends SIGTERM and polls up to 3 s before killing; on Windows it kills outright. The child is forgotten when its `Terminated` event arrives. On Windows the child is also bound to a kill-on-close Job Object (`windows-sys 0.59`), so even a hard-killed app takes the daemon with it.
- `app/src/lib.rs`: a SIGTERM handler (Unix) stops the sidecar and exits 0 without touching LaunchAgents.
- `app/src/lifecycle.rs`: `quit_origin` stops the sidecar before exiting, both in the isolated run and on the normal path (covers the "isolated handover leaves the sidecar alive" finding on #603).
- `app/windows/installer-hooks.nsh` + `app/tauri.windows.conf.json`: `NSIS_HOOK_PREINSTALL` moves the default `$INSTDIR` from `$LOCALAPPDATA\Wenlan` to `$LOCALAPPDATA\Programs\Wenlan`. An explicit user choice is kept.
- `scripts/first-run/windows-nsis.ps1`: looks for the app under `Programs\Wenlan` and asserts the install dir is outside the data root.
- `docs/cross-platform.md`: the install-dir and sidecar-lifetime notes.

## Verification

- `cargo fmt --check -p wenlan-app` rc=0; `cargo clippy -p wenlan-app --all-targets -- -D warnings` rc=0; `cargo test -p wenlan-app --lib` 441 passed / 0 failed / 1 ignored.
- Windows code: the `job` module compiled and clippy-clean with `--target x86_64-pc-windows-msvc` in a scratch crate; a mutation control (wrong pid type) failed as expected.
- Live, isolated macOS debug app (`WENLAN_PORT=17993`, scratch `HOME`/`WENLAN_DATA_DIR`, `WENLAN_NO_AUTOSTART=1`): after SIGTERM the log shows `[app] SIGTERM received; stopping the sidecar and exiting` and `sidecar 66675 exited after SIGTERM`; the app and sidecar pids were gone and port 17993 closed. The guarded-quit route (tray/Cmd-Q) calls the same `stop_sidecar` but was not driven live: an Apple event cannot target the unbundled debug binary. `unchecked` live for that route.
- The NSIS hook and the Windows first-run check run only in the release `app-bundle-windows` job and the gauntlet; `unchecked` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
