### PR TITLE
fix(install): stop depending on anonymous GitHub API calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,10 @@ jobs:
               - 'playwright.review.config.ts'
               - 'scripts/prepare-sidecars.sh'
               - 'scripts/prepare-tauri-build-sidecars.sh'
+              # The macOS app installer and its harness need a macOS runner;
+              # app-check is the only job that runs them.
+              - 'scripts/install-macos-app.sh'
+              - 'scripts/test-install-macos-app.sh'
               # Deliberate pair: fnmatch vs picomatch zero-dir ** behavior.
               - 'scripts/*.test.ts'
               - 'scripts/**/*.test.ts'
@@ -2372,6 +2376,8 @@ jobs:
         run: cargo clippy -p wenlan-app --all-targets -- -D warnings
       - name: Rust tests (app)
         run: cargo test -p wenlan-app --lib
+      - name: macOS app installer tests
+        run: bash scripts/test-install-macos-app.sh
       - name: TypeScript check
         run: pnpm exec tsc -b
       - name: i18n gates

--- a/.github/workflows/first-run-gauntlet.yml
+++ b/.github/workflows/first-run-gauntlet.yml
@@ -337,6 +337,9 @@ jobs:
       GAUNTLET_OUT: ${{ github.workspace }}/gauntlet-out
       GAUNTLET_CHANNEL: macos-app
       REPO_ROOT: ${{ github.workspace }}
+      # The app installer's release lookup is a GitHub API call; the workflow
+      # token keeps repeated runs off the anonymous per-IP limit.
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Port 7878 precheck

--- a/crates/wenlan-cli/npm/run.js
+++ b/crates/wenlan-cli/npm/run.js
@@ -28,11 +28,29 @@ function binDir() {
   return path.join(os.homedir(), ".wenlan", "bin");
 }
 
-function githubApiUrl() {
-  if (REQUESTED_TAG) {
-    return `https://api.github.com/repos/${REPO}/releases/tags/${REQUESTED_TAG}`;
-  }
-  return `https://api.github.com/repos/${REPO}/releases/latest`;
+// The public releases page redirects to the latest tag. Unlike the GitHub API
+// it has no limit of 60 anonymous calls per hour per IP address, which a
+// shared network can exhaust before a first install.
+function latestTag() {
+  const url = `https://github.com/${REPO}/releases/latest`;
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { "User-Agent": "wenlan" } }, (res) => {
+        res.resume();
+        const match = /\/releases\/tag\/([^/?#]+)$/.exec(res.headers.location || "");
+        if (!match) {
+          reject(
+            new Error(
+              `Could not find the latest Wenlan release at ${url} (HTTP ${res.statusCode}). ` +
+                "Check the network, or pin one with WENLAN_RELEASE_TAG=vX.Y.Z."
+            )
+          );
+          return;
+        }
+        resolve(decodeURIComponent(match[1]));
+      })
+      .on("error", reject);
+  });
 }
 
 function request(url, headers = {}) {
@@ -53,15 +71,6 @@ function request(url, headers = {}) {
       })
       .on("error", reject);
   });
-}
-
-async function fetchJson(url) {
-  const res = await request(url, { Accept: "application/vnd.github+json" });
-  let body = "";
-  for await (const chunk of res) {
-    body += chunk;
-  }
-  return JSON.parse(body);
 }
 
 async function download(url, dest) {
@@ -109,9 +118,7 @@ async function installBinaries() {
     throw new Error("Wenlan setup currently supports macOS Apple Silicon only.");
   }
 
-  const release = await fetchJson(githubApiUrl());
-  const tag = release.tag_name;
-  if (!tag) throw new Error("Could not determine Wenlan release tag.");
+  const tag = REQUESTED_TAG || (await latestTag());
 
   const dir = binDir();
   fs.mkdirSync(dir, { recursive: true });
@@ -121,7 +128,13 @@ async function installBinaries() {
   process.stderr.write(`Downloading Wenlan ${tag}...\n`);
 
   try {
-    await download(url, archivePath);
+    try {
+      await download(url, archivePath);
+    } catch (err) {
+      throw new Error(
+        `${err.message}. Check that the release exists at https://github.com/${REPO}/releases/tag/${tag}`
+      );
+    }
     extractBinaries(archivePath, dir);
   } finally {
     try {

--- a/crates/wenlan-cli/npm/run.js
+++ b/crates/wenlan-cli/npm/run.js
@@ -17,8 +17,20 @@ const REQUESTED_TAG =
   "";
 const BINARIES = ["wenlan", "wenlan-server", "wenlan-mcp"];
 
+const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
 function safeTag(tag) {
   return tag.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function checkTag(tag) {
+  if (!RELEASE_TAG_PATTERN.test(tag)) {
+    throw new Error(
+      `'${tag}' is not a Wenlan release tag (expected vX.Y.Z, like v0.17.0). ` +
+        `See https://github.com/${REPO}/releases.`
+    );
+  }
+  return tag;
 }
 
 function binDir() {
@@ -33,21 +45,24 @@ function binDir() {
 // shared network can exhaust before a first install.
 function latestTag() {
   const url = `https://github.com/${REPO}/releases/latest`;
+  const tagPage = `https://github.com/${REPO}/releases/tag/`;
   return new Promise((resolve, reject) => {
     https
       .get(url, { headers: { "User-Agent": "wenlan" } }, (res) => {
         res.resume();
-        const match = /\/releases\/tag\/([^/?#]+)$/.exec(res.headers.location || "");
-        if (!match) {
-          reject(
-            new Error(
+        try {
+          const redirected = res.statusCode >= 300 && res.statusCode < 400;
+          const location = (res.headers.location || "").split(/[?#]/)[0];
+          if (!redirected || !location.startsWith(tagPage)) {
+            throw new Error(
               `Could not find the latest Wenlan release at ${url} (HTTP ${res.statusCode}). ` +
                 "Check the network, or pin one with WENLAN_RELEASE_TAG=vX.Y.Z."
-            )
-          );
-          return;
+            );
+          }
+          resolve(checkTag(decodeURIComponent(location.slice(tagPage.length))));
+        } catch (err) {
+          reject(err);
         }
-        resolve(decodeURIComponent(match[1]));
       })
       .on("error", reject);
   });
@@ -118,7 +133,7 @@ async function installBinaries() {
     throw new Error("Wenlan setup currently supports macOS Apple Silicon only.");
   }
 
-  const tag = REQUESTED_TAG || (await latestTag());
+  const tag = REQUESTED_TAG ? checkTag(REQUESTED_TAG) : await latestTag();
 
   const dir = binDir();
   fs.mkdirSync(dir, { recursive: true });

--- a/crates/wenlan-mcp/src/self_update_check.rs
+++ b/crates/wenlan-mcp/src/self_update_check.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
 const CACHE_TTL: Duration = Duration::from_secs(24 * 3600);
-const RELEASES_URL: &str = "https://api.github.com/repos/7xuanlu/origin/releases/latest";
+const LATEST_RELEASE_URL: &str = "https://github.com/7xuanlu/wenlan/releases/latest";
 
 /// Process-wide in-memory fallback for environments where on-disk cache writes
 /// fail (locked-down sandboxes, missing dirs::cache_dir, etc). Without this,
@@ -71,9 +71,27 @@ fn store_cache(entry: &CacheEntry) {
     }
 }
 
+/// The version a GitHub "latest release" redirect points at, without its `v`.
+/// A repository with no releases redirects to the releases list instead, which
+/// yields `None`.
+fn version_from_location(location: &str) -> Option<String> {
+    let tag = location.rsplit_once("/releases/tag/")?.1;
+    let tag = tag.split(['?', '#']).next().unwrap_or(tag);
+    if tag.is_empty() || tag.contains('/') {
+        return None;
+    }
+    Some(tag.trim_start_matches('v').to_string())
+}
+
+/// The public releases page redirects to the latest tag. Unlike the API it has
+/// no limit of 60 anonymous calls per hour per IP address, a budget the
+/// install scripts share with this check on the user's network.
 async fn fetch_latest_tag() -> Option<String> {
-    let resp = reqwest::Client::new()
-        .get(RELEASES_URL)
+    let resp = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .ok()?
+        .get(LATEST_RELEASE_URL)
         .header(
             "User-Agent",
             concat!("wenlan-mcp/", env!("CARGO_PKG_VERSION")),
@@ -82,10 +100,12 @@ async fn fetch_latest_tag() -> Option<String> {
         .send()
         .await
         .ok()?;
-    let body: serde_json::Value = resp.json().await.ok()?;
-    body["tag_name"]
-        .as_str()
-        .map(|s| s.trim_start_matches('v').to_string())
+    let location = resp
+        .headers()
+        .get(reqwest::header::LOCATION)?
+        .to_str()
+        .ok()?;
+    version_from_location(location)
 }
 
 /// Check for a newer published release. Returns Some(message) if behind,
@@ -129,6 +149,24 @@ mod tests {
     /// override is per-test (set inside the lock) so each disk-test gets its
     /// own temp dir — no pollution of the user's real cache.
     static CACHE_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn the_latest_version_comes_from_the_release_page_redirect() {
+        assert_eq!(
+            version_from_location("https://github.com/7xuanlu/wenlan/releases/tag/v0.17.0")
+                .as_deref(),
+            Some("0.17.0")
+        );
+        assert_eq!(
+            version_from_location("/7xuanlu/wenlan/releases/tag/v0.18.0-rc.1?raw=1").as_deref(),
+            Some("0.18.0-rc.1")
+        );
+        assert_eq!(
+            version_from_location("https://github.com/7xuanlu/wenlan/releases"),
+            None
+        );
+        assert_eq!(version_from_location(""), None);
+    }
 
     fn set_temp_cache(label: &str) -> PathBuf {
         let dir =

--- a/crates/wenlan-mcp/src/self_update_check.rs
+++ b/crates/wenlan-mcp/src/self_update_check.rs
@@ -11,7 +11,7 @@ const LATEST_RELEASE_URL: &str = "https://github.com/7xuanlu/wenlan/releases/lat
 /// fail (locked-down sandboxes, missing dirs::cache_dir, etc). Without this,
 /// `store_cache` would silently no-op and every invocation in the same
 /// long-lived process (e.g. an MCP server hosting many sessions) would re-hit
-/// the GitHub API, risking the 60-req/hr unauthenticated rate limit.
+/// the GitHub release page on every start.
 static MEMORY_FALLBACK: Mutex<Option<CacheEntry>> = Mutex::new(None);
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -131,7 +131,8 @@ pub async fn check() -> Option<String> {
     if latest > mcp {
         Some(format!(
             "A newer wenlan-mcp is available (v{latest}, you are on v{mcp}). \
-             Run `brew upgrade wenlan-mcp`."
+             Run `brew upgrade wenlan-mcp`, `npm update -g wenlan-mcp`, or \
+             `cargo install wenlan-mcp`, whichever installed it."
         ))
     } else {
         None

--- a/install.sh
+++ b/install.sh
@@ -67,17 +67,25 @@ info "Detected platform: ${OS}-${ARCH} (${ASSET})"
 # allows 60 anonymous calls per hour per IP address, which a shared network can
 # exhaust before a first install.
 
+TAG_PAGE_PREFIX="https://github.com/${REPO}/releases/tag/"
+TAG_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+
 if [[ -n "${REQUESTED_TAG}" ]]; then
   TAG="${REQUESTED_TAG}"
   ok "Requested release: ${TAG}"
 else
   info "Finding the latest release on GitHub..."
   LATEST_URL="$(curl -fsSI -o /dev/null -w '%{redirect_url}' "https://github.com/${REPO}/releases/latest" || true)"
-  TAG="${LATEST_URL##*/releases/tag/}"
-  if [[ -z "${LATEST_URL}" || -z "${TAG}" || "${TAG}" == "${LATEST_URL}" ]]; then
+  LATEST_URL="${LATEST_URL%%[?#]*}"
+  if [[ "${LATEST_URL}" != "${TAG_PAGE_PREFIX}"* ]]; then
     die "Could not find the latest release at ${RELEASE_PAGE}. Check the network, or pin a release with WENLAN_RELEASE_TAG=vX.Y.Z."
   fi
+  TAG="${LATEST_URL#"${TAG_PAGE_PREFIX}"}"
   ok "Latest release: ${TAG}"
+fi
+
+if [[ ! "${TAG}" =~ ${TAG_PATTERN} ]]; then
+  die "'${TAG}' is not a Wenlan release tag (expected vX.Y.Z, like v0.17.0). See https://github.com/${REPO}/releases."
 fi
 
 # ── Download & extract ───────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -14,11 +14,9 @@ REQUESTED_TAG="${WENLAN_RELEASE_TAG:-${WENLAN_TAG:-${ORIGIN_RELEASE_TAG:-${ORIGI
 if [[ -n "${REQUESTED_TAG}" ]]; then
   SAFE_TAG="$(printf '%s' "${REQUESTED_TAG}" | LC_ALL=C tr -c 'A-Za-z0-9._-' '_')"
   BIN_DIR="${HOME}/.wenlan/releases/${SAFE_TAG}"
-  API_URL="https://api.github.com/repos/${REPO}/releases/tags/${REQUESTED_TAG}"
   RELEASE_PAGE="https://github.com/${REPO}/releases/tag/${REQUESTED_TAG}"
 else
   BIN_DIR="${HOME}/.wenlan/bin"
-  API_URL="https://api.github.com/repos/${REPO}/releases/latest"
   RELEASE_PAGE="https://github.com/${REPO}/releases"
 fi
 
@@ -63,19 +61,22 @@ esac
 
 info "Detected platform: ${OS}-${ARCH} (${ASSET})"
 
-# ── Fetch latest release tag ──────────────────────────────────────────────────
-
-info "Fetching latest release from GitHub..."
-
-TAG="$(curl -fsSL "${API_URL}" \
-  | grep '"tag_name"' \
-  | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
-
-[[ -n "${TAG}" ]] || die "Could not determine release tag. Is the GitHub API reachable?"
+# ── Resolve the release tag ───────────────────────────────────────────────────
+# No GitHub API call on either path: a pinned tag is used as given, and the
+# latest release is read from the redirect of the public releases page. The API
+# allows 60 anonymous calls per hour per IP address, which a shared network can
+# exhaust before a first install.
 
 if [[ -n "${REQUESTED_TAG}" ]]; then
+  TAG="${REQUESTED_TAG}"
   ok "Requested release: ${TAG}"
 else
+  info "Finding the latest release on GitHub..."
+  LATEST_URL="$(curl -fsSI -o /dev/null -w '%{redirect_url}' "https://github.com/${REPO}/releases/latest" || true)"
+  TAG="${LATEST_URL##*/releases/tag/}"
+  if [[ -z "${LATEST_URL}" || -z "${TAG}" || "${TAG}" == "${LATEST_URL}" ]]; then
+    die "Could not find the latest release at ${RELEASE_PAGE}. Check the network, or pin a release with WENLAN_RELEASE_TAG=vX.Y.Z."
+  fi
   ok "Latest release: ${TAG}"
 fi
 
@@ -91,7 +92,7 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 
 info "Downloading ${ASSET}..."
 if ! curl -fSL --progress-bar -o "${TMP_DIR}/${ASSET}" "${DOWNLOAD_URL}"; then
-  die "Failed to download ${ASSET} from ${DOWNLOAD_URL}"
+  die "Failed to download ${ASSET} from ${DOWNLOAD_URL}. Check that the release exists at ${RELEASE_PAGE} and has that asset."
 fi
 ok "Downloaded ${ASSET}"
 

--- a/scripts/install-macos-app.sh
+++ b/scripts/install-macos-app.sh
@@ -61,11 +61,12 @@ extract_dir="$tmp_dir/extracted"
 # The release lookup is this installer's one GitHub API call (the asset's
 # SHA-256 digest comes from it). Anonymous callers get 60 calls per hour per IP
 # address, so a token is sent when the user has one, and a rate-limited answer
-# is named as such instead of surfacing as a bare curl error.
+# is named as such instead of surfacing as a bare curl error. The token goes to
+# GitHub's API only, never to a plaintext or overridden metadata URL.
 fetch_release_json() {
   local curl_args=(-sSL -o "$release_json" -w '%{http_code}')
-  local token=${GITHUB_TOKEN:-${GH_TOKEN:-}}
-  if [[ -n $token && $RELEASE_JSON_URL == http* ]]; then
+  local token=${GH_TOKEN:-${GITHUB_TOKEN:-}}
+  if [[ -n $token && $RELEASE_JSON_URL == https://api.github.com/* ]]; then
     curl_args+=(-H "Authorization: Bearer $token")
   fi
 
@@ -73,8 +74,11 @@ fetch_release_json() {
   http_code=$(curl "${curl_args[@]}" "$RELEASE_JSON_URL") || die "could not fetch release metadata from $RELEASE_JSON_URL"
   case $http_code in
     000 | 2??) ;;
+    401)
+      die "GitHub rejected the token sent with the release lookup (HTTP 401): GH_TOKEN or GITHUB_TOKEN is invalid or expired."
+      ;;
     403 | 429)
-      die "GitHub's API rate limit blocked the release lookup (HTTP $http_code). Wait an hour, or set GITHUB_TOKEN to a GitHub token and run the command again."
+      die "GitHub's API rate limit blocked the release lookup (HTTP $http_code). Wait for the limit to reset (up to an hour for anonymous callers), or set GITHUB_TOKEN to a GitHub token and run the command again."
       ;;
     *) die "release lookup at $RELEASE_JSON_URL failed (HTTP $http_code)" ;;
   esac

--- a/scripts/install-macos-app.sh
+++ b/scripts/install-macos-app.sh
@@ -58,8 +58,30 @@ release_json="$tmp_dir/release.json"
 archive="$tmp_dir/$ASSET_NAME"
 extract_dir="$tmp_dir/extracted"
 
+# The release lookup is this installer's one GitHub API call (the asset's
+# SHA-256 digest comes from it). Anonymous callers get 60 calls per hour per IP
+# address, so a token is sent when the user has one, and a rate-limited answer
+# is named as such instead of surfacing as a bare curl error.
+fetch_release_json() {
+  local curl_args=(-sSL -o "$release_json" -w '%{http_code}')
+  local token=${GITHUB_TOKEN:-${GH_TOKEN:-}}
+  if [[ -n $token && $RELEASE_JSON_URL == http* ]]; then
+    curl_args+=(-H "Authorization: Bearer $token")
+  fi
+
+  local http_code
+  http_code=$(curl "${curl_args[@]}" "$RELEASE_JSON_URL") || die "could not fetch release metadata from $RELEASE_JSON_URL"
+  case $http_code in
+    000 | 2??) ;;
+    403 | 429)
+      die "GitHub's API rate limit blocked the release lookup (HTTP $http_code). Wait an hour, or set GITHUB_TOKEN to a GitHub token and run the command again."
+      ;;
+    *) die "release lookup at $RELEASE_JSON_URL failed (HTTP $http_code)" ;;
+  esac
+}
+
 echo "Finding the latest Wenlan app release..."
-curl -fsSL "$RELEASE_JSON_URL" -o "$release_json"
+fetch_release_json
 
 asset_count=$(plutil -extract assets raw -o - "$release_json" 2>/dev/null) || die "release metadata has no assets"
 asset_url=

--- a/scripts/smoke-mcp.sh
+++ b/scripts/smoke-mcp.sh
@@ -73,7 +73,7 @@ echo "==> Driving wenlan-mcp over stdio JSON-RPC"
 # The JSON-RPC driver lives in the first-run gauntlet helper (shared with the
 # release-artifact workflow); it records every step and never exits early.
 # WENLAN_MCP_CACHE_DIR keeps the self-update probe out of the user cache (the
-# empty temp cache still forces one GET to api.github.com; its 3s timeout is
+# empty temp cache still forces one GET to github.com; its 3s timeout is
 # fail-soft).
 GAUNTLET_OUT="$DATA_DIR/gauntlet" GAUNTLET_CHANNEL=smoke-mcp \
 WENLAN_MCP_CACHE_DIR="$DATA_DIR/mcp-cache" \

--- a/scripts/test-install-macos-app.sh
+++ b/scripts/test-install-macos-app.sh
@@ -4,7 +4,14 @@ set -euo pipefail
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 INSTALLER="$ROOT_DIR/scripts/install-macos-app.sh"
 TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/wenlan-app-installer-test.XXXXXX")
-trap 'rm -rf "$TMP_DIR"' EXIT
+STUB_SERVER=
+cleanup() {
+  if [[ -n $STUB_SERVER ]]; then
+    kill "$STUB_SERVER" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
 
 make_fixture() {
   local fixture_dir=$1
@@ -195,7 +202,79 @@ test_fails_when_running_app_does_not_quit() {
   test -f "$install_dir/Wenlan.app/existing-marker"
 }
 
+test_names_rate_limiting_and_sends_the_token() {
+  local fixture_dir="$TMP_DIR/rate-limit"
+  local install_dir="$fixture_dir/Applications"
+  mkdir -p "$fixture_dir"
+
+  # A loopback stand-in for api.github.com that answers 403 like a rate limit
+  # and records the Authorization header it was sent.
+  cat > "$fixture_dir/server.py" <<'PY'
+import http.server
+import pathlib
+import sys
+
+auth_log = pathlib.Path(sys.argv[1])
+port_file = pathlib.Path(sys.argv[2])
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        auth_log.write_text(self.headers.get("Authorization", "") + "\n")
+        body = b'{"message":"API rate limit exceeded"}'
+        self.send_response(403)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+server = http.server.HTTPServer(("127.0.0.1", 0), Handler)
+port_file.write_text(str(server.server_address[1]))
+server.serve_forever()
+PY
+  python3 "$fixture_dir/server.py" "$fixture_dir/auth.log" "$fixture_dir/port" &
+  STUB_SERVER=$!
+  disown "$STUB_SERVER"
+  for _ in $(seq 1 50); do
+    [[ -s "$fixture_dir/port" ]] && break
+    sleep 0.1
+  done
+  if [[ ! -s "$fixture_dir/port" ]]; then
+    echo "rate-limit stub server did not start" >&2
+    return 1
+  fi
+
+  local status=0
+  GITHUB_TOKEN=test-token \
+    WENLAN_APP_RELEASE_JSON_URL="http://127.0.0.1:$(cat "$fixture_dir/port")/releases/latest" \
+    WENLAN_APP_INSTALL_DIR="$install_dir" \
+    WENLAN_APP_NO_LAUNCH=1 \
+    WENLAN_APP_SKIP_PLATFORM_CHECK=1 \
+    bash "$INSTALLER" > "$fixture_dir/installer.log" 2>&1 || status=$?
+  kill "$STUB_SERVER" 2>/dev/null || true
+  STUB_SERVER=
+
+  if [[ $status -eq 0 ]]; then
+    echo "installer succeeded against a rate-limited release lookup" >&2
+    return 1
+  fi
+  if ! grep -q "GitHub's API rate limit" "$fixture_dir/installer.log"; then
+    echo "installer did not name rate limiting:" >&2
+    cat "$fixture_dir/installer.log" >&2
+    return 1
+  fi
+  if [[ $(cat "$fixture_dir/auth.log") != "Bearer test-token" ]]; then
+    echo "installer did not send GITHUB_TOKEN as a bearer token" >&2
+    return 1
+  fi
+}
+
 test_installs_verified_app_without_quarantine
+test_names_rate_limiting_and_sends_the_token
 test_rejects_bad_digest_before_replacing_existing_app
 test_restores_existing_app_when_interrupted_after_backup
 test_quits_running_app_before_replacing_it

--- a/scripts/test-install-macos-app.sh
+++ b/scripts/test-install-macos-app.sh
@@ -202,13 +202,14 @@ test_fails_when_running_app_does_not_quit() {
   test -f "$install_dir/Wenlan.app/existing-marker"
 }
 
-test_names_rate_limiting_and_sends_the_token() {
+test_names_rate_limiting_without_sending_the_token_elsewhere() {
   local fixture_dir="$TMP_DIR/rate-limit"
   local install_dir="$fixture_dir/Applications"
   mkdir -p "$fixture_dir"
 
-  # A loopback stand-in for api.github.com that answers 403 like a rate limit
-  # and records the Authorization header it was sent.
+  # A loopback server that answers 403 like a rate limit and records the
+  # Authorization header it was sent. It is not GitHub's API, so the token
+  # must not reach it.
   cat > "$fixture_dir/server.py" <<'PY'
 import http.server
 import pathlib
@@ -267,14 +268,55 @@ PY
     cat "$fixture_dir/installer.log" >&2
     return 1
   fi
-  if [[ $(cat "$fixture_dir/auth.log") != "Bearer test-token" ]]; then
-    echo "installer did not send GITHUB_TOKEN as a bearer token" >&2
+  if [[ -s "$fixture_dir/auth.log" && $(cat "$fixture_dir/auth.log") != "" ]]; then
+    echo "installer sent the token to a host that is not api.github.com: $(cat "$fixture_dir/auth.log")" >&2
+    return 1
+  fi
+}
+
+test_sends_the_token_to_the_github_api() {
+  local fixture_dir="$TMP_DIR/token"
+  local fake_bin="$fixture_dir/fake-bin"
+  mkdir -p "$fake_bin"
+
+  # A stand-in curl that records its arguments and answers like an expired
+  # token, so nothing reaches the network.
+  cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$CURL_RECORD"
+printf '401'
+SH
+  chmod +x "$fake_bin/curl"
+
+  local status=0
+  PATH="$fake_bin:$PATH" \
+    CURL_RECORD="$fixture_dir/curl-args" \
+    GH_TOKEN=test-token \
+    WENLAN_APP_RELEASE_JSON_URL="https://api.github.com/repos/7xuanlu/wenlan/releases/latest" \
+    WENLAN_APP_INSTALL_DIR="$fixture_dir/Applications" \
+    WENLAN_APP_NO_LAUNCH=1 \
+    WENLAN_APP_SKIP_PLATFORM_CHECK=1 \
+    bash "$INSTALLER" > "$fixture_dir/installer.log" 2>&1 || status=$?
+
+  if [[ $status -eq 0 ]]; then
+    echo "installer succeeded against a rejected token" >&2
+    return 1
+  fi
+  if ! grep -q "invalid or expired" "$fixture_dir/installer.log"; then
+    echo "installer did not name the rejected token:" >&2
+    cat "$fixture_dir/installer.log" >&2
+    return 1
+  fi
+  if ! grep -qx "Authorization: Bearer test-token" "$fixture_dir/curl-args"; then
+    echo "installer did not send GH_TOKEN as a bearer token to api.github.com:" >&2
+    cat "$fixture_dir/curl-args" >&2
     return 1
   fi
 }
 
 test_installs_verified_app_without_quarantine
-test_names_rate_limiting_and_sends_the_token
+test_names_rate_limiting_without_sending_the_token_elsewhere
+test_sends_the_token_to_the_github_api
 test_rejects_bad_digest_before_replacing_existing_app
 test_restores_existing_app_when_interrupted_after_backup
 test_quits_running_app_before_replacing_it


### PR DESCRIPTION
## What

The install paths depended on anonymous GitHub API calls, which GitHub limits to 60 per hour per IP address. First-run gauntlet finding on the rate limit: `npx -y wenlan setup` and the plugin bootstrap's `install.sh` both failed with HTTP 403 before downloading anything.

## Why

A user behind a shared network (office, campus, CI) can hit the same 403 on their very first command, and nothing honored `GITHUB_TOKEN` or said what the 403 was.

## How

- `install.sh` and `crates/wenlan-cli/npm/run.js` make no API call at all: a pinned tag (`WENLAN_RELEASE_TAG`) is used as given, and the latest release comes from the redirect of `https://github.com/7xuanlu/wenlan/releases/latest` (a plain page, no API quota). The redirect is accepted only from `https://github.com/7xuanlu/wenlan/releases/tag/` on a 3xx, and every tag, pinned or resolved, must match `vX.Y.Z[-pre]`. A wrong tag now fails at the download with the release page named.
- `scripts/install-macos-app.sh` still needs the API for the asset's SHA-256 digest. It sends `Authorization: Bearer $GH_TOKEN` (or `GITHUB_TOKEN`) when set, and only to `https://api.github.com/`; on HTTP 403/429 it says it is GitHub's rate limit (wait for the reset or set `GITHUB_TOKEN`), and on 401 that the token is invalid or expired. The gauntlet's macOS app job passes `github.token`.
- `crates/wenlan-mcp/src/self_update_check.rs` reads the same redirect (no redirect following, `Location` header parsed) instead of the API. It also still pointed at `7xuanlu/origin`, the repository's old name.

## Verification

- `bash scripts/test-install-macos-app.sh`: 5 cases pass. A loopback server answering 403 proves the rate-limit message and that the token is withheld from a non-GitHub host; a recording fake `curl` proves `GH_TOKEN` reaches `api.github.com` as `Authorization: Bearer test-token` and that HTTP 401 names an expired token. The harness now runs in the `app-check` CI job. Mutation controls: the `main` installer fails with `installer did not name rate limiting`; sending the token to any `http*` URL fails with `installer sent the token to a host that is not api.github.com`.
- Live, in a scratch `HOME`: `install.sh` unpinned resolves `Latest release: v0.17.0` and installs; pinned `v0.17.0` installs without any lookup; pinned `v9.9.9` fails with the download URL and the release page named. `node run.js --version` unpinned downloads v0.17.0 and prints `wenlan 0.17.0`; pinned `v9.9.9` fails with the release page named.
- `cargo test -p wenlan-mcp --lib self_update_check`: 4 passed (includes the redirect parsing test); `cargo fmt --check` and `cargo clippy -p wenlan-mcp --all-targets -- -D warnings` clean. The live reqwest path of the MCP check is `unchecked` here; the redirect itself was confirmed with `curl -I` (302, `Location: …/releases/tag/v0.17.0`).
- `shellcheck -S warning` clean on the three shell files; `node --check` and `actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh

