### PR TITLE
fix(core): merge same-topic sibling shards before distill writes a page

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -2659,10 +2659,19 @@ const RESPLIT_MAX_THRESHOLD: f64 = 0.92;
 ///
 /// Two clusters of one bucket merge when their centroids' cosine is at or above
 /// `RESPLIT_MAX_THRESHOLD` — the same ceiling the ladder tightens toward, so a
-/// merge can only undo a split the ladder itself made. A merge that would push
-/// the result back over the bucket's member cap or over the LLM token limit is
-/// skipped: those two bounds are exactly why the ladder split in the first
-/// place, and re-merging past them would reintroduce the oversized cluster.
+/// merge can only undo a split the ladder itself made.
+///
+/// The member caps (`max_grouped_cluster_size` / `max_unlinked_cluster_size`)
+/// deliberately do NOT gate this merge. They are formation-time bounds: they
+/// tell the greedy grouping and the re-split ladder when a blob is still too
+/// coarse to be one topic, which is a statement about the threshold the blob
+/// was cut at, not a ceiling on how large a genuine topic may be. Once two
+/// shards' centroids meet the ladder's own ceiling, the evidence that they are
+/// one topic is stronger than the size heuristic that separated them, and a cap
+/// check here would just re-impose the split it exists to repair: a 20-memory
+/// topic under a cap of 12 emits [10, 10], and both halves would still become
+/// their own page. The LLM token limit is the real page-size guard, and it is
+/// still enforced below.
 ///
 /// Deterministic and model-free: candidates are scanned in emission order, the
 /// earlier cluster absorbs the later one, and the absorbing cluster is rebuilt
@@ -2672,7 +2681,6 @@ const RESPLIT_MAX_THRESHOLD: f64 = 0.92;
 fn merge_sibling_shards(
     memories: &[ClusterMemRow],
     clusters: Vec<DistillationCluster>,
-    cap: usize,
     token_limit: usize,
 ) -> Vec<DistillationCluster> {
     if clusters.len() < 2 {
@@ -2725,9 +2733,6 @@ fn merge_sibling_shards(
             // just a concatenation.
             let mut union = members[i].clone();
             union.extend_from_slice(&members[j]);
-            if union.len() > cap {
-                continue;
-            }
             let merged = build_distillation_cluster(memories, &union);
             if merged.estimated_tokens > token_limit {
                 continue;
@@ -2841,7 +2846,7 @@ fn cluster_distillation_rows(
         // about. Cross-space candidates (`Global`) are a different feature and
         // are left untouched.
         if matches!(mode, DistillationClusterMode::SpaceScoped) {
-            bucket = merge_sibling_shards(memories, bucket, cap, token_limit);
+            bucket = merge_sibling_shards(memories, bucket, token_limit);
         }
         clusters.extend(bucket);
     };

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -2642,6 +2642,114 @@ const RESPLIT_STEP: f64 = 0.05;
 /// rather than tightened further.
 const RESPLIT_MAX_THRESHOLD: f64 = 0.92;
 
+/// Same-topic sibling shards (issue #596). The re-split ladder above can slice
+/// one coherent topic into several shards, and nothing downstream ever compares
+/// a pending cluster with its siblings: the Jaccard/subset filter in
+/// `handle_distill` scores a cluster only against *existing* pages, and two
+/// disjoint shards of one topic score 0 there. The page each shard creates is
+/// born `unconfirmed`, so shard one cannot deduplicate shard two inside the
+/// same pass either — one topic becomes two pages.
+///
+/// Merge those siblings back together before the pass writes anything, using
+/// the one same-pass signal already computed for every cluster: the mean-pooled
+/// `centroid_embedding`. (Entity identity is not usable here — a cluster
+/// carries a single `entity_id` taken from its first member, not the member set
+/// a "shared majority of entities" rule would need, so computing it would mean
+/// new work rather than reusing what the pass already has.)
+///
+/// Two clusters of one bucket merge when their centroids' cosine is at or above
+/// `RESPLIT_MAX_THRESHOLD` — the same ceiling the ladder tightens toward, so a
+/// merge can only undo a split the ladder itself made. A merge that would push
+/// the result back over the bucket's member cap or over the LLM token limit is
+/// skipped: those two bounds are exactly why the ladder split in the first
+/// place, and re-merging past them would reintroduce the oversized cluster.
+///
+/// Deterministic and model-free: candidates are scanned in emission order, the
+/// earlier cluster absorbs the later one, and the absorbing cluster is rebuilt
+/// through `build_distillation_cluster` so its centroid, token estimate, and
+/// member order match any other cluster of the pass. Survivors keep their
+/// emission order, which the `max_clusters` truncation below relies on.
+fn merge_sibling_shards(
+    memories: &[ClusterMemRow],
+    clusters: Vec<DistillationCluster>,
+    cap: usize,
+    token_limit: usize,
+) -> Vec<DistillationCluster> {
+    if clusters.len() < 2 {
+        return clusters;
+    }
+
+    let position: std::collections::HashMap<&str, usize> = memories
+        .iter()
+        .enumerate()
+        .map(|(index, memory)| (memory.source_id.as_str(), index))
+        .collect();
+
+    // Member indices per cluster. A cluster whose members can't all be resolved
+    // back to `memories` is left alone rather than guessed at.
+    let mut members: Vec<Vec<usize>> = Vec::with_capacity(clusters.len());
+    let mut survivors: Vec<Option<DistillationCluster>> = Vec::with_capacity(clusters.len());
+    for cluster in clusters {
+        let resolved: Option<Vec<usize>> = cluster
+            .source_ids
+            .iter()
+            .map(|source_id| position.get(source_id.as_str()).copied())
+            .collect();
+        members.push(resolved.unwrap_or_default());
+        survivors.push(Some(cluster));
+    }
+
+    for i in 0..survivors.len() {
+        if members[i].is_empty() {
+            continue;
+        }
+        for j in (i + 1)..survivors.len() {
+            if survivors[j].is_none() || members[j].is_empty() {
+                continue;
+            }
+            let same_topic = match (
+                survivors[i]
+                    .as_ref()
+                    .and_then(|c| c.centroid_embedding.as_deref()),
+                survivors[j]
+                    .as_ref()
+                    .and_then(|c| c.centroid_embedding.as_deref()),
+            ) {
+                (Some(a), Some(b)) => cosine_similarity(a, b) >= RESPLIT_MAX_THRESHOLD,
+                _ => false,
+            };
+            if !same_topic {
+                continue;
+            }
+            // Clusters of one bucket partition their members, so the union is
+            // just a concatenation.
+            let mut union = members[i].clone();
+            union.extend_from_slice(&members[j]);
+            if union.len() > cap {
+                continue;
+            }
+            let merged = build_distillation_cluster(memories, &union);
+            if merged.estimated_tokens > token_limit {
+                continue;
+            }
+            log::info!(
+                "[distill] merging same-topic sibling shards: {} + {} memories -> {} \
+                 (centroids at or above the {:.2} re-split ceiling)",
+                members[i].len(),
+                members[j].len(),
+                union.len(),
+                RESPLIT_MAX_THRESHOLD,
+            );
+            members[i] = union;
+            members[j].clear();
+            survivors[i] = Some(merged);
+            survivors[j] = None;
+        }
+    }
+
+    survivors.into_iter().flatten().collect()
+}
+
 #[derive(Debug, Clone, Copy)]
 enum DistillationClusterMode {
     SpaceScoped,
@@ -2673,6 +2781,9 @@ fn cluster_distillation_rows(
                           indices: &[usize],
                           cap: usize,
                           clusters: &mut Vec<DistillationCluster>| {
+        // Clusters this bucket produces are collected here first so the
+        // sibling-shard merge below sees the whole bucket at once.
+        let mut bucket: Vec<DistillationCluster> = Vec::new();
         // Each base group is drained, together with every re-split
         // descendant, before the next sibling starts. That keeps the output
         // order of the one-shot re-split this replaces: a group that never
@@ -2722,9 +2833,17 @@ fn cluster_distillation_rows(
                     continue;
                 }
                 let cluster = build_distillation_cluster(memories, &group);
-                emit_split(cluster, clusters);
+                emit_split(cluster, &mut bucket);
             }
         }
+        // One bucket is one space (or the single "no declared space"
+        // catch-all), so its clusters are exactly the siblings issue #596 is
+        // about. Cross-space candidates (`Global`) are a different feature and
+        // are left untouched.
+        if matches!(mode, DistillationClusterMode::SpaceScoped) {
+            bucket = merge_sibling_shards(memories, bucket, cap, token_limit);
+        }
+        clusters.extend(bucket);
     };
 
     match mode {

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -14887,33 +14887,52 @@ async fn find_distillation_clusters_treats_empty_entity_id_as_unlinked() {
     // cap. entity_id is irrelevant to partitioning here — these rows have
     // space = None, so the unlinked cap must hold regardless of entity_id.
     //
-    // Setup: 8 highly-similar memories with no space and empty-string
-    // entity_id, with max_unlinked_cluster_size = 5. They land in the
-    // unlinked catch-all → cap kicks in → returned cluster sizes <= 5.
+    // Setup: 8 memories with no space and empty-string entity_id, split across
+    // TWO unrelated subjects (4 each), with max_unlinked_cluster_size = 5.
+    // They land in the unlinked catch-all, the group of 8 is over the cap, and
+    // the ladder re-splits it along the subject boundary → sizes <= 5.
+    //
+    // The subjects have to be genuinely unrelated: since issue #596 the sibling
+    // merge rejoins two clusters of one bucket whose centroids meet the 0.92
+    // ceiling, so a fixture of eight paraphrases of one sentence would be
+    // re-merged (correctly) into a single 8-member topic and would no longer
+    // say anything about the cap. Two subjects keep the centroids far apart, so
+    // what this test observes is the cap alone.
     let (db, _dir) = test_db().await;
 
     let now = chrono::Utc::now().timestamp_millis();
-    for i in 0..8 {
-        let doc = RawDocument {
-            source: "memory".to_string(),
-            source_id: format!("mem_empty_eid_{}", i),
-            content: format!("origin notes about distillation iteration {}", i),
-            title: format!("Note {}", i),
-            last_modified: now + i as i64,
-            memory_type: None,
-            space: None,
-            entity_id: Some(String::new()), // <-- the marker
-            ..Default::default()
-        };
-        db.upsert_documents(vec![doc]).await.unwrap();
-        db.record_enrichment_step(
-            &format!("mem_empty_eid_{}", i),
-            "entity_backfill",
-            "skipped",
-            None,
-        )
-        .await
-        .unwrap();
+    for (subject, sentence) in [
+        (
+            "sourdough",
+            "The sourdough starter doubled in volume after six hours on the warm counter",
+        ),
+        (
+            "derailleur",
+            "The rear derailleur cable had stretched and needed a quarter turn of the barrel adjuster",
+        ),
+    ] {
+        for i in 0..4 {
+            let doc = RawDocument {
+                source: "memory".to_string(),
+                source_id: format!("mem_empty_eid_{subject}_{i}"),
+                content: format!("{sentence}, batch {i}"),
+                title: format!("{subject} note {i}"),
+                last_modified: now + i as i64,
+                memory_type: None,
+                space: None,
+                entity_id: Some(String::new()), // <-- the marker
+                ..Default::default()
+            };
+            db.upsert_documents(vec![doc]).await.unwrap();
+            db.record_enrichment_step(
+                &format!("mem_empty_eid_{subject}_{i}"),
+                "entity_backfill",
+                "skipped",
+                None,
+            )
+            .await
+            .unwrap();
+        }
     }
 
     let clusters = db
@@ -14921,6 +14940,16 @@ async fn find_distillation_clusters_treats_empty_entity_id_as_unlinked() {
         .await
         .unwrap();
 
+    // Non-vacuous: the cap assertion below says nothing at all if the pass
+    // returned no clusters, so pin that the split actually happened first.
+    assert!(
+        clusters.len() >= 2,
+        "the unlinked group of 8 must be re-split, not dropped: {:?}",
+        clusters
+            .iter()
+            .map(|cluster| cluster.source_ids.len())
+            .collect::<Vec<_>>()
+    );
     for cluster in &clusters {
         assert!(
             cluster.source_ids.len() <= 5,
@@ -14935,37 +14964,70 @@ async fn find_distillation_clusters_treats_empty_entity_id_as_unlinked() {
 async fn find_distillation_clusters_caps_oversized_unlinked() {
     let (db, _dir) = test_db().await;
 
-    // Insert 60 unlinked memories (no entity_id, no domain) with similar
-    // content — should form ONE big unlinked cluster.
+    // Insert 60 unlinked memories (no entity_id, no domain) spread over THREE
+    // unrelated subjects, 20 each. At the formation threshold they collapse
+    // into one oversized unlinked blob; the ladder must re-split it along the
+    // subject boundaries so nothing over the cap is returned.
+    //
+    // The subjects are unrelated on purpose. Since issue #596 the sibling merge
+    // rejoins two clusters of one bucket whose centroids meet the 0.92 ceiling,
+    // so 60 paraphrases of one sentence would be re-merged into a single
+    // 60-member topic — correct behavior, but it would leave this test with
+    // nothing to say about the cap. Distinct subjects keep the emitted
+    // centroids far below the ceiling, so the cap is what the test observes.
     let now = chrono::Utc::now().timestamp_millis();
-    for i in 0..60 {
-        let doc = RawDocument {
-            source: "memory".to_string(),
-            source_id: format!("mem_unlinked_{}", i),
-            // Highly similar content — all about same topic
-            content: format!("notes on origin distillation pipeline iteration {}", i),
-            title: format!("Note {}", i),
-            url: None,
-            last_modified: now + i as i64,
-            memory_type: None,
-            space: None,
-            entity_id: None,
-            ..Default::default()
-        };
-        db.upsert_documents(vec![doc]).await.unwrap();
-        // Mark enriched (must satisfy Task 4 gate)
-        db.record_enrichment_step(&format!("mem_unlinked_{}", i), "dedup", "ok", None)
-            .await
-            .unwrap();
+    for (subject, sentence) in [
+        (
+            "sourdough",
+            "The sourdough starter doubled in volume after six hours on the warm counter",
+        ),
+        (
+            "derailleur",
+            "The rear derailleur cable had stretched and needed a quarter turn of the barrel adjuster",
+        ),
+        (
+            "hohmann",
+            "A Hohmann transfer orbit spends two engine burns raising the apoapsis toward the target",
+        ),
+    ] {
+        for i in 0..20 {
+            let doc = RawDocument {
+                source: "memory".to_string(),
+                source_id: format!("mem_unlinked_{subject}_{i}"),
+                content: format!("{sentence}, entry {i}"),
+                title: format!("{subject} note {i}"),
+                url: None,
+                last_modified: now + i as i64,
+                memory_type: None,
+                space: None,
+                entity_id: None,
+                ..Default::default()
+            };
+            db.upsert_documents(vec![doc]).await.unwrap();
+            // Mark enriched (must satisfy Task 4 gate)
+            db.record_enrichment_step(&format!("mem_unlinked_{subject}_{i}"), "dedup", "ok", None)
+                .await
+                .unwrap();
+        }
     }
 
-    // Run with cap = 30. The single 60-memory unlinked cluster should be
-    // skipped entirely. No clusters > 30 should be returned.
+    // Run with cap = 30. The 60-memory unlinked blob must come back re-split,
+    // never as one oversized cluster.
     let clusters = db
         .find_distillation_clusters(0.3, 2, 20, 3500, 30, 50)
         .await
         .unwrap();
 
+    // Non-vacuous: an empty result would satisfy the cap loop below without
+    // proving anything, so pin that the re-split really produced clusters.
+    assert!(
+        clusters.len() >= 2,
+        "the oversized unlinked blob must be re-split, not dropped: {:?}",
+        clusters
+            .iter()
+            .map(|cluster| cluster.source_ids.len())
+            .collect::<Vec<_>>()
+    );
     for cluster in &clusters {
         assert!(
             cluster.source_ids.len() <= 30,
@@ -14986,32 +15048,67 @@ async fn find_distillation_clusters_caps_oversized_entity_group() {
     let (db, _dir) = test_db().await;
 
     let now = chrono::Utc::now().timestamp_millis();
-    // 20 memories on the same entity, all with similar prose so they
-    // collapse into one greedy cluster at threshold 0.3 — well above the
-    // grouped cap of 6 used below.
-    for i in 0..20 {
-        let doc = RawDocument {
-            source: "memory".to_string(),
-            source_id: format!("mem_origin_{}", i),
-            content: format!("origin distillation pipeline note number {}", i),
-            title: format!("Note {}", i),
-            url: None,
-            last_modified: now + i as i64,
-            memory_type: None,
-            space: Some("origin".to_string()),
-            entity_id: Some("ent_origin".to_string()),
-            ..Default::default()
-        };
-        db.upsert_documents(vec![doc]).await.unwrap();
+    // 20 memories on the same entity in one space, spread over FOUR unrelated
+    // subjects (5 each). At threshold 0.3 they collapse into one greedy cluster
+    // — well above the grouped cap of 6 used below — so the ladder has to
+    // re-split along the subject boundaries.
+    //
+    // Unrelated subjects are load-bearing: since issue #596 the sibling merge
+    // rejoins two clusters of one bucket whose centroids meet the 0.92 ceiling,
+    // so 20 paraphrases of one sentence would (correctly) come back as one
+    // 20-member topic and this test would no longer observe the cap at all.
+    for (subject, sentence) in [
+        (
+            "sourdough",
+            "The sourdough starter doubled in volume after six hours on the warm counter",
+        ),
+        (
+            "derailleur",
+            "The rear derailleur cable had stretched and needed a quarter turn of the barrel adjuster",
+        ),
+        (
+            "hohmann",
+            "A Hohmann transfer orbit spends two engine burns raising the apoapsis toward the target",
+        ),
+        (
+            "estimated_tax",
+            "Quarterly estimated tax payments fall due on the fifteenth of the month after the quarter closes",
+        ),
+    ] {
+        for i in 0..5 {
+            let doc = RawDocument {
+                source: "memory".to_string(),
+                source_id: format!("mem_origin_{subject}_{i}"),
+                content: format!("{sentence}, note {i}"),
+                title: format!("{subject} note {i}"),
+                url: None,
+                last_modified: now + i as i64,
+                memory_type: None,
+                space: Some("origin".to_string()),
+                entity_id: Some("ent_origin".to_string()),
+                ..Default::default()
+            };
+            db.upsert_documents(vec![doc]).await.unwrap();
+        }
     }
 
-    // grouped cap = 6 → original blob must re-split or drop; no cluster
-    // returned can exceed 6 memories.
+    // grouped cap = 6 → original blob must re-split; no cluster returned can
+    // exceed 6 memories.
     let clusters = db
         .find_distillation_clusters(0.3, 2, 20, 3500, 50, 6)
         .await
         .unwrap();
 
+    // Non-vacuous: with no clusters the cap loop below asserts nothing, so pin
+    // that the re-split produced the sub-topics first.
+    assert!(
+        clusters.len() >= 2,
+        "the oversized space blob must be re-split, not dropped: {:?}",
+        clusters
+            .iter()
+            .map(|cluster| cluster.source_ids.len())
+            .collect::<Vec<_>>()
+    );
     for cluster in &clusters {
         assert!(
             cluster.source_ids.len() <= 6,
@@ -21930,8 +22027,9 @@ fn same_topic_sibling_shards_merge_before_distill_writes_pages() {
     // the rung really does split them) — while the two mean-pooled centroids
     // sit at 0.932, above the ceiling. The 20 scattered members make the base
     // group oversized so the ladder fires at all, then fall out as singletons
-    // below the member floor, which leaves the merged 10 members inside the
-    // grouped cap of 12.
+    // below the member floor. (See `ladder_shards_of_one_topic_rejoin_into_one_
+    // distill_cluster` for the case where the rejoined topic is larger than the
+    // grouped cap — the cap does not gate the merge.)
     let shared = 0.88f32.sqrt();
     let topic = 0.05f32.sqrt();
     let noise = 0.07f32.sqrt();
@@ -22094,6 +22192,234 @@ fn unrelated_distill_clusters_are_not_merged_as_siblings() {
     for cluster in &clusters {
         assert_eq!(cluster.source_ids.len(), 5, "{:?}", cluster.source_ids);
     }
+}
+
+/// Shared geometry for the ladder-rejoin tests below. Builds `2 * members`
+/// rows in one space: two halves of ONE topic, laid out so the re-split ladder
+/// separates them at the 0.92 ceiling and nowhere earlier.
+///
+/// Squared weights are shared 0.88, per-half topic 0.05, per-member noise 0.07,
+/// which gives within-half member cosine 0.930 (at or above the 0.92 rung, so
+/// each half survives it), a cross-half member against the other half's
+/// centroid at 0.909 (below 0.92 so the ceiling rung splits them, but at or
+/// above 0.90 so no earlier rung does), and mean-pooled centroids 0.939 apart —
+/// above the ceiling, so the two halves are one topic by the merge rule.
+fn one_topic_two_ladder_halves(members: usize, content: &str) -> Vec<ClusterMemRow> {
+    let shared = 0.88f32.sqrt();
+    let topic = 0.05f32.sqrt();
+    let noise = 0.07f32.sqrt();
+
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    for (half, topic_dim) in [("a", 1usize), ("b", 2usize)] {
+        for i in 0..members {
+            let mut emb = vec![0.0f32; 768];
+            emb[0] = shared;
+            emb[topic_dim] = topic;
+            emb[10 + memories.len()] = noise;
+            memories.push(ClusterMemRow {
+                source_id: format!("{half}_m{i}"),
+                content: content.to_string(),
+                entity_id: None,
+                entity_name: None,
+                space: Some("wenlan".to_string()),
+                can_seed_page: true,
+                embedding: emb,
+            });
+        }
+    }
+    memories
+}
+
+#[test]
+fn ladder_shards_of_one_topic_rejoin_into_one_distill_cluster() {
+    // Issue #596, the case that matters in production: ONE coherent topic of 20
+    // memories under a grouped cap of 12. The ladder tightens from the default
+    // formation threshold (0.60) rung by rung, and at the 0.92 ceiling it emits
+    // [10, 10] — two halves of one topic, each already inside the cap, so the
+    // ladder stops there and both halves would become their own unconfirmed
+    // page in this pass.
+    //
+    // The member cap must NOT gate the sibling merge: it is a formation-time
+    // bound on how coarse a group may be, not a ceiling on how large a real
+    // topic is, and the union here (20) is over the cap by construction. The
+    // centroids are 0.939 apart, above the ladder's own ceiling, so the pass
+    // must hand back ONE cluster of all 20.
+    let memories = one_topic_two_ladder_halves(10, "one topic note");
+
+    // Fixture self-checks — the whole point is WHERE the ladder splits.
+    let within = cosine_similarity(&memories[0].embedding, &memories[1].embedding);
+    assert!(
+        (within - 0.930).abs() < 0.005,
+        "within-half cosine drifted: {within}"
+    );
+    let half_a = build_distillation_cluster(&memories, &(0..10).collect::<Vec<_>>());
+    let half_b = build_distillation_cluster(&memories, &(10..20).collect::<Vec<_>>());
+    let centroid_cos = cosine_similarity(
+        half_a.centroid_embedding.as_ref().unwrap(),
+        half_b.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        (centroid_cos - 0.939).abs() < 0.005,
+        "sibling centroid cosine drifted: {centroid_cos}"
+    );
+    let member_vs_sibling_centroid = cosine_similarity(
+        &memories[10].embedding,
+        half_a.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        (0.90..0.92).contains(&member_vs_sibling_centroid),
+        "the ladder must split this topic at the 0.92 ceiling and no earlier rung: \
+         {member_vs_sibling_centroid}"
+    );
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.60, // the default formation threshold
+        3,    // min_size
+        20,   // max_clusters
+        16_000,
+        50, // max_unlinked_cluster_size
+        12, // max_grouped_cluster_size — the union of 20 is deliberately over it
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    assert_eq!(
+        clusters.len(),
+        1,
+        "a coherent topic the ladder cut in half must come back as one cluster, \
+         even though the rejoined 20 members exceed the grouped cap of 12: {:?}",
+        clusters
+            .iter()
+            .map(|c| c.source_ids.len())
+            .collect::<Vec<_>>()
+    );
+    let mut merged: Vec<String> = clusters[0].source_ids.clone();
+    merged.sort();
+    let mut expected: Vec<String> = memories
+        .iter()
+        .map(|memory| memory.source_id.clone())
+        .collect();
+    expected.sort();
+    assert_eq!(merged, expected, "every member must survive the rejoin");
+}
+
+#[test]
+fn sibling_merge_refuses_a_union_over_the_token_limit() {
+    // Safety control for the lifted member cap: the LLM token limit is now the
+    // only size guard on a merge, so it has to actually hold. Same geometry as
+    // the rejoin test — centroids 0.939 apart, so the merge rule qualifies —
+    // but each member carries 400 characters. Each half estimates at 1250
+    // tokens (inside the 1500 limit, so `sub_cluster_by_tokens` leaves it
+    // alone) while the union estimates at 2400, over the limit. The two halves
+    // must stay two clusters.
+    let memories = one_topic_two_ladder_halves(10, &"x".repeat(400));
+
+    let half_a = build_distillation_cluster(&memories, &(0..10).collect::<Vec<_>>());
+    let half_b = build_distillation_cluster(&memories, &(10..20).collect::<Vec<_>>());
+    let centroid_cos = cosine_similarity(
+        half_a.centroid_embedding.as_ref().unwrap(),
+        half_b.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        centroid_cos >= 0.92,
+        "fixture must qualify for the merge on similarity, so that only the token \
+         limit can stop it: {centroid_cos}"
+    );
+    assert_eq!(half_a.estimated_tokens, 1250);
+    let union = build_distillation_cluster(&memories, &(0..20).collect::<Vec<_>>());
+    assert_eq!(union.estimated_tokens, 2400);
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.60,
+        3,
+        20,
+        1_500, // token_limit: fits one half, not both
+        50,
+        12,
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    assert_eq!(
+        clusters.len(),
+        2,
+        "a merge whose union exceeds the token limit must be refused: {:?}",
+        clusters
+            .iter()
+            .map(|c| c.source_ids.len())
+            .collect::<Vec<_>>()
+    );
+    for cluster in &clusters {
+        assert_eq!(cluster.source_ids.len(), 10, "{:?}", cluster.source_ids);
+        assert!(cluster.estimated_tokens <= 1_500);
+    }
+}
+
+#[test]
+fn sibling_shards_in_different_spaces_are_not_merged() {
+    // Safety control on the bucket boundary: the merge runs per space bucket,
+    // so two near-identical clusters that live in DIFFERENT spaces must stay
+    // two clusters. Their centroids are ~1.0 apart here, so similarity alone
+    // would merge them — only the space scoping stops it.
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    for space in ["alpha", "beta"] {
+        for i in 0..5 {
+            let mut emb = vec![0.0f32; 768];
+            emb[0] = 0.999f32.sqrt();
+            emb[10 + memories.len()] = 0.001f32.sqrt();
+            memories.push(ClusterMemRow {
+                source_id: format!("{space}_m{i}"),
+                content: format!("{space} note {i}"),
+                entity_id: None,
+                entity_name: None,
+                space: Some(space.to_string()),
+                can_seed_page: true,
+                embedding: emb,
+            });
+        }
+    }
+
+    let alpha = build_distillation_cluster(&memories, &(0..5).collect::<Vec<_>>());
+    let beta = build_distillation_cluster(&memories, &(5..10).collect::<Vec<_>>());
+    let centroid_cos = cosine_similarity(
+        alpha.centroid_embedding.as_ref().unwrap(),
+        beta.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        centroid_cos >= 0.92,
+        "fixture must qualify on similarity so only the space bucket can stop the \
+         merge: {centroid_cos}"
+    );
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.60,
+        3,
+        20,
+        16_000,
+        50,
+        12,
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    assert_eq!(
+        clusters.len(),
+        2,
+        "clusters of two different spaces must never merge: {:?}",
+        clusters
+            .iter()
+            .map(|c| c.source_ids.clone())
+            .collect::<Vec<_>>()
+    );
+    let spaces: std::collections::BTreeSet<&str> = clusters
+        .iter()
+        .filter_map(|cluster| cluster.space.as_deref())
+        .collect();
+    assert_eq!(
+        spaces,
+        ["alpha", "beta"].into_iter().collect(),
+        "one cluster per space"
+    );
 }
 
 #[test]

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -21913,6 +21913,190 @@ fn a_threshold_that_cannot_advance_drops_instead_of_looping() {
 }
 
 #[test]
+fn same_topic_sibling_shards_merge_before_distill_writes_pages() {
+    // Regression test for issue #596: the re-split ladder tightens an
+    // oversized same-space cluster up to RESPLIT_MAX_THRESHOLD (0.92) and can
+    // slice one coherent topic into two near-duplicate shards. Nothing
+    // downstream ever compares siblings — the Jaccard filter scores a cluster
+    // only against *existing* pages, and the page a shard creates is born
+    // unconfirmed — so both shards became pages in the same pass.
+    // `cluster_distillation_rows` must hand back ONE cluster instead.
+    //
+    // Fixture: two 5-member shards of one topic plus 20 scattered members, all
+    // in space "wenlan". Squared member weights are shared 0.88, topic 0.05,
+    // per-member noise 0.07, which puts within-shard member cosine at 0.93 (at
+    // or above the 0.92 rung, so each shard survives it) and a cross-shard
+    // member against the other shard's centroid at 0.906 (below the rung, so
+    // the rung really does split them) — while the two mean-pooled centroids
+    // sit at 0.932, above the ceiling. The 20 scattered members make the base
+    // group oversized so the ladder fires at all, then fall out as singletons
+    // below the member floor, which leaves the merged 10 members inside the
+    // grouped cap of 12.
+    let shared = 0.88f32.sqrt();
+    let topic = 0.05f32.sqrt();
+    let noise = 0.07f32.sqrt();
+    let scattered_shared = 0.85f32.sqrt();
+    let scattered_own = 0.15f32.sqrt();
+
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    for (shard, topic_dim) in [("a", 1usize), ("b", 2usize)] {
+        for i in 0..5 {
+            let mut emb = vec![0.0f32; 768];
+            emb[0] = shared;
+            emb[topic_dim] = topic;
+            emb[10 + memories.len()] = noise;
+            memories.push(ClusterMemRow {
+                source_id: format!("{shard}_m{i}"),
+                content: format!("{shard} note {i}"),
+                entity_id: None,
+                entity_name: None,
+                space: Some("wenlan".to_string()),
+                can_seed_page: true,
+                embedding: emb,
+            });
+        }
+    }
+    for i in 0..20 {
+        let mut emb = vec![0.0f32; 768];
+        emb[0] = scattered_shared;
+        emb[100 + i] = scattered_own;
+        memories.push(ClusterMemRow {
+            source_id: format!("x_m{i}"),
+            content: format!("scattered note {i}"),
+            entity_id: None,
+            entity_name: None,
+            space: Some("wenlan".to_string()),
+            can_seed_page: true,
+            embedding: emb,
+        });
+    }
+
+    // Fixture self-checks: the shards must be separable at the 0.92 rung and
+    // still be one topic by centroid.
+    let within = cosine_similarity(&memories[0].embedding, &memories[1].embedding);
+    assert!(
+        (within - 0.93).abs() < 0.005,
+        "within-shard cosine drifted: {within}"
+    );
+    let shard_a = build_distillation_cluster(&memories, &(0..5).collect::<Vec<_>>());
+    let shard_b = build_distillation_cluster(&memories, &(5..10).collect::<Vec<_>>());
+    let centroid_cos = cosine_similarity(
+        shard_a.centroid_embedding.as_ref().unwrap(),
+        shard_b.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        (centroid_cos - 0.932).abs() < 0.005,
+        "sibling centroid cosine drifted: {centroid_cos}"
+    );
+    let member_vs_sibling_centroid = cosine_similarity(
+        &memories[5].embedding,
+        shard_a.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        member_vs_sibling_centroid < 0.92,
+        "fixture no longer splits at the ceiling: {member_vs_sibling_centroid}"
+    );
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.87, // one rung below the 0.92 ceiling
+        3,    // min_size
+        20,   // max_clusters
+        16_000,
+        50, // max_unlinked_cluster_size
+        12, // max_grouped_cluster_size
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    assert_eq!(
+        clusters.len(),
+        1,
+        "two shards of one topic must merge into one cluster before any page is written: {:?}",
+        clusters
+            .iter()
+            .map(|c| c.source_ids.clone())
+            .collect::<Vec<_>>()
+    );
+    let mut merged: Vec<String> = clusters[0].source_ids.clone();
+    merged.sort();
+    let mut expected: Vec<String> = memories
+        .iter()
+        .take(10)
+        .map(|memory| memory.source_id.clone())
+        .collect();
+    expected.sort();
+    assert_eq!(
+        merged, expected,
+        "the merged cluster must carry both shards' members"
+    );
+}
+
+#[test]
+fn unrelated_distill_clusters_are_not_merged_as_siblings() {
+    // Control for the sibling merge above: two same-space clusters whose
+    // centroids sit far below the 0.92 ceiling are two topics, and must stay
+    // two clusters. Same geometry, but the topic component carries 0.33 of the
+    // squared weight instead of 0.05, so centroid cosine is ~0.64.
+    let shared = 0.60f32.sqrt();
+    let topic = 0.33f32.sqrt();
+    let noise = 0.07f32.sqrt();
+
+    let mut memories: Vec<ClusterMemRow> = Vec::new();
+    for (cluster, topic_dim) in [("a", 1usize), ("b", 2usize)] {
+        for i in 0..5 {
+            let mut emb = vec![0.0f32; 768];
+            emb[0] = shared;
+            emb[topic_dim] = topic;
+            emb[10 + memories.len()] = noise;
+            memories.push(ClusterMemRow {
+                source_id: format!("{cluster}_m{i}"),
+                content: format!("{cluster} note {i}"),
+                entity_id: None,
+                entity_name: None,
+                space: Some("wenlan".to_string()),
+                can_seed_page: true,
+                embedding: emb,
+            });
+        }
+    }
+
+    let cluster_a = build_distillation_cluster(&memories, &(0..5).collect::<Vec<_>>());
+    let cluster_b = build_distillation_cluster(&memories, &(5..10).collect::<Vec<_>>());
+    let centroid_cos = cosine_similarity(
+        cluster_a.centroid_embedding.as_ref().unwrap(),
+        cluster_b.centroid_embedding.as_ref().unwrap(),
+    );
+    assert!(
+        (centroid_cos - 0.636).abs() < 0.005,
+        "control centroid cosine drifted: {centroid_cos}"
+    );
+
+    let clusters = cluster_distillation_rows(
+        &memories,
+        0.87,
+        3,
+        20,
+        16_000,
+        50,
+        12,
+        DistillationClusterMode::SpaceScoped,
+    );
+
+    assert_eq!(
+        clusters.len(),
+        2,
+        "unrelated same-space clusters must not be merged as siblings: {:?}",
+        clusters
+            .iter()
+            .map(|c| c.source_ids.clone())
+            .collect::<Vec<_>>()
+    );
+    for cluster in &clusters {
+        assert_eq!(cluster.source_ids.len(), 5, "{:?}", cluster.source_ids);
+    }
+}
+
+#[test]
 fn sub_cluster_by_tokens_drops_single_member_subclusters_after_split() {
     // A token-split can strand a single memory in its own sub-cluster
     // (the farthest-first orthogonal outlier). The floor re-check (spec

--- a/crates/wenlan-core/src/eval/shared.rs
+++ b/crates/wenlan-core/src/eval/shared.rs
@@ -2254,7 +2254,10 @@ pub async fn run_title_enrichment_batch_api(
 /// with a batch API approach. Same DB queries and PageWrite-backed concept
 /// storage, different LLM execution model.
 ///
-/// Two batch submissions: refinement (merge/split clusters), then synthesis.
+/// One batch submission: synthesis only. Cluster refinement is skipped here --
+/// the implementation goes straight to synthesis (see the note in the body),
+/// because refinement only bites when an entity has 2+ clusters, which is rare
+/// in a single benchmark run.
 pub async fn run_concept_distillation_batch_api(
     db: &MemoryDB,
     api_key: &str,

--- a/crates/wenlan-core/src/post_write/post_write_tests.rs
+++ b/crates/wenlan-core/src/post_write/post_write_tests.rs
@@ -5512,21 +5512,30 @@ async fn update_page_shrink_guard_skips_human_edits() {
 
 // merge_shrink_threshold parse tests
 
-#[test]
-fn merge_shrink_threshold_unset_returns_none() {
+// These three read and write the same process-global env var as the
+// `update_page_shrink_guard_*` integration tests above, but were the only
+// members of that group that never took `env_lock()`. Run in parallel they
+// raced each other (one test's `remove_var` landing between another's
+// `set_var` and its assertion), which surfaces as whichever of the three
+// happened to read at the wrong moment. They take the same lock now.
+#[tokio::test]
+async fn merge_shrink_threshold_unset_returns_none() {
+    let _lock = env_lock().await;
     std::env::remove_var("WENLAN_MERGE_SHRINK_GUARD");
     assert!(merge_shrink_threshold().is_none());
 }
 
-#[test]
-fn merge_shrink_threshold_valid_float() {
+#[tokio::test]
+async fn merge_shrink_threshold_valid_float() {
+    let _lock = env_lock().await;
     std::env::set_var("WENLAN_MERGE_SHRINK_GUARD", "0.7");
     assert_eq!(merge_shrink_threshold(), Some(0.7));
     std::env::remove_var("WENLAN_MERGE_SHRINK_GUARD");
 }
 
-#[test]
-fn merge_shrink_threshold_garbage_returns_none() {
+#[tokio::test]
+async fn merge_shrink_threshold_garbage_returns_none() {
+    let _lock = env_lock().await;
     std::env::set_var("WENLAN_MERGE_SHRINK_GUARD", "garbage");
     assert!(merge_shrink_threshold().is_none());
     std::env::remove_var("WENLAN_MERGE_SHRINK_GUARD");

--- a/crates/wenlan-core/src/prompts/defaults.rs
+++ b/crates/wenlan-core/src/prompts/defaults.rs
@@ -232,26 +232,27 @@ Change NOTHING else: do not rewrite, reorder, add, or remove any text. \
 If you are unsure a source supports a claim, leave the claim unmarked. \
 Output the complete page body with the markers inserted.";
 
+// `split` used to be offered here alongside keep/merge/rename, but no parser
+// ever implemented it — `refine_clusters_with_llm` fell through to the catch-all
+// arm, so a SPLIT answer was silently a KEEP. Offering an action the system
+// ignores only spends tokens and misleads the model, so it is gone (issue #596).
 pub(crate) const REFINE_CLUSTERS: &str = r#"You are organizing memory clusters for wiki compilation. Each cluster will become a separate concept page.
 
 Given clusters for an entity, decide for each:
 - KEEP: cluster is a coherent topic, compile as-is
 - MERGE [i,j]: clusters i and j should be one concept (same topic from different angles)
-- SPLIT [i]: cluster i covers two distinct topics — provide two sub-topic titles
 - RENAME [i]: better title for cluster i
 
 Return a JSON array of actions, one per line:
 [
   {"action": "keep", "cluster": 0},
   {"action": "merge", "clusters": [1, 3], "title": "Combined Topic"},
-  {"action": "split", "cluster": 2, "titles": ["Sub-topic A", "Sub-topic B"]},
   {"action": "rename", "cluster": 4, "title": "Better Name"}
 ]
 
 Rules:
 - Default to KEEP unless you're confident about a change
 - MERGE when two clusters are clearly the same topic from different angles
-- SPLIT when a cluster mixes unrelated topics (e.g., licensing + architecture)
 - Only return valid JSON"#;
 
 pub(crate) const COMPRESS_CONTEXT: &str = "\
@@ -290,5 +291,19 @@ mod tests {
         assert!(!UPDATE_PAGE.contains("Open Questions, Sources"));
         assert!(UPDATE_PAGE.contains("appending [N]"));
         assert!(UPDATE_PAGE.contains("HTML comment"));
+    }
+
+    #[test]
+    fn refine_clusters_does_not_offer_the_unimplemented_split_action() {
+        // Issue #596: `refine_clusters_with_llm` implements only merge and
+        // rename, so a SPLIT answer fell through to the catch-all arm and was
+        // silently a KEEP. The action must not be advertised.
+        let prompt = REFINE_CLUSTERS.to_lowercase();
+        assert!(
+            !prompt.contains("split"),
+            "REFINE_CLUSTERS still offers an action no parser implements"
+        );
+        assert!(REFINE_CLUSTERS.contains(r#""action": "merge""#));
+        assert!(REFINE_CLUSTERS.contains(r#""action": "rename""#));
     }
 }

--- a/crates/wenlan-core/src/synthesis/distill.rs
+++ b/crates/wenlan-core/src/synthesis/distill.rs
@@ -289,6 +289,14 @@ pub(crate) async fn refine_clusters_with_llm(
                                         }
                                     }
                                 }
+                                // Anything else (including the `split` action
+                                // the prompt used to offer) is a keep. `split`
+                                // was never implemented and landed here
+                                // silently, so it is no longer offered — see
+                                // the note above `REFINE_CLUSTERS` in
+                                // `prompts/defaults.rs`. An overridden prompt
+                                // can still emit it; keeping is the same
+                                // behavior it always had.
                                 _ => {}
                             }
                         }

--- a/crates/wenlan-core/src/synthesis/distill.rs
+++ b/crates/wenlan-core/src/synthesis/distill.rs
@@ -137,7 +137,7 @@ pub(crate) async fn build_page_compile_user_prompt(
     format!("{titles_hint}Topic: {capped_topic}\n\n{memories_block}")
 }
 
-/// LLM cluster refinement: for entities with multiple clusters, ask the LLM to merge/split/rename.
+/// LLM cluster refinement: for entities with multiple clusters, ask the LLM to merge/rename.
 pub(crate) async fn refine_clusters_with_llm(
     llm: &Arc<dyn LlmProvider>,
     prompts: &PromptRegistry,
@@ -157,7 +157,7 @@ pub(crate) async fn refine_clusters_with_llm(
         by_entity.entry(key).or_default().push(i);
     }
 
-    // Only refine entities with 2+ clusters (single clusters = nothing to merge/split)
+    // Only refine entities with 2+ clusters (single clusters = nothing to merge)
     let entities_to_refine: Vec<(String, Vec<usize>)> = by_entity
         .into_iter()
         .filter(|(_, indices)| indices.len() >= 2)
@@ -992,7 +992,7 @@ pub async fn distill_pages_scoped(
 }
 
 /// Same as `distill_pages_scoped`, with an explicit switch for the LLM
-/// coherence gate (merge/split/rename cluster review, spec §3.1). The compile
+/// coherence gate (merge/rename cluster review, spec §3.1). The compile
 /// router (`refinery::run_periodic_steep_with_api`) skips the gate for an
 /// on-device-only compile — the page's keep-card carries that judgment
 /// instead of an LLM review. Every other caller goes through the
@@ -1089,7 +1089,7 @@ pub(crate) async fn distill_pages_scoped_gated(
     let raw_clusters =
         cap_document_majority_clusters(db, raw_clusters, tuning.page_min_cluster_size).await?;
 
-    // LLM cluster refinement: let LLM merge/split/rename clusters per entity.
+    // LLM cluster refinement: let LLM merge/rename clusters per entity.
     // Coherence gate (spec §3.1) — skipped for an on-device-only compile.
     let clusters = if run_coherence_gate {
         refine_clusters_with_llm(llm, prompts, raw_clusters, token_limit).await


### PR DESCRIPTION
## What

Closes #596. Stepped re-splitting (PR #595) can slice one topic into several near-duplicate shards, and nothing compared sibling clusters with each other: two shards of one topic became two unconfirmed pages in one distill pass. Pending clusters of one space are now merged when their centroids meet the re-split ceiling, before any page is written. The LLM refinery prompt no longer offers the `split` action, which the parser always treated as keep.

## How

- `merge_sibling_shards` (`crates/wenlan-core/src/db.rs`) runs inside `cluster_distillation_rows` after a bucket's base groups and every re-split descendant are emitted, before the size sort and `max_clusters` truncation. Both the server route and Basic Memory mode reach it through `find_distillation_clusters_scoped`.
- Two clusters of one bucket (one space, or the no-declared-space bucket) merge when their centroid cosine is at or above `RESPLIT_MAX_THRESHOLD` (0.92) and the merged estimated tokens stay within the token limit. The scan is in emission order; the earlier cluster absorbs the later one and is rebuilt through `build_distillation_cluster`, so its centroid, tokens and entity fields match any other cluster. The cross-space `Global` slice is untouched.
- The grouped cluster caps are formation-time bounds on how coarse the greedy grouping and the re-split ladder may be, not a ceiling on a real topic's size, so the merge does not check member count: a coherent 20-memory topic under cap 12 that the ladder cut into `[10, 10]` comes back as one cluster of 20. The token limit is the page-size guard. (The first cut kept the cap as a merge guard; the review showed that left the common case unfixed.)
- `crates/wenlan-core/src/prompts/defaults.rs` drops `split` from the refine-clusters prompt; `synthesis/distill.rs` says on the catch-all arm why. The entity signal is not used: a cluster carries one `entity_id` from its first member, not the member set a shared-majority rule needs.
- Three tests in `post_write/post_write_tests.rs` that set the process-global `WENLAN_MERGE_SHRINK_GUARD` now take the file's `env_lock()` like their neighbours; they flaked in parallel runs (`docs/ci-flake-policy.md`).
- Skipped on purpose: the issue's two P3 items (typed drop reasons, `formation_threshold` range check).

## Verification

- New tests: `same_topic_sibling_shards_merge_before_distill_writes_pages`, `ladder_shards_of_one_topic_rejoin_into_one_distill_cluster` (formation 0.60, cap 12, 20-memory topic, ladder emits `[10, 10]`, one cluster returned), `sibling_merge_refuses_a_union_over_the_token_limit`, `sibling_shards_in_different_spaces_are_not_merged`, `unrelated_distill_clusters_are_not_merged_as_siblings`, `refine_clusters_does_not_offer_the_unimplemented_split_action`. The three existing cap-asserting tests use unrelated subjects (centroids well below 0.92) and assert at least two clusters before the cap loop.
- `cargo test -p wenlan-core --lib distill` 71 passed; `sibling` 5; `cluster` 36; `threshold` 23; `formation` 2; `refine_clusters` 2; `prompt` 35. `cargo check -p wenlan-server`, `cargo fmt --check`, `cargo clippy -p wenlan-core --all-targets -- -D warnings`, `git diff --check` clean.
- Mutation controls: with the merge call disabled, `same_topic_sibling_shards_merge_before_distill_writes_pages` fails with `left: 2 right: 1`; with the member-cap check restored as `if union.len() > 12 { continue; }`, `ladder_shards_of_one_topic_rejoin_into_one_distill_cluster` fails with `… must come back as one cluster … [10, 10] left: 2 right: 1`. Raising each cap in the three cap tests collapses their fixtures to one blob (`[20]`, `[60]`, `[8]`), so the cap assertions are load-bearing.
- The full wenlan-core suite is `unchecked` locally; CI is the gate. No live daemon or model load beyond the cached BGE model the cap tests already used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
