### PR TITLE
fix(server): a blocked agent storing a memory gets 403, not 500

### DIFF
--- a/crates/wenlan-server/src/indexed_files_routes.rs
+++ b/crates/wenlan-server/src/indexed_files_routes.rs
@@ -75,7 +75,7 @@ pub async fn handle_update_chunk(
     };
     db.update_memory(&id, &req.content)
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
     Ok(Json(wenlan_types::responses::SuccessResponse { ok: true }))
 }
 

--- a/crates/wenlan-server/src/memory_routes.rs
+++ b/crates/wenlan-server/src/memory_routes.rs
@@ -383,7 +383,7 @@ pub async fn handle_store_memory(
         wait_at_store_lock_test_hook(StoreLockTestStage::AgentGate).await;
         db.check_agent_for_write(&resolved_agent)
             .await
-            .map_err(|e| ServerError::Internal(e.to_string()))?
+            .map_err(ServerError::from)?
     };
     let ambient_route_mode = wenlan_core::refinery::resolve_everyday(
         everyday_pin,
@@ -1835,7 +1835,7 @@ pub async fn handle_correct_memory(
     // Update the memory with corrected content
     db.update_memory(&id, &corrected)
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
 
     Ok(Json(serde_json::json!({
         "corrected": corrected,
@@ -2966,6 +2966,84 @@ mod gated_store_tests {
             accepted.get("target_source_id").and_then(|v| v.as_str()),
             Some("mem_forge_target"),
             "accept must apply the memory correction, not the forged page write: {accepted}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod blocked_agent_store_tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower::ServiceExt;
+
+    use crate::state::ServerState;
+
+    async fn build_state_with_db() -> (Arc<RwLock<ServerState>>, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("failed to create tempdir");
+        let emitter: Arc<dyn wenlan_core::events::EventEmitter> =
+            Arc::new(wenlan_core::events::NoopEmitter);
+        let db = wenlan_core::db::MemoryDB::new(tmp.path(), emitter)
+            .await
+            .expect("MemoryDB::new should succeed");
+        let server_state = ServerState {
+            db: Some(Arc::new(db)),
+            ..Default::default()
+        };
+        (Arc::new(RwLock::new(server_state)), tmp)
+    }
+
+    /// Registers `agent` (auto-registers at "full" trust on first write) then
+    /// disables it, mirroring a human toggling it off in Settings.
+    async fn disable_agent(state: &Arc<RwLock<ServerState>>, agent: &str) {
+        let s = state.read().await;
+        let db = s.db.as_ref().unwrap();
+        db.check_agent_for_write(agent).await.unwrap();
+        db.update_agent(agent, None, None, Some(false), None, None)
+            .await
+            .unwrap();
+    }
+
+    /// #586: `check_agent_for_write` returns `WenlanError::AgentDisabled`,
+    /// which maps to `ServerError::AgentDisabled` (403). The store handler
+    /// used to force every error through `ServerError::Internal` (500),
+    /// hiding the disabled-agent refusal behind a fake daemon fault.
+    #[tokio::test]
+    async fn store_from_disabled_agent_is_forbidden_not_internal_error() {
+        let (state, _tmp) = build_state_with_db().await;
+        disable_agent(&state, "blocked-agent").await;
+        let app = crate::router::build_router(state.clone());
+
+        let body = serde_json::json!({
+            "content": "a fact from a blocked agent",
+            "source_agent": "blocked-agent",
+        });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/memory/store")
+                    .header("content-type", "application/json")
+                    .header("x-agent-name", "blocked-agent")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1_048_576)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("parse error body");
+        let message = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .expect("error body must carry a message");
+        assert!(
+            message.contains("disabled"),
+            "error message must name the disabled agent, got: {message}"
         );
     }
 }

--- a/crates/wenlan-server/src/memory_routes.rs
+++ b/crates/wenlan-server/src/memory_routes.rs
@@ -1806,14 +1806,16 @@ pub async fn handle_correct_memory(
         let llm = s.llm.clone();
         (db, llm)
     };
-    let llm =
-        llm.ok_or_else(|| ServerError::Internal("LLM not available for correction".to_string()))?;
-    // Get the existing memory content
+    // Get the existing memory content first: a missing memory is a 404
+    // regardless of whether an LLM is configured, so this must not wait on
+    // the availability check below.
     let memory = db
         .get_memory_detail(&id)
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?
-        .ok_or_else(|| ServerError::Internal(format!("memory {} not found", id)))?;
+        .map_err(ServerError::from)?
+        .ok_or_else(|| ServerError::NotFound(format!("memory {} not found", id)))?;
+    let llm =
+        llm.ok_or_else(|| ServerError::Internal("LLM not available for correction".to_string()))?;
 
     // Build a correction prompt for the LLM
     let prompt = format!(
@@ -3041,10 +3043,70 @@ mod blocked_agent_store_tests {
             .get("error")
             .and_then(|v| v.as_str())
             .expect("error body must carry a message");
-        assert!(
-            message.contains("disabled"),
+        assert_eq!(
+            message, "Agent 'blocked-agent' is disabled",
             "error message must name the disabled agent, got: {message}"
         );
+    }
+}
+
+#[cfg(test)]
+mod missing_memory_correction_tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower::ServiceExt;
+
+    use crate::state::ServerState;
+
+    async fn build_state_with_db() -> (Arc<RwLock<ServerState>>, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("failed to create tempdir");
+        let emitter: Arc<dyn wenlan_core::events::EventEmitter> =
+            Arc::new(wenlan_core::events::NoopEmitter);
+        let db = wenlan_core::db::MemoryDB::new(tmp.path(), emitter)
+            .await
+            .expect("MemoryDB::new should succeed");
+        let server_state = ServerState {
+            db: Some(Arc::new(db)),
+            ..Default::default()
+        };
+        (Arc::new(RwLock::new(server_state)), tmp)
+    }
+
+    /// The lookup that turns a missing memory into 404 must run before the
+    /// LLM-availability check, so this deliberately leaves `state.llm` unset
+    /// (its `Default`) -- if the ordering regressed back to checking the LLM
+    /// first, this would fail on the LLM-unavailable 500 instead of ever
+    /// reaching the assertion below.
+    #[tokio::test]
+    async fn correct_missing_memory_is_not_found_not_internal_error() {
+        let (state, _tmp) = build_state_with_db().await;
+        let app = crate::router::build_router(state.clone());
+
+        let body = serde_json::json!({ "correction_prompt": "fix the date" });
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/memory/does-not-exist/correct")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1_048_576)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("parse error body");
+        let message = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .expect("error body must carry a message");
+        assert_eq!(message, "memory does-not-exist not found");
     }
 }
 

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -622,7 +622,7 @@ pub async fn handle_distill(
                 }
                 db.clear_user_edited(page_id)
                     .await
-                    .map_err(|e| ServerError::Internal(e.to_string()))?;
+                    .map_err(ServerError::from)?;
                 let updated = wenlan_core::refinery::deep_distill_single(
                     &db,
                     prefer_llm,
@@ -910,7 +910,7 @@ pub async fn handle_redistill(
         // run. The skipped no-LLM path must leave user prose locked.
         db.clear_user_edited(&page_id)
             .await
-            .map_err(|e| ServerError::Internal(e.to_string()))?;
+            .map_err(ServerError::from)?;
         let updated = wenlan_core::refinery::deep_distill_single(
             &db,
             prefer_llm,

--- a/crates/wenlan-server/src/spaces_routes.rs
+++ b/crates/wenlan-server/src/spaces_routes.rs
@@ -132,7 +132,7 @@ pub async fn handle_create_space(
     let space = db
         .create_space(&req.name, req.description.as_deref(), false)
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
     Ok(Json(space))
 }
 
@@ -149,7 +149,7 @@ pub async fn handle_update_space(
     let space = db
         .update_space(&name, new_name, req.description.as_deref())
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
     Ok(Json(space))
 }
 
@@ -163,7 +163,7 @@ pub async fn handle_delete_space(
     };
     db.delete_space(&name, "keep")
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
     Ok(Json(serde_json::json!({"deleted": name})))
 }
 
@@ -273,6 +273,70 @@ pub async fn handle_set_document_space(
         registered_request_space(&db, &requested_space, "set_document_space").await?;
     db.update_memory_space_opt(&source_id, registered_space.as_deref())
         .await
-        .map_err(|e| ServerError::Internal(e.to_string()))?;
+        .map_err(ServerError::from)?;
     Ok(Json(wenlan_types::responses::SuccessResponse { ok: true }))
+}
+
+#[cfg(test)]
+mod not_found_mapping_tests {
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::state::ServerState;
+
+    async fn build_state_with_db() -> (
+        std::sync::Arc<tokio::sync::RwLock<ServerState>>,
+        tempfile::TempDir,
+    ) {
+        let tmp = tempfile::tempdir().expect("failed to create tempdir");
+        let emitter: std::sync::Arc<dyn wenlan_core::events::EventEmitter> =
+            std::sync::Arc::new(wenlan_core::events::NoopEmitter);
+        let db = wenlan_core::db::MemoryDB::new(tmp.path(), emitter)
+            .await
+            .expect("MemoryDB::new should succeed");
+        let server_state = ServerState {
+            db: Some(std::sync::Arc::new(db)),
+            ..Default::default()
+        };
+        (
+            std::sync::Arc::new(tokio::sync::RwLock::new(server_state)),
+            tmp,
+        )
+    }
+
+    /// Same #586 pattern as the blocked-agent store handler: `delete_space`
+    /// returns `WenlanError::NotFound`, which maps to `ServerError::NotFound`
+    /// (404). Forcing it through `ServerError::Internal` would hide a normal
+    /// "no such space" refusal behind a fake daemon fault (500).
+    #[tokio::test]
+    async fn delete_missing_space_is_not_found_not_internal_error() {
+        let (state, _tmp) = build_state_with_db().await;
+        let app = crate::router::build_router(state.clone());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/spaces/does-not-exist")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1_048_576)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes).expect("parse error body");
+        let message = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .expect("error body must carry a message");
+        assert!(
+            message.contains("not found"),
+            "error message must say the space was not found, got: {message}"
+        );
+    }
 }


### PR DESCRIPTION
## What

Closes #586. `POST /api/memory` from an agent whose store is blocked returned 500 (`Internal`) because the store handler wrapped `check_agent_for_write`'s `WenlanError::AgentDisabled` in `ServerError::Internal(e.to_string())`. The daemon already has `impl From<WenlanError> for ServerError` (`AgentDisabled` to 403, `Conflict` to 409, `NotFound` to 404, `Validation` to 422); that site just never used it.

## How

Every `.map_err(|e| ServerError::Internal(e.to_string()))` in `crates/wenlan-server/src/` (91 at the base) was traced to its `wenlan-core` callee, directly and through helpers it calls with `?`. Nine sites whose callee can raise one of the four mapped variants now use `.map_err(ServerError::from)`:

| Site | Callee | Code before the fix |
|---|---|---|
| `memory_routes.rs` store handler | `check_agent_for_write` | 500 instead of 403 (the issue) |
| `indexed_files_routes.rs`, `memory_routes.rs` | `db.update_memory` (via `apply_memory_update`) | 500 instead of 404 (memory gone) or 409 (concurrent edit) |
| `spaces_routes.rs` | `db.update_memory_space_opt` | same 404/409 masking |
| `spaces_routes.rs` | `create_space` | 500 instead of 422 (reserved name) |
| `spaces_routes.rs` | `update_space` | 500 instead of 404 or 422 |
| `spaces_routes.rs` | `delete_space` | 500 instead of 404 |
| `routes.rs` (two sites) | `db.clear_user_edited` (via `reject_page_draft_on_conn`) | 500 instead of 422 (page is a draft) |

The memory-correction handler (`handle_correct_memory`) also turned a missing target into a hand-written `ServerError::Internal("memory … not found")`. It now looks the memory up before the LLM-availability check and returns 404 (`{"error":"memory <id> not found"}`), with the DB error mapped through `ServerError::from`.

The other sites wrap callees that only raise `VectorDb`, `Io`, `Json` or `Embedding`, which map to 500 either way, so they are unchanged. `run_periodic_steep_with_api` is also unchanged: refinery phase errors are captured in `SteepResult.phases[].error` and the function returns `Ok`, so no `Validation` can reach its `map_err`.

Client effect: the CLI, the MCP server and the desktop app retry only connection failures, never HTTP statuses, so the new 4xx codes surface as the same immediate errors the 500s did, with the correct class. No status contract is documented anywhere in the repo.

## Verification

- `cargo fmt --check -p wenlan-server` and `cargo clippy -p wenlan-server --all-targets -- -D warnings` clean; `git diff --check` clean.
- New tests, all full-router (`build_router` + `tower::ServiceExt`): `memory_routes::blocked_agent_store_tests::store_from_disabled_agent_is_forbidden_not_internal_error` (asserts the body is exactly `Agent 'blocked-agent' is disabled`), `memory_routes::missing_memory_correction_tests::correct_missing_memory_is_not_found_not_internal_error`, `spaces_routes::not_found_mapping_tests::delete_missing_space_is_not_found_not_internal_error`.
- `cargo test -p wenlan-server --lib memory_routes -- --test-threads=1`: 41 passed; `spaces_routes`: 2 passed.
- Mutation controls: with the old `Internal` closure restored at the store handler, the 403 test fails with `left: 500, right: 403`; with the old LLM-first / `Internal`-on-`None` ordering restored in `handle_correct_memory`, the 404 test fails with `left: 500, right: 404`. Both restored and green.
- The ONNX `LoggingManager` panic seen once under the default parallel thread count did not reproduce: `cargo test -p wenlan-server --lib memory_routes` at default threads ran 3 times on this head (41 passed each) and 3 times on a detached checkout of main `81c4f073` (39 passed each), zero failures on either side, so the fixtures were left alone. The full server suite is `unchecked` locally; CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
