### PR TITLE
fix(db): roll back when COMMIT fails so the writer connection is not left in a transaction

### DIFF
--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -893,7 +893,7 @@ impl MemoryDB {
 
         match result {
             Ok(folded) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("fold commit: {e}")))?;
                 Ok(folded)
@@ -1017,7 +1017,7 @@ impl MemoryDB {
 
         match result {
             Ok(n) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("fold_entity commit: {e}")))?;
                 Ok(n)
@@ -1110,7 +1110,7 @@ impl MemoryDB {
 
         match result {
             Ok(n) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("retype commit: {e}")))?;
                 Ok(n)
@@ -1223,6 +1223,34 @@ fn take_fail_before_commit(page_id: &str) -> bool {
 #[inline(always)]
 fn take_fail_before_commit(_page_id: &str) -> bool {
     false
+}
+
+/// `COMMIT`, rolling the transaction back when the commit itself fails.
+///
+/// SQLite leaves the transaction open when `COMMIT` returns an error —
+/// `SQLITE_BUSY` raised by a checkpoint or by a reader still holding the WAL
+/// is the one seen in the field. `MemoryDB` owns ONE writer connection, so a
+/// caller that returns the commit error without rolling back leaves that
+/// connection mid-transaction: the next `BEGIN` fails with "cannot start a
+/// transaction within a transaction", and so does every write after it until
+/// something issues `ROLLBACK`. One failed commit would wedge every write in
+/// the daemon.
+///
+/// Drop-in for a bare `COMMIT` execute — same result, same error — so
+/// every call site keeps its own `map_err` label. Sites whose own
+/// commit-error arm already rolls back call `execute` directly and are left
+/// as they are.
+pub(crate) async fn commit_or_rollback(conn: &libsql::Connection) -> libsql::Result<u64> {
+    match conn.execute("COMMIT", ()).await {
+        Ok(rows) => Ok(rows),
+        Err(error) => {
+            // Best effort. If the failure did end the transaction after all,
+            // this reports "cannot rollback - no transaction is active",
+            // which is the state we wanted anyway.
+            let _ = conn.execute("ROLLBACK", ()).await;
+            Err(error)
+        }
+    }
 }
 
 /// One recorded version of a page, as stored in `page_history`.
@@ -4767,7 +4795,7 @@ impl MemoryDB {
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("set user_version=2: {}", e)))?;
 
-            conn.execute("COMMIT", ())
+            commit_or_rollback(&conn)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("migration2 commit: {}", e)))?;
 
@@ -4829,7 +4857,7 @@ impl MemoryDB {
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("set user_version=3: {}", e)))?;
 
-            conn.execute("COMMIT", ())
+            commit_or_rollback(&conn)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("migration3 commit: {}", e)))?;
 
@@ -4962,7 +4990,7 @@ impl MemoryDB {
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("set user_version=10: {}", e)))?;
 
-            conn.execute("COMMIT", ())
+            commit_or_rollback(&conn)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("migration10 commit: {}", e)))?;
 
@@ -5044,7 +5072,7 @@ impl MemoryDB {
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("set user_version=12: {}", e)))?;
 
-            conn.execute("COMMIT", ())
+            commit_or_rollback(&conn)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("migration12 commit: {}", e)))?;
 
@@ -5273,7 +5301,7 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("migration 19 update {}: {}", source_id, e)))?;
                 }
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
                 log::info!(
@@ -5335,7 +5363,7 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("migration 20 update {}: {}", source_id, e)))?;
                 }
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
                 log::info!(
@@ -5423,7 +5451,7 @@ impl MemoryDB {
             conn.execute("PRAGMA user_version = 22", ())
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("set user_version=22: {}", e)))?;
-            conn.execute("COMMIT", ())
+            commit_or_rollback(&conn)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("migration 22 commit: {}", e)))?;
 
@@ -5461,7 +5489,7 @@ impl MemoryDB {
             conn.execute("PRAGMA user_version = 23", ())
                 .await
                 .map_err(|e| WenlanError::VectorDb(e.to_string()))?;
-            conn.execute("COMMIT", ())
+            commit_or_rollback(&conn)
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("migration 23 commit: {}", e)))?;
 
@@ -5686,7 +5714,7 @@ impl MemoryDB {
                 .await
                 .ok();
 
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m24 commit: {}", e)))?;
 
@@ -5791,7 +5819,7 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = conn.execute("COMMIT", ()).await {
+                    if let Err(e) = commit_or_rollback(&conn).await {
                         log::warn!("[memory_db] m24 re-embed batch commit: {}", e);
                     }
                     drop(conn);
@@ -5888,7 +5916,7 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = conn.execute("COMMIT", ()).await {
+                    if let Err(e) = commit_or_rollback(&conn).await {
                         log::warn!("[memory_db] m24 entity re-embed commit: {}", e);
                     }
                     drop(conn);
@@ -6092,7 +6120,7 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = conn.execute("COMMIT", ()).await {
+                    if let Err(e) = commit_or_rollback(&conn).await {
                         log::warn!("[memory_db] null embed recovery commit: {}", e);
                     }
                     drop(conn);
@@ -6823,7 +6851,7 @@ impl MemoryDB {
                         }
                     }
 
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("migration 40 backfill commit: {e}"))
                     })?;
                 }
@@ -7130,7 +7158,7 @@ impl MemoryDB {
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("m43 create view: {e}")))?;
 
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m43 commit: {e}")))?;
 
@@ -7205,7 +7233,7 @@ impl MemoryDB {
                     }
                 }
 
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m44 commit: {e}")))?;
 
@@ -7238,7 +7266,7 @@ impl MemoryDB {
                 .await
                 .map_err(|e| WenlanError::VectorDb(format!("m45 update: {e}")))?;
 
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m45 commit: {e}")))?;
 
@@ -7477,7 +7505,7 @@ impl MemoryDB {
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m46 agent_activity: {e}")))?;
 
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m46 commit: {e}")))?;
 
@@ -7715,7 +7743,7 @@ impl MemoryDB {
                     .await;
                     match result {
                         Ok(()) => {
-                            conn.execute("COMMIT", ())
+                            commit_or_rollback(&conn)
                                 .await
                                 .map_err(|e| WenlanError::VectorDb(format!("m50 commit: {e}")))?;
                         }
@@ -7771,7 +7799,7 @@ impl MemoryDB {
                 .await;
                 match result {
                     Ok(()) => {
-                        conn.execute("COMMIT", ())
+                        commit_or_rollback(&conn)
                             .await
                             .map_err(|e| WenlanError::VectorDb(format!("m51 commit: {e}")))?;
                         log::info!("[migration] Migration 51 applied: document_tags table created");
@@ -7839,7 +7867,7 @@ impl MemoryDB {
                     .await;
                     match result {
                         Ok(()) => {
-                            conn.execute("COMMIT", ())
+                            commit_or_rollback(&conn)
                                 .await
                                 .map_err(|e| WenlanError::VectorDb(format!("m52 commit: {e}")))?;
                             log::info!("[migration] Migration 52 applied: event_date + event_end columns + indexes");
@@ -9652,7 +9680,7 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = conn.execute("COMMIT", ()).await {
+                    if let Err(e) = commit_or_rollback(&conn).await {
                         log::warn!("[memory_db] null entity embed recovery commit: {}", e);
                     }
                     drop(conn);
@@ -9770,7 +9798,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m80 commit setup: {e}")))?;
                 }
@@ -9841,13 +9869,13 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(Some(hi)) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m80 commit batch: {e}")))?;
                     cursor = hi;
                 }
                 Ok(None) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("m80 commit final batch: {e}"))
                     })?;
                     break;
@@ -9891,7 +9919,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m80 commit assert: {e}")))?;
                 }
@@ -10245,7 +10273,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m81 commit: {e}")))?;
             }
@@ -10384,7 +10412,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m82 commit: {e}")))?;
             }
@@ -10497,7 +10525,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m89 commit setup: {e}")))?;
                 }
@@ -10581,13 +10609,13 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(Some(hi)) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m89 commit batch: {e}")))?;
                     cursor = hi;
                 }
                 Ok(None) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("m89 commit final batch: {e}"))
                     })?;
                     break;
@@ -10620,7 +10648,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m89 commit assert: {e}")))?;
                 }
@@ -10727,7 +10755,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m90 commit: {e}")))?;
             }
@@ -10837,13 +10865,13 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(Some(hi)) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m91 commit batch: {e}")))?;
                     cursor = hi;
                 }
                 Ok(None) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("m91 commit final batch: {e}"))
                     })?;
                     break;
@@ -10878,7 +10906,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m91 commit assert: {e}")))?;
                 }
@@ -11342,7 +11370,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m92 commit setup: {e}")))?;
                 }
@@ -11535,14 +11563,14 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(Some((hi, created))) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m92 commit batch: {e}")))?;
                     cursor = hi;
                     total_created += created;
                 }
                 Ok(None) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("m92 commit final batch: {e}"))
                     })?;
                     break;
@@ -11578,7 +11606,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m92 commit assert: {e}")))?;
                 }
@@ -11747,13 +11775,13 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(Some(hi)) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m93 commit batch: {e}")))?;
                     cursor = hi;
                 }
                 Ok(None) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("m93 commit final batch: {e}"))
                     })?;
                     break;
@@ -11868,7 +11896,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m94 commit: {e}")))?;
             }
@@ -11920,7 +11948,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m97 commit: {e}")))?;
             }
@@ -12356,7 +12384,7 @@ impl MemoryDB {
         let result = Self::ensure_community_substrate_tables(&conn).await;
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|error| WenlanError::VectorDb(format!("m95 commit: {error}")))?;
             }
@@ -14074,7 +14102,7 @@ impl MemoryDB {
 
         let (backfilled, healed, orphans_retracted, generation_updates) = match result {
             Ok(value) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m111 commit: {e}")))?;
                 value
@@ -14255,7 +14283,7 @@ impl MemoryDB {
 
         let (classified, defaulted) = match result {
             Ok(value) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m112 commit: {e}")))?;
                 value
@@ -14396,7 +14424,7 @@ impl MemoryDB {
 
         let repaired = match result {
             Ok(value) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m113 commit: {e}")))?;
                 value
@@ -14489,7 +14517,7 @@ impl MemoryDB {
 
         let resynced = match result {
             Ok(value) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m114 commit: {e}")))?;
                 value
@@ -14882,7 +14910,7 @@ impl MemoryDB {
 
         let (relates_updated, cites_updated, links_updated) = match result {
             Ok(counts) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m115 commit: {e}")))?;
                 counts
@@ -14982,7 +15010,7 @@ impl MemoryDB {
 
         let updated = match result {
             Ok(count) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m116 commit: {e}")))?;
                 count
@@ -15095,7 +15123,7 @@ impl MemoryDB {
 
         let updated = match result {
             Ok(count) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m117 commit: {e}")))?;
                 count
@@ -15236,13 +15264,13 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(Some(hi)) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m118 commit batch: {e}")))?;
                     cursor = hi;
                 }
                 Ok(None) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("m118 commit final batch: {e}"))
                     })?;
                     break;
@@ -15278,7 +15306,7 @@ impl MemoryDB {
             .await;
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("m118 commit assert: {e}")))?;
                 }
@@ -15452,7 +15480,7 @@ impl MemoryDB {
 
         let reactivated = match result {
             Ok(count) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m119 commit: {e}")))?;
                 count
@@ -15508,7 +15536,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m120 commit: {e}")))?;
             }
@@ -15667,7 +15695,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m121 commit: {e}")))?;
             }
@@ -16364,7 +16392,7 @@ impl MemoryDB {
 
         let (retired, requeued, downgraded, generation_updates) = match result {
             Ok(value) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m124 commit: {e}")))?;
                 value
@@ -16441,7 +16469,7 @@ impl MemoryDB {
 
         let deleted = match result {
             Ok(value) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m125 commit: {e}")))?;
                 value
@@ -16513,8 +16541,7 @@ impl MemoryDB {
             .map_err(|error| WenlanError::VectorDb(format!("M4 startup repair begin: {error}")))?;
         let result = Self::ensure_community_substrate_tables(&conn).await;
         match result {
-            Ok(()) => conn
-                .execute("COMMIT", ())
+            Ok(()) => commit_or_rollback(&conn)
                 .await
                 .map_err(|error| {
                     WenlanError::VectorDb(format!("M4 startup repair commit: {error}"))
@@ -18340,7 +18367,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok((flipped, generation_updates)) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("promote_edges_grounded commit: {e}"))
                 })?;
                 self.record_community_dirty_nodes(generation_updates);
@@ -19897,7 +19924,7 @@ impl MemoryDB {
         .await;
         let (input_generation, candidates, space_snapshots) = match snapshot_result {
             Ok(snapshot) => {
-                snapshot_conn.execute("COMMIT", ()).await.map_err(|error| {
+                commit_or_rollback(&snapshot_conn).await.map_err(|error| {
                     WenlanError::VectorDb(format!("community parity snapshot commit: {error}"))
                 })?;
                 snapshot
@@ -24047,7 +24074,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("reorder commit: {}", e)))?;
                 Ok(())
@@ -24188,7 +24215,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("set_document_tags commit: {e}")))?;
             }
@@ -29767,7 +29794,7 @@ impl MemoryDB {
 
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("insert_summary_node srcs commit: {e}"))
                     })?;
                 }
@@ -32771,7 +32798,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("rebuild_child commit: {e}")))?;
                 Ok(())
@@ -33562,7 +33589,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("create_entity commit: {}", e)))?;
             }
@@ -33640,7 +33667,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("store_entity commit: {}", e)))?;
             }
@@ -33801,7 +33828,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("store_minhash commit: {e}")))?;
                 Ok(())
@@ -34392,7 +34419,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("refresh_entity_embedding commit: {}", e))
                 })?;
                 Ok(())
@@ -34487,7 +34514,7 @@ impl MemoryDB {
 
         let inserted = match result {
             Ok(inserted) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("add_observation commit: {}", e)))?;
                 inserted
@@ -35378,7 +35405,7 @@ impl MemoryDB {
 
         match result {
             Ok((generation_updates, observations_moved, aliases_added)) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("merge_entities commit: {e}")))?;
                 self.record_community_dirty_nodes(generation_updates);
@@ -35498,7 +35525,7 @@ impl MemoryDB {
 
         match exec {
             Ok((snapshot, generation_updates)) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("supersede_relation commit: {e}"))
                 })?;
                 self.record_community_dirty_nodes(generation_updates);
@@ -35817,7 +35844,7 @@ impl MemoryDB {
 
         match exec {
             Ok((edge_id, existed_before, generation_updates)) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("create_relation commit: {e}")))?;
                 self.record_community_dirty_nodes(generation_updates);
@@ -36199,7 +36226,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok(archived) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("archive_entity commit: {e}")))?;
                 Ok(archived)
@@ -36333,7 +36360,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok(restored) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("restore_entity commit: {e}")))?;
                 Ok(restored)
@@ -36676,7 +36703,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("link_memory_entities COMMIT: {e}"))
                 })?;
                 Ok(())
@@ -37704,7 +37731,7 @@ impl MemoryDB {
 
         match result {
             Ok(true) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("entity enrichment commit: {e}")))?;
                 self.record_community_dirty_nodes(generation_updates);
@@ -37856,7 +37883,7 @@ impl MemoryDB {
 
         match result {
             Ok(true) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("entity link commit: {e}")))?;
                 Ok(true)
@@ -38424,7 +38451,7 @@ impl MemoryDB {
 
         match result {
             Ok(true) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("versioned enrichment receipt commit: {e}"))
                 })?;
                 Ok(true)
@@ -38712,7 +38739,7 @@ impl MemoryDB {
     ) -> Result<(), WenlanError> {
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("confirm_entity commit: {}", e)))?;
                 Ok(())
@@ -41107,7 +41134,7 @@ impl MemoryDB {
             return Err(error);
         }
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("accept_pending_revision commit: {}", e)))?;
 
@@ -41863,7 +41890,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("mark_packaged commit: {}", e)))?;
                 Ok(())
@@ -43982,7 +44009,7 @@ impl MemoryDB {
 
         match result {
             Ok(updated) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("set_event_dates commit: {e}")))?;
                 Ok(updated)
@@ -44187,7 +44214,7 @@ impl MemoryDB {
             .await;
             match res {
                 Ok(n) => {
-                    conn.execute("COMMIT", ()).await.map_err(|e| {
+                    commit_or_rollback(&conn).await.map_err(|e| {
                         WenlanError::VectorDb(format!("backfill_episodes commit: {e}"))
                     })?;
                     written += n;
@@ -44689,7 +44716,7 @@ impl MemoryDB {
         .await;
         match result {
             Ok(true) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("title commit: {e}")))?;
                 Ok(true)
@@ -45074,7 +45101,7 @@ impl MemoryDB {
 
         match result {
             Ok(true) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("classification commit commit: {e}"))
                 })?;
                 Ok(true)
@@ -45198,7 +45225,7 @@ impl MemoryDB {
 
         match result {
             Ok(true) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("structured extraction commit commit: {e}"))
                 })?;
                 Ok(true)
@@ -45567,7 +45594,7 @@ impl MemoryDB {
 
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("decay commit: {}", e)))?;
                 }
@@ -45613,7 +45640,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("flush_access commit: {}", e)))?;
                 Ok(())
@@ -45655,7 +45682,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("log_accesses commit: {}", e)))?;
                 Ok(())
@@ -47148,7 +47175,7 @@ impl MemoryDB {
 
             match result {
                 Ok(()) => {
-                    conn.execute("COMMIT", ())
+                    commit_or_rollback(&conn)
                         .await
                         .map_err(|e| WenlanError::VectorDb(format!("evict commit: {e}")))?;
                 }
@@ -47708,7 +47735,7 @@ impl MemoryDB {
             return Err(WenlanError::VectorDb(format!("insert_page history: {e}")));
         }
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("insert_page commit: {e}")))?;
         drop(conn);
@@ -49320,7 +49347,7 @@ impl MemoryDB {
             ));
         }
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("update_page_content commit: {e}")))?;
         drop(conn);
@@ -50030,7 +50057,7 @@ impl MemoryDB {
 
         match result {
             Ok(()) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("accept_page_merge commit: {e}")))?;
             }
@@ -50649,7 +50676,7 @@ impl MemoryDB {
         .await;
         match exec {
             Ok(()) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("replace_page_links commit: {e}"))
                 })?;
                 Ok(())
@@ -50709,6 +50736,58 @@ impl MemoryDB {
 /// the last examined one; deleted once a sweep reaches the tail, so the next
 /// sweep starts fresh from the head.
 const ORPHAN_SWEEP_CURSOR_KEY: &str = "orphan_sweep_cursor";
+
+// Test-only fault injection: fail the orphan sweep's `COMMIT` with the
+// transaction still open, the state SQLite leaves behind when a commit hits
+// `SQLITE_BUSY`. Task-scoped, like the repair verifier's control, so a sweep
+// running in a parallel test cannot consume another test's armed fault.
+#[cfg(test)]
+tokio::task_local! {
+    static FAIL_ORPHAN_SWEEP_COMMIT: std::cell::Cell<bool>;
+}
+
+/// Run `future` with the next orphan sweep's `COMMIT` armed to fail.
+#[cfg(test)]
+pub(crate) async fn with_failing_orphan_sweep_commit<T>(
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    FAIL_ORPHAN_SWEEP_COMMIT
+        .scope(std::cell::Cell::new(true), future)
+        .await
+}
+
+/// Stage a deferred foreign-key violation inside the caller's open
+/// transaction when the fault is armed, so the `COMMIT` that follows fails
+/// while the transaction stays open on the connection.
+///
+/// Contention cannot produce that state here: a second connection holding the
+/// write lock fails the sweep at its first write, long before `COMMIT` (see
+/// `a_review_meeting_a_foreign_writer_marks_nothing` in the presence-review
+/// tests). A deferred constraint is only checked at commit time, so it fails
+/// the `COMMIT` statement itself and leaves the transaction active — the same
+/// end state as a busy commit, without the timing.
+#[cfg(test)]
+async fn arm_orphan_sweep_commit_failure(conn: &libsql::Connection) {
+    let armed = FAIL_ORPHAN_SWEEP_COMMIT
+        .try_with(|flag| flag.replace(false))
+        .unwrap_or(false);
+    if !armed {
+        return;
+    }
+    for sql in [
+        "CREATE TABLE commit_fault_parent (id INTEGER PRIMARY KEY)",
+        "CREATE TABLE commit_fault_child (
+             id INTEGER PRIMARY KEY,
+             parent_id INTEGER NOT NULL
+                 REFERENCES commit_fault_parent(id) DEFERRABLE INITIALLY DEFERRED
+         )",
+        "INSERT INTO commit_fault_child (id, parent_id) VALUES (1, 404)",
+    ] {
+        conn.execute(sql, ())
+            .await
+            .expect("stage the deferred foreign-key violation");
+    }
+}
 
 impl MemoryDB {
     /// Per-invocation cap on the orphan sweep: bounds how long the sweep can
@@ -51033,9 +51112,11 @@ impl MemoryDB {
             Ok(resolved_labels.len())
         }
         .await;
+        #[cfg(test)]
+        arm_orphan_sweep_commit_failure(&conn).await;
         match result {
             Ok(resolved) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("resolve_orphan_links commit: {e}"))
                 })?;
                 Ok(resolved)
@@ -51610,8 +51691,7 @@ impl MemoryDB {
         }
         .await;
         match result {
-            Ok(()) => conn
-                .execute("COMMIT", ())
+            Ok(()) => commit_or_rollback(&conn)
                 .await
                 .map(|_| ())
                 .map_err(|e| WenlanError::VectorDb(format!("link_page_source commit: {e}"))),
@@ -51812,8 +51892,7 @@ impl MemoryDB {
         .await;
 
         match result {
-            Ok(()) => conn
-                .execute("COMMIT", ())
+            Ok(()) => commit_or_rollback(&conn)
                 .await
                 .map(|_| ())
                 .map_err(|e| WenlanError::VectorDb(format!("replace_page_sources commit: {e}"))),
@@ -52035,7 +52114,7 @@ impl MemoryDB {
         .await;
         match exec {
             Ok(()) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("set_page_citations commit: {e}"))
                 })?;
                 Ok(())
@@ -52077,7 +52156,7 @@ impl MemoryDB {
         .await;
         match exec {
             Ok(()) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("set_page_citations_with_changelog commit: {e}"))
                 })?;
                 Ok(())
@@ -52127,7 +52206,7 @@ impl MemoryDB {
         .await;
         match exec {
             Ok(affected) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!(
                         "set_page_citations_with_changelog_at_version commit: {e}"
                     ))
@@ -52287,7 +52366,7 @@ impl MemoryDB {
 
         match exec {
             Ok(()) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("link_page_evidence commit: {e}"))
                 })?;
                 Ok(())
@@ -52330,7 +52409,7 @@ impl MemoryDB {
         }
         .await;
         match res {
-            Ok(()) => conn.execute("COMMIT", ()).await.map_err(|e| {
+            Ok(()) => commit_or_rollback(&conn).await.map_err(|e| {
                 WenlanError::VectorDb(format!("stamp_last_distilled_at commit: {e}"))
             })?,
             Err(e) => {
@@ -53174,7 +53253,7 @@ impl MemoryDB {
                 return Err(error);
             }
         };
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("acknowledge_page_compile commit: {e}")))?;
         Ok(acknowledged)
@@ -54503,7 +54582,7 @@ impl MemoryDB {
                 "store raw import origin: {e}"
             )));
         }
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("store raw import commit: {e}")))?;
         Ok(memory_id)
@@ -54574,7 +54653,7 @@ impl MemoryDB {
             count += 1;
         }
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("batch import commit: {e}")))?;
         Ok(count)
@@ -54945,7 +55024,7 @@ impl MemoryDB {
 
                 match result {
                     Ok(()) => {
-                        conn.execute("COMMIT", ())
+                        commit_or_rollback(&conn)
                             .await
                             .map_err(|e| WenlanError::VectorDb(format!("m55a commit: {e}")))?;
                     }
@@ -55077,7 +55156,7 @@ impl MemoryDB {
 
         let inserted = match result {
             Ok(inserted) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("m55b commit: {e}")))?;
                 inserted

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1240,7 +1240,9 @@ fn take_fail_before_commit(_page_id: &str) -> bool {
 /// every call site keeps its own `map_err` label. Sites whose own
 /// commit-error arm already rolls back call `execute` directly and are left
 /// as they are.
-pub(crate) async fn commit_or_rollback(conn: &libsql::Connection) -> libsql::Result<u64> {
+/// Private on purpose: the R4 drift guard forbids crate-visible `db.rs` functions that
+/// take a raw `libsql::Connection`; the `db/*` child modules reach it through `super::`.
+async fn commit_or_rollback(conn: &libsql::Connection) -> libsql::Result<u64> {
     match conn.execute("COMMIT", ()).await {
         Ok(rows) => Ok(rows),
         Err(error) => {

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1244,12 +1244,85 @@ pub(crate) async fn commit_or_rollback(conn: &libsql::Connection) -> libsql::Res
     match conn.execute("COMMIT", ()).await {
         Ok(rows) => Ok(rows),
         Err(error) => {
-            // Best effort. If the failure did end the transaction after all,
-            // this reports "cannot rollback - no transaction is active",
-            // which is the state we wanted anyway.
-            let _ = conn.execute("ROLLBACK", ()).await;
+            // A rollback error is usually "cannot rollback - no transaction is
+            // active", meaning the failed commit had already ended the
+            // transaction — the state we wanted, so nothing to report. Only a
+            // rollback that leaves the connection still inside a transaction
+            // is a real recovery failure, and that one is silent otherwise:
+            // the caller sees the commit error either way.
+            let rollback = conn.execute("ROLLBACK", ()).await;
+            if let Err(rollback_error) = rollback {
+                if !conn.is_autocommit() {
+                    log::error!(
+                        "[tx-watchdog] COMMIT failed ({error}) and the recovery ROLLBACK \
+                         failed too ({rollback_error}); the writer connection is still \
+                         inside a transaction and every later write will fail with \
+                         \"cannot start a transaction within a transaction\""
+                    );
+                }
+            }
             Err(error)
         }
+    }
+}
+
+// Test-only fault injection: fail one named site's `COMMIT` with the
+// transaction still open, the state SQLite leaves behind when a commit hits
+// `SQLITE_BUSY`. Task-scoped, like the repair verifier's control, so the same
+// code running in a parallel test cannot consume another test's armed fault.
+// Keyed by site so one mechanism serves every caller that needs it.
+#[cfg(test)]
+tokio::task_local! {
+    static FAIL_COMMIT_AT: std::cell::Cell<Option<&'static str>>;
+}
+
+/// Run `future` with the next `COMMIT` at `site` armed to fail.
+#[cfg(test)]
+pub(crate) async fn with_failing_commit_at<T>(
+    site: &'static str,
+    future: impl std::future::Future<Output = T>,
+) -> T {
+    FAIL_COMMIT_AT
+        .scope(std::cell::Cell::new(Some(site)), future)
+        .await
+}
+
+/// Stage a deferred foreign-key violation inside the caller's open
+/// transaction when `site` is the armed one, so the `COMMIT` that follows
+/// fails while the transaction stays open on the connection.
+///
+/// Contention cannot produce that state here: a second connection holding the
+/// write lock fails the caller at its first write, long before `COMMIT` (see
+/// `a_review_meeting_a_foreign_writer_marks_nothing` in the presence-review
+/// tests). A deferred constraint is only checked at commit time, so it fails
+/// the `COMMIT` statement itself and leaves the transaction active — the same
+/// end state as a busy commit, without the timing.
+#[cfg(test)]
+async fn arm_commit_failure(conn: &libsql::Connection, site: &'static str) {
+    let armed = FAIL_COMMIT_AT
+        .try_with(|armed| {
+            if armed.get() == Some(site) {
+                armed.set(None);
+                return true;
+            }
+            false
+        })
+        .unwrap_or(false);
+    if !armed {
+        return;
+    }
+    for sql in [
+        "CREATE TABLE commit_fault_parent (id INTEGER PRIMARY KEY)",
+        "CREATE TABLE commit_fault_child (
+             id INTEGER PRIMARY KEY,
+             parent_id INTEGER NOT NULL
+                 REFERENCES commit_fault_parent(id) DEFERRABLE INITIALLY DEFERRED
+         )",
+        "INSERT INTO commit_fault_child (id, parent_id) VALUES (1, 404)",
+    ] {
+        conn.execute(sql, ())
+            .await
+            .expect("stage the deferred foreign-key violation");
     }
 }
 
@@ -5819,9 +5892,15 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = commit_or_rollback(&conn).await {
-                        log::warn!("[memory_db] m24 re-embed batch commit: {}", e);
-                    }
+                    // Propagated, not logged: the batch is chosen by
+                    // `embedding IS NULL`, so a rolled-back commit leaves the
+                    // same rows selected next time round. Swallowing the error
+                    // re-selects them forever while `embedded` climbs past
+                    // `total_memories` and the migrations behind this one
+                    // never run.
+                    commit_or_rollback(&conn).await.map_err(|e| {
+                        WenlanError::VectorDb(format!("m24 re-embed batch commit: {e}"))
+                    })?;
                     drop(conn);
 
                     embedded += batch.len();
@@ -5916,9 +5995,10 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = commit_or_rollback(&conn).await {
-                        log::warn!("[memory_db] m24 entity re-embed commit: {}", e);
-                    }
+                    // Same unbounded-loop reason as the memories batch above.
+                    commit_or_rollback(&conn).await.map_err(|e| {
+                        WenlanError::VectorDb(format!("m24 entity re-embed commit: {e}"))
+                    })?;
                     drop(conn);
 
                     entity_embedded += batch.len();
@@ -6120,9 +6200,12 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = commit_or_rollback(&conn).await {
-                        log::warn!("[memory_db] null embed recovery commit: {}", e);
-                    }
+                    #[cfg(test)]
+                    arm_commit_failure(&conn, "null_embed_recovery").await;
+                    // Same unbounded-loop reason as migration 24's batches.
+                    commit_or_rollback(&conn).await.map_err(|e| {
+                        WenlanError::VectorDb(format!("null embed recovery commit: {e}"))
+                    })?;
                     drop(conn);
 
                     recovered += batch.len();
@@ -9680,9 +9763,10 @@ impl MemoryDB {
                             }
                         }
                     }
-                    if let Err(e) = commit_or_rollback(&conn).await {
-                        log::warn!("[memory_db] null entity embed recovery commit: {}", e);
-                    }
+                    // Same unbounded-loop reason as migration 24's batches.
+                    commit_or_rollback(&conn).await.map_err(|e| {
+                        WenlanError::VectorDb(format!("null entity embed recovery commit: {e}"))
+                    })?;
                     drop(conn);
 
                     recovered += batch.len();
@@ -50737,58 +50821,6 @@ impl MemoryDB {
 /// sweep starts fresh from the head.
 const ORPHAN_SWEEP_CURSOR_KEY: &str = "orphan_sweep_cursor";
 
-// Test-only fault injection: fail the orphan sweep's `COMMIT` with the
-// transaction still open, the state SQLite leaves behind when a commit hits
-// `SQLITE_BUSY`. Task-scoped, like the repair verifier's control, so a sweep
-// running in a parallel test cannot consume another test's armed fault.
-#[cfg(test)]
-tokio::task_local! {
-    static FAIL_ORPHAN_SWEEP_COMMIT: std::cell::Cell<bool>;
-}
-
-/// Run `future` with the next orphan sweep's `COMMIT` armed to fail.
-#[cfg(test)]
-pub(crate) async fn with_failing_orphan_sweep_commit<T>(
-    future: impl std::future::Future<Output = T>,
-) -> T {
-    FAIL_ORPHAN_SWEEP_COMMIT
-        .scope(std::cell::Cell::new(true), future)
-        .await
-}
-
-/// Stage a deferred foreign-key violation inside the caller's open
-/// transaction when the fault is armed, so the `COMMIT` that follows fails
-/// while the transaction stays open on the connection.
-///
-/// Contention cannot produce that state here: a second connection holding the
-/// write lock fails the sweep at its first write, long before `COMMIT` (see
-/// `a_review_meeting_a_foreign_writer_marks_nothing` in the presence-review
-/// tests). A deferred constraint is only checked at commit time, so it fails
-/// the `COMMIT` statement itself and leaves the transaction active — the same
-/// end state as a busy commit, without the timing.
-#[cfg(test)]
-async fn arm_orphan_sweep_commit_failure(conn: &libsql::Connection) {
-    let armed = FAIL_ORPHAN_SWEEP_COMMIT
-        .try_with(|flag| flag.replace(false))
-        .unwrap_or(false);
-    if !armed {
-        return;
-    }
-    for sql in [
-        "CREATE TABLE commit_fault_parent (id INTEGER PRIMARY KEY)",
-        "CREATE TABLE commit_fault_child (
-             id INTEGER PRIMARY KEY,
-             parent_id INTEGER NOT NULL
-                 REFERENCES commit_fault_parent(id) DEFERRABLE INITIALLY DEFERRED
-         )",
-        "INSERT INTO commit_fault_child (id, parent_id) VALUES (1, 404)",
-    ] {
-        conn.execute(sql, ())
-            .await
-            .expect("stage the deferred foreign-key violation");
-    }
-}
-
 impl MemoryDB {
     /// Per-invocation cap on the orphan sweep: bounds how long the sweep can
     /// hold the sole connection mutex. The sweep re-runs after every publish,
@@ -51113,7 +51145,7 @@ impl MemoryDB {
         }
         .await;
         #[cfg(test)]
-        arm_orphan_sweep_commit_failure(&conn).await;
+        arm_commit_failure(&conn, "orphan_sweep").await;
         match result {
             Ok(resolved) => {
                 commit_or_rollback(&conn).await.map_err(|e| {

--- a/crates/wenlan-core/src/db/derived_artifact_sweep.rs
+++ b/crates/wenlan-core/src/db/derived_artifact_sweep.rs
@@ -1,4 +1,4 @@
-use super::MemoryDB;
+use super::{commit_or_rollback, MemoryDB};
 use crate::derived_artifact_state::summary_eligible_predicate;
 use crate::error::WenlanError;
 
@@ -155,8 +155,7 @@ impl MemoryDB {
         }
         .await;
         match result {
-            Ok(()) => conn
-                .execute("COMMIT", ())
+            Ok(()) => commit_or_rollback(&conn)
                 .await
                 .map(|_| ())
                 .map_err(|error| WenlanError::VectorDb(format!("derived sweep commit: {error}"))),

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -52846,6 +52846,85 @@ async fn a_poisoned_orphan_does_not_block_the_other_repairs() {
     assert_eq!(db.resolve_orphan_page_links().await.unwrap(), 0);
 }
 
+/// A failed `COMMIT` must not leave the sweep's transaction open.
+///
+/// SQLite keeps the transaction active when `COMMIT` itself fails --
+/// `SQLITE_BUSY` from a checkpoint or a reader still holding the WAL is the
+/// shape seen in the field. `MemoryDB` owns ONE writer connection, so a sweep
+/// that returns the commit error without rolling back leaves that connection
+/// mid-transaction: the next `BEGIN` fails with "cannot start a transaction
+/// within a transaction", and so does every write after it until something
+/// rolls back. One failed sweep commit wedges the whole daemon.
+///
+/// The busy commit is not reproducible by contention here. A second
+/// connection holding the write lock fails the sweep at its first write, long
+/// before `COMMIT` (`a_review_meeting_a_foreign_writer_marks_nothing` in the
+/// presence-review tests documents that window). So the fault is staged
+/// instead: a deferred foreign-key violation inside the sweep's own
+/// transaction is checked only at commit time, which fails the `COMMIT`
+/// statement and leaves the transaction active -- the same end state,
+/// deterministically.
+#[tokio::test]
+async fn a_failed_orphan_sweep_commit_does_not_wedge_the_writer_connection() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_commit_src",
+        "Commit Src",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    db.replace_page_links(
+        "page_commit_src",
+        &[crate::synthesis::wikilinks::Wikilink {
+            label: "Commit Target".to_string(),
+            target_page_id: None,
+        }],
+    )
+    .await
+    .unwrap();
+    db.insert_page(
+        "page_commit_target",
+        "Commit Target",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+
+    let error = crate::db::with_failing_orphan_sweep_commit(db.resolve_orphan_page_links())
+        .await
+        .expect_err("the staged commit failure must reach the caller");
+    assert!(
+        error.to_string().contains("resolve_orphan_links commit"),
+        "the sweep must surface its own commit label, got: {error}"
+    );
+
+    // The wedge itself: the next `BEGIN`-using write on the same connection.
+    db.insert_page(
+        "page_after_failed_commit",
+        "After Failed Commit",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .expect("a failed sweep commit must not wedge later writes");
+}
+
 /// A full batch of unresolvable orphans in front of the ordered backlog must
 /// not starve the resolvable rows behind it forever: the rotating keyset
 /// cursor advances past every examined row -- resolved or not -- so the next

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -52902,7 +52902,7 @@ async fn a_failed_orphan_sweep_commit_does_not_wedge_the_writer_connection() {
     .await
     .unwrap();
 
-    let error = crate::db::with_failing_orphan_sweep_commit(db.resolve_orphan_page_links())
+    let error = crate::db::with_failing_commit_at("orphan_sweep", db.resolve_orphan_page_links())
         .await
         .expect_err("the staged commit failure must reach the caller");
     assert!(
@@ -52923,6 +52923,67 @@ async fn a_failed_orphan_sweep_commit_does_not_wedge_the_writer_connection() {
     )
     .await
     .expect("a failed sweep commit must not wedge later writes");
+}
+
+/// A failed commit inside the NULL-embedding recovery loop must abort the
+/// migration, not be logged and walked past.
+///
+/// That loop selects its batch with `WHERE embedding IS NULL` and bumps a
+/// progress counter after each batch. `commit_or_rollback` rolls a failed
+/// commit back, so the rows it just embedded go back to NULL and the very
+/// next iteration selects the same batch again. Swallowing the error means
+/// the loop never ends, `recovered` climbs past the declared total, and every
+/// migration behind this one is never reached -- a worse failure than the
+/// stuck transaction the rollback was added to prevent.
+///
+/// The recovery pass is unconditional on startup, so a memory row with no
+/// embedding plus a second `run_migrations` is the whole fixture. The staged
+/// fault is one-shot, so before the fix this test does not hang: the loop
+/// swallows the error, re-embeds the same row, commits, and `run_migrations`
+/// returns `Ok` -- which is exactly what the assertion below catches.
+#[tokio::test]
+async fn a_failed_recovery_commit_aborts_the_migration_instead_of_looping() {
+    let (db, _dir) = test_db().await;
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO memories
+                (id, content, source, source_id, title, chunk_index,
+                 last_modified, chunk_type, space)
+             VALUES ('mem_null_embedding', 'a memory whose embedding never landed',
+                     'memory', 'mem_null_embedding', 'Null Embedding',
+                     0, 1, 'text', ?1)",
+            libsql::params![UNFILED_SPACE_ID],
+        )
+        .await
+        .unwrap();
+    }
+
+    let error = crate::db::with_failing_commit_at(
+        "null_embed_recovery",
+        db.run_migrations(&crate::events::NoopEmitter),
+    )
+    .await
+    .expect_err("the staged commit failure must abort the migration");
+    assert!(
+        error.to_string().contains("null embed recovery commit"),
+        "the recovery loop must surface its own commit label, got: {error}"
+    );
+
+    // And the connection it ran on is still usable, same as the sweep.
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_after_failed_recovery",
+        "After Failed Recovery",
+        None,
+        "content",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .expect("a failed recovery commit must not wedge later writes");
 }
 
 /// A full batch of unresolvable orphans in front of the ordered backlog must

--- a/crates/wenlan-core/src/db/migrations_v004_v009.rs
+++ b/crates/wenlan-core/src/db/migrations_v004_v009.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-use super::{MemoryDB, WenlanError};
+use super::{commit_or_rollback, MemoryDB, WenlanError};
 
 impl MemoryDB {
     // Migration 4: Refinement pipeline columns + queue table
@@ -73,7 +73,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("set user_version=4: {}", e)))?;
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("migration4 commit: {}", e)))?;
 
@@ -150,7 +150,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("set user_version=5: {}", e)))?;
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("migration5 commit: {}", e)))?;
 
@@ -203,7 +203,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("set user_version=6: {}", e)))?;
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("migration6 commit: {}", e)))?;
 
@@ -234,7 +234,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("set user_version=7: {}", e)))?;
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("migration7 commit: {}", e)))?;
 
@@ -265,7 +265,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("set user_version=8: {}", e)))?;
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("migration8 commit: {}", e)))?;
 
@@ -313,7 +313,7 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("set user_version=9: {}", e)))?;
 
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("migration9 commit: {}", e)))?;
 

--- a/crates/wenlan-core/src/db/page_map.rs
+++ b/crates/wenlan-core/src/db/page_map.rs
@@ -12,7 +12,7 @@
 // `PageMapEdge` / the create outcomes as real cross-crate types, not just
 // methods on `MemoryDB`.
 
-use super::MemoryDB;
+use super::{commit_or_rollback, MemoryDB};
 use crate::WenlanError;
 
 /// A `page_maps` row.
@@ -768,7 +768,7 @@ impl MemoryDB {
                 return Err(e);
             }
         };
-        conn.execute("COMMIT", ())
+        commit_or_rollback(&conn)
             .await
             .map_err(|e| WenlanError::VectorDb(format!("init_page_map commit: {e}")))?;
 
@@ -875,7 +875,7 @@ impl MemoryDB {
 
         match result {
             Ok(outcome) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("create_map_node commit: {e}")))?;
                 Ok(outcome)
@@ -991,7 +991,7 @@ impl MemoryDB {
 
         match result {
             Ok(outcome) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("create_suggested_map_node commit: {e}"))
                 })?;
                 Ok(outcome)
@@ -1151,7 +1151,7 @@ impl MemoryDB {
 
         match result {
             Ok(node) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("patch_map_node commit: {e}")))?;
                 Ok(node)
@@ -1274,7 +1274,7 @@ impl MemoryDB {
 
         match result {
             Ok(outcome) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("create_map_edge commit: {e}")))?;
                 Ok(outcome)
@@ -1394,7 +1394,7 @@ impl MemoryDB {
 
         match result {
             Ok(outcome) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("create_suggested_map_edge commit: {e}"))
                 })?;
                 Ok(outcome)
@@ -1473,7 +1473,7 @@ impl MemoryDB {
 
         match result {
             Ok(edge) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("patch_map_edge commit: {e}")))?;
                 Ok(edge)
@@ -1569,7 +1569,7 @@ impl MemoryDB {
 
         match result {
             Ok(data) => {
-                conn.execute("COMMIT", ()).await.map_err(|e| {
+                commit_or_rollback(&conn).await.map_err(|e| {
                     WenlanError::VectorDb(format!("put_page_map_layout commit: {e}"))
                 })?;
                 Ok(data)

--- a/crates/wenlan-core/src/db/presence_review.rs
+++ b/crates/wenlan-core/src/db/presence_review.rs
@@ -7,7 +7,7 @@
 //! presence-carrying mutation later, and the wrong order is not a crash — it is
 //! a retry that reports failure over a write that succeeded.
 
-use super::MemoryDB;
+use super::{commit_or_rollback, MemoryDB};
 use crate::error::WenlanError;
 use crate::presence::{PresenceAction, PresenceDemand, PresenceRefusal, VerifiedPresence};
 use std::path::Path;
@@ -88,7 +88,7 @@ impl MemoryDB {
 
         match result {
             Ok(ReviewOutcome::Applied(receipt)) => {
-                conn.execute("COMMIT", ())
+                commit_or_rollback(&conn)
                     .await
                     .map_err(|e| WenlanError::VectorDb(format!("presence review commit: {e}")))?;
                 Ok(ReviewOutcome::Applied(receipt))

--- a/crates/wenlan-core/src/db/repair_page_rename.rs
+++ b/crates/wenlan-core/src/db/repair_page_rename.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::MemoryDB;
+use super::{commit_or_rollback, MemoryDB};
 use crate::{
     error::WenlanError,
     post_write::RepairWriteProof,
@@ -510,8 +510,7 @@ pub(crate) async fn recover_rename_page_title_apply_receipt(
             ));
         }
     }
-    connection
-        .execute("COMMIT", ())
+    commit_or_rollback(&connection)
         .await
         .map_err(|_| WenlanError::Conflict("repair_apply_recovery_required".to_string()))?;
     #[cfg(test)]

--- a/crates/wenlan-core/src/db/repair_verification.rs
+++ b/crates/wenlan-core/src/db/repair_verification.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::MemoryDB;
+use super::{commit_or_rollback, MemoryDB};
 use crate::{
     error::WenlanError,
     export::knowledge::{KnowledgeProjectionWrite, OwnedRepairProjectionSession},
@@ -400,8 +400,7 @@ pub(crate) async fn record_repair_verification_atomic(
             "repair verify commit: injected test failure".to_string(),
         ));
     }
-    connection
-        .execute("COMMIT", ())
+    commit_or_rollback(&connection)
         .await
         .map_err(|error| WenlanError::VectorDb(format!("repair verify commit: {error}")))?;
     Ok(receipt)

--- a/crates/wenlan-core/src/db/repair_verification_test.rs
+++ b/crates/wenlan-core/src/db/repair_verification_test.rs
@@ -205,7 +205,12 @@ fn r4_24a_source_contract_is_atomic_bounded_and_caller_ordered() {
     assert_eq!(precommit.matches("ROLLBACK").count(), 0);
     assert_eq!(precommit.matches("COMMIT").count(), 0);
     assert_eq!(finalization.matches("ROLLBACK").count(), 1);
-    assert_eq!(finalization.matches("COMMIT").count(), 1);
+    // The commit goes through the shared `commit_or_rollback`, which rolls the
+    // transaction back when the COMMIT itself fails; a bare `execute("COMMIT")`
+    // here would leave the daemon's one writer connection inside the
+    // transaction after a busy commit.
+    assert_eq!(finalization.matches("COMMIT").count(), 0);
+    assert_eq!(finalization.matches("commit_or_rollback(").count(), 1);
     assert_eq!(
         precommit
             .matches("KnowledgeProjectionWrite::with_projection_lock(")
@@ -242,7 +247,7 @@ fn r4_24a_source_contract_is_atomic_bounded_and_caller_ordered() {
             "persist_verification_receipt(",
         ],
     );
-    ordered(finalization, &["ROLLBACK", "COMMIT"]);
+    ordered(finalization, &["ROLLBACK", "commit_or_rollback("]);
     assert_eq!(
         precommit.matches("persist_verification_receipt(").count(),
         3
@@ -542,7 +547,7 @@ fn r4_24b_test_control_is_scoped_consumed_capability_free_and_ordered() {
         .find("if consume_repair_verification_test_commit_failure()")
         .expect("commit failure control");
     let commit = finalization
-        .find(".execute(\"COMMIT\", ())")
+        .find("commit_or_rollback(")
         .expect("literal commit");
     assert!(commit_fault < commit);
 


### PR DESCRIPTION
## What

Closes #593. When `COMMIT` failed in `resolve_orphan_page_links`, the error was returned with the transaction still open on the single writer connection, so the next `BEGIN` failed with `cannot start a transaction within a transaction`. The same shape existed at 130 `COMMIT` sites across `wenlan-core`; four of them logged the failure and kept going inside the open transaction.

## How

- One helper, `commit_or_rollback(conn) -> libsql::Result<u64>` in `crates/wenlan-core/src/db.rs`: runs `COMMIT`, and on failure issues `ROLLBACK` before returning the original commit error. When the rollback itself fails and `!conn.is_autocommit()` (recovery failed, the connection is still inside a transaction) it logs at error level under the `[tx-watchdog]` tag; the harmless `no transaction is active` case stays quiet. It is private to `db.rs` (the `db/*` child modules reach it through `super::`) because the R4 drift guard forbids crate-visible `db.rs` functions that take a raw `libsql::Connection`. It returns the raw `libsql` error on purpose so every call site keeps its existing `.map_err(...)` and every log string stays byte-identical; a label parameter would have forced rewriting messages that are not of the `"{label}: {e}"` form.
- The 130 sites whose commit-failure path left the transaction open now call the helper: `db.rs` (112), `db/page_map.rs` (8), `db/migrations_v004_v009.rs` (6), and one each in `db/derived_artifact_sweep.rs`, `db/presence_review.rs`, `db/repair_page_rename.rs`, `db/repair_verification.rs`. `wenlan-server` has no `BEGIN`/`COMMIT`/`ROLLBACK` sites of its own.
- The four embedding loops that logged a failed commit and kept going (`m24 re-embed batch commit`, `m24 entity re-embed commit`, `null embed recovery commit`, `null entity embed recovery commit`) now propagate the error under that label and count progress only after the commit succeeds. Before, a persistent commit failure spun those loops forever while reporting progress. One consequence, kept on purpose: if the loop's `BEGIN` fails (still log-and-continue, issue #389), the following `COMMIT` errors with `no transaction is active` and the migration now aborts instead of carrying on with non-durable updates.
- Left alone: 24 production sites whose commit error arm already rolls back (including `rollback_repair_transaction` callers), and 10 test-module sites that `.unwrap()` fixture commits or pair a `commit()` with an explicit `rollback()` twin.
- Three source-text assertions in `db/repair_verification_test.rs` that pinned the literal `COMMIT` inside the verifier's finalization body now pin `commit_or_rollback(`; the order they encode (roll back the body error, then commit) is unchanged.

## Verification

- Fault injection: a busy second connection cannot make `COMMIT` itself fail in WAL mode (the first write fails instead; `db/presence_review_test.rs` documents that window). So the tests arm a `#[cfg(test)]` site-keyed `tokio::task_local!` hook (`with_failing_commit_at(site, fut)` and `arm_commit_failure(&conn, site)`, same mechanism as `repair_verification.rs`) that stages a deferred foreign-key violation inside the transaction; deferred constraints are checked at commit time, so `COMMIT` itself fails and the transaction stays active. Confirmed against SQLite directly: `FOREIGN KEY constraint failed (19)` on commit, then `cannot start a transaction within a transaction` on the next `BEGIN`.
- New test `a_failed_orphan_sweep_commit_does_not_wedge_the_writer_connection` (`db/main_tests.rs`): the commit error surfaces with its `resolve_orphan_links commit` label, and a following `insert_page` on the same connection succeeds.
- Mutation control, run twice: against the pre-fix code with only the hook and test added, and again with only the sweep's `COMMIT` reverted to a bare `conn.execute("COMMIT", ())` on the finished tree. Both fail with `a failed sweep commit must not wedge later writes: VectorDb("insert_page begin: SQLite failure: \`cannot start a transaction within a transaction\`")`; restored, green.
- New test `a_failed_recovery_commit_aborts_the_migration_instead_of_looping`: a `memories` row with no embedding, `run_migrations` again with the fault armed at `null_embed_recovery`; the error carries the loop's label and the connection is still usable afterwards. The fault is one-shot, so this proves the swallow (the mechanism), not the hang. Mutation control with that one site reverted to log-and-continue: `the staged commit failure must abort the migration: ()`; restored, green.
- `cargo fmt --check -p wenlan-core`, `cargo clippy -p wenlan-core --all-targets -- -D warnings`, `cargo check -p wenlan-server`, `git diff --check` clean; `scripts/m5-reader-sweep.py --update-inventory` unchanged.
- `cargo test -p wenlan-core --lib` filters after the follow-up: `orphan` 69, `migration` 179 (1 ignored), `commit` 46, `embed` 37, `r4_24` 5; before it also `repair` 238, `page_map` 39, `presence_review` 21, `derived` 14 — all passed.
- `unchecked`: the full wenlan-core lib suite (started, 331 passed, stopped for time) and `crates/wenlan-core/tests/` (`m4_community_gates` asserts two RAII-transaction functions contain no raw `BEGIN`/`COMMIT`/`ROLLBACK`; they were not touched). CI is the gate.
- Noted, not changed: the `#[cfg(test)]` `consume_repair_verification_test_commit_failure()` branch in `repair_verification.rs` returns before `COMMIT` without rolling back; test-only scaffolding, outside this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
