### PR TITLE
fix(lint): a fresh store without a model source is not a failing lint

### DIFF
--- a/crates/wenlan-cli/src/commands/lint.rs
+++ b/crates/wenlan-cli/src/commands/lint.rs
@@ -155,6 +155,19 @@ fn render_human(report: &LintReport) -> String {
     }
     append_findings(&mut output, "Findings", report, LintGateEffect::Actionable);
     append_findings(&mut output, "Advisories", report, LintGateEffect::Advisory);
+    // A check that passed but still carries advice is waiting on the owner, not
+    // broken — e.g. a graph channel with no model source chosen. It is not a
+    // finding and does not change the exit code, but the reader still has to see
+    // the one thing they can do about it.
+    output.push_str("Waiting on you");
+    let waiting: Vec<_> = report
+        .checks()
+        .iter()
+        .filter(|check| {
+            check.outcome() == LintOutcome::Pass && check.recommendation_code().is_some()
+        })
+        .collect();
+    append_selected(&mut output, &waiting);
     output.push_str("Incomplete");
     let incomplete: Vec<_> = report
         .checks()
@@ -198,6 +211,18 @@ fn append_selected(output: &mut String, checks: &[&wenlan_types::lint::LintCheck
             )),
             None => output.push_str(&format!("  {}: {summary}\n", check.check_id())),
         }
+        // The codes above are stable identifiers for scripts. This line is the
+        // same thing in plain English for the person reading the terminal.
+        output.push_str(&format!(
+            "    {}{}\n",
+            check.summary_code().meaning(),
+            check
+                .recommendation_code()
+                .map_or_else(String::new, |recommendation| format!(
+                    " {}",
+                    recommendation.action()
+                ))
+        ));
         let affected = check.metrics().iter().find_map(|metric| {
             if metric.code() == LintMetricCode::AffectedRecords {
                 match metric.value() {
@@ -302,6 +327,7 @@ const fn recommendation_name(recommendation: LintRecommendationCode) -> &'static
         LintRecommendationCode::RestorePrerequisite => "restore_prerequisite",
         LintRecommendationCode::RerunAfterSnapshotStabilizes => "rerun_after_snapshot_stabilizes",
         LintRecommendationCode::InspectRuntime => "inspect_runtime",
+        LintRecommendationCode::ChooseModelSource => "choose_model_source",
     }
 }
 
@@ -313,5 +339,188 @@ const fn summary_name(summary: LintSummaryCode) -> &'static str {
         LintSummaryCode::SnapshotInconsistent => "snapshot_inconsistent",
         LintSummaryCode::ExecutionFailed => "execution_failed",
         LintSummaryCode::ExpectedEmpty => "expected_empty",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{exit_code, render_human};
+    use wenlan_types::lint::{
+        LintApplicability, LintCapabilityContext, LintCheckResult, LintCheckResultInput,
+        LintConfigFingerprint, LintCoverage, LintDbSnapshotMode, LintDbSnapshotReceipt, LintDigest,
+        LintOutcome, LintPageSnapshotMode, LintPageSnapshotReceipt, LintPrecondition,
+        LintPrecondition as Pre, LintProducerReceipt, LintProfile, LintRecommendationCode,
+        LintReport, LintScope, LintSeverity, LintSnapshotReceipts, LintSummaryCode,
+        LintValidationMethod, LINT_MAX_EVIDENCE_PER_CHECK,
+    };
+
+    /// The two checks a fresh store with no model source used to fail on, as the
+    /// daemon now produces them: complete, passing, expected-empty, each asking
+    /// the owner to pick a model source.
+    fn fresh_store_report() -> LintReport {
+        report(vec![
+            model_source_check("kg.substrate_liveness"),
+            model_source_check("serving.channel.graph"),
+        ])
+    }
+
+    fn model_source_check(check_id: &str) -> LintCheckResult {
+        check(
+            check_id,
+            LintOutcome::Pass,
+            LintSeverity::Info,
+            LintApplicability::ExpectedEmpty,
+            Pre::ExpectedEmpty,
+            LintSummaryCode::ExpectedEmpty,
+            Some(LintRecommendationCode::ChooseModelSource),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn check(
+        check_id: &str,
+        outcome: LintOutcome,
+        severity: LintSeverity,
+        applicability: LintApplicability,
+        precondition: LintPrecondition,
+        summary_code: LintSummaryCode,
+        recommendation_code: Option<LintRecommendationCode>,
+    ) -> LintCheckResult {
+        LintCheckResult::try_new(LintCheckResultInput {
+            check_id: check_id.to_string(),
+            outcome,
+            severity,
+            applicability,
+            precondition,
+            coverage: LintCoverage::new(
+                LintValidationMethod::ExactAggregate,
+                2,
+                2,
+                LINT_MAX_EVIDENCE_PER_CHECK,
+                false,
+                0,
+            )
+            .expect("valid synthetic coverage"),
+            metrics: vec![],
+            summary_code,
+            recommendation_code,
+            evidence: vec![],
+            duration_ms: 1,
+        })
+        .expect("valid synthetic check")
+    }
+
+    fn report(checks: Vec<LintCheckResult>) -> LintReport {
+        LintReport::try_new_for_profile(
+            LintProfile::General,
+            LintScope::global(),
+            LintCapabilityContext::daemon_operator_endpoint(),
+            LintSnapshotReceipts::new(
+                LintDbSnapshotReceipt::new(
+                    LintDbSnapshotMode::TransactionalReadOnly,
+                    LintDigest::from_u64(1),
+                    Some(LintDigest::from_u64(1)),
+                ),
+                LintPageSnapshotReceipt::new(
+                    LintPageSnapshotMode::BestEffort,
+                    LintDigest::from_u64(2),
+                    Some(LintDigest::from_u64(2)),
+                ),
+            ),
+            LintConfigFingerprint::from_effective_config(&[]),
+            LintProducerReceipt::new(None),
+            checks,
+        )
+        .expect("valid synthetic report")
+    }
+
+    // Tracker row 17: a first-hour install must not read as broken to a script.
+    #[test]
+    fn a_fresh_store_without_a_model_source_exits_zero() {
+        let report = fresh_store_report();
+
+        assert!(report.complete());
+        assert_eq!(report.totals().actionable_findings(), 0);
+        assert_eq!(exit_code(&report), 0);
+    }
+
+    #[test]
+    fn exit_code_is_one_only_for_actionable_findings_and_two_for_incomplete() {
+        let finding = report(vec![check(
+            "pages.projection.identity",
+            LintOutcome::Finding,
+            LintSeverity::Error,
+            LintApplicability::Applicable,
+            Pre::Ready,
+            LintSummaryCode::FindingDetected,
+            Some(LintRecommendationCode::ReviewFinding),
+        )]);
+        assert_eq!(exit_code(&finding), 1);
+
+        let incomplete = report(vec![check(
+            "runtime.provider_inventory",
+            LintOutcome::NotRunPrerequisite,
+            LintSeverity::Error,
+            LintApplicability::NotApplicable,
+            Pre::MissingPrerequisite,
+            LintSummaryCode::PrerequisiteUnavailable,
+            Some(LintRecommendationCode::RestorePrerequisite),
+        )]);
+        assert_eq!(exit_code(&incomplete), 2);
+    }
+
+    #[test]
+    fn the_model_source_checks_render_with_a_plain_sentence_and_no_findings() {
+        let rendered = render_human(&fresh_store_report());
+
+        assert!(rendered.contains("0 actionable findings"), "{rendered}");
+        assert!(rendered.contains("Findings: none\n"), "{rendered}");
+        assert!(rendered.contains("Waiting on you (2):"), "{rendered}");
+        for check_id in ["kg.substrate_liveness", "serving.channel.graph"] {
+            assert!(
+                rendered.contains(&format!(
+                    "  {check_id}: expected_empty; recommendation: choose_model_source\n"
+                )),
+                "{rendered}"
+            );
+        }
+        assert!(
+            rendered.contains(
+                "    There was nothing here to check, which is the expected state right now. \
+                 Run `wenlan setup` and choose a model source so Wenlan can build this in the \
+                 background.\n"
+            ),
+            "{rendered}"
+        );
+    }
+
+    // Every rendered line carries the sentence, not just the new one -- the
+    // codes stay for scripts, the English is for the person reading.
+    #[test]
+    fn a_rendered_finding_carries_both_the_code_and_the_plain_sentence() {
+        let rendered = render_human(&report(vec![check(
+            "pages.projection.identity",
+            LintOutcome::Finding,
+            LintSeverity::Error,
+            LintApplicability::Applicable,
+            Pre::Ready,
+            LintSummaryCode::FindingDetected,
+            Some(LintRecommendationCode::ReviewFinding),
+        )]));
+
+        assert!(
+            rendered.contains(
+                "  pages.projection.identity: finding_detected; recommendation: review_finding\n"
+            ),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains(
+                "    This check found records that do not match what Wenlan expects. \
+                 Look at the listed records and fix or dismiss them.\n"
+            ),
+            "{rendered}"
+        );
+        assert!(rendered.contains("Waiting on you: none\n"), "{rendered}");
     }
 }

--- a/crates/wenlan-cli/src/commands/lint.rs
+++ b/crates/wenlan-cli/src/commands/lint.rs
@@ -4,9 +4,9 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use wenlan_types::lint::{
-    LintAgentSubmission, LintCheckGroup, LintEvidenceRef, LintGateEffect, LintMetricCode,
-    LintMetricValue, LintOutcome, LintProfile, LintReasonCode, LintRecommendationCode, LintReport,
-    LintSummaryCode,
+    LintActionCode, LintAgentSubmission, LintCheckGroup, LintEvidenceRef, LintGateEffect,
+    LintMetricCode, LintMetricValue, LintOutcome, LintProfile, LintReasonCode,
+    LintRecommendationCode, LintReport, LintSummaryCode,
 };
 
 use crate::client::WenlanClient;
@@ -163,9 +163,7 @@ fn render_human(report: &LintReport) -> String {
     let waiting: Vec<_> = report
         .checks()
         .iter()
-        .filter(|check| {
-            check.outcome() == LintOutcome::Pass && check.recommendation_code().is_some()
-        })
+        .filter(|check| check.outcome() == LintOutcome::Pass && check.action_code().is_some())
         .collect();
     append_selected(&mut output, &waiting);
     output.push_str("Incomplete");
@@ -203,25 +201,24 @@ fn append_selected(output: &mut String, checks: &[&wenlan_types::lint::LintCheck
     output.push_str(&format!(" ({}):\n", checks.len()));
     for check in checks {
         let summary = summary_name(check.summary_code());
-        match check.recommendation_code() {
-            Some(recommendation) => output.push_str(&format!(
-                "  {}: {summary}; recommendation: {}\n",
-                check.check_id(),
-                recommendation_name(recommendation)
-            )),
-            None => output.push_str(&format!("  {}: {summary}\n", check.check_id())),
-        }
+        let code_suffix = match (check.recommendation_code(), check.action_code()) {
+            (Some(recommendation), _) => {
+                format!("; recommendation: {}", recommendation_name(recommendation))
+            }
+            (None, Some(action)) => format!("; action: {}", action_name(action)),
+            (None, None) => String::new(),
+        };
+        output.push_str(&format!("  {}: {summary}{code_suffix}\n", check.check_id()));
         // The codes above are stable identifiers for scripts. This line is the
         // same thing in plain English for the person reading the terminal.
         output.push_str(&format!(
             "    {}{}\n",
             check.summary_code().meaning(),
-            check
-                .recommendation_code()
-                .map_or_else(String::new, |recommendation| format!(
-                    " {}",
-                    recommendation.action()
-                ))
+            match (check.recommendation_code(), check.action_code()) {
+                (Some(recommendation), _) => format!(" {}", recommendation.action()),
+                (None, Some(action)) => format!(" {}", action.action()),
+                (None, None) => String::new(),
+            }
         ));
         let affected = check.metrics().iter().find_map(|metric| {
             if metric.code() == LintMetricCode::AffectedRecords {
@@ -327,7 +324,12 @@ const fn recommendation_name(recommendation: LintRecommendationCode) -> &'static
         LintRecommendationCode::RestorePrerequisite => "restore_prerequisite",
         LintRecommendationCode::RerunAfterSnapshotStabilizes => "rerun_after_snapshot_stabilizes",
         LintRecommendationCode::InspectRuntime => "inspect_runtime",
-        LintRecommendationCode::ChooseModelSource => "choose_model_source",
+    }
+}
+
+const fn action_name(action: LintActionCode) -> &'static str {
+    match action {
+        LintActionCode::ChooseModelSource => "choose_model_source",
     }
 }
 
@@ -346,12 +348,12 @@ const fn summary_name(summary: LintSummaryCode) -> &'static str {
 mod tests {
     use super::{exit_code, render_human};
     use wenlan_types::lint::{
-        LintApplicability, LintCapabilityContext, LintCheckResult, LintCheckResultInput,
-        LintConfigFingerprint, LintCoverage, LintDbSnapshotMode, LintDbSnapshotReceipt, LintDigest,
-        LintOutcome, LintPageSnapshotMode, LintPageSnapshotReceipt, LintPrecondition,
-        LintPrecondition as Pre, LintProducerReceipt, LintProfile, LintRecommendationCode,
-        LintReport, LintScope, LintSeverity, LintSnapshotReceipts, LintSummaryCode,
-        LintValidationMethod, LINT_MAX_EVIDENCE_PER_CHECK,
+        LintActionCode, LintApplicability, LintCapabilityContext, LintCheckResult,
+        LintCheckResultInput, LintConfigFingerprint, LintCoverage, LintDbSnapshotMode,
+        LintDbSnapshotReceipt, LintDigest, LintOutcome, LintPageSnapshotMode,
+        LintPageSnapshotReceipt, LintPrecondition, LintPrecondition as Pre, LintProducerReceipt,
+        LintProfile, LintRecommendationCode, LintReport, LintScope, LintSeverity,
+        LintSnapshotReceipts, LintSummaryCode, LintValidationMethod, LINT_MAX_EVIDENCE_PER_CHECK,
     };
 
     /// The two checks a fresh store with no model source used to fail on, as the
@@ -372,8 +374,9 @@ mod tests {
             LintApplicability::ExpectedEmpty,
             Pre::ExpectedEmpty,
             LintSummaryCode::ExpectedEmpty,
-            Some(LintRecommendationCode::ChooseModelSource),
+            None,
         )
+        .with_action_code(Some(LintActionCode::ChooseModelSource))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -479,7 +482,7 @@ mod tests {
         for check_id in ["kg.substrate_liveness", "serving.channel.graph"] {
             assert!(
                 rendered.contains(&format!(
-                    "  {check_id}: expected_empty; recommendation: choose_model_source\n"
+                    "  {check_id}: expected_empty; action: choose_model_source\n"
                 )),
                 "{rendered}"
             );

--- a/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
+++ b/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
@@ -757,11 +757,12 @@ must be demoted individually with a recorded reason. **Every MCP tool is
 | `verify_lint_repair` | yes | automatic | `none` | tool handler |
 | `write_page` | yes | automatic | `none` | tool handler |
 
-## CLI — all 22 `Commands` variants
+## CLI — all 23 `Commands` variants
 
-From `crates/wenlan-cli/src/main.rs:45`. The count is 22, not 20: `Connect` and
+From `crates/wenlan-cli/src/main.rs:45`. The count is 23, not 20: `Connect` and
 `Brief` are tuple variants, easy to miss when scanning for brace-shaped
-variants, and `Outbox` is the last brace variant before `Entities`. The CLI
+variants, `Outbox` is the last brace variant before `Entities`, and `Sweep`
+follows `Entities`. The CLI
 renders daemon responses, so it inherits the daemon's classification and adds
 the projection-directory reader.
 
@@ -789,6 +790,7 @@ the projection-directory reader.
 | `wenlan spaces` | yes | automatic | `none` | subcommand renderer |
 | `wenlan outbox` | yes | automatic | `none` | subcommand renderer |
 | `wenlan entities` | yes | automatic | `none` | subcommand renderer |
+| `wenlan sweep` | yes | automatic | `none` | subcommand renderer |
 
 ## Projection, export, internal
 

--- a/crates/wenlan-core/src/lint/kg/config.rs
+++ b/crates/wenlan-core/src/lint/kg/config.rs
@@ -5,6 +5,19 @@ pub(crate) struct KgRunConfig {
     pub(crate) serving_enabled: bool,
     pub(crate) sweep_enabled: bool,
     pub(crate) provider_ready: bool,
+    /// Whether the owner has chosen a model source for everyday background work.
+    ///
+    /// This is the config pin, not a runtime latch. `provider_ready` above is
+    /// `llm_provider_ready()`, a sticky process-wide "some provider has served
+    /// traffic" flag: it is false on a freshly started daemon even when a source
+    /// is configured, so it cannot answer "has the owner picked a model source".
+    /// The pin is what `refinery::resolve_everyday` reads to produce
+    /// `RouteMode::Unconfigured`, which is the exact condition on which the
+    /// capture path tells the user that "background enrichment is paused until
+    /// you choose a model source". A source that is chosen but unavailable
+    /// resolves to `PinnedUnavailable`, so it stays `true` here and is never
+    /// told to choose a source it already chose.
+    pub(crate) model_source_configured: bool,
     pub(crate) hub_cap: u64,
 }
 
@@ -14,6 +27,10 @@ impl KgRunConfig {
             serving_enabled: crate::db::graph_memory_stream_enabled(),
             sweep_enabled: crate::db::entity_sweep_enabled(),
             provider_ready: crate::llm_provider::llm_provider_ready(),
+            model_source_configured: crate::refinery::EverydaySource::parse(
+                crate::config::load_config().everyday_source.as_deref(),
+            )
+            .is_some(),
             hub_cap: u64::try_from(crate::db::graph_hub_cap()).unwrap_or(u64::MAX),
         }
     }
@@ -23,18 +40,24 @@ impl KgRunConfig {
         serving_enabled: bool,
         sweep_enabled: bool,
         provider_ready: bool,
+        model_source_configured: bool,
         hub_cap: u64,
     ) -> Self {
         Self {
             serving_enabled,
             sweep_enabled,
             provider_ready,
+            model_source_configured,
             hub_cap,
         }
     }
 
-    pub(crate) fn fingerprint_selections(self) -> [LintConfigSelection; 4] {
+    pub(crate) fn fingerprint_selections(self) -> [LintConfigSelection; 5] {
         [
+            selection(
+                LintConfigSetting::ModelSourceConfigured,
+                self.model_source_configured,
+            ),
             selection(
                 LintConfigSetting::KnowledgeGraphServingEnabled,
                 self.serving_enabled,

--- a/crates/wenlan-core/src/lint/kg/result.rs
+++ b/crates/wenlan-core/src/lint/kg/result.rs
@@ -19,6 +19,17 @@ pub(super) struct Assessment {
     evidence_positions: Vec<usize>,
     method: LintValidationMethod,
     basis: PopulationBasis,
+    /// Whether this assessment can point at individual records at all.
+    ///
+    /// `truncated` means "there was more evidence than we listed". An
+    /// aggregate-only assessment never produces evidence positions, so its
+    /// affected count can never be evidence that was cut off — reporting
+    /// `truncated=true` there tells the reader to go look for a list that does
+    /// not exist. Only an assessment that does emit positions can truncate.
+    reports_evidence: bool,
+    /// Advice to attach when the check passes. A finding always recommends
+    /// reviewing it; a pass is silent unless it is waiting on the owner.
+    passing_recommendation: Option<LintRecommendationCode>,
 }
 
 impl Assessment {
@@ -34,6 +45,8 @@ impl Assessment {
             evidence_positions: rows.evidence_positions,
             method: LintValidationMethod::FullEnumeration,
             basis: PopulationBasis::SelectedScope,
+            reports_evidence: true,
+            passing_recommendation: None,
         }
     }
 
@@ -66,11 +79,21 @@ impl Assessment {
             evidence_positions: Vec::new(),
             method: LintValidationMethod::ExactAggregate,
             basis,
+            reports_evidence: false,
+            passing_recommendation: None,
         }
     }
 
     pub(super) fn liveness(config: KgRunConfig, eligible: u64, linked: u64) -> Self {
-        let affected = if config.serving_enabled && eligible > 0 && linked == 0 {
+        // An empty graph substrate is only a defect once the graph could
+        // actually have been built. Two states make it the expected shape:
+        // the channel is switched off, or nobody has chosen a model source yet,
+        // so the enrichment that would populate it has never been authorized to
+        // run. `serving_enabled` is checked first: an owner who turned the
+        // channel off should not be told to go pick a model source for it.
+        let waiting_on_model_source = config.serving_enabled && !config.model_source_configured;
+        let live = config.serving_enabled && config.model_source_configured;
+        let affected = if live && eligible > 0 && linked == 0 {
             eligible
         } else {
             0
@@ -80,13 +103,15 @@ impl Assessment {
             population: eligible,
             affected,
             severity: LintSeverity::Warning,
-            applicability: if config.serving_enabled {
+            applicability: if live {
                 LintApplicability::Applicable
             } else {
                 LintApplicability::ExpectedEmpty
             },
-            precondition: if config.serving_enabled {
+            precondition: if live {
                 LintPrecondition::Ready
+            } else if waiting_on_model_source {
+                LintPrecondition::ExpectedEmpty
             } else {
                 LintPrecondition::ConfiguredOff
             },
@@ -110,6 +135,9 @@ impl Assessment {
             evidence_positions: Vec::new(),
             method: LintValidationMethod::ExactAggregate,
             basis: PopulationBasis::SelectedScope,
+            reports_evidence: false,
+            passing_recommendation: waiting_on_model_source
+                .then_some(LintRecommendationCode::ChooseModelSource),
         }
     }
 }
@@ -157,18 +185,23 @@ pub(super) fn finish(
             assessment.population,
             assessment.population,
             LINT_MAX_EVIDENCE_PER_CHECK,
-            assessment.affected > u64::try_from(evidence.len()).unwrap_or(u64::MAX),
+            assessment.reports_evidence
+                && assessment.affected > u64::try_from(evidence.len()).unwrap_or(u64::MAX),
             u64::try_from(evidence.len()).unwrap_or(u64::MAX),
         )?,
         metrics: assessment.metrics,
         summary_code: if finding {
             LintSummaryCode::FindingDetected
-        } else if assessment.precondition == LintPrecondition::ConfiguredOff {
+        } else if assessment.applicability == LintApplicability::ExpectedEmpty {
             LintSummaryCode::ExpectedEmpty
         } else {
             LintSummaryCode::CheckPassed
         },
-        recommendation_code: finding.then_some(LintRecommendationCode::ReviewFinding),
+        recommendation_code: if finding {
+            Some(LintRecommendationCode::ReviewFinding)
+        } else {
+            assessment.passing_recommendation
+        },
         evidence,
         duration_ms: context.clock().duration_ms(),
     })?;

--- a/crates/wenlan-core/src/lint/kg/result.rs
+++ b/crates/wenlan-core/src/lint/kg/result.rs
@@ -2,10 +2,10 @@ use super::config::KgRunConfig;
 use super::query::RowCheck;
 use crate::lint::context::{LintContext, PopulationBasis, PopulationLedgerError};
 use wenlan_types::lint::{
-    LintApplicability, LintCheckResult, LintCheckResultInput, LintContractError, LintCoverage,
-    LintEvidenceRef, LintMetric, LintMetricCode, LintMetricStringCode, LintMetricValue,
-    LintOpaqueId, LintOutcome, LintPrecondition, LintRecommendationCode, LintSeverity,
-    LintSummaryCode, LintValidationMethod, LINT_MAX_EVIDENCE_PER_CHECK,
+    LintActionCode, LintApplicability, LintCheckResult, LintCheckResultInput, LintContractError,
+    LintCoverage, LintEvidenceRef, LintMetric, LintMetricCode, LintMetricStringCode,
+    LintMetricValue, LintOpaqueId, LintOutcome, LintPrecondition, LintRecommendationCode,
+    LintSeverity, LintSummaryCode, LintValidationMethod, LINT_MAX_EVIDENCE_PER_CHECK,
 };
 
 pub(super) struct Assessment {
@@ -29,7 +29,9 @@ pub(super) struct Assessment {
     reports_evidence: bool,
     /// Advice to attach when the check passes. A finding always recommends
     /// reviewing it; a pass is silent unless it is waiting on the owner.
-    passing_recommendation: Option<LintRecommendationCode>,
+    /// Carried as `action_code`, not `recommendation_code` — see
+    /// [`LintActionCode`] for why the wire keeps the two apart.
+    passing_action: Option<LintActionCode>,
 }
 
 impl Assessment {
@@ -46,7 +48,7 @@ impl Assessment {
             method: LintValidationMethod::FullEnumeration,
             basis: PopulationBasis::SelectedScope,
             reports_evidence: true,
-            passing_recommendation: None,
+            passing_action: None,
         }
     }
 
@@ -80,7 +82,7 @@ impl Assessment {
             method: LintValidationMethod::ExactAggregate,
             basis,
             reports_evidence: false,
-            passing_recommendation: None,
+            passing_action: None,
         }
     }
 
@@ -136,8 +138,7 @@ impl Assessment {
             method: LintValidationMethod::ExactAggregate,
             basis: PopulationBasis::SelectedScope,
             reports_evidence: false,
-            passing_recommendation: waiting_on_model_source
-                .then_some(LintRecommendationCode::ChooseModelSource),
+            passing_action: waiting_on_model_source.then_some(LintActionCode::ChooseModelSource),
         }
     }
 }
@@ -197,14 +198,11 @@ pub(super) fn finish(
         } else {
             LintSummaryCode::CheckPassed
         },
-        recommendation_code: if finding {
-            Some(LintRecommendationCode::ReviewFinding)
-        } else {
-            assessment.passing_recommendation
-        },
+        recommendation_code: finding.then_some(LintRecommendationCode::ReviewFinding),
         evidence,
         duration_ms: context.clock().duration_ms(),
-    })?;
+    })?
+    .with_action_code(assessment.passing_action);
     context.record_population(assessment.id, basis, assessment.population)?;
     Ok(result)
 }

--- a/crates/wenlan-core/src/lint/kg_config_test.rs
+++ b/crates/wenlan-core/src/lint/kg_config_test.rs
@@ -54,6 +54,7 @@ fn production_capture_reads_process_provider_readiness_once() {
         config.serving_enabled,
         config.sweep_enabled,
         !config.provider_ready,
+        config.model_source_configured,
         config.hub_cap,
     );
     let captured = wenlan_types::lint::LintConfigFingerprint::from_effective_config(
@@ -71,14 +72,29 @@ async fn production_run(
     sweep: &str,
     hub_cap: &str,
 ) -> wenlan_types::lint::LintReport {
+    // `capture()` reads the everyday-source pin from config, and an empty
+    // substrate is only a finding once a model source exists to have filled it.
+    // Point the config at a scratch data dir that has one, so this test keeps
+    // measuring what it is about: fingerprint separation.
+    let data_dir = tempfile::tempdir().expect("scratch data dir");
+    std::fs::write(
+        data_dir.path().join("config.json"),
+        br#"{"everyday_source":"on_device"}"#,
+    )
+    .expect("scratch config");
     let config = temp_env::with_vars(
         [
             ("WENLAN_GRAPH_MEMORY_STREAM", Some(stream)),
             ("WENLAN_ENABLE_ENTITY_SWEEP", Some(sweep)),
             ("WENLAN_GRAPH_HUB_CAP", Some(hub_cap)),
+            (
+                "WENLAN_DATA_DIR",
+                Some(data_dir.path().to_str().expect("utf-8 scratch path")),
+            ),
         ],
         super::KgRunConfig::capture,
     );
+    assert!(config.model_source_configured);
     LintRunner::new(LintClock::fixed(), CancellationToken::new())
         .with_test_kg_config(config)
         .run(

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -3,8 +3,8 @@ use crate::lint::context::{CancellationToken, LintClock};
 use crate::lint::runner::LintRunner;
 use crate::lint::test_support::DbSemanticFingerprint;
 use wenlan_types::lint::{
-    LintApplicability, LintMetricCode, LintMetricValue, LintOutcome, LintPrecondition, LintQuery,
-    LintRecommendationCode, LintSeverity, LintSummaryCode,
+    LintActionCode, LintApplicability, LintMetricCode, LintMetricValue, LintOutcome,
+    LintPrecondition, LintQuery, LintSeverity, LintSummaryCode,
 };
 
 const ENTITY_INTEGRITY: &str = "entities.structural_integrity";
@@ -156,9 +156,10 @@ async fn no_model_source_is_a_complete_expected_empty_pass_that_says_to_choose_o
     assert_eq!(liveness.applicability(), LintApplicability::ExpectedEmpty);
     assert_eq!(liveness.precondition(), LintPrecondition::ExpectedEmpty);
     assert_eq!(liveness.summary_code(), LintSummaryCode::ExpectedEmpty);
+    assert_eq!(liveness.recommendation_code(), None);
     assert_eq!(
-        liveness.recommendation_code(),
-        Some(LintRecommendationCode::ChooseModelSource)
+        liveness.action_code(),
+        Some(LintActionCode::ChooseModelSource)
     );
     // The substrate is still reported honestly; only the verdict changed.
     assert_eq!(metric(liveness, LintMetricCode::EligibleRecords), 1);

--- a/crates/wenlan-core/src/lint/kg_test.rs
+++ b/crates/wenlan-core/src/lint/kg_test.rs
@@ -4,7 +4,7 @@ use crate::lint::runner::LintRunner;
 use crate::lint::test_support::DbSemanticFingerprint;
 use wenlan_types::lint::{
     LintApplicability, LintMetricCode, LintMetricValue, LintOutcome, LintPrecondition, LintQuery,
-    LintSeverity,
+    LintRecommendationCode, LintSeverity, LintSummaryCode,
 };
 
 const ENTITY_INTEGRITY: &str = "entities.structural_integrity";
@@ -140,6 +140,58 @@ async fn configured_off_is_expected_empty_and_enabled_empty_substrate_is_actiona
     assert_eq!(metric(on_liveness, LintMetricCode::EligibleRecords), 1);
 }
 
+// Tracker row 17: on a fresh store whose owner has not chosen a model source,
+// nothing has been authorized to build the graph, so an empty graph is the
+// expected state -- not a warning a first-hour user has to decode.
+#[tokio::test]
+async fn no_model_source_is_a_complete_expected_empty_pass_that_says_to_choose_one() {
+    let (db, _tmp) = test_db().await;
+    insert_memory(&db, "eligible", None).await;
+
+    let report = run(&db, None, test_config_with_model_source(true, false)).await;
+    let liveness = check(&report, LIVENESS);
+
+    assert_eq!(liveness.outcome(), LintOutcome::Pass);
+    assert_eq!(liveness.severity(), LintSeverity::Info);
+    assert_eq!(liveness.applicability(), LintApplicability::ExpectedEmpty);
+    assert_eq!(liveness.precondition(), LintPrecondition::ExpectedEmpty);
+    assert_eq!(liveness.summary_code(), LintSummaryCode::ExpectedEmpty);
+    assert_eq!(
+        liveness.recommendation_code(),
+        Some(LintRecommendationCode::ChooseModelSource)
+    );
+    // The substrate is still reported honestly; only the verdict changed.
+    assert_eq!(metric(liveness, LintMetricCode::EligibleRecords), 1);
+    assert_eq!(metric(liveness, LintMetricCode::AffectedRecords), 0);
+    // The report stays complete -- routing this through NotRunPrerequisite would
+    // make it incomplete and force exit 2 instead of 0.
+    assert!(report.complete());
+
+    // ...and this check stops contributing to the gate the CLI's exit code
+    // reads. The same store with a model source chosen counts it again.
+    let configured = run(&db, None, test_config(true)).await;
+    assert_eq!(check(&configured, LIVENESS).outcome(), LintOutcome::Finding);
+    assert!(configured.totals().actionable_findings() > report.totals().actionable_findings());
+}
+
+// Reporting bug in the same tracker row: liveness is an aggregate-only check --
+// it never produces evidence positions -- so it must never claim it truncated a
+// list of evidence it could not have produced.
+#[tokio::test]
+async fn aggregate_only_liveness_never_claims_truncated_evidence() {
+    let (db, _tmp) = test_db().await;
+    insert_memory(&db, "eligible", None).await;
+
+    let report = run(&db, None, test_config(true)).await;
+    let liveness = check(&report, LIVENESS);
+
+    assert_eq!(liveness.outcome(), LintOutcome::Finding);
+    assert_eq!(metric(liveness, LintMetricCode::AffectedRecords), 1);
+    assert!(liveness.evidence().is_empty());
+    assert!(!liveness.coverage().truncated());
+    assert_eq!(liveness.coverage().evidence_returned(), 0);
+}
+
 #[tokio::test]
 async fn duplicate_names_hubs_and_semantic_suspicion_are_advisory_only() {
     let (db, _tmp) = test_db().await;
@@ -199,7 +251,14 @@ async fn run(
 }
 
 fn test_config(serving_enabled: bool) -> super::KgRunConfig {
-    super::KgRunConfig::for_test(serving_enabled, true, true, 20)
+    test_config_with_model_source(serving_enabled, true)
+}
+
+fn test_config_with_model_source(
+    serving_enabled: bool,
+    model_source_configured: bool,
+) -> super::KgRunConfig {
+    super::KgRunConfig::for_test(serving_enabled, true, true, model_source_configured, 20)
 }
 
 fn check<'a>(

--- a/crates/wenlan-core/src/lint/runner.rs
+++ b/crates/wenlan-core/src/lint/runner.rs
@@ -208,7 +208,11 @@ impl LintRunner {
             #[cfg(not(test))]
             super::kg::KgRunConfig::capture()
         };
-        let serving_config = super::serving::capture(memory_config, kg_config.serving_enabled);
+        let serving_config = super::serving::capture(
+            memory_config,
+            kg_config.serving_enabled,
+            kg_config.model_source_configured,
+        );
         let semantic_provider_ready = self
             .semantic_provider
             .as_deref()

--- a/crates/wenlan-core/src/lint/serving.rs
+++ b/crates/wenlan-core/src/lint/serving.rs
@@ -31,6 +31,10 @@ pub(crate) struct ServingRunConfig {
     pub(crate) reranker_deep: bool,
     pub(crate) reranker_paths: u64,
     pub(crate) fact_limit: usize,
+    /// Whether the owner has chosen a model source. Threaded from
+    /// [`crate::lint::kg::KgRunConfig`] so both this check and
+    /// `kg.substrate_liveness` read one captured value.
+    model_source_configured: bool,
 }
 
 impl ServingRunConfig {
@@ -41,6 +45,7 @@ impl ServingRunConfig {
         fact_limit: usize,
         reranker_light: bool,
         reranker_deep: bool,
+        model_source_configured: bool,
     ) -> Self {
         Self {
             page,
@@ -53,15 +58,29 @@ impl ServingRunConfig {
             reranker_deep,
             reranker_paths: u64::from(reranker_light) + u64::from(reranker_deep),
             fact_limit,
+            model_source_configured,
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ChannelAssessment {
-    ExpectedEmpty { eligible: u64 },
-    Finding { eligible: u64 },
-    Live { eligible: u64, observed: u64 },
+    ExpectedEmpty {
+        eligible: u64,
+    },
+    /// The channel is on, but the substrate it serves is built by background
+    /// enrichment that has no model source to run on. Empty is the expected
+    /// state, and the fix is a settings choice, not a repair.
+    ModelSourceUnconfigured {
+        eligible: u64,
+    },
+    Finding {
+        eligible: u64,
+    },
+    Live {
+        eligible: u64,
+        observed: u64,
+    },
 }
 
 pub(crate) const fn assess_channel(
@@ -95,18 +114,24 @@ pub(crate) async fn run(
         route_scope_finding(bypasses),
         false,
     )];
-    for (id, enabled, count) in [
-        (CHANNEL_EPISODE_ID, config.episode, counts.episode),
-        (CHANNEL_FACT_ID, config.fact, counts.fact),
-        (CHANNEL_GRAPH_ID, config.graph, counts.graph),
-        (CHANNEL_PAGE_ID, config.page, counts.page),
-        (CHANNEL_SUMMARY_ID, config.summary, counts.summary),
+    // The graph channel is the one channel here whose substrate is built by
+    // model-backed background enrichment. With no model source chosen, an empty
+    // graph is the expected state, not a dead channel.
+    for (id, enabled, count, needs_model_source) in [
+        (CHANNEL_EPISODE_ID, config.episode, counts.episode, false),
+        (CHANNEL_FACT_ID, config.fact, counts.fact, false),
+        (CHANNEL_GRAPH_ID, config.graph, counts.graph, true),
+        (CHANNEL_PAGE_ID, config.page, counts.page, false),
+        (CHANNEL_SUMMARY_ID, config.summary, counts.summary, false),
     ] {
-        results.push(result::channel(
-            context,
-            id,
-            assess_channel(id, enabled, count.eligible, count.observed),
-        ));
+        let assessment = if enabled && needs_model_source && !config.model_source_configured {
+            ChannelAssessment::ModelSourceUnconfigured {
+                eligible: count.eligible,
+            }
+        } else {
+            assess_channel(id, enabled, count.eligible, count.observed)
+        };
+        results.push(result::channel(context, id, assessment));
     }
     let fact_probe = if config.fact {
         match fact_probe::run(context, config.fact_limit).await {

--- a/crates/wenlan-core/src/lint/serving/config.rs
+++ b/crates/wenlan-core/src/lint/serving/config.rs
@@ -1,7 +1,11 @@
 use super::ServingRunConfig;
 use crate::lint::memories::MemoryFeatureConfig;
 
-pub(crate) fn capture(memory: MemoryFeatureConfig, graph: bool) -> ServingRunConfig {
+pub(crate) fn capture(
+    memory: MemoryFeatureConfig,
+    graph: bool,
+    model_source_configured: bool,
+) -> ServingRunConfig {
     let mode = crate::reranker::reranker_mode_resolved(&crate::config::load_config());
     let legacy = std::env::var("WENLAN_RERANKER_ENABLED").as_deref() == Ok("1");
     let plan = crate::reranker::resolve_reranker_plan(mode, legacy);
@@ -12,5 +16,6 @@ pub(crate) fn capture(memory: MemoryFeatureConfig, graph: bool) -> ServingRunCon
         crate::retrieval::fact_channel::fact_channel_limit(),
         plan.light.is_some(),
         plan.deep.is_some(),
+        model_source_configured,
     )
 }

--- a/crates/wenlan-core/src/lint/serving/result.rs
+++ b/crates/wenlan-core/src/lint/serving/result.rs
@@ -1,9 +1,9 @@
 use super::{ChannelAssessment, OBSERVABILITY_ID, RERANKER_ID, ROUTE_SCOPE_ID};
 use crate::lint::context::{LintClock, LintContext, PopulationBasis};
 use wenlan_types::lint::{
-    LintApplicability, LintCheckResult, LintCheckResultInput, LintCoverage, LintEvidenceRef,
-    LintMetric, LintMetricCode, LintMetricValue, LintOpaqueId, LintOutcome, LintPrecondition,
-    LintRecommendationCode, LintSeverity, LintSummaryCode, LintValidationMethod,
+    LintActionCode, LintApplicability, LintCheckResult, LintCheckResultInput, LintCoverage,
+    LintEvidenceRef, LintMetric, LintMetricCode, LintMetricValue, LintOpaqueId, LintOutcome,
+    LintPrecondition, LintRecommendationCode, LintSeverity, LintSummaryCode, LintValidationMethod,
     LINT_MAX_EVIDENCE_PER_CHECK,
 };
 
@@ -207,15 +207,13 @@ fn build(clock: &LintClock, id: &'static str, spec: ResultSpec) -> LintCheckResu
         } else {
             LintSummaryCode::CheckPassed
         },
-        recommendation_code: if finding {
-            Some(LintRecommendationCode::ReviewFinding)
-        } else if state == ChannelState::ModelSourceUnconfigured {
-            Some(LintRecommendationCode::ChooseModelSource)
-        } else {
-            None
-        },
+        recommendation_code: finding.then_some(LintRecommendationCode::ReviewFinding),
         evidence,
         duration_ms: clock.duration_ms(),
     })
     .unwrap()
+    .with_action_code(
+        (state == ChannelState::ModelSourceUnconfigured)
+            .then_some(LintActionCode::ChooseModelSource),
+    )
 }

--- a/crates/wenlan-core/src/lint/serving/result.rs
+++ b/crates/wenlan-core/src/lint/serving/result.rs
@@ -17,12 +17,12 @@ pub(super) fn channel(
     id: &'static str,
     assessment: ChannelAssessment,
 ) -> LintCheckResult {
-    let (eligible, observed, finding, off) = parts(assessment);
+    let (eligible, observed, finding, state) = parts(assessment);
     let _ = context.record_population(id, selected_basis(context), eligible);
     build(
         context.clock(),
         id,
-        ResultSpec::new(eligible, observed, finding, off, false, finding),
+        ResultSpec::new(eligible, observed, finding, state, false, finding),
     )
 }
 
@@ -32,19 +32,35 @@ pub(super) fn channel_for_test(
     id: &'static str,
     assessment: ChannelAssessment,
 ) -> LintCheckResult {
-    let (eligible, observed, finding, off) = parts(assessment);
+    let (eligible, observed, finding, state) = parts(assessment);
     build(
         clock,
         id,
-        ResultSpec::new(eligible, observed, finding, off, false, finding),
+        ResultSpec::new(eligible, observed, finding, state, false, finding),
     )
 }
 
-fn parts(assessment: ChannelAssessment) -> (u64, u64, bool, bool) {
+/// Why a channel reported what it did — drives applicability, precondition, and
+/// whether the reader is told to do anything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelState {
+    Ready,
+    ConfiguredOff,
+    ModelSourceUnconfigured,
+}
+
+fn parts(assessment: ChannelAssessment) -> (u64, u64, bool, ChannelState) {
     match assessment {
-        ChannelAssessment::ExpectedEmpty { eligible } => (eligible, 0, false, true),
-        ChannelAssessment::Finding { eligible } => (eligible, 0, true, false),
-        ChannelAssessment::Live { eligible, observed } => (eligible, observed, false, false),
+        ChannelAssessment::ExpectedEmpty { eligible } => {
+            (eligible, 0, false, ChannelState::ConfiguredOff)
+        }
+        ChannelAssessment::ModelSourceUnconfigured { eligible } => {
+            (eligible, 0, false, ChannelState::ModelSourceUnconfigured)
+        }
+        ChannelAssessment::Finding { eligible } => (eligible, 0, true, ChannelState::Ready),
+        ChannelAssessment::Live { eligible, observed } => {
+            (eligible, observed, false, ChannelState::Ready)
+        }
     }
 }
 
@@ -68,7 +84,7 @@ pub(super) fn fixed(
             population,
             if finding { 0 } else { population },
             finding,
-            false,
+            ChannelState::Ready,
             inventory,
             finding && !matches!(id, ROUTE_SCOPE_ID | OBSERVABILITY_ID | RERANKER_ID),
         ),
@@ -87,7 +103,7 @@ struct ResultSpec {
     eligible: u64,
     observed: u64,
     finding: bool,
-    off: bool,
+    state: ChannelState,
     inventory: bool,
     evidence_allowed: bool,
 }
@@ -97,7 +113,7 @@ impl ResultSpec {
         eligible: u64,
         observed: u64,
         finding: bool,
-        off: bool,
+        state: ChannelState,
         inventory: bool,
         evidence_allowed: bool,
     ) -> Self {
@@ -105,7 +121,7 @@ impl ResultSpec {
             eligible,
             observed,
             finding,
-            off,
+            state,
             inventory,
             evidence_allowed,
         }
@@ -117,10 +133,11 @@ fn build(clock: &LintClock, id: &'static str, spec: ResultSpec) -> LintCheckResu
         eligible,
         observed,
         finding,
-        off,
+        state,
         inventory,
         evidence_allowed,
     } = spec;
+    let expected_empty = state != ChannelState::Ready;
     let evidence_cap = if evidence_allowed {
         eligible.min(u64::from(LINT_MAX_EVIDENCE_PER_CHECK))
     } else {
@@ -146,17 +163,17 @@ fn build(clock: &LintClock, id: &'static str, spec: ResultSpec) -> LintCheckResu
         } else {
             LintSeverity::Info
         },
-        applicability: if off {
+        applicability: if expected_empty {
             LintApplicability::ExpectedEmpty
         } else if inventory {
             LintApplicability::Inventory
         } else {
             LintApplicability::Applicable
         },
-        precondition: if off {
-            LintPrecondition::ConfiguredOff
-        } else {
-            LintPrecondition::Ready
+        precondition: match state {
+            ChannelState::Ready => LintPrecondition::Ready,
+            ChannelState::ConfiguredOff => LintPrecondition::ConfiguredOff,
+            ChannelState::ModelSourceUnconfigured => LintPrecondition::ExpectedEmpty,
         },
         coverage: LintCoverage::new(
             LintValidationMethod::ExactAggregate,
@@ -185,12 +202,18 @@ fn build(clock: &LintClock, id: &'static str, spec: ResultSpec) -> LintCheckResu
         ],
         summary_code: if finding {
             LintSummaryCode::FindingDetected
-        } else if off {
+        } else if expected_empty {
             LintSummaryCode::ExpectedEmpty
         } else {
             LintSummaryCode::CheckPassed
         },
-        recommendation_code: finding.then_some(LintRecommendationCode::ReviewFinding),
+        recommendation_code: if finding {
+            Some(LintRecommendationCode::ReviewFinding)
+        } else if state == ChannelState::ModelSourceUnconfigured {
+            Some(LintRecommendationCode::ChooseModelSource)
+        } else {
+            None
+        },
         evidence,
         duration_ms: clock.duration_ms(),
     })

--- a/crates/wenlan-core/src/lint/serving_test.rs
+++ b/crates/wenlan-core/src/lint/serving_test.rs
@@ -3,8 +3,8 @@ use crate::db::tests::test_db;
 use crate::lint::context::{CancellationToken, LintClock};
 use crate::lint::runner::LintRunner;
 use wenlan_types::lint::{
-    LintApplicability, LintMetricCode, LintMetricValue, LintOutcome, LintPrecondition, LintQuery,
-    LintRecommendationCode, LintSummaryCode,
+    LintActionCode, LintApplicability, LintMetricCode, LintMetricValue, LintOutcome,
+    LintPrecondition, LintQuery, LintSummaryCode,
 };
 
 #[path = "serving_review_fact_test.rs"]
@@ -55,9 +55,10 @@ fn graph_channel_without_a_model_source_passes_and_says_to_choose_one() {
     assert_eq!(result.applicability(), LintApplicability::ExpectedEmpty);
     assert_eq!(result.precondition(), LintPrecondition::ExpectedEmpty);
     assert_eq!(result.summary_code(), LintSummaryCode::ExpectedEmpty);
+    assert_eq!(result.recommendation_code(), None);
     assert_eq!(
-        result.recommendation_code(),
-        Some(LintRecommendationCode::ChooseModelSource)
+        result.action_code(),
+        Some(LintActionCode::ChooseModelSource)
     );
     // No opaque ordinals for a state that is not a defect.
     assert!(result.evidence().is_empty());
@@ -80,16 +81,15 @@ async fn the_model_source_pin_reaches_only_the_graph_channel_through_the_runner(
     assert_eq!(graph.outcome(), LintOutcome::Pass);
     assert_eq!(graph.applicability(), LintApplicability::ExpectedEmpty);
     assert_eq!(graph.precondition(), LintPrecondition::ExpectedEmpty);
-    assert_eq!(
-        graph.recommendation_code(),
-        Some(LintRecommendationCode::ChooseModelSource)
-    );
+    assert_eq!(graph.recommendation_code(), None);
+    assert_eq!(graph.action_code(), Some(LintActionCode::ChooseModelSource));
     assert!(unconfigured.complete());
 
     // The fact channel is off in this fixture and stays configured-off.
     let fact = channel(&unconfigured, CHANNEL_FACT_ID);
     assert_eq!(fact.precondition(), LintPrecondition::ConfiguredOff);
     assert_eq!(fact.recommendation_code(), None);
+    assert_eq!(fact.action_code(), None);
 
     // The same store with a model source chosen: the graph channel and the kg
     // liveness check are exactly what the fresh-store report stops gating on.

--- a/crates/wenlan-core/src/lint/serving_test.rs
+++ b/crates/wenlan-core/src/lint/serving_test.rs
@@ -1,10 +1,10 @@
-use super::{assess_channel, ChannelAssessment, CHANNEL_FACT_ID, ROUTE_SCOPE_ID};
+use super::{assess_channel, ChannelAssessment, CHANNEL_FACT_ID, CHANNEL_GRAPH_ID, ROUTE_SCOPE_ID};
 use crate::db::tests::test_db;
 use crate::lint::context::{CancellationToken, LintClock};
 use crate::lint::runner::LintRunner;
 use wenlan_types::lint::{
     LintApplicability, LintMetricCode, LintMetricValue, LintOutcome, LintPrecondition, LintQuery,
-    LintSummaryCode,
+    LintRecommendationCode, LintSummaryCode,
 };
 
 #[path = "serving_review_fact_test.rs"]
@@ -37,6 +37,132 @@ fn disabled_channel_is_expected_empty() {
     assert_eq!(result.applicability(), LintApplicability::ExpectedEmpty);
     assert_eq!(result.precondition(), LintPrecondition::ConfiguredOff);
     assert_eq!(result.summary_code(), LintSummaryCode::ExpectedEmpty);
+}
+
+// Tracker row 17: the graph channel serves a substrate that model-backed
+// background enrichment builds. With no model source chosen, an empty channel
+// is the expected state and the fix is a settings choice, not a repair -- so it
+// passes, carries the "choose a model source" advice, and does not gate a fresh
+// install's exit code.
+#[test]
+fn graph_channel_without_a_model_source_passes_and_says_to_choose_one() {
+    let result = super::channel_result(
+        &LintClock::fixed(),
+        CHANNEL_GRAPH_ID,
+        ChannelAssessment::ModelSourceUnconfigured { eligible: 2 },
+    );
+    assert_eq!(result.outcome(), LintOutcome::Pass);
+    assert_eq!(result.applicability(), LintApplicability::ExpectedEmpty);
+    assert_eq!(result.precondition(), LintPrecondition::ExpectedEmpty);
+    assert_eq!(result.summary_code(), LintSummaryCode::ExpectedEmpty);
+    assert_eq!(
+        result.recommendation_code(),
+        Some(LintRecommendationCode::ChooseModelSource)
+    );
+    // No opaque ordinals for a state that is not a defect.
+    assert!(result.evidence().is_empty());
+    assert!(!result.coverage().truncated());
+    assert_eq!(result.coverage().denominator(), 2);
+}
+
+// End to end through the runner: the captured model-source pin reaches the
+// graph channel, and it is the only channel it reaches. A channel the owner
+// switched off keeps saying so rather than nagging about a model source it will
+// not use, and dropping the graph finding takes the report's actionable count
+// down with it.
+#[tokio::test]
+async fn the_model_source_pin_reaches_only_the_graph_channel_through_the_runner() {
+    let (db, _tmp) = test_db().await;
+    insert_memory(&db, "eligible", None).await;
+
+    let unconfigured = run_with_kg_config(&db, kg_config(false)).await;
+    let graph = channel(&unconfigured, CHANNEL_GRAPH_ID);
+    assert_eq!(graph.outcome(), LintOutcome::Pass);
+    assert_eq!(graph.applicability(), LintApplicability::ExpectedEmpty);
+    assert_eq!(graph.precondition(), LintPrecondition::ExpectedEmpty);
+    assert_eq!(
+        graph.recommendation_code(),
+        Some(LintRecommendationCode::ChooseModelSource)
+    );
+    assert!(unconfigured.complete());
+
+    // The fact channel is off in this fixture and stays configured-off.
+    let fact = channel(&unconfigured, CHANNEL_FACT_ID);
+    assert_eq!(fact.precondition(), LintPrecondition::ConfiguredOff);
+    assert_eq!(fact.recommendation_code(), None);
+
+    // The same store with a model source chosen: the graph channel and the kg
+    // liveness check are exactly what the fresh-store report stops gating on.
+    let configured = run_with_kg_config(&db, kg_config(true)).await;
+    assert_eq!(
+        channel(&configured, CHANNEL_GRAPH_ID).outcome(),
+        LintOutcome::Finding
+    );
+    let mut newly_gating = actionable_ids(&configured);
+    for id in actionable_ids(&unconfigured) {
+        assert!(newly_gating.remove(&id), "{id} lost its finding");
+    }
+    assert_eq!(
+        newly_gating,
+        ["kg.substrate_liveness", CHANNEL_GRAPH_ID]
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    );
+}
+
+fn actionable_ids(report: &wenlan_types::lint::LintReport) -> std::collections::BTreeSet<String> {
+    report
+        .checks()
+        .iter()
+        .filter(|check| {
+            check.outcome() == LintOutcome::Finding
+                && check.gate_effect() == wenlan_types::lint::LintGateEffect::Actionable
+        })
+        .map(|check| check.check_id().to_string())
+        .collect()
+}
+
+fn kg_config(model_source_configured: bool) -> crate::lint::kg::KgRunConfig {
+    crate::lint::kg::KgRunConfig::for_test(true, true, true, model_source_configured, 20)
+}
+
+async fn run_with_kg_config(
+    db: &crate::db::MemoryDB,
+    config: crate::lint::kg::KgRunConfig,
+) -> wenlan_types::lint::LintReport {
+    temp_env::async_with_vars(
+        [
+            ("WENLAN_ENABLE_PAGE_CHANNEL", Some("0")),
+            ("WENLAN_ENABLE_EPISODE_CHANNEL", Some("0")),
+            ("WENLAN_ENABLE_FACT_CHANNEL", Some("0")),
+            ("WENLAN_ENABLE_GLOBAL_PRELUDE", Some("0")),
+        ],
+        LintRunner::new(LintClock::fixed(), CancellationToken::new())
+            .with_test_kg_config(config)
+            .run(
+                db,
+                &LintQuery {
+                    profile: None,
+                    space: None,
+                },
+                None,
+                false,
+            ),
+    )
+    .await
+    .unwrap()
+}
+
+fn channel<'a>(
+    report: &'a wenlan_types::lint::LintReport,
+    id: &str,
+) -> &'a wenlan_types::lint::LintCheckResult {
+    report
+        .checks()
+        .iter()
+        .find(|check| check.check_id() == id)
+        .unwrap()
 }
 
 #[tokio::test]

--- a/crates/wenlan-core/src/truth_manifest.rs
+++ b/crates/wenlan-core/src/truth_manifest.rs
@@ -409,6 +409,7 @@ pub const CLI_READERS: &[CliReader] = &[
     CliReader { subcommand: "wenlan spaces", page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "subcommand renderer" },
     CliReader { subcommand: "wenlan outbox", page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "subcommand renderer" },
     CliReader { subcommand: "wenlan entities", page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "subcommand renderer" },
+    CliReader { subcommand: "wenlan sweep", page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "subcommand renderer" },
 ];
 
 /// Look up a registered HTTP reader by its runtime identity.

--- a/crates/wenlan-core/src/truth_manifest.rs
+++ b/crates/wenlan-core/src/truth_manifest.rs
@@ -384,7 +384,7 @@ pub const MCP_READERS: &[McpReader] = &[
     McpReader { tool: "write_page", page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "tool handler" },
 ];
 
-/// All 22 top-level `Commands` variants in `crates/wenlan-cli/src/main.rs`.
+/// All 23 top-level `Commands` variants in `crates/wenlan-cli/src/main.rs`.
 #[rustfmt::skip]
 pub const CLI_READERS: &[CliReader] = &[
     CliReader { subcommand: "wenlan status", page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "subcommand renderer" },

--- a/crates/wenlan-types/src/lint_catalog.rs
+++ b/crates/wenlan-types/src/lint_catalog.rs
@@ -186,10 +186,6 @@ pub enum LintRecommendationCode {
     RestorePrerequisite,
     RerunAfterSnapshotStabilizes,
     InspectRuntime,
-    /// The check needs a model source and none is chosen yet. Pairs with a
-    /// passing, expected-empty verdict: nothing is broken, the owner simply has
-    /// not picked where inference runs.
-    ChooseModelSource,
 }
 impl LintRecommendationCode {
     /// One plain sentence saying what to do next. See [`LintSummaryCode::meaning`].
@@ -205,6 +201,33 @@ impl LintRecommendationCode {
             Self::InspectRuntime => {
                 "Check the daemon logs for the error behind this, then run `wenlan lint` again."
             }
+        }
+    }
+}
+/// Something the owner can do about a check that is *not* a defect.
+///
+/// This is deliberately a separate field from `recommendation_code` rather than
+/// a fifth variant of it. `recommendation_code` is part of the frozen
+/// `LINT_REPORT_SCHEMA_VERSION` 5 wire shape, and a patch-ahead daemon is
+/// explicitly compatible with an older CLI or MCP client
+/// (`wenlan-mcp/src/version_check.rs`). Serde rejects an unknown enum variant,
+/// so teaching the daemon to emit a fifth `recommendation_code` would make an
+/// old reader fail to parse the whole report; an added optional *field* is
+/// simply ignored by that same reader, because `LintCheckResultInput` does not
+/// deny unknown fields. Additive field now, enum variant at the next schema
+/// bump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LintActionCode {
+    /// The check needs a model source and none is chosen yet. Pairs with a
+    /// passing, expected-empty verdict: nothing is broken, the owner simply has
+    /// not picked where inference runs.
+    ChooseModelSource,
+}
+impl LintActionCode {
+    /// One plain sentence saying what to do next. See [`LintSummaryCode::meaning`].
+    pub const fn action(self) -> &'static str {
+        match self {
             Self::ChooseModelSource => {
                 "Run `wenlan setup` and choose a model source so Wenlan can build this in the background."
             }

--- a/crates/wenlan-types/src/lint_catalog.rs
+++ b/crates/wenlan-types/src/lint_catalog.rs
@@ -152,6 +152,33 @@ pub enum LintSummaryCode {
     ExecutionFailed,
     ExpectedEmpty,
 }
+impl LintSummaryCode {
+    /// One plain sentence saying what this outcome means for the reader.
+    ///
+    /// Every surface that shows a check line pairs this with
+    /// [`LintRecommendationCode::action`] so the reader never has to decode a
+    /// snake_case code. The table lives here, beside the codes, because the
+    /// CLI and the MCP tool both render it; `wenlan-types` stays dependency
+    /// free, so these are plain `&'static str`.
+    pub const fn meaning(self) -> &'static str {
+        match self {
+            Self::CheckPassed => "This check looked at everything it covers and found nothing wrong.",
+            Self::FindingDetected => {
+                "This check found records that do not match what Wenlan expects."
+            }
+            Self::PrerequisiteUnavailable => {
+                "This check could not run because something it depends on was missing."
+            }
+            Self::SnapshotInconsistent => {
+                "Your data changed while this check was reading it, so its answer is not trustworthy."
+            }
+            Self::ExecutionFailed => "This check hit an error and did not finish.",
+            Self::ExpectedEmpty => {
+                "There was nothing here to check, which is the expected state right now."
+            }
+        }
+    }
+}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LintRecommendationCode {
@@ -159,6 +186,30 @@ pub enum LintRecommendationCode {
     RestorePrerequisite,
     RerunAfterSnapshotStabilizes,
     InspectRuntime,
+    /// The check needs a model source and none is chosen yet. Pairs with a
+    /// passing, expected-empty verdict: nothing is broken, the owner simply has
+    /// not picked where inference runs.
+    ChooseModelSource,
+}
+impl LintRecommendationCode {
+    /// One plain sentence saying what to do next. See [`LintSummaryCode::meaning`].
+    pub const fn action(self) -> &'static str {
+        match self {
+            Self::ReviewFinding => "Look at the listed records and fix or dismiss them.",
+            Self::RestorePrerequisite => {
+                "Restore the missing piece this check needs, then run `wenlan lint` again."
+            }
+            Self::RerunAfterSnapshotStabilizes => {
+                "Run `wenlan lint` again once writes have settled."
+            }
+            Self::InspectRuntime => {
+                "Check the daemon logs for the error behind this, then run `wenlan lint` again."
+            }
+            Self::ChooseModelSource => {
+                "Run `wenlan setup` and choose a model source so Wenlan can build this in the background."
+            }
+        }
+    }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/crates/wenlan-types/src/lint_check.rs
+++ b/crates/wenlan-types/src/lint_check.rs
@@ -14,6 +14,12 @@ pub struct LintCheckResult {
     metrics: Vec<LintMetric>,
     summary_code: LintSummaryCode,
     recommendation_code: Option<LintRecommendationCode>,
+    /// Additive since schema 5; see [`LintActionCode`] for why this is a field
+    /// and not a fifth `recommendation_code` variant. Omitted from the wire
+    /// entirely when absent, so a report that carries no action serializes
+    /// exactly as it did before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    action_code: Option<LintActionCode>,
     evidence: Vec<LintEvidenceRef>,
     duration_ms: u64,
 }
@@ -37,6 +43,11 @@ struct LintCheckResultWire {
     input: LintCheckResultInput,
     #[serde(default)]
     gate_effect: LintGateEffect,
+    /// Read outside `LintCheckResultInput` on purpose: the input struct is the
+    /// frozen schema-5 shape that older readers also parse, and keeping the
+    /// additive field out of it means the two stay the same struct.
+    #[serde(default)]
+    action_code: Option<LintActionCode>,
 }
 impl LintCheckResult {
     pub fn try_new(input: LintCheckResultInput) -> Result<Self, LintContractError> {
@@ -134,9 +145,21 @@ impl LintCheckResult {
             metrics,
             summary_code,
             recommendation_code,
+            action_code: None,
             evidence,
             duration_ms,
         })
+    }
+
+    /// Attach an owner-facing action to an already legal result.
+    ///
+    /// Separate from `try_new` so the ~20 existing `LintCheckResultInput`
+    /// literals in the tree keep compiling unchanged; only a producer that has
+    /// something to ask of the owner calls this.
+    #[must_use]
+    pub fn with_action_code(mut self, action_code: Option<LintActionCode>) -> Self {
+        self.action_code = action_code;
+        self
     }
     pub fn check_id(&self) -> &str {
         &self.check_id
@@ -168,6 +191,9 @@ impl LintCheckResult {
     pub const fn recommendation_code(&self) -> Option<LintRecommendationCode> {
         self.recommendation_code
     }
+    pub const fn action_code(&self) -> Option<LintActionCode> {
+        self.action_code
+    }
     pub fn evidence(&self) -> &[LintEvidenceRef] {
         &self.evidence
     }
@@ -181,6 +207,8 @@ impl<'de> Deserialize<'de> for LintCheckResult {
         D: Deserializer<'de>,
     {
         let wire = LintCheckResultWire::deserialize(deserializer)?;
-        Self::try_new_with_gate_effect(wire.input, wire.gate_effect).map_err(D::Error::custom)
+        Self::try_new_with_gate_effect(wire.input, wire.gate_effect)
+            .map(|result| result.with_action_code(wire.action_code))
+            .map_err(D::Error::custom)
     }
 }

--- a/crates/wenlan-types/src/lint_config.rs
+++ b/crates/wenlan-types/src/lint_config.rs
@@ -30,6 +30,7 @@ pub enum LintConfigSetting {
     SemanticProviderOnDevice,
     SemanticExternalEgressEnabled,
     SemanticCallingAgentEnabled,
+    ModelSourceConfigured,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -93,6 +94,7 @@ impl LintConfigSelection {
             LintConfigSetting::SemanticProviderOnDevice => 24,
             LintConfigSetting::SemanticExternalEgressEnabled => 25,
             LintConfigSetting::SemanticCallingAgentEnabled => 26,
+            LintConfigSetting::ModelSourceConfigured => 27,
         };
         let mut bytes = vec![setting];
         match self.value {

--- a/crates/wenlan-types/src/lint_tests.rs
+++ b/crates/wenlan-types/src/lint_tests.rs
@@ -773,3 +773,91 @@ fn coverage_deserialization_preserves_valid_methods_and_additive_fields() {
         assert!(coverage.is_ok());
     }
 }
+
+const ALL_SUMMARY_CODES: [LintSummaryCode; 6] = [
+    LintSummaryCode::CheckPassed,
+    LintSummaryCode::FindingDetected,
+    LintSummaryCode::PrerequisiteUnavailable,
+    LintSummaryCode::SnapshotInconsistent,
+    LintSummaryCode::ExecutionFailed,
+    LintSummaryCode::ExpectedEmpty,
+];
+
+const ALL_RECOMMENDATION_CODES: [LintRecommendationCode; 5] = [
+    LintRecommendationCode::ReviewFinding,
+    LintRecommendationCode::RestorePrerequisite,
+    LintRecommendationCode::RerunAfterSnapshotStabilizes,
+    LintRecommendationCode::InspectRuntime,
+    LintRecommendationCode::ChooseModelSource,
+];
+
+// The match arms are exhaustive by the compiler. What a test has to hold is
+// that nobody satisfied the compiler with a shared placeholder: every code says
+// its own thing, in a full sentence, so a rendered line reads as English.
+#[test]
+fn every_summary_and_recommendation_code_carries_its_own_plain_sentence() {
+    let meanings = ALL_SUMMARY_CODES
+        .iter()
+        .map(|code| code.meaning())
+        .collect::<Vec<_>>();
+    let actions = ALL_RECOMMENDATION_CODES
+        .iter()
+        .map(|code| code.action())
+        .collect::<Vec<_>>();
+
+    for sentence in meanings.iter().chain(actions.iter()) {
+        assert!(sentence.len() > 20, "{sentence:?} is not a sentence");
+        assert!(sentence.ends_with('.'), "{sentence:?} is not a sentence");
+        assert!(
+            !sentence.to_ascii_lowercase().contains("unknown"),
+            "{sentence:?} is a fallback, not a sentence"
+        );
+    }
+
+    assert_eq!(
+        meanings
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        meanings.len()
+    );
+    assert_eq!(
+        actions
+            .iter()
+            .collect::<std::collections::BTreeSet<_>>()
+            .len(),
+        actions.len()
+    );
+    assert!(LintRecommendationCode::ChooseModelSource
+        .action()
+        .contains("model source"));
+}
+
+// A passing, expected-empty check is allowed to carry advice: nothing is wrong,
+// the owner simply has to choose a model source before the substrate can exist.
+// This shape must stay legal and must round-trip on the wire.
+#[test]
+fn expected_empty_pass_may_recommend_choosing_a_model_source() {
+    let result = LintCheckResult::try_new(LintCheckResultInput {
+        check_id: "kg.substrate_liveness".to_string(),
+        outcome: LintOutcome::Pass,
+        severity: LintSeverity::Info,
+        applicability: LintApplicability::ExpectedEmpty,
+        precondition: LintPrecondition::ExpectedEmpty,
+        coverage: coverage(0),
+        metrics: vec![],
+        summary_code: LintSummaryCode::ExpectedEmpty,
+        recommendation_code: Some(LintRecommendationCode::ChooseModelSource),
+        evidence: vec![],
+        duration_ms: 0,
+    })
+    .expect("expected-empty pass with advice is a legal check result");
+
+    let encoded = serde_json::to_value(&result).unwrap();
+    assert_eq!(encoded["recommendation_code"], json!("choose_model_source"));
+    assert_eq!(encoded["precondition"], json!("expected_empty"));
+    assert_eq!(
+        serde_json::from_value::<LintCheckResult>(encoded).unwrap(),
+        result
+    );
+}

--- a/crates/wenlan-types/src/lint_tests.rs
+++ b/crates/wenlan-types/src/lint_tests.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
+use serde::Deserialize;
 use serde_json::json;
 
 fn coverage(authorized_denominator: u64) -> LintCoverage {
@@ -783,13 +784,14 @@ const ALL_SUMMARY_CODES: [LintSummaryCode; 6] = [
     LintSummaryCode::ExpectedEmpty,
 ];
 
-const ALL_RECOMMENDATION_CODES: [LintRecommendationCode; 5] = [
+const ALL_RECOMMENDATION_CODES: [LintRecommendationCode; 4] = [
     LintRecommendationCode::ReviewFinding,
     LintRecommendationCode::RestorePrerequisite,
     LintRecommendationCode::RerunAfterSnapshotStabilizes,
     LintRecommendationCode::InspectRuntime,
-    LintRecommendationCode::ChooseModelSource,
 ];
+
+const ALL_ACTION_CODES: [LintActionCode; 1] = [LintActionCode::ChooseModelSource];
 
 // The match arms are exhaustive by the compiler. What a test has to hold is
 // that nobody satisfied the compiler with a shared placeholder: every code says
@@ -803,6 +805,7 @@ fn every_summary_and_recommendation_code_carries_its_own_plain_sentence() {
     let actions = ALL_RECOMMENDATION_CODES
         .iter()
         .map(|code| code.action())
+        .chain(ALL_ACTION_CODES.iter().map(|code| code.action()))
         .collect::<Vec<_>>();
 
     for sentence in meanings.iter().chain(actions.iter()) {
@@ -828,17 +831,16 @@ fn every_summary_and_recommendation_code_carries_its_own_plain_sentence() {
             .len(),
         actions.len()
     );
-    assert!(LintRecommendationCode::ChooseModelSource
+    assert!(LintActionCode::ChooseModelSource
         .action()
         .contains("model source"));
 }
 
-// A passing, expected-empty check is allowed to carry advice: nothing is wrong,
-// the owner simply has to choose a model source before the substrate can exist.
-// This shape must stay legal and must round-trip on the wire.
-#[test]
-fn expected_empty_pass_may_recommend_choosing_a_model_source() {
-    let result = LintCheckResult::try_new(LintCheckResultInput {
+/// The fresh-store shape: a passing, expected-empty check that still has one
+/// thing to ask of the owner. Nothing is wrong, so `recommendation_code` stays
+/// empty; the ask travels in the additive `action_code` field.
+fn fresh_store_check() -> LintCheckResult {
+    LintCheckResult::try_new(LintCheckResultInput {
         check_id: "kg.substrate_liveness".to_string(),
         outcome: LintOutcome::Pass,
         severity: LintSeverity::Info,
@@ -847,17 +849,107 @@ fn expected_empty_pass_may_recommend_choosing_a_model_source() {
         coverage: coverage(0),
         metrics: vec![],
         summary_code: LintSummaryCode::ExpectedEmpty,
-        recommendation_code: Some(LintRecommendationCode::ChooseModelSource),
+        recommendation_code: None,
         evidence: vec![],
         duration_ms: 0,
     })
-    .expect("expected-empty pass with advice is a legal check result");
+    .expect("expected-empty pass with an action is a legal check result")
+    .with_action_code(Some(LintActionCode::ChooseModelSource))
+}
+
+// A passing, expected-empty check is allowed to carry advice: nothing is wrong,
+// the owner simply has to choose a model source before the substrate can exist.
+// This shape must stay legal and must round-trip on the wire.
+#[test]
+fn expected_empty_pass_may_carry_a_choose_model_source_action() {
+    let result = fresh_store_check();
 
     let encoded = serde_json::to_value(&result).unwrap();
-    assert_eq!(encoded["recommendation_code"], json!("choose_model_source"));
+    assert_eq!(encoded["action_code"], json!("choose_model_source"));
     assert_eq!(encoded["precondition"], json!("expected_empty"));
+    // The frozen schema-5 field stays empty: a pass is not a recommendation.
+    assert!(encoded
+        .get("recommendation_code")
+        .is_none_or(serde_json::Value::is_null));
     assert_eq!(
         serde_json::from_value::<LintCheckResult>(encoded).unwrap(),
         result
     );
+}
+
+// A check with nothing to ask of the owner must serialize exactly as it did
+// before `action_code` existed -- the key is absent, not null.
+#[test]
+fn a_check_without_an_action_does_not_grow_a_wire_key() {
+    let result = LintCheckResult::try_new(LintCheckResultInput {
+        check_id: "kg.substrate_liveness".to_string(),
+        outcome: LintOutcome::Pass,
+        severity: LintSeverity::Info,
+        applicability: LintApplicability::ExpectedEmpty,
+        precondition: LintPrecondition::ConfiguredOff,
+        coverage: coverage(0),
+        metrics: vec![],
+        summary_code: LintSummaryCode::ExpectedEmpty,
+        recommendation_code: None,
+        evidence: vec![],
+        duration_ms: 0,
+    })
+    .expect("configured-off pass is a legal check result");
+
+    let encoded = serde_json::to_value(&result).unwrap();
+    assert!(
+        encoded.get("action_code").is_none(),
+        "absent action must not appear on the wire: {encoded}"
+    );
+}
+
+/// A byte-for-byte copy of the `recommendation_code` enum as it stands in the
+/// released schema-5 wire shape (base `43c00470`). Frozen on purpose: it must
+/// NOT gain variants when the live enum does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FrozenRecommendationCode {
+    ReviewFinding,
+    RestorePrerequisite,
+    RerunAfterSnapshotStabilizes,
+    InspectRuntime,
+}
+
+/// A copy of `LintCheckResultInput` as an older CLI or MCP client parses it.
+/// Like the real one it does not deny unknown fields, so an added field is
+/// ignored -- but serde rejects an unknown *enum variant*, which is exactly the
+/// break this test exists to catch.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct FrozenReaderCheck {
+    check_id: String,
+    outcome: LintOutcome,
+    severity: LintSeverity,
+    applicability: LintApplicability,
+    precondition: LintPrecondition,
+    coverage: LintCoverage,
+    metrics: Vec<LintMetric>,
+    summary_code: LintSummaryCode,
+    recommendation_code: Option<FrozenRecommendationCode>,
+    evidence: Vec<LintEvidenceRef>,
+    duration_ms: u64,
+}
+
+// Patch-ahead daemons are explicitly compatible with older clients
+// (`wenlan-mcp/src/version_check.rs`), so a daemon on this build must not emit
+// a report that a client on the released schema-5 shape cannot parse. Putting
+// `choose_model_source` into `recommendation_code` would do exactly that.
+#[test]
+fn a_frozen_schema_five_reader_still_parses_the_fresh_store_check() {
+    let encoded = serde_json::to_value(fresh_store_check()).unwrap();
+    assert_eq!(encoded["action_code"], json!("choose_model_source"));
+
+    let old = serde_json::from_value::<FrozenReaderCheck>(encoded)
+        .expect("a released schema-5 reader must still parse this check");
+
+    assert_eq!(old.check_id, "kg.substrate_liveness");
+    assert_eq!(old.outcome, LintOutcome::Pass);
+    assert_eq!(old.precondition, LintPrecondition::ExpectedEmpty);
+    assert_eq!(old.summary_code, LintSummaryCode::ExpectedEmpty);
+    // The old reader simply does not see the action; it does not choke on it.
+    assert_eq!(old.recommendation_code, None);
 }

--- a/crates/wenlan-types/tests/plugin_distribution.rs
+++ b/crates/wenlan-types/tests/plugin_distribution.rs
@@ -148,6 +148,78 @@ fn pages_skill_replaces_read() {
     }
 }
 
+// The MCP surface hands the agent raw snake_case codes; the plain sentence the
+// CLI prints is not in that payload. Both lint skills therefore carry the
+// mapping in prose -- and it has to stay the *same* prose, so this test reads
+// the sentences straight off the enums rather than from a second hardcoded
+// copy.
+#[test]
+fn both_lint_skills_spell_out_every_check_code_in_plain_english() {
+    use wenlan_types::lint::{LintActionCode, LintRecommendationCode, LintSummaryCode};
+
+    let expected: Vec<(&str, &str)> = vec![
+        ("check_passed", LintSummaryCode::CheckPassed.meaning()),
+        (
+            "finding_detected",
+            LintSummaryCode::FindingDetected.meaning(),
+        ),
+        (
+            "prerequisite_unavailable",
+            LintSummaryCode::PrerequisiteUnavailable.meaning(),
+        ),
+        (
+            "snapshot_inconsistent",
+            LintSummaryCode::SnapshotInconsistent.meaning(),
+        ),
+        (
+            "execution_failed",
+            LintSummaryCode::ExecutionFailed.meaning(),
+        ),
+        ("expected_empty", LintSummaryCode::ExpectedEmpty.meaning()),
+        (
+            "review_finding",
+            LintRecommendationCode::ReviewFinding.action(),
+        ),
+        (
+            "restore_prerequisite",
+            LintRecommendationCode::RestorePrerequisite.action(),
+        ),
+        (
+            "rerun_after_snapshot_stabilizes",
+            LintRecommendationCode::RerunAfterSnapshotStabilizes.action(),
+        ),
+        (
+            "inspect_runtime",
+            LintRecommendationCode::InspectRuntime.action(),
+        ),
+        (
+            "choose_model_source",
+            LintActionCode::ChooseModelSource.action(),
+        ),
+    ];
+
+    for path in [
+        "plugin/skills/lint/SKILL.md",
+        "plugin-codex/skills/lint/SKILL.md",
+    ] {
+        let text = read_text(path);
+        for (code, sentence) in &expected {
+            assert!(
+                text.contains(&format!("`{code}`")),
+                "{path} never names the `{code}` code"
+            );
+            assert!(
+                text.contains(sentence),
+                "{path} does not say what `{code}` means: expected {sentence:?}"
+            );
+        }
+        assert!(
+            text.contains("does not count toward actionable"),
+            "{path} must say a passing check with an action is not a finding"
+        );
+    }
+}
+
 #[test]
 fn lint_is_the_only_public_repair_flow_on_both_surfaces() {
     for path in [

--- a/plugin-codex/skills/lint/SKILL.md
+++ b/plugin-codex/skills/lint/SKILL.md
@@ -68,6 +68,52 @@ denominator, evaluated, and truncation metadata. Unjudged packet candidates,
 provider failure, or unresolved disagreement are never clean. Do not expose
 packet excerpts.
 
+## Say what each code means
+
+The report identifies every check with stable snake_case codes. Never show a
+code on its own: pair it with the plain sentence below so the reader does not
+have to decode it. These sentences are the same ones `wenlan lint` prints, and
+they come from `LintSummaryCode::meaning`, `LintRecommendationCode::action`,
+and `LintActionCode::action` in `wenlan-types`. If the daemon sends a code that
+is not listed here, show the code and say it is unrecognized; never invent a
+sentence for it.
+
+`summary_code` -- what the check found:
+
+| code | say |
+|---|---|
+| `check_passed` | This check looked at everything it covers and found nothing wrong. |
+| `finding_detected` | This check found records that do not match what Wenlan expects. |
+| `prerequisite_unavailable` | This check could not run because something it depends on was missing. |
+| `snapshot_inconsistent` | Your data changed while this check was reading it, so its answer is not trustworthy. |
+| `execution_failed` | This check hit an error and did not finish. |
+| `expected_empty` | There was nothing here to check, which is the expected state right now. |
+
+`recommendation_code` -- what to do about a problem. Present only when
+something is actually wrong:
+
+| code | say |
+|---|---|
+| `review_finding` | Look at the listed records and fix or dismiss them. |
+| `restore_prerequisite` | Restore the missing piece this check needs, then run `wenlan lint` again. |
+| `rerun_after_snapshot_stabilizes` | Run `wenlan lint` again once writes have settled. |
+| `inspect_runtime` | Check the daemon logs for the error behind this, then run `wenlan lint` again. |
+
+`action_code` -- an optional field carrying something the owner can do about a
+check that is **not** a defect. It may be absent entirely, and older daemons
+never send it:
+
+| code | say |
+|---|---|
+| `choose_model_source` | Run `wenlan setup` and choose a model source so Wenlan can build this in the background. |
+
+A passing check that carries an `action_code` is waiting on the owner, not
+broken. Report it separately from findings: it does not count toward actionable
+findings and does not make the state `findings`. A fresh store where nobody has
+chosen a model source yet is the common case -- `kg.substrate_liveness` and
+`serving.channel.graph` both come back as passing, expected-empty checks asking
+for a model source, and that report is `clean`.
+
 ## `/lint repair`: resolve the complete plan
 
 There is no live-data auto-repair or automatic rollback.

--- a/plugin/skills/lint/SKILL.md
+++ b/plugin/skills/lint/SKILL.md
@@ -67,6 +67,52 @@ denominator, evaluated, and truncation metadata. Unjudged packet candidates,
 provider failure, or unresolved disagreement are never clean. Do not expose
 packet excerpts.
 
+## Say what each code means
+
+The report identifies every check with stable snake_case codes. Never show a
+code on its own: pair it with the plain sentence below so the reader does not
+have to decode it. These sentences are the same ones `wenlan lint` prints, and
+they come from `LintSummaryCode::meaning`, `LintRecommendationCode::action`,
+and `LintActionCode::action` in `wenlan-types`. If the daemon sends a code that
+is not listed here, show the code and say it is unrecognized; never invent a
+sentence for it.
+
+`summary_code` -- what the check found:
+
+| code | say |
+|---|---|
+| `check_passed` | This check looked at everything it covers and found nothing wrong. |
+| `finding_detected` | This check found records that do not match what Wenlan expects. |
+| `prerequisite_unavailable` | This check could not run because something it depends on was missing. |
+| `snapshot_inconsistent` | Your data changed while this check was reading it, so its answer is not trustworthy. |
+| `execution_failed` | This check hit an error and did not finish. |
+| `expected_empty` | There was nothing here to check, which is the expected state right now. |
+
+`recommendation_code` -- what to do about a problem. Present only when
+something is actually wrong:
+
+| code | say |
+|---|---|
+| `review_finding` | Look at the listed records and fix or dismiss them. |
+| `restore_prerequisite` | Restore the missing piece this check needs, then run `wenlan lint` again. |
+| `rerun_after_snapshot_stabilizes` | Run `wenlan lint` again once writes have settled. |
+| `inspect_runtime` | Check the daemon logs for the error behind this, then run `wenlan lint` again. |
+
+`action_code` -- an optional field carrying something the owner can do about a
+check that is **not** a defect. It may be absent entirely, and older daemons
+never send it:
+
+| code | say |
+|---|---|
+| `choose_model_source` | Run `wenlan setup` and choose a model source so Wenlan can build this in the background. |
+
+A passing check that carries an `action_code` is waiting on the owner, not
+broken. Report it separately from findings: it does not count toward actionable
+findings and does not make the state `findings`. A fresh store where nobody has
+chosen a model source yet is the common case -- `kg.substrate_liveness` and
+`serving.channel.graph` both come back as passing, expected-empty checks asking
+for a model source, and that report is `clean`.
+
 ## `/lint repair`: resolve the complete plan
 
 There is no live-data auto-repair or automatic rollback.


### PR DESCRIPTION
## What

Gauntlet finding 15 and soak gap 4. On a fresh store with no model source chosen, `wenlan lint` reported 56 checks / 54 passed, two findings (`kg.substrate_liveness`, `serving.channel.graph`) and exit 1, with only machine codes to explain them. There was nothing to check yet: background enrichment is paused until the owner picks a model source, and the capture path already says so.

## How

- Readiness signal: `model_source_configured` = `EverydaySource::parse(load_config().everyday_source)` is `Some`. That is the same input `refinery::resolve_everyday` reads to produce the capture hint "background enrichment is paused until you choose a model source", so lint and capture agree. The existing `provider_ready` latch was not used: it is a process-wide "some provider has served traffic" flag that is false on a freshly started daemon even with a source configured. A source that is chosen but currently unavailable keeps the pin true, so nobody is told to choose a source they already chose.
- The flag is threaded into `KgRunConfig` and `ServingRunConfig` only. It joins the config fingerprint as `LintConfigSetting::ModelSourceConfigured` (byte id 27) so reports before and after the setting differ.
- With no source configured, `kg.substrate_liveness` and `serving.channel.graph` are `outcome: pass`, `applicability: expected_empty`, `precondition: expected_empty`, `summary_code: expected_empty`, no `recommendation_code`, and a new `action_code: choose_model_source`. That combination was already legal in the check legality table; `LintPrecondition::ExpectedEmpty` simply had no producer.
- `action_code` is a new optional field on `LintCheckResult` holding a one-variant `LintActionCode`, `#[serde(default, skip_serializing_if = "Option::is_none")]`. `LintRecommendationCode` keeps its four released values, so a CLI or MCP one patch behind still parses a report from this daemon (older readers ignore unknown keys). `LintCheckResultInput` is untouched; the field is read on `LintCheckResultWire` beside `gate_effect`, and producers opt in with `with_action_code`.
- `crates/wenlan-types/src/lint_catalog.rs` gains one plain sentence per summary, recommendation and action code; the CLI renders each check as code plus sentence, and prints these expected-empty checks under a `Waiting on you (N):` section instead of hiding them among passes. Both lint `SKILL.md` files carry the same code-to-sentence tables, and `plugin_distribution.rs` asserts the tables match the catalog so the two copies cannot drift.
- Exit code: 0 unless there are actionable findings (1) or the report is incomplete (2).
- A related bug fixed on the way: the kg liveness assessment reported `truncated=true` with zero evidence. `Assessment::reports_evidence` now says whether an assessment can point at records at all (`structural` true, `inventory_with_basis` and `liveness` false). No global `LintCoverage` rule was added: three producers (`identity/result.rs`, `operations/result.rs`, `semantic.rs`) legitimately emit `truncated=true` with no evidence, and `semantic_test.rs` asserts one of them.
- No schema or catalog version bump: no check ids changed, the wire change is additive, nothing persists a `LintCheckResult`, and bumping `LINT_REPORT_SCHEMA_VERSION` would re-point `PREVIOUS_LINT_REPORT_SCHEMA_VERSION` in `repair.rs` and invalidate persisted repair manifests.
- `CLI_READERS` in `truth_manifest.rs` gains the `wenlan sweep` row clap already had, so the `wenlan` bin-target manifest test passes again.

## Verification

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean for wenlan-types, wenlan-core and wenlan (the CLI package). `git diff --check` clean.
- `cargo test -p wenlan-types`: 185 passed (new: `a_frozen_schema_five_reader_still_parses_the_fresh_store_check`, `a_check_without_an_action_does_not_grow_a_wire_key`). `cargo test -p wenlan-core --lib lint`: 239 passed, 2 ignored. `cargo test -p wenlan`: all 11 targets green, including the bin-target `truth_manifest_cli_rows_match_clap_subcommands`. `cargo test -p wenlan --lib`: 57 passed (four new: `a_fresh_store_without_a_model_source_exits_zero`, `exit_code_is_one_only_for_actionable_findings_and_two_for_incomplete`, `the_model_source_checks_render_with_a_plain_sentence_and_no_findings`, `a_rendered_finding_carries_both_the_code_and_the_plain_sentence`). `cargo test -p wenlan --test lint_cli`: 19 passed; `--test cli_integration`: 40 passed.
- Mutation controls (break confirmed with `git diff`, then restored): putting `ChooseModelSource` back into `LintRecommendationCode` fails the frozen-reader test with `unknown variant \`choose_model_source\`, expected one of \`review_finding\`, \`restore_prerequisite\`, \`rerun_after_snapshot_stabilizes\`, \`inspect_runtime\``; reverting the liveness reclassification fails `no_model_source_is_a_complete_expected_empty_pass_that_says_to_choose_one` with `left: Finding, right: Pass`; dropping the `reports_evidence` guard fails `aggregate_only_liveness_never_claims_truncated_evidence` with `assertion failed: !liveness.coverage().truncated()`.
- Live, rerun after the wire change on `WENLAN_PORT=17932`: raw `GET /api/lint` emits no `recommendation_code` outside the released set and `action_code` on exactly 2 of 56 checks; `wenlan lint` prints `action: choose_model_source` under `Waiting on you (2)`. First run: an isolated daemon (`WENLAN_PORT=17931`, scratch `WENLAN_DATA_DIR`, `WENLAN_NO_AUTOSTART=1`, scratch `knowledge_path`, no `everyday_source`). Two captures returned `"enrichment": "paused"` with the choose-a-source hint; `wenlan lint` then exited 0 with `Lint: 56 checks, 56 passed, 0 actionable findings, 0 advisories, 0 incomplete` and both checks under `Waiting on you (2)` with the sentence "There was nothing here to check, which is the expected state right now. Run `wenlan setup` and choose a model source so Wenlan can build this in the background." The developer daemon on 7878 was untouched.
- `unchecked`: CI does not run the `wenlan` bin-target unit test, so the manifest check that was failing on main went unnoticed there; adding `--bin wenlan` to the canonical test inventory is left as a follow-up. Fake `HOME` was not set for the live run (the worktree guard refuses it); every home-touching startup path was checked to be a no-op on this machine instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
