### PR TITLE
ci(gauntlet): expect the health-verified background-on line

### DIFF
--- a/scripts/first-run/linux-install.sh
+++ b/scripts/first-run/linux-install.sh
@@ -69,7 +69,7 @@ fi
 export PATH="$BIN_DIR:$PATH"
 info path-export "export PATH=\"$BIN_DIR:\$PATH\""
 check_output setup-basic "Wenlan is set up for local memory." -- wenlan setup --basic
-check_output background-on "Installed and started com.wenlan.server." -- wenlan background on
+check_output background-on "Installed and started com.wenlan.server; daemon healthy at" -- wenlan background on
 check unit-file-exists -- test -f "$UNIT"
 check_output unit-enabled "enabled" -- systemctl --user is-enabled wenlan-server
 wait_health "$HEALTH" 240 || true

--- a/scripts/first-run/npx-setup.sh
+++ b/scripts/first-run/npx-setup.sh
@@ -48,7 +48,7 @@ GAUNTLET_TIMEOUT=900 check npx-setup -- bash -c "$CMD"
 LOG="$GAUNTLET_OUT/checks/npx-setup.log"
 check_output npx-downloading-line "Downloading Wenlan $TAG..." -- grep -F "Downloading Wenlan $TAG..." "$LOG"
 check_output npx-binaries-installed-line "Wenlan binaries are installed in" -- grep -F "Wenlan binaries are installed in" "$LOG"
-check_output npx-background-on-line "Installed and started com.wenlan.server." -- grep -F "Installed and started com.wenlan.server." "$LOG"
+check_output npx-background-on-line "Installed and started com.wenlan.server; daemon healthy at" -- grep -F "Installed and started com.wenlan.server; daemon healthy at" "$LOG"
 for b in wenlan wenlan-server wenlan-mcp; do
     check "bin-$b-executable" -- test -x "$BIN_DIR/$b"
 done

--- a/scripts/first-run/plugin-setup.sh
+++ b/scripts/first-run/plugin-setup.sh
@@ -107,7 +107,7 @@ GAUNTLET_TIMEOUT=600 check skill-bootstrap -- bash -c "$BOOTSTRAP"
 export PATH="$HOME/.wenlan/bin:$PATH"
 info path-export 'export PATH="$HOME/.wenlan/bin:$PATH"'
 check_output setup-basic "Wenlan is set up for local memory." -- wenlan setup --basic
-check_output background-on "Installed and started com.wenlan.server." -- wenlan background on
+check_output background-on "Installed and started com.wenlan.server; daemon healthy at" -- wenlan background on
 if [ "$OS" = Linux ]; then
     check unit-file-exists -- test -f "$UNIT"
 else


### PR DESCRIPTION
## What

The first-run gauntlet still asserted the pre-#600 `wenlan background on` line, `Installed and started com.wenlan.server.` (trailing period). Since PR #600 the CLI waits for the daemon to answer before it claims a start, and on success prints `Installed and started com.wenlan.server; daemon healthy at http://127.0.0.1:7878.`. The three scripts that check that line (`linux-install.sh`, `plugin-setup.sh`, `npx-setup.sh`) now expect the health-verified form, `Installed and started com.wenlan.server; daemon healthy at`, so the assertion also proves the health wait ran.

## Why

The v0.17.1 gauntlet (run 32981419005) came back red on `linux-install` (both Ubuntu runners), `plugin-setup` (both runners) and `npx-setup` with the daemon healthy in 1–3 s on every one of them — the only failing row was this stale substring. The macOS app channel's `plist-server-exists` failure is a real product finding and is left untouched.

## Verification

- `bash -n` on the three scripts.
- The v0.17.1 findings show the exact new line on all five red jobs, e.g. `got: Installed and started com.wenlan.server; daemon healthy at http://127.0.0.1:7878.`
- Will be proven by re-dispatching `first-run-gauntlet.yml` against `v0.17.1` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
