### PR TITLE
fix(app): register the daemon with launchd first; the sidecar is the fallback

### DIFF
--- a/app/src/daemon_start.rs
+++ b/app/src/daemon_start.rs
@@ -14,7 +14,7 @@
 //! and [`stop_sidecar`] ends it on quit, and on Windows the process is bound
 //! to a kill-on-close job object so a hard kill of the app takes it too.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri_plugin_shell::process::CommandChild;
@@ -36,18 +36,48 @@ fn startup_preflight_ok() -> bool {
     STARTUP_PREFLIGHT_OK.load(Ordering::Relaxed)
 }
 
-/// Whether `setup()`'s first-run LaunchAgent install is still running. While
-/// it is, the on-demand "Start Wenlan" command must not spawn a sidecar that
-/// would race the launchd job being registered (first-run gauntlet finding
-/// F16); `setup()` clears it once the install has settled.
-static LAUNCHD_INSTALL_PENDING: AtomicBool = AtomicBool::new(false);
+/// How many launchd registrations are in flight: `setup()`'s first-run
+/// install and the "Run at Login" toggle each hold a [`LaunchdInstallPending`]
+/// while they run `wenlan background on`. Above zero, the on-demand "Start
+/// Wenlan" command must not spawn a sidecar that would race the job being
+/// registered (first-run gauntlet finding F16).
+static LAUNCHD_INSTALLS_PENDING: AtomicUsize = AtomicUsize::new(0);
 
-pub fn set_launchd_install_pending(pending: bool) {
-    LAUNCHD_INSTALL_PENDING.store(pending, Ordering::Relaxed);
+/// Marks a launchd registration in flight for as long as it is held. The
+/// count is released on drop, so a registration that panics or returns early
+/// can never leave the "Start Wenlan" button stuck on `launchd_managed`.
+pub struct LaunchdInstallPending(());
+
+impl LaunchdInstallPending {
+    pub fn begin() -> Self {
+        LAUNCHD_INSTALLS_PENDING.fetch_add(1, Ordering::Relaxed);
+        Self(())
+    }
+}
+
+impl Drop for LaunchdInstallPending {
+    fn drop(&mut self) {
+        LAUNCHD_INSTALLS_PENDING.fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 fn launchd_install_pending() -> bool {
-    LAUNCHD_INSTALL_PENDING.load(Ordering::Relaxed)
+    LAUNCHD_INSTALLS_PENDING.load(Ordering::Relaxed) > 0
+}
+
+/// Serialises each owner decision with the spawn it leads to. Without it the
+/// startup path and the on-demand command could both read "nothing owns the
+/// daemon" and each spawn a sidecar; the second spawn kills the first, and a
+/// second child that had already seen the first one healthy exits 75, which
+/// leaves zero owners.
+static OWNER_DECISION: Mutex<()> = Mutex::new(());
+
+/// Whether this app's own sidecar is in the slot: booting or serving.
+fn sidecar_alive() -> bool {
+    SIDECAR
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .is_some()
 }
 
 /// The sidecar this app spawned, so quitting can stop it. Empty when launchd
@@ -223,7 +253,11 @@ mod job {
 pub enum DaemonStartDecision {
     /// The port already answers — never double-spawn.
     AlreadyRunning,
-    /// launchd owns a matching daemon — it will restart it; don't fight it.
+    /// This app's own sidecar is alive (booting or serving). One child is the
+    /// most it ever runs: a second spawn kills the first.
+    SidecarStarting,
+    /// launchd holds a loaded job for the selected data root — it will
+    /// (re)start the daemon; don't fight it.
     LaunchdManaged,
     /// The startup plist preflight failed — same skip as `setup()`.
     PreflightFailed,
@@ -266,12 +300,15 @@ pub fn decide_startup_sidecar(preflight_ok: bool, launchd_owns_daemon: bool) -> 
 /// could answer, but the button runs when one might already be back up.
 pub fn decide_daemon_start(
     port_healthy: bool,
+    sidecar_alive: bool,
     launchd_managed: bool,
     launchd_install_pending: bool,
     preflight_ok: bool,
 ) -> DaemonStartDecision {
     if port_healthy {
         DaemonStartDecision::AlreadyRunning
+    } else if sidecar_alive {
+        DaemonStartDecision::SidecarStarting
     } else if launchd_managed {
         DaemonStartDecision::LaunchdManaged
     } else if !preflight_ok {
@@ -347,6 +384,85 @@ pub fn spawn_daemon_sidecar(app: &tauri::AppHandle) -> Result<(), String> {
 /// Probes the port first (a daemon that came back on its own must not be
 /// double-spawned), then defers to launchd, then honors the startup preflight,
 /// and only then spawns. Returns a discriminated result the UI renders inline.
+/// `setup()`'s owner decision once the first-run LaunchAgent install has
+/// settled: launchd when it holds a loaded job for the selected data root,
+/// otherwise this app's sidecar. Takes the install's [`LaunchdInstallPending`]
+/// so the flag clears under the same lock that decides and spawns; the
+/// on-demand command then sees either "still pending" or the final owner,
+/// never the gap between the two.
+pub fn settle_startup_owner(
+    app: &tauri::AppHandle,
+    preflight_ok: bool,
+    pending: LaunchdInstallPending,
+) {
+    let _decision = OWNER_DECISION
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    drop(pending);
+    let launchd_owns_daemon =
+        crate::lifecycle::launchd_owns_server_daemon(&crate::lifecycle::SystemLaunchctl);
+    match decide_startup_sidecar(preflight_ok, launchd_owns_daemon) {
+        StartupSidecar::SkipPreflightFailed => {
+            log::warn!("[init] skipping daemon sidecar because server plist preflight failed");
+        }
+        StartupSidecar::SkipLaunchdOwns => {
+            log::info!("[init] launchd owns the daemon after the first-run install; no sidecar");
+        }
+        StartupSidecar::Spawn => {
+            if let Err(e) = spawn_daemon_sidecar(app) {
+                log::error!(
+                    "[init] {e}. Run: xattr -cr /Applications/Origin.app or /Applications/Wenlan.app"
+                );
+            }
+        }
+    }
+}
+
+/// Start the daemon only when nothing owns it. Shared by the on-demand "Start
+/// Wenlan" command and the "Run at Login" toggle's failure path. The health
+/// probe awaits before the lock; everything the decision reads, and the spawn,
+/// sit under it.
+pub async fn start_daemon_if_unowned(
+    app: &tauri::AppHandle,
+    client: &crate::api::WenlanClient,
+) -> DaemonStartResult {
+    let port_healthy = client.health().await.is_ok();
+    start_daemon_under_owner_lock(app, port_healthy)
+}
+
+fn start_daemon_under_owner_lock(app: &tauri::AppHandle, port_healthy: bool) -> DaemonStartResult {
+    let _decision = OWNER_DECISION
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let launchd_managed =
+        crate::lifecycle::launchd_owns_server_daemon(&crate::lifecycle::SystemLaunchctl);
+    match decide_daemon_start(
+        port_healthy,
+        sidecar_alive(),
+        launchd_managed,
+        launchd_install_pending(),
+        startup_preflight_ok(),
+    ) {
+        DaemonStartDecision::AlreadyRunning => DaemonStartResult::AlreadyRunning,
+        // Our own child is still booting: to the UI that is a start in
+        // progress, not a failure and not a second daemon.
+        DaemonStartDecision::SidecarStarting => DaemonStartResult::Started,
+        // The job is being registered right now; to the UI that is the
+        // same "the system service starts it" outcome.
+        DaemonStartDecision::LaunchdManaged | DaemonStartDecision::LaunchdInstallPending => {
+            DaemonStartResult::LaunchdManaged
+        }
+        DaemonStartDecision::PreflightFailed => DaemonStartResult::Failed {
+            message: "Wenlan's startup configuration needs repair. Restart the app to fix it."
+                .to_string(),
+        },
+        DaemonStartDecision::Spawn => match spawn_daemon_sidecar(app) {
+            Ok(()) => DaemonStartResult::Started,
+            Err(e) => DaemonStartResult::Failed { message: e },
+        },
+    }
+}
+
 #[tauri::command]
 pub async fn start_daemon_sidecar(
     app: tauri::AppHandle,
@@ -356,32 +472,7 @@ pub async fn start_daemon_sidecar(
         let s = state.read().await;
         s.client.clone()
     };
-    let port_healthy = client.health().await.is_ok();
-    let launchd_managed = crate::lifecycle::current_server_plist_matches_selected_data_dir();
-
-    Ok(
-        match decide_daemon_start(
-            port_healthy,
-            launchd_managed,
-            launchd_install_pending(),
-            startup_preflight_ok(),
-        ) {
-            DaemonStartDecision::AlreadyRunning => DaemonStartResult::AlreadyRunning,
-            // The job is being registered right now; to the UI that is the
-            // same "the system service starts it" outcome.
-            DaemonStartDecision::LaunchdManaged | DaemonStartDecision::LaunchdInstallPending => {
-                DaemonStartResult::LaunchdManaged
-            }
-            DaemonStartDecision::PreflightFailed => DaemonStartResult::Failed {
-                message: "Wenlan's startup configuration needs repair. Restart the app to fix it."
-                    .to_string(),
-            },
-            DaemonStartDecision::Spawn => match spawn_daemon_sidecar(&app) {
-                Ok(()) => DaemonStartResult::Started,
-                Err(e) => DaemonStartResult::Failed { message: e },
-            },
-        },
-    )
+    Ok(start_daemon_if_unowned(&app, &client).await)
 }
 
 #[cfg(test)]
@@ -393,11 +484,11 @@ mod tests {
     #[test]
     fn healthy_port_reports_already_running_without_spawning() {
         assert_eq!(
-            decide_daemon_start(true, false, false, true),
+            decide_daemon_start(true, false, false, false, true),
             DaemonStartDecision::AlreadyRunning
         );
         assert_eq!(
-            decide_daemon_start(true, true, false, false),
+            decide_daemon_start(true, false, true, false, false),
             DaemonStartDecision::AlreadyRunning
         );
     }
@@ -406,7 +497,7 @@ mod tests {
     #[test]
     fn launchd_managed_defers_without_spawning() {
         assert_eq!(
-            decide_daemon_start(false, true, false, true),
+            decide_daemon_start(false, false, true, false, true),
             DaemonStartDecision::LaunchdManaged
         );
     }
@@ -415,7 +506,7 @@ mod tests {
     #[test]
     fn preflight_failure_skips_spawn() {
         assert_eq!(
-            decide_daemon_start(false, false, false, false),
+            decide_daemon_start(false, false, false, false, false),
             DaemonStartDecision::PreflightFailed
         );
     }
@@ -424,7 +515,7 @@ mod tests {
     #[test]
     fn clear_field_spawns() {
         assert_eq!(
-            decide_daemon_start(false, false, false, true),
+            decide_daemon_start(false, false, false, false, true),
             DaemonStartDecision::Spawn
         );
     }
@@ -434,13 +525,42 @@ mod tests {
     #[test]
     fn pending_launchd_install_defers_the_sidecar() {
         assert_eq!(
-            decide_daemon_start(false, false, true, true),
+            decide_daemon_start(false, false, false, true, true),
             DaemonStartDecision::LaunchdInstallPending
         );
         assert_eq!(
-            decide_daemon_start(true, false, true, true),
+            decide_daemon_start(true, false, false, true, true),
             DaemonStartDecision::AlreadyRunning
         );
+    }
+
+    // This app's sidecar is already booting: a second spawn would kill it, and
+    // a second child that saw the first one healthy exits 75 — zero owners.
+    #[test]
+    fn a_live_sidecar_is_never_spawned_twice() {
+        assert_eq!(
+            decide_daemon_start(false, true, false, false, true),
+            DaemonStartDecision::SidecarStarting
+        );
+        assert_eq!(
+            decide_daemon_start(true, true, false, false, true),
+            DaemonStartDecision::AlreadyRunning
+        );
+    }
+
+    // Two registrations can overlap (the first-run install and the Run at
+    // Login toggle): the flag holds until the last one releases, and releases
+    // on drop so an aborted install cannot pin the button on launchd_managed.
+    #[test]
+    #[serial_test::serial]
+    fn pending_flag_counts_overlapping_installs_and_releases_on_drop() {
+        assert!(!launchd_install_pending());
+        let first = LaunchdInstallPending::begin();
+        let second = LaunchdInstallPending::begin();
+        drop(first);
+        assert!(launchd_install_pending());
+        drop(second);
+        assert!(!launchd_install_pending());
     }
 
     // Startup owner: launchd first, sidecar only when no LaunchAgent took the

--- a/app/src/daemon_start.rs
+++ b/app/src/daemon_start.rs
@@ -36,6 +36,20 @@ fn startup_preflight_ok() -> bool {
     STARTUP_PREFLIGHT_OK.load(Ordering::Relaxed)
 }
 
+/// Whether `setup()`'s first-run LaunchAgent install is still running. While
+/// it is, the on-demand "Start Wenlan" command must not spawn a sidecar that
+/// would race the launchd job being registered (first-run gauntlet finding
+/// F16); `setup()` clears it once the install has settled.
+static LAUNCHD_INSTALL_PENDING: AtomicBool = AtomicBool::new(false);
+
+pub fn set_launchd_install_pending(pending: bool) {
+    LAUNCHD_INSTALL_PENDING.store(pending, Ordering::Relaxed);
+}
+
+fn launchd_install_pending() -> bool {
+    LAUNCHD_INSTALL_PENDING.load(Ordering::Relaxed)
+}
+
 /// The sidecar this app spawned, so quitting can stop it. Empty when launchd
 /// or the Task Scheduler owns the daemon, or once the sidecar exited. The
 /// handle used to be dropped at spawn, so the daemon outlived the app on
@@ -213,8 +227,37 @@ pub enum DaemonStartDecision {
     LaunchdManaged,
     /// The startup plist preflight failed — same skip as `setup()`.
     PreflightFailed,
+    /// `setup()` is still registering the launchd job; it decides the owner
+    /// when that settles, so don't spawn a rival meanwhile.
+    LaunchdInstallPending,
     /// Nothing is serving and it's safe to spawn our own sidecar.
     Spawn,
+}
+
+/// What `setup()` does with the sidecar once the first-run LaunchAgent
+/// install has settled. Pure output of [`decide_startup_sidecar`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartupSidecar {
+    /// The startup plist preflight failed: no daemon start at all.
+    SkipPreflightFailed,
+    /// The server LaunchAgent targets the selected data root: launchd owns
+    /// the daemon and restarts it; a sidecar would only fight it for the port.
+    SkipLaunchdOwns,
+    /// No usable LaunchAgent (install skipped or failed): the app runs its
+    /// own sidecar, the fallback owner.
+    Spawn,
+}
+
+/// Owner decision for the startup path: launchd first, sidecar as fallback.
+/// Pure so it is unit-testable without a running app.
+pub fn decide_startup_sidecar(preflight_ok: bool, launchd_owns_daemon: bool) -> StartupSidecar {
+    if !preflight_ok {
+        StartupSidecar::SkipPreflightFailed
+    } else if launchd_owns_daemon {
+        StartupSidecar::SkipLaunchdOwns
+    } else {
+        StartupSidecar::Spawn
+    }
 }
 
 /// Guard order for the on-demand start. Pure so it is unit-testable without a
@@ -224,6 +267,7 @@ pub enum DaemonStartDecision {
 pub fn decide_daemon_start(
     port_healthy: bool,
     launchd_managed: bool,
+    launchd_install_pending: bool,
     preflight_ok: bool,
 ) -> DaemonStartDecision {
     if port_healthy {
@@ -232,6 +276,8 @@ pub fn decide_daemon_start(
         DaemonStartDecision::LaunchdManaged
     } else if !preflight_ok {
         DaemonStartDecision::PreflightFailed
+    } else if launchd_install_pending {
+        DaemonStartDecision::LaunchdInstallPending
     } else {
         DaemonStartDecision::Spawn
     }
@@ -314,9 +360,18 @@ pub async fn start_daemon_sidecar(
     let launchd_managed = crate::lifecycle::current_server_plist_matches_selected_data_dir();
 
     Ok(
-        match decide_daemon_start(port_healthy, launchd_managed, startup_preflight_ok()) {
+        match decide_daemon_start(
+            port_healthy,
+            launchd_managed,
+            launchd_install_pending(),
+            startup_preflight_ok(),
+        ) {
             DaemonStartDecision::AlreadyRunning => DaemonStartResult::AlreadyRunning,
-            DaemonStartDecision::LaunchdManaged => DaemonStartResult::LaunchdManaged,
+            // The job is being registered right now; to the UI that is the
+            // same "the system service starts it" outcome.
+            DaemonStartDecision::LaunchdManaged | DaemonStartDecision::LaunchdInstallPending => {
+                DaemonStartResult::LaunchdManaged
+            }
             DaemonStartDecision::PreflightFailed => DaemonStartResult::Failed {
                 message: "Wenlan's startup configuration needs repair. Restart the app to fix it."
                     .to_string(),
@@ -338,11 +393,11 @@ mod tests {
     #[test]
     fn healthy_port_reports_already_running_without_spawning() {
         assert_eq!(
-            decide_daemon_start(true, false, true),
+            decide_daemon_start(true, false, false, true),
             DaemonStartDecision::AlreadyRunning
         );
         assert_eq!(
-            decide_daemon_start(true, true, false),
+            decide_daemon_start(true, true, false, false),
             DaemonStartDecision::AlreadyRunning
         );
     }
@@ -351,7 +406,7 @@ mod tests {
     #[test]
     fn launchd_managed_defers_without_spawning() {
         assert_eq!(
-            decide_daemon_start(false, true, true),
+            decide_daemon_start(false, true, false, true),
             DaemonStartDecision::LaunchdManaged
         );
     }
@@ -360,7 +415,7 @@ mod tests {
     #[test]
     fn preflight_failure_skips_spawn() {
         assert_eq!(
-            decide_daemon_start(false, false, false),
+            decide_daemon_start(false, false, false, false),
             DaemonStartDecision::PreflightFailed
         );
     }
@@ -369,8 +424,41 @@ mod tests {
     #[test]
     fn clear_field_spawns() {
         assert_eq!(
-            decide_daemon_start(false, false, true),
+            decide_daemon_start(false, false, false, true),
             DaemonStartDecision::Spawn
+        );
+    }
+
+    // setup() is still registering the launchd job: a click must not spawn a
+    // sidecar that races it for the port (F16). A healthy port still wins.
+    #[test]
+    fn pending_launchd_install_defers_the_sidecar() {
+        assert_eq!(
+            decide_daemon_start(false, false, true, true),
+            DaemonStartDecision::LaunchdInstallPending
+        );
+        assert_eq!(
+            decide_daemon_start(true, false, true, true),
+            DaemonStartDecision::AlreadyRunning
+        );
+    }
+
+    // Startup owner: launchd first, sidecar only when no LaunchAgent took the
+    // daemon, and nothing at all when the preflight failed.
+    #[test]
+    fn startup_sidecar_is_the_fallback_owner() {
+        assert_eq!(
+            decide_startup_sidecar(true, true),
+            StartupSidecar::SkipLaunchdOwns
+        );
+        assert_eq!(decide_startup_sidecar(true, false), StartupSidecar::Spawn);
+        assert_eq!(
+            decide_startup_sidecar(false, false),
+            StartupSidecar::SkipPreflightFailed
+        );
+        assert_eq!(
+            decide_startup_sidecar(false, true),
+            StartupSidecar::SkipPreflightFailed
         );
     }
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -693,9 +693,18 @@ pub fn run() {
 
             // First-run silent install — H6: run on a blocking task so we
             // don't block setup() (which delays Tauri start by hundreds of ms).
+            //
+            // The daemon's owner is decided here, once that install has
+            // settled: launchd when the server LaunchAgent is in place,
+            // otherwise our own sidecar. Spawning the sidecar at once and
+            // registering launchd in parallel made the two fight for the port
+            // on a fresh Mac (first-run gauntlet finding F16): `wenlan
+            // background on` failed against the still-booting sidecar, or
+            // launchd's daemon lost the port to it and looped on exit 75.
             if launch_agent_startup {
                 use tauri::Emitter;
                 let install_handle = handle.clone();
+                crate::daemon_start::set_launchd_install_pending(true);
                 tauri::async_runtime::spawn(async move {
                     let result = tauri::async_runtime::spawn_blocking(|| {
                         let launchctl = crate::lifecycle::SystemLaunchctl;
@@ -715,6 +724,31 @@ pub fn run() {
                         Err(e) => {
                             log::warn!("[first-run] install task join error: {e}");
                             let _ = install_handle.emit("origin-fallback-mode", ());
+                        }
+                    }
+                    crate::daemon_start::set_launchd_install_pending(false);
+                    let launchd_owns_daemon =
+                        crate::lifecycle::current_server_plist_matches_selected_data_dir();
+                    match crate::daemon_start::decide_startup_sidecar(
+                        daemon_startup_preflight_ok,
+                        launchd_owns_daemon,
+                    ) {
+                        crate::daemon_start::StartupSidecar::SkipPreflightFailed => {
+                            log::warn!(
+                                "[init] skipping daemon sidecar because server plist preflight failed"
+                            );
+                        }
+                        crate::daemon_start::StartupSidecar::SkipLaunchdOwns => {
+                            log::info!(
+                                "[init] launchd owns the daemon after the first-run install; no sidecar"
+                            );
+                        }
+                        crate::daemon_start::StartupSidecar::Spawn => {
+                            if let Err(e) =
+                                crate::daemon_start::spawn_daemon_sidecar(&install_handle)
+                            {
+                                log::error!("[init] {e}. Run: xattr -cr /Applications/Origin.app or /Applications/Wenlan.app");
+                            }
                         }
                     }
                 });
@@ -1090,28 +1124,17 @@ pub fn run() {
                 }
             }
 
-            // Launch wenlan-server daemon as a sidecar process.
-            // If a daemon is already running on the port, the sidecar exits cleanly.
-            // The quit flow stops it (`daemon_start::stop_sidecar`); the shell
-            // plugin only kills children spawned from its JS `execute` command.
+            // Launch wenlan-server daemon as a sidecar process where no
+            // LaunchAgent exists (Windows, Linux). If a daemon is already
+            // running on the port, the sidecar exits cleanly. The quit flow
+            // stops it (`daemon_start::stop_sidecar`); the shell plugin only
+            // kills children spawned from its JS `execute` command.
             //
-            // Skip the sidecar only when the current Wenlan launchd service
-            // already targets this app-selected data root. A stale launchd
-            // plist can exist during migration and first-run repair, but it
-            // must not suppress the selected-data-dir sidecar fallback.
-            if !daemon_startup_preflight_ok {
-                log::warn!(
-                    "[init] skipping daemon sidecar because server plist preflight failed"
-                );
-            } else {
-                let launchd_managed = launch_agent_startup
-                    && crate::lifecycle::current_server_plist_matches_selected_data_dir();
-                if launchd_managed {
-                    log::info!(
-                        "[init] launchd-managed daemon detected, skipping sidecar spawn"
-                    );
-                } else if let Err(e) = crate::daemon_start::spawn_daemon_sidecar(app.handle()) {
-                    log::error!("[init] {e}. Run: xattr -cr /Applications/Origin.app or /Applications/Wenlan.app");
+            // On macOS the first-run install task above decides the owner once
+            // it has settled, so nothing is spawned here.
+            if !launch_agent_startup {
+                if let Err(e) = crate::daemon_start::spawn_daemon_sidecar(app.handle()) {
+                    log::error!("[init] {e}");
                 }
             }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -704,7 +704,7 @@ pub fn run() {
             if launch_agent_startup {
                 use tauri::Emitter;
                 let install_handle = handle.clone();
-                crate::daemon_start::set_launchd_install_pending(true);
+                let pending = crate::daemon_start::LaunchdInstallPending::begin();
                 tauri::async_runtime::spawn(async move {
                     let result = tauri::async_runtime::spawn_blocking(|| {
                         let launchctl = crate::lifecycle::SystemLaunchctl;
@@ -726,31 +726,14 @@ pub fn run() {
                             let _ = install_handle.emit("origin-fallback-mode", ());
                         }
                     }
-                    crate::daemon_start::set_launchd_install_pending(false);
-                    let launchd_owns_daemon =
-                        crate::lifecycle::current_server_plist_matches_selected_data_dir();
-                    match crate::daemon_start::decide_startup_sidecar(
+                    // The guard moved into this task, so a panic above
+                    // releases it too; here it is released under the owner
+                    // lock, together with the decision it was protecting.
+                    crate::daemon_start::settle_startup_owner(
+                        &install_handle,
                         daemon_startup_preflight_ok,
-                        launchd_owns_daemon,
-                    ) {
-                        crate::daemon_start::StartupSidecar::SkipPreflightFailed => {
-                            log::warn!(
-                                "[init] skipping daemon sidecar because server plist preflight failed"
-                            );
-                        }
-                        crate::daemon_start::StartupSidecar::SkipLaunchdOwns => {
-                            log::info!(
-                                "[init] launchd owns the daemon after the first-run install; no sidecar"
-                            );
-                        }
-                        crate::daemon_start::StartupSidecar::Spawn => {
-                            if let Err(e) =
-                                crate::daemon_start::spawn_daemon_sidecar(&install_handle)
-                            {
-                                log::error!("[init] {e}. Run: xattr -cr /Applications/Origin.app or /Applications/Wenlan.app");
-                            }
-                        }
-                    }
+                        pending,
+                    );
                 });
             }
 

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -212,6 +212,15 @@ pub fn current_server_plist_matches_selected_data_dir() -> bool {
         .is_some_and(|content| server_plist_has_selected_data_dir(&content))
 }
 
+/// True when launchd owns the daemon: the server LaunchAgent targets the
+/// selected data root *and* launchd has the job loaded. The file alone is not
+/// ownership — `wenlan background on` writes it before `launchctl load`, and a
+/// failed load leaves it behind with no job to run the daemon.
+pub fn launchd_owns_server_daemon(launchctl: &dyn LaunchctlExec) -> bool {
+    current_server_plist_matches_selected_data_dir()
+        && label_is_loaded(launchctl, SERVER_PLIST_LABEL)
+}
+
 pub fn legacy_server_plist_exists() -> bool {
     legacy_server_plist_path()
         .map(|p| p.exists())
@@ -800,6 +809,9 @@ pub async fn set_run_at_login(enabled: bool, launchctl: &dyn LaunchctlExec) -> R
             );
         }
         set_user_opted_out(false)?;
+        // The "Start Wenlan" button must not spawn a sidecar between the stop
+        // below and the launchd registration; the count releases on drop.
+        let _pending = crate::daemon_start::LaunchdInstallPending::begin();
         // A sidecar this app spawned holds the port that `wenlan background
         // on` is about to hand to launchd, and the CLI's pre-install shutdown
         // request failed against it (first-run gauntlet finding F16). Stop it
@@ -2074,6 +2086,60 @@ mod tests {
 
         assert!(current_server_plist_exists());
         assert!(current_server_plist_matches_selected_data_dir());
+    }
+
+    // The owner test behind the startup sidecar decision and the "Start
+    // Wenlan" button: a server plist that targets the selected data root is
+    // only launchd's daemon when launchd has the job loaded. `wenlan
+    // background on` writes the file before `launchctl load`, so a failed
+    // load leaves a matching file and no job; trusting the file alone would
+    // skip the sidecar and leave the user with no daemon.
+    #[test]
+    #[serial_test::serial]
+    fn launchd_owns_the_daemon_only_when_its_job_is_loaded() {
+        let _env = EnvGuard::capture(LIFECYCLE_ENV_KEYS);
+        let tmp = tempfile::tempdir().unwrap();
+        let data = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("WENLAN_DATA_DIR", data.path());
+        std::env::remove_var("ORIGIN_DATA_DIR");
+        let loaded = MockLaunchctl::default();
+        *loaded.list_stdout.lock().unwrap() = format!("123\t0\t{SERVER_PLIST_LABEL}\n");
+        let unloaded = MockLaunchctl::default();
+
+        // A loaded job with no plist for the selected data root is not ours.
+        assert!(!launchd_owns_server_daemon(&loaded));
+
+        let plist = server_plist_path().unwrap();
+        std::fs::create_dir_all(plist.parent().unwrap()).unwrap();
+        std::fs::write(
+            &plist,
+            format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.wenlan.server</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>WENLAN_DATA_DIR</key>
+        <string>{}</string>
+    </dict>
+</dict>
+</plist>
+"#,
+                data.path().display()
+            ),
+        )
+        .unwrap();
+        assert!(current_server_plist_matches_selected_data_dir());
+
+        assert!(
+            !launchd_owns_server_daemon(&unloaded),
+            "a matching plist that launchd never loaded must not count as launchd's daemon"
+        );
+        assert!(launchd_owns_server_daemon(&loaded));
     }
 
     #[test]

--- a/app/src/lifecycle.rs
+++ b/app/src/lifecycle.rs
@@ -800,6 +800,12 @@ pub async fn set_run_at_login(enabled: bool, launchctl: &dyn LaunchctlExec) -> R
             );
         }
         set_user_opted_out(false)?;
+        // A sidecar this app spawned holds the port that `wenlan background
+        // on` is about to hand to launchd, and the CLI's pre-install shutdown
+        // request failed against it (first-run gauntlet finding F16). Stop it
+        // through its child handle first; a launchd-owned daemon is never in
+        // that slot, so this is a no-op once launchd owns the daemon.
+        crate::daemon_start::stop_sidecar().await;
         install_server_plist_via_subprocess(launchctl)?;
         install_app_plist(launchctl)?;
     } else {

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -4656,12 +4656,20 @@ pub async fn is_run_at_login_enabled() -> Result<bool, String> {
 }
 
 #[tauri::command]
-pub async fn set_run_at_login(enabled: bool) -> Result<(), String> {
+pub async fn set_run_at_login(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
     crate::lifecycle::run_at_login_capability(std::env::consts::OS).map_err(str::to_string)?;
     use crate::lifecycle::{set_run_at_login as inner, SystemLaunchctl};
-    inner(enabled, &SystemLaunchctl)
-        .await
-        .map_err(|e| e.to_string())
+    let result = inner(enabled, &SystemLaunchctl).await;
+    if enabled && result.is_err() {
+        // Turning the toggle on stops an app-owned sidecar before the launchd
+        // handover; a handover that then fails must not leave the user with
+        // no daemon at all, so start one again unless something owns it.
+        let outcome =
+            crate::daemon_start::start_daemon_if_unowned(&app, &crate::api::WenlanClient::new())
+                .await;
+        log::warn!("[run-at-login] launchd handover failed; daemon fallback: {outcome:?}");
+    }
+    result.map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -28,6 +28,11 @@ app crash takes it down too; when that binding fails the app logs it and keeps t
 daemon running, and the crash case is then not covered. A launchd, systemd, or Task
 Scheduler daemon is service-owned and outlives the app by design.
 
+On macOS the app registers the launchd job first on a fresh install and starts its
+own sidecar only when that registration is skipped (opted out, unstable app path,
+isolated data dir) or fails, so the two never compete for the port; turning on
+"Run at Login" stops an app-owned sidecar before it hands the daemon to launchd.
+
 ## llama-cpp-2 backend
 
 macOS builds use Metal, Windows x86_64 builds use Vulkan with observable CPU/OpenMP fallback, and Linux builds remain CPU/OpenMP. Windows setup, device selection, CI/release prerequisites, and physical Qwen live-smoke commands are in [`windows-vulkan.md`](windows-vulkan.md).

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -29,9 +29,13 @@ daemon running, and the crash case is then not covered. A launchd, systemd, or T
 Scheduler daemon is service-owned and outlives the app by design.
 
 On macOS the app registers the launchd job first on a fresh install and starts its
-own sidecar only when that registration is skipped (opted out, unstable app path,
-isolated data dir) or fails, so the two never compete for the port; turning on
-"Run at Login" stops an app-owned sidecar before it hands the daemon to launchd.
+own sidecar only when launchd does not end up with a loaded job for the selected
+data root (registration skipped for an opted-out user, an unstable app path, or an
+isolated data dir, or it failed), so the two never compete for the port. Every owner
+decision is made and acted on under one lock, so startup and the "Start Wenlan"
+button cannot both spawn a sidecar. Turning on "Run at Login" stops an app-owned
+sidecar before it hands the daemon to launchd, and starts one again if the handover
+fails.
 
 ## llama-cpp-2 backend
 


### PR DESCRIPTION
## What

On a fresh Mac the app now registers the daemon with launchd first and starts its own sidecar only when that registration is skipped or fails. Before, `setup()` spawned the sidecar at once and ran the first-run `wenlan background on` in parallel, and the two fought for port 7878 (first-run gauntlet finding F16, tracker row 23):

- v0.17.1 run 32981419005: `[first-run] wenlan background on failed: … Error: request graceful daemon shutdown before reinstall` — the CLI's pre-install shutdown request hit the still-booting sidecar, so `com.wenlan.server.plist` was never written.
- v0.17.1 run 33003051324: `background on` won, but launchd's daemon found the sidecar on the port and looped on `Existing healthy daemon on port 7878 — exiting 75 (launchd retry)`; `launchctl print` showed `runs = 1`, `last exit code = 1`, `state = spawn scheduled`.

Both runs at 0.17.0 failed the same check; the crash-loop (F4) had hidden it.

## How

- `app/src/lib.rs`: the macOS sidecar spawn moves from `setup()` into the completion of the first-run install task. Once the install has settled, `decide_startup_sidecar(preflight_ok, current_server_plist_matches_selected_data_dir())` picks the owner: launchd when the server LaunchAgent targets the selected data root, otherwise the sidecar (opted out, unstable app path, isolated data dir, or a failed `background on`). Windows and Linux keep the immediate spawn.
- `app/src/daemon_start.rs`: `StartupSidecar` + `decide_startup_sidecar` (pure, tested); a `LAUNCHD_INSTALL_PENDING` flag so the on-demand "Start Wenlan" command does not spawn a rival sidecar while the job is being registered (`decide_daemon_start` gains the input; the UI sees it as `launchd_managed`).
- `app/src/lifecycle.rs`: `set_run_at_login(true)` stops an app-owned sidecar (`daemon_start::stop_sidecar`, a no-op when launchd owns the daemon) before `wenlan background on`, since the toggle hit the same refusal.
- `docs/cross-platform.md`: one paragraph on the ownership order.

## Verification

- `cargo test -p wenlan-app --lib`: full suite (see the CI note below for the local run).
- New tests: `pending_launchd_install_defers_the_sidecar`, `startup_sidecar_is_the_fallback_owner`; the four existing `decide_daemon_start` tests carry the new input.
- `cargo clippy -p wenlan-app --all-targets -- -D warnings` clean, `cargo fmt` clean.
- Real proof needs a published build: after 0.17.2 is cut, the gauntlet's `macos-app` channel must pass `plist-server-exists`, `plist-desktop-exists`, and `launchctl-server-loaded` with the daemon run by launchd, and `daemon-after-app-quit` must then report the daemon still reachable (service-owned by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
