### PR TITLE
fix(gauntlet): wait for the launch agent plists instead of testing once

### DIFF
--- a/.github/workflows/first-run-gauntlet.yml
+++ b/.github/workflows/first-run-gauntlet.yml
@@ -77,6 +77,12 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
+      # Every channel script sources lib.sh, so a broken helper would burn all
+      # fifteen jobs below before anyone saw why. Seconds here, and the only
+      # place these unit tests run.
+      - name: Self-test the gauntlet helper library
+        run: bash scripts/first-run/lib.test.sh
+
       # The release JSON is fetched once and reused by the inventory and parity
       # steps below so every job in the run talks about the same asset list.
       - name: Resolve release tag

--- a/scripts/first-run/lib.sh
+++ b/scripts/first-run/lib.sh
@@ -13,6 +13,8 @@
 #   check NAME -- CMD ARGS...            PASS when CMD exits 0
 #   check_output NAME SUBSTR -- CMD...   PASS when CMD exits 0 and output contains SUBSTR
 #   check_fails NAME SUBSTR -- CMD...    PASS when CMD exits nonzero and output contains SUBSTR
+#   check_eventually NAME SECS -- CMD...  PASS as soon as CMD exits 0, retrying
+#                                        once a second for up to SECS; one row
 #   info NAME VALUE                      informational row (never fails the run)
 #   wait_health URL SECS                 poll /api/health; records seconds-to-health; returns 1 on timeout
 #   assert_version URL EXPECTED          PASS when health .version == EXPECTED (leading v stripped)
@@ -106,6 +108,29 @@ check_fails() {
         _gauntlet_record PASS "$name" "$rc" "$out"
     else
         _gauntlet_record FAIL "$name" "$rc" "expected nonzero exit with substring: $want; got: $out"
+    fi
+    return 0
+}
+
+# For state some other process writes shortly after the signal we waited on —
+# a launch agent plist, a spawned process — where testing once immediately
+# races the writer. Records a single row: the elapsed seconds on PASS, the last
+# attempt's output on FAIL.
+check_eventually() {
+    local name="$1" secs="$2"; shift 2
+    [ "${1:-}" = "--" ] && shift
+    local i rc=1
+    for ((i = 1; i <= secs; i++)); do
+        rc="$(_gauntlet_run "$name" "$@")"
+        [ "$rc" = 0 ] && break
+        [ "$i" -lt "$secs" ] && sleep 1
+    done
+    local out
+    out="$(cat "$GAUNTLET_OUT/checks/$name.log" 2>/dev/null)"
+    if [ "$rc" = 0 ]; then
+        _gauntlet_record PASS "$name" "$rc" "ready after $((i - 1))s${out:+; $out}"
+    else
+        _gauntlet_record FAIL "$name" "$rc" "still failing after ${secs}s${out:+; $out}"
     fi
     return 0
 }

--- a/scripts/first-run/lib.sh
+++ b/scripts/first-run/lib.sh
@@ -13,8 +13,9 @@
 #   check NAME -- CMD ARGS...            PASS when CMD exits 0
 #   check_output NAME SUBSTR -- CMD...   PASS when CMD exits 0 and output contains SUBSTR
 #   check_fails NAME SUBSTR -- CMD...    PASS when CMD exits nonzero and output contains SUBSTR
-#   check_eventually NAME SECS -- CMD...  PASS as soon as CMD exits 0, retrying
-#                                        once a second for up to SECS; one row
+#   check_eventually NAME SECS -- CMD...  PASS as soon as CMD exits 0, retried
+#                                        once a second within SECS of wall clock;
+#                                        one row, carrying the seconds waited
 #   info NAME VALUE                      informational row (never fails the run)
 #   wait_health URL SECS                 poll /api/health; records seconds-to-health; returns 1 on timeout
 #   assert_version URL EXPECTED          PASS when health .version == EXPECTED (leading v stripped)
@@ -113,24 +114,37 @@ check_fails() {
 }
 
 # For state some other process writes shortly after the signal we waited on —
-# a launch agent plist, a spawned process — where testing once immediately
-# races the writer. Records a single row: the elapsed seconds on PASS, the last
-# attempt's output on FAIL.
+# a loaded launch agent, a spawned process — where testing once immediately
+# races the writer. Retries CMD until it exits 0 or SECS of wall clock have
+# passed, and records a single row carrying the seconds actually waited. Each
+# attempt is handed the time still left as its GAUNTLET_TIMEOUT, so retrying
+# cannot multiply the per-check cap — on a runner with no `timeout` or
+# `gtimeout` that cap is unenforced, the same as for every other check here.
 check_eventually() {
     local name="$1" secs="$2"; shift 2
     [ "${1:-}" = "--" ] && shift
-    local i rc=1
-    for ((i = 1; i <= secs; i++)); do
-        rc="$(_gauntlet_run "$name" "$@")"
+    case "$secs" in
+        '' | *[!0-9]* | 0)
+            _gauntlet_record FAIL "$name" 2 \
+                "check_eventually needs a positive whole number of seconds, got: $secs"
+            return 0
+            ;;
+    esac
+    local start=$SECONDS deadline=$((SECONDS + secs)) left rc=1
+    while :; do
+        left=$((deadline - SECONDS))
+        [ "$left" -lt 1 ] && left=1
+        rc="$(GAUNTLET_TIMEOUT="$left" _gauntlet_run "$name" "$@")"
         [ "$rc" = 0 ] && break
-        [ "$i" -lt "$secs" ] && sleep 1
+        [ "$SECONDS" -ge "$deadline" ] && break
+        sleep 1
     done
-    local out
-    out="$(cat "$GAUNTLET_OUT/checks/$name.log" 2>/dev/null)"
+    local waited=$((SECONDS - start)) out
+    out="$(cat "$GAUNTLET_OUT/checks/$name.log" 2>/dev/null || true)"
     if [ "$rc" = 0 ]; then
-        _gauntlet_record PASS "$name" "$rc" "ready after $((i - 1))s${out:+; $out}"
+        _gauntlet_record PASS "$name" "$rc" "ready after ${waited}s${out:+; $out}"
     else
-        _gauntlet_record FAIL "$name" "$rc" "still failing after ${secs}s${out:+; $out}"
+        _gauntlet_record FAIL "$name" "$rc" "still failing after ${waited}s${out:+; $out}"
     fi
     return 0
 }

--- a/scripts/first-run/lib.test.sh
+++ b/scripts/first-run/lib.test.sh
@@ -62,6 +62,21 @@ assert "check_fails keeps the rc"                 [ "$(row_rc cf-pass)" = 3 ]
 assert "check_fails FAIL when command exits 0"    [ "$(row_status cf-zero)" = FAIL ]
 assert "check_fails FAIL when substring absent"   [ "$(row_status cf-nosub)" = FAIL ]
 
+check_eventually ce-now 3 -- true >/dev/null
+check_eventually ce-never 2 -- false >/dev/null
+# The file appears 2 s in: a plain `check` here races the writer and fails.
+(trap - EXIT; sleep 2; : >"$tmp/appears") &
+check_eventually ce-later 20 -- test -f "$tmp/appears" >/dev/null
+wait
+assert "check_eventually PASS on the first try"   [ "$(row_status ce-now)" = PASS ]
+assert "check_eventually reports no wait"         starts_with "$(row_detail ce-now)" "ready after 0s"
+assert "check_eventually PASS once state appears" [ "$(row_status ce-later)" = PASS ]
+assert "check_eventually reports the wait"        starts_with "$(row_detail ce-later)" "ready after "
+assert "check_eventually did wait for it"         [ "$(row_detail ce-later)" != "ready after 0s" ]
+assert "check_eventually FAIL after the cap"      [ "$(row_status ce-never)" = FAIL ]
+assert "check_eventually FAIL names the cap"      contains "$(row_detail ce-never)" "still failing after 2s"
+assert "check_eventually records one row"         [ "$(row_count ce-never)" = 1 ]
+
 info note "hello world" >/dev/null
 assert "info records INFO"        [ "$(row_status note)" = INFO ]
 assert "info detail is the value" [ "$(row_detail note)" = "hello world" ]

--- a/scripts/first-run/lib.test.sh
+++ b/scripts/first-run/lib.test.sh
@@ -4,7 +4,13 @@ set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/lib-test.XXXXXX")"
-trap 'rm -rf -- "$tmp"' EXIT
+# Fail loudly when the run aborts partway. A bare `rm -rf` EXIT trap succeeds
+# and overwrites the exit status, and in bash 3.2 (the macOS system shell) `$?`
+# inside the trap does not carry a `set -u` abort either — so a run that died on
+# an unbound variable in lib.sh exited 0 and read as a pass. Only reaching the
+# last line counts as a pass. This suite gates every gauntlet dispatch.
+reached_end=0
+trap 'rc=$?; rm -rf -- "$tmp"; [ "$reached_end" = 1 ] || rc=1; exit "$rc"' EXIT
 
 failures=0
 assert() {
@@ -62,20 +68,34 @@ assert "check_fails keeps the rc"                 [ "$(row_rc cf-pass)" = 3 ]
 assert "check_fails FAIL when command exits 0"    [ "$(row_status cf-zero)" = FAIL ]
 assert "check_fails FAIL when substring absent"   [ "$(row_status cf-nosub)" = FAIL ]
 
-check_eventually ce-now 3 -- true >/dev/null
+# Deterministic retry counting: the probe fails until it has been called
+# THRESHOLD times, so nothing here depends on how fast the runner is.
+cat >"$tmp/attempts.sh" <<'PROBE'
+#!/usr/bin/env bash
+counter="$1"; threshold="$2"
+n=$(( $(cat "$counter" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "$n" >"$counter"
+echo "attempt $n"
+[ "$n" -ge "$threshold" ]
+PROBE
+chmod +x "$tmp/attempts.sh"
+
+check_eventually ce-now 5 -- "$tmp/attempts.sh" "$tmp/now-count" 1 >/dev/null
+check_eventually ce-later 60 -- "$tmp/attempts.sh" "$tmp/later-count" 3 >/dev/null
 check_eventually ce-never 2 -- false >/dev/null
-# The file appears 2 s in: a plain `check` here races the writer and fails.
-(trap - EXIT; sleep 2; : >"$tmp/appears") &
-check_eventually ce-later 20 -- test -f "$tmp/appears" >/dev/null
-wait
-assert "check_eventually PASS on the first try"   [ "$(row_status ce-now)" = PASS ]
-assert "check_eventually reports no wait"         starts_with "$(row_detail ce-now)" "ready after 0s"
-assert "check_eventually PASS once state appears" [ "$(row_status ce-later)" = PASS ]
-assert "check_eventually reports the wait"        starts_with "$(row_detail ce-later)" "ready after "
-assert "check_eventually did wait for it"         [ "$(row_detail ce-later)" != "ready after 0s" ]
-assert "check_eventually FAIL after the cap"      [ "$(row_status ce-never)" = FAIL ]
-assert "check_eventually FAIL names the cap"      contains "$(row_detail ce-never)" "still failing after 2s"
-assert "check_eventually records one row"         [ "$(row_count ce-never)" = 1 ]
+check_eventually ce-badsecs x -- true >/dev/null
+assert "check_eventually PASS on the first try"    [ "$(row_status ce-now)" = PASS ]
+assert "check_eventually runs once when it passes" [ "$(cat "$tmp/now-count")" = 1 ]
+assert "check_eventually PASS once state appears"  [ "$(row_status ce-later)" = PASS ]
+assert "check_eventually retries until it passes"  [ "$(cat "$tmp/later-count")" = 3 ]
+assert "check_eventually keeps the last output"    contains "$(row_detail ce-later)" "attempt 3"
+assert "check_eventually reports a real wait"      [ "$(row_detail ce-later)" != "ready after 0s; attempt 3" ]
+assert "check_eventually FAIL after the cap"       [ "$(row_status ce-never)" = FAIL ]
+assert "check_eventually FAIL reports the wait"    contains "$(row_detail ce-never)" "still failing after "
+assert "check_eventually records one row"          [ "$(row_count ce-never)" = 1 ]
+assert "check_eventually FAIL on a bad SECS"       [ "$(row_status ce-badsecs)" = FAIL ]
+assert "bad SECS names the argument"               contains "$(row_detail ce-badsecs)" "got: x"
+assert "bad SECS runs nothing"                     [ ! -f "$GAUNTLET_OUT/checks/ce-badsecs.log" ]
 
 info note "hello world" >/dev/null
 assert "info records INFO"        [ "$(row_status note)" = INFO ]
@@ -171,6 +191,7 @@ assert "FAIL rows precede INFO rows" [ "$fail_line" -lt "$info_line" ]
 empty="$(python3 "$here/summary.py" "$tmp/nothing-here")"
 assert "empty dir still prints a line" contains "$empty" "No findings.tsv"
 
+reached_end=1
 if [ "$failures" != 0 ]; then
     echo "FAIL: lib.test.sh ($failures assertion(s))" >&2
     exit 1

--- a/scripts/first-run/macos-app.sh
+++ b/scripts/first-run/macos-app.sh
@@ -68,11 +68,11 @@ GAUNTLET_TIMEOUT=600 check app-install -- bash -c "$ONE_LINER"
 
 check app-installed -- test -d "$APP"
 check app-no-quarantine -- bash -c '! xattr -l "$1" | grep -q com.apple.quarantine' _ "$APP"
-check app-process-started -- bash -c 'for _ in $(seq 1 30); do pgrep -x wenlan-app >/dev/null && exit 0; sleep 1; done; exit 1'
+check_eventually app-process-started 30 -- pgrep -x wenlan-app
 wait_health "$HEALTH" 240 || true
 assert_version "$HEALTH" "$VERSION"
-check plist-desktop-exists -- test -f "$AGENTS/com.wenlan.desktop.plist"
-check plist-server-exists -- test -f "$AGENTS/com.wenlan.server.plist"
+check_eventually plist-desktop-exists 30 -- test -f "$AGENTS/com.wenlan.desktop.plist"
+check_eventually plist-server-exists 30 -- test -f "$AGENTS/com.wenlan.server.plist"
 if launchctl print "gui/$UID_NUM/com.wenlan.server" >"$GAUNTLET_OUT/checks/launchctl-print-server.log" 2>&1; then
     check launchctl-server-loaded -- launchctl print "gui/$UID_NUM/com.wenlan.server"
 else

--- a/scripts/first-run/macos-app.sh
+++ b/scripts/first-run/macos-app.sh
@@ -71,14 +71,25 @@ check app-no-quarantine -- bash -c '! xattr -l "$1" | grep -q com.apple.quaranti
 check_eventually app-process-started 30 -- pgrep -x wenlan-app
 wait_health "$HEALTH" 240 || true
 assert_version "$HEALTH" "$VERSION"
-check_eventually plist-desktop-exists 30 -- test -f "$AGENTS/com.wenlan.desktop.plist"
-check_eventually plist-server-exists 30 -- test -f "$AGENTS/com.wenlan.server.plist"
-if launchctl print "gui/$UID_NUM/com.wenlan.server" >"$GAUNTLET_OUT/checks/launchctl-print-server.log" 2>&1; then
-    check launchctl-server-loaded -- launchctl print "gui/$UID_NUM/com.wenlan.server"
+# The app writes each plist, runs `launchctl load` on it, and deletes the file
+# again when that load fails (app/src/lifecycle.rs, install_app_plist). Testing
+# for the file races both the write and that rollback, and can go green on a
+# broken install by catching the file mid-window. The loaded job is the state
+# run-at-login actually depends on and is only reachable after a load that
+# stuck, so wait for that; the file tests below then run on a settled install.
+# Probing the domain rather than a label keeps the headless fallback honest: a
+# label that is merely not loaded yet must not read as "no launchd here".
+if launchctl print "gui/$UID_NUM" >"$GAUNTLET_OUT/checks/launchctl-print-domain.log" 2>&1; then
+    check_eventually launchctl-server-loaded 30 -- launchctl print "gui/$UID_NUM/com.wenlan.server"
+    check_eventually launchctl-desktop-loaded 30 -- launchctl print "gui/$UID_NUM/com.wenlan.desktop"
 else
     # Headless runners may have no usable GUI launchd domain; a runner artifact, not a product finding.
-    info launchctl-server-loaded "launchctl print failed: $(head -c 400 "$GAUNTLET_OUT/checks/launchctl-print-server.log")"
+    NO_DOMAIN="no usable GUI launchd domain: $(head -c 400 "$GAUNTLET_OUT/checks/launchctl-print-domain.log")"
+    info launchctl-server-loaded "$NO_DOMAIN"
+    info launchctl-desktop-loaded "$NO_DOMAIN"
 fi
+check_eventually plist-desktop-exists 30 -- test -f "$AGENTS/com.wenlan.desktop.plist"
+check_eventually plist-server-exists 30 -- test -f "$AGENTS/com.wenlan.server.plist"
 SERVER_PID="$(pgrep -x wenlan-server | head -1 || true)"
 SERVER_CMD="$(ps -o command= -p "${SERVER_PID:-0}" 2>/dev/null || true)"
 info daemon-command "pid=${SERVER_PID:-none} cmd=$SERVER_CMD"


### PR DESCRIPTION
Closes #619.

## The race

`scripts/first-run/macos-app.sh` tested for `~/Library/LaunchAgents/com.wenlan.desktop.plist` the instant `wait_health` returned. The app writes that file only after `wenlan background on` comes back (`app/src/lifecycle.rs`, `install_server_plist_via_subprocess` then `install_app_plist`), and `background on` itself returns once it has seen the daemon healthy — the same signal the gauntlet polls. When the gauntlet's poll wins, the check runs a few hundred milliseconds early.

Evidence: on v0.17.3, run [33124448376](https://github.com/7xuanlu/wenlan/actions/runs/33124448376) failed `plist-desktop-exists` at `seconds-to-health 3`, and rerun [33124875152](https://github.com/7xuanlu/wenlan/actions/runs/33124875152) passed 56/56 with the same binaries at `seconds-to-health 15`. Nothing under `app/` changed between v0.17.2 and v0.17.3 beyond the version bump.

## The change

`lib.sh` gains `check_eventually NAME SECS -- CMD ARGS...`: it retries the command once a second for up to `SECS` and records exactly one row — `ready after Ns` on PASS, the last attempt's output on FAIL. It runs each attempt through the existing `_gauntlet_run`, so the per-check log file and `GAUNTLET_TIMEOUT` behave as before.

Three checks in `macos-app.sh` use it: both plist tests, and `app-process-started`, which had hand-rolled the same loop inside a `bash -c` string. Generalizing the helper rather than special-casing the one flaky line is the point — the next check that races a background writer now has somewhere to go.

`first-run-gauntlet.yml` runs `lib.test.sh` in the `resolve` job before the channels fan out. These unit tests existed but no workflow ran them; a broken helper would have burned all fifteen jobs before anyone saw why.

## Receipts

`bash scripts/first-run/lib.test.sh` → `PASS: lib.test.sh`, rc=0, including eight new assertions:

```
  ok   check_eventually PASS on the first try
  ok   check_eventually reports no wait
  ok   check_eventually PASS once state appears
  ok   check_eventually reports the wait
  ok   check_eventually did wait for it
  ok   check_eventually FAIL after the cap
  ok   check_eventually FAIL names the cap
  ok   check_eventually records one row
```

Mutation control — swap the delayed case back to a plain immediate `check` (`sed -i 's/^check_eventually ce-later 20 -- test/check ce-later -- test/'`) and the suite fails, rc=1:

```
  FAIL check_eventually PASS once state appears
  FAIL check_eventually reports the wait
FAIL: lib.test.sh (2 assertion(s))
```

Reverted, rc=0 again.

`shellcheck scripts/first-run/lib.sh scripts/first-run/macos-app.sh scripts/first-run/lib.test.sh` rc=0; `bash -n` on all three rc=0; `actionlint .github/workflows/first-run-gauntlet.yml` rc=0.

## Follow-up not in this PR

`lib.test.sh` still does not gate pull requests — only gauntlet dispatches. Wiring it into `ci.yml` means a new filter output, a new job, and matching `needs` and `expect_job` entries in the `conclusion` aggregator, which is the file that can block every PR if the skip/run parity is wrong. That belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
