### PR TITLE
fix(deps): raise five transitive npm packages past their advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "comment": "overrides: smallest safe version for an advisory, held inside the major the parents already use, and applied only to the vulnerable range so an already-safe copy is left alone. Drop an entry once every parent resolves past it by itself; `pnpm audit` is the check.",
     "overrides": {
       "brace-expansion@>=4.0.0 <5.0.9": "^5.0.9",
-      "fast-uri@>=3.0.0 <3.1.5": "^3.1.5",
+      "fast-uri@>=3.0.0 <3.1.6": "^3.1.6",
       "nanoid@<3.3.18": "^3.3.18",
       "postcss@<=8.5.22": "^8.5.23",
       "undici@>=7.0.0 <7.29.0": "^7.29.0"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,15 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "comment": "overrides: smallest safe version for an advisory, held inside the major the parents already use, and applied only to the vulnerable range so an already-safe copy is left alone. Drop an entry once every parent resolves past it by itself; `pnpm audit` is the check.",
+    "overrides": {
+      "brace-expansion@>=4.0.0 <5.0.9": "^5.0.9",
+      "fast-uri@>=3.0.0 <3.1.5": "^3.1.5",
+      "nanoid@<3.3.18": "^3.3.18",
+      "postcss@<=8.5.22": "^8.5.23",
+      "undici@>=7.0.0 <7.29.0": "^7.29.0"
+    }
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
-  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
+  fast-uri@>=3.0.0 <3.1.6: ^3.1.6
   nanoid@<3.3.18: ^3.3.18
   postcss@<=8.5.22: ^8.5.23
   undici@>=7.0.0 <7.29.0: ^7.29.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@>=4.0.0 <5.0.9: ^5.0.9
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
+  nanoid@<3.3.18: ^3.3.18
+  postcss@<=8.5.22: ^8.5.23
+  undici@>=7.0.0 <7.29.0: ^7.29.0
+
 importers:
 
   .:
@@ -1739,9 +1746,9 @@ packages:
     peerDependencies:
       react: '>=17.0.1'
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2046,8 +2053,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2652,8 +2659,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2753,8 +2760,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.29.7:
@@ -3085,8 +3092,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4661,7 +4668,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4710,7 +4717,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5043,7 +5050,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.6: {}
 
   fastq@1.20.1:
     dependencies:
@@ -5254,7 +5261,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -5785,13 +5792,13 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5944,9 +5951,9 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss@8.5.20:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -6331,7 +6338,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6406,7 +6413,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.26
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
`pnpm audit` on `main` reports **10 advisories — 5 high, 5 moderate**, every one of them in a package nothing in this repository depends on directly. GitHub's Dependabot alerts, switched on today, report 7 of the same set.

| Package | Was | Now | Advisories |
|---|---|---|---|
| brace-expansion | 5.0.7 | 5.0.9 | GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 (both high) |
| undici | 7.28.0 | 7.29.0 | GHSA-4cwx-7wf7-3272 (high), GHSA-8xcm-r25x-g524, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5, GHSA-v3r7-h72x-cjcm |
| fast-uri | 3.1.4 | 3.1.6 | GHSA-7p8r-x3mc-p8w7 (high) |
| nanoid | 3.3.16 | 3.3.18 | GHSA-2v37-7h3g-55p8 (high) |
| postcss | 8.5.20 | 8.5.26 | GHSA-fxqj-rqcc-2cmp |

## Why overrides and not an update

`pnpm update brace-expansion postcss undici fast-uri nanoid --depth Infinity` fixes all five, but re-resolves far beyond them: 334 lockfile lines moved, pulling new Sentry, OpenTelemetry, Babel, ESLint and Vite-plugin versions along for the ride. That is a large surface to review for five security bumps.

Each override here is written as `"<pkg>@<vulnerable range>": "^<smallest safe version>"`, which does two things worth keeping:

- **Scoped to the vulnerable range**, so a copy of the package that already resolves to a safe version is left exactly where it is.
- **Held inside the major the parents already use.** Writing `">=3.1.5"` instead of `"^3.1.5"` is what a plain minimum looks like, and it resolved fast-uri to 4.1.3, nanoid to **6.0.1** (from 3.x, where 4.0 went ESM-only) and undici to 8.10.0 — three unrequested major bumps. The caret form keeps them on 3.1.6, 3.3.18 and 7.29.0.

The lockfile moves 49 lines.

The `comment` key next to `overrides` says when an entry can go: once every parent resolves past it on its own, `pnpm audit` stays clean without it.

## Receipts

- `pnpm audit` → **No known vulnerabilities found** (was 10)
- `pnpm install --frozen-lockfile` → clean, so `package.json` and the lockfile agree
- `pnpm exec tsc --noEmit -p tsconfig.json` → `TypeScript: No errors found`, rc=0
- `pnpm build` (`tsc -b && vite build`) → rc=0, built in 2.74s — this is the path postcss is actually on
- `pnpm exec vitest run` → **1979 passed**, 2 failed, 26 skipped. The two failures are the known environment ones in `scripts/dev-runtime.test.ts` (`isolated dev port 27991 is already in use`, and 27992), caused by another worktree's dev runtime holding those ports on this machine. Same two, same count as the recorded baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
