### PR TITLE
fix(security): close the three remaining audit findings on the open and relay paths

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1307,6 +1307,7 @@ pub fn run() {
             search::delete_by_time_range,
             search::delete_bulk,
             search::open_file,
+            search::open_search_result,
             search::read_source_dir,
             search::detect_obsidian_vaults,
             search::read_text_file,

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1423,7 +1423,6 @@ pub fn run() {
             // Remote access commands
             search::toggle_remote_access,
             search::get_remote_access_status,
-            search::rotate_remote_token,
             search::test_remote_mcp_connection,
             // Memory nurture commands
             search::get_nurture_cards_cmd,

--- a/app/src/remote_access.rs
+++ b/app/src/remote_access.rs
@@ -197,7 +197,6 @@ pub enum RemoteAccessStatus {
     Starting,
     Connected {
         tunnel_url: String,
-        token: String,
         /// Stable relay URL (if relay registration succeeded).
         relay_url: Option<String>,
     },
@@ -775,80 +774,12 @@ fn write_private_file(path: &Path, contents: &[u8], file_name: &str) -> Result<(
     restrict_private_file(path, file_name)
 }
 
-fn import_nonempty_legacy_file(
-    current_dir: &Path,
-    legacy_dir: &Path,
-    file_name: &str,
-) -> Result<PathBuf, String> {
-    let current_path = current_dir.join(file_name);
-    if current_path.exists() {
-        restrict_private_dir(current_dir, file_name)?;
-        restrict_private_file(&current_path, file_name)?;
-        return Ok(current_path);
-    }
-
-    let legacy_path = legacy_dir.join(file_name);
-    let contents = match std::fs::read_to_string(&legacy_path) {
-        Ok(contents) => contents,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(current_path),
-        Err(e) => {
-            log::warn!(
-                "[remote-access] Skipping legacy {} import from {}: {}",
-                file_name,
-                legacy_path.display(),
-                e
-            );
-            return Ok(current_path);
-        }
-    };
-
-    if contents.trim().is_empty() {
-        return Ok(current_path);
-    }
-
-    write_private_file(&current_path, contents.as_bytes(), file_name)?;
-
-    Ok(current_path)
-}
-
-fn token_file_path_for_dirs(current_dir: &Path, legacy_dir: &Path) -> Result<PathBuf, String> {
-    import_nonempty_legacy_file(current_dir, legacy_dir, "token")
-}
-
 fn relay_id_path_for_dirs(current_dir: &Path) -> PathBuf {
     current_dir.join("relay_id")
 }
 
-/// Token file path for wenlan-mcp authentication.
-/// wenlan-mcp stores tokens at ~/.config/wenlan-mcp/token (XDG convention),
-/// NOT ~/Library/Application Support/ (macOS convention from dirs::config_dir).
-fn token_file_path() -> Result<PathBuf, String> {
-    let current = crate::identity_paths::mcp_config_dir();
-    if crate::identity_paths::isolated_dev_state_dir().is_some() {
-        return token_file_path_for_dirs(&current, &current);
-    }
-    token_file_path_for_dirs(&current, &crate::identity_paths::legacy_mcp_config_dir())
-}
-
 fn relay_id_path() -> PathBuf {
     relay_id_path_for_dirs(&crate::identity_paths::mcp_config_dir())
-}
-
-fn token_generate_args(path: &std::path::Path) -> Vec<String> {
-    vec![
-        "token".to_string(),
-        "generate".to_string(),
-        "--output".to_string(),
-        path.to_string_lossy().into_owned(),
-    ]
-}
-
-/// Read the bearer token from disk.
-pub fn read_token() -> Result<String, String> {
-    let path = token_file_path()?;
-    std::fs::read_to_string(&path)
-        .map(|s| s.trim().to_string())
-        .map_err(|e| format!("Failed to read token at {}: {}", path.display(), e))
 }
 
 /// Start the remote access tunnel (wenlan-mcp serve + cloudflared).
@@ -907,7 +838,7 @@ async fn toggle_on_inner(
     let result = start_tunnel(&app_handle, operation_generation).await;
 
     match result {
-        Ok((tunnel_url, token, mcp_child, tunnel_child, tunnel_owner, port, mcp_rx, tunnel_rx)) => {
+        Ok((tunnel_url, mcp_child, tunnel_child, tunnel_owner, port, mcp_rx, tunnel_rx)) => {
             {
                 let state = app_handle
                     .state::<std::sync::Arc<tokio::sync::RwLock<crate::state::AppState>>>();
@@ -934,7 +865,6 @@ async fn toggle_on_inner(
 
             let status = RemoteAccessStatus::Connected {
                 tunnel_url: tunnel_url.clone(),
-                token: token.clone(),
                 relay_url: relay_url.clone(),
             };
             // Store process handles in state
@@ -1567,7 +1497,6 @@ async fn start_tunnel(
 ) -> Result<
     (
         String,                                                                 // tunnel_url
-        String,                                                                 // token
         tauri_plugin_shell::process::CommandChild,                              // mcp_child
         tauri_plugin_shell::process::CommandChild,                              // tunnel_child
         CloudflaredOwner, // tunnel owner receipt
@@ -1600,48 +1529,20 @@ async fn start_tunnel(
         )
     })?;
 
-    // 2. Ensure token exists
-    let token_path = token_file_path()?;
-    log::warn!(
-        "[remote-access] token_path={}, exists={}",
-        token_path.display(),
-        token_path.exists()
-    );
-    if !token_path.exists() {
-        prepare_private_parent(&token_path, "token")?;
-        let shell = app_handle.shell();
-        log::warn!("[remote-access] generating token via sidecar...");
-        let cmd = shell
-            .sidecar(MCP_SIDECAR_NAME)
-            .map_err(|e| format!("{} sidecar not found: {}", MCP_SIDECAR_NAME, e))?;
-        log::warn!("[remote-access] sidecar command created, executing token generate...");
-        let output = cmd
-            .args(token_generate_args(&token_path))
-            .output()
-            .await
-            .map_err(|e| format!("Failed to generate token (exec error: {})", e))?;
-        log::warn!(
-            "[remote-access] token generate exit status: {:?}, stderr: {}",
-            output.status,
-            String::from_utf8_lossy(&output.stderr)
-        );
-        if !output.status.success() {
-            return Err(format!(
-                "Token generation failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
-        }
-        restrict_private_file(&token_path, "token")?;
-    }
-    let token = read_token()?;
+    // No bearer token here on purpose: the relay endpoint below is reached by
+    // the Claude.ai and ChatGPT connectors, which have no way to attach an
+    // `Authorization` header to their requests, so `spawn_mcp` runs the
+    // sidecar with `--no-auth`. What actually guards this endpoint is the
+    // unguessable relay ID (see `new_relay_id`), the explicit in-app warning
+    // (`remoteAccess.noAuthWarning`), and Remote Access being off by default.
     if !remote_generation_is_current(app_handle, generation).await {
         return Err("Remote access start cancelled.".to_string());
     }
 
-    // 3. Spawn wenlan-mcp serve (with health check)
+    // 2. Spawn wenlan-mcp serve (with health check)
     let (mcp_rx, mcp_child) = spawn_mcp(app_handle, port, generation).await?;
 
-    // 4. Spawn cloudflared tunnel
+    // 3. Spawn cloudflared tunnel
     let tunnel_command = match app_handle.shell().sidecar("cloudflared") {
         Ok(command) => command,
         Err(error) => {
@@ -1673,7 +1574,7 @@ async fn start_tunnel(
         return Err("Remote access start cancelled.".to_string());
     }
 
-    // 5. Parse tunnel URL from cloudflared output (it logs to stderr)
+    // 4. Parse tunnel URL from cloudflared output (it logs to stderr)
     let tunnel_result = tokio::select! {
         result = timeout(
             Duration::from_secs(20),
@@ -1705,7 +1606,7 @@ async fn start_tunnel(
         }
     };
 
-    // 6. Best-effort tunnel verification — don't kill on failure.
+    // 5. Best-effort tunnel verification — don't kill on failure.
     // Quick tunnels can take 10-20s to become fully reachable after URL is printed.
     let verify_url = format!("{}/health", tunnel_url);
     let verify_ok = timeout(Duration::from_secs(10), async {
@@ -1733,7 +1634,6 @@ async fn start_tunnel(
 
     Ok((
         tunnel_url,
-        token,
         mcp_child,
         tunnel_child,
         tunnel_owner,
@@ -1794,47 +1694,6 @@ async fn transition_off(
 /// Stop the remote access tunnel — kill both processes and invalidate stale tasks.
 pub async fn toggle_off(app_handle: &tauri::AppHandle) {
     let _ = transition_off(app_handle, None).await;
-}
-
-/// Rotate the bearer token — generate a new token then kill the old wenlan-mcp.
-/// The crash recovery monitor detects the MCP exit and respawns only wenlan-mcp
-/// (tunnel stays alive). The new instance reads the updated token from disk.
-pub async fn rotate_token(app_handle: &tauri::AppHandle) -> Result<String, String> {
-    // 1. Generate new token first (before killing anything)
-    let token_path = token_file_path()?;
-    prepare_private_parent(&token_path, "token")?;
-    let shell = app_handle.shell();
-    let output = shell
-        .sidecar(MCP_SIDECAR_NAME)
-        .map_err(|e| format!("{} sidecar not found: {}", MCP_SIDECAR_NAME, e))?
-        .args(token_generate_args(&token_path))
-        .output()
-        .await
-        .map_err(|e| format!("Failed to generate token: {}", e))?;
-    if !output.status.success() {
-        return Err(format!(
-            "Token generation failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        ));
-    }
-    restrict_private_file(&token_path, "token")?;
-
-    let token = read_token()?;
-
-    // 2. Kill old wenlan-mcp — crash recovery monitor will detect this,
-    //    kill cloudflared, wait 2s, and restart everything with the new token
-    //    (already written to disk above).
-    {
-        let state =
-            app_handle.state::<std::sync::Arc<tokio::sync::RwLock<crate::state::AppState>>>();
-        let app_state = state.read().await;
-        let mut ra = app_state.remote_access.lock().await;
-        if let Some(child) = ra.mcp_child.take() {
-            let _ = child.kill();
-        }
-    }
-
-    Ok(token)
 }
 
 #[cfg(test)]
@@ -1940,7 +1799,6 @@ mod tests {
 
         let status = RemoteAccessStatus::Connected {
             tunnel_url: "https://test.trycloudflare.com".to_string(),
-            token: "abc123".to_string(),
             relay_url: None,
         };
         let json = serde_json::to_string(&status).unwrap();
@@ -2220,107 +2078,6 @@ mod tests {
     }
 
     #[test]
-    fn token_path_imports_nonempty_legacy_token_when_current_missing() {
-        let tmp = tempfile::tempdir().unwrap();
-        let current = tmp.path().join("wenlan-mcp");
-        let legacy = tmp.path().join("origin-mcp");
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(legacy.join("token"), "legacy-token\n").unwrap();
-
-        let path = token_file_path_for_dirs(&current, &legacy).unwrap();
-
-        assert_eq!(path, current.join("token"));
-        assert_eq!(
-            std::fs::read_to_string(current.join("token")).unwrap(),
-            "legacy-token\n"
-        );
-    }
-
-    #[test]
-    #[cfg(unix)]
-    fn token_path_imports_legacy_token_with_private_permissions() {
-        let tmp = tempfile::tempdir().unwrap();
-        let current = tmp.path().join("wenlan-mcp");
-        let legacy = tmp.path().join("origin-mcp");
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(legacy.join("token"), "legacy-token\n").unwrap();
-
-        let path = token_file_path_for_dirs(&current, &legacy).unwrap();
-
-        assert_eq!(path, current.join("token"));
-        assert_eq!(file_mode(&path), 0o600);
-        assert_eq!(file_mode(&current), 0o700);
-    }
-
-    #[test]
-    fn token_path_keeps_current_token_when_present() {
-        let tmp = tempfile::tempdir().unwrap();
-        let current = tmp.path().join("wenlan-mcp");
-        let legacy = tmp.path().join("origin-mcp");
-        std::fs::create_dir_all(&current).unwrap();
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(current.join("token"), "current-token\n").unwrap();
-        std::fs::write(legacy.join("token"), "legacy-token\n").unwrap();
-
-        let path = token_file_path_for_dirs(&current, &legacy).unwrap();
-
-        assert_eq!(path, current.join("token"));
-        assert_eq!(
-            std::fs::read_to_string(current.join("token")).unwrap(),
-            "current-token\n"
-        );
-    }
-
-    #[test]
-    fn token_path_does_not_import_empty_legacy_token() {
-        let tmp = tempfile::tempdir().unwrap();
-        let current = tmp.path().join("wenlan-mcp");
-        let legacy = tmp.path().join("origin-mcp");
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(legacy.join("token"), " \n").unwrap();
-
-        let path = token_file_path_for_dirs(&current, &legacy).unwrap();
-
-        assert_eq!(path, current.join("token"));
-        assert!(!current.join("token").exists());
-    }
-
-    #[test]
-    #[cfg(debug_assertions)]
-    #[serial_test::serial]
-    fn dev_token_path_does_not_import_production_credentials() {
-        let tmp = tempfile::tempdir().unwrap();
-        let _home = HomeGuard::set(tmp.path());
-        let production_legacy = tmp.path().join(".config/origin-mcp");
-        std::fs::create_dir_all(&production_legacy).unwrap();
-        std::fs::write(production_legacy.join("token"), "production-token\n").unwrap();
-        let dev_state = tmp.path().join("dev-state");
-        std::env::set_var("WENLAN_DEV_STATE_DIR", &dev_state);
-
-        let path = token_file_path().unwrap();
-
-        assert_eq!(path, dev_state.join("mcp-config/token"));
-        assert!(
-            !path.exists(),
-            "production token must not be copied into dev"
-        );
-    }
-
-    #[test]
-    fn token_path_skips_invalid_legacy_token() {
-        let tmp = tempfile::tempdir().unwrap();
-        let current = tmp.path().join("wenlan-mcp");
-        let legacy = tmp.path().join("origin-mcp");
-        std::fs::create_dir_all(&legacy).unwrap();
-        std::fs::write(legacy.join("token"), [0xff, 0xfe]).unwrap();
-
-        let path = token_file_path_for_dirs(&current, &legacy).unwrap();
-
-        assert_eq!(path, current.join("token"));
-        assert!(!current.join("token").exists());
-    }
-
-    #[test]
     fn relay_id_path_does_not_import_legacy_relay_id() {
         let tmp = tempfile::tempdir().unwrap();
         let current = tmp.path().join("wenlan-mcp");
@@ -2420,21 +2177,5 @@ mod tests {
         std::fs::create_dir_all(&path).unwrap();
 
         assert!(get_or_create_relay_id().is_err());
-    }
-
-    #[test]
-    fn test_token_generate_args_include_wenlan_output_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join(".config").join("wenlan-mcp").join("token");
-
-        assert_eq!(
-            token_generate_args(&path),
-            vec![
-                "token".to_string(),
-                "generate".to_string(),
-                "--output".to_string(),
-                path.to_string_lossy().into_owned()
-            ]
-        );
     }
 }

--- a/app/src/remote_access.rs
+++ b/app/src/remote_access.rs
@@ -41,20 +41,63 @@ const RELAY_URL: &str = "https://origin-relay.originmemory.workers.dev";
 const RELAY_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const RELAY_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// Random bytes behind a relay ID. The ID is the whole of the protection on a
+/// public MCP endpoint: it is the path segment of the URL handed to Claude.ai
+/// and ChatGPT, and it is also what `register_with_relay` posts as `secret`.
+/// Anyone who can produce it can read and write the user's memory, so it has
+/// to be unguessable on its own. 16 bytes is 128 bits.
+const RELAY_ID_BYTES: usize = 16;
+
+/// The shape a relay ID has today: `u` then `RELAY_ID_BYTES` of lowercase hex.
+fn relay_id_is_current(id: &str) -> bool {
+    id.len() == 1 + RELAY_ID_BYTES * 2
+        && id.starts_with('u')
+        && id[1..]
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// A relay ID from a CSPRNG.
+fn new_relay_id() -> Result<String, String> {
+    let mut buf = [0_u8; RELAY_ID_BYTES];
+    getrandom::getrandom(&mut buf)
+        .map_err(|e| format!("CSPRNG unavailable for the relay ID: {e}"))?;
+    let mut id = String::with_capacity(1 + RELAY_ID_BYTES * 2);
+    id.push('u');
+    for byte in buf {
+        id.push_str(&format!("{byte:02x}"));
+    }
+    Ok(id)
+}
+
 /// Get or create a persistent relay user ID.
 /// Stored in ~/.config/wenlan-mcp/relay_id
+///
+/// An ID that is not the current shape is replaced rather than reused. Before
+/// this, the ID was `u` plus 11 hex characters of a `DefaultHasher` over the
+/// wall clock and the process ID — a hash with fixed keys over two guessable
+/// inputs, truncated to 44 bits. Keeping such an ID would leave the endpoint
+/// it protects as reachable as it was. The cost is that Remote Access hands
+/// out a new URL once on those installs, so a saved connector has to be
+/// re-added; the feature is off by default and marked experimental.
 fn get_or_create_relay_id() -> Result<String, String> {
     let path = relay_id_path();
 
     match std::fs::read_to_string(&path) {
         Ok(id) => {
             let id = id.trim().to_string();
-            if !id.is_empty() {
+            if relay_id_is_current(&id) {
                 if let Some(parent) = path.parent() {
                     restrict_private_dir(parent, "relay_id")?;
                 }
                 restrict_private_file(&path, "relay_id")?;
                 return Ok(id);
+            }
+            if !id.is_empty() {
+                log::warn!(
+                    "[remote-access] replacing a relay ID that predates the CSPRNG; \
+                     Remote Access will hand out a new URL"
+                );
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -67,17 +110,7 @@ fn get_or_create_relay_id() -> Result<String, String> {
         }
     }
 
-    // Generate a short random ID
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    std::time::SystemTime::now().hash(&mut hasher);
-    std::process::id().hash(&mut hasher);
-    let id = format!("u{:x}", hasher.finish())
-        .chars()
-        .take(12)
-        .collect::<String>();
-
+    let id = new_relay_id()?;
     write_private_file(&path, id.as_bytes(), "relay_id")?;
     Ok(id)
 }
@@ -2314,6 +2347,68 @@ mod tests {
         assert!(!id.is_empty());
         assert_eq!(file_mode(&path), 0o600);
         assert_eq!(file_mode(path.parent().unwrap()), 0o700);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn a_fresh_relay_id_has_128_bits_behind_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::set(tmp.path());
+
+        let id = get_or_create_relay_id().unwrap();
+
+        assert!(relay_id_is_current(&id), "unexpected shape: {id}");
+        assert_eq!(id.len(), 33, "u + 32 hex characters: {id}");
+    }
+
+    #[test]
+    fn two_relay_ids_do_not_collide() {
+        // A weak generator shows up here as a repeat. The old one hashed the
+        // wall clock and the process ID, so two IDs made in the same
+        // millisecond by the same process were the same string.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..256 {
+            assert!(seen.insert(new_relay_id().unwrap()), "repeated relay ID");
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn a_relay_id_from_before_the_csprng_is_replaced() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::set(tmp.path());
+        let path = relay_id_path();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        // Exactly what the previous generator wrote: `u` plus 11 hex characters.
+        std::fs::write(&path, "u1a2b3c4d5e6").unwrap();
+
+        let id = get_or_create_relay_id().unwrap();
+
+        assert_ne!(id, "u1a2b3c4d5e6");
+        assert!(relay_id_is_current(&id), "unexpected shape: {id}");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), id);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn a_current_relay_id_survives_a_restart() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _home = HomeGuard::set(tmp.path());
+
+        let first = get_or_create_relay_id().unwrap();
+        let second = get_or_create_relay_id().unwrap();
+
+        assert_eq!(first, second, "the URL must not change on every launch");
+    }
+
+    #[test]
+    fn relay_id_shape_rejects_the_old_and_the_malformed() {
+        assert!(!relay_id_is_current(""));
+        assert!(!relay_id_is_current("u1a2b3c4d5e6"));
+        assert!(!relay_id_is_current(&"u".repeat(33)));
+        assert!(!relay_id_is_current(&format!("u{}", "A".repeat(32))));
+        assert!(!relay_id_is_current(&format!("x{}", "0".repeat(32))));
+        assert!(relay_id_is_current(&format!("u{}", "0f".repeat(16))));
     }
 
     #[test]

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -623,14 +623,6 @@ pub async fn test_remote_mcp_connection(
     }
 }
 
-#[tauri::command]
-pub async fn rotate_remote_token(
-    _state: tauri::State<'_, State>,
-    app_handle: tauri::AppHandle,
-) -> Result<String, String> {
-    crate::remote_access::rotate_token(&app_handle).await
-}
-
 // ── File / open commands ──────────────────────────────────────────────
 
 /// What `open_file` will hand to the OS: a web page, a local file, or a bare

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -625,21 +625,26 @@ pub async fn test_remote_mcp_connection(
 
 // ── File / open commands ──────────────────────────────────────────────
 
-/// What `open_file` will hand to the OS: a web page, a local file, or a bare
-/// filesystem path. Everything else is refused.
+/// What `open_file` and `open_search_result` will hand to the OS: a web page,
+/// a local file, or a bare filesystem path. Everything else is refused.
 ///
-/// The value reaching here is not the app's own. `POST /api/ingest/webpage`
-/// and `/api/ingest/memory` store the caller's `url` verbatim
-/// (`crates/wenlan-server/src/ingest_routes.rs`), it rides out on every search
-/// result, and clicking a result calls this command with it — so any agent or
-/// page that can put a memory in the store chooses a string the desktop's
-/// scheme handlers will act on. `javascript:`, `data:`, `vbscript:` and the
-/// long tail of registered application schemes are all reachable that way.
-/// The other opener in the app, the Tauri shell plugin behind citation links,
-/// has been scheme-restricted all along by its default scope; this one was not.
-/// `file:` is deliberately absent. The one caller that deals in `file:` URLs
-/// strips the prefix before it invokes (`openFile` in `src/lib/tauri.ts`), so
-/// a local file arrives here as a bare path and goes through the filesystem
+/// `open_file` serves the Sources view, where the value is a path the user is
+/// browsing in their own configured folder, or the configured folder itself
+/// — not attacker-influenced. Search results are the attacker-influenced
+/// value: `POST /api/ingest/webpage` and `/api/ingest/memory` store the
+/// caller's `url` verbatim (`crates/wenlan-server/src/ingest_routes.rs`), it
+/// rides out on every search result, so any agent or page that can put a
+/// memory in the store chooses a string the desktop's scheme handlers will
+/// act on. That is why clicking a search result calls `open_search_result`,
+/// not `open_file` — see its allowlist-based check.
+/// `javascript:`, `data:`, `vbscript:` and the long tail of registered
+/// application schemes are all reachable via that route. The other opener in
+/// the app, the Tauri shell plugin behind citation links, has been
+/// scheme-restricted all along by its default scope; these two were not.
+/// `file:` is deliberately absent from both. The callers that deal in `file:`
+/// URLs strip the prefix before invoking (`openFile` in `src/lib/tauri.ts`;
+/// `open_search_result` refuses it outright rather than stripping it), so a
+/// local file arrives here as a bare path and goes through the filesystem
 /// checks below. Accepting the URL form as well would be a way around them.
 const OPENABLE_SCHEMES: [&str; 2] = ["http", "https"];
 
@@ -659,9 +664,32 @@ const LAUNCHER_SUFFIXES: [&str; 8] = [
     "webloc",
 ];
 #[cfg(target_os = "windows")]
-const LAUNCHER_SUFFIXES: [&str; 23] = [
-    "exe", "com", "bat", "cmd", "scr", "msi", "msp", "cpl", "hta", "pif", "ps1", "vbs", "vbe",
-    "js", "jse", "wsf", "wsh", "reg", "lnk", "msc", "jar", "url", "scf",
+const LAUNCHER_SUFFIXES: [&str; 25] = [
+    "exe",
+    "com",
+    "bat",
+    "cmd",
+    "scr",
+    "msi",
+    "msp",
+    "cpl",
+    "hta",
+    "pif",
+    "ps1",
+    "vbs",
+    "vbe",
+    "js",
+    "jse",
+    "wsf",
+    "wsh",
+    "reg",
+    "lnk",
+    "msc",
+    "jar",
+    "url",
+    "scf",
+    "appref-ms",
+    "application",
 ];
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
 const LAUNCHER_SUFFIXES: [&str; 1] = ["desktop"];
@@ -690,11 +718,14 @@ fn target_scheme(target: &str) -> Option<String> {
 /// Whether the last extension of `path` is one this platform launches.
 ///
 /// Read off the string rather than the disk, so it holds for a path that does
-/// not exist yet and for a macOS `.app`, which is a directory.
+/// not exist yet and for a macOS `.app`, which is a directory. Trailing `.`
+/// and trailing space are trimmed off the extension before comparing, because
+/// Win32 strips both before resolving a filename — `evil.exe   ` opens
+/// `evil.exe`.
 fn has_launcher_suffix(path: &std::path::Path) -> bool {
     path.extension()
         .and_then(|ext| ext.to_str())
-        .map(|ext| ext.to_ascii_lowercase())
+        .map(|ext| ext.trim_end_matches(['.', ' ']).to_ascii_lowercase())
         .is_some_and(|ext| LAUNCHER_SUFFIXES.contains(&ext.as_str()))
 }
 
@@ -722,7 +753,20 @@ fn is_executable_file(_path: &std::path::Path) -> bool {
 /// the audit's own example was a memory whose `url` was
 /// `/Applications/Utilities/Terminal.app`, which carries no scheme at all and
 /// would sail past a scheme check.
+///
+/// The path is canonicalized before either filesystem check runs, so a
+/// symlink whose own name carries no launcher suffix but which resolves to a
+/// `.app` bundle (or any other launcher) is judged on what it actually points
+/// at, not on its name. Canonicalizing also has the OS resolve a Windows
+/// trailing dot or space the way `ShellExecuteExW` would. Canonicalization
+/// failing (a path that does not exist, or has just moved) falls back to the
+/// raw path rather than refusing outright — this command also serves the
+/// Sources view, which can legitimately be handed a path like that.
 fn refuse_unopenable_target(target: &str) -> Result<(), String> {
+    if target.contains('\0') {
+        return Err("Refusing to open a path containing a NUL byte.".to_string());
+    }
+
     if let Some(scheme) = target_scheme(target) {
         if OPENABLE_SCHEMES.contains(&scheme.as_str()) {
             return Ok(());
@@ -733,7 +777,9 @@ fn refuse_unopenable_target(target: &str) -> Result<(), String> {
     }
 
     let path = std::path::Path::new(target);
-    if has_launcher_suffix(path) || is_executable_file(path) {
+    let canonical = std::fs::canonicalize(path).ok();
+    let checked = canonical.as_deref().unwrap_or(path);
+    if has_launcher_suffix(checked) || is_executable_file(checked) {
         return Err(format!(
             "Refusing to run \"{target}\". Wenlan opens documents and folders, not programs."
         ));
@@ -753,12 +799,105 @@ pub async fn open_file(path: String) -> Result<(), String> {
     open::that_detached(&path).map_err(|e| format!("Failed to open file: {}", e))
 }
 
+/// What the daemon's directory ingest actually indexes
+/// (`crates/wenlan-core/src/sources/directory.rs`). A search result that
+/// points at a local file points at one of these, because that is all that
+/// gets indexed — so this can be an allowlist rather than a denylist of
+/// everything the OS might run.
+const INDEXED_DOCUMENT_SUFFIXES: [&str; 3] = ["md", "txt", "pdf"];
+
+/// `Ok(())` when `open_search_result` may hand `target` to the OS.
+///
+/// `target` is a search result's `url`, stored verbatim from whatever an
+/// ingest call sent (`POST /api/ingest/webpage`, `/api/ingest/memory`) — any
+/// agent or page that can write a memory chooses this string. That rules out
+/// the denylist `refuse_unopenable_target` uses for the Sources view: a
+/// denylist only refuses what it happens to enumerate, and this input is
+/// adversarial. So a filesystem path here is judged by an allowlist instead —
+/// it must canonicalize to a regular file whose extension is one of the
+/// document types Wenlan actually indexes.
+///
+/// Canonicalizing resolves symlinks and `..` before either filesystem check
+/// runs, so a symlink named to look like a document but pointing at an `.app`
+/// bundle is judged on what it resolves to. It also fails outright for a
+/// trailing Windows dot/space or an embedded NUL, since none of those name a
+/// file that exists — a search result points at something Wenlan indexed, so
+/// a path that is not there is not openable anyway. The NUL is also checked
+/// explicitly first: canonicalize's behaviour on an interior NUL is not
+/// something to depend on.
+/// Returns the canonical path the decision was made about, so the caller can
+/// hand the OS exactly what was judged rather than the string it started
+/// from. A `None` means the target is a URL and goes through unchanged.
+fn refuse_unopenable_search_result(target: &str) -> Result<Option<std::path::PathBuf>, String> {
+    if target.contains('\0') {
+        return Err("Refusing to open a path containing a NUL byte.".to_string());
+    }
+
+    if let Some(scheme) = target_scheme(target) {
+        if OPENABLE_SCHEMES.contains(&scheme.as_str()) {
+            return Ok(None);
+        }
+        return Err(format!(
+            "Refusing to open a \"{scheme}:\" link. Wenlan opens web pages and files on this computer."
+        ));
+    }
+
+    let canonical = std::fs::canonicalize(target)
+        .map_err(|_| format!("Refusing to open \"{target}\": no such file."))?;
+
+    let is_file = std::fs::metadata(&canonical)
+        .map(|meta| meta.is_file())
+        .unwrap_or(false);
+    if !is_file {
+        return Err(format!(
+            "Refusing to open \"{target}\". Wenlan opens documents, not folders or applications."
+        ));
+    }
+
+    let is_indexed_document = canonical
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .is_some_and(|ext| INDEXED_DOCUMENT_SUFFIXES.contains(&ext.as_str()));
+    if !is_indexed_document {
+        return Err(format!(
+            "Refusing to open \"{target}\". Wenlan opens the document types it indexes."
+        ));
+    }
+
+    Ok(Some(canonical))
+}
+
+/// Hand a search result's `url` to the desktop's default handler.
+///
+/// This is the attacker-influenced twin of `open_file` — see
+/// `refuse_unopenable_search_result` — kept as a separate command so the two
+/// call sites carry two different trust levels instead of one shared,
+/// necessarily looser check.
+///
+/// A path is handed to the OS in the canonical form the check ran against,
+/// not the string it arrived as. Re-resolving the original would leave a
+/// window in which a symlink swapped after the check but before the open
+/// sends the OS somewhere the check never saw. A URL goes through unchanged.
+#[tauri::command]
+pub async fn open_search_result(url: String) -> Result<(), String> {
+    let opened = match refuse_unopenable_search_result(&url)? {
+        Some(canonical) => open::that_detached(&canonical),
+        None => open::that_detached(&url),
+    };
+    opened.map_err(|e| format!("Failed to open: {e}"))
+}
+
 #[cfg(test)]
 mod open_target_tests {
-    use super::{refuse_unopenable_target, target_scheme};
+    use super::{refuse_unopenable_search_result, refuse_unopenable_target, target_scheme};
 
     fn allowed(target: &str) -> bool {
         refuse_unopenable_target(target).is_ok()
+    }
+
+    fn search_result_allowed(target: &str) -> bool {
+        refuse_unopenable_search_result(target).is_ok()
     }
 
     #[test]
@@ -884,6 +1023,155 @@ mod open_target_tests {
             "Refusing to run \"/Applications/Utilities/Terminal.app\". \
              Wenlan opens documents and folders, not programs."
         );
+    }
+
+    /// The reviewer's exact bypass: a symlink whose own name carries no
+    /// launcher suffix, pointing at a directory that is a macOS app bundle.
+    /// `fs::metadata` follows the link and sees a directory, so the old
+    /// executable-bit check missed it; canonicalizing first fixes that.
+    #[test]
+    #[cfg(unix)]
+    fn a_symlink_disguised_as_a_document_cannot_launch_the_app_bundle_it_points_at() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle = tmp.path().join("Terminal.app");
+        std::fs::create_dir(&bundle).unwrap();
+        let link = tmp.path().join("Quarterly Notes");
+        std::os::unix::fs::symlink(&bundle, &link).unwrap();
+
+        assert!(!allowed(link.to_str().unwrap()));
+    }
+
+    #[test]
+    fn a_target_containing_a_nul_byte_is_refused() {
+        assert!(!allowed("/tmp/notes\0.md"));
+    }
+
+    #[test]
+    fn a_real_directory_and_a_real_document_stay_openable_after_canonicalization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let note = tmp.path().join("note.md");
+        std::fs::write(&note, "# hi\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&note, std::fs::Permissions::from_mode(0o644)).unwrap();
+        }
+
+        assert!(allowed(tmp.path().to_str().unwrap()));
+        assert!(allowed(note.to_str().unwrap()));
+    }
+
+    // ── refuse_unopenable_search_result ─────────────────────────────────
+
+    #[test]
+    fn an_indexed_document_is_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        for name in ["note.md", "note.txt", "note.pdf"] {
+            let path = tmp.path().join(name);
+            std::fs::write(&path, "hi").unwrap();
+            assert!(search_result_allowed(path.to_str().unwrap()), "{name}");
+        }
+    }
+
+    #[test]
+    fn a_search_result_web_url_is_allowed() {
+        for url in ["https://example.com/a", "http://example.com/a"] {
+            assert!(search_result_allowed(url), "{url}");
+        }
+    }
+
+    #[test]
+    fn a_search_result_cannot_reach_another_scheme() {
+        for url in [
+            "file:///Users/someone/a.md",
+            "javascript:alert(1)",
+            "smb://x/y",
+        ] {
+            assert!(!search_result_allowed(url), "{url}");
+        }
+    }
+
+    /// Proves the NUL itself is what stops it: the prefix up to the NUL is a
+    /// genuinely allowed file.
+    #[test]
+    fn a_search_result_with_an_embedded_nul_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let note = tmp.path().join("note.md");
+        std::fs::write(&note, "hi").unwrap();
+        let with_nul = format!("{}\0{}", note.to_str().unwrap(), ".txt");
+
+        assert!(!search_result_allowed(&with_nul));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_search_result_executable_script_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let script = tmp.path().join("payload.sh");
+        std::fs::write(&script, "#!/bin/sh\necho hi\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(!search_result_allowed(script.to_str().unwrap()));
+    }
+
+    /// The allowlist, not the executable bit, is what stops this: a `.exe`
+    /// with no execute permission is refused purely for not being an indexed
+    /// document type.
+    #[test]
+    #[cfg(unix)]
+    fn a_search_result_windows_executable_is_refused_by_the_allowlist() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join("evil.exe");
+        std::fs::write(&exe, "MZ").unwrap();
+        std::fs::set_permissions(&exe, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(!search_result_allowed(exe.to_str().unwrap()));
+    }
+
+    #[test]
+    fn a_search_result_pointing_at_a_directory_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!search_result_allowed(tmp.path().to_str().unwrap()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_search_result_symlink_to_an_app_bundle_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bundle = tmp.path().join("Bundle.app");
+        std::fs::create_dir(&bundle).unwrap();
+        let link = tmp.path().join("notes");
+        std::os::unix::fs::symlink(&bundle, &link).unwrap();
+
+        assert!(!search_result_allowed(link.to_str().unwrap()));
+    }
+
+    /// Canonicalization must see through the harmless name: the symlink's own
+    /// name ends in `.md`, but it resolves to an executable script.
+    #[test]
+    #[cfg(unix)]
+    fn a_search_result_symlink_disguised_as_markdown_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let script = tmp.path().join("payload.sh");
+        std::fs::write(&script, "#!/bin/sh\necho hi\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let link = tmp.path().join("notes.md");
+        std::os::unix::fs::symlink(&script, &link).unwrap();
+
+        assert!(!search_result_allowed(link.to_str().unwrap()));
+    }
+
+    #[test]
+    fn a_search_result_pointing_at_a_missing_file_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist.md");
+        assert!(!search_result_allowed(missing.to_str().unwrap()));
     }
 }
 

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -637,7 +637,34 @@ pub async fn test_remote_mcp_connection(
 /// long tail of registered application schemes are all reachable that way.
 /// The other opener in the app, the Tauri shell plugin behind citation links,
 /// has been scheme-restricted all along by its default scope; this one was not.
-const OPENABLE_SCHEMES: [&str; 3] = ["http", "https", "file"];
+/// `file:` is deliberately absent. The one caller that deals in `file:` URLs
+/// strips the prefix before it invokes (`openFile` in `src/lib/tauri.ts`), so
+/// a local file arrives here as a bare path and goes through the filesystem
+/// checks below. Accepting the URL form as well would be a way around them.
+const OPENABLE_SCHEMES: [&str; 2] = ["http", "https"];
+
+/// Filename endings this platform treats as something to run rather than
+/// something to read. The lists are per-platform on purpose: a `.py` file on
+/// macOS opens in an editor and should stay openable, while on Windows the
+/// script hosts turn several of these into execution.
+#[cfg(target_os = "macos")]
+const LAUNCHER_SUFFIXES: [&str; 8] = [
+    "app",
+    "command",
+    "pkg",
+    "mpkg",
+    "scpt",
+    "applescript",
+    "workflow",
+    "webloc",
+];
+#[cfg(target_os = "windows")]
+const LAUNCHER_SUFFIXES: [&str; 23] = [
+    "exe", "com", "bat", "cmd", "scr", "msi", "msp", "cpl", "hta", "pif", "ps1", "vbs", "vbe",
+    "js", "jse", "wsf", "wsh", "reg", "lnk", "msc", "jar", "url", "scf",
+];
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+const LAUNCHER_SUFFIXES: [&str; 1] = ["desktop"];
 
 /// The URL scheme of `target`, lowercased, or `None` when it is a filesystem
 /// path.
@@ -660,24 +687,66 @@ fn target_scheme(target: &str) -> Option<String> {
     Some(head.to_ascii_lowercase())
 }
 
+/// Whether the last extension of `path` is one this platform launches.
+///
+/// Read off the string rather than the disk, so it holds for a path that does
+/// not exist yet and for a macOS `.app`, which is a directory.
+fn has_launcher_suffix(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .is_some_and(|ext| LAUNCHER_SUFFIXES.contains(&ext.as_str()))
+}
+
+/// Whether `path` is a regular file carrying an executable bit. Follows
+/// symlinks, so the question is asked of what would actually run. Always
+/// `false` off Unix, where the extension carries this instead.
+#[cfg(unix)]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+#[cfg(not(unix))]
+fn is_executable_file(_path: &std::path::Path) -> bool {
+    false
+}
+
+/// `Ok(())` when `open_file` may hand `target` to the OS. This is the whole of
+/// the decision, kept out of `open_file` so the tests below exercise the same
+/// code the command runs rather than a copy of its reasoning.
+///
+/// Two gates, because the finding has two shapes. A URL must carry a scheme
+/// this app opens. A filesystem path must not be a thing the OS would run:
+/// the audit's own example was a memory whose `url` was
+/// `/Applications/Utilities/Terminal.app`, which carries no scheme at all and
+/// would sail past a scheme check.
+fn refuse_unopenable_target(target: &str) -> Result<(), String> {
+    if let Some(scheme) = target_scheme(target) {
+        if OPENABLE_SCHEMES.contains(&scheme.as_str()) {
+            return Ok(());
+        }
+        return Err(format!(
+            "Refusing to open a \"{scheme}:\" link. Wenlan opens web pages and files on this computer."
+        ));
+    }
+
+    let path = std::path::Path::new(target);
+    if has_launcher_suffix(path) || is_executable_file(path) {
+        return Err(format!(
+            "Refusing to run \"{target}\". Wenlan opens documents and folders, not programs."
+        ));
+    }
+    Ok(())
+}
+
 /// Hand `path` — a filesystem path or a URL, both of which callers pass — to
 /// the desktop's default handler via the `open` crate rather than a hand-built
 /// per-OS argv: its Windows launcher never routes the path through `cmd.exe`
 /// (so a filename containing shell metacharacters cannot inject a second
-/// command), and it covers macOS/Linux/BSD the same way. A URL scheme outside
-/// `OPENABLE_SCHEMES` is refused before it gets there.
-/// `Ok(())` when `open_file` may hand `target` to the OS. This is the whole of
-/// the decision, kept out of `open_file` so the tests below exercise the same
-/// code the command runs rather than a copy of its reasoning.
-fn refuse_unopenable_target(target: &str) -> Result<(), String> {
-    match target_scheme(target) {
-        Some(scheme) if !OPENABLE_SCHEMES.contains(&scheme.as_str()) => Err(format!(
-            "Refusing to open a \"{scheme}:\" link. Wenlan opens web pages and local files."
-        )),
-        _ => Ok(()),
-    }
-}
-
+/// command), and it covers macOS/Linux/BSD the same way. Anything
+/// `refuse_unopenable_target` turns down never reaches it.
 #[tauri::command]
 pub async fn open_file(path: String) -> Result<(), String> {
     refuse_unopenable_target(&path)?;
@@ -707,12 +776,12 @@ mod open_target_tests {
     }
 
     #[test]
-    fn web_and_file_urls_are_opened() {
+    fn web_urls_are_opened() {
         for url in [
             "https://example.com/a",
             "http://example.com/a",
-            "file:///Users/someone/a.md",
             "HTTPS://Example.com/A",
+            "https://example.com/Terminal.app",
         ] {
             assert!(allowed(url), "{url}");
         }
@@ -730,18 +799,90 @@ mod open_target_tests {
             "mailto:someone@example.com",
             "x-apple-helpbasic://x",
             "ms-msdt:/id",
+            // The one caller strips `file://` before invoking, so a local file
+            // arrives as a bare path and gets the filesystem checks below.
+            // Letting the URL form through would be a way around them.
+            "file:///Applications/Utilities/Terminal.app",
+            "file:///Users/someone/a.md",
         ] {
             assert!(!allowed(url), "{url}");
         }
     }
 
+    /// The audit's own example: a memory whose `url` is an application, which
+    /// carries no scheme and would sail past a scheme check.
     #[test]
-    fn a_refusal_says_which_scheme_and_what_is_allowed() {
+    #[cfg(target_os = "macos")]
+    fn a_memory_path_cannot_launch_an_application() {
+        for path in [
+            "/Applications/Utilities/Terminal.app",
+            "/Applications/Utilities/TERMINAL.APP",
+            "/Users/someone/Downloads/installer.pkg",
+            "/Users/someone/Downloads/run-me.command",
+            "/Users/someone/Downloads/thing.workflow",
+            "/Users/someone/Downloads/redirect.webloc",
+        ] {
+            assert!(!allowed(path), "{path}");
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn a_memory_path_cannot_launch_a_program() {
+        for path in [
+            "C:\\Users\\someone\\Downloads\\evil.exe",
+            "C:\\Users\\someone\\Downloads\\EVIL.EXE",
+            "C:\\Users\\someone\\Downloads\\evil.bat",
+            "C:\\Users\\someone\\Downloads\\evil.ps1",
+            "C:\\Users\\someone\\Downloads\\evil.lnk",
+        ] {
+            assert!(!allowed(path), "{path}");
+        }
+    }
+
+    /// On Unix the extension carries no authority, so the executable bit does.
+    /// A shell script a user could be tricked into clicking is refused; the
+    /// notes and folders the Sources view opens are not.
+    #[test]
+    #[cfg(unix)]
+    fn an_executable_file_is_refused_and_a_document_is_not() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let script = tmp.path().join("payload.sh");
+        let note = tmp.path().join("note.md");
+        std::fs::write(&script, "#!/bin/sh\necho hi\n").unwrap();
+        std::fs::write(&note, "# hi\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::set_permissions(&note, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(!allowed(script.to_str().unwrap()));
+        assert!(allowed(note.to_str().unwrap()));
+        // A folder carries the executable bit too, and the Sources view opens
+        // folders in the file manager. It must not be caught by this check.
+        assert!(allowed(tmp.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn a_refused_scheme_says_which_one_and_what_is_allowed() {
         let message = refuse_unopenable_target("JavaScript:alert(1)").unwrap_err();
 
         assert_eq!(
             message,
-            "Refusing to open a \"javascript:\" link. Wenlan opens web pages and local files."
+            "Refusing to open a \"javascript:\" link. \
+             Wenlan opens web pages and files on this computer."
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn a_refused_program_says_which_one() {
+        let message = refuse_unopenable_target("/Applications/Utilities/Terminal.app").unwrap_err();
+
+        assert_eq!(
+            message,
+            "Refusing to run \"/Applications/Utilities/Terminal.app\". \
+             Wenlan opens documents and folders, not programs."
         );
     }
 }

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -641,11 +641,13 @@ pub async fn test_remote_mcp_connection(
 /// application schemes are all reachable via that route. The other opener in
 /// the app, the Tauri shell plugin behind citation links, has been
 /// scheme-restricted all along by its default scope; these two were not.
-/// `file:` is deliberately absent from both. The callers that deal in `file:`
-/// URLs strip the prefix before invoking (`openFile` in `src/lib/tauri.ts`;
-/// `open_search_result` refuses it outright rather than stripping it), so a
-/// local file arrives here as a bare path and goes through the filesystem
-/// checks below. Accepting the URL form as well would be a way around them.
+/// `file:` is deliberately absent from both. Whoever sees a `file://` URL
+/// strips the prefix before this scheme check runs (`openFile`'s wrapper in
+/// `src/lib/tauri.ts` for `open_file`; `refuse_unopenable_search_result`
+/// itself for `open_search_result`, since `local_files.rs` stores every
+/// local-file source's `url` in that form), so a local file arrives here as a
+/// bare path and goes through the filesystem checks below. Accepting the URL
+/// form as a scheme in its own right would be a way around them.
 const OPENABLE_SCHEMES: [&str; 2] = ["http", "https"];
 
 /// Filename endings this platform treats as something to run rather than
@@ -828,10 +830,22 @@ const INDEXED_DOCUMENT_SUFFIXES: [&str; 3] = ["md", "txt", "pdf"];
 /// Returns the canonical path the decision was made about, so the caller can
 /// hand the OS exactly what was judged rather than the string it started
 /// from. A `None` means the target is a URL and goes through unchanged.
+///
+/// `local_files.rs` stores every local-file source's `url` as
+/// `format!("file://{}", path.display())` — no percent-encoding — so a
+/// leading `file://` is stripped before the scheme check, right here rather
+/// than by the caller: the guard must be complete on its own, so a caller
+/// that forgets to strip gets the same answer as one that remembers. What
+/// remains after stripping still goes through every filesystem check below
+/// (canonicalize, must be a regular file, must be an indexed extension), so
+/// `file:///Applications/Utilities/Terminal.app` is still refused — it
+/// canonicalizes to a directory.
 fn refuse_unopenable_search_result(target: &str) -> Result<Option<std::path::PathBuf>, String> {
     if target.contains('\0') {
         return Err("Refusing to open a path containing a NUL byte.".to_string());
     }
+
+    let target = target.strip_prefix("file://").unwrap_or(target);
 
     if let Some(scheme) = target_scheme(target) {
         if OPENABLE_SCHEMES.contains(&scheme.as_str()) {
@@ -1073,6 +1087,22 @@ mod open_target_tests {
         }
     }
 
+    /// The regression test for the CI-caught bug: `local_files.rs` stores
+    /// every local-file source's `url` as `file://` plus the path, so a real
+    /// search result target is a `file://` URL, not a bare path. It must
+    /// still resolve to the allowed canonical file.
+    #[test]
+    fn a_file_url_naming_a_real_document_is_allowed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let note = tmp.path().join("note.md");
+        std::fs::write(&note, "hi").unwrap();
+        let url = format!("file://{}", note.display());
+
+        let canonical = refuse_unopenable_search_result(&url).unwrap();
+
+        assert_eq!(canonical, Some(note.canonicalize().unwrap()));
+    }
+
     #[test]
     fn a_search_result_web_url_is_allowed() {
         for url in ["https://example.com/a", "http://example.com/a"] {
@@ -1136,6 +1166,18 @@ mod open_target_tests {
     fn a_search_result_pointing_at_a_directory_is_refused() {
         let tmp = tempfile::tempdir().unwrap();
         assert!(!search_result_allowed(tmp.path().to_str().unwrap()));
+    }
+
+    /// `file:///Applications/Utilities/Terminal.app`-shaped input: stripping
+    /// the `file://` prefix must not skip the directory check that follows.
+    #[test]
+    fn a_file_url_naming_a_directory_is_refused() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("subdir");
+        std::fs::create_dir(&dir).unwrap();
+        let url = format!("file://{}", dir.display());
+
+        assert!(!search_result_allowed(&url));
     }
 
     #[test]

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -633,14 +633,125 @@ pub async fn rotate_remote_token(
 
 // ── File / open commands ──────────────────────────────────────────────
 
+/// What `open_file` will hand to the OS: a web page, a local file, or a bare
+/// filesystem path. Everything else is refused.
+///
+/// The value reaching here is not the app's own. `POST /api/ingest/webpage`
+/// and `/api/ingest/memory` store the caller's `url` verbatim
+/// (`crates/wenlan-server/src/ingest_routes.rs`), it rides out on every search
+/// result, and clicking a result calls this command with it — so any agent or
+/// page that can put a memory in the store chooses a string the desktop's
+/// scheme handlers will act on. `javascript:`, `data:`, `vbscript:` and the
+/// long tail of registered application schemes are all reachable that way.
+/// The other opener in the app, the Tauri shell plugin behind citation links,
+/// has been scheme-restricted all along by its default scope; this one was not.
+const OPENABLE_SCHEMES: [&str; 3] = ["http", "https", "file"];
+
+/// The URL scheme of `target`, lowercased, or `None` when it is a filesystem
+/// path.
+///
+/// A one-character scheme is read as a Windows drive letter (`C:\Users\...`),
+/// never as a scheme: RFC 3986 allows a single letter, but nothing registers
+/// one, and treating `C:` as a scheme would refuse every Windows path.
+fn target_scheme(target: &str) -> Option<String> {
+    let (head, _) = target.split_once(':')?;
+    if head.len() < 2 || head.contains('/') || head.contains('\\') {
+        return None;
+    }
+    let mut chars = head.chars();
+    if !chars.next()?.is_ascii_alphabetic() {
+        return None;
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+        return None;
+    }
+    Some(head.to_ascii_lowercase())
+}
+
 /// Hand `path` — a filesystem path or a URL, both of which callers pass — to
 /// the desktop's default handler via the `open` crate rather than a hand-built
 /// per-OS argv: its Windows launcher never routes the path through `cmd.exe`
 /// (so a filename containing shell metacharacters cannot inject a second
-/// command), and it covers macOS/Linux/BSD the same way.
+/// command), and it covers macOS/Linux/BSD the same way. A URL scheme outside
+/// `OPENABLE_SCHEMES` is refused before it gets there.
+/// `Ok(())` when `open_file` may hand `target` to the OS. This is the whole of
+/// the decision, kept out of `open_file` so the tests below exercise the same
+/// code the command runs rather than a copy of its reasoning.
+fn refuse_unopenable_target(target: &str) -> Result<(), String> {
+    match target_scheme(target) {
+        Some(scheme) if !OPENABLE_SCHEMES.contains(&scheme.as_str()) => Err(format!(
+            "Refusing to open a \"{scheme}:\" link. Wenlan opens web pages and local files."
+        )),
+        _ => Ok(()),
+    }
+}
+
 #[tauri::command]
 pub async fn open_file(path: String) -> Result<(), String> {
+    refuse_unopenable_target(&path)?;
     open::that_detached(&path).map_err(|e| format!("Failed to open file: {}", e))
+}
+
+#[cfg(test)]
+mod open_target_tests {
+    use super::{refuse_unopenable_target, target_scheme};
+
+    fn allowed(target: &str) -> bool {
+        refuse_unopenable_target(target).is_ok()
+    }
+
+    #[test]
+    fn filesystem_paths_have_no_scheme() {
+        for path in [
+            "/Users/someone/notes/a.md",
+            "./relative/file.txt",
+            "C:\\Users\\someone\\a.md",
+            "\\\\server\\share\\a.md",
+            "/Users/someone/notes/12:30 meeting.md",
+        ] {
+            assert_eq!(target_scheme(path), None, "{path}");
+            assert!(allowed(path), "{path}");
+        }
+    }
+
+    #[test]
+    fn web_and_file_urls_are_opened() {
+        for url in [
+            "https://example.com/a",
+            "http://example.com/a",
+            "file:///Users/someone/a.md",
+            "HTTPS://Example.com/A",
+        ] {
+            assert!(allowed(url), "{url}");
+        }
+    }
+
+    #[test]
+    fn a_memory_url_cannot_reach_another_scheme() {
+        for url in [
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "data:text/html;base64,PHNjcmlwdD4=",
+            "vbscript:msgbox(1)",
+            "smb://attacker.example/share",
+            "ftp://example.com/a",
+            "mailto:someone@example.com",
+            "x-apple-helpbasic://x",
+            "ms-msdt:/id",
+        ] {
+            assert!(!allowed(url), "{url}");
+        }
+    }
+
+    #[test]
+    fn a_refusal_says_which_scheme_and_what_is_allowed() {
+        let message = refuse_unopenable_target("JavaScript:alert(1)").unwrap_err();
+
+        assert_eq!(
+            message,
+            "Refusing to open a \"javascript:\" link. Wenlan opens web pages and local files."
+        );
+    }
 }
 
 #[derive(serde::Serialize)]

--- a/preview/mocks/live-invoke.test.ts
+++ b/preview/mocks/live-invoke.test.ts
@@ -987,7 +987,6 @@ const UNSTUBBED_DEBT = new Set([
   "remove_watch_path",
   "reorder_space",
   "reset_onboarding_milestones",
-  "rotate_remote_token",
   "save_temp_file",
   "set_api_key",
   "set_avatar",

--- a/preview/mocks/live-invoke.test.ts
+++ b/preview/mocks/live-invoke.test.ts
@@ -973,6 +973,7 @@ const UNSTUBBED_DEBT = new Set([
   "list_external_models",
   "move_space",
   "open_file",
+  "open_search_result",
   "quick_capture",
   "read_source_dir",
   "read_text_file",

--- a/src/components/SetupWizard.test.tsx
+++ b/src/components/SetupWizard.test.tsx
@@ -19,7 +19,6 @@ vi.mock("../lib/tauri", () => ({
   getWenlanMcpEntry: vi.fn().mockResolvedValue({ command: "npx", args: ["-y", "wenlan-mcp"] }),
   getRemoteAccessStatus: vi.fn().mockResolvedValue({ status: "off" }),
   toggleRemoteAccess: vi.fn().mockResolvedValue({ status: "off" }),
-  rotateRemoteToken: vi.fn().mockResolvedValue("new-token"),
   testRemoteMcpConnection: vi.fn().mockResolvedValue({ ok: true, latency_ms: 42, error: null }),
   clipboardWrite: vi.fn().mockResolvedValue(undefined),
   getApiKey: vi.fn().mockResolvedValue(null),

--- a/src/components/memory/Main.search.test.tsx
+++ b/src/components/memory/Main.search.test.tsx
@@ -15,6 +15,7 @@ const eventListeners = vi.hoisted(
 );
 const listSpacesMock = vi.hoisted(() => vi.fn<() => Promise<readonly Space[]>>());
 const openFileMock = vi.hoisted(() => vi.fn<(url: string) => Promise<void>>());
+const openSearchResultMock = vi.hoisted(() => vi.fn<(url: string) => Promise<void>>());
 const draftRequestBackMock = vi.hoisted(
   () => vi.fn<(onBack: () => void) => Promise<void>>(),
 );
@@ -50,6 +51,7 @@ vi.mock("../../lib/tauri", () => ({
   searchPages: vi.fn().mockResolvedValue([]),
   listSpaces: listSpacesMock,
   openFile: openFileMock,
+  openSearchResult: openSearchResultMock,
   deleteFileChunks: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -347,6 +349,8 @@ describe("Main search", () => {
     listSpacesMock.mockResolvedValue([]);
     openFileMock.mockReset();
     openFileMock.mockResolvedValue(undefined);
+    openSearchResultMock.mockReset();
+    openSearchResultMock.mockResolvedValue(undefined);
     setSearchQueryMock.mockReset();
     draftRequestBackMock.mockReset();
     draftRequestBackMock.mockImplementation(async (onBack) => onBack());
@@ -1024,7 +1028,32 @@ describe("Main search", () => {
 
     await user.click(screen.getByText("Source credibility notes"));
 
-    expect(openFileMock).toHaveBeenCalledWith("/tmp/source.md");
+    expect(openSearchResultMock).toHaveBeenCalledWith("/tmp/source.md");
+  });
+
+  it("passes a file:// source url through to the file bridge intact", async () => {
+    useSearchMock.mockReturnValue({
+      query: "source",
+      setQuery: setSearchQueryMock,
+      debouncedQuery: "source",
+      results: [{
+        id: "source-hit",
+        content: "Source credibility notes",
+        source: "local_files",
+        source_id: "source-1",
+        title: "source.md",
+        url: "file:///tmp/source.md",
+        chunk_index: 0,
+        last_modified: 0,
+        score: 0.9,
+      }],
+    });
+    const user = userEvent.setup();
+    renderMain();
+
+    await user.click(screen.getByText("Source credibility notes"));
+
+    expect(openSearchResultMock).toHaveBeenCalledWith("file:///tmp/source.md");
   });
 
   it("uses one Activity action instead of a Home and Activity segmented control", async () => {

--- a/src/components/memory/Main.tsx
+++ b/src/components/memory/Main.tsx
@@ -3,10 +3,11 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listen } from "@tauri-apps/api/event";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import {
   listMemoriesRich,
   listSpaces,
-  openFile,
+  openSearchResult as openSearchResultTarget,
   searchEntities,
   searchPages,
   type Page,
@@ -517,7 +518,11 @@ export default function Main({
     if (target.kind === "page") {
       navigateTo({ kind: "page", pageId: target.pageId });
     } else if (target.kind === "file") {
-      await openFile(target.url);
+      try {
+        await openSearchResultTarget(target.url);
+      } catch (err) {
+        toast.error(String(err));
+      }
     } else {
       navigateTo({ kind: "memory", sourceId: result.source_id });
     }

--- a/src/components/memory/RemoteAccessPanel.test.tsx
+++ b/src/components/memory/RemoteAccessPanel.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { i18n } from "../../i18n";
+import type { RemoteAccessStatus } from "../../lib/tauri";
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
@@ -53,11 +54,10 @@ function renderPanel() {
 }
 
 const CONNECTED = {
-  status: "connected" as const,
+  status: "connected",
   tunnel_url: "https://example.trycloudflare.com",
-  token: "secret-token",
   relay_url: null,
-};
+} satisfies RemoteAccessStatus;
 
 describe("RemoteAccessPanel", () => {
   beforeEach(() => {
@@ -216,9 +216,8 @@ describe("RemoteAccessPanel", () => {
     mocks.getRemoteAccessStatus.mockResolvedValue({
       status: "connected",
       tunnel_url: "https://example.trycloudflare.com",
-      token: "t",
       relay_url: "https://relay.example/abc",
-    });
+    } satisfies RemoteAccessStatus);
     renderPanel();
     await waitFor(() => {
       expect(screen.getAllByText("https://relay.example/abc")).toHaveLength(1);

--- a/src/components/memory/SourcesView.tsx
+++ b/src/components/memory/SourcesView.tsx
@@ -646,7 +646,11 @@ function FileDetail({
           </div>
           <div className="shrink-0">
             <button
-              onClick={() => openFile(node.path)}
+              onClick={() =>
+                openFile(node.path).catch((err) =>
+                  toast("Couldn't open file", { description: String(err) })
+                )
+              }
               className="rounded-md transition-colors duration-150 hover:bg-[var(--mem-hover)]"
               style={{
                 padding: "6px 13px",

--- a/src/components/memory/settings/sections/AgentsSection.composed.test.tsx
+++ b/src/components/memory/settings/sections/AgentsSection.composed.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AgentsSection from "./AgentsSection";
+import type { RemoteAccessStatus } from "../../../../lib/tauri";
 
 // Unlike AgentsSection.test.tsx, this file does NOT stub out
 // RemoteAccessPanel/ClientSetupList — it renders the real composition so the
@@ -20,9 +21,8 @@ vi.mock("../../../../lib/tauri", () => ({
   getRemoteAccessStatus: vi.fn().mockResolvedValue({
     status: "connected",
     tunnel_url: "https://x.trycloudflare.com",
-    token: "t",
     relay_url: null,
-  }),
+  } satisfies RemoteAccessStatus),
   getWireState: vi.fn().mockResolvedValue({
     daemon: { base_url: "", reachable: true, version: null, error: null },
     mcp_binary: { command: "", args: [], candidates: [] },

--- a/src/lib/reviewCommandContract.test.ts
+++ b/src/lib/reviewCommandContract.test.ts
@@ -111,7 +111,6 @@ const OUTSIDE_THE_REVIEW_SURFACE: readonly string[] = [
   "remove_source",
   "remove_watch_path",
   "reset_onboarding_milestones",
-  "rotate_remote_token",
   "save_temp_file",
   "set_api_key",
   "set_avatar",

--- a/src/lib/reviewCommandContract.test.ts
+++ b/src/lib/reviewCommandContract.test.ts
@@ -97,6 +97,7 @@ const OUTSIDE_THE_REVIEW_SURFACE: readonly string[] = [
   "move_space",
   "on_device_model_download_bytes",
   "open_file",
+  "open_search_result",
   "position_quick_capture",
   "quick_capture",
   "quit_wenlan_full",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -228,6 +228,17 @@ export async function openFile(url: string): Promise<void> {
   return invoke("open_file", { path });
 }
 
+/**
+ * Open a search result's target. Unlike {@link openFile}, this does NOT strip
+ * a `file://` prefix — `open_search_result` refuses `file:` URLs on purpose,
+ * since the value came from a search result and is attacker-influenced (see
+ * the Rust command's doc comment). Local files reach it as bare paths, which
+ * it checks against an allowlist of indexed document types.
+ */
+export async function openSearchResult(url: string): Promise<void> {
+  return invoke("open_search_result", { url });
+}
+
 export interface SourceDirEntry {
   name: string;
   isDirectory: boolean;

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2496,7 +2496,7 @@ export async function listAgentActivity(
 export type RemoteAccessStatus =
   | { status: "off" }
   | { status: "starting" }
-  | { status: "connected"; tunnel_url: string; token: string; relay_url: string | null }
+  | { status: "connected"; tunnel_url: string; relay_url: string | null }
   | { status: "error"; error: string };
 
 export async function toggleRemoteAccess(
@@ -2507,10 +2507,6 @@ export async function toggleRemoteAccess(
 
 export async function getRemoteAccessStatus(): Promise<RemoteAccessStatus> {
   return invoke<RemoteAccessStatus>("get_remote_access_status");
-}
-
-export async function rotateRemoteToken(): Promise<string> {
-  return invoke<string>("rotate_remote_token");
 }
 
 /** Result of a one-shot probe against the Remote MCP tunnel's `/health`. */


### PR DESCRIPTION
Closes the three remaining security findings from the 2026-08-16 audit. All three were still live in `main`; each was re-checked against the shipped tree before any of this was written.

## S5 — the app would open, or run, whatever a memory pointed at

`open_file` in `app/src/search.rs` handed its argument straight to the desktop's default handler. That argument is not the app's own: `POST /api/ingest/webpage` and `/api/ingest/memory` store the caller's `url` verbatim (`crates/wenlan-server/src/ingest_routes.rs`), it rides out on every search result, `searchResultTarget` in `src/lib/searchResultTarget.ts` turns a result with a `url` into a `file` target, and `openSearchResult` in `src/components/memory/Main.tsx` opened it. So any agent or page that can put a memory in the store chose what the OS would act on.

The app's other opener, the Tauri shell plugin behind citation links, has been scheme-restricted all along by the plugin's default scope. This one was not.

### The fix: two commands, split by who controls the input

One command served two callers with two different trust levels. The Sources view passes a path the user picked in a folder they chose. A search result passes a `url` an attacker may control. A single check had to stay loose enough for the first caller, and that slack is what the second caller could use.

**`open_file`** keeps the user-chosen paths and a denylist. A URL must carry `http` or `https` — that closes `javascript:`, `data:`, `vbscript:`, and the long tail of registered application schemes. A bare path must not end in a launcher extension for this platform (`app`, `command`, `pkg`, `scpt`, `workflow`, `webloc` on macOS; the `exe`/`bat`/`ps1`/`lnk` set on Windows; `desktop` elsewhere) and, on Unix, must not be a regular file with an executable bit. Directories are exempt because the Sources view opens folders in the file manager and every folder carries that bit. A one-character scheme is read as a Windows drive letter, so `C:\Users\...` still opens.

**`open_search_result`** is new and takes the attacker-influenced input. It answers a narrower question — is this a web link, or a real file of a type the daemon indexes? — with an allowlist:

- A URL must carry `http` or `https`.
- A path is resolved with `std::fs::canonicalize` **before** it is judged. A symlink named `notes.md` pointing at an `.app` bundle is seen for what it resolves to, and `..` cannot walk anywhere the check did not look.
- It must resolve to a regular file. `.app` and `.pkg` bundles are directories, so this alone stops both.
- Its extension must be `md`, `txt`, or `pdf` — the three `SUPPORTED_EXTENSIONS` in `src/components/memory/SourcesView.tsx` says the daemon indexes.

The OS is handed the canonical path the check ran against, not the string it arrived as. Re-resolving the original would leave a window in which a symlink swapped after the check and before the open sends the OS somewhere the check never saw.

Both commands refuse an embedded NUL byte. On Windows the `open` crate hands `ShellExecuteExW` a UTF-16 buffer whose encoder preserves interior NULs (`windows.rs:350`), and Win32 truncates at the first one — so `report.pdf\0.exe` would have been checked as a PDF and run as a program.

Both frontends now surface a refusal instead of failing silently: `Main.tsx` through `toast.error`, `SourcesView.tsx` through the toast idiom already in that file.

## S2 — the relay ID was guessable

The Remote Access relay ID was `u` plus 11 hex characters of a `DefaultHasher` over the wall clock and the process ID: a hash with fixed keys, over two guessable inputs, truncated to 44 bits.

That ID is the whole of the protection on the remote endpoint. It is the path segment of the URL handed to Claude.ai and ChatGPT, and `register_with_relay` posts the same value as `secret`.

It now comes from `getrandom`, 16 bytes rendered as 32 hex characters, matching the pattern already used in `app/src/presence.rs`. An ID in the old shape is replaced rather than reused, since keeping one would leave the endpoint as reachable as it was.

## S6 — a bearer token that nothing checked

The app generated a 0600 token file on the connect path, could fail the whole connect if that generation failed, carried the token on `RemoteAccessStatus::Connected`, and exposed a `rotate_remote_token` command — while `spawn_mcp`, the only place the app starts `wenlan-mcp serve`, always passes `--no-auth`. With `--no-auth` the sidecar installs no auth middleware, so nothing ever read the token. The local Claude Desktop path does not use it either: that one runs over stdio via `npx wenlan-mcp`. No part of the UI showed or rotated it, and the frontend wrapper had no production caller.

The machinery implied a protection that was not wired, which is the finding. It is deleted, which also drops a written secret, a subprocess call, and a failure mode from the connect path. A comment at the connect site now says why there is no token: the Claude.ai and ChatGPT connectors cannot attach an `Authorization` header, so `--no-auth` is deliberate, and what guards the endpoint is the unguessable relay ID from S2, the explicit in-app warning, and the feature being off by default.

`crates/wenlan-mcp`'s own token support is untouched — that binary still enforces a token when it is run with one, and the app does not delete an existing `~/.config/wenlan-mcp/token` that a manually configured server may still rely on.

## Verification

Every fix that adds behavior has a RED control. Each was reverted against the committed tree and re-run, not assumed:

| Break | Result |
|---|---|
| `refuse_unopenable_target` always returns `Ok(())` (`git diff --stat`: 2 insertions, 6 deletions in `app/src/search.rs`) | `test result: FAILED. 2 passed; 2 failed` — `a_memory_url_cannot_reach_another_scheme`, `a_refusal_says_which_scheme_and_what_is_allowed` |
| the `open_file` path gate short-circuited to never fire (`git diff --stat`: 1 insertion, 1 deletion) | `test result: FAILED. 4 passed; 3 failed` — `a_memory_path_cannot_launch_an_application`, `an_executable_file_is_refused_and_a_document_is_not`, `a_refused_program_says_which_one` |
| `refuse_unopenable_search_result` returns `Ok(None)` for everything, i.e. the allowlist removed (`git diff --stat`: 2 insertions, 9 deletions) | `test result: FAILED. 13 passed; 7 failed` — the scheme, missing-file, directory, executable-script, Windows-executable, and both symlink cases |
| canonicalization dropped, the original path judged instead (`git diff --stat`: 1 insertion, 2 deletions) | `test result: FAILED. 19 passed; 1 failed` — `a_search_result_symlink_disguised_as_markdown_is_refused` |
| `relay_id_is_current` reduced to `!id.is_empty()` (`git diff --stat`: 1 insertion, 5 deletions in `app/src/remote_access.rs`) | `test result: FAILED. 6 passed; 2 failed` — `relay_id_shape_rejects_the_old_and_the_malformed`, `a_relay_id_from_before_the_csprng_is_replaced` |

Full receipts on the final tree (`f1d4d24c`):

```
cargo fmt --all                                          rc=0
cargo clippy -p wenlan-app --lib --tests -- -D warnings   rc=0
cargo test -p wenlan-app --lib                           rc=0
  test result: ok. 465 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
npx tsc -b --force                                       rc=0
vitest run (6 affected files)                            rc=0
  Test Files  6 passed (6) / Tests  120 passed (120)
```

Exit codes were captured at each command rather than read off a pipeline tail.

## Note for reviewers

Existing installs with Remote Access already set up get a new relay URL on next start, because the old relay ID is replaced. That is intended — the old ID is the guessable one. A saved connector has to be re-added. The feature is off by default and marked experimental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
