### PR TITLE
ci: read Apple's notarization log on every verdict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -588,6 +588,24 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build --target aarch64-apple-darwin
 
+      # Tauri submits the .app to the notary service from inside `tauri build`
+      # and reports only that notarization failed, never Apple's reasons. That
+      # submission is invisible from here otherwise, so on a failed build read
+      # the queue back and print the log Apple keeps for each entry.
+      - name: Read Apple's notarization verdicts after a failed build
+        if: failure() && env.APPLE_SIGNING_CONFIGURED == 'true' && env.APPLE_ID != ''
+        shell: bash
+        run: |
+          set -uo pipefail
+          history="$(xcrun notarytool history --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" 2>&1)"
+          echo "$history"
+          for id in $(sed -n 's/^ *id: \([0-9a-f-]*\)$/\1/p' <<<"$history" | head -3); do
+            echo "--- notarytool log for $id ---"
+            xcrun notarytool log "$id" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" 2>&1 | head -120
+          done
+
       # Tauri notarizes and staples the .app but only signs the .dmg
       # (tauri-bundler crates/tauri-bundler/src/bundle/macos/dmg/mod.rs). The
       # .dmg is what a browser download hands a new user, and a browser stamps
@@ -608,6 +626,16 @@ jobs:
           rc=$?
           set -e
           echo "$out"
+          # --wait prints a verdict but never a cause. Apple keeps the reasons
+          # in the per-submission log alone, so read it on every verdict: a
+          # rejected release then explains itself here instead of costing
+          # another hour-long build to diagnose.
+          sub_id="$(sed -n 's/^ *id: \([0-9a-f-]*\)$/\1/p' <<<"$out" | head -1)"
+          if [[ -n "$sub_id" ]]; then
+            echo "--- notarytool log for $sub_id ---"
+            xcrun notarytool log "$sub_id" --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" 2>&1 | head -200 || true
+          fi
           [[ "$rc" -eq 0 ]] || { echo "ERROR: notarytool exited $rc for the DMG." >&2; exit 1; }
           grep -q 'status: Accepted' <<<"$out" || { echo "ERROR: DMG notarization was not Accepted." >&2; exit 1; }
           xcrun stapler staple "$dmg"


### PR DESCRIPTION
`xcrun notarytool submit --wait` prints `status: Accepted` or `status: Invalid` and nothing about why. Apple keeps the reasons in a per-submission log that has to be fetched separately — this is what Apple's *Resolving common notarization issues* tells you to read. Today a rejected release build fails with no usable detail, and finding out why costs another hour-long run.

Two additions, both diagnostic only:

- The **Notarize and staple the DMG** step now fetches `notarytool log` for its own submission on every verdict, accepted or not. Accepted submissions can still carry warnings worth seeing.
- Tauri submits the `.app` to the notary service from inside `pnpm tauri build`, where there is no hook. A new step reads the queue back with `notarytool history` and prints the log for the three most recent entries, but only when the build failed and the Apple secrets are present.

Neither step can turn a red build green: the history dump runs under `if: failure()`, and the DMG log fetch is followed by the same exit-code and `status: Accepted` assertions as before.

While writing this I audited the whole macOS pipeline against Apple's published guidance. It conforms on every point I could check against the pinned bundler source at `tauri-cli-v2.11.4`: sidecars and frameworks are signed individually before the app bundle, inside out, with `--options runtime` and without `--deep`; the disk image is signed, notarized and stapled as the outermost container; and the updater tarball is built after the app is stapled, so the archived app carries its own ticket as Apple requires for archives that cannot be stapled themselves.

`actionlint` is clean and `scripts/release-workflow-contract.test.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh