### PR TITLE
fix(app): stop cloudflared from replacing its own signed binary

### DIFF
--- a/app/src/remote_access.rs
+++ b/app/src/remote_access.rs
@@ -586,6 +586,27 @@ fn wenlan_mcp_process_identity(pid: u32, port: u16) -> Option<String> {
     Some(format!("{}\n{}", started.trim(), command.trim()))
 }
 
+/// The exact argument vector `start_remote_access` hands to the cloudflared
+/// sidecar.
+///
+/// This lives in one place, rather than inline at the spawn site, so the
+/// regression test can drive the argv the app really spawns. When the two were
+/// written out independently, deleting `--no-autoupdate` from production left
+/// the test green -- the fix could be removed without anything failing.
+///
+/// Order matters as much as membership. cloudflared accepts `--no-autoupdate`
+/// before `tunnel` as well, but `is_expected_remote_tunnel_command` requires
+/// `tunnel` at index 1, so that placement would break the app's own recognition
+/// of the process it started and leave the tunnel running after a quit.
+fn remote_tunnel_args(port: u16) -> [String; 4] {
+    [
+        "tunnel".to_string(),
+        "--no-autoupdate".to_string(),
+        "--url".to_string(),
+        format!("http://localhost:{port}"),
+    ]
+}
+
 fn is_expected_remote_tunnel_command(command: &str, port: u16) -> bool {
     let args: Vec<_> = command.split_whitespace().collect();
     let Some(executable) = args.first() else {
@@ -1560,14 +1581,7 @@ async fn start_tunnel(
     // periodic request to a Cloudflare update host. Wenlan ships cloudflared
     // on its own release cadence; upgrading it is a Wenlan release, not
     // something the sidecar decides for itself.
-    let (mut tunnel_rx, tunnel_child) = match tunnel_command
-        .args([
-            "tunnel",
-            "--no-autoupdate",
-            "--url",
-            &format!("http://localhost:{}", port),
-        ])
-        .spawn()
+    let (mut tunnel_rx, tunnel_child) = match tunnel_command.args(remote_tunnel_args(port)).spawn()
     {
         Ok(child) => child,
         Err(error) => {
@@ -1889,11 +1903,20 @@ mod tests {
             "/tmp/cloudflared tunnel --url http://localhost:22000",
             22000,
         ));
-        // The exact argv `start_remote_access` spawns. If this stops matching,
-        // orphan cleanup no longer recognizes the tunnel it started and leaves
-        // it running after the app quits.
+        // The argv `start_remote_access` actually spawns, taken from the same
+        // builder the spawn site calls rather than written out again here. A
+        // hand-written copy stays green when the production flag is deleted,
+        // which is the whole failure this test exists to catch.
+        let args = remote_tunnel_args(22000);
+        assert_eq!(args[0], "tunnel");
+        assert_eq!(args[1], "--no-autoupdate");
+        assert_eq!(args[2], "--url");
+        assert_eq!(args[3], "http://localhost:22000");
+        // And orphan cleanup still recognizes that argv. If it stops matching,
+        // the app no longer knows the tunnel it started and leaves it running
+        // after a quit, holding an unauthenticated public URL open.
         assert!(is_expected_remote_tunnel_command(
-            "/tmp/cloudflared-aarch64-apple-darwin tunnel --no-autoupdate --url http://localhost:22000",
+            &format!("/tmp/cloudflared-aarch64-apple-darwin {}", args.join(" ")),
             22000,
         ));
         assert!(!is_expected_remote_tunnel_command(

--- a/app/src/remote_access.rs
+++ b/app/src/remote_access.rs
@@ -1550,8 +1550,23 @@ async fn start_tunnel(
             return Err(format!("cloudflared sidecar not found: {error}"));
         }
     };
+    // `--no-autoupdate` because cloudflared's default is to check for a new
+    // version every 24 hours and then overwrite its own binary and restart.
+    // Inside an installed Wenlan that binary is a bundled sidecar covered by
+    // the app's code signature, so a self-update would silently replace a
+    // signed file with an unsigned one -- Gatekeeper and Authenticode both
+    // stop trusting it, and on Windows that is exactly what the installer
+    // signature is meant to vouch for. It would also add an undisclosed
+    // periodic request to a Cloudflare update host. Wenlan ships cloudflared
+    // on its own release cadence; upgrading it is a Wenlan release, not
+    // something the sidecar decides for itself.
     let (mut tunnel_rx, tunnel_child) = match tunnel_command
-        .args(["tunnel", "--url", &format!("http://localhost:{}", port)])
+        .args([
+            "tunnel",
+            "--no-autoupdate",
+            "--url",
+            &format!("http://localhost:{}", port),
+        ])
         .spawn()
     {
         Ok(child) => child,
@@ -1872,6 +1887,13 @@ mod tests {
         ));
         assert!(is_expected_remote_tunnel_command(
             "/tmp/cloudflared tunnel --url http://localhost:22000",
+            22000,
+        ));
+        // The exact argv `start_remote_access` spawns. If this stops matching,
+        // orphan cleanup no longer recognizes the tunnel it started and leaves
+        // it running after the app quits.
+        assert!(is_expected_remote_tunnel_command(
+            "/tmp/cloudflared-aarch64-apple-darwin tunnel --no-autoupdate --url http://localhost:22000",
             22000,
         ));
         assert!(!is_expected_remote_tunnel_command(


### PR DESCRIPTION
## What

Pass `--no-autoupdate` when the app starts the cloudflared tunnel for Remote Access.

## Why

`cloudflared tunnel` leaves auto-update **on** by default. From the shipped CLI's own help text:

```
--no-autoupdate  Disable periodic check for updates, restarting the server with the new version. (default: false)
--autoupdate-freq value  Autoupdate frequency. Default is 24h0m0s.
```

So a running tunnel checks for a new version every 24 hours, downloads it, **overwrites its own binary**, and restarts.

Inside an installed Wenlan, that binary is not a loose tool. It is a bundled sidecar declared in `app/tauri.conf.json` and covered by the app's code signature. A self-update replaces a signed file with an unsigned one, on the user's disk, after installation, with nothing to tell them.

That defeats the point of signing the bundle at all:

- On macOS it breaks the app's signature and its notarization ticket no longer describes what is on disk.
- On Windows it means the installer's Authenticode signature vouches for bytes that have since been swapped out — while we are in the middle of applying for a code signing certificate precisely so that signature means something.

It also adds a periodic request to a Cloudflare update host that no Wenlan document discloses. `PRIVACY.md` is being rewritten in #630 to list every network request; this one should not exist rather than be documented.

Wenlan ships cloudflared on its own release cadence. Upgrading it is a Wenlan release, not something a sidecar decides for itself.

## The test

`is_expected_remote_tunnel_command` is what orphan cleanup uses to recognize the tunnel process. If it stops matching the argv we spawn, a tunnel survives the app quitting — a leaked process holding an unauthenticated public URL to the user's memory.

The new case is the exact argv `start_remote_access` now produces.

**Mutation control.** Narrowing the matcher to require `--url` at argument index 2 makes the new case fail:

```
thread 'remote_access::tests::orphan_cleanup_requires_the_exact_remote_tunnel_process_identity' panicked at app/src/remote_access.rs:1894:9:
assertion failed: is_expected_remote_tunnel_command("/tmp/cloudflared-aarch64-apple-darwin tunnel --no-autoupdate --url http://localhost:22000",
    22000)
```

The matcher was then restored and the suite re-run.

## Verification

- `cargo test -p wenlan-app --lib remote_access` — 29 passed
- `cargo clippy -p wenlan-app --all-targets` — clean
- `cloudflared tunnel --help` on the shipped CLI (version 2026.5.0) for the default quoted above

Not verified: the flag's effect on a live tunnel. Remote Access needs a real Cloudflare tunnel to exercise, and the change is a documented CLI flag rather than logic, so this is a reading of the interface rather than an observed run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh
