### PR TITLE
fix(app): show and open the file path behind a document citation

### DIFF
--- a/src/components/memory/page/CitationChip.test.tsx
+++ b/src/components/memory/page/CitationChip.test.tsx
@@ -5,6 +5,7 @@ import userEvent from "@testing-library/user-event";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import type { MemoryItem, PageCitation } from "../../../lib/tauri";
 import CitationChip from "./CitationChip";
+import { citationFilePath } from "./CitationPopover";
 
 const cite = (over: Partial<PageCitation> = {}): PageCitation => ({
   occurrence: 1,
@@ -164,9 +165,35 @@ describe("CitationChip", () => {
     expect(vi.mocked(shellOpen)).toHaveBeenCalledWith("/notes/design.md");
   });
 
+  it("shows only the path of a document citation whose locator carries the source id", async () => {
+    const user = userEvent.setup();
+    renderChip({
+      citation: cite({
+        source_kind: "external_file",
+        locator: "directory-notes::/Users/me/Tally/notes/architecture-notes.md",
+      }),
+      sourceMemory: null,
+    });
+    fireEvent.focus(screen.getByRole("button", { name: /architecture-notes\.md/ }));
+    expect(screen.getByText("/Users/me/Tally/notes/architecture-notes.md")).toBeInTheDocument();
+    expect(screen.queryByText(/directory-notes::/)).toBeNull();
+    await user.click(screen.getByRole("button", { name: /Open file/ }));
+    expect(vi.mocked(shellOpen)).toHaveBeenCalledWith("/Users/me/Tally/notes/architecture-notes.md");
+  });
+
   it("explains that authored content survives re-distillation", () => {
     renderChip({ citation: cite({ source_kind: "authored" }), sourceMemory: null });
     fireEvent.focus(screen.getByRole("button", { name: /authored/ }));
     expect(screen.getByText(/kept unchanged when the page is re-distilled/i)).toBeInTheDocument();
+  });
+});
+
+
+describe("citationFilePath", () => {
+  it("strips a document source id prefix and leaves plain locators alone", () => {
+    expect(citationFilePath("directory-notes::/Users/me/notes/a.md")).toBe("/Users/me/notes/a.md");
+    expect(citationFilePath("obsidian-vault::C:\\Users\\me\\vault\\a.md")).toBe("C:\\Users\\me\\vault\\a.md");
+    expect(citationFilePath("/notes/design.md")).toBe("/notes/design.md");
+    expect(citationFilePath("https://docs.rs/serde")).toBe("https://docs.rs/serde");
   });
 });

--- a/src/components/memory/page/CitationPopover.tsx
+++ b/src/components/memory/page/CitationPopover.tsx
@@ -15,6 +15,14 @@ interface CitationPopoverProps {
 
 const WIDTH = 280;
 
+// A document citation's locator is the document source id
+// (`<source id>::<absolute path>`); only the path part is a file the shell can
+// open or a human wants to read. Web and memory locators pass through unchanged.
+export function citationFilePath(locator: string): string {
+  const sep = locator.lastIndexOf("::");
+  return sep === -1 ? locator : locator.slice(sep + 2);
+}
+
 // Spec: external_url shows a *domain* badge, other kinds a fixed label.
 function kindBadge(citation: PageCitation): string {
   if (citation.source_kind === "external_url") {
@@ -90,10 +98,11 @@ export default function CitationPopover({
       );
     }
     if (citation.source_kind === "external_file") {
+      const filePath = citationFilePath(citation.locator);
       return (
         <>
-          <p style={{ ...mono, wordBreak: "break-all" }}>{citation.locator}</p>
-          <button style={actionStyle} onClick={() => void shellOpen(citation.locator)}>
+          <p style={{ ...mono, wordBreak: "break-all" }}>{filePath}</p>
+          <button style={actionStyle} onClick={() => void shellOpen(filePath)}>
             Open file →
           </button>
         </>


### PR DESCRIPTION
## What

A document citation's locator on the API is the document source id, which carries the source id in front of the path (`directory-notes::/Users/me/Tally/notes/architecture-notes.md`). The citation popover printed that whole string and passed it to Open file, so the prefix showed in the UI and the button could not open the file.

This strips everything up to the last `::` before showing or opening the path. Plain paths and URLs pass through unchanged.

## Why

Found while rehearsing the launch demo on a fresh store: every citation to a connected folder showed `directory-notes::` in front of the path, and Open file did nothing.

## Tests

- `CitationChip.test.tsx`: a document citation with a prefixed locator shows only the path and Open file receives the path; `citationFilePath` strips the prefix and leaves plain paths, Windows paths, and URLs alone.
- `pnpm vitest run src/components/memory/page/CitationChip.test.tsx`: 15 passed.
- `pnpm exec tsc -b`: no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY