### PR TITLE
fix(core): stop sending an empty think block to models without a thinking mode

### DIFF
--- a/crates/wenlan-core/src/bin/model_benchmark.rs
+++ b/crates/wenlan-core/src/bin/model_benchmark.rs
@@ -401,7 +401,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Size: {:.2} GB", model_size as f64 / 1e9);
 
     let prompts = PromptRegistry::default();
-    let engine = LlmEngine::new(&model_path, prompts.clone())?;
+    let engine = LlmEngine::new(&model_path, prompts.clone())?.with_thinking_mode(
+        wenlan_core::on_device_models::thinking_mode_for_model_file(&model_path),
+    );
     println!("Model loaded.\n");
 
     let mut all_results = vec![];

--- a/crates/wenlan-core/src/bin/model_probe.rs
+++ b/crates/wenlan-core/src/bin/model_probe.rs
@@ -31,7 +31,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let model_path = PathBuf::from(&args[1]);
     let prompts = PromptRegistry::default();
-    let engine = LlmEngine::new(&model_path, prompts.clone())?;
+    let engine = LlmEngine::new(&model_path, prompts.clone())?.with_thinking_mode(
+        wenlan_core::on_device_models::thinking_mode_for_model_file(&model_path),
+    );
     let runtime = engine.inference_runtime_info();
 
     println!("--- Inference backend: {} ---", runtime.backend);

--- a/crates/wenlan-core/src/engine.rs
+++ b/crates/wenlan-core/src/engine.rs
@@ -383,6 +383,8 @@ pub struct LlmEngine {
     pub(crate) model: LlamaCppModel,
     pub(crate) prompts: crate::prompts::PromptRegistry,
     backend_plan: InferenceBackendPlan,
+    /// See [`crate::on_device_models::OnDeviceModel::thinking_mode`].
+    thinking_mode: bool,
 }
 
 // SAFETY: LlamaCppModel and LlamaBackend are created once on the init thread
@@ -484,6 +486,7 @@ impl LlmEngine {
             model,
             prompts,
             backend_plan,
+            thinking_mode: false,
         })
     }
 
@@ -505,6 +508,22 @@ impl LlmEngine {
     /// Backward-compatible Metal-specific probe retained for existing callers.
     pub fn probe_metal_context(&self) -> bool {
         self.probe_context().is_ok()
+    }
+
+    /// Set whether prompts open with an empty think block. Off by default;
+    /// the provider sets it from the model registry.
+    pub fn with_thinking_mode(mut self, on: bool) -> Self {
+        self.thinking_mode = on;
+        self
+    }
+
+    pub fn thinking_mode(&self) -> bool {
+        self.thinking_mode
+    }
+
+    /// The ChatML prompt this engine sends for a system/user pair.
+    pub fn format_prompt(&self, system_prompt: Option<&str>, prompt: &str) -> String {
+        format_chatml_prompt(system_prompt, prompt, self.thinking_mode)
     }
 
     pub(crate) fn inference_backend_plan(&self) -> &InferenceBackendPlan {
@@ -530,6 +549,7 @@ impl LlmEngine {
             model,
             prompts,
             backend_plan: plan,
+            thinking_mode: false,
         })
     }
 
@@ -791,6 +811,7 @@ impl LlmEngine {
         let mut decoder = encoding_rs::UTF_8.new_decoder();
         let mut output = String::new();
         let mut n_cur = batch.n_tokens();
+        let batch_len_start = n_cur;
         let max_pos = n_cur + max_output_tokens;
         let mut failed = false;
 
@@ -852,6 +873,16 @@ impl LlmEngine {
                 start.elapsed()
             );
             if trimmed.is_empty() {
+                // Diagnostic: the caller only sees "inference returned no
+                // output"; show what the model actually emitted so a
+                // thinking-mode leak or an immediate stop is visible in the log.
+                log::warn!(
+                    "[llm_engine] persistent inference{} produced no usable text; raw ({} chars, {} tokens): {:?}",
+                    label_suffix,
+                    output.len(),
+                    n_cur - batch_len_start,
+                    output.chars().take(400).collect::<String>()
+                );
                 None
             } else {
                 Some(trimmed)
@@ -873,7 +904,7 @@ impl LlmEngine {
 
     /// Count tokens for the formatted ChatML prompt used by the provider path.
     pub fn count_prompt_tokens(&self, system_prompt: Option<&str>, prompt: &str) -> usize {
-        let formatted = format_chatml_prompt(system_prompt, prompt);
+        let formatted = self.format_prompt(system_prompt, prompt);
         self.model
             .str_to_token(&formatted, AddBos::Always)
             .map(|t| t.len())

--- a/crates/wenlan-core/src/eval/engine_throughput.rs
+++ b/crates/wenlan-core/src/eval/engine_throughput.rs
@@ -247,6 +247,7 @@ pub fn synthetic_mixed_workload(n: usize, temperature: f32) -> Vec<WorkloadItem>
                 let prompt = crate::llm_provider::format_chatml_prompt(
                     Some("You are a terse sentiment classifier."),
                     &user,
+                    crate::on_device_models::get_default_model().thinking_mode,
                 );
                 WorkloadItem {
                     prompt: (
@@ -270,6 +271,7 @@ pub fn synthetic_mixed_workload(n: usize, temperature: f32) -> Vec<WorkloadItem>
                 let prompt = crate::llm_provider::format_chatml_prompt(
                     Some("You extract knowledge-graph entities and relations as JSON."),
                     &user,
+                    crate::on_device_models::get_default_model().thinking_mode,
                 );
                 WorkloadItem {
                     prompt: (
@@ -317,7 +319,11 @@ pub fn shared_prefix_workload(n: usize, temperature: f32) -> Vec<WorkloadItem> {
         .map(|i| {
             let (canary, s) = base[i % base.len()];
             let user = format!("Sentence: \"{s}\"");
-            let prompt = crate::llm_provider::format_chatml_prompt(Some(SYSTEM), &user);
+            let prompt = crate::llm_provider::format_chatml_prompt(
+                Some(SYSTEM),
+                &user,
+                crate::on_device_models::get_default_model().thinking_mode,
+            );
             // Vary the output budget too, so decode width drains raggedly.
             let max_out = if i % 2 == 0 { 24 } else { 64 };
             WorkloadItem {

--- a/crates/wenlan-core/src/llm_provider.rs
+++ b/crates/wenlan-core/src/llm_provider.rs
@@ -172,20 +172,33 @@ pub(crate) fn hf_snapshot_model_version(repo_id: &str, model_path: &Path) -> Opt
 
 /// Wrap a user/system prompt pair in the Qwen ChatML template.
 ///
-/// The empty `<think></think>` block disables thinking mode for Qwen3.5
-/// (which defaults to thinking-on). Without it, all output tokens go to
-/// reasoning and `strip_think_tags` removes them, leaving empty output.
-/// Harmless for Qwen3 (which has no thinking mode).
-pub(crate) fn format_chatml_prompt(system: Option<&str>, user: &str) -> String {
+/// `thinking_mode` is true for models that default to thinking-on (Qwen3.5):
+/// the assistant turn then opens with an empty `<think></think>` block so no
+/// output tokens go to reasoning (`strip_think_tags` would otherwise remove
+/// them all). Models without a thinking mode (Qwen3-4B-Instruct-2507) must
+/// not get that block: they read it as an answer that already ended and, at
+/// the title job's sampling temperature, stop before the first word (greedy
+/// decoding still answers). Callers outside this module go through
+/// [`crate::engine::LlmEngine::format_prompt`], which knows its model.
+pub(crate) fn format_chatml_prompt(
+    system: Option<&str>,
+    user: &str,
+    thinking_mode: bool,
+) -> String {
+    let prefill = if thinking_mode {
+        "<think>\n\n</think>\n\n"
+    } else {
+        ""
+    };
     match system {
         Some(sys) => format!(
             "<|im_start|>system\n{sys}\n<|im_end|>\n\
              <|im_start|>user\n{user}\n<|im_end|>\n\
-             <|im_start|>assistant\n<think>\n\n</think>\n\n"
+             <|im_start|>assistant\n{prefill}"
         ),
         None => format!(
             "<|im_start|>user\n{user}\n<|im_end|>\n\
-             <|im_start|>assistant\n<think>\n\n</think>\n\n"
+             <|im_start|>assistant\n{prefill}"
         ),
     }
 }
@@ -374,7 +387,8 @@ impl OnDeviceProvider {
         #[cfg(target_os = "macos")]
         std::env::set_var("GGML_METAL_NO_RESIDENCY", "1");
 
-        let engine = LlmEngine::new(&model_path, prompts.clone())?;
+        let engine = LlmEngine::new(&model_path, prompts.clone())?
+            .with_thinking_mode(model_spec.thinking_mode);
         let backend_plan = engine.inference_backend_plan().clone();
         log::info!(
             "[on_device_provider] selected inference backend: {}",
@@ -406,7 +420,8 @@ impl OnDeviceProvider {
                 drop(engine);
                 // Sleep to let autorelease pool fully drain queues from the dropped engine.
                 std::thread::sleep(std::time::Duration::from_millis(500));
-                let fallback = LlmEngine::new(&model_path, prompts)?;
+                let fallback = LlmEngine::new(&model_path, prompts)?
+                    .with_thinking_mode(model_spec.thinking_mode);
                 if !Self::probe_metal_with_retries(&fallback, "BF16-disabled") {
                     log::error!(
                         "[on_device_provider] Metal context still fails with BF16 disabled \
@@ -428,7 +443,8 @@ impl OnDeviceProvider {
                 if backend_plan.supports_cpu_fallback() {
                     log::warn!("[on_device_provider] {message}; reloading the model on CPU");
                     drop(engine);
-                    let fallback = LlmEngine::reload_on_cpu(&model_path, prompts, message.clone())?;
+                    let fallback = LlmEngine::reload_on_cpu(&model_path, prompts, message.clone())?
+                        .with_thinking_mode(model_spec.thinking_mode);
                     fallback.probe_context().map_err(|cpu_cause| {
                         crate::error::WenlanError::Llm(format!(
                             "{message}; CPU fallback context creation failed: {cpu_cause}"
@@ -653,7 +669,7 @@ impl OnDeviceProvider {
                             let batch_n_seqs = batch_reqs.len();
                             let req = batch_reqs.pop().expect("batch has at least 1 req");
                             let full_prompt =
-                                format_chatml_prompt(req.system_prompt.as_deref(), &req.prompt);
+                                engine.format_prompt(req.system_prompt.as_deref(), &req.prompt);
                             let (timeout_secs, strip_think) = match req.timeout_secs {
                                 Some(secs) => (secs, false),
                                 None => (30, true),
@@ -729,10 +745,8 @@ impl OnDeviceProvider {
                             batch_reqs
                                 .iter()
                                 .map(|req| {
-                                    let prompt = format_chatml_prompt(
-                                        req.system_prompt.as_deref(),
-                                        &req.prompt,
-                                    );
+                                    let prompt = engine
+                                        .format_prompt(req.system_prompt.as_deref(), &req.prompt);
                                     let (timeout_secs, strip_think) = match req.timeout_secs {
                                         Some(secs) => (secs, false),
                                         None => (30, true),
@@ -1696,18 +1710,28 @@ mod tests {
 
     #[test]
     fn test_format_chatml_prompt_with_system() {
-        let p = format_chatml_prompt(Some("you are helpful"), "hi");
+        let p = format_chatml_prompt(Some("you are helpful"), "hi", true);
         assert!(p.contains("<|im_start|>system\nyou are helpful\n<|im_end|>"));
         assert!(p.contains("<|im_start|>user\nhi\n<|im_end|>"));
-        assert!(p.contains("<|im_start|>assistant\n<think>"));
+        assert!(p.ends_with("<|im_start|>assistant\n<think>\n\n</think>\n\n"));
     }
 
     #[test]
     fn test_format_chatml_prompt_no_system() {
-        let p = format_chatml_prompt(None, "hello world");
+        let p = format_chatml_prompt(None, "hello world", true);
         assert!(!p.contains("<|im_start|>system"));
         assert!(p.contains("<|im_start|>user\nhello world\n<|im_end|>"));
-        assert!(p.contains("<|im_start|>assistant\n<think>"));
+        assert!(p.ends_with("<|im_start|>assistant\n<think>\n\n</think>\n\n"));
+    }
+
+    #[test]
+    fn test_format_chatml_prompt_without_thinking_mode_has_no_think_block() {
+        let p = format_chatml_prompt(Some("you are helpful"), "hi", false);
+        assert!(!p.contains("<think>"));
+        assert!(p.ends_with("<|im_start|>assistant\n"));
+        let p = format_chatml_prompt(None, "hi", false);
+        assert!(!p.contains("<think>"));
+        assert!(p.ends_with("<|im_start|>assistant\n"));
     }
 
     #[test]

--- a/crates/wenlan-core/src/on_device_models.rs
+++ b/crates/wenlan-core/src/on_device_models.rs
@@ -45,6 +45,13 @@ pub struct OnDeviceModel {
     /// re-distillation). Smaller models produce thin/repetitive output at
     /// high token counts, so this is quality-constrained, not context-constrained.
     pub max_output_tokens: u32,
+    /// True when the model starts every answer in thinking mode unless told
+    /// not to. The prompt then opens with an empty `<think></think>` block so
+    /// the whole output budget goes to the answer. Models without a thinking
+    /// mode must NOT get that block: Qwen3-4B-Instruct-2507 reads it as an
+    /// answer that already ended and, at the title job's sampling
+    /// temperature, stops before its first word (greedy decoding answers).
+    pub thinking_mode: bool,
 }
 
 /// All available on-device models, ordered by size.
@@ -60,6 +67,7 @@ pub const MODELS: &[OnDeviceModel] = &[
         synthesis_token_limit: 6_000, // 32K context, ~19% — conservative for 4B quantized
         context_size: 8_192,          // 25% of 32K. KV cache ~2GB on Metal.
         max_output_tokens: 1_024,     // 4B quality degrades past ~750 words
+        thinking_mode: false,         // Instruct-2507 has no thinking mode
     },
     OnDeviceModel {
         id: "qwen3.5-9b",
@@ -74,6 +82,7 @@ pub const MODELS: &[OnDeviceModel] = &[
         // 6K prompt + 2K output. Same as 4B. Avoids the 4x KV cache
         // overhead of 16K which slows prefill without benefit.
         max_output_tokens: 2_048, // 9B sustains quality up to ~1500 words
+        thinking_mode: true,      // defaults to thinking-on
     },
 ];
 
@@ -81,6 +90,18 @@ pub const MODELS: &[OnDeviceModel] = &[
 /// fall back to `get_default_model()`.
 pub fn get_model(id: &str) -> Option<&'static OnDeviceModel> {
     MODELS.iter().find(|m| m.id == id)
+}
+
+/// Whether prompts for the model file at `path` should open with an empty
+/// think block. Files not in the registry get `false` (no block); see
+/// [`OnDeviceModel::thinking_mode`].
+pub fn thinking_mode_for_model_file(path: &std::path::Path) -> bool {
+    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    MODELS
+        .iter()
+        .find(|m| m.filename == name)
+        .map(|m| m.thinking_mode)
+        .unwrap_or(false)
 }
 
 /// Get the default model (smallest tier, runs on any laptop).
@@ -148,6 +169,20 @@ pub fn is_cached(model: &OnDeviceModel) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn thinking_mode_follows_the_model_family() {
+        use std::path::Path;
+        assert!(!get_model("qwen3-4b").unwrap().thinking_mode);
+        assert!(get_model("qwen3.5-9b").unwrap().thinking_mode);
+        assert!(!thinking_mode_for_model_file(Path::new(
+            "/x/Qwen3-4B-Instruct-2507-Q4_K_M.gguf"
+        )));
+        assert!(thinking_mode_for_model_file(Path::new(
+            "/x/Qwen3.5-9B-Q4_K_M.gguf"
+        )));
+        assert!(!thinking_mode_for_model_file(Path::new("/x/unknown.gguf")));
+    }
 
     #[test]
     fn registry_has_two_models() {

--- a/crates/wenlan-core/tests/on_device_prompt_smoke.rs
+++ b/crates/wenlan-core/tests/on_device_prompt_smoke.rs
@@ -1,0 +1,36 @@
+//! Live smoke (ignored): the default on-device model must answer the title
+//! job's prompt with real text.
+//!
+//! Regression for the empty-title bug: the prompt used to open the assistant
+//! turn with an empty `<think></think>` block for every model. The default
+//! model (Qwen3-4B-Instruct-2507) has no thinking mode, read the block as an
+//! answer that had already ended, and stopped before its first word, so every
+//! memory and page title fell back to the raw topic key.
+//!
+//! Needs the default model in the hf-hub cache and a GPU-capable process:
+//! `cargo test -p wenlan-core --release --test on_device_prompt_smoke -- --ignored --nocapture`
+use wenlan_core::engine::LlmEngine;
+use wenlan_core::on_device_models::get_default_model;
+
+const TITLE_SYSTEM: &str = "Given a note, write a 3-5 word title. Output ONLY the title.\n\nExample: 'The system uses libsql for vector storage with DiskANN indexing' → libsql Vector Storage\nExample: 'Google Sign-In fails with developer_error status 10' → Google Sign-In SHA Fix";
+const NOTE: &str = "The Tally reminder email goes out at 9am local time. The copy is being shortened to one sentence so it reads well on a phone lock screen, and the subject line now names the amount owed.";
+
+#[test]
+#[ignore = "live GPU smoke: needs the default GGUF in the hf-hub cache"]
+fn default_model_answers_the_title_prompt() {
+    let spec = get_default_model();
+    let path = LlmEngine::download_model().expect("default model cached");
+    let engine = LlmEngine::new(&path, Default::default())
+        .expect("engine")
+        .with_thinking_mode(spec.thinking_mode);
+    let mut ctx = engine
+        .build_persistent_context_with_seq_max(spec.context_size, 1)
+        .expect("persistent context");
+
+    // Same budget and temperature as `refinery::generate_short_title`.
+    let prompt = engine.format_prompt(Some(TITLE_SYSTEM), NOTE);
+    let out = engine.run_inference_persistent(&mut ctx, &prompt, 16, 0.3, 30, true, Some("title"));
+    eprintln!("title answer: {out:?}");
+    let out = out.expect("title prompt produced no text");
+    assert!(!out.trim().is_empty());
+}


### PR DESCRIPTION
## What

Every on-device title (memories and distilled pages) failed with `inference returned no output`, so pages fell back to their raw topic key (a fresh demo store produced a hero page called "tally"). Two list-shaped notes paused the document worker the same way.

The ChatML prompt opened the assistant turn with an empty `<think></think>` block for every model. The default model, Qwen3-4B-Instruct-2507, has no thinking mode: it reads that block as an answer that already ended and, at the title job's temperature, stops before its first word.

## Evidence

A diagnostic in `run_inference_persistent` now logs the raw output when an answer is empty. On a copy of the demo store it showed `raw (0 chars, 0 tokens)` for the title job while classify, extract, and page refresh worked in the same session. A live probe against the real GGUF (same sampler, same code path):

| prompt | result |
|---|---|
| exact title prompt with the think block, 16 tokens, temp 0.3 | empty (first token is end-of-answer) |
| same without the think block | "Shorter Tally Email Copy" |
| same with the think block, temp 0.0 (greedy) | "The Tally Reminder Email Update" |

## Change

- `OnDeviceModel` gains `thinking_mode` (false for `qwen3-4b`, true for `qwen3.5-9b`, which defaults to thinking-on and still needs the block).
- `LlmEngine` carries the flag (`with_thinking_mode`) and owns `format_prompt`; the worker, the token counter, the throughput harness, and the probe and benchmark binaries go through it. `thinking_mode_for_model_file` maps a GGUF file name back to the registry for the binaries.
- `format_chatml_prompt(system, user, thinking_mode)` only adds the block when the flag is on.
- The raw-output warn line stays so the next silent stop is visible.

## Tests

- Unit: registry flag per model and file name; formatter with and without the block.
- New ignored live smoke `crates/wenlan-core/tests/on_device_prompt_smoke.rs`: the default model must answer the title prompt with text. Ran green locally on Metal ("Shorter Tally Email Copy").
- Daemon proof: the rebuilt server over a copy of the demo store now logs `[title] clean='Shorter Tally Email Copy' (4 words, 24 chars)` where it logged `[title] generation failed` before.
- `cargo test -p wenlan-core --lib` (formatter and registry tests), `cargo clippy -p wenlan-core -p wenlan-server --all-targets -- -D warnings`, `cargo fmt --all -- --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY