### PR TITLE
docs: macOS is notarized now, so stop telling users to click through a warning

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=88d923d235219b5c409efc4a64626449317121e7c636a66097b86407e6beff65 -->
+<!-- README_SYNC: source=README.md sha256=a7f245c59fc508721b4e1de6c76c629fdef5956542440925d317f76bc84877b3 -->
 
 <p align="center">
   <picture>
@@ -55,7 +55,7 @@ Wenlan funciona como un único daemon local. La aplicación de escritorio lo lle
 
 No hay nada más que instalar. La aplicación incluye el daemon, la CLI y el conector MCP, arranca el daemon al abrirse y ofrece conectar los clientes de IA que detecta: el plugin para Claude Code y Codex, una entrada MCP para el resto. A partir de ahí lees Páginas, inspeccionas la Fuente detrás de cualquier cita y gestionas el sistema de conocimiento.
 
-Esta vista previa está firmada ad hoc y no notarizada, así que macOS bloquea el primer arranque: puede decir que Wenlan "no se puede abrir" o que no ha podido comprobar si contiene software malicioso. Cierra ese aviso y luego permite la aplicación una vez en Ajustes del Sistema, Privacidad y seguridad, "Abrir de todos modos". Un comando se salta ese paso: comprueba la descarga contra el SHA-256 publicado en GitHub, elimina la cuarentena solo para esta aplicación y no cambia ninguna configuración de seguridad de macOS.
+La aplicación está firmada con un certificado Apple Developer ID y notarizada por Apple, así que macOS la abre en el primer arranque sin ningún aviso. Si prefieres instalarla desde el terminal, un comando la descarga, la comprueba contra el SHA-256 publicado en GitHub y la mueve a Aplicaciones.
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Wenlan runs as one local daemon. The desktop app carries that daemon inside it; 
 
 Nothing else to install. The app bundles the daemon, CLI, and MCP connector, starts the daemon on launch, and offers to connect the AI clients it detects: the plugin for Claude Code and Codex, an MCP entry for the rest. From there you read Pages, inspect the Source behind any citation, and curate the knowledge system.
 
-This preview is ad-hoc signed and not notarized, so macOS blocks the first launch: it may say Wenlan "cannot be opened" or that it could not check it for malicious software. Close that dialog, then allow the app once under System Settings, Privacy & Security, "Open Anyway". One command skips that step: it verifies the download against GitHub's published SHA-256, clears quarantine for this app alone, and changes no macOS security settings.
+The app is signed with an Apple Developer ID certificate and notarized by Apple, so macOS opens it on a first launch with no warning to click through. If you would rather install it from the terminal, one command downloads it, checks it against GitHub's published SHA-256, and moves it into Applications.
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=88d923d235219b5c409efc4a64626449317121e7c636a66097b86407e6beff65 -->
+<!-- README_SYNC: source=README.md sha256=a7f245c59fc508721b4e1de6c76c629fdef5956542440925d317f76bc84877b3 -->
 
 <p align="center">
   <picture>
@@ -55,7 +55,7 @@ Wenlan 以单个本地 daemon 运行。桌面 app 内置这个 daemon；无 GUI 
 
 不需要再安装别的东西。App 内已打包 daemon、CLI 与 MCP 连接器，启动时会自动运行 daemon，并会为检测到的 AI 客户端提供接入：Claude Code 与 Codex 安装 plugin，其余客户端写入 MCP 配置。之后你就可以阅读 Page、检查任一引用背后的 Source，并整理整个知识体系。
 
-这个预览版只做了 ad-hoc 签名、未经 Apple notarization，首次启动会被 macOS 拦下：可能提示 Wenlan「无法打开」，或者无法检查它是否包含恶意软件。关掉这个提示，再到「系统设置」的「隐私与安全性」里点一次「仍要打开」即可。一条命令可以跳过这一步：它会用 GitHub 发布的 SHA-256 核对下载文件，只为这一个 app 清除 quarantine，不会更改任何 macOS 安全设置。
+这个版本使用 Apple Developer ID 证书签名，并通过了 Apple 的 notarization（公证），首次启动不会再被 macOS 拦下，也不需要额外点击确认。如果你更习惯用命令行安装，一条命令会下载它、用 GitHub 发布的 SHA-256 核对下载文件，并把它放进「应用程序」。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=88d923d235219b5c409efc4a64626449317121e7c636a66097b86407e6beff65 -->
+<!-- README_SYNC: source=README.md sha256=a7f245c59fc508721b4e1de6c76c629fdef5956542440925d317f76bc84877b3 -->
 
 <p align="center">
   <picture>
@@ -55,7 +55,7 @@ Wenlan 以單一本地 daemon 運行。桌面 app 內建這個 daemon；無 GUI 
 
 不需要再安裝其他東西。App 內已打包 daemon、CLI 與 MCP 連接器，啟動時會自動執行 daemon，並會為偵測到的 AI 用戶端提供接入：Claude Code 與 Codex 安裝 plugin，其餘用戶端寫入 MCP 設定。之後你就可以閱讀 Page、檢查任一引用背後的 Source，並整理整個知識體系。
 
-這個預覽版只做了 ad-hoc 簽署、未經 Apple notarization，首次啟動會被 macOS 擋下：可能提示 Wenlan「無法打開」，或者無法檢查它是否含有惡意軟體。關掉這個提示，再到「系統設定」的「隱私權與安全性」裡點一次「仍要打開」即可。一條指令可以跳過這一步：它會用 GitHub 發布的 SHA-256 核對下載檔案，只為這一個 app 清除 quarantine，不會變更任何 macOS 安全設定。
+這個版本使用 Apple Developer ID 憑證簽署，並通過了 Apple 的 notarization（公證），首次啟動不會再被 macOS 擋下，也不需要額外點擊確認。如果你更習慣用指令列安裝，一條指令會下載它、用 GitHub 發布的 SHA-256 核對下載檔案，並把它放進「應用程式」。
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/main/scripts/install-macos-app.sh)"

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -4,7 +4,7 @@ What ships today, and what it takes to make the installers trusted by the OS.
 
 | Artifact | Today | What the OS shows | Fix |
 | --- | --- | --- | --- |
-| `Wenlan_<ver>_aarch64.dmg`, `Wenlan_aarch64.app.tar.gz` | ad-hoc signed (`"signingIdentity": "-"` in `app/tauri.conf.json`; `APPLE_SIGNING_IDENTITY` falls back to `-` in `release.yml`), not notarized | Gatekeeper: "Wenlan cannot be opened" (first-run gauntlet finding F11, `spctl --assess` → `rejected`) | Developer ID certificate + notarization, section 1 |
+| `Wenlan_<ver>_aarch64.dmg`, `Wenlan_aarch64.app.tar.gz` | Developer ID signed and notarized, ticket stapled, from v0.17.4 | None. The first-run gauntlet on v0.17.4 reports `spctl --assess` as `accepted`, `source=Notarized Developer ID` | Done |
 | `Wenlan_<ver>_x64-setup.exe` | unsigned; the READMEs walk the user through the warning | SmartScreen: "Windows protected your PC", unknown publisher | a free SignPath Foundation certificate, section 2; the warning itself fades only as that publisher identity earns reputation |
 | `*.sig` next to the app bundles | signed with the Tauri updater key (`TAURI_SIGNING_PRIVATE_KEY`) | nothing; this is what the in-app updater verifies | already done; unrelated to Gatekeeper and SmartScreen |
 | CLI tarballs, `wenlan-windows-x64.zip` | unsigned; `install.sh` strips quarantine and verifies `SHA256SUMS` | none for a terminal install | not needed for launch |
@@ -13,7 +13,7 @@ The Tauri updater signature protects updates after the first install. Gatekeeper
 
 ## 1. macOS: Developer ID and notarization
 
-The workflow is already wired: once the secrets below exist, the next release is signed and notarized with no code change. Without them the build stays ad-hoc and the verify step says so.
+The workflow is already wired, and the secrets are in place: releases from v0.17.4 are signed and notarized. If the secrets are ever removed, the build falls back to ad-hoc signing and the verify step says so.
 
 ### One-time setup (about an hour, plus Apple's review of the membership)
 
@@ -53,7 +53,7 @@ The workflow is already wired: once the secrets below exist, the next release is
    3. *Notarize and staple the DMG* makes the single submission and staples the ticket to the disk image.
    4. *Staple the app and rebuild the updater archive* staples the same ticket to the `.app` (a lookup, not a second submission), rebuilds `Wenlan_aarch64.app.tar.gz` from the stapled app, and re-signs it with `tauri signer sign`.
    5. *Verify Apple signature and notarization* fails the job unless `codesign --verify --deep --strict` passes and the signing authority is a Developer ID Application certificate, and — when the notarization secrets are set — `spctl --assess --type execute` and `xcrun stapler validate` pass on the `.app`, `stapler validate` plus `spctl --assess --type open` pass on the `.dmg`, and the app mounted from inside the disk image assesses as `source=Notarized Developer ID`.
-7. **Prove it from a user's seat.** Run the first-run gauntlet on the new tag (`gh workflow run first-run-gauntlet.yml --ref main -f release_tag=vX.Y.Z -f channels=macos-app`). Its macOS leg stamps the quarantine attribute a browser would set, then requires `dmg-stapled`, `dmg-gatekeeper`, `dmg-developer-id`, `dmg-codesign-valid`, and `app-gatekeeper` (which must report `source=Notarized Developer ID`) to pass. Then delete the "ad-hoc signed and not notarized" paragraph from the four READMEs (`README.md`, `README.es-ES.md`, `README.zh-Hans.md`, `README.zh-Hant.md`) and close F11 in the gauntlet report.
+7. **Prove it from a user's seat.** Run the first-run gauntlet on the new tag (`gh workflow run first-run-gauntlet.yml --ref main -f release_tag=vX.Y.Z -f channels=macos-app`). Its macOS leg stamps the quarantine attribute a browser would set, then requires `dmg-stapled`, `dmg-gatekeeper`, `dmg-developer-id`, `dmg-codesign-valid`, and `app-gatekeeper` (which must report `source=Notarized Developer ID`) to pass. Then delete the "ad-hoc signed and not notarized" paragraph from the four READMEs (`README.md`, `README.es-ES.md`, `README.zh-Hans.md`, `README.zh-Hant.md`) and close F11 in the gauntlet report. Done for v0.17.4: run 33287491599 passed all five checks, with both Gatekeeper legs reporting `accepted`, `source=Notarized Developer ID`, `origin=Developer ID Application: Qi-Xuan Lu (TDFFZXRF3D)`.
 
 ### Things to know
 


### PR DESCRIPTION
v0.17.4 is the first release signed with the Developer ID certificate and notarized by Apple. The first-run gauntlet on that tag ([run 33287491599](https://github.com/7xuanlu/wenlan/actions/runs/33287491599), macOS leg) passed every check from a fresh download:

- `dmg-quarantine-applied` — the quarantine attribute a browser would set was present.
- `dmg-stapled` — `stapler validate` reported the ticket attached, so Gatekeeper works offline.
- `dmg-gatekeeper` and `app-gatekeeper` — both `accepted`, `source=Notarized Developer ID`, `origin=Developer ID Application: Qi-Xuan Lu (TDFFZXRF3D)`.
- `dmg-developer-id` and `dmg-codesign-valid` — signature valid on the app inside.

The app then installed, launched, registered both launch agents, and answered on the CLI and MCP surfaces.

So the paragraph in all four READMEs telling users macOS would block the first launch, and walking them through System Settings to allow it, is now false. It would send someone hunting for a dialog that no longer appears. The install script stays, described as a terminal option rather than a way around a warning.

`docs/code-signing.md` listed the macOS artifacts as an open gap with gauntlet finding F11 against them. That row now records what shipped, and step 7 carries the run id so the claim can be rechecked.

Windows is unchanged and still unsigned — the SmartScreen guidance stays as it is until SignPath approves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh