### PR TITLE
docs: record the SignPath question that would delete three pipeline steps

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -86,6 +86,8 @@ Two consequences of choosing the Foundation tier, both worth knowing before appl
 
 ### After acceptance
 
+**Ask them one question before building any of this.** SignPath also offers a Windows Key Storage Provider, which would let the build sign the installer in place through Tauri's own `bundle.windows.signCommand` hook. That path skips steps 2, 3 and 4 below outright: nothing is uploaded and re-downloaded, so the updater signature and the checksums are computed once, over the already-signed bytes. The catch is that it produces no GitHub workflow artifact, and origin verification, which the free tier requires, appears to need one. SignPath has not ruled the combination out in writing, so ask; a yes removes most of the work on this page.
+
 Signing is a submission from inside the workflow, not a local `signtool` call: [`signpath/github-action-submit-signing-request`](https://github.com/SignPath/github-action-submit-signing-request) uploads the built installer, waits for the approval, and downloads the signed file. The pieces to add to `app-bundle-windows` in `release.yml`, in order:
 
 1. Upload `*-setup.exe` as a GitHub artifact and submit it, guarded on a `SIGNPATH_CONFIGURED` flag the way the macOS steps are guarded by `APPLE_SIGNING_CONFIGURED`, so a fork without the secret still builds. Raise the action's `wait-for-completion-timeout-in-seconds` past its 600-second default, because it is waiting for a person.


### PR DESCRIPTION
Windows signing work is moving to another machine, so this moves the last load-bearing note out of a local scratch file and into the repository.

`docs/code-signing.md` section 2 plans the Windows signing pipeline around SignPath's submit-and-retrieve GitHub Action: upload the built installer, wait for approval, download it back signed. That path forces three follow-up steps, because the installer's bytes change after the build has already measured them.

1. Overwrite the built installer with the returned file.
2. Regenerate the updater `.sig`, which was computed over the unsigned bytes.
3. Recompute the published SHA-256 checksums from the signed installer.

SignPath also ships a Windows Key Storage Provider. That signs in place through Tauri's own `bundle.windows.signCommand` hook, so the bytes never leave the build and none of those three steps exist.

It may not be available on the free tier. Origin verification is required there and appears to need a GitHub workflow artifact, which the in-place path does not produce. SignPath has not ruled the combination out in writing, which is exactly why it is worth asking during onboarding rather than discovering afterwards.

The question was sitting in a scratch file outside the repository. Whoever wires up Windows signing would never have seen it.

## Verification

`python3 scripts/check-readme-translations.py` — README translations are in sync. Docs-only change; two lines added, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEPWkx6eM4zNpDG9VB2nZh