### PR TITLE
fix(app): open the Home review dialog on the decisions the rail counted

### DIFF
--- a/src/components/memory/HomePage.redesign.test.tsx
+++ b/src/components/memory/HomePage.redesign.test.tsx
@@ -716,6 +716,53 @@ describe("HomePage redesign", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("opens the dialog on the decisions the rail counted, not the merged queue", async () => {
+    const user = userEvent.setup();
+    vi.mocked(tauri.listPages).mockResolvedValue([
+      page({ id: "page-current", title: "Current page" }),
+    ]);
+    vi.mocked(tauri.listPendingRevisions).mockResolvedValue([
+      {
+        target_source_id: "mem-a",
+        revision_source_id: "mem-a-rev",
+        revision_content: "Proposed wording",
+        source_agent: "claude-code",
+        last_modified: 1_782_365_076,
+        target_kind: "memory" as const,
+      },
+    ]);
+    vi.mocked(tauri.listUnconfirmedMemories).mockResolvedValue([
+      {
+        kind: "memory",
+        id: "mem-capture-1",
+        title: "First new memory",
+        snippet: "Captured a moment ago.",
+        timestamp_ms: 1_782_365_080_000,
+        badge: { kind: "needs_review" },
+      },
+      {
+        kind: "memory",
+        id: "mem-capture-2",
+        title: "Second new memory",
+        snippet: "Captured a moment ago.",
+        timestamp_ms: 1_782_365_081_000,
+        badge: { kind: "needs_review" },
+      },
+    ]);
+
+    renderHome({ onOpenDistillReview: vi.fn() });
+
+    const rail = await screen.findByTestId("wiki-page-updates");
+    await within(rail).findByText("1");
+    await user.click(await screen.findByRole("button", { name: /Target memory/ }));
+
+    // The header counter walks the rail's one decision; the two captures in
+    // the merged queue never make it "1 of 3" beside a badge that says 1.
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("1 of 1")).toBeInTheDocument();
+    expect(within(dialog).queryByText("First new memory")).not.toBeInTheDocument();
+  });
+
   it("opens the contradiction dialog with before/after panes and resolves it", async () => {
     const user = userEvent.setup();
     vi.mocked(tauri.listRefinements).mockResolvedValue({

--- a/src/components/memory/HomePage.tsx
+++ b/src/components/memory/HomePage.tsx
@@ -367,7 +367,9 @@ function WikiHome({
   } = useReviewQueue();
   const [openReviewId, setOpenReviewId] = useState<string | null>(null);
   // New-memory captures are inflow, not decisions — they're unconfirmed but
-  // already live (recalled, feeding pages), so they stay out of the rail.
+  // already live (recalled, feeding pages), so they stay out of the rail AND
+  // out of the dialog the rail opens: its "n of total" header must walk the
+  // same list the badge counted, or "1 of 33" sits beside a badge that says 5.
   const decisionItems = reviewItems.filter((item) => item.kind !== "capture");
   return (
     <div
@@ -427,7 +429,7 @@ function WikiHome({
       </div>
 
       <ReviewDialog
-        items={reviewItems}
+        items={decisionItems}
         openId={openReviewId}
         onOpenChange={setOpenReviewId}
         onResolve={resolve}


### PR DESCRIPTION
## What

The Home "Needs review" rail filters new-memory captures out of the review queue and counts what is left, but the dialog it opens was handed the full merged queue. On the launch-video demo store (28 unconfirmed memories, 1 pending revision, 4 refinement proposals) the badge said **5** while the dialog header said **1 of 33**.

The dialog now receives the same filtered list as the rail, so its "n of total" walks exactly the items the badge counted. Captures still surface on the distill review panel, which builds its own item set.

## Proof

- New test in `HomePage.redesign.test.tsx`: 1 revision + 2 captures, open the rail row, header reads `1 of 1` and no capture is shown. Mutation check: with the one-line fix reverted the test fails (`PASS 0 / FAIL 1`); with it, the file passes (39 tests).
- `pnpm exec tsc -b` clean.
- Browser preview against the demo daemon: badge `5`, dialog header `2 of 5` on the second row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY