### PR TITLE
fix(app): keep an Atlas region name off other nodes and off its hub's own label

### DIFF
--- a/src/components/memory/AtlasView.tsx
+++ b/src/components/memory/AtlasView.tsx
@@ -597,7 +597,14 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       const lod = lodRef.current;
       // A dim island carries no name yet; its name comes up with its colour.
       const named = lod.islandsSolid ? scene : { regions: scene.regions.filter((r) => !r.island) };
-      drawRegionNames(ctx, named, project, paletteRef.current, { width, height });
+      // Sigma (3.0.3) keeps the nodes it drew a label for this paint on a
+      // private field with no public getter. A region is named after its
+      // hub, so while the hub's own label is on screen the region name would
+      // print the same word twice; the placer skips it. If a later sigma
+      // drops the field the names simply stay on, as before.
+      const labelledNodes = (renderer as unknown as { displayedNodeLabels?: ReadonlySet<string> })
+        .displayedNodeLabels;
+      drawRegionNames(ctx, named, project, paletteRef.current, { width, height }, labelledNodes);
       drawDustCounts(
         ctx,
         graph,

--- a/src/lib/graph/cartography.test.ts
+++ b/src/lib/graph/cartography.test.ts
@@ -13,6 +13,7 @@ import {
   MAX_REGION_LABELS,
   MIN_LABELLED_SPAN_PX,
   REGION_NAME_LIFT_MIN_PX,
+  REGION_NAME_KEEP_OUT_PX,
 } from "./cartography";
 import type { CartographyScene, Region } from "./cartography";
 
@@ -533,12 +534,18 @@ describe("communitiesFor", () => {
 });
 
 function graphOf(
-  nodes: { id: string; x: number; y: number; label: string; entityType?: string }[],
+  nodes: { id: string; x: number; y: number; label: string; entityType?: string; size?: number }[],
   edges: [string, string][] = [],
 ): Graph {
   const graph = new Graph({ multi: true });
   for (const n of nodes) {
-    graph.addNode(n.id, { x: n.x, y: n.y, label: n.label, ...(n.entityType ? { entityType: n.entityType } : {}) });
+    graph.addNode(n.id, {
+      x: n.x,
+      y: n.y,
+      label: n.label,
+      ...(n.entityType ? { entityType: n.entityType } : {}),
+      ...(n.size !== undefined ? { size: n.size } : {}),
+    });
   }
   edges.forEach(([source, target], i) => graph.addEdgeWithKey(`e${i}`, source, target));
   return graph;
@@ -548,8 +555,8 @@ describe("communityRegions", () => {
   it("measures communities of 3+, names them after the highest-degree member, and sorts largest-first", () => {
     const graph = graphOf(
       [
-        { id: "a1", x: 0, y: 0, label: "Wenlan" },
-        { id: "a2", x: 10, y: 0, label: "Tauri" },
+        { id: "a1", x: 0, y: 0, label: "Wenlan", size: 9 },
+        { id: "a2", x: 10, y: 0, label: "Tauri", size: 4 },
         { id: "a3", x: 0, y: 10, label: "React" },
         { id: "a4", x: 10, y: 10, label: "Rust" },
         { id: "b1", x: 50, y: 50, label: "Claude Code" },
@@ -581,6 +588,14 @@ describe("communityRegions", () => {
     expect(regions[0].memberCount).toBe(4);
     expect(regions[0].centroid).toEqual({ x: 5, y: 5 });
     expect(regions[0].bounds).toEqual({ minX: 0, maxX: 10, minY: 0, maxY: 10 });
+    // The hub carries its own position and px radius; the rest are what the
+    // name must keep clear of. A node without a size counts as a point.
+    expect(regions[0].hub).toEqual({ id: "a1", x: 0, y: 0, size: 9 });
+    expect(regions[0].otherMembers).toEqual([
+      { x: 10, y: 0, size: 4 },
+      { x: 0, y: 10, size: 0 },
+      { x: 10, y: 10, size: 0 },
+    ]);
     expect(regions[1].name).toBe("Claude Code");
     expect(regions[1].memberCount).toBe(3);
   });
@@ -671,6 +686,8 @@ describe("drawRegionNames", () => {
   function region(name: string, centroidX: number, centroidY: number, spanX = 200): Region {
     return {
       name,
+      hub: { id: name, x: centroidX, y: centroidY, size: 0 },
+      otherMembers: [],
       memberCount: 3,
       island: false,
       centroid: { x: centroidX, y: centroidY },
@@ -713,6 +730,15 @@ describe("drawRegionNames", () => {
     ]);
     expect(drawOrder).toEqual(["stroke:Wenlan", "fill:Wenlan", "stroke:Tauri", "fill:Tauri"]);
   });
+
+  it("leaves out the name of a region whose hub sigma already labelled", () => {
+    const { ctx, texts } = mockCtx();
+    const scene: CartographyScene = {
+      regions: [region("Wenlan", 100, 100), region("Tauri", 600, 300)],
+    };
+    drawRegionNames(ctx, scene, identity, PALETTE, undefined, new Set(["Wenlan"]));
+    expect(texts.map((t) => t.text)).toEqual(["Tauri"]);
+  });
 });
 
 describe("placeRegionLabels", () => {
@@ -725,6 +751,8 @@ describe("placeRegionLabels", () => {
   function boxRegion(name: string, x: number, y: number, width: number, members = 3): Region {
     return {
       name,
+      hub: { id: name, x: x + width / 2, y: y + 10, size: 0 },
+      otherMembers: [],
       memberCount: members,
       island: false,
       centroid: { x: x + width / 2, y: y + 10 },
@@ -809,6 +837,8 @@ describe("placeRegionLabels", () => {
     // A tall region lifts by a share of its on-screen height instead.
     const tall: Region = {
       name: "Tall",
+      hub: { id: "Tall", x: 100, y: 200, size: 0 },
+      otherMembers: [],
       memberCount: 5,
       island: false,
       centroid: { x: 100, y: 200 },
@@ -816,6 +846,41 @@ describe("placeRegionLabels", () => {
     };
     const [label] = placeRegionLabels(sceneOf([tall]), identity, measure);
     expect(label.y).toBe(200 - 0.3 * 200);
+  });
+
+  it("skips a region whose hub's own label is on screen, without spending a slot", () => {
+    // Both regions are placeable and far apart; only the hub label decides.
+    const first = boxRegion("Wenlan", 0, 100, 200, 9);
+    const second = boxRegion("Tauri", 0, 400, 200, 4);
+    const placed = placeRegionLabels(sceneOf([first, second]), identity, measure, undefined, new Set(["Wenlan"]));
+    expect(placed.map((label) => label.name)).toEqual(["Tauri"]);
+    // The skipped region did not take the dominant slot with it.
+    expect(placed[0].size).toBe(15);
+    // Some other node's label on screen changes nothing.
+    expect(
+      placeRegionLabels(sceneOf([first, second]), identity, measure, undefined, new Set(["Rust"])).map((l) => l.name),
+    ).toEqual(["Wenlan", "Tauri"]);
+  });
+
+  it("moves the name onto its hub when the lifted centroid would caption another member", () => {
+    // The lifted spot is (110, 210 - 18) = (110, 192). A member sitting
+    // 30px below that box's bottom edge is within the keep-out; the hub sits
+    // well to the right.
+    const region: Region = {
+      ...boxRegion("sqlite", 40, 200, 140),
+      hub: { id: "sqlite", x: 400, y: 210, size: 8 },
+      otherMembers: [{ x: 110, y: 192 + 7.5 + 30, size: 5 }],
+    };
+    const [label] = placeRegionLabels(sceneOf([region]), identity, measure);
+    expect(label.x).toBe(400);
+    expect(label.y).toBe(210 - 8 - 4 - 7.5);
+    // The same member just beyond its reach leaves the name on the land.
+    const clear: Region = {
+      ...region,
+      otherMembers: [{ x: 110, y: 192 + 7.5 + REGION_NAME_KEEP_OUT_PX + 5 + 1, size: 5 }],
+    };
+    const [onLand] = placeRegionLabels(sceneOf([clear]), identity, measure);
+    expect(onLand).toEqual({ name: "sqlite", x: 110, y: 192, size: 15 });
   });
 });
 
@@ -831,6 +896,8 @@ describe("region label measurement includes its tracking", () => {
   function twoWideRegions(gap: number): CartographyScene {
     const region = (name: string, centroidX: number): Region => ({
       name,
+      hub: { id: name, x: centroidX, y: 0, size: 0 },
+      otherMembers: [],
       memberCount: 3,
       island: false,
       centroid: { x: centroidX, y: 0 },

--- a/src/lib/graph/cartography.ts
+++ b/src/lib/graph/cartography.ts
@@ -36,6 +36,9 @@ export const REGION_NAME_LIFT_MAX_PX = 60;
  *  land in the viewport: zoomed in, a dozen big regions off to the side must
  *  not spend the cap and leave the regions in view nameless. */
 export const MAX_REGION_LABELS = 12;
+/** A name closer than this (CSS px) to a member that is NOT the region's hub
+ *  reads as that node's caption. Such a name moves onto its hub instead. */
+export const REGION_NAME_KEEP_OUT_PX = 36;
 
 /** Clear air demanded around a candidate label before it may sit next to an
  *  already-placed one. */
@@ -300,6 +303,14 @@ export function regionLeader<T extends { id: string; name: string; degree: numbe
 export interface Region {
   /** Highest-degree member's name — the region's label. */
   name: string;
+  /** The member the region is named after: its GRAPH position and CSS-px
+   *  radius. When sigma draws this node's own label the place is already
+   *  named, so the region name yields; and when the lifted centroid would
+   *  sit on some other member, the name sits above this node instead. */
+  hub: { id: string; x: number; y: number; size: number };
+  /** Every other member's GRAPH position and CSS-px radius — what the name
+   *  keeps REGION_NAME_KEEP_OUT_PX clear of. */
+  otherMembers: { x: number; y: number; size: number }[];
   memberCount: number;
   /** Mean of member GRAPH positions — where the name sits. */
   centroid: { x: number; y: number };
@@ -341,9 +352,21 @@ export function communityRegions(graph: Graph, communities: Map<string, string>)
     let sumY = 0;
     const bounds = { minX: Infinity, maxX: -Infinity, minY: Infinity, maxY: -Infinity };
     let island = true;
+    const hub = { id: hubId, x: 0, y: 0, size: 0 };
+    const otherMembers: Region["otherMembers"] = [];
     for (const id of ids) {
       const x = graph.getNodeAttribute(id, "x") as number;
       const y = graph.getNodeAttribute(id, "y") as number;
+      // Node sizes are true CSS px at every zoom (AtlasView's
+      // zoomToSizeRatioFunction), so a radius here is a screen radius.
+      const size = (graph.getNodeAttribute(id, "size") as number | undefined) ?? 0;
+      if (id === hubId) {
+        hub.x = x;
+        hub.y = y;
+        hub.size = size;
+      } else {
+        otherMembers.push({ x, y, size });
+      }
       if (graph.getNodeAttribute(id, "island") !== true) island = false;
       sumX += x;
       sumY += y;
@@ -354,6 +377,8 @@ export function communityRegions(graph: Graph, communities: Map<string, string>)
     }
     regions.push({
       name: graph.getNodeAttribute(hubId, "label") as string,
+      hub,
+      otherMembers,
       memberCount: ids.length,
       centroid: { x: sumX / ids.length, y: sumY / ids.length },
       bounds,
@@ -399,17 +424,27 @@ export interface PlacedLabel {
  * MAX_REGION_LABELS. Because on-screen span grows with zoom, more names
  * appear as you approach. With a `viewport` (CSS px), a name whose box lies
  * wholly outside it is skipped without counting toward the cap.
+ *
+ * A region is named after its hub node, so the name never doubles that
+ * node's own label: a hub in `labelledNodes` (the nodes sigma drew a label
+ * for this paint) costs its region the name, again without counting toward
+ * the cap. And a name that would land within REGION_NAME_KEEP_OUT_PX of a
+ * member that is not the hub — where it reads as that node's caption —
+ * sits just above the hub instead.
  */
 export function placeRegionLabels(
   scene: CartographyScene,
   project: (pos: { x: number; y: number }) => { x: number; y: number },
   measure: (text: string, size: number) => number,
   viewport?: { width: number; height: number },
+  labelledNodes?: ReadonlySet<string>,
 ): PlacedLabel[] {
   const placed: PlacedLabel[] = [];
   const boxes: { left: number; right: number; top: number; bottom: number }[] = [];
   for (const region of scene.regions) {
     if (placed.length >= MAX_REGION_LABELS) break;
+    // The hub's own label is on screen: the place already has its name.
+    if (labelledNodes?.has(region.hub.id)) continue;
     const { bounds } = region;
     // Project all four corners: the camera may rotate, so a graph-space width
     // is not a screen width.
@@ -428,15 +463,34 @@ export function placeRegionLabels(
       Math.max(REGION_NAME_LIFT_MIN_PX, REGION_NAME_LIFT_FRACTION * (Math.max(...ys) - Math.min(...ys))),
     );
     // Viewport y grows downward, so "above" is smaller y.
-    const at = { x: centroid.x, y: centroid.y - lift };
+    let at = { x: centroid.x, y: centroid.y - lift };
     const size = placed.length === 0 ? 15 : 12;
     const halfWidth = measure(region.name, size) / 2;
-    const box = {
-      left: at.x - halfWidth,
-      right: at.x + halfWidth,
-      top: at.y - size / 2,
-      bottom: at.y + size / 2,
-    };
+    const boxAround = (p: { x: number; y: number }) => ({
+      left: p.x - halfWidth,
+      right: p.x + halfWidth,
+      top: p.y - size / 2,
+      bottom: p.y + size / 2,
+    });
+    let box = boxAround(at);
+    // Beside some other member the name reads as that node's caption (the
+    // region "sqlite" once sat right over the node "tally"). The name is the
+    // hub's, so put it on the hub — just above its disc, like its own label.
+    const captionsAnotherNode = region.otherMembers.some((member) => {
+      const p = project(member);
+      const reach = member.size + REGION_NAME_KEEP_OUT_PX;
+      return (
+        p.x - reach < box.right &&
+        box.left < p.x + reach &&
+        p.y - reach < box.bottom &&
+        box.top < p.y + reach
+      );
+    });
+    if (captionsAnotherNode) {
+      const hub = project(region.hub);
+      at = { x: hub.x, y: hub.y - region.hub.size - LABEL_BOX_PAD - size / 2 };
+      box = boxAround(at);
+    }
     if (
       viewport &&
       (box.right < 0 || box.left > viewport.width || box.bottom < 0 || box.top > viewport.height)
@@ -473,6 +527,7 @@ export function drawRegionNames(
   project: (pos: { x: number; y: number }) => { x: number; y: number },
   palette: GraphPalette,
   viewport?: { width: number; height: number },
+  labelledNodes?: ReadonlySet<string>,
 ): void {
   const measure = (text: string, size: number): number => {
     ctx.font = regionLabelFont(size);
@@ -488,7 +543,7 @@ export function drawRegionNames(
   ctx.lineWidth = LABEL_HALO_WIDTH;
   ctx.strokeStyle = palette.surface;
   ctx.fillStyle = palette.labelMuted;
-  for (const label of placeRegionLabels(scene, project, measure, viewport)) {
+  for (const label of placeRegionLabels(scene, project, measure, viewport, labelledNodes)) {
     ctx.font = regionLabelFont(label.size);
     // Same tracking the measurement used; jsdom's mock ctx simply ignores it.
     ctx.letterSpacing = regionLabelTracking(label.size);


### PR DESCRIPTION
## What

An Atlas region is named after its highest-degree member (its hub) and the name sat above the community centroid. On the launch-video demo map that put the name **sqlite** right over the **tally** node, so tally read as sqlite; and once sigma drew the sqlite node's own label the word appeared twice on screen.

Two placement rules in `placeRegionLabels`:

1. **No double word.** A region whose hub sigma labelled this paint (read from sigma's `displayedNodeLabels` after render) gets no region name, without spending one of the `MAX_REGION_LABELS` slots. If a later sigma drops that field the names simply stay on, as before.
2. **No captioning a stranger.** A name that would land within `REGION_NAME_KEEP_OUT_PX` (36 px) of a member that is not the hub moves onto the hub, just above its disc, like the node's own label.

`Region` now carries `hub` (id, position, px radius) and `otherMembers` (positions and radii) so the placer can apply both rules; `drawRegionNames` and `AtlasView`'s overlay pass the labelled-node set through.

## Proof

- `cartography.test.ts`: 41 tests pass, three new: hub skip without spending a slot, keep-out moves the name onto the hub (and leaves it on the land just beyond reach), `drawRegionNames` pass-through. `communityRegions` test now checks `hub` and `otherMembers`.
- `AtlasView.test.tsx` + `src/lib/graph`: 273 pass. `pnpm exec tsc -b` clean.
- Browser preview against the demo daemon: screenshots in the PR conversation below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY