### PR TITLE
fix(app): fade archived cards in list view and guard computed opacity in Playwright

### DIFF
--- a/e2e/archived-memory-opacity.spec.ts
+++ b/e2e/archived-memory-opacity.spec.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Computed-opacity guard for archive-superseded memories.
+//
+// PR #564 faded such memories to ARCHIVED_MEMORY_OPACITY and every jsdom test
+// passed while Chrome computed 1 for the list row: the `mem-fade-up` entry
+// animation runs with `both` fill, so its final keyframe keeps applying after
+// the animation ends, and an animation outranks an inline style (#568). jsdom
+// runs no cascade and no keyframes, so only a real browser can catch that
+// class of defect. Each test puts an archived memory next to an unarchived one
+// on one surface and reads the computed opacity of both — after checking that
+// the entry animation really targets the faded element or its wrapper, since
+// the guard proves nothing if the animation quietly stops running.
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { installTauriMock } from "./tauriMock";
+import type { MemoryItem } from "../src/lib/tauri";
+import { ARCHIVED_MEMORY_OPACITY } from "../src/components/memory/archivedMemoryOpacity";
+
+// With reduced motion Chromium skips the animation and the guard would pass
+// whatever the keyframes say. Pin the preference so a config change cannot
+// silently defuse it.
+test.use({ reducedMotion: "no-preference" });
+
+const ARCHIVED_TITLE = "Ship the beta on Friday";
+const NEIGHBOUR_TITLE = "Keep the review workflow local-first";
+const MUTED = String(ARCHIVED_MEMORY_OPACITY);
+
+function makeMemory(
+  overrides: Partial<MemoryItem> & Pick<MemoryItem, "source_id" | "title">,
+): MemoryItem {
+  return {
+    content: overrides.title,
+    summary: null,
+    memory_type: "fact",
+    domain: "Wenlan",
+    space: "Wenlan",
+    source_agent: "claude-code",
+    confidence: 0.9,
+    confirmed: true,
+    pinned: false,
+    supersedes: null,
+    last_modified: 1_700_000_000,
+    chunk_count: 1,
+    access_count: 0,
+    is_recap: false,
+    // Confirmed on purpose: the grid card derives an unarchived row's opacity
+    // from stability and confidence, and only a confirmed row rests at 1.
+    stability: "confirmed",
+    ...overrides,
+  };
+}
+
+// The predecessor a decision replaced in 'archive' mode. The daemon stamps it
+// `is_archived`; that flag is all the surfaces read.
+const memories: readonly MemoryItem[] = [
+  makeMemory({
+    source_id: "mem-archived",
+    title: ARCHIVED_TITLE,
+    is_archived: true,
+    last_modified: 1_700_000_100,
+  }),
+  makeMemory({ source_id: "mem-neighbour", title: NEIGHBOUR_TITLE }),
+];
+
+async function openApp(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await installTauriMock(page, { locale: "en", rawActions: [], memories });
+  await page.goto("/");
+}
+
+// Space detail renders its memories through the embedded MemoryStream, the one
+// surface with a grid/list toggle.
+async function openRawMemories(page: Page): Promise<Locator> {
+  await openApp(page);
+  await page
+    .getByRole("navigation", { name: "Primary navigation" })
+    .getByRole("button", { name: "Spaces", exact: true })
+    .click();
+  await page
+    .getByTestId("space-row-space-wenlan")
+    .getByRole("button", { name: "Wenlan", exact: true })
+    .click();
+  await expect(page.getByRole("heading", { level: 1, name: "Wenlan" })).toBeVisible();
+  const rawMemories = page.getByRole("region", { name: "Raw memories" });
+  await rawMemories.getByRole("button", { name: /^Raw memories \(\d+\)$/ }).click();
+  return rawMemories;
+}
+
+// The card root is the nearest ancestor of the title that carries an inline
+// opacity: MemoryCard sets one on its root for every memory, archived or not.
+function cardRoot(scope: Locator, title: string): Locator {
+  return scope
+    .getByText(title, { exact: true })
+    .locator("xpath=ancestor::*[contains(@style,'opacity')][1]");
+}
+
+async function expectMuted(archived: Locator, neighbour: Locator): Promise<void> {
+  await expect(archived).toHaveCSS("opacity", MUTED);
+  await expect(neighbour).toHaveCSS("opacity", "1");
+}
+
+test("list row on the Memories page", async ({ page }) => {
+  await openApp(page);
+  await page.getByRole("button", { name: "Memories" }).click();
+  const list = page.getByRole("region", { name: "Memory list" });
+  const archived = list.getByRole("article", { name: ARCHIVED_TITLE, exact: true });
+  const neighbour = list.getByRole("article", { name: NEIGHBOUR_TITLE, exact: true });
+
+  await expect(archived.getByText("archived")).toBeVisible();
+  // The row itself is the animated element — the shape that failed before #568.
+  await expect(archived).toHaveCSS("animation-name", "mem-fade-up");
+  await expectMuted(archived, neighbour);
+});
+
+test("grid card in a space's raw memories", async ({ page }) => {
+  const rawMemories = await openRawMemories(page);
+  const archived = cardRoot(rawMemories, ARCHIVED_TITLE);
+  const neighbour = cardRoot(rawMemories, NEIGHBOUR_TITLE);
+
+  // Grid tiles animate a wrapper; the card's own opacity sits on a child of it.
+  await expect(archived.locator("xpath=..")).toHaveCSS("animation-name", "mem-fade-up");
+  await expectMuted(archived, neighbour);
+});
+
+test("list card in a space's raw memories", async ({ page }) => {
+  const rawMemories = await openRawMemories(page);
+  await page.getByTitle("Switch to list view").click();
+  const archived = cardRoot(rawMemories, ARCHIVED_TITLE);
+  const neighbour = cardRoot(rawMemories, NEIGHBOUR_TITLE);
+
+  // Here the card root is the animated element, exactly like the list row.
+  await expect(archived).toHaveCSS("animation-name", "mem-fade-up");
+  await expectMuted(archived, neighbour);
+});

--- a/e2e/archived-memory-opacity.spec.ts
+++ b/e2e/archived-memory-opacity.spec.ts
@@ -16,11 +16,6 @@ import { installTauriMock } from "./tauriMock";
 import type { MemoryItem } from "../src/lib/tauri";
 import { ARCHIVED_MEMORY_OPACITY } from "../src/components/memory/archivedMemoryOpacity";
 
-// With reduced motion Chromium skips the animation and the guard would pass
-// whatever the keyframes say. Pin the preference so a config change cannot
-// silently defuse it.
-test.use({ reducedMotion: "no-preference" });
-
 const ARCHIVED_TITLE = "Ship the beta on Friday";
 const NEIGHBOUR_TITLE = "Keep the review workflow local-first";
 const MUTED = String(ARCHIVED_MEMORY_OPACITY);

--- a/src/components/memory/MemoryCard.tsx
+++ b/src/components/memory/MemoryCard.tsx
@@ -5,6 +5,7 @@ import { FACET_COLORS, STABILITY_TIERS, agentDisplayName, type MemoryItem, type 
 import { formatTimeAgo } from "../../lib/dateFormat";
 import ContentRenderer from "./ContentRenderer";
 import MemoryListRow from "./MemoryListRow";
+import { ARCHIVED_MEMORY_OPACITY } from "./archivedMemoryOpacity";
 
 interface MemoryCardProps {
   memory: MemoryItem;
@@ -225,21 +226,27 @@ export default function MemoryCard({
   }
 
   // ── Standard memory card ──
+  // Resting opacity. The list view passes the `mem-fade-up` entry animation in
+  // `style`, and it runs with `both` fill on this very element: without
+  // `--mem-enter-opacity` its final keyframe would hold the card at 1 and the
+  // fade would never show (see index.css). The grid animates a wrapper instead.
+  const restingOpacity = isSuperseded || memory.is_archived
+    ? ARCHIVED_MEMORY_OPACITY
+    : stability === "confirmed" || maturity === "distilled"
+      ? 1
+      : stability === "learned"
+        ? 0.85
+        : Math.max(0.4, Math.min(0.85, 0.4 + confidence * 0.45));
   return (
     <div
       className="group relative h-full flex flex-col"
       style={{
         borderLeft: `3px solid ${borderColor}`,
-        opacity: isSuperseded || memory.is_archived
-          ? 0.55
-          : stability === "confirmed" || maturity === "distilled"
-            ? 1
-            : stability === "learned"
-              ? 0.85
-              : Math.max(0.4, Math.min(0.85, 0.4 + confidence * 0.45)),
+        opacity: restingOpacity,
+        "--mem-enter-opacity": restingOpacity,
         animation: isNew ? "mem-shimmer 8s ease-in-out infinite" : undefined,
         ...style,
-      }}
+      } as React.CSSProperties}
     >
       <div
         className="py-4 pr-4 transition-colors duration-150 flex-1"

--- a/src/components/memory/MemoryListRow.tsx
+++ b/src/components/memory/MemoryListRow.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../lib/tauri";
 import { formatTimeAgo } from "../../lib/dateFormat";
 import ContentRenderer from "./ContentRenderer";
+import { ARCHIVED_MEMORY_OPACITY } from "./archivedMemoryOpacity";
 
 interface MemoryListRowProps {
   memory: MemoryItem;
@@ -98,8 +99,8 @@ export default function MemoryListRow({
         memory.is_archived
           ? ({
               ...style,
-              opacity: 0.55,
-              "--mem-enter-opacity": 0.55,
+              opacity: ARCHIVED_MEMORY_OPACITY,
+              "--mem-enter-opacity": ARCHIVED_MEMORY_OPACITY,
             } as CSSProperties)
           : style
       }

--- a/src/components/memory/archivedMemoryOpacity.ts
+++ b/src/components/memory/archivedMemoryOpacity.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Resting opacity of a memory that an 'archive'-mode superseder has replaced:
+ * kept visible but muted. Every surface that renders memory rows uses this
+ * value, and so does the Playwright guard in e2e/archived-memory-opacity.spec.ts,
+ * which asserts the browser's *computed* opacity against it — jsdom cannot,
+ * because it runs no cascade and no keyframes.
+ */
+export const ARCHIVED_MEMORY_OPACITY = 0.55;


### PR DESCRIPTION
## What

A Playwright guard that reads the browser's **computed** opacity of an archive-superseded memory on every surface that renders memory rows, and the one-line fix it caught on the way in.

**The user-visible change:** unarchived cards in a space's Raw memories list view (list mode; the view preference is `wenlan-memory-view-mode`, which defaults to grid) now rest at the same stability opacity the grid view already used — confirmed or distilled 1, learned 0.85, new 0.4 plus 0.45 times confidence, archived 0.55 — instead of always 1.

- `e2e/archived-memory-opacity.spec.ts` — three tests, one per surface, each with an archived memory next to an unarchived neighbour:
  - the list row on the Memories page (`MemoryListRow`, the element that failed before #568),
  - the grid card in a space's raw memories (`MemoryCard` inside the animated masonry wrapper),
  - the list card in a space's raw memories (`MemoryCard` carrying the entry animation itself).
  Each test also asserts `animation-name: mem-fade-up` on the animated element, so the guard cannot go vacuous if the animation is dropped. The fixture is plain `installTauriMock({ memories })` with `is_archived: true`, so the suite stays daemon-free.
- `src/components/memory/archivedMemoryOpacity.ts` — `ARCHIVED_MEMORY_OPACITY = 0.55`, now the single source for both components and the spec, so the test asserts the value the components use rather than a copy of it.
- `src/components/memory/MemoryCard.tsx` — the fix. The space list view passes `mem-fade-up ... both` into the card's own root (`MemoryStream.renderCard`), the same shape #568 fixed for the row, and the card never set `--mem-enter-opacity`, so every card in that view rested at 1 whatever its inline opacity. The root now carries its resting opacity in `--mem-enter-opacity` as well, for archived cards and for the stability/confidence formula alike.

There is no decision log surface any more: `DecisionLog.tsx` was deleted in #574 (dead surface), so the third surface here is the embedded list card, which turned out to be the one still broken.

## Why

On 2026-08-19 browser verification found that #564's fade never rendered: `mem-fade-up` runs with `both` fill and outranks an inline style, and all four jsdom tests in `MemoryCard.archived.test.tsx` stayed green because jsdom runs no cascade and no keyframes. #568 fixed the row but shipped no guard, and the card path in the space list view had the identical defect (first run below).

## Verification

All Playwright runs: `E2E_PORT=14331 pnpm exec playwright test e2e/archived-memory-opacity.spec.ts` (Chromium 1228, Playwright 1.61.1, headless).

1. **Spec against origin/main components (before the card fix)** — rc=1, 2 passed, 1 failed. This is the live bug:
   ```
   ✓ list row on the Memories page (2.1s)
   ✓ grid card in a space's raw memories (639ms)
   ✘ list card in a space's raw memories (10.7s)
     Expected: "0.55"   Received: "1"
     locator resolved to <div class="group relative h-full flex flex-col">
     unexpected value "0" → "0.250766" → "0.688211" → "0.955078" → "0.993898" → 19 × "1"
   ```
2. **After the `MemoryCard` fix** — rc=0, 3 passed (7.7s).
3. **Mutation control: fade re-broken** by deleting the `"--mem-enter-opacity"` line from both `MemoryListRow.tsx` (the #568 fix) and `MemoryCard.tsx`; `diff -u` against the saved copies shows exactly those two lines removed. rc=1, 1 passed, 2 failed:
   ```
   ✘ list row on the Memories page (14.7s)      Expected: "0.55"  Received: "1"
   ✓ grid card in a space's raw memories (1.0s)   (wrapper is animated, card is its child — passes by design)
   ✘ list card in a space's raw memories (11.0s)  Expected: "0.55"  Received: "1"
   ```
4. **Restored** (`diff -u` against the saved copies is empty) — rc=0, 3 passed (10.9s).
5. `E2E_PORT=14332 pnpm exec playwright test e2e/memory-list.spec.ts` — rc=0, 2 passed.
6. `pnpm exec tsc -b` — rc=0.
7. `pnpm exec vitest run src/components/memory/MemoryCard src/components/memory/MemoryStream.test.tsx` — rc=0, 3 files, 17 passed.
8. **After a review finding removed a dead line** — the spec used to carry `test.use({ reducedMotion: "no-preference" })`, but `reducedMotion` is not a key of `PlaywrightTestOptions` in Playwright 1.61.1 (it lives under `contextOptions`), so Playwright registered it as a value fixture nobody read and the pin did nothing; `tsc -b` cannot catch it because `tsconfig.json` includes only `src`. Reduced motion would not have defused the guard anyway: the only rule that opts out, `.mem-fade-up { animation: none }` in `src/index.css`, is keyed on a class none of the three tested elements carry — they get the animation inline from `MemoryStream.tsx` — and the `animation-name` assertions already fail if the animation stops. `pnpm exec playwright test e2e/archived-memory-opacity.spec.ts` — rc=0, 3 passed (7.9s).

CI: `app-check` runs `pnpm test:e2e` (`playwright test`, `testDir: ./e2e`, ignoring only `*.review.spec.ts`) whenever `src/**` or `e2e/**` changes, so this spec runs on every frontend PR.

## Left out on purpose

- No special case for the unarchived list cards described above: they rest at the stability/confidence formula's value because the fix lets the formula reach them, not because anything pins them there.
- `MemoryCard` still fades the *superseder* (`isSuperseded`) as well as the superseded row; #564 flagged that as its own decision and this PR does not touch it.
- No `data-testid` on the card root: the spec finds the card as the nearest ancestor of the title with an inline opacity, which `MemoryCard` always sets.
- The jsdom tests in `MemoryCard.archived.test.tsx` keep their literal `"0.55"` — they are the second opinion on the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7

