### PR TITLE
docs(readme): link workflow guides

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=a7f245c59fc508721b4e1de6c76c629fdef5956542440925d317f76bc84877b3 -->
+<!-- README_SYNC: source=README.md sha256=23240a69a98330b13102549c9b2d900a3485adf87f46c70b320c06baa529bde2 -->
 
 <p align="center">
   <picture>
@@ -321,6 +321,13 @@ Documentación más detallada, conceptos y comparaciones:
 - [Primeros pasos](https://wenlan.app/docs/get-started): instala y verifica el primer bucle local.
 - [Flujo diario](https://wenlan.app/docs/daily-workflow): brief, capture, recall, handoff, distill, lint y curate.
 - [Clientes MCP](https://wenlan.app/docs/mcp-clients): conecta Claude Code, Codex, Cursor, Claude Desktop y otros clientes.
+
+### Guías de flujo de trabajo
+
+- [Crear una base de conocimiento de proyectos para consultoría](https://wenlan.app/learn/build-client-project-knowledge-base-for-consulting)
+- [Crear una base de conocimiento para investigación de inversiones](https://wenlan.app/learn/build-investment-research-knowledge-base)
+- [Crear una base de conocimiento de investigación de producto antes de redactar un PRD](https://wenlan.app/learn/build-product-research-knowledge-base-for-prd)
+- [Crear una base de conocimiento de incidentes SRE](https://wenlan.app/learn/build-sre-incident-knowledge-base)
 
 ### Conceptos
 

--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ More detailed documentation, concepts, and comparisons:
 - [Daily workflow](https://wenlan.app/docs/daily-workflow): brief, capture, recall, handoff, distill, lint, and curate.
 - [MCP clients](https://wenlan.app/docs/mcp-clients): connect Claude Code, Codex, Cursor, Claude Desktop, and other clients.
 
+### Workflow guides
+
+- [Build a client project knowledge base for consulting](https://wenlan.app/learn/build-client-project-knowledge-base-for-consulting)
+- [Build an investment research knowledge base](https://wenlan.app/learn/build-investment-research-knowledge-base)
+- [Build a product research knowledge base before writing a PRD](https://wenlan.app/learn/build-product-research-knowledge-base-for-prd)
+- [Build an SRE incident knowledge base](https://wenlan.app/learn/build-sre-incident-knowledge-base)
+
 ### Concepts
 
 - [Why a living wiki, not just AI memory](https://wenlan.app/learn/ai-work-memory): the problem and product model in depth.

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=a7f245c59fc508721b4e1de6c76c629fdef5956542440925d317f76bc84877b3 -->
+<!-- README_SYNC: source=README.md sha256=23240a69a98330b13102549c9b2d900a3485adf87f46c70b320c06baa529bde2 -->
 
 <p align="center">
   <picture>
@@ -323,6 +323,13 @@ a1b2c3d distill: 4 pages
 - [开始使用](https://wenlan.app/docs/get-started)：安装并验证第一个本地循环。
 - [日常工作流程](https://wenlan.app/docs/daily-workflow)：brief、capture、recall、handoff、distill、lint 与 curate。
 - [MCP 客户端](https://wenlan.app/docs/mcp-clients)：连接 Claude Code、Codex、Cursor、Claude Desktop 与其他工具。
+
+### 工作流指南
+
+- [为咨询项目建立客户知识库](https://wenlan.app/zh-CN/learn/build-client-project-knowledge-base-for-consulting)
+- [建立有来源支撑的投资研究知识库](https://wenlan.app/zh-CN/learn/build-investment-research-knowledge-base)
+- [在撰写 PRD 前建立产品研究知识库](https://wenlan.app/zh-CN/learn/build-product-research-knowledge-base-for-prd)
+- [用运行手册与故障复盘建立 SRE 故障知识库](https://wenlan.app/zh-CN/learn/build-sre-incident-knowledge-base)
 
 ### 概念
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=a7f245c59fc508721b4e1de6c76c629fdef5956542440925d317f76bc84877b3 -->
+<!-- README_SYNC: source=README.md sha256=23240a69a98330b13102549c9b2d900a3485adf87f46c70b320c06baa529bde2 -->
 
 <p align="center">
   <picture>
@@ -323,6 +323,13 @@ a1b2c3d distill: 4 pages
 - [開始使用](https://wenlan.app/docs/get-started)：安裝並驗證第一個本地循環。
 - [日常工作流程](https://wenlan.app/docs/daily-workflow)：brief、capture、recall、handoff、distill、lint 與 curate。
 - [MCP 用戶端](https://wenlan.app/docs/mcp-clients)：連接 Claude Code、Codex、Cursor、Claude Desktop 與其他工具。
+
+### 工作流程指南
+
+- [為顧問專案建立客戶知識庫](https://wenlan.app/zh-TW/learn/build-client-project-knowledge-base-for-consulting)
+- [建立有來源支撐的投資研究知識庫](https://wenlan.app/zh-TW/learn/build-investment-research-knowledge-base)
+- [在撰寫 PRD 前建立產品研究知識庫](https://wenlan.app/zh-TW/learn/build-product-research-knowledge-base-for-prd)
+- [用 runbook 與事故復盤建立 SRE 事故知識庫](https://wenlan.app/zh-TW/learn/build-sre-incident-knowledge-base)
 
 ### 概念
 


### PR DESCRIPTION
## Summary
- add compact workflow-guide acquisition links to the English, Traditional Chinese, and Simplified Chinese READMEs
- keep the Spanish README structurally synchronized with the existing translation contract
- link only to already-live Wenlan pages for consulting, investment research, product research to PRD, and SRE incident workflows

## Verification
- python3 scripts/check-readme-translations.py
- bash scripts/check-readme-translations.test.sh
- git diff --check
- all 12 English, zh-TW, and zh-CN wenlan.app routes return HTTP 200