### PR TITLE
fix(mcp): recall no longer filters results to the calling agent

### DIFF
--- a/crates/wenlan-mcp/src/tools.rs
+++ b/crates/wenlan-mcp/src/tools.rs
@@ -62,6 +62,34 @@ pub fn effective_space(inbound: &Option<String>) -> Option<String> {
     }
 }
 
+/// Build the daemon search request for `recall`.
+///
+/// `SearchMemoryRequest::source_agent` is a filter on the daemon side
+/// (`c.source_agent = ?` in `search_memory`), not caller attribution.
+/// Recall used to send the caller's own agent name here, which scoped every
+/// MCP recall to rows that same agent had written: a Codex session never saw
+/// what Claude Code captured, and nobody saw folder-ingested or refinery rows.
+/// Attribution for activity logging already travels in the `x-agent-name`
+/// header (`WenlanClient::with_agent_name`), so the body field stays `None`.
+fn recall_search_request(params: RecallParams) -> SearchMemoryRequest {
+    SearchMemoryRequest {
+        query: params.query,
+        // Clamp: an unbounded caller-supplied limit either trips the MCP
+        // client's 8MB response cap (client.rs MAX_RESPONSE_BYTES) as an
+        // opaque transport error, or floods the agent's context window.
+        limit: params.limit.unwrap_or(10).clamp(1, 100),
+        memory_type: params.memory_type,
+        space: effective_space(&params.space),
+        source_agent: None,
+        // Opt-in cross-encoder rerank. Default `false` preserves the
+        // current cost/latency for callers that don't pass the flag.
+        // Requires WENLAN_RERANKER_ENABLED=1 on the daemon to take
+        // effect; otherwise the daemon logs and falls back to plain
+        // hybrid ordering.
+        rerank: params.rerank.unwrap_or(false),
+    }
+}
+
 /// Controls which operations are allowed based on transport.
 #[derive(Clone, Debug, PartialEq)]
 pub enum TransportMode {
@@ -1203,23 +1231,7 @@ impl WenlanMcpServer {
     }
 
     pub async fn recall_impl(&self, params: RecallParams) -> Result<CallToolResult, McpError> {
-        let space_arg = effective_space(&params.space);
-        let req = SearchMemoryRequest {
-            query: params.query,
-            // Clamp: an unbounded caller-supplied limit either trips the MCP
-            // client's 8MB response cap (client.rs MAX_RESPONSE_BYTES) as an
-            // opaque transport error, or floods the agent's context window.
-            limit: params.limit.unwrap_or(10).clamp(1, 100),
-            memory_type: params.memory_type,
-            space: space_arg,
-            source_agent: self.resolve_source_agent(None),
-            // Opt-in cross-encoder rerank. Default `false` preserves the
-            // current cost/latency for callers that don't pass the flag.
-            // Requires WENLAN_RERANKER_ENABLED=1 on the daemon to take
-            // effect; otherwise the daemon logs and falls back to plain
-            // hybrid ordering.
-            rerank: params.rerank.unwrap_or(false),
-        };
+        let req = recall_search_request(params);
 
         let resp: SearchMemoryResponse =
             try_call!(self.client.post("/api/memory/search", &req), "search");
@@ -4989,6 +5001,32 @@ mod tests {
     }
 
     // ===== Recall request construction =====
+
+    #[test]
+    fn test_recall_request_never_filters_by_caller_agent() {
+        // Regression: the daemon treats `source_agent` on a search request as
+        // a filter (`c.source_agent = ?`). Recall used to send the caller's own
+        // agent name, so a Codex session only saw rows Codex had written and
+        // never what Claude Code captured (found filming the launch demo,
+        // 2026-08-30). Attribution goes in the `x-agent-name` header instead.
+        let req = recall_search_request(RecallParams {
+            query: "which database did we pick".into(),
+            limit: Some(5),
+            memory_type: None,
+            space: None,
+            rerank: Some(true),
+        });
+        assert!(
+            req.source_agent.is_none(),
+            "recall must not scope results to the calling agent; got {:?}",
+            req.source_agent
+        );
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json["source_agent"].is_null());
+        assert_eq!(json["query"], "which database did we pick");
+        assert_eq!(json["limit"], 5);
+        assert_eq!(json["rerank"], true);
+    }
 
     #[test]
     fn test_recall_constructs_search_request() {

--- a/crates/wenlan-mcp/tests/type_contract.rs
+++ b/crates/wenlan-mcp/tests/type_contract.rs
@@ -467,10 +467,14 @@ async fn t4_recall_roundtrip() {
     assert_eq!(body["limit"], serde_json::json!(10));
     assert!(body["memory_type"].is_null());
     assert!(body["space"].is_null());
-    assert_eq!(
-        body["source_agent"],
-        serde_json::json!("test-agent"),
-        "recall should send resolved agent name, not null"
+    // `source_agent` on the search request is a FILTER (`c.source_agent = ?`),
+    // not attribution: sending the caller's own name here hid every memory
+    // written by other agents. Attribution travels in the `x-agent-name`
+    // header, which `origin_client_sends_x_agent_name_header` covers.
+    assert!(
+        body["source_agent"].is_null(),
+        "recall must not filter results to the calling agent; got: {}",
+        body["source_agent"]
     );
 }
 

--- a/crates/wenlan-types/src/requests.rs
+++ b/crates/wenlan-types/src/requests.rs
@@ -47,6 +47,9 @@ pub struct SearchMemoryRequest {
     pub memory_type: Option<String>,
     #[serde(default, alias = "domain")]
     pub space: Option<String>,
+    /// Filter: return only memories written by this agent. This is not
+    /// caller attribution (that travels in the `x-agent-name` header); a
+    /// client that puts its own name here sees nothing but its own rows.
     #[serde(default)]
     pub source_agent: Option<String>,
     /// When `true` AND the daemon has a reranker wired (via


### PR DESCRIPTION
## What this PR does
The daemon treats `source_agent` on `POST /api/memory/search` as a filter (`c.source_agent = ?` in `search_memory`), but the MCP `recall` tool sent the caller's own agent name in that field. Every MCP client therefore only saw rows it had written itself: a Codex session got 0 results for memories Claude Code captured, and no client saw folder-ingested or refinery rows. Attribution already travels in the `x-agent-name` header, so the body field is now `None`.

The request builder is extracted into `recall_search_request` so a regression test can assert the real construction, and `SearchMemoryRequest.source_agent` now documents that it is a filter, not attribution.

Found while filming the launch demo: `$wenlan:recall which database did we pick` from Codex returned `0 results` against a demo store holding 34 Tally rows (26 written by claude-code, 6 by the folder source, 2 by the refinery).

## How to test
- `cargo test -p wenlan-mcp --lib recall` (new: `test_recall_request_never_filters_by_caller_agent`)
- Live: build `wenlan-mcp`, run it with `--agent-name codex` against a daemon whose rows were written by another agent, call `recall`. Before: `0 results`. After: results come back (5/5 on the demo store, plain and `rerank: true`).
- `curl -X POST :PORT/api/memory/search -d '{"query":"...","source_agent":"codex"}'` still returns only codex rows, so the daemon filter is unchanged for callers that want it.

## Checklist
- [x] Tests pass (`cargo test -p wenlan-mcp --lib recall`; full workspace left to CI)
- [x] `cargo clippy` and `cargo fmt` pass (pre-commit ran both on the changed crates)
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY