### PR TITLE
fix(plugin-codex): skills locate resolve-space.sh in the installed plugin

### DIFF
--- a/plugin-codex/skills/brief/SKILL.md
+++ b/plugin-codex/skills/brief/SKILL.md
@@ -21,7 +21,10 @@ never be read as product state.
 raw_args="<the full argument string passed to /brief>"
 space_arg="$(printf '%s\n' "$raw_args" | grep -oE 'space:[A-Za-z0-9_-]+' | head -1 | cut -d: -f2)"
 topic_arg="$(printf '%s\n' "$raw_args" | sed -E 's/[[:space:]]*space:[A-Za-z0-9_-]+[[:space:]]*/ /g' | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
-resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
+# The resolver ships inside the installed plugin; the relative path only
+# exists in a wenlan checkout.
+resolver="$(find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh' 2>/dev/null | head -1)"
+resolved="$("${resolver:-plugin-codex/bin/resolve-space.sh}" --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 ```

--- a/plugin-codex/skills/capture/SKILL.md
+++ b/plugin-codex/skills/capture/SKILL.md
@@ -32,7 +32,10 @@ If `content` is empty, ask the user what they want to capture.
 Call the Codex resolver:
 
 ```bash
-resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
+# The resolver ships inside the installed plugin; the relative path only
+# exists in a wenlan checkout.
+resolver="$(find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh' 2>/dev/null | head -1)"
+resolved="$("${resolver:-plugin-codex/bin/resolve-space.sh}" --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 ```

--- a/plugin-codex/skills/distill/SKILL.md
+++ b/plugin-codex/skills/distill/SKILL.md
@@ -26,7 +26,10 @@ target="$(printf '%s\n' "$raw_args" | sed -E 's/[[:space:]]*space:[A-Za-z0-9_-]+
 Resolve space:
 
 ```bash
-resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
+# The resolver ships inside the installed plugin; the relative path only
+# exists in a wenlan checkout.
+resolver="$(find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh' 2>/dev/null | head -1)"
+resolved="$("${resolver:-plugin-codex/bin/resolve-space.sh}" --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 ```

--- a/plugin-codex/skills/handoff/SKILL.md
+++ b/plugin-codex/skills/handoff/SKILL.md
@@ -24,7 +24,10 @@ Never read, edit, or overwrite that receipt as authority.
 
 ```bash
 handoff_arg="<the Space name passed to /handoff, empty when none>"
-resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" --arg "$handoff_arg" --new-repo-fallback 2>/dev/null)"
+# The resolver ships inside the installed plugin; the relative path only
+# exists in a wenlan checkout.
+resolver="$(find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh' 2>/dev/null | head -1)"
+resolved="$("${resolver:-plugin-codex/bin/resolve-space.sh}" --cwd "$PWD" --arg "$handoff_arg" --new-repo-fallback 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 ```

--- a/plugin-codex/skills/lint/SKILL.md
+++ b/plugin-codex/skills/lint/SKILL.md
@@ -17,8 +17,11 @@ not exist.
 
 For `global`, omit `space`. For `uncategorized`, pass
 `space="uncategorized"`. For `space:<name>`, pass that name. With no explicit
-scope, call `plugin-codex/bin/resolve-space.sh --cwd "$PWD"`; use a non-empty
-result, otherwise omit `space`. Bash is allowed only for that exact resolver.
+scope, call the installed resolver with `--cwd "$PWD"`: locate it with
+`find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh'`
+and fall back to `plugin-codex/bin/resolve-space.sh` only inside a wenlan
+checkout. Use a non-empty result, otherwise omit `space`. Bash is allowed only
+for that exact resolver.
 CLI fallback: `wenlan lint --profile deep --agent-assist` (submissions via
 `--agent-submission <file>`); the MCP repair-manifest tools have no CLI
 equivalent yet.

--- a/plugin-codex/skills/recall/SKILL.md
+++ b/plugin-codex/skills/recall/SKILL.md
@@ -31,7 +31,10 @@ If `query` is empty, ask the user what they want to search for.
 Call the Codex resolver:
 
 ```bash
-resolved="$(plugin-codex/bin/resolve-space.sh --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
+# The resolver ships inside the installed plugin; the relative path only
+# exists in a wenlan checkout.
+resolver="$(find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh' 2>/dev/null | head -1)"
+resolved="$("${resolver:-plugin-codex/bin/resolve-space.sh}" --cwd "$PWD" ${space_arg:+--arg "$space_arg"} 2>/dev/null)"
 space="$(printf '%s\n' "$resolved" | cut -f1)"
 source_layer="$(printf '%s\n' "$resolved" | cut -f2)"
 ```

--- a/scripts/validate-codex-plugin-slice.py
+++ b/scripts/validate-codex-plugin-slice.py
@@ -62,6 +62,11 @@ REQUIRED_SKILL_INTERFACE = {
 }
 SKILLS_WITHOUT_MCP_REFERENCE = {"handoff", "help", "pages"}
 SKILLS_USING_RESOLVER = {"brief", "capture", "distill", "handoff", "lint", "recall"}
+# Installed plugins live under ~/.codex/plugins/cache/<marketplace>/wenlan/<version>/;
+# the checkout-relative `plugin-codex/bin/...` path only resolves inside this repo.
+RESOLVER_LOCATOR = (
+    "find \"$HOME/.codex/plugins/cache\" -path '*/wenlan/*/bin/resolve-space.sh'"
+)
 REQUIRED_GUARDRAILS = {
     "forget": [
         "cannot be undone",
@@ -244,8 +249,14 @@ def validate_skills() -> None:
             fail(f"{path.relative_to(ROOT)} must be marked user-invocable for slash autocomplete")
         if skill not in SKILLS_WITHOUT_MCP_REFERENCE and "mcp__wenlan__" not in text:
             fail(f"{path.relative_to(ROOT)} must use Codex wenlan MCP tool names")
-        if skill in SKILLS_USING_RESOLVER and "plugin-codex/bin/resolve-space.sh" not in text:
-            fail(f"{path.relative_to(ROOT)} must use plugin-codex/bin/resolve-space.sh")
+        if skill in SKILLS_USING_RESOLVER:
+            if "plugin-codex/bin/resolve-space.sh" not in text:
+                fail(f"{path.relative_to(ROOT)} must use plugin-codex/bin/resolve-space.sh")
+            if RESOLVER_LOCATOR not in text:
+                fail(
+                    f"{path.relative_to(ROOT)} must locate the installed resolver with "
+                    f"{RESOLVER_LOCATOR}"
+                )
         for needle in REQUIRED_GUARDRAILS.get(skill, []):
             if " ".join(needle.split()) not in normalized_text:
                 fail(f"{path.relative_to(ROOT)} must contain guardrail {needle!r}")

--- a/scripts/validate-plugin-contract.py
+++ b/scripts/validate-plugin-contract.py
@@ -27,6 +27,11 @@ CODEX_SKILLS_USING_RESOLVER = {
     "lint",
     "recall",
 }
+# Installed plugins live under ~/.codex/plugins/cache/<marketplace>/wenlan/<version>/;
+# the checkout-relative `plugin-codex/bin/...` path only resolves inside this repo.
+CODEX_RESOLVER_LOCATOR = (
+    "find \"$HOME/.codex/plugins/cache\" -path '*/wenlan/*/bin/resolve-space.sh'"
+)
 CODEX_REQUIRED_GUARDRAILS = {
     "forget": [
         "cannot be undone",
@@ -695,8 +700,14 @@ def validate_skill_surface(
             )
             if name not in CODEX_SKILLS_WITHOUT_MCP_REFERENCE and expected_prefix not in text:
                 fail(f"{rel(root, skill_path)} must use MCP prefix {expected_prefix!r}")
-            if name in CODEX_SKILLS_USING_RESOLVER and "plugin-codex/bin/resolve-space.sh" not in text:
-                fail(f"{rel(root, skill_path)} must use plugin-codex/bin/resolve-space.sh")
+            if name in CODEX_SKILLS_USING_RESOLVER:
+                if "plugin-codex/bin/resolve-space.sh" not in text:
+                    fail(f"{rel(root, skill_path)} must use plugin-codex/bin/resolve-space.sh")
+                if CODEX_RESOLVER_LOCATOR not in text:
+                    fail(
+                        f"{rel(root, skill_path)} must locate the installed resolver with "
+                        f"{CODEX_RESOLVER_LOCATOR}"
+                    )
             for needle in CODEX_REQUIRED_GUARDRAILS.get(name, []):
                 if needle not in text:
                     fail(f"{rel(root, skill_path)} must contain guardrail {needle!r}")

--- a/scripts/validate-plugin-contract.test.sh
+++ b/scripts/validate-plugin-contract.test.sh
@@ -177,6 +177,10 @@ assert_rejects "codex resolver parity drift" \
     perl -0pi -e 's/locked-env/codex-locked-env/' \
         "$TMPDIR_TEST/root/plugin-codex/bin/resolve-space.sh"
 
+assert_rejects "codex resolver checkout-only path regression" \
+    perl -0pi -e 's|find "\$HOME/.codex/plugins/cache"|find "\$HOME/.codex/plugins/stale"|' \
+    "$TMPDIR_TEST/root/plugin-codex/skills/recall/SKILL.md"
+
 assert_rejects "codex MCP plugin-relative cwd drift" \
     perl -0pi -e 's/"cwd": "\."/"cwd": ".."/' \
     "$TMPDIR_TEST/root/plugin-codex/.mcp.json"


### PR DESCRIPTION
## What this PR does
The six Codex skills that resolve the active Space (`brief`, `capture`, `distill`, `handoff`, `lint`, `recall`) called `plugin-codex/bin/resolve-space.sh` relative to the working directory. That path only exists inside a wenlan checkout; an installed plugin lives under `~/.codex/plugins/cache/<marketplace>/wenlan/<version>/`, so from any other project the call failed silently and every skill fell back to an unscoped call.

Seen on camera while filming the launch demo: `/recall` from `~/Tally` ran `./plugin-codex/bin/resolve-space.sh ... || ~/.codex/plugins/cache/.../plugin-codex/bin/resolve-space.sh` (Codex guessed a second wrong path), got no output, and printed `Resolved space: none (unscoped)` even though `WENLAN_DEFAULT_SPACE` would have resolved it.

Each skill now finds the installed resolver with `find "$HOME/.codex/plugins/cache" -path '*/wenlan/*/bin/resolve-space.sh'` and keeps the checkout-relative path as the fallback (`"${resolver:-plugin-codex/bin/resolve-space.sh}"`). Both plugin validators require the locator string, and the contract test gains a case that rejects a skill without it.

## How to test
- `python3 scripts/validate-codex-plugin-slice.py`
- `python3 scripts/validate-plugin-contract.py`
- `bash scripts/validate-plugin-contract.test.sh` (102 PASS lines locally; new case `codex resolver checkout-only path regression`)
- Live: with the plugin installed, from a directory that is not a wenlan checkout, `WENLAN_DEFAULT_SPACE=Tally` and `/recall <query>` should print `Resolved space: Tally (from default-env)` instead of `none (unscoped)`.

## Checklist
- [x] Tests pass (validators above; no Rust changes)
- [x] `cargo clippy` and `cargo fmt` pass (no Rust changes)
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY