### PR TITLE
fix(core): a rebuilt page gets a rebuilt summary, and old first-bullet summaries are reconciled at start

### DIFF
--- a/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
+++ b/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
@@ -968,6 +968,7 @@ carrying the authority of agreement.
 | `core/db/maintenance_duplicate_reads.rs::scan_near_duplicate_slice` | `pub(crate)` | no | no | — | — |
 | `core/db/maintenance_retro_scan.rs::scan_automatic_retro_stub_slice` | `pub(crate)` | no | no | — | — |
 | `core/db/page_drafts.rs::publish_page_draft` | `pub` | no | **yes** | `server/page_routes.rs::handle_publish_page_draft` | — |
+| `core/db/page_summary_backfill.rs::backfill_page_summaries` | `pub` | no | **yes** | `server/main/startup.rs::prepare_startup_state` | — |
 | `core/db/presence_review.rs::page_binding` | `private` | no | no | — | — |
 | `core/db/repair_deterministic.rs::apply_deterministic_repair_cas` | `pub` | no | no | — | — |
 | `core/db/repair_page_rename.rs::page_on_connection` | `private` | no | no | — | — |
@@ -1096,6 +1097,7 @@ carrying the authority of agreement.
 | `server/entity_graph_routes.rs::handle_list_entities` | `pub` | no | no | — | `core/db/scoped_entities.rs::list_entities_scoped` |
 | `server/entity_graph_routes.rs::handle_merge_entity` | `pub` | no | no | — | `core/db.rs::merge_entities_in_scope` |
 | `server/entity_graph_routes.rs::handle_search_entities` | `pub` | no | no | — | `core/db/scoped_entities.rs::search_entities_by_vector_scoped` |
+| `server/main/startup.rs::prepare_startup_state` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db/page_summary_backfill.rs::backfill_page_summaries` |
 | `server/memory_revision_routes.rs::handle_list_pending_revisions` | `pub` | no | no | — | `core/db.rs::list_pending_revisions_scoped` |
 | `server/memory_routes.rs::handle_store_memory` | `pub` | no | no | — | `core/db.rs::resolve_entity_by_name` |
 | `server/page_map_routes.rs::compute_ref_state` | `private` | no | no | `server/page_map_routes.rs::wire_node` | `core/db.rs::get_entity_name_type` |
@@ -1228,8 +1230,8 @@ carrying the authority of agreement.
 | `server/cmd_prune_junk_entities.rs::restore` | `pub` | yes | no | — | `core/db.rs::restore_entity` |
 | `server/cmd_prune_junk_entities.rs::run` | `pub` | yes | no | — | `core/db.rs::archive_entity` |
 | `server/entity_graph_routes.rs::handle_add_entity_alias` | `pub` | no | no | — | `core/db.rs::add_entity_alias_in_scope` |
+| `server/main.rs::run_daemon` | `private` | no | no | `server/main.rs::main` | `server/main/startup.rs::prepare_startup_state` |
 | `server/main/runtime.rs::register_optional_runtime_workers` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db/claim_derivation.rs::reconcile_supported_pages` |
-| `server/main/startup.rs::prepare_startup_state` | `pub(super)` | no | no | `server/main.rs::run_daemon` | `core/db.rs::list_pages` |
 | `server/memory_routes.rs::handle_search_memory` | `pub` | no | no | — | `core/db.rs::search_memory` |
 | `server/page_map_routes.rs::ensure_page_is_active` | `private` | no | no | `server/page_map_routes.rs::handle_create_map_edge`, `server/page_map_routes.rs::handle_create_map_node`, `server/page_map_routes.rs::handle_delete_map_edge`, `server/page_map_routes.rs::handle_delete_map_node`, `server/page_map_routes.rs::handle_improve_page_map`, `server/page_map_routes.rs::handle_patch_map_edge`, `server/page_map_routes.rs::handle_patch_map_node`, `server/page_map_routes.rs::handle_put_page_map_layout`, `server/page_map_routes.rs::handle_reset_page_map` | `core/db.rs::get_page` |
 | `server/page_map_routes.rs::visible_page` | `private` | no | no | `server/page_map_routes.rs::compute_ref_state`, `server/page_map_routes.rs::ensure_page_exists` | `core/db.rs::get_page` |
@@ -1312,7 +1314,7 @@ carrying the authority of agreement.
 | `core/truth_adapter.rs::filter_pages` | `pub` | no | **yes** | `server/page_routes.rs::handle_list_pages`, `server/page_routes.rs::handle_search_pages`, `server/routes.rs::handle_distill` | `core/truth_adapter.rs::verdicts` |
 | `core/truth_adapter.rs::page_write_permit` | `pub` | no | **yes** | `server/page_routes.rs::handle_export_page`, `server/page_routes.rs::handle_export_pages` | `core/db/truth_exposure.rs::page_visibility` |
 | `server/cmd_cutover.rs::run` | `pub` | yes | no | — | `core/export/knowledge.rs::plan_truth_cutover` |
-| `server/main.rs::run_daemon` | `private` | no | no | `server/main.rs::main` | `server/main/runtime.rs::register_optional_runtime_workers`, `server/main/startup.rs::prepare_startup_state` |
+| `server/main.rs::main` | `private` | yes | no | — | `server/main.rs::run_daemon` |
 | `server/page_map_routes.rs::build_map_response` | `private` | no | no | `server/page_map_routes.rs::handle_get_page_map`, `server/page_map_routes.rs::handle_improve_page_map`, `server/page_map_routes.rs::handle_put_page_map_layout` | `server/page_map_routes.rs::wire_node` |
 | `server/page_map_routes.rs::ensure_page_exists` | `private` | no | no | `server/page_map_routes.rs::handle_get_page_map` | `server/page_map_routes.rs::visible_page` |
 | `server/page_map_routes.rs::handle_create_map_edge` | `pub` | no | no | — | `server/page_map_routes.rs::ensure_page_is_active` |

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -58,6 +58,7 @@ mod migrations_v004_v009;
 mod onboarding_milestones;
 mod page_drafts;
 pub mod page_map;
+mod page_summary_backfill;
 mod presence_review;
 pub(crate) mod repair_deterministic;
 mod repair_memory_cas;

--- a/crates/wenlan-core/src/db/page_summary_backfill.rs
+++ b/crates/wenlan-core/src/db/page_summary_backfill.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//! One-time repair for page summaries written by the old "first bullet
+//! anywhere" rule (fixed in #642 to "first prose sentence"). Pages distilled
+//! before that fix keep their bullet, which on a page with an Open Questions
+//! list is a question standing in for the page's claim. Nothing rewrites an
+//! existing page's summary without an LLM pass, so the daemon reconciles
+//! them once at start.
+
+use super::MemoryDB;
+use crate::error::WenlanError;
+use crate::synthesis::distill::extract_page_summary;
+
+impl MemoryDB {
+    /// Set every distilled, machine-owned page's summary to the first prose
+    /// sentence of its body when the stored summary differs. Pages a human
+    /// edited (`user_edited = 1`) and pages of other kinds (authored, entity,
+    /// source documents) are left alone: their summaries are not derived
+    /// from the body by this rule. Idempotent; returns the number of pages
+    /// changed. `last_modified` is untouched so the pass does not surface as
+    /// recent activity.
+    pub async fn backfill_page_summaries(&self) -> Result<usize, WenlanError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT id, summary, content FROM pages
+                  WHERE COALESCE(creation_kind, 'distilled') = 'distilled'
+                    AND COALESCE(user_edited, 0) = 0",
+                (),
+            )
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("summary backfill select: {error}")))?;
+        let mut updates: Vec<(String, Option<String>)> = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| WenlanError::VectorDb(format!("summary backfill row: {error}")))?
+        {
+            let id: String = row
+                .get(0)
+                .map_err(|error| WenlanError::VectorDb(format!("summary backfill id: {error}")))?;
+            let stored: Option<String> = row.get(1).map_err(|error| {
+                WenlanError::VectorDb(format!("summary backfill summary: {error}"))
+            })?;
+            let content: String = row.get(2).map_err(|error| {
+                WenlanError::VectorDb(format!("summary backfill content: {error}"))
+            })?;
+            let derived = extract_page_summary(&content);
+            if derived != stored {
+                updates.push((id, derived));
+            }
+        }
+        drop(rows);
+        for (id, summary) in &updates {
+            conn.execute(
+                "UPDATE pages SET summary = ?1 WHERE id = ?2",
+                libsql::params![summary.clone(), id.clone()],
+            )
+            .await
+            .map_err(|error| {
+                WenlanError::VectorDb(format!("summary backfill update {id}: {error}"))
+            })?;
+        }
+        Ok(updates.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::tests::test_db;
+
+    const BODY: &str = "Tally stores all data in one SQLite file next to the app [2][6]. \
+The app process is the only writer [3].\n\n## Open Questions\n\
+- Is there evidence that iCloud backups have ever failed?\n";
+
+    #[tokio::test]
+    async fn rewrites_a_first_bullet_summary_to_the_first_sentence() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        db.insert_page(
+            "page_old_rule",
+            "Tally",
+            Some("Is there evidence that iCloud backups have ever failed?"),
+            BODY,
+            None,
+            None,
+            &[],
+            &now,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(db.backfill_page_summaries().await.unwrap(), 1);
+        let page = db.get_page("page_old_rule").await.unwrap().unwrap();
+        assert_eq!(
+            page.summary.as_deref(),
+            Some("Tally stores all data in one SQLite file next to the app.")
+        );
+
+        // Idempotent: a second pass finds nothing to change.
+        assert_eq!(db.backfill_page_summaries().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn leaves_human_edited_and_non_distilled_pages_alone() {
+        let (db, _dir) = test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        for id in ["page_human", "page_authored"] {
+            db.insert_page(
+                id,
+                "Tally",
+                Some("A summary someone chose."),
+                BODY,
+                None,
+                None,
+                &[],
+                &now,
+            )
+            .await
+            .unwrap();
+        }
+        {
+            let conn = db.test_primary_session().await;
+            conn.execute(
+                "UPDATE pages SET user_edited = 1 WHERE id = 'page_human'",
+                (),
+            )
+            .await
+            .unwrap();
+            conn.execute(
+                "UPDATE pages SET creation_kind = 'authored' WHERE id = 'page_authored'",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+
+        assert_eq!(db.backfill_page_summaries().await.unwrap(), 0);
+        for id in ["page_human", "page_authored"] {
+            let page = db.get_page(id).await.unwrap().unwrap();
+            assert_eq!(page.summary.as_deref(), Some("A summary someone chose."));
+        }
+    }
+}

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -942,6 +942,8 @@ crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::re
 crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::refresh_page_re_projects_md_when_path_passed|test_primary_session|1
 crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::refresh_page_rebuilds_machine_page_and_bumps_changelog|TestDbSession::execute|1
 crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::refresh_page_rebuilds_machine_page_and_bumps_changelog|test_primary_session|1
+crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::refresh_page_rebuilds_the_summary_from_the_new_body|TestDbSession::execute|1
+crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::refresh_page_rebuilds_the_summary_from_the_new_body|test_primary_session|1
 crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::resolve_distill_target_ignores_unregistered_memory_space|TestDbSession::execute|1
 crates/wenlan-core/src/synthesis/distill.rs|crate::synthesis::distill::tests::resolve_distill_target_ignores_unregistered_memory_space|test_primary_session|1
 crates/wenlan-core/src/synthesis/distill_truth_test.rs|crate::synthesis::distill::distill_truth_test::refresh_page_skips_re_distill_for_a_page_the_automatic_reader_may_not_see|TestDbSession::execute|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,7 +3229,7 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        1039,
+        1041,
         "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
          the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, \
          the 7 G6 BindPageLink repair-test calls (G6 Stage 2 PR 2b, item 3: \
@@ -3344,7 +3344,11 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
          (round 5, F1 revision-card source_revision fencing) contributes \
          TestDbSession::query|1, TestDbRows::next|1, TestDbRow::get|1, and \
          test_primary_session|1 reading the page back after a fenced update to assert \
-         source_revision landed"
+         source_revision landed; plus the fix/page-summary-follows-content +2: \
+         synthesis/distill.rs's new refresh_page_rebuilds_the_summary_from_the_new_body \
+         contributes test_primary_session|1 and TestDbSession::execute|1 (the raw UPDATE that \
+         plants an old first-bullet summary on the page before the refresh re-derives it from \
+         the new body)"
     );
 }
 

--- a/crates/wenlan-core/src/synthesis/distill.rs
+++ b/crates/wenlan-core/src/synthesis/distill.rs
@@ -1436,6 +1436,7 @@ pub(crate) async fn refresh_page_with_prompt(
     // NOT NULL`, so a concurrent agent PUT that cleared staleness wins the race
     // without TOCTOU.
     let citations_json = serde_json::to_string(&cites).unwrap_or_else(|_| "[]".to_string());
+    let summary = extract_page_summary(&content);
     let result = crate::post_write::update_page_at_source_revision(
         db,
         page_id,
@@ -1453,6 +1454,13 @@ pub(crate) async fn refresh_page_with_prompt(
         Some((citations_json, stats.summary())),
     )
     .await?;
+
+    // The one-line summary is derived from the body, so a rebuilt body gets
+    // a rebuilt summary; otherwise the pull quote outlives the prose it
+    // summarised. A gated or unchanged outcome leaves the stored page alone.
+    if result.wrote {
+        db.update_page_summary(page_id, summary.as_deref()).await?;
+    }
 
     Ok(RefreshOutcome {
         wrote: result.wrote,
@@ -2176,6 +2184,60 @@ The app process is the only writer [3].\n\n## Backup\n\nNightly copy to iCloud D
         assert!(
             latest.get("citations_summary").is_some(),
             "citations committed atomically with the content bump"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_page_rebuilds_the_summary_from_the_new_body() {
+        let (db, _db_dir) = crate::db::tests::test_db().await;
+        let now = chrono::Utc::now().to_rfc3339();
+        let now_ts = chrono::Utc::now().timestamp();
+        {
+            let conn = db.test_primary_session().await;
+            conn.execute(
+                "INSERT INTO memories (id, source_id, title, content, chunk_index, chunk_type, memory_type, space, source_agent, created_at, last_modified, confirmed, stability, source) \
+                 VALUES (?1, ?1, ?1, 'Tokio is an async runtime for Rust programs', 0, 'text', 'fact', 'test', 'claude-code', ?2, ?2, 1, 'confirmed', 'memory')",
+                libsql::params!["mem_seed".to_string(), now_ts],
+            )
+            .await
+            .unwrap();
+        }
+        // The stored summary is the pre-#642 symptom: an open question that
+        // used to be the page's first bullet.
+        db.insert_page(
+            "page_m",
+            "Tokio",
+            Some("Does Tokio scale past one core?"),
+            "original body\n\n## Open Questions\n- Does Tokio scale past one core?",
+            None,
+            None,
+            &["mem_seed"],
+            &now,
+        )
+        .await
+        .unwrap();
+        db.set_page_stale("page_m", "source_updated").await.unwrap();
+
+        let llm: Arc<dyn LlmProvider> = Arc::new(MockProvider::new(
+            "Tokio is an async runtime for Rust programs [1]",
+        ));
+        let outcome = refresh_page(
+            &db,
+            &llm,
+            &PromptRegistry::default(),
+            "page_m",
+            RefreshReason::SourceChanged,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(outcome.wrote);
+
+        let page = db.get_page("page_m").await.unwrap().unwrap();
+        assert_eq!(
+            page.summary.as_deref(),
+            Some("Tokio is an async runtime for Rust programs"),
+            "a rebuilt body gets a rebuilt summary"
         );
     }
 

--- a/crates/wenlan-server/src/main/startup.rs
+++ b/crates/wenlan-server/src/main/startup.rs
@@ -132,6 +132,16 @@ pub(super) async fn prepare_startup_state(
             m55.event_dates_scanned,
             m55.entity_links_inserted
         );
+        // Pages distilled before the first-sentence summary rule still carry
+        // their first bullet, often an open question. Reconcile once; the
+        // pass is idempotent and skips human-edited pages.
+        match db_arc.backfill_page_summaries().await {
+            Ok(0) => {}
+            Ok(changed) => tracing::info!(
+                "[pages] rewrote {changed} page summaries to the first prose sentence"
+            ),
+            Err(error) => tracing::warn!("[pages] summary backfill failed: {error}"),
+        }
     }
 
     // Requeue any document-enrichment rows left `in_progress` by a previous run


### PR DESCRIPTION
## What this PR does
#642 changed how a freshly distilled page gets its one-line summary (first prose sentence instead of first bullet), but nothing touched pages that already existed, and `refresh_page` rewrote the body while leaving the summary as it was. So a page distilled before #642 kept its first bullet, on any page with an Open Questions list an open question, as the pull quote through every rebuild. Seen on the launch-demo store: the hero page "Tally: Simple SQLite Invoicing" was rebuilt from 7 to 16 memories and still opens with "Is there evidence that iCloud Drive backups have ever failed under network conditions?" as its summary; the same question also stood as the summary of two other distilled pages.

Two changes, same rule (the summary is derived from the body):
- `refresh_page_with_prompt` derives the summary from the new body after a `Wrote` outcome, through `extract_page_summary` (the #642 helper). Gated, refused or unchanged outcomes leave the stored page alone, same as the content.
- `MemoryDB::backfill_page_summaries` runs once at daemon start (next to the migration-55 pass) and sets the summary of every distilled, machine-owned page (`creation_kind = 'distilled'`, `user_edited = 0`) whose stored summary is not the first prose sentence. Authored, entity and source pages, and pages a human edited, are never touched; `last_modified` is left alone so the pass does not show up as recent activity. Idempotent.

An agent-supplied summary on a distilled page (the `summary` field of the refresh route) is re-derived by the start-up pass once, and by the next ambient rewrite of that page anyway; that is the same ownership the refresh rule already implies.

Second commit: the drift guard's support-call census. The new distill test uses `test_primary_session` and one `TestDbSession::execute`, so the frozen count moves from 1039 to 1041 and `r4_test_support_api_manifest.txt` gains the two rows (the first CI run failed on exactly those two census tests).

## How to test
- `cargo nextest run -p wenlan-core -E 'test(page_summary_backfill) | test(refresh_page_rebuilds_the_summary) | test(summary_is_the_first_prose)'` (4 passed locally: backfill rewrites a first-bullet summary and is idempotent; backfill leaves human-edited and authored pages alone; refresh derives the summary from the rebuilt body; the #642 extractor test still passes)
- `cargo test -p wenlan-core --lib -- drift_guard::r4_test_support_test::repository_module_graph_matches_r4_25_group_6_census drift_guard::r4_test_support_test::r4_test_support_raw_and_api_manifests_match_exactly` (2 passed locally after the census update)
- Live: start a daemon built from this branch over a store holding a pre-#642 distilled page; the log prints `[pages] rewrote N page summaries to the first prose sentence` and `GET /api/pages` shows the first sentence, markers stripped. On the launch-demo store it printed `rewrote 3`, and the hero page's next automatic rebuild re-derived the summary again.

## Checklist
- [x] Tests pass (`cargo nextest run -p wenlan-core ...` above; full workspace left to CI)
- [x] `cargo clippy` and `cargo fmt` pass (pre-commit ran both on the changed crates)
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (`page_summary_backfill.rs` carries `Apache-2.0` like its siblings in `db/`)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY