### PR TITLE
fix(app): the page lede keeps its citation chips when it is the first sentence

### DIFF
--- a/src/components/memory/ContentRenderer.tsx
+++ b/src/components/memory/ContentRenderer.tsx
@@ -12,7 +12,8 @@ import { CITATION_ANCHOR_PREFIX } from "../../lib/pageCitations";
 interface ContentRendererProps {
   content: string;
   structuredFields?: string | null;
-  variant: "card" | "detail";
+  /** "lede" renders bare paragraphs so the surrounding pull-quote styles apply. */
+  variant: "card" | "detail" | "lede";
   className?: string;
   /** Render #citation:k links as inline chips (page detail). */
   renderCitation?: (occurrence: number) => React.ReactNode;
@@ -251,9 +252,16 @@ export default function ContentRenderer({
   const shape = classifyContent(normalized, structuredFields);
   const prepared = prepareForRender(normalized, shape);
 
+  const baseComponents =
+    variant === "lede"
+      ? {
+          ...markdownComponents,
+          p: ({ children }: { children?: React.ReactNode }) => <p>{children}</p>,
+        }
+      : markdownComponents;
   const components = renderCitation
     ? {
-        ...markdownComponents,
+        ...baseComponents,
         a: (props: { href?: string; children?: React.ReactNode }) => {
           const href = props.href ?? "";
           if (href.startsWith(CITATION_ANCHOR_PREFIX)) {
@@ -263,7 +271,7 @@ export default function ContentRenderer({
           return markdownComponents.a(props);
         },
       }
-    : markdownComponents;
+    : baseComponents;
 
   return (
     <div className={["content-renderer", className].filter(Boolean).join(" ")}>

--- a/src/components/memory/PageDetail.citations.test.tsx
+++ b/src/components/memory/PageDetail.citations.test.tsx
@@ -186,9 +186,10 @@ describe("PageDetail citations", () => {
     const quote = screen.getByText(/It stays fast under load\./);
     expect(quote.textContent).not.toMatch(/\[\d+\]/);
     expect(quote.textContent).not.toContain("#citation");
-    // Known ceiling (spec §4.3): the first-sentence citation gets no inline
-    // chip; the second citation still renders in the body.
-    expect(screen.queryByRole("button", { name: /mem-1/ })).toBeNull();
+    // The first-sentence citation renders as a chip inside the pull quote;
+    // the second citation still renders in the body.
+    const lede = document.querySelector(".page-detail-lede") as HTMLElement;
+    expect(within(lede).getByRole("button", { name: /mem-1/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /mem-2/ })).toBeInTheDocument();
   });
 
@@ -217,7 +218,45 @@ describe("PageDetail citations", () => {
     renderPage();
     expect(await screen.findByText("Cited Page")).toBeInTheDocument();
     expect(screen.getAllByText(/It stays fast under load\./)).toHaveLength(1);
-    expect(screen.queryByRole("button", { name: /mem-1/ })).toBeNull();
+    // The sentence moved up into the lede and took its chip with it.
+    const lede = document.querySelector(".page-detail-lede") as HTMLElement;
+    expect(within(lede).getByRole("button", { name: /mem-1/ })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /mem-1/ })).toHaveLength(1);
     expect(screen.getByRole("button", { name: /mem-2/ })).toBeInTheDocument();
+  });
+
+  it("keeps the chips in the lede when the distiller put the markers before the period", async () => {
+    // The daemon's summary is the first sentence with its markers stripped;
+    // the body keeps "setup [1][2]." with a space before the markers.
+    tauriMocks.getPage.mockResolvedValue({
+      ...BASE_PAGE,
+      summary: "Tally stores all data in one SQLite file next to the app.",
+      content:
+        "# Cited Page\n\nTally stores all data in one SQLite file next to the app [1][2]. The app process is the only writer.",
+      citations: [cite(1, 1), cite(2, 2)],
+    });
+    renderPage();
+    expect(await screen.findByText("Cited Page")).toBeInTheDocument();
+    const lede = document.querySelector(".page-detail-lede") as HTMLElement;
+    expect(within(lede).getByText(/Tally stores all data in one SQLite file/)).toBeInTheDocument();
+    expect(within(lede).getByRole("button", { name: /mem-1/ })).toBeInTheDocument();
+    expect(within(lede).getByRole("button", { name: /mem-2/ })).toBeInTheDocument();
+    expect(screen.getAllByText(/Tally stores all data in one SQLite file/)).toHaveLength(1);
+    expect(screen.getByText(/The app process is the only writer\./)).toBeInTheDocument();
+  });
+
+  it("renders a hand-set summary plain and keeps the first sentence in the body", async () => {
+    tauriMocks.getPage.mockResolvedValue({
+      ...BASE_PAGE,
+      summary: "A claim an agent chose.",
+      content:
+        "# Cited Page\n\nThe daemon is local-first.[1] Second paragraph here.[2]",
+    });
+    renderPage();
+    expect(await screen.findByText("Cited Page")).toBeInTheDocument();
+    const lede = document.querySelector(".page-detail-lede") as HTMLElement;
+    expect(within(lede).getByText("A claim an agent chose.")).toBeInTheDocument();
+    expect(within(lede).queryByRole("button")).toBeNull();
+    expect(screen.getByRole("button", { name: /mem-1/ })).toBeInTheDocument();
   });
 });

--- a/src/components/memory/PageDetail.citations.test.tsx
+++ b/src/components/memory/PageDetail.citations.test.tsx
@@ -243,6 +243,10 @@ describe("PageDetail citations", () => {
     expect(within(lede).getByRole("button", { name: /mem-2/ })).toBeInTheDocument();
     expect(screen.getAllByText(/Tally stores all data in one SQLite file/)).toHaveLength(1);
     expect(screen.getByText(/The app process is the only writer\./)).toBeInTheDocument();
+    // The pull quote is italic; the popover that opens from its chip is not.
+    fireEvent.focus(within(lede).getByRole("button", { name: /mem-1/ }));
+    const popover = await screen.findByRole("tooltip");
+    expect(popover.style.fontStyle).toBe("normal");
   });
 
   it("renders a hand-set summary plain and keeps the first sentence in the body", async () => {

--- a/src/components/memory/PageDetail.tsx
+++ b/src/components/memory/PageDetail.tsx
@@ -1300,14 +1300,35 @@ export default function PageDetail({
   // cut from the body only when it is what the lede shows (no summary, or a
   // summary that repeats it). Cutting it under a different summary dropped
   // that sentence, and its citations, from the page.
+  // Markers sit before the period ("... setup [1][2]."), so stripping them
+  // leaves " ." behind; drop that space with the period before comparing.
   const normalizeSentence = (s: string) =>
-    s.replace(/\[\d+\]/g, "").replace(/\s+/g, " ").trim().replace(/\.$/, "").toLowerCase();
+    s.replace(/\[\d+\]/g, "").replace(/\s+/g, " ").trim().replace(/\s*\.$/, "").toLowerCase();
   const ledeText = page.summary || tldr;
   const ledeIsFirstSentence =
     !page.summary || (tldr !== "" && normalizeSentence(page.summary) === normalizeSentence(tldr));
+  // When the lede is the first sentence, render that sentence with its
+  // citation links so the chips move up with it instead of disappearing.
+  const ledeMarkdown = tldr && ledeIsFirstSentence
+    ? bodyAfterHeadings.slice(0, sentenceEnd + 1).trim()
+    : "";
   const displayContent = tldr && ledeIsFirstSentence
     ? (cleanedContent.slice(0, leadingHeadings) + bodyAfterHeadings.slice(sentenceEnd + 1).trimStart()).trim()
     : cleanedContent;
+
+  const renderCitation = (k: number) => {
+    const c = processed.byOccurrence.get(k);
+    if (!c) return null;
+    return (
+      <CitationChip
+        occurrence={k}
+        citation={c}
+        sourceMemory={sourceMemoryByLocator.get(c.locator) ?? null}
+        sourcesLoading={pageSources === undefined}
+        onOpenMemory={onMemoryClick}
+      />
+    );
+  };
 
   // Intercept page/memory link clicks in rendered content (capture phase beats target="_blank")
   const handleContentClick = (e: React.MouseEvent) => {
@@ -2092,25 +2113,21 @@ export default function PageDetail({
           <div className="page-detail-prose" onClickCapture={handleContentClick}>
             {ledeText && (
               <div className="page-detail-lede">
-                <p>{ledeText}</p>
+                {ledeMarkdown ? (
+                  <ContentRenderer
+                    content={ledeMarkdown}
+                    variant="lede"
+                    renderCitation={renderCitation}
+                  />
+                ) : (
+                  <p>{ledeText}</p>
+                )}
               </div>
             )}
             <ContentRenderer
               content={displayContent}
               variant="detail"
-              renderCitation={(k) => {
-                const c = processed.byOccurrence.get(k);
-                if (!c) return null;
-                return (
-                  <CitationChip
-                    occurrence={k}
-                    citation={c}
-                    sourceMemory={sourceMemoryByLocator.get(c.locator) ?? null}
-                    sourcesLoading={pageSources === undefined}
-                    onOpenMemory={onMemoryClick}
-                  />
-                );
-              }}
+              renderCitation={renderCitation}
             />
           </div>
           {hasRail && (

--- a/src/components/memory/page/CitationPopover.tsx
+++ b/src/components/memory/page/CitationPopover.tsx
@@ -179,6 +179,8 @@ export default function CitationPopover({
         left: pos?.left ?? -9999,
         width: `${WIDTH}px`,
         zIndex: 50,
+        // A chip inside the italic pull quote must not hand its slant down.
+        fontStyle: "normal",
         backgroundColor: "var(--mem-surface)",
         border: "1px solid var(--mem-border)",
         boxShadow: "0 4px 12px rgba(0,0,0,0.3)",

--- a/src/index.css
+++ b/src/index.css
@@ -2707,7 +2707,10 @@ html[data-theme="light"] {
   padding: 2px 0 2px 18px;
 }
 
-.page-detail-lede p {
+/* Only the pull quote's own paragraphs: a citation popover opened from a
+   lede chip renders inside this block and must keep its upright type. */
+.page-detail-lede > p,
+.page-detail-lede > .content-renderer > p {
   margin: 0;
   color: var(--mem-text-secondary);
   font-family: var(--mem-font-heading);

--- a/src/lib/pageCitations.test.ts
+++ b/src/lib/pageCitations.test.ts
@@ -88,6 +88,12 @@ describe("processCitations", () => {
     const r = processCitations("A. [1] middle [2] B.", []);
     expect(r.content).toBe("A. middle B.");
   });
+
+  it("drops the space a marker before the period leaves behind, but not one inside code", () => {
+    const r = processCitations("Stores all data in one file [5][13]. Run `rm -rf .` first [2].", []);
+    expect(r.state).toBe("stripped-empty");
+    expect(r.content).toBe("Stores all data in one file. Run `rm -rf .` first.");
+  });
 });
 
 describe("stripCitationLinks", () => {
@@ -96,6 +102,7 @@ describe("stripCitationLinks", () => {
       "First claim done.",
     );
     expect(stripCitationLinks("Tail.[2](#citation:2)")).toBe("Tail.");
+    expect(stripCitationLinks("One file [5](#citation:5)[13](#citation:13).")).toBe("One file.");
   });
 });
 

--- a/src/lib/pageCitations.ts
+++ b/src/lib/pageCitations.ts
@@ -47,14 +47,21 @@ function codeRanges(content: string): Array<[number, number]> {
   return ranges;
 }
 
-/** Mirror the backend's strip_markers: remove [N], collapse doubled spaces. */
+/** Mirror the backend's strip_markers: remove [N], collapse doubled spaces.
+ *  Only eat the space in front of a marker that sits before closing
+ *  punctuation: the distiller often writes "one file [5][13]." and a display
+ *  strip must not show "one file .". Code such as "rm -rf ." keeps its space */
 function stripMarkers(text: string): string {
-  return text.replace(/\[\d+\]/g, "").replace(/ {2,}/g, " ");
+  return text
+    .replace(/ *(?:\[\d+\])+(?=[.,;:!?])/g, "")
+    .replace(/\[\d+\]/g, "")
+    .replace(/ {2,}/g, " ");
 }
 
 /** Remove rewritten citation links from plain-text contexts (TLDR pull-quote). */
 export function stripCitationLinks(text: string): string {
   return text
+    .replace(/ *(?:\[\d+\]\(#citation:\d+\))+(?=[.,;:!?])/g, "")
     .replace(/\[\d+\]\(#citation:\d+\)/g, "")
     .replace(/ {2,}/g, " ")
     .trim();


### PR DESCRIPTION
## What this PR does
Since #641 the page detail shows the first prose sentence as the pull quote and, when the daemon summary is that same sentence, cuts it from the body so it does not read twice. The pull quote was a plain `<p>` with the citation links stripped, so the sentence's chips vanished with it. On the launch-demo hero page that is the one sentence every source backs ("...stores all data in one local SQLite file... [5][13]"), and it was the only sentence on the page with nothing to hover.

- `PageDetail` renders the lede through `ContentRenderer` with the same `renderCitation` as the body, so the chips (and their popovers) stay on the pull quote. The markdown slice is the raw first sentence, citation links intact.
- `ContentRenderer` gains a `"lede"` variant: bare `<p>` so the existing `.page-detail-lede p` styles apply, everything else identical to `"detail"`.
- The first-sentence match tolerates a space before the closing period, which is what a `[1][2].` marker run leaves behind once the markers are stripped (the daemon summary has no such space).
- A hand-set summary that is not the first sentence still renders plain, and the sentence stays in the body with its chips (unchanged behavior, now pinned by a test).
- Two follow-up commits from the live check: a popover opened from a lede chip renders inside the italic block, so the popover root sets `font-style: normal` and the lede rule is scoped to the lede's own paragraphs (`.page-detail-lede > p, .page-detail-lede > .content-renderer > p`); the old descendant rule was re-italicizing the popover's paragraphs.
- Third follow-up, seen while a page waited for its rebuild: the daemon clears the page's citations for that window, so the app falls back to stripping the markers, and "one file [5][13]." came out as "one file ." on screen. The strip now eats the space only when it belonged to a marker sitting before closing punctuation; code such as "rm -rf ." keeps its space. Same rule for the pull quote's citation links.

Pairs with #651 (daemon side: the summary follows the body on refresh, old first-bullet summaries reconciled at start). Either merges alone; together they give the demo hero page its real pull quote with clickable sources.

## How to test
- `pnpm exec vitest run src/lib/pageCitations.test.ts src/components/memory/PageDetail.citations.test.tsx src/components/memory/page/CitationChip.test.tsx` (all green; two updated assertions now expect the chip inside `.page-detail-lede`, two new tests cover the "markers before the period" body and the hand-set summary, the lede test also opens the popover and checks its inline font-style, and two strip tests cover the space before the period and the code span that keeps its space)
- `pnpm exec tsc --noEmit -p tsconfig.json` (no errors)
- In the app: open a distilled page whose summary equals its first sentence; the pull quote shows numbered chips, hovering one opens an upright source popover, and the body starts at the second sentence. Verified live on the launch-demo store with a local bundle.

## Checklist
- [x] Tests pass (`vitest` files above; full suite left to CI)
- [x] `tsc --noEmit` passes; no Rust changes so clippy/fmt do not apply
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY