### PR TITLE
fix(pages): the lede drops a "TLDR:" label and keeps its chips when it is long

### DIFF
--- a/crates/wenlan-core/src/prompts/defaults.rs
+++ b/crates/wenlan-core/src/prompts/defaults.rs
@@ -176,7 +176,7 @@ Compile these memories into a wiki-style knowledge page.\n\
 \n\
 Format:\n\
 Do NOT start with a title heading (# Title) -- the title is displayed separately by the UI.\n\
-Start directly with a one-sentence TLDR summary.\n\
+Start directly with a one-sentence summary of the topic, with no label in front of it.\n\
 \n\
 Then write the body organized with short topical headers (## Header) and prose paragraphs under each, \
 like a Wikipedia article with sections. \
@@ -202,7 +202,7 @@ the wiki currently covers, not a deep-dive page.\n\
 \n\
 Format:\n\
 Do NOT start with a title heading (# Title) -- the title is displayed separately by the UI.\n\
-Start directly with a one-sentence TLDR describing the wiki's current focus.\n\
+Start directly with a one-sentence summary of the wiki's current focus, with no label in front of it.\n\
 \n\
 Then, for the sources given, write ONE short entry per DISTINCT topic they represent -- \
 naming the topic and summarizing what it covers in a sentence or two. Group sources that \
@@ -222,7 +222,7 @@ Do not remove existing content unless it is explicitly superseded.\n\
 Do NOT include a title heading (# Title) -- the title is displayed separately by the UI.\n\
 Cite each factual claim by appending [N] immediately after it, where N is the number of the supporting source in the numbered source list. Attach the marker to the exact sentence that states the fact — never at the end of a paragraph, and never on a sentence that only explains or elaborates. A claim drawing on several sources may carry several markers, like [1][3]. Use only numbers that appear in the list. Do NOT add a sources or citations section — the system renders citations from the markers.\n\
 Do not write HTML comments (the <!-- ... --> form) anywhere in the page.\n\
-Output the complete updated page in the same format (TLDR, prose paragraphs, Open Questions).";
+Output the complete updated page in the same format (opening summary sentence, prose paragraphs, Open Questions).";
 
 pub(crate) const ANNOTATE_CITATIONS: &str = "\
 You annotate an existing wiki page with citations. You are given the page body \
@@ -284,6 +284,18 @@ mod tests {
         assert!(DISTILL_PAGE.contains("appending [N]"));
         // HTML comments banned so the LLM can't forge the delimiter.
         assert!(DISTILL_PAGE.contains("HTML comment"));
+    }
+
+    #[test]
+    fn page_prompts_do_not_ask_for_a_labelled_opener() {
+        // A literal "TLDR:" opener lands in the page summary and in the app's
+        // pull quote under the title. Naming the label even in a negative
+        // instruction invites it, so the word stays out of the prompts.
+        for prompt in [DISTILL_PAGE, OVERVIEW_SUMMARY, UPDATE_PAGE] {
+            let upper = prompt.to_ascii_uppercase();
+            assert!(!upper.contains("TLDR"));
+            assert!(!upper.contains("TL;DR"));
+        }
     }
 
     #[test]

--- a/crates/wenlan-core/src/synthesis/distill.rs
+++ b/crates/wenlan-core/src/synthesis/distill.rs
@@ -460,9 +460,11 @@ fn estimate_cluster_tokens(contents: &[String]) -> usize {
 /// `DISTILL_CLUSTER_CONCURRENCY`.
 /// The summary of a distilled page: the first sentence of its first prose
 /// line, skipping headings, blank lines, and everything under an
-/// "Open Questions" heading. Citation markers like `[3]` are removed. A page
-/// with no prose outside "Open Questions" gets no summary rather than a
-/// question standing in for one.
+/// "Open Questions" heading. Citation markers like `[3]` are removed, and so
+/// is a leading "TLDR:" label when the model wrote one: the label is not part
+/// of the sentence and reads as noise in the app's pull quote. A page with no
+/// prose outside "Open Questions" gets no summary rather than a question
+/// standing in for one.
 pub(crate) fn extract_page_summary(content: &str) -> Option<String> {
     let mut in_open_questions = false;
     for raw in content.lines() {
@@ -483,6 +485,7 @@ pub(crate) fn extract_page_summary(content: &str) -> Option<String> {
             .trim_start_matches("* ")
             .trim_start_matches("> ")
             .trim();
+        let text = strip_summary_label(text);
         let sentence = match text.find(". ") {
             Some(end) => &text[..=end],
             None => text,
@@ -491,6 +494,34 @@ pub(crate) fn extract_page_summary(content: &str) -> Option<String> {
         return (!cleaned.is_empty()).then_some(cleaned);
     }
     None
+}
+
+/// Remove a leading "TLDR:" label, with any markdown emphasis around it, so a
+/// labelled opener does not put the label in the page summary. The label must
+/// be followed by a separator, so prose that merely starts with the letters
+/// ("TLDRs are no substitute for the page") is left alone.
+fn strip_summary_label(text: &str) -> &str {
+    let rest = text.trim_start().trim_start_matches(['*', '_']);
+    let lower = rest.to_ascii_lowercase();
+    let Some(label_len) = ["tl;dr", "tldr"]
+        .into_iter()
+        .find(|label| lower.starts_with(label))
+        .map(str::len)
+    else {
+        return text;
+    };
+    let after = rest[label_len..]
+        .trim_start_matches(['*', '_'])
+        .trim_start();
+    let Some(after) = after.strip_prefix([':', '-', '\u{2013}', '\u{2014}']) else {
+        return text;
+    };
+    let after = after.trim_start_matches(['*', '_']).trim_start();
+    if after.is_empty() {
+        text
+    } else {
+        after
+    }
 }
 
 /// Remove `[N]` citation markers and the space that precedes them.
@@ -1580,6 +1611,33 @@ The app process is the only writer [3].\n\n## Backup\n\nNightly copy to iCloud D
         assert_eq!(
             extract_page_summary(content).as_deref(),
             Some("Stripe over PayPal for EU clients.")
+        );
+    }
+
+    #[test]
+    fn summary_drops_a_tldr_label_the_model_wrote() {
+        let content = "TLDR: Tally stores all data in one SQLite file [2]. More prose.\n";
+        assert_eq!(
+            extract_page_summary(content).as_deref(),
+            Some("Tally stores all data in one SQLite file.")
+        );
+    }
+
+    #[test]
+    fn summary_drops_a_bold_tl_dr_label_with_a_dash() {
+        let content = "**TL;DR** \u{2014} Stripe over PayPal for EU clients. Fees are lower.\n";
+        assert_eq!(
+            extract_page_summary(content).as_deref(),
+            Some("Stripe over PayPal for EU clients.")
+        );
+    }
+
+    #[test]
+    fn summary_keeps_prose_that_merely_starts_with_those_letters() {
+        let content = "TLDRs are no substitute for the page. More prose.\n";
+        assert_eq!(
+            extract_page_summary(content).as_deref(),
+            Some("TLDRs are no substitute for the page.")
         );
     }
 

--- a/src/components/memory/PageDetail.citations.test.tsx
+++ b/src/components/memory/PageDetail.citations.test.tsx
@@ -249,6 +249,46 @@ describe("PageDetail citations", () => {
     expect(popover.style.fontStyle).toBe("normal");
   });
 
+  it("keeps a long first sentence in the lede when its citation links are what pushed it past the cap", async () => {
+    const sentence =
+      "Tally stores all data in one SQLite file next to the application, with automated nightly backups to iCloud Drive and manual restoration procedures, magic link authentication for the single user, fourteen day payment terms with overdue reminders at days seven and fourteen, and no Kubernetes or Postgres anywhere in the stack because the requirements stay deliberately minimal [1][2].";
+    // The regression: the cap was measured after the markers became links, so
+    // a sentence a reader sees as 376 characters counted as 409 and lost its
+    // place in the quote.
+    expect(sentence.replace(/ ?\[\d+\]/g, "").length).toBeLessThan(400);
+    expect(sentence.replace(/\[(\d+)\]/g, "[$1](#citation:$1)").length).toBeGreaterThan(400);
+    tauriMocks.getPage.mockResolvedValue({
+      ...BASE_PAGE,
+      summary: null,
+      content: `# Cited Page\n\n${sentence} The app process is the only writer.`,
+      citations: [cite(1, 1), cite(2, 2)],
+    });
+    renderPage();
+    expect(await screen.findByText("Cited Page")).toBeInTheDocument();
+    const lede = document.querySelector(".page-detail-lede") as HTMLElement;
+    expect(within(lede).getByRole("button", { name: /mem-1/ })).toBeInTheDocument();
+    expect(within(lede).getByRole("button", { name: /mem-2/ })).toBeInTheDocument();
+    expect(screen.getAllByText(/deliberately minimal/)).toHaveLength(1);
+  });
+
+  it("drops a TLDR label the model wrote, in the quote and in the body", async () => {
+    tauriMocks.getPage.mockResolvedValue({
+      ...BASE_PAGE,
+      // What a daemon without the matching core fix stored.
+      summary: "TLDR: Tally stores all data in one SQLite file next to the app.",
+      content:
+        "# Cited Page\n\nTLDR: Tally stores all data in one SQLite file next to the app [1][2]. The app process is the only writer.",
+      citations: [cite(1, 1), cite(2, 2)],
+    });
+    renderPage();
+    expect(await screen.findByText("Cited Page")).toBeInTheDocument();
+    const lede = document.querySelector(".page-detail-lede") as HTMLElement;
+    expect(lede.textContent).not.toContain("TLDR");
+    expect(within(lede).getByRole("button", { name: /mem-1/ })).toBeInTheDocument();
+    // The sentence moved up into the quote instead of being repeated below it.
+    expect(screen.getAllByText(/Tally stores all data in one SQLite file/)).toHaveLength(1);
+  });
+
   it("renders a hand-set summary plain and keeps the first sentence in the body", async () => {
     tauriMocks.getPage.mockResolvedValue({
       ...BASE_PAGE,

--- a/src/components/memory/PageDetail.tsx
+++ b/src/components/memory/PageDetail.tsx
@@ -38,6 +38,7 @@ import PageInfo from "./page/PageInfo";
 import { pageReviewNotice, type PageReviewNotice } from "./page/pageReviewNotice";
 import { RailPanelTitle } from "./MemoryDetailPrimitives";
 import { processCitations, stripCitationLinks } from "../../lib/pageCitations";
+import { stripLedeLabel } from "../../lib/pageLede";
 import CitationChip from "./page/CitationChip";
 import PageCanvas from "./PageCanvas";
 import {
@@ -1286,16 +1287,25 @@ export default function PageDetail({
       .map((cs) => [cs.source.memory_source_id, cs.memory]),
   );
 
-  // Extract TLDR (first sentence) for native rendering under title.
+  // Extract the lede (first sentence) for native rendering under title.
   // Match first sentence ending with ". " or ".\n" — but not inside [[wikilinks]] or after abbreviations.
   // Scan starts after any leading heading lines so a body that opens with
   // "## Section" doesn't leak raw markdown into the plain-text lede.
   const leadingHeadings = cleanedContent.match(/^(?:#{1,6}[^\n]*\n+)+/)?.[0].length ?? 0;
   const bodyAfterHeadings = cleanedContent.slice(leadingHeadings);
   const sentenceEnd = bodyAfterHeadings.search(/\.\s/);
-  const tldr = sentenceEnd > 0 && sentenceEnd < 400
-    ? stripCitationLinks(bodyAfterHeadings.slice(0, sentenceEnd + 1).trim())
-    : "";
+  // The first sentence in two forms: markdown, with its citation links intact
+  // for the quote, and the plain text a reader sees. A leading "TLDR:" label
+  // is not part of the sentence, so it comes off both. The length cap is
+  // measured on the plain text, because the markers here have already been
+  // rewritten to `[1](#citation:1)` links: a short sentence carrying a few of
+  // them was pushed past the cap and dropped out of the lede, which left the
+  // quote without its chips and repeated the sentence in the body.
+  const firstSentenceMarkdown =
+    sentenceEnd > 0 ? stripLedeLabel(bodyAfterHeadings.slice(0, sentenceEnd + 1).trim()) : "";
+  const firstSentenceText = stripCitationLinks(firstSentenceMarkdown);
+  const tldr =
+    firstSentenceText.length > 0 && firstSentenceText.length < 400 ? firstSentenceText : "";
   // The lede shows the page summary when there is one; the first sentence is
   // cut from the body only when it is what the lede shows (no summary, or a
   // summary that repeats it). Cutting it under a different summary dropped
@@ -1303,15 +1313,14 @@ export default function PageDetail({
   // Markers sit before the period ("... setup [1][2]."), so stripping them
   // leaves " ." behind; drop that space with the period before comparing.
   const normalizeSentence = (s: string) =>
-    s.replace(/\[\d+\]/g, "").replace(/\s+/g, " ").trim().replace(/\s*\.$/, "").toLowerCase();
-  const ledeText = page.summary || tldr;
+    stripLedeLabel(s)
+      .replace(/\[\d+\]/g, "").replace(/\s+/g, " ").trim().replace(/\s*\.$/, "").toLowerCase();
+  const ledeText = page.summary ? stripLedeLabel(page.summary) : tldr;
   const ledeIsFirstSentence =
     !page.summary || (tldr !== "" && normalizeSentence(page.summary) === normalizeSentence(tldr));
   // When the lede is the first sentence, render that sentence with its
   // citation links so the chips move up with it instead of disappearing.
-  const ledeMarkdown = tldr && ledeIsFirstSentence
-    ? bodyAfterHeadings.slice(0, sentenceEnd + 1).trim()
-    : "";
+  const ledeMarkdown = tldr && ledeIsFirstSentence ? firstSentenceMarkdown : "";
   const displayContent = tldr && ledeIsFirstSentence
     ? (cleanedContent.slice(0, leadingHeadings) + bodyAfterHeadings.slice(sentenceEnd + 1).trimStart()).trim()
     : cleanedContent;

--- a/src/lib/pageLede.test.ts
+++ b/src/lib/pageLede.test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { describe, it, expect } from "vitest";
+import { stripLedeLabel } from "./pageLede";
+
+describe("stripLedeLabel", () => {
+  it("drops a plain TLDR label", () => {
+    expect(stripLedeLabel("TLDR: Tally stores all data in one SQLite file.")).toBe(
+      "Tally stores all data in one SQLite file.",
+    );
+  });
+
+  it("drops a bold TL;DR label with a dash", () => {
+    expect(stripLedeLabel("**TL;DR** — Stripe over PayPal for EU clients.")).toBe(
+      "Stripe over PayPal for EU clients.",
+    );
+  });
+
+  it("drops the label but keeps the sentence's citation links", () => {
+    expect(stripLedeLabel("TLDR: One file [5](#citation:5).")).toBe(
+      "One file [5](#citation:5).",
+    );
+  });
+
+  it("leaves prose that merely starts with those letters", () => {
+    const prose = "TLDRs are no substitute for the page.";
+    expect(stripLedeLabel(prose)).toBe(prose);
+  });
+
+  it("leaves an ordinary sentence untouched", () => {
+    const prose = "Tally is a single-user invoicing app.";
+    expect(stripLedeLabel(prose)).toBe(prose);
+  });
+});

--- a/src/lib/pageLede.ts
+++ b/src/lib/pageLede.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// The lede is a page's first sentence, shown as the pull quote under the
+// title. A model sometimes opens the body with a "TLDR:" label; the label is
+// not part of the sentence, so it must not reach the quote. Mirrors
+// `strip_summary_label` in crates/wenlan-core/src/synthesis/distill.rs, which
+// does the same for the stored summary.
+
+// Optional markdown emphasis, the label, optional emphasis, then a separator.
+// The separator is required, so prose that merely starts with the letters
+// ("TLDRs are no substitute for the page") is left alone.
+const LEDE_LABEL =
+  /^\s*(?:\*{1,2}|_{1,2})?\s*TL;?DR\s*(?:\*{1,2}|_{1,2})?\s*[:\-–—]\s*(?:\*{1,2}|_{1,2})?\s*/i;
+
+/** Drop a leading "TLDR:" label from a lede sentence or a stored summary. */
+export function stripLedeLabel(text: string): string {
+  return text.replace(LEDE_LABEL, "");
+}


### PR DESCRIPTION
Found while filming the launch video on a demo page whose refreshed body opened with `TLDR: Tally is a simple, single-user invoicing app ...` (404 characters). Three defects stacked up on screen: the pull quote under the title started with the label, showed no citation chips, and the same sentence was repeated in the body right underneath it.

## What was wrong

1. `extract_page_summary` takes the first prose sentence verbatim, so the label went into the stored summary and into the quote.
2. `PageDetail` promotes the first sentence to the lede only when it ends under 400 characters, but measured that on content where `[3]` had already been rewritten to `[3](#citation:3)`. A sentence a reader sees as 376 characters counted as 409, so it stayed in the body and the quote fell back to plain text with no chips.
3. `DISTILL_PAGE`, `OVERVIEW_SUMMARY` and `UPDATE_PAGE` all asked for a "TLDR" opener, which is where the label came from.

## What changed

- `strip_summary_label` (core) and `stripLedeLabel` (app, `src/lib/pageLede.ts`) remove a leading TLDR or TL;DR label with any markdown emphasis around it. A separator after the label is required, so prose that merely starts with those letters ("TLDRs are no substitute for the page") is untouched.
- The app strips the label from a stored summary as well, so a page written by an older daemon renders cleanly without waiting for a rebuild.
- The lede length cap is measured on the plain sentence, after the citation links and the label come off.
- The three page prompts now ask for an unlabelled opening sentence. They do not name the label: naming it even in a negative instruction invites it, and a test asserts the word stays out.

Existing pages are reconciled by the startup backfill from #651: their derived summary now differs from the stored one, so it is rewritten once at start.

## Tests

- `cargo test -p wenlan-core --lib -- summary_`: 43 passed, including three new cases (plain label, bold `**TL;DR** —` label, and prose that only starts with the letters).
- `cargo test -p wenlan-core --lib -- prompts::`: 11 passed, including the new prompt assertion.
- `cargo test -p wenlan-core --lib -- drift_guard`: 156 passed (no new test-support calls, so the census is unchanged).
- `pnpm exec vitest run src/lib/pageLede.test.ts src/components/memory/PageDetail.citations.test.tsx`: 17 passed. The new component test pins the regression by asserting the sentence is under 400 characters plain and over 400 once the links are rewritten.
- `cargo fmt --all -- --check` and `pnpm exec tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY