### PR TITLE
docs(readme): link business metric guide

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=23240a69a98330b13102549c9b2d900a3485adf87f46c70b320c06baa529bde2 -->
+<!-- README_SYNC: source=README.md sha256=60ff19e3c08b15f0a823f138a73bc8b1eb94a59c6940f3e924853ecfc8985146 -->
 
 <p align="center">
   <picture>

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ More detailed documentation, concepts, and comparisons:
 - [Build an investment research knowledge base](https://wenlan.app/learn/build-investment-research-knowledge-base)
 - [Build a product research knowledge base before writing a PRD](https://wenlan.app/learn/build-product-research-knowledge-base-for-prd)
 - [Build an SRE incident knowledge base](https://wenlan.app/learn/build-sre-incident-knowledge-base)
+- [Build a business metric definition knowledge base](https://wenlan.app/learn/build-business-metric-definition-knowledge-base): turn approved KPI specifications into a source-backed data dictionary with formula text, grain, exclusions, owners, revisions, and review state.
 
 ### Concepts
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=23240a69a98330b13102549c9b2d900a3485adf87f46c70b320c06baa529bde2 -->
+<!-- README_SYNC: source=README.md sha256=60ff19e3c08b15f0a823f138a73bc8b1eb94a59c6940f3e924853ecfc8985146 -->
 
 <p align="center">
   <picture>
@@ -330,6 +330,7 @@ a1b2c3d distill: 4 pages
 - [建立有来源支撑的投资研究知识库](https://wenlan.app/zh-CN/learn/build-investment-research-knowledge-base)
 - [在撰写 PRD 前建立产品研究知识库](https://wenlan.app/zh-CN/learn/build-product-research-knowledge-base-for-prd)
 - [用运行手册与故障复盘建立 SRE 故障知识库](https://wenlan.app/zh-CN/learn/build-sre-incident-knowledge-base)
+- [建立业务指标定义知识库](https://wenlan.app/zh-CN/learn/build-business-metric-definition-knowledge-base)：把获准的 KPI 规范整理成有来源的数据字典，保留公式文本、粒度、排除条件、负责人、修订和审核状态。
 
 ### 概念
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=23240a69a98330b13102549c9b2d900a3485adf87f46c70b320c06baa529bde2 -->
+<!-- README_SYNC: source=README.md sha256=60ff19e3c08b15f0a823f138a73bc8b1eb94a59c6940f3e924853ecfc8985146 -->
 
 <p align="center">
   <picture>
@@ -330,6 +330,7 @@ a1b2c3d distill: 4 pages
 - [建立有來源支撐的投資研究知識庫](https://wenlan.app/zh-TW/learn/build-investment-research-knowledge-base)
 - [在撰寫 PRD 前建立產品研究知識庫](https://wenlan.app/zh-TW/learn/build-product-research-knowledge-base-for-prd)
 - [用 runbook 與事故復盤建立 SRE 事故知識庫](https://wenlan.app/zh-TW/learn/build-sre-incident-knowledge-base)
+- [建立商業指標定義知識庫](https://wenlan.app/zh-TW/learn/build-business-metric-definition-knowledge-base)：把核准的 KPI 規格整理成有來源的資料字典，保留公式文字、粒度、排除條件、負責人、修訂與複核狀態。
 
 ### 概念
 


### PR DESCRIPTION
Adds one locale-matched Workflow guides link to the live Business Metric Definition Knowledge Base in English, Traditional Chinese, and Simplified Chinese.\n\nThe Spanish README content is unchanged; only its required source-sync marker advances with the English README hash.\n\nVerification:\n- python3 scripts/check-readme-translations.py\n- bash scripts/check-readme-translations.test.sh\n- repository pre-commit checks\n- WENLAN_PUSH_FULL=1 pre-push affected-package closure\n- all three wenlan.app targets return direct 200