### PR TITLE
fix(app): open citation files through open_file and surface refused opens

### DIFF
--- a/src/components/memory/page/CitationChip.test.tsx
+++ b/src/components/memory/page/CitationChip.test.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { invoke } from "@tauri-apps/api/core";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import type { MemoryItem, PageCitation } from "../../../lib/tauri";
 import CitationChip from "./CitationChip";
@@ -49,6 +50,11 @@ function renderChip(over: Partial<React.ComponentProps<typeof CitationChip>> = {
   );
   return { onOpenMemory, ...utils };
 }
+
+beforeEach(() => {
+  vi.mocked(invoke).mockReset();
+  vi.mocked(shellOpen).mockReset();
+});
 
 afterEach(() => {
   vi.useRealTimers();
@@ -162,7 +168,54 @@ describe("CitationChip", () => {
     fireEvent.focus(screen.getByRole("button", { name: /design\.md/ }));
     expect(screen.getByText("/notes/design.md")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /Open file/ }));
-    expect(vi.mocked(shellOpen)).toHaveBeenCalledWith("/notes/design.md");
+    // A bare path must not go to the shell plugin: its `open` validator only
+    // admits URL schemes, so the app's own `open_file` command opens files.
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith("open_file", { path: "/notes/design.md" });
+    expect(vi.mocked(shellOpen)).not.toHaveBeenCalled();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("shows why a file could not be opened instead of failing silently", async () => {
+    const user = userEvent.setup();
+    vi.mocked(invoke).mockRejectedValueOnce(
+      'Refusing to run "/notes/run.command". Wenlan opens documents and folders, not programs.',
+    );
+    renderChip({
+      citation: cite({ source_kind: "external_file", locator: "/notes/run.command" }),
+      sourceMemory: null,
+    });
+    fireEvent.focus(screen.getByRole("button", { name: /run\.command/ }));
+    await user.click(screen.getByRole("button", { name: /Open file/ }));
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not open this file.");
+    expect(alert).toHaveTextContent(/Refusing to run/);
+  });
+
+  it("shows why a link could not be opened from the popover action", async () => {
+    const user = userEvent.setup();
+    vi.mocked(shellOpen).mockRejectedValueOnce(new Error("scope validation failed"));
+    renderChip({
+      citation: cite({ source_kind: "external_url", locator: "https://docs.rs/serde" }),
+      sourceMemory: null,
+    });
+    fireEvent.focus(screen.getByRole("button", { name: /docs\.rs/ }));
+    await user.click(screen.getByRole("button", { name: /Open in browser/ }));
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not open this link.");
+    expect(alert).toHaveTextContent("scope validation failed");
+  });
+
+  it("opens the popover with the reason when a chip click on a link is refused", async () => {
+    const user = userEvent.setup();
+    vi.mocked(shellOpen).mockRejectedValueOnce(new Error("scope validation failed"));
+    renderChip({
+      citation: cite({ source_kind: "external_url", locator: "https://docs.rs/serde" }),
+      sourceMemory: null,
+    });
+    await user.click(screen.getByRole("button", { name: /docs\.rs/ }));
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not open this link.");
+    expect(screen.getByRole("tooltip")).toContainElement(alert);
   });
 
   it("shows only the path of a document citation whose locator carries the source id", async () => {
@@ -178,7 +231,9 @@ describe("CitationChip", () => {
     expect(screen.getByText("/Users/me/Tally/notes/architecture-notes.md")).toBeInTheDocument();
     expect(screen.queryByText(/directory-notes::/)).toBeNull();
     await user.click(screen.getByRole("button", { name: /Open file/ }));
-    expect(vi.mocked(shellOpen)).toHaveBeenCalledWith("/Users/me/Tally/notes/architecture-notes.md");
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith("open_file", {
+      path: "/Users/me/Tally/notes/architecture-notes.md",
+    });
   });
 
   it("explains that authored content survives re-distillation", () => {

--- a/src/components/memory/page/CitationChip.tsx
+++ b/src/components/memory/page/CitationChip.tsx
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import { useEffect, useId, useRef, useState } from "react";
-import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import type { MemoryItem, PageCitation } from "../../../lib/tauri";
 import { citationDisplayLabel } from "../../../lib/pageCitations";
-import CitationPopover from "./CitationPopover";
+import CitationPopover, { openCitationTarget } from "./CitationPopover";
 
 interface CitationChipProps {
   occurrence: number;
@@ -24,6 +23,7 @@ export default function CitationChip({
   onOpenMemory,
 }: CitationChipProps) {
   const [open, setOpen] = useState(false);
+  const [openFailure, setOpenFailure] = useState<string | null>(null);
   const chipRef = useRef<HTMLButtonElement>(null);
   const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -35,6 +35,21 @@ export default function CitationChip({
     if (closeTimer.current) clearTimeout(closeTimer.current);
   };
   useEffect(() => clearTimers, []);
+  // A refusal is about the click that caused it, not the next hover.
+  useEffect(() => {
+    if (!open) setOpenFailure(null);
+  }, [open]);
+
+  // Never resolves to a rejection: a refused open is shown in the popover,
+  // which is opened if it was not already (a chip click on a link skips it).
+  const openTarget = async () => {
+    setOpenFailure(null);
+    const failure = await openCitationTarget(citation);
+    if (failure !== null) {
+      setOpenFailure(failure);
+      setOpen(true);
+    }
+  };
 
   const activate = () => {
     // Touch has no hover: first tap opens the popover, its buttons navigate.
@@ -51,7 +66,7 @@ export default function CitationChip({
       }
       onOpenMemory(citation.locator);
     } else if (citation.source_kind === "external_url") {
-      void shellOpen(citation.locator);
+      void openTarget();
     } else {
       setOpen((v) => !v);
     }
@@ -119,6 +134,8 @@ export default function CitationChip({
           sourcesLoading={sourcesLoading}
           anchorRef={chipRef}
           onOpenMemory={onOpenMemory}
+          openFailure={openFailure}
+          onOpenTarget={() => void openTarget()}
         />
       )}
     </span>

--- a/src/components/memory/page/CitationPopover.tsx
+++ b/src/components/memory/page/CitationPopover.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import { useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { open as shellOpen } from "@tauri-apps/plugin-shell";
-import type { MemoryItem, PageCitation } from "../../../lib/tauri";
+import { openFile, type MemoryItem, type PageCitation } from "../../../lib/tauri";
 import { relativeMs } from "./format";
 
 interface CitationPopoverProps {
@@ -11,6 +12,9 @@ interface CitationPopoverProps {
   sourcesLoading: boolean;
   anchorRef: React.RefObject<HTMLButtonElement | null>;
   onOpenMemory: (sourceId: string) => void;
+  /** Why the last attempt to open this citation's file or link was refused. */
+  openFailure: string | null;
+  onOpenTarget: () => void;
 }
 
 const WIDTH = 280;
@@ -21,6 +25,25 @@ const WIDTH = 280;
 export function citationFilePath(locator: string): string {
   const sep = locator.lastIndexOf("::");
   return sep === -1 ? locator : locator.slice(sep + 2);
+}
+
+// Opens the file or link a citation points at and returns the refusal text
+// instead of dropping it. Files go through the app's own `open_file` command:
+// the shell plugin's `open` only admits URL schemes (its default validator is
+// `^((mailto:\w+)|(tel:\w+)|(https?://\w+)).+`), so a bare path handed to it
+// is refused inside the plugin, and a discarded rejection is exactly how #656
+// shipped a button that did nothing.
+export async function openCitationTarget(citation: PageCitation): Promise<string | null> {
+  try {
+    if (citation.source_kind === "external_file") {
+      await openFile(citationFilePath(citation.locator));
+    } else {
+      await shellOpen(citation.locator);
+    }
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
 }
 
 // Spec: external_url shows a *domain* badge, other kinds a fixed label.
@@ -44,7 +67,10 @@ export default function CitationPopover({
   sourcesLoading,
   anchorRef,
   onOpenMemory,
+  openFailure,
+  onOpenTarget,
 }: CitationPopoverProps) {
+  const { t } = useTranslation();
   const boxRef = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
 
@@ -88,6 +114,16 @@ export default function CitationPopover({
     ? sourceMemory.content.replace(/\s+/g, " ").trim().slice(0, 200)
     : null;
 
+  function failureNotice(headline: "citation.openFileFailed" | "citation.openLinkFailed") {
+    if (openFailure === null) return null;
+    return (
+      <div role="alert" className="flex flex-col gap-1">
+        <p style={{ ...bodyText, color: "var(--mem-accent-amber)" }}>{t(headline)}</p>
+        <p style={{ ...mono, wordBreak: "break-word" }}>{openFailure}</p>
+      </div>
+    );
+  }
+
   function body() {
     if (citation.source_kind === "authored") {
       return (
@@ -102,9 +138,10 @@ export default function CitationPopover({
       return (
         <>
           <p style={{ ...mono, wordBreak: "break-all" }}>{filePath}</p>
-          <button style={actionStyle} onClick={() => void shellOpen(filePath)}>
+          <button style={actionStyle} onClick={onOpenTarget}>
             Open file →
           </button>
+          {failureNotice("citation.openFileFailed")}
         </>
       );
     }
@@ -112,9 +149,10 @@ export default function CitationPopover({
       return (
         <>
           <p style={{ ...mono, wordBreak: "break-all" }}>{citation.locator}</p>
-          <button style={actionStyle} onClick={() => void shellOpen(citation.locator)}>
+          <button style={actionStyle} onClick={onOpenTarget}>
             Open in browser →
           </button>
+          {failureNotice("citation.openLinkFailed")}
         </>
       );
     }

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -386,6 +386,10 @@ const en = {
     suggestedLabel: "Auto-created by an agent",
     viewAllEntities: "View all {{count}}",
   },
+  citation: {
+    openFileFailed: "Could not open this file.",
+    openLinkFailed: "Could not open this link.",
+  },
   pageDetail: {
     actions: "Page actions",
     copied: "Copied!",
@@ -1935,6 +1939,10 @@ const zhHans = {
     suggestedLabel: "由代理自动创建",
     viewAllEntities: "查看全部 {{count}} 个",
   },
+  citation: {
+    openFileFailed: "无法打开此文件。",
+    openLinkFailed: "无法打开此链接。",
+  },
   pageDetail: {
     actions: "页面操作",
     copied: "已复制！",
@@ -3453,6 +3461,10 @@ const zhHant = {
     sourceCount_other: "{{count}} 個來源",
     suggestedLabel: "由代理自動建立",
     viewAllEntities: "檢視全部 {{count}} 個",
+  },
+  citation: {
+    openFileFailed: "無法開啟此檔案。",
+    openLinkFailed: "無法開啟此連結。",
   },
   pageDetail: {
     actions: "頁面操作",


### PR DESCRIPTION
## Problem

Clicking "Open file →" in a page citation popover for a file source did nothing in the packaged app (#656). Two layers:

1. `app/capabilities/default.json` grants plain `shell:allow-open`, and the shell plugin's default validator (`tauri-plugin-shell` 2.3.5, `src/lib.rs:152`) is `^((mailto:\w+)|(tel:\w+)|(https?://\w+)).+`. A bare filesystem path never matches, so the plugin refused it.
2. `CitationPopover.tsx` called `void shellOpen(filePath)`, so the rejection was discarded and the UI showed nothing. The "Open in browser →" button shared the `void` pattern and only worked because URLs pass the validator.

## Changes

- Files now open through the app's existing `open_file` command (`src/lib/tauri.ts` `openFile`, `app/src/search.rs`), the same route the Sources view uses, with its launcher and scheme checks. Links keep using the shell plugin. No capability, Cargo, or npm changes.
- Every open is awaited: both popover buttons and the chip's direct link click. A refused open is shown inside the popover as a `role="alert"` notice with a translated headline and the reason, and clears when the popover closes.
- New keys `citation.openFileFailed` and `citation.openLinkFailed` in `en`, `zh-Hans`, `zh-Hant`.

## Tests

- `src/components/memory/page/CitationChip.test.tsx`: file sources now assert `invoke("open_file", { path })` and that the shell plugin is not called; three new tests cover a refused file open, a refused link open from the popover, and a refused chip click opening the popover with the reason. 18 passed. With the two components reverted to main, 5 of the 18 fail.
- `pnpm exec tsc -b`: no errors.
- `pnpm test:i18n`: 54 passed (parity and hardcoded copy guard).
- `src/components/memory/page` plus `PageDetail.test.tsx` and `PageDetail.tabs.test.tsx`: 245 passed.

## Not verified

- The button was not clicked in a running packaged build. The evidence that `open_file` is reachable from the main window is that the Sources view already ships on it.
- The exact rejection text the shell plugin returns for a refused link; tests use a stand-in string.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY