### PR TITLE
feat(graph): name a hovered node's neighbors on the atlas

### DIFF
--- a/src/lib/graph/atlas.test.ts
+++ b/src/lib/graph/atlas.test.ts
@@ -21,6 +21,7 @@ import {
   lodFor,
   HOVER_DUST_MAX,
   hoverStateFor,
+  NEIGHBOR_LABEL_MAX,
   nodeDisplay,
   edgeDisplay,
   drawRadialNodeLabel,
@@ -483,13 +484,24 @@ describe("nodeDisplay", () => {
     expect(result.zIndex).toBe(2);
   });
 
-  it("keeps a neighbor's own color and label, at zIndex 1", () => {
+  it("keeps a neighbor's own color and names it, at zIndex 1", () => {
     const state: HoverState = { hovered: "a", neighbors: new Set(["b"]) };
     const result = nodeDisplay(state, "b", attrs, PALETTE);
     expect(result.color).toBe(attrs.color);
     expect(result.label).toBe(attrs.label);
+    expect(result.forceLabel).toBe(true);
+    expect(result.zIndex).toBe(1);
+  });
+
+  it("stops naming neighbors outright past NEIGHBOR_LABEL_MAX, leaving them lit", () => {
+    const many = new Set(Array.from({ length: NEIGHBOR_LABEL_MAX + 1 }, (_, i) => `n${i}`));
+    const result = nodeDisplay({ hovered: "a", neighbors: many }, "n0", attrs, PALETTE);
+    expect(result.color).toBe(attrs.color);
+    expect(result.label).toBe(attrs.label);
     expect(result.forceLabel).toBeUndefined();
     expect(result.zIndex).toBe(1);
+    const atCap = new Set(Array.from({ length: NEIGHBOR_LABEL_MAX }, (_, i) => `n${i}`));
+    expect(nodeDisplay({ hovered: "a", neighbors: atCap }, "n0", attrs, PALETTE).forceLabel).toBe(true);
   });
 
   it("mutes and blanks everyone else, at zIndex 0", () => {

--- a/src/lib/graph/atlas.ts
+++ b/src/lib/graph/atlas.ts
@@ -363,6 +363,10 @@ export function dustVisibleCount(zoomIn: number): number {
  *  many. Zoom in past 4x to see them all. */
 export const HOVER_DUST_MAX = 48;
 
+/** How many neighbors a hover names outright (`forceLabel`). Beyond this the
+ *  label grid decides, so a hub with dozens of memories stays readable. */
+export const NEIGHBOR_LABEL_MAX = 12;
+
 /** Zoomed in this much past the opening view, the islands (every component
  *  but the core) are drawn solid with their names and edges; before that they
  *  sit dim at the rim so the core is the one thing the eye lands on. */
@@ -1231,7 +1235,12 @@ function dimFill(color: string, surface: string): string {
  *   unless the anchor is hovered, which shows the first HOVER_DUST_MAX. An island node (`island`) is drawn dim and nameless until
  *   `lod.islandsSolid`.
  * - HOVER, the round-2 spec: no-hover passthrough, the hovered node itself,
- *   its neighbors, everyone else muted and blanked.
+ *   its neighbors, everyone else muted and blanked. Neighbors are also named
+ *   (`forceLabel`) when there are at most NEIGHBOR_LABEL_MAX of them: the
+ *   whole point of lighting them is to show what the node connects to, and
+ *   small nodes never earn a label from sigma's size threshold on their own.
+ *   Past the cap the label grid decides, so a hub with dozens of memories
+ *   does not turn into a wall of text.
  */
 export function nodeDisplay(
   state: HoverState,
@@ -1251,7 +1260,9 @@ export function nodeDisplay(
   }
   if (state.hovered === null) return base;
   if (nodeId === state.hovered) return { ...attrs, forceLabel: true, zIndex: 2 };
-  if (state.neighbors.has(nodeId)) return { ...attrs, zIndex: 1 };
+  if (state.neighbors.has(nodeId)) {
+    return state.neighbors.size <= NEIGHBOR_LABEL_MAX ? { ...attrs, forceLabel: true, zIndex: 1 } : { ...attrs, zIndex: 1 };
+  }
   return { ...base, color: palette.edge, label: "", zIndex: 0 };
 }
 


### PR DESCRIPTION
## What

Hovering a node, or jumping to it from the graph search, lit its neighbors but left them nameless. Node sizes are constant on the atlas, so small nodes never cross sigma's label size threshold, and the only way to learn what a lit dot was to hover it too.

Now a hover names every neighbor outright (`forceLabel`), capped at `NEIGHBOR_LABEL_MAX = 12` neighbors. Past the cap the label grid decides, so a hub with dozens of memories does not become a wall of text.

Found while cutting the launch video: after "jump to Tally" the five connected dots (sqlite, and four memories) were unlabeled.

## Change

- `src/lib/graph/atlas.ts`: `nodeDisplay` returns `forceLabel: true` for neighbors when the hovered node has at most 12; new exported `NEIGHBOR_LABEL_MAX`.
- `src/lib/graph/atlas.test.ts`: neighbor test now expects the label; new test for the cap boundary (12 named, 13 not).

## Verification

- `pnpm exec vitest run src/lib/graph/atlas.test.ts`: 85 passed, 0 failed.
- `pnpm exec tsc --noEmit`: no errors. Prettier: clean.
- eslint: unchecked locally (the linter process died in the sandbox wrapper); CI owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY