### PR TITLE
fix(graph): lay out a focused neighborhood's names so none is buried

### DIFF
--- a/src/components/memory/AtlasView.test.tsx
+++ b/src/components/memory/AtlasView.test.tsx
@@ -401,10 +401,15 @@ describe("AtlasView", () => {
     const { settings } = capturedSigmaInstances[0];
     expect(typeof settings.nodeReducer).toBe("function");
     expect(typeof settings.edgeReducer).toBe("function");
-    // Must stay a no-op override: sigma's built-in hover renderer hardcodes a
-    // #FFF label box that's unreadable under the dark theme's label ink.
+    // Sigma's built-in hover renderer hardcodes a #FFF label box that's
+    // unreadable under the dark theme's label ink; ours is the same painter
+    // the labels layer uses, so a lifted (highlighted) name draws on the
+    // hover layer above every other label, and a blank label paints nothing.
     expect(typeof settings.defaultDrawNodeHover).toBe("function");
-    expect(settings.defaultDrawNodeHover()).toBeUndefined();
+    expect(settings.defaultDrawNodeHover).toBe(settings.defaultDrawNodeLabel);
+    const ctx = { fillText: vi.fn(), strokeText: vi.fn(), measureText: vi.fn(() => ({ width: 0 })) };
+    settings.defaultDrawNodeHover(ctx, { key: "e1", label: "", x: 0, y: 0, size: 4 }, {});
+    expect(ctx.fillText).not.toHaveBeenCalled();
   });
 
   it("wires the radial label drawer over the live graph and lowers sigma's edge-thickness floor", async () => {

--- a/src/components/memory/AtlasView.tsx
+++ b/src/components/memory/AtlasView.tsx
@@ -31,8 +31,12 @@ import {
   drawRadialNodeLabel,
   lodFor,
   OPENING_LOD,
+  drawNodeLabelAt,
+  layoutFocusLabels,
+  NEIGHBOR_LABEL_MAX,
+  NODE_LABEL_FONT,
 } from "../../lib/graph/atlas";
-import type { HoverState, AtlasSimulation, LodState } from "../../lib/graph/atlas";
+import type { HoverState, AtlasSimulation, LodState, LabelPlacement } from "../../lib/graph/atlas";
 import { dustBadgeAnchors, drawDustCounts } from "../../lib/graph/dust";
 import type { CartographyScene } from "../../lib/graph/cartography";
 import {
@@ -173,6 +177,9 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
   // Reducer inputs, read from refs so hover/theme changes repaint without a
   // React re-render or a renderer rebuild (see the mount effect below).
   const hoverStateRef = useRef<HoverState>({ hovered: null, neighbors: new Set() });
+  // Names of the focused neighborhood, laid out once per (focus, camera) and
+  // reused for every label sigma paints in that frame — see layoutFocusLabels.
+  const focusLayoutRef = useRef<{ key: string; placements: Map<string, LabelPlacement> } | null>(null);
   const paletteRef = useRef<GraphPalette>(palette);
   // Zoom level of detail the reducers and the overlay read at paint time:
   // how much of each anchor's memory dust is drawn, and whether the islands
@@ -509,6 +516,52 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
     overlay.style.display = showRegionsRef.current ? "" : "none";
     overlayRef.current = overlay;
 
+    // The label painter for both the labels layer and the hover layer. With a
+    // node focused (hover or search jump) the lit neighborhood's names come
+    // from layoutFocusLabels so they never cover each other or a lit dot; a
+    // neighborhood name with no free spot is skipped rather than painted over
+    // something. Every other label keeps the radial rule. `labelSigma` is
+    // bound right after construction; sigma's constructor render runs with
+    // nothing focused, so the radial path is all it can reach.
+    let labelSigma: Sigma | null = null;
+    const focusLayout = (ctx: CanvasRenderingContext2D): Map<string, LabelPlacement> | null => {
+      const state = hoverStateRef.current;
+      const sigma = labelSigma;
+      if (state.hovered === null || sigma === null) return null;
+      const camera = sigma.getCamera().getState();
+      const { width, height } = sigma.getDimensions();
+      const key = `${state.hovered}|${camera.x}|${camera.y}|${camera.ratio}|${camera.angle}|${width}x${height}`;
+      if (focusLayoutRef.current?.key === key) return focusLayoutRef.current.placements;
+      const nodeAt = (id: string) => {
+        const display = sigma.getNodeDisplayData(id);
+        if (!display || display.hidden) return null;
+        const { x, y } = sigma.framedGraphToViewport(display);
+        return { key: id, x, y, size: display.size, label: display.label ?? "" };
+      };
+      const focus = nodeAt(state.hovered);
+      if (!focus) return null;
+      const neighbors =
+        state.neighbors.size <= NEIGHBOR_LABEL_MAX
+          ? [...state.neighbors].map(nodeAt).filter((n): n is NonNullable<typeof n> => n !== null)
+          : [];
+      ctx.font = NODE_LABEL_FONT;
+      const placements = layoutFocusLabels(focus, neighbors, (text) => ctx.measureText(text).width);
+      focusLayoutRef.current = { key, placements };
+      return placements;
+    };
+    const drawLabel = (ctx: CanvasRenderingContext2D, data: Record<string, any>, s: Record<string, any>) => {
+      const placements = focusLayout(ctx);
+      if (placements) {
+        const at = placements.get(data.key);
+        if (at) {
+          drawNodeLabelAt(ctx, data, s, at, paletteRef.current.surface);
+          return;
+        }
+        const state = hoverStateRef.current;
+        if (state.hovered === data.key || (state.neighbors.has(data.key) && state.neighbors.size <= NEIGHBOR_LABEL_MAX)) return;
+      }
+      drawRadialNodeLabel(ctx, data, s, graph, paletteRef.current.surface);
+    };
     const renderer = new Sigma(graph, container, {
       // Only nodes at least this big carry a label. With the log2 size scale
       // (atlas.ts) that is roughly degree >= 5 for an entity and >= 6 for a
@@ -539,10 +592,12 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       zIndex: true,
       // Sigma's default hover renderer (drawDiscNodeHover) paints a hardcoded
       // #FFF label box — unreadable under the dark theme's light label ink.
-      // The hovered label already renders theme-correct on the labels layer
-      // (nodeDisplay forces it; renderLabels doesn't skip the hovered node),
-      // so the box is pure loss. No-op it.
-      defaultDrawNodeHover: () => {},
+      // The focused neighborhood is `highlighted` (nodeDisplay), which sigma
+      // redraws on the hover layer above every other label: its discs via the
+      // hoverNodes program, its names through this painter, laid out by
+      // layoutFocusLabels. The labels-layer copy underneath is fully covered
+      // by this one's halo, so a lifted name never reads darker.
+      defaultDrawNodeHover: drawLabel,
       // Node/edge sizes are true CSS px at every zoom. The default divides
       // sizes by sqrt(camera ratio), which shrinks items badly once the
       // density cap below zooms the camera out ~5x from fit.
@@ -553,11 +608,7 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
       // 12px body-font labels placed radially around the node, facing the
       // cluster center, over a ground-coloured halo — sigma's default is
       // 14px Arial pinned to the right.
-      defaultDrawNodeLabel: (
-        ctx: CanvasRenderingContext2D,
-        data: Record<string, any>,
-        s: Record<string, any>,
-      ) => drawRadialNodeLabel(ctx, data, s, graph, paletteRef.current.surface),
+      defaultDrawNodeLabel: drawLabel,
       nodeReducer: (node, attrs) =>
         nodeDisplay(hoverStateRef.current, node, attrs, paletteRef.current, lodRef.current),
       edgeReducer: (edge, attrs) => {
@@ -574,6 +625,7 @@ export default function AtlasView({ onNodeClick, focusEntityId, onBack }: AtlasV
         );
       },
     });
+    labelSigma = renderer;
     sigmaRef.current = renderer;
     container.appendChild(overlay);
     if (import.meta.env.DEV) {

--- a/src/lib/graph/atlas.test.ts
+++ b/src/lib/graph/atlas.test.ts
@@ -23,6 +23,8 @@ import {
   hoverStateFor,
   NEIGHBOR_LABEL_MAX,
   nodeDisplay,
+  labelAnchor,
+  layoutFocusLabels,
   edgeDisplay,
   drawRadialNodeLabel,
   NODE_LABEL_FONT,
@@ -475,30 +477,33 @@ describe("nodeDisplay", () => {
     expect(nodeDisplay(state, "a", attrs, PALETTE)).toEqual(attrs);
   });
 
-  it("keeps the hovered node's own color, forces its label, and puts it on top", () => {
+  it("keeps the hovered node's own color, forces its label, lifts it, and puts it on top", () => {
     const state: HoverState = { hovered: "a", neighbors: new Set(["b"]) };
     const result = nodeDisplay(state, "a", attrs, PALETTE);
     expect(result.color).toBe(attrs.color);
     expect(result.label).toBe(attrs.label);
     expect(result.forceLabel).toBe(true);
+    expect(result.highlighted).toBe(true);
     expect(result.zIndex).toBe(2);
   });
 
-  it("keeps a neighbor's own color and names it, at zIndex 1", () => {
+  it("keeps a neighbor's own color, names it, and lifts it, at zIndex 1", () => {
     const state: HoverState = { hovered: "a", neighbors: new Set(["b"]) };
     const result = nodeDisplay(state, "b", attrs, PALETTE);
     expect(result.color).toBe(attrs.color);
     expect(result.label).toBe(attrs.label);
     expect(result.forceLabel).toBe(true);
+    expect(result.highlighted).toBe(true);
     expect(result.zIndex).toBe(1);
   });
 
-  it("stops naming neighbors outright past NEIGHBOR_LABEL_MAX, leaving them lit", () => {
+  it("stops naming and lifting neighbors past NEIGHBOR_LABEL_MAX, leaving them lit", () => {
     const many = new Set(Array.from({ length: NEIGHBOR_LABEL_MAX + 1 }, (_, i) => `n${i}`));
     const result = nodeDisplay({ hovered: "a", neighbors: many }, "n0", attrs, PALETTE);
     expect(result.color).toBe(attrs.color);
     expect(result.label).toBe(attrs.label);
     expect(result.forceLabel).toBeUndefined();
+    expect(result.highlighted).toBeUndefined();
     expect(result.zIndex).toBe(1);
     const atCap = new Set(Array.from({ length: NEIGHBOR_LABEL_MAX }, (_, i) => `n${i}`));
     expect(nodeDisplay({ hovered: "a", neighbors: atCap }, "n0", attrs, PALETTE).forceLabel).toBe(true);
@@ -705,6 +710,94 @@ describe("drawRadialNodeLabel", () => {
     const ctx = mockCtx();
     drawRadialNodeLabel(ctx as any, data, settings, graphWithNodeAt(10, 0));
     expect(ctx.strokeText).not.toHaveBeenCalled();
+  });
+});
+
+describe("layoutFocusLabels", () => {
+  // 6 px per character, the way a fixed-width test face would measure.
+  const measure = (text: string) => text.length * 6;
+  const focus = { key: "tally", x: 400, y: 300, size: 4, label: "tally" };
+  const LINE = 14;
+
+  function box(at: { x: number; y: number; align: string; baseline: string }, width: number) {
+    const x = at.align === "left" ? at.x : at.align === "right" ? at.x - width : at.x - width / 2;
+    const y = at.baseline === "top" ? at.y : at.baseline === "bottom" ? at.y - LINE : at.y - LINE / 2;
+    return { x, y, w: width, h: LINE };
+  }
+  function disjoint(a: ReturnType<typeof box>, b: ReturnType<typeof box>) {
+    return a.x + a.w <= b.x || b.x + b.w <= a.x || a.y + a.h <= b.y || b.y + b.h <= a.y;
+  }
+
+  it("hangs each neighbor's name on the side facing away from the focus", () => {
+    const neighbors = [
+      { key: "east", x: 460, y: 300, size: 3, label: "east" },
+      { key: "west", x: 340, y: 300, size: 3, label: "west" },
+      { key: "north", x: 400, y: 240, size: 3, label: "north" },
+      { key: "south", x: 400, y: 360, size: 3, label: "south" },
+    ];
+    const out = layoutFocusLabels(focus, neighbors, measure);
+    expect(out.get("east")).toEqual(labelAnchor(460, 300, 3, "right"));
+    expect(out.get("west")).toEqual(labelAnchor(340, 300, 3, "left"));
+    expect(out.get("north")).toEqual(labelAnchor(400, 240, 3, "above"));
+    expect(out.get("south")).toEqual(labelAnchor(400, 360, 3, "below"));
+  });
+
+  it("faces the focus's own name away from where its neighbors sit", () => {
+    const neighbors = [
+      { key: "a", x: 460, y: 290, size: 3, label: "a" },
+      { key: "b", x: 470, y: 310, size: 3, label: "b" },
+    ];
+    expect(layoutFocusLabels(focus, neighbors, measure).get("tally")).toEqual(labelAnchor(400, 300, 4, "left"));
+    expect(layoutFocusLabels(focus, [], measure).get("tally")).toEqual(labelAnchor(400, 300, 4, "right"));
+  });
+
+  it("never lets two names overlap, nor a name cover a lit dot — the Tally cluster", () => {
+    // Positions from the launch-video take: sqlite and Backup & Review on one
+    // row left of tally, Gap-Free just right of it, two memories far below.
+    const neighbors = [
+      { key: "sqlite", x: 756, y: 254, size: 4, label: "sqlite" },
+      { key: "backup", x: 801, y: 254, size: 3, label: "Tally Backup & Review" },
+      { key: "gapfree", x: 887, y: 277, size: 3, label: "Tally's Gap-Free Invoice System" },
+      { key: "arch", x: 803, y: 678, size: 3, label: "architecture-notes" },
+      { key: "uses", x: 839, y: 742, size: 3, label: "Tally Uses SQLite Only" },
+    ];
+    const tally = { key: "tally", x: 845, y: 274, size: 5, label: "tally" };
+    const out = layoutFocusLabels(tally, neighbors, measure);
+    const boxes = [...out.entries()].map(([key, at]) => ({
+      key,
+      box: box(at, measure([tally, ...neighbors].find((n) => n.key === key)!.label)),
+    }));
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        expect(disjoint(boxes[i].box, boxes[j].box), `${boxes[i].key} vs ${boxes[j].key}`).toBe(true);
+      }
+      for (const dot of [tally, ...neighbors]) {
+        const disc = { x: dot.x - dot.size, y: dot.y - dot.size, w: 2 * dot.size, h: 2 * dot.size };
+        expect(disjoint(boxes[i].box, disc), `${boxes[i].key} over ${dot.key}`).toBe(true);
+      }
+    }
+    // Everyone in this cluster has room; the focus always goes first.
+    expect(out.size).toBe(6);
+    expect([...out.keys()][0]).toBe("tally");
+  });
+
+  it("leaves a name off rather than paint it over another when nothing fits", () => {
+    // Four neighbors sitting on top of each other, all wanting the same spot,
+    // with long names that leave no free side or push.
+    const long = "a name long enough to block every side of the focus at once";
+    const neighbors = ["p", "q", "r", "s"].map((key) => ({ key, x: 406, y: 300, size: 3, label: long }));
+    const out = layoutFocusLabels({ ...focus, label: long }, neighbors, measure);
+    expect(out.size).toBeGreaterThanOrEqual(1);
+    expect(out.size).toBeLessThan(5);
+    const boxes = [...out.values()].map((at) => box(at, measure(long)));
+    for (let i = 0; i < boxes.length; i++)
+      for (let j = i + 1; j < boxes.length; j++) expect(disjoint(boxes[i], boxes[j])).toBe(true);
+  });
+
+  it("skips a blank name and keeps the rest", () => {
+    const out = layoutFocusLabels(focus, [{ key: "blank", x: 460, y: 300, size: 3, label: "" }], measure);
+    expect(out.has("blank")).toBe(false);
+    expect(out.has("tally")).toBe(true);
   });
 });
 

--- a/src/lib/graph/atlas.ts
+++ b/src/lib/graph/atlas.ts
@@ -1235,12 +1235,16 @@ function dimFill(color: string, surface: string): string {
  *   unless the anchor is hovered, which shows the first HOVER_DUST_MAX. An island node (`island`) is drawn dim and nameless until
  *   `lod.islandsSolid`.
  * - HOVER, the round-2 spec: no-hover passthrough, the hovered node itself,
- *   its neighbors, everyone else muted and blanked. Neighbors are also named
- *   (`forceLabel`) when there are at most NEIGHBOR_LABEL_MAX of them: the
+ *   its neighbors, everyone else muted and blanked. The hovered node and, when
+ *   there are at most NEIGHBOR_LABEL_MAX of them, its neighbors are LIFTED:
+ *   `highlighted` makes sigma redraw their discs and labels on the hover
+ *   layer, above every label the grid paints, so a lit dot is never buried
+ *   under a neighbouring name. Neighbors are named (`forceLabel`) because the
  *   whole point of lighting them is to show what the node connects to, and
- *   small nodes never earn a label from sigma's size threshold on their own.
- *   Past the cap the label grid decides, so a hub with dozens of memories
- *   does not turn into a wall of text.
+ *   small nodes never earn a label from sigma's size threshold on their own;
+ *   where those names land is layoutFocusLabels' job. Past the cap the label
+ *   grid decides, so a hub with dozens of memories does not turn into a wall
+ *   of text.
  */
 export function nodeDisplay(
   state: HoverState,
@@ -1259,9 +1263,11 @@ export function nodeDisplay(
     base = { ...attrs, color: dimFill(attrs.color as string, palette.surface), label: "" };
   }
   if (state.hovered === null) return base;
-  if (nodeId === state.hovered) return { ...attrs, forceLabel: true, zIndex: 2 };
+  if (nodeId === state.hovered) return { ...attrs, forceLabel: true, highlighted: true, zIndex: 2 };
   if (state.neighbors.has(nodeId)) {
-    return state.neighbors.size <= NEIGHBOR_LABEL_MAX ? { ...attrs, forceLabel: true, zIndex: 1 } : { ...attrs, zIndex: 1 };
+    return state.neighbors.size <= NEIGHBOR_LABEL_MAX
+      ? { ...attrs, forceLabel: true, highlighted: true, zIndex: 1 }
+      : { ...attrs, zIndex: 1 };
   }
   return { ...base, color: palette.edge, label: "", zIndex: 0 };
 }
@@ -1326,26 +1332,53 @@ export function drawRadialNodeLabel(
   halo?: string,
 ): void {
   if (!data.label) return;
-  const pad = (data.size as number) + 8;
   const gx = graph.getNodeAttribute(data.key, "x") as number;
   const gy = graph.getNodeAttribute(data.key, "y") as number;
   const angle = Math.atan2(-gy, gx);
   const sector = Math.round((angle + Math.PI) / (Math.PI / 2)) % 4;
+  const side: LabelSide = sector === 0 ? "right" : sector === 2 ? "left" : sector === 1 ? "below" : "above";
+  drawNodeLabelAt(context, data, settings, labelAnchor(data.x as number, data.y as number, data.size as number, side), halo);
+}
 
-  let x = data.x as number;
-  let y = data.y as number;
-  if (sector === 0 || sector === 2) {
-    const isRight = sector === 0;
-    context.textAlign = isRight ? "left" : "right";
-    context.textBaseline = "middle";
-    x += isRight ? pad : -pad;
-  } else {
-    const isBelow = sector === 1;
-    context.textAlign = "center";
-    context.textBaseline = isBelow ? "top" : "bottom";
-    y += isBelow ? pad : -pad;
+/** Which side of its dot a label sits on. */
+export type LabelSide = "left" | "right" | "above" | "below";
+
+/** A resolved label position: the canvas anchor plus how the text hangs off it. */
+export interface LabelPlacement {
+  x: number;
+  y: number;
+  align: CanvasTextAlign;
+  baseline: CanvasTextBaseline;
+}
+
+/** Anchor for a label on `side` of a dot at (x, y) of radius `size`, `push`
+ *  extra px further out. The same geometry drawRadialNodeLabel always used. */
+export function labelAnchor(x: number, y: number, size: number, side: LabelSide, push = 0): LabelPlacement {
+  const pad = size + 8 + push;
+  switch (side) {
+    case "right":
+      return { x: x + pad, y, align: "left", baseline: "middle" };
+    case "left":
+      return { x: x - pad, y, align: "right", baseline: "middle" };
+    case "below":
+      return { x, y: y + pad, align: "center", baseline: "top" };
+    case "above":
+      return { x, y: y - pad, align: "center", baseline: "bottom" };
   }
+}
 
+/** Paint one label at a resolved placement: the shared 12px face at 85% ink
+ *  over an optional ground-coloured halo. */
+export function drawNodeLabelAt(
+  context: CanvasRenderingContext2D,
+  data: Record<string, any>,
+  settings: Record<string, any>,
+  at: LabelPlacement,
+  halo?: string,
+): void {
+  if (!data.label) return;
+  context.textAlign = at.align;
+  context.textBaseline = at.baseline;
   context.font = NODE_LABEL_FONT;
   context.fillStyle = settings.labelColor?.color ?? "#000000";
   context.globalAlpha = 0.85;
@@ -1353,8 +1386,117 @@ export function drawRadialNodeLabel(
     context.lineJoin = "round";
     context.lineWidth = NODE_LABEL_HALO_WIDTH;
     context.strokeStyle = halo;
-    context.strokeText(data.label, x, y);
+    context.strokeText(data.label, at.x, at.y);
   }
-  context.fillText(data.label, x, y);
+  context.fillText(data.label, at.x, at.y);
   context.globalAlpha = 1;
+}
+
+/** A node as the focus layout sees it: viewport px, CSS-px radius, its name. */
+export interface FocusLabelNode {
+  key: string;
+  x: number;
+  y: number;
+  size: number;
+  label: string;
+}
+
+/** Height of one 12px label line, in CSS px, for collision boxes. */
+const LABEL_LINE_HEIGHT = 14;
+/** Clearance kept around a lit dot and between two names, in CSS px. */
+const LABEL_CLEARANCE = 2;
+
+interface Box {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+function overlaps(a: Box, b: Box): boolean {
+  return (
+    a.x < b.x + b.w + LABEL_CLEARANCE &&
+    a.x + a.w + LABEL_CLEARANCE > b.x &&
+    a.y < b.y + b.h + LABEL_CLEARANCE &&
+    a.y + a.h + LABEL_CLEARANCE > b.y
+  );
+}
+
+function boxFor(at: LabelPlacement, width: number): Box {
+  const x = at.align === "left" ? at.x : at.align === "right" ? at.x - width : at.x - width / 2;
+  const y =
+    at.baseline === "top" ? at.y : at.baseline === "bottom" ? at.y - LABEL_LINE_HEIGHT : at.y - LABEL_LINE_HEIGHT / 2;
+  return { x, y, w: width, h: LABEL_LINE_HEIGHT };
+}
+
+function discBox(node: FocusLabelNode): Box {
+  const r = node.size + LABEL_CLEARANCE;
+  return { x: node.x - r, y: node.y - r, w: 2 * r, h: 2 * r };
+}
+
+/** The side of `from` that points away from (dx, dy): the dominant axis wins. */
+function sideAway(dx: number, dy: number): LabelSide {
+  if (Math.abs(dx) >= Math.abs(dy)) return dx >= 0 ? "right" : "left";
+  return dy >= 0 ? "below" : "above";
+}
+
+const SIDES: LabelSide[] = ["right", "left", "above", "below"];
+
+/**
+ * Where the names of a focused neighborhood go. A hover or a search jump
+ * lights one node and its neighbors and names them all; in a tight cluster
+ * the plain radial rule stacks those names on top of each other and over the
+ * lit dots themselves, and the last one painted wins. This pass lays them
+ * out instead:
+ *
+ * - each name radiates AWAY from the focus (a neighbor right of the focus
+ *   hangs its name to the right), the focus's own name away from where its
+ *   neighbors sit, so the cluster reads as a hub with spokes;
+ * - names are placed nearest-first and never overlap a placed name or any
+ *   lit dot; a name whose preferred side is taken tries the other sides,
+ *   then its preferred side pushed further out;
+ * - a name that fits nowhere is left off the map rather than painted over
+ *   something. Its dot stays lit and hoverable.
+ *
+ * Coordinates are viewport CSS px; `measure` is the canvas text width for
+ * the label font. Returns a placement per node key that got one.
+ */
+export function layoutFocusLabels(
+  focus: FocusLabelNode,
+  neighbors: FocusLabelNode[],
+  measure: (text: string) => number,
+): Map<string, LabelPlacement> {
+  const placed: Box[] = [focus, ...neighbors].map(discBox);
+  const out = new Map<string, LabelPlacement>();
+  const tryPlace = (node: FocusLabelNode, preferred: LabelSide) => {
+    if (!node.label) return;
+    const width = measure(node.label);
+    const candidates: Array<[LabelSide, number]> = [
+      [preferred, 0],
+      ...SIDES.filter((side) => side !== preferred).map((side): [LabelSide, number] => [side, 0]),
+      [preferred, LABEL_LINE_HEIGHT],
+      [preferred, 2 * LABEL_LINE_HEIGHT],
+    ];
+    for (const [side, push] of candidates) {
+      const at = labelAnchor(node.x, node.y, node.size, side, push);
+      const box = boxFor(at, width);
+      if (placed.some((other) => overlaps(box, other))) continue;
+      placed.push(box);
+      out.set(node.key, at);
+      return;
+    }
+  };
+  // The focus faces away from the centroid of its neighbors.
+  let cx = 0;
+  let cy = 0;
+  for (const n of neighbors) {
+    cx += n.x - focus.x;
+    cy += n.y - focus.y;
+  }
+  tryPlace(focus, neighbors.length === 0 ? "right" : sideAway(-cx, -cy));
+  const byDistance = [...neighbors].sort(
+    (a, b) => Math.hypot(a.x - focus.x, a.y - focus.y) - Math.hypot(b.x - focus.x, b.y - focus.y),
+  );
+  for (const n of byDistance) tryPlace(n, sideAway(n.x - focus.x, n.y - focus.y));
+  return out;
 }


### PR DESCRIPTION
## What

Follow-up to #659. Naming a focused node's neighbors drew every name with the plain radial rule onto the labels layer, in node order, each over a ground-coloured halo. In a tight cluster (Tally's, in the launch-video data) the names stacked on each other, a later halo covered an earlier name and even the lit dot under it, and the focused node's own name could vanish under a neighbor's.

## Design

The focused neighborhood is lifted above the map.

- The hovered node and its named neighbors are sigma `highlighted` nodes, so their discs and names redraw on the hover layer above every label the grid paints. The old no-op hover renderer is replaced by the same painter the labels layer uses; the labels-layer copy underneath is fully covered by the lifted halo, so a lifted name never reads darker.
- Their names come from a small placement pass, `layoutFocusLabels`: each name radiates away from the focus (a neighbor right of the focus hangs its name to the right), the focus's own name away from where its neighbors sit, placed nearest-first and never over a placed name or a lit dot, trying the other sides and then a push outward before giving up.
- A name with no free spot is left off rather than painted over something; its dot stays lit and hoverable. Everything outside the neighborhood keeps the radial rule. Past `NEIGHBOR_LABEL_MAX` neighbors nothing is lifted or forced, as before.

## Change

- `src/lib/graph/atlas.ts`: `nodeDisplay` marks the focused neighborhood `highlighted`; `drawRadialNodeLabel` split into `labelAnchor` + `drawNodeLabelAt`; new `layoutFocusLabels`.
- `src/components/memory/AtlasView.tsx`: one label painter for `defaultDrawNodeLabel` and `defaultDrawNodeHover`; the layout is computed once per (focus, camera state) and reused across the frame's labels.
- Tests: layout side selection, the focus facing away from its neighbors, the real Tally cluster with no overlaps and no covered dots, the no-room fallback, blank names; AtlasView hover-renderer test updated.

## Verification

- `pnpm exec vitest run src/components/memory src/lib/graph`: 1196 passed, 2 skipped.
- `pnpm exec tsc --noEmit`: no errors. Prettier clean.
- eslint: unchecked locally (the linter process dies in the sandbox wrapper); CI owns it.
- On-screen check follows in the launch-video demo build once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vkkwnPdVWKvtPxbyaRBVY