### PR TITLE
feat(ci): watch the SignPath application and require the signing secrets to be there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       plugin-rust-contract: ${{ steps.filter.outputs.plugin-rust-contract }}
       plugin-version-contract: ${{ steps.filter.outputs.plugin-version-contract }}
       npm:     ${{ steps.filter.outputs.npm }}
+      release-contract: ${{ steps.filter.outputs.release-contract }}
       app:     ${{ steps.filter.outputs.app }}
       macos:   ${{ steps.filter.outputs.macos }}
       windows: ${{ steps.filter.outputs.windows }}
@@ -281,6 +282,22 @@ jobs:
               - 'scripts/bump-version.test.sh'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
+            # The release workflow's shipped contracts. `docs` already routes
+            # release.yml and ci.yml to the Ubuntu provenance lane, which runs
+            # this suite -- but the Authenticode half of it needs a host that
+            # can call Get-AuthenticodeSignature over a real signed file, and
+            # Ubuntu reports those rows UNCHECKED and moves on. This filter
+            # feeds the Windows lane that runs the same suite with
+            # WENLAN_REQUIRE_AUTHENTICODE=1, where UNCHECKED is fatal.
+            #
+            # The suite's own file is listed, which `docs` does not do: a change
+            # to release-workflow-contract.test.py alone currently runs nothing
+            # at all.
+            release-contract:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release.yml'
+              - '.github/workflows/signpath-status.yml'
+              - 'scripts/release-workflow-contract.test.py'
             npm:
               - 'crates/*/npm/**'
             macos:
@@ -2178,6 +2195,42 @@ jobs:
           python3 scripts/update-readme-eval.test.py
           bash scripts/validate-versions.test.sh
 
+  # The Authenticode half of scripts/release-workflow-contract.test.py needs a
+  # Windows host. No CI job ran that suite before this one; on an Ubuntu lane
+  # Get-AuthenticodeSignature does not exist, so five of the truth table's six
+  # rows and four of its five mutations print UNCHECKED and the suite exits 0. That is the repository's own recurring defect: a measurement
+  # that could not be taken, reported in a way that reads like one that came
+  # back clean. WENLAN_REQUIRE_AUTHENTICODE=1 turns those UNCHECKED lines fatal,
+  # and it is set HERE and only here, because a lane that cannot run the check
+  # must not be told to require it.
+  #
+  # Deliberately not folded into app-windows-bundle: that job is
+  # workflow_dispatch-only and is not in `conclusion` below, so nothing it
+  # measures is required of a pull request. This one is small (a checkout and a
+  # python run, no cargo) and it is required.
+  windows-release-contract:
+    name: windows release contract
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.release-contract == 'true'
+    runs-on: windows-2022
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      # `shell: bash` is Git Bash on this runner, which is what the suite's own
+      # posix_bash() resolves for the SignPath guard fragments; pwsh is found by
+      # its _powershell(). Nothing here installs anything: python, Git Bash and
+      # PowerShell are all on the windows-2022 image.
+      - name: Run the release workflow contract with Authenticode required
+        shell: bash
+        env:
+          WENLAN_REQUIRE_AUTHENTICODE: "1"
+        run: python scripts/release-workflow-contract.test.py
+
   runtime-image:
     name: runtime image smoke
     needs: [detect-changes]
@@ -2240,7 +2293,7 @@ jobs:
   # with no matching diff must be skipped.
   conclusion:
     name: conclusion
-    needs: [detect-changes, release-base-proof, fmt, lint, linux-nextest-build, linux-nextest, macos-nextest-build, macos-nextest, test, mcp-platform, canonical-acceptance, contract-integration, release-preflight, docs, plugin, plugin-rust-contract, npm, runtime-image, app-check]
+    needs: [detect-changes, release-base-proof, fmt, lint, linux-nextest-build, linux-nextest, macos-nextest-build, macos-nextest, test, mcp-platform, canonical-acceptance, contract-integration, release-preflight, docs, windows-release-contract, plugin, plugin-rust-contract, npm, runtime-image, app-check]
     if: always() && !cancelled()
     runs-on: ubuntu-24.04
     steps:
@@ -2287,6 +2340,7 @@ jobs:
           expect_job contract-integration "$run_contract" '${{ needs.contract-integration.result }}'
           expect_job release-preflight '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && (github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--branches--') || needs.detect-changes.outputs.release-preflight == 'true') }}' '${{ needs.release-preflight.result }}'
           expect_job docs '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.docs == 'true' }}' '${{ needs.docs.result }}'
+          expect_job windows-release-contract '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.release-contract == 'true' }}' '${{ needs.windows-release-contract.result }}'
           expect_job plugin '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin == 'true' }}' '${{ needs.plugin.result }}'
           expect_job plugin-rust-contract '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.plugin-rust-contract == 'true' }}' '${{ needs.plugin-rust-contract.result }}'
           expect_job npm '${{ needs.detect-changes.outputs.verified-release-merge != 'true' && needs.detect-changes.outputs.npm == 'true' }}' '${{ needs.npm.result }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -817,9 +817,65 @@ jobs:
     name: Build Windows desktop app bundle
     needs: [resolve-promotion, bind-release-tag]
     runs-on: windows-2022
-    timeout-minutes: 120
+    # A job timeout starts when the JOB starts, not when the signing step does,
+    # so budgeting only the SignPath wait would let a slow compile kill the job
+    # before the action ever reaches its own limit -- the same trap the macOS
+    # comment above describes. Measured on this repository's last four tag
+    # releases (runs 33043452863, 33121699208, 33284603345, 33291555184) the
+    # job took 38m21s to 39m00s end to end; in the most recent of those the
+    # bundle build alone was 36m10s and the whole post-build tail -- stage, DLL
+    # check, upload -- was 15s. So:
+    #    40  measured pre-signing work
+    #   +10  a 62 MB installer up to Actions, on to SignPath, and back down
+    #   +90  the wait-for-completion-timeout-in-seconds: 5400 set below, which
+    #        is waiting for a human approver, not for a machine
+    #   + 5  replace, re-sign, stage, verify Authenticode
+    #   +20  margin
+    #   =165
+    # Raise the wait and this together, and with them the exact value pinned in
+    # scripts/release-workflow-contract.test.py.
+    timeout-minutes: 165
     permissions:
+      # The SignPath action's github-token reads this run's job details and
+      # downloads the artifact the step before it uploaded; contents:read alone
+      # does not allow either. An explicit permissions block sets every scope it
+      # does not list to none, so this has to be spelled out.
+      actions: read
       contents: read
+    env:
+      # TWO questions, because they have different answers and the gap between
+      # them is where an unsigned installer ships green.
+      #
+      # SIGNPATH_CONFIGURED -- ARE the secrets here? Derived from all four, not
+      # from the token alone. The token-only form was not a bypass (the
+      # unconditional check below rejects any 1-to-3-of-4 combination before the
+      # build starts) but it said something false: a reader saw a sentinel that
+      # claimed to mean "SignPath is configured" while measuring one fifth of it.
+      # A set-but-empty secret still reads as empty to `!= ''`, which is why this
+      # is a boolean computed here rather than a bash test on the secret itself.
+      #
+      # SIGNPATH_REQUIRED -- MUST this build be signed? Nothing about the
+      # secrets. It is true only in the upstream repository AND only once
+      # signing has been switched on deliberately, and it is what turns
+      # "SignPath is not configured" from a description of the world into a
+      # failure. Without it, the day the Foundation accepts the application, a
+      # repository whose secrets were never installed -- or were installed in
+      # the wrong environment, or resolve as empty -- looks EXACTLY like this
+      # one does today: zero of four, every signing step skipped, the original
+      # unsigned installer staged, hashed, uploaded, and the job green. An
+      # accepted-but-unwired repository would be indistinguishable, at the
+      # release conclusion, from a pending one.
+      #
+      # `vars.` and not `secrets.`, deliberately, and it is the first Actions
+      # variable in this repository. A secret's value cannot be read back by a
+      # human or printed in a log, so a switch stored as a secret is a switch
+      # nobody can audit; this one is a visible, single flip in the repository
+      # settings, and signpath-status.yml reports on the day it is missing.
+      # Comparing to the literal 'true' rather than testing emptiness means
+      # `vars.SIGNPATH_ACTIVE` set to `false`, `0` or `no` reads as off instead
+      # of as on.
+      SIGNPATH_CONFIGURED: ${{ secrets.SIGNPATH_API_TOKEN != '' && secrets.SIGNPATH_ORGANIZATION_ID != '' && secrets.SIGNPATH_PROJECT_SLUG != '' && secrets.SIGNPATH_SIGNING_POLICY_SLUG != '' }}
+      SIGNPATH_REQUIRED: ${{ github.repository == '7xuanlu/wenlan' && vars.SIGNPATH_ACTIVE == 'true' }}
     outputs:
       setup_filename: ${{ steps.stage.outputs.setup_filename }}
       sig_filename: ${{ steps.stage.outputs.sig_filename }}
@@ -864,6 +920,134 @@ jobs:
           if [[ "v$APP_VERSION" != "$RELEASE_TAG" ]]; then
             echo "ERROR: Milestone-B 4b lockstep guard: app/tauri.conf.json version $APP_VERSION does not match release tag $RELEASE_TAG."
             exit 1
+          fi
+
+      # Deliberately unguarded, and deliberately first. Every signing step below
+      # carries `if: env.SIGNPATH_CONFIGURED`, so if this check carried it too it
+      # would skip alongside them in exactly the configurations it exists to
+      # reject, and a green run would publish an unsigned installer. This is the
+      # one step that must run whatever the configuration is. It runs before the
+      # ~40-minute bundle build so a misconfigured repository is told in seconds
+      # rather than at the end.
+      #
+      # It answers two questions and they are not the same question:
+      #
+      #   1. ALL-OR-NOTHING. Any 1-to-3-of-4 combination is a repository where
+      #      somebody began wiring SignPath and stopped, and it fails here.
+      #   2. REQUIRED-BUT-ABSENT. Zero of four is correct behaviour TODAY -- the
+      #      Foundation application is pending and every fork is in this state --
+      #      and it becomes a critical hole the day the application is accepted,
+      #      because an accepted repository whose secrets were never installed
+      #      produces the identical green unsigned release. SIGNPATH_REQUIRED is
+      #      what tells those two apart, and this step is where it bites.
+      - name: Check SignPath configuration is all-or-nothing, and present when required
+        shell: bash
+        env:
+          # Read here rather than branched on in `if:`, so the step runs in every
+          # configuration and the decision is in the script the contract test can
+          # execute. A step whose `if:` encodes the rule is a step that skips
+          # whenever the rule is about to fire.
+          SIGNPATH_REQUIRED: ${{ env.SIGNPATH_REQUIRED }}
+          SECRET_SIGNPATH_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          SECRET_SIGNPATH_PROJECT_SLUG: ${{ secrets.SIGNPATH_PROJECT_SLUG }}
+          SECRET_SIGNPATH_SIGNING_POLICY_SLUG: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG }}
+          SECRET_SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          # Optional to the signing action, but not optional as evidence -- see
+          # the check on it below.
+          SECRET_SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ secrets.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+        run: |
+          set -euo pipefail
+          names=(
+            SIGNPATH_ORGANIZATION_ID
+            SIGNPATH_PROJECT_SLUG
+            SIGNPATH_SIGNING_POLICY_SLUG
+            SIGNPATH_API_TOKEN
+          )
+          present=0
+          for name in "${names[@]}"; do
+            var="SECRET_${name}"
+            if [[ -n "${!var:-}" ]]; then
+              present=$((present + 1))
+            fi
+          done
+          if [[ "$present" -ne 0 && "$present" -ne "${#names[@]}" ]]; then
+            for name in "${names[@]}"; do
+              var="SECRET_${name}"
+              if [[ -z "${!var:-}" ]]; then
+                echo "ERROR: SignPath secrets must be all set or all unset; $name is missing." >&2
+              fi
+            done
+            exit 1
+          fi
+          # The artifact configuration slug is optional to the signing action --
+          # unset selects the project's default configuration in the portal --
+          # but it is not optional as evidence. Set on its own it means somebody
+          # began wiring SignPath and stopped, and since this job keys on the
+          # four required values, the release would otherwise go green and
+          # publish an UNSIGNED installer. signpath-status.yml already reports
+          # exactly this state as half-configured; without this check the two
+          # shipping controls disagree about the same repository.
+          if [[ "$present" -eq 0 && -n "${SECRET_SIGNPATH_ARTIFACT_CONFIGURATION_SLUG:-}" ]]; then
+            echo "ERROR: SIGNPATH_ARTIFACT_CONFIGURATION_SLUG is set while none of the four required SignPath secrets are." >&2
+            echo "       The optional slug on its own signs nothing. Set all four, or unset it." >&2
+            exit 1
+          fi
+          # The sentinel and the count have to agree, or the guarded steps act on
+          # a different answer than the one this step just printed.
+          if [[ "$present" -eq "${#names[@]}" && "${SIGNPATH_CONFIGURED:-}" != "true" ]]; then
+            echo "ERROR: all four SignPath secrets are set but SIGNPATH_CONFIGURED is '${SIGNPATH_CONFIGURED:-}'." >&2
+            exit 1
+          fi
+          if [[ "$present" -eq 0 && "${SIGNPATH_CONFIGURED:-}" == "true" ]]; then
+            echo "ERROR: SIGNPATH_CONFIGURED is true but no SignPath secret is set." >&2
+            exit 1
+          fi
+          # THE LATCH. Everything above measures whether the secrets are HERE.
+          # This asks whether they were supposed to be, and it is the only thing
+          # in this job that can tell an intentionally unsigned release from a
+          # repository that was meant to sign and silently did not.
+          #
+          # Ordered after the all-or-nothing check on purpose: a half-configured
+          # repository gets the more specific message, naming the one secret it
+          # is missing, rather than this one.
+          if [[ "${SIGNPATH_REQUIRED:-}" == "true" && "$present" -ne "${#names[@]}" ]]; then
+            echo "ERROR: this repository has switched SignPath signing ON (vars.SIGNPATH_ACTIVE)" >&2
+            echo "       and the secrets it needs are not all readable from this job." >&2
+            echo "" >&2
+            for name in "${names[@]}"; do
+              var="SECRET_${name}"
+              if [[ -z "${!var:-}" ]]; then
+                echo "       MISSING: $name" >&2
+              else
+                echo "       present: $name" >&2
+              fi
+            done
+            echo "" >&2
+            echo "       Every signing step in this job is guarded on SIGNPATH_CONFIGURED, so" >&2
+            echo "       without this check the job would skip all five, stage and hash the" >&2
+            echo "       ORIGINAL UNSIGNED installer, upload it, and finish green. Refusing" >&2
+            echo "       instead: a release that was required to be signed will not publish" >&2
+            echo "       an unsigned installer." >&2
+            echo "" >&2
+            echo "       If a secret is set but reads as empty here, check that it is on the" >&2
+            echo "       repository rather than on an environment this job does not use, and" >&2
+            echo "       that this workflow is running in ${GITHUB_REPOSITORY:-the upstream repository}." >&2
+            echo "       To stand signing down deliberately, unset vars.SIGNPATH_ACTIVE." >&2
+            exit 1
+          fi
+
+          if [[ "$present" -eq 0 ]]; then
+            echo "SignPath is not configured. This release publishes an UNSIGNED Windows installer."
+            echo "SIGNPATH_REQUIRED is '${SIGNPATH_REQUIRED:-false}', so that is the intended state:"
+            echo "either this is a fork, or signing has not been switched on upstream yet."
+            echo "This step measures the secrets and that switch, and nothing else. Whether"
+            echo "SignPath Foundation has ACCEPTED the application is UNMEASURED here -- an"
+            echo "accepted application whose secrets were never installed looks exactly like an"
+            echo "application still pending. signpath-status.yml is what asks that question, and"
+            echo "it runs on a schedule precisely so accepted-but-not-switched-on is noticed."
+          else
+            echo "SignPath is configured. The installer will be Authenticode-signed before staging."
+            echo "SIGNPATH_REQUIRED is '${SIGNPATH_REQUIRED:-false}'."
           fi
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master 2026-05-13
@@ -964,6 +1148,162 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: pnpm tauri build --target x86_64-pc-windows-msvc
 
+      # ---- Authenticode signing, SignPath Foundation ----------------------
+      # Everything from here to the Authenticode assertion is guarded on
+      # SIGNPATH_CONFIGURED, so a fork and this repository (whose Foundation
+      # application is still pending) both build green with no SignPath secret
+      # present. The unguarded all-or-nothing check near the top of this job is
+      # what stops a half-configured repository from taking that same silent
+      # path.
+      #
+      # Signing has to land BEFORE *Stage app bundle assets and checksums*: that
+      # step copies and hashes the installer immediately, and promote-app-assets
+      # rechecks those exact digests. Signing after it would publish either
+      # unsigned bytes or a digest that no longer matches the file.
+      - name: Upload the unsigned installer for SignPath
+        id: unsigned-installer
+        if: env.SIGNPATH_CONFIGURED == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: unsigned-windows-installer-${{ github.run_id }}
+          # A glob that matches exactly one file, so the artifact ZIP holds that
+          # installer at its root. That root is what the SignPath artifact
+          # configuration has to describe, and it is why this upload keeps
+          # `archive` at its default rather than using `archive: false`: raw
+          # mode ignores `name:` and derives the artifact name from the
+          # basename, which makes a run-attempt-scoped name useless for
+          # collision avoidance and pairs badly with `overwrite: true`.
+          path: target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe
+          # The installer is already compressed; recompressing 62 MB buys
+          # nothing, exactly as in the staged upload at the end of this job.
+          compression-level: 0
+          # A re-run of this job would otherwise collide with the previous
+          # attempt's artifact of the same name.
+          overwrite: true
+          retention-days: 1
+          if-no-files-found: error
+
+      # Pinned by SHA, and listed in EXPECTED_NODE24_ACTIONS in
+      # scripts/release-workflow-contract.test.py -- that allowlist silently
+      # skips any action it does not know, so an unpinned SignPath reference
+      # would otherwise pass unnoticed.
+      - name: Submit the installer to SignPath for signing
+        id: signpath-request
+        if: env.SIGNPATH_CONFIGURED == 'true'
+        uses: SignPath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2.3
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ secrets.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG }}
+          # Optional in the action's own manifest: unset selects the project's
+          # default artifact configuration in the portal, which must describe a
+          # ZIP root to match the upload above.
+          artifact-configuration-slug: ${{ secrets.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          wait-for-completion: true
+          # 600 by default, and this is waiting for a person: the Foundation's
+          # terms require a team member to approve each signing request. 5400
+          # matches the macOS notary wait and is budgeted into this job's
+          # timeout-minutes above.
+          wait-for-completion-timeout-in-seconds: "5400"
+          # WITHOUT THIS THE ACTION DOWNLOADS NOTHING AND SAYS NOTHING. The
+          # input is optional and its absence is silent -- the manifest reads
+          # "If not specified, the task will not download the signed artifact
+          # from SignPath" -- so the job would go green, staging would find the
+          # original unsigned installer exactly where it left it, and the
+          # release would ship unsigned.
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+          # Left at its default on purpose: SignPath returns the ZIP that was
+          # submitted, and false makes the action extract it into the directory
+          # above, which is where the replacement step expects a bare
+          # *-setup.exe.
+          skip-decompress: "false"
+
+      - name: Replace the unsigned installer with the signed one
+        if: env.SIGNPATH_CONFIGURED == 'true'
+        shell: pwsh
+        env:
+          SIGNED_DIR: ${{ runner.temp }}/signpath-signed
+        run: |
+          $ErrorActionPreference = "Stop"
+          $nsisDir = "target/x86_64-pc-windows-msvc/release/bundle/nsis"
+
+          if (-not (Test-Path -LiteralPath $env:SIGNED_DIR)) {
+            throw "SignPath returned nothing to $env:SIGNED_DIR. output-artifact-directory is the input that makes the download happen at all; without a downloaded file this release would ship the unsigned installer."
+          }
+
+          # Cardinality first, on both sides. `find -print -quit` in the staging
+          # step takes whichever *-setup.exe it meets first, so more than one
+          # here is not a warning, it is a coin toss over what gets published.
+          $unsigned = @(Get-ChildItem -LiteralPath $nsisDir -Filter '*-setup.exe' -File)
+          if ($unsigned.Count -ne 1) {
+            throw "expected exactly one *-setup.exe under $nsisDir, found $($unsigned.Count)"
+          }
+          $signed = @(Get-ChildItem -LiteralPath $env:SIGNED_DIR -Filter '*-setup.exe' -File -Recurse)
+          if ($signed.Count -ne 1) {
+            throw "expected exactly one signed *-setup.exe under $env:SIGNED_DIR, found $($signed.Count)"
+          }
+
+          # Then the filename, because *Stage app bundle assets and checksums*
+          # looks the installer up by shape and the updater reaches it by the
+          # URL latest.json spells out.
+          if ($signed[0].Name -ne $unsigned[0].Name) {
+            throw "SignPath returned '$($signed[0].Name)' but the build produced '$($unsigned[0].Name)'"
+          }
+
+          # Content, not mtime. An mtime comparison is unsound in both
+          # directions here, because ZIP extraction restores the archive entry's
+          # own timestamp -- a correctly signed installer can come back older
+          # than the file submitted, and an unrelated stale file can come back
+          # newer. A SHA-256 inequality is the assertion that actually holds,
+          # with Authenticode below as the authenticity gate.
+          # docs/code-signing.md step 2 says the same thing.
+          $before = (Get-FileHash -Algorithm SHA256 -LiteralPath $unsigned[0].FullName).Hash
+          $after = (Get-FileHash -Algorithm SHA256 -LiteralPath $signed[0].FullName).Hash
+          if ($before -eq $after) {
+            throw "the file SignPath returned is byte-identical to the one submitted ($before); nothing was signed"
+          }
+
+          Copy-Item -LiteralPath $signed[0].FullName -Destination $unsigned[0].FullName -Force
+          $installed = (Get-FileHash -Algorithm SHA256 -LiteralPath $unsigned[0].FullName).Hash
+          if ($installed -ne $after) {
+            throw "replacement did not take: $($unsigned[0].FullName) hashes $installed, expected $after"
+          }
+          Write-Host "unsigned $before"
+          Write-Host "signed   $after"
+          Write-Host "replaced $($unsigned[0].FullName)"
+
+      # The .sig beside the installer was computed over the UNSIGNED bytes, so
+      # Authenticode signing invalidates it and the updater would reject the
+      # download. This is the same repair the macOS path makes after stapling.
+      # TAURI_SIGNING_PRIVATE_KEY and its password are `env:` on the bundle
+      # build step alone, so this step needs its own copy of both or it cannot
+      # sign at all. Nothing may touch the installer's bytes after this point;
+      # regenerating the sidecar .sig does not disturb its Authenticode
+      # signature.
+      - name: Regenerate the updater signature over the signed installer
+        if: env.SIGNPATH_CONFIGURED == 'true'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          nsis_dir="target/x86_64-pc-windows-msvc/release/bundle/nsis"
+          setup="$(find "$nsis_dir" -maxdepth 1 -type f -name '*-setup.exe' -print -quit)"
+          [[ -n "$setup" && -f "$setup" ]] || { echo "ERROR: no *-setup.exe under $nsis_dir to re-sign." >&2; exit 1; }
+          sig="${setup}.sig"
+          [[ -s "$sig" ]] || { echo "ERROR: $sig is missing; the bundle build did not sign the installer." >&2; exit 1; }
+          before_sig="$(cat "$sig")"
+
+          rm -f "$sig"
+          pnpm tauri signer sign "$setup"
+          [[ -s "$sig" ]] || { echo "ERROR: re-signing produced no $sig." >&2; exit 1; }
+          [[ "$(cat "$sig")" != "$before_sig" ]] || { echo "ERROR: $sig is unchanged; it still covers the unsigned bytes." >&2; exit 1; }
+          echo "Regenerated $sig over the Authenticode-signed installer."
+
       # Staging runs before verification on purpose. Verifying the bundle
       # directory and then staging from it independently would let the two steps
       # pick different files if more than one setup.exe ever sits there; this way
@@ -1010,6 +1350,73 @@ jobs:
             echo "setup_sha256=$setup_sha256"
             echo "sig_sha256=$sig_sha256"
           } >> "$GITHUB_OUTPUT"
+
+      # Pointed at the STAGED installer -- the exact bytes that get uploaded and
+      # whose digest promote-app-assets rechecks -- rather than at the bundle
+      # directory, so this cannot pass against a different file than the one
+      # that ships. A silently skipped download (see output-artifact-directory
+      # above) leaves an unsigned installer in place, and Status would be
+      # NotSigned here; a signature from anyone else fails the subject check.
+      - name: Verify the installer carries a valid SignPath signature
+        if: env.SIGNPATH_CONFIGURED == 'true'
+        shell: pwsh
+        env:
+          STAGED_SETUP: ${{ runner.temp }}/app-bundle-windows-staging/${{ steps.stage.outputs.setup_filename }}
+        run: |
+          $ErrorActionPreference = "Stop"
+          if (-not (Test-Path -LiteralPath $env:STAGED_SETUP)) {
+            throw "staged installer missing at $env:STAGED_SETUP"
+          }
+          $signature = Get-AuthenticodeSignature -LiteralPath $env:STAGED_SETUP
+          Write-Host "Status: $($signature.Status)"
+          if ($signature.Status -ne 'Valid') {
+            throw "Authenticode status is '$($signature.Status)', expected 'Valid'. $($signature.StatusMessage)"
+          }
+          $certificate = $signature.SignerCertificate
+          if ($null -eq $certificate) {
+            throw "Authenticode reported Valid with no signer certificate"
+          }
+          # SignerCertificate.Subject is a full distinguished name, so a raw
+          # string comparison against the bare publisher name is either always
+          # false or a substring match that a hostile CN could satisfy. Ask the
+          # certificate for the parsed common name instead.
+          $publisher = $certificate.GetNameInfo(
+            [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+            $false)
+          # Printed BEFORE the comparison and never conditionally, because on the
+          # first real signed build these three lines are the only record of what
+          # SignPath Foundation's certificate actually says. Nobody here has seen
+          # it: the application is pending, so every string this step compares
+          # against is taken from the Foundation's published terms rather than
+          # from a certificate anyone has held. A run that FAILS the comparison
+          # must still leave the exact values behind, or diagnosing it means
+          # cutting another release to look.
+          #
+          # TODO(after the first signed release): read Subject and Thumbprint out
+          # of that run's log and pin them here -- the full distinguished name
+          # instead of the simple name, and the thumbprint as a second,
+          # independent witness. Both are written down below for exactly that.
+          # Do not invent either value in advance; a pinned string nobody has
+          # verified is a gate that fails the first real build for the wrong
+          # reason.
+          Write-Host "Publisher:  $publisher"
+          Write-Host "Subject:    $($certificate.Subject)"
+          Write-Host "Issuer:     $($certificate.Issuer)"
+          Write-Host "Thumbprint: $($certificate.Thumbprint)"
+          # -cne, not -ne. PowerShell's -ne is CASE-INSENSITIVE, so `signpath
+          # foundation` and `SIGNPATH FOUNDATION` both passed a check written to
+          # assert one exact publisher name. A certificate is an identity
+          # document; matching it loosely is how a different issuer with a
+          # similarly-cased common name gets waved through.
+          #
+          # What this still does NOT establish, said plainly rather than implied:
+          # SimpleName is the common name alone, so a DIFFERENT full
+          # distinguished name carrying the same common name passes here. Closing
+          # that needs the real Subject, which is what the TODO above is for.
+          if ($publisher -cne 'SignPath Foundation') {
+            throw "installer publisher is '$publisher', expected 'SignPath Foundation'"
+          }
+          Write-Host "PASS $env:STAGED_SETUP is signed by SignPath Foundation"
 
       # The same unpack-and-look check ci.yml's app-windows-bundle runs, pointed
       # at the staged installer. A release must never ship an installer that

--- a/.github/workflows/signpath-status.yml
+++ b/.github/workflows/signpath-status.yml
@@ -1,0 +1,704 @@
+# Ask SignPath what is wired, what SignPath makes of it, and whether this
+# repository has actually been switched on. Builds nothing.
+#
+# Three questions, and they have three different answers:
+#
+#   1. ARE the secrets here?          -- presence arithmetic, offline.
+#   2. Does SignPath ACCEPT them?     -- the API, one token, one org, and a
+#                                        differential probe for the project and
+#                                        signing-policy slugs.
+#   3. Is signing SWITCHED ON?        -- vars.SIGNPATH_ACTIVE, which is what
+#                                        release.yml's SIGNPATH_REQUIRED reads.
+#
+# The state this exists for is the gap between 2 and 3. The Foundation
+# application is pending as this is written, so today every answer is "nothing
+# is wired", and that is reported and exits 0 -- an unwired fork and an unwired
+# upstream are both the expected steady state, and a monitor that burns a red
+# run on its own steady state is one nobody looks at. The day the application is
+# accepted and the secrets are installed but vars.SIGNPATH_ACTIVE is still
+# unset, release.yml will publish a green UNSIGNED installer and nothing else in
+# this repository will say so. That state is RED here, by name, and this
+# workflow runs on a schedule so that nobody has to remember to ask.
+#
+# Every arm is one of three verdicts and they are never merged: measured-good,
+# measured-bad, and COULD NOT MEASURE. A 200 that does not parse is the third,
+# not the first -- it was previously reported as "still a working credential",
+# which is a claim about a payload nobody could read.
+name: SignPath status
+
+on:
+  workflow_dispatch:
+  # Weekly, Mondays 09:17 UTC. The offset keeps it off the hour, where hosted
+  # runner queues are worst. GitHub disables schedules on forks and after 60
+  # days without repository activity; both are acceptable here, because this is
+  # a monitor for the upstream repository's own configuration.
+  schedule:
+    - cron: "17 9 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  status:
+    # One HTTPS call and some presence arithmetic. Nothing here is
+    # platform-specific, so it does not borrow the Windows runner that the
+    # release bundle job needs.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # A fork that enables Actions would otherwise get a weekly red run for a
+    # configuration it is not supposed to have. Dispatch still works everywhere,
+    # because a fork maintainer asking the question deliberately deserves the
+    # answer.
+    if: github.repository == '7xuanlu/wenlan' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Ask SignPath
+        env:
+          # All five are secrets, not `vars`. The organization id and the three
+          # slugs are identifiers rather than credentials, so `vars.` would be
+          # their natural home -- but they arrive together with the token and
+          # sharing one idiom keeps a reviewer checking one thing:
+          # `secrets.SIGNPATH_API_TOKEN != ''` reads identically to
+          # `secrets.APPLE_CERTIFICATE != ''` in release.yml.
+          SIGNPATH_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
+          SIGNPATH_PROJECT_SLUG: ${{ secrets.SIGNPATH_PROJECT_SLUG }}
+          SIGNPATH_SIGNING_POLICY_SLUG: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG }}
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          # The fifth value, and optional. signpath/github-action-submit-signing-request
+          # marks `artifact-configuration-slug` `required: false` in its own
+          # manifest; leaving it unset selects the project's default artifact
+          # configuration in the SignPath portal. It is reported separately so
+          # that "not set" cannot be mistaken for "not needed".
+          SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ secrets.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          # The switch, and the ONLY value here that is a `vars.` rather than a
+          # `secrets.`. A secret cannot be read back by a human or printed in a
+          # log, so a switch stored as a secret is a switch nobody can audit.
+          # This is the same expression release.yml's SIGNPATH_REQUIRED is built
+          # from, and the two must stay identical: this workflow's entire job is
+          # to report on what that one will do.
+          SIGNPATH_ACTIVE: ${{ vars.SIGNPATH_ACTIVE }}
+        run: |
+          set -euo pipefail
+
+          required=(
+            SIGNPATH_ORGANIZATION_ID
+            SIGNPATH_PROJECT_SLUG
+            SIGNPATH_SIGNING_POLICY_SLUG
+            SIGNPATH_API_TOKEN
+          )
+
+          present=0
+          echo "== Configuration =="
+          for name in "${required[@]}"; do
+            if [[ -n "${!name:-}" ]]; then
+              echo "  $name: set"
+              present=$((present + 1))
+            else
+              echo "  $name: absent"
+            fi
+          done
+          if [[ -n "${SIGNPATH_ARTIFACT_CONFIGURATION_SLUG:-}" ]]; then
+            echo "  SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: set (optional)"
+            artifact_configuration=set
+          else
+            echo "  SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: absent (optional)"
+            artifact_configuration=absent
+          fi
+          # Compared to the literal 'true', exactly as release.yml compares it,
+          # so `false`, `0`, `no` and `TRUE` all read as off in both places.
+          if [[ "${SIGNPATH_ACTIVE:-}" == "true" ]]; then
+            active=true
+          else
+            active=false
+          fi
+          echo "  vars.SIGNPATH_ACTIVE: '${SIGNPATH_ACTIVE:-}' -> signing required: $active"
+          echo
+
+          if [[ "$present" -eq 0 && "$artifact_configuration" == "absent" ]]; then
+            if [[ "$active" == "true" ]]; then
+              echo "RESULT: SWITCHED ON WITH NOTHING WIRED." >&2
+              echo "vars.SIGNPATH_ACTIVE is 'true', so release.yml's SIGNPATH_REQUIRED is" >&2
+              echo "true, and no SIGNPATH_* secret is set. The next tag release will fail" >&2
+              echo "in app-bundle-windows before it builds anything -- which is the" >&2
+              echo "designed behaviour, and better found here than there. Install the four" >&2
+              echo "secrets, or unset vars.SIGNPATH_ACTIVE." >&2
+              exit 1
+            fi
+            echo "RESULT: nothing is wired in this repository."
+            echo "No SIGNPATH_* secret is set, so release.yml's SIGNPATH_CONFIGURED"
+            echo "sentinel is false and every signing step in app-bundle-windows"
+            echo "skips. Installers ship unsigned. vars.SIGNPATH_ACTIVE is unset, so"
+            echo "SIGNPATH_REQUIRED is false and that is the INTENDED state."
+            echo
+            echo "This run canNOT tell you whether SignPath Foundation has accepted"
+            echo "the application. With no token there is nothing to ask the API with,"
+            echo "so the acceptance state is UNMEASURED here, not 'pending' -- an"
+            echo "accepted application whose secrets were never added looks exactly"
+            echo "like this. Acceptance arrives by email; the repository-side signal"
+            echo "is this workflow going from 'nothing wired' to a validated token."
+            echo
+            echo "Exiting 0: an unwired fork and an unwired upstream are both the"
+            echo "expected steady state, and a monitor that burns a red run on its"
+            echo "own steady state is one nobody dispatches."
+            exit 0
+          fi
+
+          if [[ "$present" -ne "${#required[@]}" ]]; then
+            echo "RESULT: half-configured. This is the state that would ship an" >&2
+            echo "unsigned installer from a green release run." >&2
+            for name in "${required[@]}"; do
+              if [[ -z "${!name:-}" ]]; then
+                echo "  missing: $name" >&2
+              fi
+            done
+            if [[ "$present" -eq 0 ]]; then
+              echo "  SIGNPATH_ARTIFACT_CONFIGURATION_SLUG is set while none of the" >&2
+              echo "  four required values are; the optional slug alone signs nothing." >&2
+            fi
+            echo >&2
+            echo "release.yml's SIGNPATH_CONFIGURED is false unless all four are set," >&2
+            echo "so every signing step skips and the companion check fails the job." >&2
+            echo "Set all four together or none of them." >&2
+            exit 1
+          fi
+
+          # The token stays off every command line. curl's -H @file form reads
+          # one header per line out of a file, which is the closest thing curl
+          # has to notarytool's keychain profile: nothing sensitive appears in
+          # the process list, and the file is 0600 and removed on exit.
+          umask 077
+          header_file="$RUNNER_TEMP/signpath-auth-header"
+          cleanup() { rm -f "$header_file"; }
+          trap cleanup EXIT
+          printf 'Authorization: Bearer %s\n' "$SIGNPATH_API_TOKEN" > "$header_file"
+
+          base="https://app.signpath.io/API/v1/${SIGNPATH_ORGANIZATION_ID}"
+
+          # One place that talks to the network. Prints the code on stdout,
+          # leaves the body in $2, and RETURNS CURL'S OWN STATUS.
+          #
+          # ROUND 5. This ended `|| true`, and that discarded the only signal
+          # that says the transfer failed. `-w '%{http_code}'` prints the status
+          # line curl received, which it has as soon as the headers arrive --
+          # so a request that gets `200` and then times out, or ends on a
+          # Content-Length mismatch, or has its connection reset mid-body,
+          # prints `200` and exits 28, 18 or 56. With the status thrown away the
+          # body that DID land was parsed as though the transfer had completed:
+          # a truncated list that happens to still be valid JSON reads as a
+          # working credential, and with SIGNPATH_ACTIVE=true the whole workflow
+          # exits 0 on a measurement that failed. A monitor whose subject is
+          # "an unmeasured thing must not look measured" cannot swallow the one
+          # status that tells it which of the two it is holding.
+          #
+          # `|| true` was not there for nothing -- the step runs under `set -e`
+          # and a bare non-zero curl would end the job before it reached its own
+          # summary. `rc` keeps that property and hands the answer over as well,
+          # which is the same correction the dev runtime's trap took.
+          signpath_get() {
+            local rc=0
+            curl -sS \
+              -H @"$header_file" \
+              -H 'Accept: application/json' \
+              -o "$2" \
+              -w '%{http_code}' \
+              --max-time 60 \
+              "$1" || rc=$?
+            return "$rc"
+          }
+
+          # ---- the verdict, in THREE states, decided at the very end ----
+          #
+          #   0  everything this run looked at answered affirmatively
+          #   1  something answered NEGATIVELY: a rejected credential, a slug
+          #      the API does not know, an accepted-but-not-switched-on repo
+          #   2  something COULD NOT BE MEASURED
+          #
+          # 2 exists because this workflow had recreated, at its own outermost
+          # boundary, the defect it was built to detect. `status` became 0 the
+          # moment the credential request succeeded, and only an `absent` slug
+          # turned it back to 1, so BOTH slugs coming back "NOT validated --
+          # this run could not measure it" exited 0: identical, to anything
+          # reading the workflow result, to both slugs resolving. A monitor
+          # whose entire subject is "an unmeasured thing must not look
+          # measured" cannot report its own unmeasured state as success.
+          #
+          # Precedence, when a run is in more than one state: a measured
+          # negative outranks an unmeasured one. Both are non-zero, both are
+          # named in full in the summary below, and what the exit code carries
+          # is "this is wrong" versus "this run did not find out".
+          verdict=affirmative
+          note_negative()   { verdict=negative; }
+          note_unmeasured() { [[ "$verdict" == "negative" ]] || verdict=unmeasured; }
+
+          body_file="$RUNNER_TEMP/signpath-response.json"
+          url="$base/SigningRequests"
+          echo "== GET $url =="
+          curl_rc=0
+          http_code="$(signpath_get "$url" "$body_file")" || curl_rc=$?
+          echo "HTTP ${http_code:-<curl produced no status>} (curl exited $curl_rc)"
+          echo
+
+          # THREE credential verdicts, never two. `unmeasured` is not a polite
+          # spelling of `ok`: it is what this prints when the run learned
+          # nothing, and it is red for the same reason a skipped test is not a
+          # passing test.
+          credential=unmeasured
+          # A FAILED TRANSFER IS NOT AN HTTP OUTCOME, and it is decided before
+          # the code is looked at. Everything in the `case` below reasons from a
+          # status line and a body that arrived together; a non-zero curl says
+          # exactly that they may not have. The affirmative arm is the one this
+          # matters for -- `200` plus a body cut off mid-list is how a run
+          # reports a validated credential it never validated -- but a `401`
+          # from a transfer that then failed is not promoted to a measured
+          # negative either: nothing here re-reads it, and a negative outranks
+          # an unmeasured one in the verdict, so guessing would be the more
+          # confident of the two wrong answers.
+          if (( curl_rc != 0 )); then
+            credential=unmeasured
+            note_unmeasured
+            echo "RESULT: COULD NOT MEASURE the credential -- curl exited $curl_rc." >&2
+            echo "It printed HTTP '${http_code:-<none>}', which is the status line it had" >&2
+            echo "received when the transfer failed: 28 is a timeout, 18 a body shorter" >&2
+            echo "than its Content-Length, 56 a reset. The response was NOT completely" >&2
+            echo "received, so neither the code nor the body below is evidence about the" >&2
+            echo "token. This is not a negative answer about it either." >&2
+          else
+          case "$http_code" in
+            200)
+              # A 200 whose body does not parse is not evidence of a working
+              # credential. It was reported as one until round 14: "That is
+              # still a working credential; the shape of the payload changed."
+              # A captive portal, a proxy error page and an API rewrite all
+              # produce exactly that, and the summary below would then have
+              # claimed the organization id and token were validated by a
+              # response nobody could read.
+              # A POSITIVE shape assertion, not "something with a length".
+              #
+              # Round 15, measured on this host with jq 1.8.2 against the
+              # expression this replaces --
+              #   if type == "object" then (.values // .items // []) else . end | length
+              #     {}             -> 0    credited as a working credential
+              #     "proxy error"  -> 11   a JSON string's length is its characters
+              #     42             -> 42   a number's length is its absolute value
+              #     null           -> 0
+              # -- only non-JSON and booleans were rejected. The negative
+              # control fed it HTML, which is the half that fails; every
+              # malformed-but-valid JSON body walked straight through. What
+              # that verdict certified was "this parsed", printed as "the
+              # organization id and the API token are both good".
+              #
+              # The body must now BE a list envelope: a top-level array, or an
+              # object whose `values` or `items` IS an array. Everything else
+              # yields `empty`, `jq -e` exits 4, and the credential is
+              # UNMEASURED. SignPath's real envelope is unknown here -- no
+              # token has ever existed -- so if the real reply is some third
+              # shape this says COULD NOT MEASURE, which is loud and wrong in
+              # the safe direction, rather than green.
+              if count="$(jq -e '
+                    if type == "array" then length
+                    elif type == "object" then
+                      if (.values | type) == "array" then (.values | length)
+                      elif (.items | type) == "array" then (.items | length)
+                      else empty end
+                    else empty end
+                  ' < "$body_file" 2>/dev/null)"; then
+                credential=ok
+                echo "RESULT: the organization id and the API token are both good."
+                # A count is enough of an answer and keeps request metadata out
+                # of the log.
+                echo "Signing requests visible to this token: $count"
+              else
+                credential=unmeasured
+                note_unmeasured
+                echo "RESULT: COULD NOT MEASURE the credential." >&2
+                echo "HTTP 200, but the body is not a signing-request list: it did not" >&2
+                echo "parse as JSON, or it parsed as something that is not a list --" >&2
+                echo "{} , a bare string and a bare number all reach this branch, and" >&2
+                echo "not one of them is an answer about the credential. This is" >&2
+                echo "NOT 'the token works and the payload changed shape' -- a proxy" >&2
+                echo "error page, a captive portal and an API rewrite all look like" >&2
+                echo "this, and none of them tells you the credential is good." >&2
+              fi
+              ;;
+            401)
+              credential=bad
+              note_negative
+              echo "RESULT: 401 Unauthorized -- SIGNPATH_API_TOKEN is wrong, expired, or revoked." >&2
+              ;;
+            403)
+              credential=bad
+              note_negative
+              echo "RESULT: 403 Forbidden -- the token authenticated but is not permitted to" >&2
+              echo "read signing requests for organization $SIGNPATH_ORGANIZATION_ID." >&2
+              echo "Check the token's scope and which user it belongs to." >&2
+              ;;
+            404)
+              credential=bad
+              note_negative
+              echo "RESULT: 404 Not Found -- SIGNPATH_ORGANIZATION_ID does not name an" >&2
+              echo "organization this token can see. The id is a GUID from the portal URL," >&2
+              echo "not the organization's display name." >&2
+              ;;
+            "")
+              credential=unmeasured
+              note_unmeasured
+              echo "RESULT: COULD NOT MEASURE -- curl produced no HTTP status at all." >&2
+              echo "DNS, TLS, the proxy, or the runner's network. Nothing was learned" >&2
+              echo "about the credential; this is not a negative answer about it." >&2
+              ;;
+            *)
+              credential=unmeasured
+              note_unmeasured
+              echo "RESULT: COULD NOT MEASURE -- unexpected HTTP $http_code from SignPath." >&2
+              echo "Not a documented outcome of this route, so it says nothing either" >&2
+              echo "way about the token." >&2
+              ;;
+          esac
+          fi
+
+          if [[ "$credential" != "ok" ]]; then
+            echo "-- response body (first 40 lines) --" >&2
+            head -n 40 "$body_file" >&2 || true
+          fi
+
+          # ---- the project and signing-policy slugs ----
+          #
+          # The organization-scoped route above exercises the org id and the
+          # token and NOTHING else, which the old summary said plainly and then
+          # left as the end of the story: a mistyped project or signing-policy
+          # slug returns 200 there and fails at the first real release.
+          #
+          # Resolving them is a filtered read -- but a filtered read is only a
+          # measurement if the server actually applies the filter. An API that
+          # ignores an unknown query parameter answers 200 for a project that
+          # does not exist, and "200" would then mean "validated" for any string
+          # whatsoever. So each slug is probed TWICE: once as configured, and
+          # once with a slug that cannot exist. The verdict is the DIFFERENCE
+          # between the two answers, which is the only thing here that co-varies
+          # with the claim:
+          #
+          #   configured answers 200 with a signing-request list, no item in
+          #   which names a different slug, and the control is rejected
+          #                                    -> the filter is real and the
+          #                                       slug resolved.       RESOLVED
+          #   configured rejected, control rejected
+          #                                    -> the filter is real and the
+          #                                       slug did not resolve.  ABSENT
+          #   both 200 (or anything else)      -> the filter is not being
+          #                                       applied, the reply is not a
+          #                                       list, an item names another
+          #                                       slug, or the route does not
+          #                                       answer this question.
+          #                                                          UNMEASURED
+          #
+          # UNMEASURED is the honest answer when SignPath's API does not support
+          # this filter at all, and it is why this cannot report a slug as good
+          # on the strength of a route that never looked at it.
+          # ROUND 6. A CONTROL THAT DIFFERS IN MORE THAN ONE WAY MEASURES THE
+          # WRONG DIFFERENCE. The control slug was the fixed prefix
+          # `wenlan-no-such-project-` plus an epoch and a pid, so it differed
+          # from the configured slug in its LENGTH, its character content and
+          # its number of separators as well as in the one property the probe
+          # is about -- whether it names anything. A server with a length cap,
+          # a charset rule, or a rule about segments then rejects the control
+          # for its SPELLING, the affirmative arm below reads "configured 200,
+          # control rejected", and `resolved` is printed for a slug the server
+          # never looked up. The differential would have validated SYNTAX while
+          # reporting that it had validated EXISTENCE.
+          #
+          # The control is now the configured slug with every alphanumeric
+          # rotated one place: a->b, z->a, A->B, Z->A, 0->1, 9->0, and every
+          # other character left exactly where it is. Length, the position of
+          # every separator, and the character CLASS at every position are all
+          # identical to the configured slug, so any rule that admits the
+          # configured spelling admits this one, and the only difference left
+          # between the two requests is whether the slug names something.
+          #
+          # Two residuals, stated rather than closed. A rule about slug CONTENT
+          # rather than shape -- a required prefix, a reserved word, an
+          # allow-list of known projects -- can still separate the two, and
+          # nothing here can tell that apart from a genuine "no such slug". And
+          # the rotation could land on a slug that really does exist, in which
+          # case the control answers 200 and the pair reads `unmeasured`: still
+          # wrong, but wrong in the direction that refuses to claim.
+          #
+          # Neither slug is printed. Both are secrets, and a rotation of a
+          # secret is not a secret GitHub knows to mask.
+          rotate_slug() { printf '%s' "$1" | tr 'a-zA-Z0-9' 'b-zaB-ZA1-90'; }
+          project_probe="$(rotate_slug "$SIGNPATH_PROJECT_SLUG")"
+          policy_probe="$(rotate_slug "$SIGNPATH_SIGNING_POLICY_SLUG")"
+          project_state=unmeasured
+          policy_state=unmeasured
+          if [[ "$credential" == "ok" ]]; then
+            probe_body="$RUNNER_TEMP/signpath-probe.json"
+
+            # ROUND 6. THE BODY IS READ HERE TOO, AND SO ARE THE ITEMS.
+            # `slug_answer` reduced the response to its status line and threw
+            # the payload away, so `200` was affirmative whatever arrived with
+            # it: the proxy error page, the captive portal and the API rewrite
+            # that the credential arm rejects BY NAME three screens above all
+            # read as "this slug resolved" down here. The same POSITIVE shape
+            # assertion is now made on the slug replies -- a top-level array, or
+            # an object whose `values` or `items` IS an array -- and anything
+            # else is 2, could-not-measure, not 1.
+            #
+            # Then the items themselves, which nothing here has ever looked at.
+            # `$k` is the query parameter this very request filtered on, so an
+            # item carrying a field of that name is an item whose slug the
+            # server has told us; if any of them names something other than what
+            # was asked for, the filter was NOT applied and the 200 says nothing
+            # about the configured slug. This can only ever REFUTE. Items that
+            # carry no such field are no evidence either way -- SignPath's real
+            # envelope is unknown here, no token has ever existed -- and then
+            # the differential below carries the verdict by itself, exactly as
+            # it did before this check existed. It cannot manufacture an
+            # affirmative, only withdraw one.
+            slug_list_probe='
+              def envelope:
+                if type == "array" then .
+                elif type == "object" then
+                  if (.values | type) == "array" then .values
+                  elif (.items | type) == "array" then .items
+                  else empty end
+                else empty end;
+              envelope
+              | [ length,
+                  ( map(select(type == "object"
+                               and has($k)
+                               and (.[$k] | type) == "string"
+                               and .[$k] != $v))
+                    | length ) ]
+              | @tsv
+            '
+
+            # 0 = the server rejected this slug, 1 = it answered 200 with a
+            # signing-request list that contradicts nothing, 2 = it said
+            # something this cannot interpret.
+            #
+            # A transfer that failed goes to 2 for the same reason as above: the
+            # differential below is only a measurement if BOTH answers came from
+            # completed requests, and 2 on either side makes `resolve_slug`
+            # answer `unmeasured`, which is exactly what a probe nobody could
+            # complete deserves. With curl's status dropped, a timed-out
+            # configured probe that had already printed 200 and a control probe
+            # that really was rejected produced `resolved` -- the affirmative --
+            # off a request that never finished.
+            slug_answer() {
+              # $1 URL, $2 the query parameter it filtered on, $3 the value it
+              # asked for.
+              local code rc=0 parsed count wrong
+              code="$(signpath_get "$1" "$probe_body")" || rc=$?
+              if (( rc != 0 )); then
+                echo 2
+                return 0
+              fi
+              case "$code" in
+                400|404) echo 0; return 0 ;;
+                200)     ;;
+                *)       echo 2; return 0 ;;
+              esac
+              # `-r`, or `@tsv` comes back as a JSON string with a literal \t in
+              # it and neither field below is ever a number. Measured on this
+              # host with jq 1.8.2: without -r, `[]` yields the six characters
+              # "0\t0" and the digit test rejects every reply there is.
+              if ! parsed="$(jq -e -r --arg k "$2" --arg v "$3" \
+                    "$slug_list_probe" < "$probe_body" 2>/dev/null)"; then
+                echo 2
+                return 0
+              fi
+              # Two fields, asserted before either is read. `@tsv` over a
+              # two-element array always emits exactly one tab, so a reply with
+              # none of them is a reply this program did not produce -- and
+              # without the assertion `${parsed%%\t*}` and `${parsed##*\t}` BOTH
+              # return the whole string, so a lone `0` would set count=0 and
+              # wrong=0 and read as the affirmative. Same rule as the table
+              # parsers in scripts/lib/host-process.sh: refuse the shape rather
+              # than index into it and hope.
+              if [[ "$parsed" != *$'\t'* ]]; then
+                echo 2
+                return 0
+              fi
+              count="${parsed%%$'\t'*}"
+              wrong="${parsed##*$'\t'}"
+              if [[ ! "$count" =~ ^[0-9]+$ || ! "$wrong" =~ ^[0-9]+$ ]]; then
+                echo 2
+                return 0
+              fi
+              if (( wrong > 0 )); then
+                echo 2
+                return 0
+              fi
+              echo 1
+            }
+
+            resolve_slug() {
+              # $1 configured URL, $2 control URL, $3 the query parameter both
+              # of them filtered on, $4 the configured slug, $5 the control.
+              local real control
+              # A rotation that landed back on the configured slug -- a slug
+              # with no alphanumeric in it at all -- makes the two probes the
+              # SAME request, and a differential against itself is not one.
+              if [[ "$4" == "$5" ]]; then
+                echo unmeasured
+                return 0
+              fi
+              real="$(slug_answer "$1" "$3" "$4")"
+              control="$(slug_answer "$2" "$3" "$5")"
+              if [[ "$real" == "1" && "$control" == "0" ]]; then
+                echo resolved
+              elif [[ "$real" == "0" && "$control" == "0" ]]; then
+                echo absent
+              else
+                echo unmeasured
+              fi
+            }
+
+            project_state="$(resolve_slug \
+              "$base/SigningRequests?projectSlug=${SIGNPATH_PROJECT_SLUG}" \
+              "$base/SigningRequests?projectSlug=${project_probe}" \
+              projectSlug "$SIGNPATH_PROJECT_SLUG" "$project_probe")"
+            policy_state="$(resolve_slug \
+              "$base/SigningRequests?projectSlug=${SIGNPATH_PROJECT_SLUG}&signingPolicySlug=${SIGNPATH_SIGNING_POLICY_SLUG}" \
+              "$base/SigningRequests?projectSlug=${SIGNPATH_PROJECT_SLUG}&signingPolicySlug=${policy_probe}" \
+              signingPolicySlug "$SIGNPATH_SIGNING_POLICY_SLUG" "$policy_probe")"
+            rm -f "$probe_body"
+          fi
+
+          if [[ "$project_state" == "absent" || "$policy_state" == "absent" ]]; then
+            note_negative
+            echo >&2
+            echo "RESULT: a configured slug does not resolve." >&2
+            # if-blocks, not `[[ ]] && echo`: under `set -e` a false test at the
+            # head of an AND-list leaves the list non-zero, and this script's
+            # whole job is to reach its own summary and exit with a verdict.
+            if [[ "$project_state" == "absent" ]]; then
+              echo "  SIGNPATH_PROJECT_SLUG does not name a project this token can see." >&2
+            fi
+            if [[ "$policy_state" == "absent" ]]; then
+              echo "  SIGNPATH_SIGNING_POLICY_SLUG does not name a signing policy of that project." >&2
+            fi
+            echo "The release job would upload the installer and then fail at the" >&2
+            echo "signing request, after the ~40-minute bundle build." >&2
+          fi
+
+          # The third state, which until now had no consequence whatsoever. The
+          # differential probe above exists to answer `unmeasured` when the
+          # server does not apply the filter -- and that answer then exited 0
+          # and shared its headline with `resolved`. Gated on a credential that
+          # worked, because when it did not the slugs were never probed at all
+          # and the credential verdict already carries the run.
+          if [[ "$credential" == "ok" ]] \
+            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then
+            note_unmeasured
+            echo >&2
+            echo "RESULT: COULD NOT MEASURE a configured slug." >&2
+            if [[ "$project_state" == "unmeasured" ]]; then
+              echo "  SIGNPATH_PROJECT_SLUG: the impossible control slug was NOT rejected" >&2
+              echo "  differently from the configured one, so 200 here says nothing." >&2
+            fi
+            if [[ "$policy_state" == "unmeasured" ]]; then
+              echo "  SIGNPATH_SIGNING_POLICY_SLUG: same -- the filter was not applied," >&2
+              echo "  or this route does not answer the question." >&2
+            fi
+            echo "This is NOT 'the slugs are fine'. A mistyped slug looks exactly like" >&2
+            echo "this from here and fails at the first real signing request, after" >&2
+            echo "the ~40-minute bundle build. Confirm both in the SignPath portal" >&2
+            echo "until this run can tell the two apart." >&2
+          fi
+
+          # ---- the switch ----
+          #
+          # This is the state the whole workflow is for. Everything resolved,
+          # and the repository still not switched on: release.yml's
+          # SIGNPATH_REQUIRED is false, so a tag release skips every signing
+          # step, stages the ORIGINAL unsigned installer, hashes it, uploads it
+          # and finishes GREEN. Nothing in the release run says a word about it,
+          # which is exactly why this run must.
+          echo
+          echo "== Activation =="
+          if [[ "$credential" == "ok" && "$active" != "true" ]] \
+            && [[ "$project_state" != "resolved" || "$policy_state" != "resolved" ]]; then
+            # Accepted, off, and NOT fully verified. Telling an operator to
+            # throw the switch from here would make release.yml require a
+            # signed installer on the strength of slugs this run could not
+            # resolve: a recommendation carrying a measurement nobody took.
+            note_negative
+            echo "RESULT: ACCEPTED, NOT ACTIVATED, AND NOT FULLY VERIFIED." >&2
+            echo "The API accepted the organization id and the token, and" >&2
+            echo "vars.SIGNPATH_ACTIVE is '${SIGNPATH_ACTIVE:-unset}' -- not 'true'." >&2
+            echo "Do NOT switch signing on yet: the project and signing-policy slugs" >&2
+            echo "are not both resolved above (see 'What this run validated'), and" >&2
+            echo "SIGNPATH_REQUIRED=true with an unresolved slug fails every release" >&2
+            echo "after its ~40-minute bundle build. Settle the slugs first, then set" >&2
+            echo "the variable." >&2
+          elif [[ "$credential" == "ok" && "$active" != "true" ]]; then
+            note_negative
+            echo "RESULT: ACCEPTED BUT NOT ACTIVATED." >&2
+            echo "The API accepted this repository's SignPath credentials, and" >&2
+            echo "vars.SIGNPATH_ACTIVE is '${SIGNPATH_ACTIVE:-unset}' -- not 'true'." >&2
+            echo "release.yml therefore computes SIGNPATH_REQUIRED=false, and a tag" >&2
+            echo "release will skip every signing step and publish an UNSIGNED" >&2
+            echo "installer, green, with no other signal anywhere that it did." >&2
+            echo >&2
+            echo "Set the repository variable SIGNPATH_ACTIVE to the literal string" >&2
+            echo "'true' (Settings -> Secrets and variables -> Actions -> Variables)." >&2
+            echo "It is a variable and not a secret on purpose: a switch nobody can" >&2
+            echo "read back is a switch nobody can audit." >&2
+          elif [[ "$active" == "true" ]]; then
+            echo "  vars.SIGNPATH_ACTIVE is 'true': release.yml requires a signed"
+            echo "  installer and fails the Windows bundle job if the secrets are"
+            echo "  not all readable there."
+          else
+            echo "  vars.SIGNPATH_ACTIVE is not 'true': signing is not required."
+            echo "  That is only the intended state while the credentials do not"
+            echo "  work, which is what the section above measures."
+          fi
+
+          # Say plainly which fields this run actually tested, and say it from
+          # the variables that hold what happened rather than from a fixed list.
+          # A hard-coded summary is a claim that cannot be wrong about the run
+          # and therefore cannot be right about it either.
+          echo
+          echo "== What this run validated =="
+          describe() {
+            case "$2" in
+              ok|resolved) echo "  $1: validated against the SignPath API" ;;
+              bad|absent)  echo "  $1: REJECTED by the SignPath API" ;;
+              *)           echo "  $1: NOT validated -- this run could not measure it" ;;
+            esac
+          }
+          describe SIGNPATH_ORGANIZATION_ID "$credential"
+          describe SIGNPATH_API_TOKEN "$credential"
+          describe SIGNPATH_PROJECT_SLUG "$project_state"
+          describe SIGNPATH_SIGNING_POLICY_SLUG "$policy_state"
+          if [[ "$artifact_configuration" == "set" ]]; then
+            echo "  SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: presence only -- NOT validated"
+          else
+            echo "  SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: not set; the project's default"
+            echo "    artifact configuration in the portal will be used. release.yml"
+            echo "    uploads a ZIP artifact, so that default must have a <zip-file>"
+            echo "    root or the first real signing request fails. Not checkable"
+            echo "    from here -- confirm it in the portal."
+          fi
+
+          # The exit code says which of the three states the run ended in, and
+          # the line above it says the same thing in words: a reader who sees
+          # only the red X on a scheduled run must be able to tell "SignPath
+          # says no" from "this run learned nothing".
+          echo
+          case "$verdict" in
+            affirmative)
+              echo "VERDICT: everything this run looked at answered. Exiting 0."
+              status=0
+              ;;
+            negative)
+              echo "VERDICT: something answered NEGATIVELY above. Exiting 1." >&2
+              status=1
+              ;;
+            *)
+              echo "VERDICT: something COULD NOT BE MEASURED above -- this run does" >&2
+              echo "not know whether it is right or wrong. Exiting 2, which is neither" >&2
+              echo "the green of a validated setup nor the red of a rejected one." >&2
+              status=2
+              ;;
+          esac
+          exit "$status"

--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -90,12 +90,48 @@ Two consequences of choosing the Foundation tier, both worth knowing before appl
 
 Signing is a submission from inside the workflow, not a local `signtool` call: [`signpath/github-action-submit-signing-request`](https://github.com/SignPath/github-action-submit-signing-request) uploads the built installer, waits for the approval, and downloads the signed file. The pieces to add to `app-bundle-windows` in `release.yml`, in order:
 
-1. Upload `*-setup.exe` as a GitHub artifact and submit it, guarded on a `SIGNPATH_CONFIGURED` flag the way the macOS steps are guarded by `APPLE_SIGNING_CONFIGURED`, so a fork without the secret still builds. Raise the action's `wait-for-completion-timeout-in-seconds` past its 600-second default, because it is waiting for a person.
-2. **Set `output-artifact-directory`, and overwrite the built installer with what comes back.** The input is optional and its absence is silent: the action's manifest describes it as "Path where the signed artifact will be saved. If not specified, the task will not download the signed artifact from SignPath". *Stage app bundle assets and checksums* then finds the original unsigned `*-setup.exe` under `target/x86_64-pc-windows-msvc/release/bundle/nsis` exactly as it does today, and a green run publishes the unsigned file. Write the returned file back over that same path — note `skip-decompress` defaults to `false`, so the action extracts the returned archive into the directory — and fail the job if the path is not newer than the submission.
+1. Upload `*-setup.exe` as a GitHub artifact and submit it, guarded on a `SIGNPATH_CONFIGURED` flag the way the macOS steps are guarded by `APPLE_SIGNING_CONFIGURED`, so a fork without the secret still builds. `SIGNPATH_CONFIGURED` is derived from **all four** required secrets, not from the token alone — a sentinel that measures one fifth of what its name claims is a sentinel a reader will trust for the other four fifths. Raise the action's `wait-for-completion-timeout-in-seconds` past its 600-second default, because it is waiting for a person.
+2. **Set `output-artifact-directory`, and overwrite the built installer with what comes back.** The input is optional and its absence is silent: the action's manifest describes it as "Path where the signed artifact will be saved. If not specified, the task will not download the signed artifact from SignPath". *Stage app bundle assets and checksums* then finds the original unsigned `*-setup.exe` under `target/x86_64-pc-windows-msvc/release/bundle/nsis` exactly as it does today, and a green run publishes the unsigned file. Write the returned file back over that same path — note `skip-decompress` defaults to `false`, so the action extracts the returned archive into the directory — then prove the swap actually happened. Not by timestamp: `skip-decompress` extraction restores the archive entry’s own mtime, so a correctly signed installer can come back older than the file submitted, and a stale leftover can come back newer. Assert instead that exactly one `*-setup.exe` exists on each side, that the returned name matches the built one, and that its SHA-256 **differs** from the submitted file’s — identical bytes mean nothing was signed. `Get-AuthenticodeSignature` in step 5 is what makes the difference *authentic* rather than merely present.
 3. **Re-sign the updater artifact, with the key in scope.** The `.sig` beside the installer is computed over the unsigned bytes, so Authenticode signing invalidates it. Delete it and re-run `pnpm tauri signer sign`, the same repair the macOS path makes after stapling. `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` are `env:` on *Build Windows desktop app bundle* alone, so the new step needs its own copy of both or it cannot sign at all. Regenerating the sidecar `.sig` does not disturb the installer's Authenticode signature, but nothing else may touch those bytes after signing.
 4. Take the SHA-256 checksums from the signed installer, not the unsigned one.
-5. Verify with `Get-AuthenticodeSignature`: status must be `Valid` **and** the subject must be SignPath Foundation, so a silently skipped download cannot pass as a signed build. Guard it the same way.
+5. Verify with `Get-AuthenticodeSignature`: status must be `Valid` **and** the publisher must be SignPath Foundation, so a silently skipped download cannot pass as a signed build. Guard it the same way. Two details that are easy to get wrong and impossible to see afterwards:
+   - Compare with **`-cne`, not `-ne`**. PowerShell's `-ne`, `-eq` and `-like` are all case-**insensitive**, so a check written to demand one exact publisher name also accepts `signpath foundation` and every other casing. A certificate is an identity document.
+   - The comparison uses `GetNameInfo(SimpleName)`, which is the common name alone — a different full distinguished name carrying the same common name still passes. Closing that needs the real `Subject`, and nobody here has seen SignPath Foundation's certificate. So the step writes `Subject`, `Issuer` and `Thumbprint` to the run log **unconditionally and before the comparison**: the first signed build's log is the only place those values will ever appear, and the run that most needs them is the one that failed. Pin them afterwards (there is a `TODO` in the step saying so). Do not invent them in advance — a pinned string nobody has verified is a gate that fails the first real build for the wrong reason.
 6. Prove it on a clean machine through the first-run gauntlet's `windows-nsis` leg.
+
+### The switch: `vars.SIGNPATH_ACTIVE`
+
+Presence is not a requirement. `SIGNPATH_CONFIGURED` answers "are the secrets here"; it cannot answer "were they supposed to be", and the difference is the whole hole:
+
+> Every signing step in `app-bundle-windows` is guarded on `SIGNPATH_CONFIGURED`. With no secrets, all five skip, the ORIGINAL unsigned installer is staged, hashed, uploaded — and the job is green. Today that is correct: the application is pending and every fork is in this state. The day the Foundation accepts the application, a repository whose secrets were never installed (or were installed on an environment this job does not use, or resolve as empty) produces **exactly the same green unsigned release**.
+
+So `release.yml` computes a second, independent sentinel:
+
+```yaml
+SIGNPATH_CONFIGURED: ${{ secrets.SIGNPATH_API_TOKEN != '' && secrets.SIGNPATH_ORGANIZATION_ID != '' && secrets.SIGNPATH_PROJECT_SLUG != '' && secrets.SIGNPATH_SIGNING_POLICY_SLUG != '' }}
+SIGNPATH_REQUIRED: ${{ github.repository == '7xuanlu/wenlan' && vars.SIGNPATH_ACTIVE == 'true' }}
+```
+
+`vars.` and not `secrets.`, deliberately: a secret's value cannot be read back by a human or printed in a log, so a switch stored as a secret is a switch nobody can audit. It is compared to the literal `'true'`, so `false`, `0`, `no` and `TRUE` all read as off.
+
+The unguarded *Check SignPath configuration is all-or-nothing, and present when required* step near the top of the job then fails the build when `SIGNPATH_REQUIRED` is true and the four secrets are not all readable, naming each missing one. It runs before the ~40-minute bundle build, so a misconfigured repository is told in seconds. The four combinations:
+
+| `SIGNPATH_REQUIRED` | `SIGNPATH_CONFIGURED` | Result |
+|---|---|---|
+| false | false | green, unsigned installer, stated in the log. Today's upstream state and every fork's. |
+| false | true | green, signed. Signing works before the switch is thrown; the switch only makes it mandatory. |
+| true | true | green, signed. The intended end state. |
+| true | false | **the job fails before building**, naming each missing secret. Never publishes an unsigned installer. |
+
+**Turning signing on is therefore two actions, not one**: install the four secrets, then set the repository variable `SIGNPATH_ACTIVE` to `true` (Settings → Secrets and variables → Actions → Variables). Doing only the first leaves a repository that signs but would silently stop signing if a secret were removed; doing only the second fails the next release loudly, which is the safe half.
+
+`.github/workflows/signpath-status.yml` is what stops the gap between those two actions from lasting. It runs weekly on a schedule as well as on demand, and it reports three states that used to be one:
+
+- **nothing wired** — reported, exits 0. An unwired fork and an unwired upstream are both the expected steady state, and it says explicitly that whether the Foundation has *accepted* the application is UNMEASURED, not "pending".
+- **accepted but not activated** — the API accepts the credentials and `vars.SIGNPATH_ACTIVE` is not `'true'`. **Red**, because this is precisely the state in which a tag release ships a green unsigned installer.
+- **could not measure** — an HTTP 200 whose body does not parse, no HTTP status at all, or an undocumented status. Its own verdict, never folded into success. It previously reported a malformed 200 as "still a working credential", which is a claim about a payload nobody could read.
+
+It also resolves the project and signing-policy slugs rather than asserting them, and does it by **differential probe**: each slug is queried as configured and again with a slug that cannot exist, and only a *difference* between the two answers counts as a measurement. If the API ignores the filter, both answers are identical and the slug is reported UNMEASURED — never validated on the strength of a route that never looked at it.
 
 Two limits to plan around.
 

--- a/scripts/negative-controls/authenticode-step-receipt.py
+++ b/scripts/negative-controls/authenticode-step-receipt.py
@@ -1,0 +1,933 @@
+"""Receipt for the release Authenticode gate's BEHAVIOURAL contract.
+
+Round 13 finding 1: `Verify the installer carries a valid SignPath signature`
+was held by substring markers only. `exit 0` at the top of its body leaves
+every marker in place, satisfies the static contract, and publishes an unsigned
+installer -- the same failed-measurement-reads-as-a-pass shape the whole
+workstream is about, sitting in the gate meant to catch it.
+
+Round 13b reopened it. The fix above was itself the same defect one level up:
+when the signed-binary fixture was unavailable -- which is the state of the
+Ubuntu `docs` job that actually runs this suite in CI, via
+`validate-versions.test.sh` at ci.yml:2169 -- the harness printed UNCHECKED,
+skipped EVERY mutation, and exited 0. A gate that cannot run reported as a gate
+that ran.
+
+Round 13e reopened it a third time, one level further out again: the arm that
+decides when an unmeasured row may be EXCUSED was itself read off an exit
+status alone, so a probe that crashed with status 2 was classified as a host
+that cannot do Authenticode -- and the receipt could not have seen it, because
+the receipt produced the arms by substituting the classification's own answer.
+
+So this receipt now measures seven things, not one:
+
+  1. the truth table, run for real against produced signature states;
+  2. every mutation a row on THIS host can catch, caught;
+  3. the degraded host: with the fixture removed, the `missing` row still runs,
+     still catches the top-of-body `exit 0`, and the mutations it cannot catch
+     are named UNCHECKED rather than skipped in silence;
+  4. the metadata gate: `continue-on-error: true` on any signing step -- as a
+     token AND as a decoded YAML property, which is the only form that can see
+     a merge key -- and the removal of `shell: pwsh` or the SIGNPATH_CONFIGURED
+     guard, all rejected: none of which any body-level assertion can see; plus
+     the gate's own no-parser fallback, driven with PyYAML forced absent,
+     because the CI lane that runs this suite installs nothing and a fallback
+     that reports "clean" about an input it cannot read is this workstream's
+     defect wearing a dependency's clothes;
+  5. environment invariance: the same row run under the release's environment,
+     under none of it and under all of it wrong, which is the only form of this
+     property that a drive name assembled at runtime cannot walk past;
+  6. the capability probe's own classification, driven by a stub shell rather
+     than by substituting its answer, including every way it can fail to
+     answer at all;
+  7. the suite's refusal on all four arms of that classification.
+
+Run: python3 scripts/negative-controls/authenticode-step-receipt.py
+"""
+
+from __future__ import annotations
+
+import atexit
+import importlib.util
+import re
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+TEST = ROOT / "scripts" / "release-workflow-contract.test.py"
+
+#: The terminal completion marker. Last line, unconditionally. Every early
+#: `sys.exit` above it is a refusal that this receipt could not be produced --
+#: which is what the aggregate runner needs to be able to tell apart from a
+#: receipt that finished and found nothing.
+MARKER = "NEGATIVE-CONTROL COMPLETE"
+HARNESS = "authenticode-step-receipt.py"
+STARTED = time.time()
+_ABORT_STARTED = time.time()
+
+
+#: ROUND 3 (Codex Sol), FINDING N7. Set immediately before the completion
+#: marker is printed. Every OTHER way out of this file -- an early
+#: `sys.exit("...")` refusal, an unhandled exception, a signal, a watchdog kill
+#: -- leaves it False, and the handler below says so. A transcript that simply
+#: stops is the one thing a reader cannot tell from a transcript that finished.
+_COMPLETED = False
+
+
+@atexit.register
+def _abort_marker():
+    if _COMPLETED:
+        return
+    # stderr first: an early `sys.exit("...")` writes its message there, and the
+    # aggregate runner reads the LAST non-empty line of the two merged.
+    sys.stderr.flush()
+    print('NEGATIVE-CONTROL ABORTED %s elapsed=%.1fs'
+          % (HARNESS, time.time() - _ABORT_STARTED))
+    print('  This run did not reach its own summary. Nothing above it is a '
+          'result about this harness.')
+    sys.stdout.flush()
+
+
+spec = importlib.util.spec_from_file_location("release_contract_test", TEST)
+if spec is None or spec.loader is None:
+    sys.exit(f"cannot load {TEST}")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+release = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+failures: list[str] = []
+
+#: The two subjects, as they were when this run started. This takes about six
+#: minutes, which is long enough for another lane to land an edit halfway
+#: through -- and then the arms scored before it and the arms scored after it
+#: are about different files, with nothing in the transcript to say so. That is
+#: not hypothetical here: the sibling POSIX harness aborted twice for exactly
+#: this reason while these were being repaired. Checked once at the end, because
+#: a change anywhere in the run invalidates the whole run, not part of it.
+#:
+#: ROUND 4. These are compared as BYTES, and that is not fastidiousness. The
+#: obvious spelling -- `read_text()` on both sides -- reads in text mode, and
+#: text mode applies universal newlines: it turns \r\n into \n before the
+#: comparison ever happens. A guard written that way cannot see a line-ending
+#: conversion at all, and it reports "unchanged" over a file whose bytes on
+#: disk are different. That is this directory's own defect, a failed
+#: measurement indistinguishable from a negative one, inside the guard written
+#: to catch exactly that.
+#:
+#: It is also not theoretical for these two files. Another lane rewrote six
+#: files today through Python's text-mode write, which performs the same
+#: translation in reverse, and `scripts/release-workflow-contract.test.py` --
+#: one of the two subjects below -- went to 4695 CRLF line endings and back.
+#: A text-mode guard would have called that run clean.
+_SUBJECTS = {
+    ".github/workflows/release.yml": (ROOT / ".github/workflows/release.yml").read_bytes(),
+    "scripts/release-workflow-contract.test.py": TEST.read_bytes(),
+}
+
+
+def _subjects_unchanged() -> None:
+    for rel, before in _SUBJECTS.items():
+        now = (ROOT / rel).read_bytes()
+        if now != before:
+            detail = ""
+            if now.replace(b"\r\n", b"\n") == before.replace(b"\r\n", b"\n"):
+                crlf = b"\r\n"
+                detail = (
+                    f" Only the line endings moved: {before.count(crlf)} CRLF "
+                    f"before, {now.count(crlf)} now."
+                )
+            sys.exit(
+                f"FATAL: {rel} changed during the run. Arms scored before the "
+                "edit and after it are about different files; nothing above "
+                f"this line is a result about either.{detail}"
+            )
+
+shell = mod._powershell()
+print(f"powershell: {shell or 'NONE'}")
+if shell is None:
+    sys.exit("UNCHECKED: no PowerShell on this host; the table cannot run here")
+
+# ---------------------------------------------------------------- 1. the table
+run = mod.authenticode_behaviour_violations(release)
+rows = mod.AUTHENTICODE_TRUTH_TABLE
+print(f"\ntruth table ({len(rows)} rows), against real signature states:")
+for description, kind, status, required in rows:
+    bad = [v for v in run.violations if description in v]
+    skipped = [u for u in run.unchecked if description in u]
+    mark = "UNCHECKED" if skipped else ("FAIL" if bad else "ok")
+    print(f"  {mark:9} exit {status}  {kind:9} {description}")
+    for line in bad + skipped:
+        print(f"            {line}")
+if run.violations:
+    failures.append(f"{len(run.violations)} truth-table violation(s)")
+print(f"  rows that ran: {sorted(run.ran) or 'none'}")
+
+# ------------------------------------------------------------ 2. the mutations
+print(f"\nmutations ({len(mod.AUTHENTICODE_MUTATIONS)}), on this host:")
+for old, new, catchers, why in mod.AUTHENTICODE_MUTATIONS:
+    live = catchers & run.ran
+    if release.count(old) != 1:
+        failures.append(f"stale mutation fixture: {why}")
+        print(f"  STALE     {why}: matched {release.count(old)} times")
+        continue
+    if not live:
+        print(f"  UNCHECKED {why}: needs one of {sorted(catchers)}")
+        continue
+    mutant = mod.authenticode_behaviour_violations(release.replace(old, new, 1))
+    if not live <= mutant.ran:
+        failures.append(f"mutation of {why} stopped rows from running")
+        print(f"  BROKEN    {why}: {sorted(live - mutant.ran)} never ran")
+    elif live <= mutant.failed:
+        # EVERY claimed catcher failed, not merely one. The catcher set is what
+        # the UNCHECKED accounting rests on, so it has to be exact: too
+        # generous and a fixture-free host reports "enforced" over a mutation
+        # nothing there can see.
+        print(f"  caught    {why}  <- {sorted(live)}")
+    else:
+        failures.append(f"claimed catcher did not catch: {why}")
+        print(f"  MISSED    {why}: {sorted(live - mutant.failed)} claim to catch it "
+              f"and did not")
+
+# ------------------------------------------------- 3. the degraded (Linux) host
+#
+# The Ubuntu lane has no Authenticode at all, so `_signed_fixture` answers
+# "no-support" there -- the incapacity arm, not the broken-probe arm (round 13d
+# replaced the OS proxy with that distinction). Reproduce that state here by
+# stubbing it, and require that what CAN still be measured IS still measured.
+# This is the round-13b finding: before the fix, this whole section was one
+# silent `else`.
+print("\ndegraded host (no Authenticode support, as on the Ubuntu `docs` lane):")
+real_fixture = mod._signed_fixture
+mod._signed_fixture = lambda shell, work: ("no-support", None, None)
+try:
+    bare = mod.authenticode_behaviour_violations(release)
+    if bare.ran != {"missing"}:
+        failures.append(f"degraded host ran {sorted(bare.ran)}, expected ['missing']")
+    print(f"  rows that ran:       {sorted(bare.ran) or 'none'}")
+    print(f"  rows unchecked:      {len(bare.unchecked)}")
+    if bare.violations:
+        failures.append("degraded host reported violations on unmutated release.yml")
+        for line in bare.violations:
+            print(f"  FAIL      {line}")
+    checked = 0
+    # ROUND 3 (Codex Sol), FINDING N8. The four refusal arms below used to
+    # compare the number of mutations the suite named as unchecked against the
+    # literal 3. That literal was written when the mutation table had four rows;
+    # a fifth landed (the case-SENSITIVE publisher comparison) and the arms
+    # started failing with "named 4, expected 3" -- a stale constant reporting
+    # as a defect. The number is not a constant: it is exactly the set of
+    # mutations no still-running row can catch, which is measured right here.
+    UNCHECKABLE_WITHOUT_A_FIXTURE: list[str] = []
+    for old, new, catchers, why in mod.AUTHENTICODE_MUTATIONS:
+        live = catchers & bare.ran
+        if not live:
+            UNCHECKABLE_WITHOUT_A_FIXTURE.append(why)
+            print(f"  UNCHECKED {why}")
+            continue
+        mutant = mod.authenticode_behaviour_violations(release.replace(old, new, 1))
+        if live <= mutant.failed:
+            checked += 1
+            print(f"  caught    {why}  <- {sorted(live)}")
+        else:
+            failures.append(f"degraded host missed: {why}")
+            print(f"  MISSED    {why}")
+    if checked != 1:
+        failures.append(
+            f"degraded host enforced {checked} mutation(s); it must enforce exactly "
+            "the one the `missing` row can catch, or CI's Ubuntu lane is a free pass"
+        )
+finally:
+    mod._signed_fixture = real_fixture
+if not UNCHECKABLE_WITHOUT_A_FIXTURE:
+    # If nothing were unchecked on a fixture-free host, the refusal arms below
+    # would be comparing two empty lists and could not fail. Say so rather than
+    # print four `ok`s that mean nothing.
+    failures.append(
+        "a fixture-free host reported nothing unchecked; the four refusal arms "
+        "below would then assert an empty set against an empty set"
+    )
+
+# ------------------------------------------------------------- 4. the metadata
+print("\nstep metadata (invisible to every body-level assertion):")
+if mod.authenticode_step_metadata_violations(release):
+    failures.append("metadata gate rejects the shipped release.yml")
+    for line in mod.authenticode_step_metadata_violations(release):
+        print(f"  FAIL      {line}")
+else:
+    print("  ok        shipped release.yml is clean")
+# Spliced inside the job, not into the whole file: several of these names also
+# exist in the macOS and Linux jobs, and a whole-file replace would mutate
+# whichever came first -- a mutation applied somewhere the contract does not
+# look, reported as a contract that did not notice.
+job_text = mod.job_body(release, "app-bundle-windows")
+job_at = release.index(job_text)
+job_end = job_at + len(job_text)
+
+# ROUND 3 (Codex Sol), FINDING N8. This used to be `mod.SIGNING_STEPS` plus a
+# hand-written UNLISTED_STEPS tuple whose own comment claimed it covered "every
+# step in the job, not a hand-listed four". It was a hand-list of five, and it
+# went stale the moment someone renamed a step: the concurrent SIGNPATH_REQUIRED
+# work renamed "Check SignPath configuration is all-or-nothing" to "... , and
+# present when required", and this receipt reported STALE for it -- which is the
+# right noise, but only because the mismatch happened to be a rename rather than
+# an ADDITION. A step added to the job would simply not have appeared here, and
+# nothing would have said so.
+#
+# So the job is the authority for which steps exist. Every `- name:` in it gets
+# the mutation, the list cannot fall behind the workflow, and a new step is
+# covered on the day it lands.
+STEP_NAME = re.compile(r"(?m)^      - name: (.+)$")
+JOB_STEPS = STEP_NAME.findall(job_text)
+if not JOB_STEPS:
+    failures.append(
+        "no steps parsed out of app-bundle-windows; the metadata section would "
+        "have run zero mutations and reported a clean sweep"
+    )
+    print("  BROKEN    no `- name:` steps found in the job")
+_dupes = sorted({n for n in JOB_STEPS if JOB_STEPS.count(n) > 1})
+if _dupes:
+    # Two steps with one name make `replace(..., 1)` mutate the first and leave
+    # the second, so the row would report on a workflow nobody wrote.
+    failures.append(f"duplicate step names in app-bundle-windows: {_dupes}")
+    print(f"  BROKEN    duplicate step name(s): {_dupes}")
+    JOB_STEPS = [n for n in JOB_STEPS if n not in _dupes]
+# The suite keeps its own list of the steps whose failure must never be
+# discarded. If one of those names is not a step in the job, the suite is
+# guarding a step that no longer exists -- report it here rather than let the
+# suite's rule quietly cover nothing.
+_absent = [s for s in mod.SIGNING_STEPS if s not in JOB_STEPS]
+if _absent:
+    failures.append(
+        f"the suite's SIGNING_STEPS names {_absent}, which are not steps in "
+        "app-bundle-windows; its metadata rule guards nothing for them"
+    )
+    print(f"  STALE     SIGNING_STEPS entries absent from the job: {_absent}")
+metadata_caught = 0
+fallback_cases = 0
+env_caught = 0
+for name in JOB_STEPS:
+    marker = f"- name: {name}\n"
+    if job_text.count(marker) != 1:
+        failures.append(f"stale continue-on-error fixture for {name!r}")
+        print(f"  STALE     {name!r} matched {job_text.count(marker)} times in the job")
+        continue
+    # Round 13d: the rule recognised one YAML spelling of the key, so a quoted
+    # key -- identical to YAML, invisible to the regex -- discarded the failure
+    # of a signing step with every control still green.
+    #
+    # Round 13e, reopened finding 1, third bullet: `"continue-on-error"`
+    # decodes to the same key and contains no matching token at all, because
+    # YAML processes escapes inside a double-quoted scalar (YAML 1.2.2 5.7).
+    # `lexical` records which rule is expected to do the work, so this row
+    # cannot quietly be credited to the token scan.
+    for spelling, label, lexical in (
+        ("        continue-on-error: true\n", "", True),
+        ('        "continue-on-error": true\n', "quoted ", True),
+        ('        "continue-on-\\u0065rror": true\n', "escaped ", False),
+    ):
+        mutated = (
+            release[:job_at]
+            + job_text.replace(marker, marker + spelling, 1)
+            + release[job_end:]
+        )
+        listed = "" if name in mod.SIGNING_STEPS else "  (not on the suite's own list)"
+        seen_by_token = "continue-on-error" in mod.job_body(
+            mutated, "app-bundle-windows"
+        )
+        if seen_by_token != lexical:
+            failures.append(
+                f"{label}continue-on-error on {name!r}: the token scan "
+                f"{'does' if seen_by_token else 'does not'} see it, which is not "
+                "what this row claims"
+            )
+            print(f"  BROKEN    {label}continue-on-error on {name!r}: wrong rule")
+        elif mod.authenticode_step_metadata_violations(mutated):
+            metadata_caught += 1
+            print(f"  caught    {label}continue-on-error on {name!r}{listed}")
+        else:
+            failures.append(f"{label}continue-on-error accepted on {name!r}")
+            print(f"  MISSED    {label}continue-on-error on {name!r}")
+
+header = f"      - name: {mod.AUTHENTICODE_STEP}\n"
+start = release.index(header) + len(header)
+body = mod.named_step_body(mod.job_body(release, "app-bundle-windows"), mod.AUTHENTICODE_STEP)
+end = release.index(body, start) + len(body)
+region = release[start:end]
+for line, why in (
+    ("        shell: pwsh\n", "shell: pwsh removed"),
+    ("        if: env.SIGNPATH_CONFIGURED == 'true'\n", "SIGNPATH_CONFIGURED guard removed"),
+):
+    mutated = release[:start] + region.replace(line, "", 1) + release[end:]
+    if mod.authenticode_step_metadata_violations(mutated):
+        metadata_caught += 1
+        print(f"  caught    {why}")
+    else:
+        failures.append(f"accepted: {why}")
+        print(f"  MISSED    {why}")
+
+# Round 13e, reopened finding 1: the rule above is a scan for the TOKEN inside
+# the job's text, and a YAML merge key puts the property on a step without the
+# token appearing there. Both halves are measured here -- that the token scan
+# is blind to it, which is why the parsed rule had to exist, and that the
+# parsed rule catches it.
+print("\ncontinue-on-error carried in by a merge key:")
+merge_anchor = f"      - name: {mod.AUTHENTICODE_STEP}\n"
+if release.count(merge_anchor) != 1:
+    failures.append(f"stale merge-key anchor: matched {release.count(merge_anchor)}")
+    print(f"  STALE     anchor matched {release.count(merge_anchor)} times")
+else:
+    for where, injected, prelude in (
+        ("the verification step", merge_anchor + "        <<: *swallow\n",
+         "x-swallow: &swallow\n  continue-on-error: true\n"),
+        ("the app-bundle-windows job itself", merge_anchor,
+         "x-swallow: &swallow\n  continue-on-error: true\n"),
+    ):
+        merged = prelude + release.replace(merge_anchor, injected, 1)
+        if where.endswith("itself"):
+            job_anchor = "  app-bundle-windows:\n"
+            if merged.count(job_anchor) != 1:
+                failures.append("stale job anchor for the merge-key control")
+                print("  STALE     job anchor")
+                continue
+            merged = merged.replace(job_anchor, job_anchor + "    <<: *swallow\n", 1)
+        blind = "continue-on-error" not in mod.job_body(merged, "app-bundle-windows")
+        caught = [
+            v for v in mod.authenticode_step_metadata_violations(merged)
+            if "decodes with continue-on-error" in v
+        ]
+        if not blind:
+            failures.append(f"merge-key control on {where} is not the case it claims")
+            print(f"  BROKEN    {where}: the token IS in the job; this proves nothing")
+        elif not caught:
+            failures.append(f"a merge key put continue-on-error on {where} unnoticed")
+            print(f"  MISSED    {where}")
+        else:
+            metadata_caught += 1
+            print(f"  caught    {where}, with the token nowhere in the job text")
+    # The parsed rule is the one that can be switched off by an absent
+    # dependency, so say out loud which one ran.
+    try:
+        import yaml as _yaml  # noqa: F401
+
+        print("  note      the parsed rule ran here; PyYAML is installed")
+    except ImportError:  # pragma: no cover - reported, never silent
+        failures.append("PyYAML is absent, so the parsed rule did not run at all")
+        print("  UNCHECKED PyYAML is absent; only the token scan ran")
+
+    # The parsed rule can be switched off by an absent dependency, and the CI
+    # lane that runs this suite -- the Ubuntu `docs` job, through
+    # validate-versions.test.sh -- installs nothing. So the fallback is itself a
+    # measurement that has to be measured. Its failure mode is the whole
+    # workstream's: reporting a clean job it could not read. It names the two
+    # constructs the token scan is blind to, and this section drives each of
+    # them with the parser forced absent.
+    #
+    # `sys.modules["yaml"] = None` makes `import yaml` raise ImportError inside
+    # the function without unloading the real module from anywhere else.
+    print("\nthe no-parser fallback (PyYAML forced absent):")
+    escaped_job = release.replace(
+        merge_anchor,
+        merge_anchor + '        "continue-on-\\u0065rror": true\n',
+        1,
+    )
+    alias_job = "x-swallow: &swallow\n  continue-on-error: true\n" + release.replace(
+        merge_anchor, merge_anchor + "        <<: *swallow\n", 1
+    )
+    _real_yaml = sys.modules.get("yaml", "absent")
+    sys.modules["yaml"] = None  # type: ignore[assignment]
+    try:
+        for label, text, want_report in (
+            ("the shipped file", release, False),
+            ("a job carrying a merge key", alias_job, True),
+            ("a job with a backslash-escaped key", escaped_job, True),
+        ):
+            body = mod.job_body(text, "app-bundle-windows")
+            reported = [
+                v
+                for v in mod.continue_on_error_violations(text, body)
+                if "unmeasured, not clean" in v
+            ]
+            if bool(reported) != want_report:
+                failures.append(
+                    f"the no-parser fallback {'stayed silent about' if want_report else 'complained about'} "
+                    f"{label}"
+                )
+                print(
+                    f"  {'MISSED' if want_report else 'FALSE+':9s} {label}: "
+                    f"{len(reported)} report(s), wanted {'one' if want_report else 'none'}"
+                )
+            else:
+                # Counted apart from metadata_caught: these are not mutations of
+                # the workflow that the gate caught, they are the fallback
+                # refusing to report on an input it cannot read. Folding them in
+                # would make the summary's arithmetic a total nobody can check.
+                fallback_cases += 1
+                print(
+                    f"  {'caught' if want_report else 'silent':9s} {label}"
+                    + ("" if want_report else "  <- nothing here needs a parser")
+                )
+    finally:
+        if _real_yaml == "absent":
+            sys.modules.pop("yaml", None)
+        else:
+            sys.modules["yaml"] = _real_yaml  # type: ignore[assignment]
+
+# The one mutation the truth table structurally CANNOT see, because the table
+# is what supplies the environment: a branch on a variable that is unset here
+# and set in the release. Every row green here, and a gate that never runs where
+# it matters. Caught statically, so a fixture-free host catches it too.
+print("\nenvironment-keyed early returns (invisible to a table that sets the environment):")
+anchor = '          $ErrorActionPreference = "Stop"\n'
+if region.count(anchor) != 1:
+    failures.append(f"stale insertion anchor: matched {region.count(anchor)} times")
+    print(f"  STALE     anchor matched {region.count(anchor)} times")
+else:
+    for inserted, why in (
+        ("          if ($env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }\n",
+         "exit 0 under the release's own guard variable"),
+        ("          if ($env:CI -eq 'true') { exit 0 }\n",
+         "exit 0 on a CI runner"),
+        ("          if ($env:RUNNER_OS -eq 'Windows') { exit 0 }\n",
+         "exit 0 on the only OS this job runs on"),
+        ("          if ($env:GITHUB_JOB -eq 'app-bundle-windows') { exit 0 }\n",
+         "exit 0 in the only job that runs it"),
+        ("          Write-Host \"ref $env:GITHUB_REF\"\n",
+         "any other read of the environment at all"),
+        # Round 13d: the rule was a case-sensitive regex for ONE spelling, so
+        # every one of these walked past it. They are the same read.
+        ("          if ($Env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }\n",
+         "the same read spelled $Env:"),
+        ("          if (${env:SIGNPATH_CONFIGURED} -eq 'true') { exit 0 }\n",
+         "the same read spelled ${env:...}"),
+        ("          if ((Get-Item Env:SIGNPATH_CONFIGURED).Value -eq 'true') { exit 0 }\n",
+         "the same read through the Env: drive"),
+        ("          if ([System.Environment]::GetEnvironmentVariable("
+         "'SIGNPATH_CONFIGURED') -eq 'true') { exit 0 }\n",
+         "the same read through [System.Environment]"),
+    ):
+        mutated = (
+            release[:start] + region.replace(anchor, anchor + inserted, 1) + release[end:]
+        )
+        if mod.authenticode_step_metadata_violations(mutated):
+            env_caught += 1
+            print(f"  caught    {why}")
+        else:
+            failures.append(f"accepted: {why}")
+            print(f"  MISSED    {why}")
+    # And the environment the rows DO run in is the release's, so even without
+    # the static scan the first of those would now be caught by every row.
+    guarded = (
+        release[:start]
+        + region.replace(
+            anchor,
+            anchor + "          if ($env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }\n",
+            1,
+        )
+        + release[end:]
+    )
+    run_guarded = mod.authenticode_behaviour_violations(guarded)
+    if run.ran and run.ran <= run_guarded.failed:
+        print(f"  caught    the same mutation at runtime  <- {sorted(run.ran)}")
+    else:
+        failures.append(
+            "the truth table ran the body without the release job's environment; "
+            f"rows that failed: {sorted(run_guarded.failed) or 'none'}"
+        )
+        print("  MISSED    the same mutation at runtime")
+
+# ------------------------- 5. the property no reading of the body can settle
+#
+# Round 13e, reopened finding 1 and new finding 3: every guard on the body was
+# lexical, and PowerShell can assemble the drive name at runtime. Nothing that
+# reads text catches `('E' + 'nv:GITHUB_WORKFLOW_REF')`. Running the step three
+# times under three environments does, and `lexical` below records which rule is
+# expected to do the work so the semantic one cannot be credited for a catch the
+# scan made anyway.
+print("\nenvironment invariance, by running the step (not by reading it):")
+base_invariance = mod.authenticode_environment_invariance(release)
+if base_invariance.violations:
+    failures.append("the shipped step's outcome already depends on the environment")
+    for line in base_invariance.violations:
+        print(f"  FAIL      {line}")
+else:
+    print(f"  ok        shipped release.yml is invariant over {base_invariance.ran}")
+for line in base_invariance.unchecked:
+    print(f"  UNCHECKED {line}")
+if not base_invariance.ran:
+    failures.append("environment invariance ran no rows at all")
+for inserted, why, lexical in (
+    ("          if ($env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }\n",
+     "the plain spelling, which the scan also catches", True),
+    ("          if ((Get-Item ('E' + 'nv:GITHUB_WORKFLOW_REF')).Value) { exit 0 }\n",
+     "a drive name assembled at runtime", False),
+    ("          $n = [char]69 + 'nv:CI'; if ((Get-Item $n).Value) { exit 0 }\n",
+     "a drive name built from a character code", False),
+    ("          $d = 'E'; $d += 'nv:GITHUB_JOB'; if (Test-Path $d) { exit 0 }\n",
+     "a drive path accumulated into a variable and tested, never read", False),
+):
+    if region.count(anchor) != 1:
+        break
+    mutated = release[:start] + region.replace(anchor, anchor + inserted, 1) + release[end:]
+    seen_by_scan = bool(mod.authenticode_body_env_violations(mutated))
+    caught = bool(mod.authenticode_environment_invariance(mutated).violations)
+    if seen_by_scan != lexical:
+        failures.append(
+            f"{why}: the lexical scan {'does' if seen_by_scan else 'does not'} "
+            "see it, which is not what this row claims"
+        )
+        print(f"  BROKEN    {why}: wrong rule")
+    elif not caught:
+        failures.append(f"environment invariance did not notice {why}")
+        print(f"  MISSED    {why}")
+    else:
+        env_caught += 1
+        print(f"  caught    {why}"
+              + ("" if lexical else "  <- only the running property sees this"))
+
+
+def _stub_shell(directory: Path, name: str, lines: tuple[str, ...], status: int) -> str:
+    """A stand-in for PowerShell that answers with exactly these bytes.
+
+    Round 13e, new finding 4. Every arm below used to be produced by replacing
+    `_signed_fixture` outright with `return ("no-support", None, None)`, which
+    measures the CALLER's handling of an answer nobody computed. The thing that
+    was wrong lived inside the replaced function -- it read the arm off an exit
+    status alone, so a probe that crashed with status 2 arrived spelled
+    "no-support", the one answer allowed to excuse an unmeasured row -- and a
+    receipt that substitutes the answer could not have seen it.
+
+    What a host actually supplies is a PowerShell. That is the input, so that
+    is what is stubbed, and the classification under test is the shipped one.
+    """
+    path = directory / f"{name}.cmd"
+    body = "@echo off\r\n" + "".join(f"{line}\r\n" for line in lines)
+    # write_BYTES, not write_text. On Windows, text mode translates every "\n"
+    # on its way to disk, and `body` already carries CRLF, so the obvious
+    # spelling wrote "\r\r\n" on every line: measured on this host, 56 bytes
+    # where 53 were meant, three doubled terminators in a four-line file. The
+    # docstring above says this stub "answers with exactly these bytes"; text
+    # mode made that sentence false. cmd.exe tolerates the doubling, which is
+    # exactly why it survived -- the harness stayed green while the file on
+    # disk was not the file this function claims to write. The same reasoning
+    # as the byte-comparison guard at the top: where the bytes are the point,
+    # do not let the runtime edit them.
+    path.write_bytes((body + f"exit /b {status}\r\n").encode("ascii"))
+    return str(path)
+
+
+# (description, what the stub prints, its exit status, the capability it must
+# be classified as). The four rows that must come out "probe-failed" are the
+# finding: every one of them was "no-support" under the status-only rule.
+CLASSIFICATION = (
+    ("the cmdlet is absent", ("echo NO-SUPPORT cmdlet-absent",), 2, "no-support"),
+    ("the cmdlet throws on this platform",
+     ("echo NO-SUPPORT cmdlet-unusable",), 2, "no-support"),
+    ("the search found nothing signed", ("echo NONE-FOUND",), 1, "none-found"),
+    ("a signed binary was found",
+     ("echo FIXTURE\tC:\\w\\stub.exe\tContoso Ltd",), 0, "fixture"),
+    ("the probe died saying nothing", (), 2, "probe-failed"),
+    ("the probe died with a message",
+     ("echo unrecognized parameter 1>&2",), 2, "probe-failed"),
+    ("the shell refused the command line", (), 64, "probe-failed"),
+    ("the status and the token disagree",
+     ("echo NO-SUPPORT cmdlet-absent",), 0, "probe-failed"),
+    ("a truncated fixture line", ("echo FIXTURE\tC:\\w\\stub.exe",), 0, "probe-failed"),
+)
+
+print("\nthe capability probe's own classification, against a stub shell:")
+with tempfile.TemporaryDirectory() as tmp:
+    stub_dir = Path(tmp) / "shells"
+    stub_dir.mkdir()
+    for index, (why, lines, status, want) in enumerate(CLASSIFICATION):
+        stub = _stub_shell(stub_dir, f"stub{index}", lines, status)
+        with tempfile.TemporaryDirectory() as work:
+            capability, path, publisher = mod._signed_fixture(stub, work)
+        if capability != want:
+            failures.append(
+                f"{why}: classified {capability!r}, expected {want!r}"
+            )
+            print(f"  MISSED    {why}: {capability!r}, expected {want!r}")
+        elif want == "fixture" and (path != "C:\\w\\stub.exe" or publisher != "Contoso Ltd"):
+            failures.append(f"{why}: parsed {path!r}/{publisher!r}")
+            print(f"  MISSED    {why}: parsed {path!r} / {publisher!r}")
+        else:
+            print(f"  ok        exit {status:<3} -> {capability:<12} {why}")
+    # And the shell that is not there at all: `subprocess` raises rather than
+    # returning a status, and an exception is not an incapacity either.
+    missing_shell = str(Path(tmp) / "no-such-shell.cmd")
+    with tempfile.TemporaryDirectory() as work:
+        capability, _, reason = mod._signed_fixture(missing_shell, work)
+    if capability != "probe-failed":
+        failures.append(f"an unlaunchable shell classified {capability!r}")
+        print(f"  MISSED    the shell could not be started: {capability!r}")
+    else:
+        print(f"  ok        unlaunchable -> probe-failed  ({str(reason)[:60]}...)")
+
+# ------------------------------- 6. UNCHECKED is fatal where it has no excuse
+#
+# In-process classification proves the measurement; this proves the SUITE
+# refuses. A copy of the shipped test pointed at a stub shell must exit
+# non-zero on every arm that is not a genuine incapacity -- printing UNCHECKED
+# and exiting 0 is the defect, not the report of it.
+#
+# The predicate's arms are the answers a real host can give, and here they are
+# produced the way a real host produces them: by what its PowerShell does. Only
+# the SHELL is substituted; `_signed_fixture` classifies it for itself, and the
+# truth table's rows keep the real PowerShell so the `missing` row still runs.
+#
+#   broken probe     -- the cmdlet works and a search of the system binary
+#                       directories still found nothing signed. That is a broken
+#                       probe or trust store on ANY OS, so unchecked rows are a
+#                       failure and the refusal has to say so;
+#   probe blew up    -- the probe did not answer at all. Nothing here knows
+#                       whether this host can measure Authenticode, so it may
+#                       not be treated as a host that cannot;
+#   opted-in lane    -- a real incapacity, but with WENLAN_REQUIRE_AUTHENTICODE=1
+#                       the lane declared it arranged a fixture, so unchecked
+#                       fails too;
+#   genuinely unable -- a real incapacity and no such declaration: Authenticode
+#                       does not exist on this platform, so the rows must be
+#                       REPORTED and the run must exit 0. Hard-failing it would
+#                       make the gate unrunnable rather than honest.
+print("\nthe suite's refusal, all four arms:")
+with tempfile.TemporaryDirectory() as tmp:
+    src = TEST.read_text(encoding="utf-8")
+    anchor = "def _signed_fixture(shell: str, work: str) -> FixtureResult:\n"
+    # The copy lives outside the repo, so its __file__-relative REPO_ROOT would
+    # point at the temp dir and every other contract in the suite would fail on
+    # a missing file -- a failure that looks exactly like the one being tested.
+    rooted = "REPO_ROOT = Path(__file__).resolve().parent.parent\n"
+    if src.count(anchor) != 1 or src.count(rooted) != 1:
+        failures.append("cannot build the stub-shell copy: an anchor is stale")
+    else:
+        rebased = src.replace(rooted, f"REPO_ROOT = Path(r{str(ROOT)!r})\n", 1)
+        stub_dir = Path(tmp) / "shells"
+        stub_dir.mkdir()
+
+        def with_shell(lines: tuple[str, ...], status: int, name: str) -> str:
+            """The shipped `_signed_fixture`, handed a shell that answers thus."""
+            stub = _stub_shell(stub_dir, name, lines, status)
+            return rebased.replace(anchor, anchor + f"    shell = {stub!r}\n", 1)
+
+        def run_copy(name: str, text: str, env: dict[str, str]):
+            copy = Path(tmp) / name
+            # Bytes for the same reason as the stub above. This copy IS the
+            # subject of the four arms below, and text mode would rewrite its
+            # line endings between `text` and the file the child runs. Nothing
+            # here compares it byte for byte today -- Python parses CRLF and LF
+            # alike, so this is a latent hole rather than a live defect -- but a
+            # harness whose subject is silently re-encoded on the way to disk
+            # has no business calling itself a receipt.
+            copy.write_bytes(text.encode("utf-8"))
+            return subprocess.run(
+                [sys.executable, str(copy)],
+                capture_output=True,
+                text=True,
+                check=False,
+                cwd=str(ROOT),
+                env={**os.environ, **env},
+            )
+
+        # ROUND 3 (Codex Sol), FINDING N6, first half. A GREEN BASELINE for the
+        # copy machinery, in this same run. Without it, "the copy exited 1" is
+        # satisfied by a rebased path that broke some other contract, by a
+        # concurrent edit to release.yml, by anything at all -- and every arm
+        # below would be credited for a red it did not cause.
+        baseline_proc = run_copy(
+            "baseline-unsubstituted.py", rebased, {"WENLAN_REQUIRE_AUTHENTICODE": ""}
+        )
+        baseline_out = baseline_proc.stdout + baseline_proc.stderr
+        if baseline_proc.returncode != 0:
+            failures.append(
+                "the UNSUBSTITUTED copy of the suite did not pass "
+                f"(exit {baseline_proc.returncode}); the arms below would be "
+                "scored against a copy that was already red"
+            )
+            print(
+                f"  MISSED    baseline: the copy exited {baseline_proc.returncode} "
+                "with no shell substituted"
+            )
+            print(f"            {baseline_out.strip()[-400:]!r}")
+        elif "PASS: release promotion" not in baseline_out:
+            failures.append(
+                "the unsubstituted copy exited 0 without its terminal PASS line; "
+                "it did not run to the end"
+            )
+            print("  BROKEN    baseline: exited 0 with no terminal PASS line")
+        else:
+            print("  ok        baseline: the unsubstituted copy passes in this run")
+
+        def terminating_assertion(text: str) -> str | None:
+            """The message of the AssertionError the process DIED on.
+
+            FINDING N6, second half. The arms used to accept "the copy exited
+            non-zero AND the expected words appear somewhere in its output".
+            The suite prints `UNCHECKED: ...` lines on its way past a row it
+            could not build, so the words can be present while the exit came
+            from an entirely different contract. The exception that terminated
+            the process is the one thing that cannot be true of an unrelated
+            failure.
+            """
+            marker = "\nAssertionError: "
+            if marker not in text:
+                return None
+            return text.rsplit(marker, 1)[-1]
+
+        arms = (
+            (
+                "broken probe",
+                "no-fixture-broken.py",
+                with_shell(("echo NONE-FOUND",), 1, "arm-none-found"),
+                {"WENLAN_REQUIRE_AUTHENTICODE": ""},
+                1,
+                "probe is broken",
+            ),
+            (
+                "probe blew up",
+                "no-fixture-crashed.py",
+                with_shell((), 2, "arm-crashed"),
+                {"WENLAN_REQUIRE_AUTHENTICODE": ""},
+                1,
+                "did not answer at all",
+            ),
+            (
+                "opted-in lane",
+                "no-fixture-required.py",
+                with_shell(("echo NO-SUPPORT cmdlet-absent",), 2, "arm-required"),
+                {"WENLAN_REQUIRE_AUTHENTICODE": "1"},
+                1,
+                "only partly measured",
+            ),
+            (
+                "genuinely unable",
+                "no-fixture-unable.py",
+                with_shell(("echo NO-SUPPORT cmdlet-absent",), 2, "arm-unable"),
+                {"WENLAN_REQUIRE_AUTHENTICODE": ""},
+                0,
+                "UNCHECKED: Authenticode step:",
+            ),
+        )
+        for arm, name, text, env, want_rc, needle in arms:
+            proc = run_copy(name, text, env)
+            out = proc.stdout + proc.stderr
+            cause = terminating_assertion(out)
+            if proc.returncode != want_rc:
+                failures.append(
+                    f"{arm}: exited {proc.returncode}, expected {want_rc}"
+                )
+                print(f"  MISSED    {arm}: exited {proc.returncode}, expected {want_rc}")
+                print(f"            {out.strip()[-400:]!r}")
+                continue
+            if want_rc != 0:
+                # The refusal under examination has to be the thing that ENDED
+                # the process, not a phrase that happened to be printed on the
+                # way to some other failure.
+                if cause is None:
+                    failures.append(
+                        f"{arm}: exited {proc.returncode} without an AssertionError; "
+                        "it died rather than refused, and nothing ties the status "
+                        "to the refusal under test"
+                    )
+                    print(f"  BROKEN    {arm}: no terminating AssertionError")
+                    print(f"            {out.strip()[-400:]!r}")
+                    continue
+                if needle not in cause:
+                    failures.append(
+                        f"{arm}: the AssertionError that ended the run does not "
+                        f"mention {needle!r}; the arm was credited for an "
+                        "unrelated failure"
+                    )
+                    print(
+                        f"  BROKEN    {arm}: died on {cause.strip()[:200]!r}, "
+                        f"which is not {needle!r}"
+                    )
+                    continue
+            else:
+                # The one arm that must SUCCEED: it has to reach the end and
+                # print the terminal PASS line, and it must not have refused.
+                if cause is not None:
+                    failures.append(
+                        f"{arm}: exited 0 but an AssertionError was raised on the way"
+                    )
+                    print(f"  BROKEN    {arm}: {cause.strip()[:200]!r}")
+                    continue
+                if "PASS: release promotion" not in out:
+                    failures.append(
+                        f"{arm}: exited 0 without its terminal PASS line; it did "
+                        "not run to the end"
+                    )
+                    print(f"  BROKEN    {arm}: no terminal PASS line")
+                    continue
+                if needle not in out:
+                    failures.append(
+                        f"{arm}: exited 0 without reporting the rows it could not "
+                        f"measure ({needle!r} absent)"
+                    )
+                    print(f"  BROKEN    {arm}: {needle!r} not in the transcript")
+                    continue
+            named = sorted(m[3] for m in mod.AUTHENTICODE_MUTATIONS if m[3] in out)
+            where = "the terminating AssertionError" if want_rc else "the transcript"
+            print(
+                f"  ok        {arm}: exited {proc.returncode}, {where} said "
+                f"{needle!r}, named {len(named)} unchecked mutation(s)"
+            )
+            # Every one of these arms is a host with no signed fixture, which is
+            # the state measured in section 3 -- so the mutations it must name
+            # are exactly the ones that section found no running row can catch.
+            # Comparing the NAMES, not just the count, means an arm that names
+            # the right number of the wrong mutations is still a failure.
+            if named != sorted(UNCHECKABLE_WITHOUT_A_FIXTURE):
+                failures.append(
+                    f"{arm}: named {named} as unchecked; without a fixture the "
+                    f"unchecked set is {sorted(UNCHECKABLE_WITHOUT_A_FIXTURE)}"
+                )
+
+_subjects_unchanged()
+if failures:
+    for line in failures:
+        print(f"\nFAILURE: {line}")
+    print(f"\nRECEIPT: {len(failures)} failure(s)")
+    globals()["_COMPLETED"] = True
+    print(f"{MARKER} {HARNESS} failures={len(failures)} "
+          f"elapsed={time.time() - STARTED:.1f}s")
+    sys.exit(1)
+# Round 13e, new finding 5: the old summary claimed "no host here has a
+# SignPath-signed file", which is not something this receipt measured. The
+# probe does not look for a SignPath-signed file and would not know one; it
+# takes the FIRST validly signed binary it finds in the system directories and
+# reports whatever publisher that binary carries. The substitution is made
+# because that publisher is not SignPath Foundation, which is a different and
+# much weaker statement than the one the summary used to make.
+steps_checked = len(JOB_STEPS)
+# Round 13f: derived, not restated. The count of substituted rows was written as
+# a literal `1` when `accepted` was the only one; adding the `casefolded` row
+# made the receipt claim one more verbatim row than actually ran verbatim --
+# the same "a claim that outlives what was measured" defect this directory
+# exists to catch, in the receipt that reports the catching. The suite owns the
+# list; read it from there so a new substituted row cannot go unreported.
+substituted = sum(1 for row in rows if row[1] in mod.AUTHENTICODE_SUBSTITUTED_KINDS)
+print(
+    f"\nRECEIPT: {len(rows) - substituted} rows verbatim + {substituted} with the "
+    "expected publisher substituted (the probe takes the first validly signed "
+    f"binary it finds, and that binary's publisher is not SignPath Foundation), "
+    f"{len(mod.AUTHENTICODE_MUTATIONS)} mutations, degraded host still enforcing, "
+    f"{metadata_caught} metadata mutations caught (every one of the "
+    f"{steps_checked} steps the job declares, enumerated from it rather than "
+    f"hand-listed, x 3 "
+    f"spellings of continue-on-error = {steps_checked * 3} (plain, quoted, and "
+    "a unicode escape only the decoded document can see), plus 2 carried in "
+    "by a merge key, plus `shell: pwsh` and the SIGNPATH_CONFIGURED guard), "
+    f"{fallback_cases} no-parser fallback cases (it reports "
+    "'unmeasured, not clean' for an alias and for an escaped key, and stays "
+    "silent on the shipped file), "
+    f"{env_caught} environment-keyed early returns "
+    f"caught, {len(CLASSIFICATION) + 1} capability classifications and all 4 "
+    "arms of the suite's refusal correct -- each tied to the AssertionError "
+    "that ended its run, off an unsubstituted copy that passed in this same run"
+)
+_COMPLETED = True
+print(f"{MARKER} {HARNESS} failures=0 elapsed={time.time() - STARTED:.1f}s")

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import atexit
+import functools
 import hashlib
 import json
 import os
@@ -2628,10 +2630,32 @@ def _stub_curl(directory: str, replies: tuple[tuple[str, str], ...]) -> None:
     os.chmod(path, 0o755)
 
 
-def signpath_status_behaviour_violations(text: str | None = None) -> list[str]:
-    """Run the shipped status script against a fake SignPath."""
+class SignPathStatusRun(NamedTuple):
+    """What one pass over the SignPath status truth table measured.
+
+    Per ROW, like `AuthenticodeRun`, so a mutation control can demand that the
+    rows it names as catchers both ran and failed instead of settling for "some
+    violation appeared somewhere in the table".
+    """
+
+    violations: list[str]
+    ran: set[str]
+    failed: set[str]
+
+
+def signpath_status_behaviour_violations(
+    text: str | None = None, only: frozenset[str] | None = None
+) -> SignPathStatusRun:
+    """Run the shipped status script against a fake SignPath.
+
+    `only` restricts the pass to the named rows. Each row starts a bash and a
+    stub curl -- 1.7s on this host -- so a mutation control that already knows
+    which rows can catch its mutation should not pay for the other twenty.
+    """
     script = signpath_status_script(text)
     violations: list[str] = []
+    ran: set[str] = set()
+    failed: set[str] = set()
     bash = posix_bash()
     # The script parses the API response with jq, so a host without jq can only
     # ever reach the could-not-parse arm. Those rows are reported UNCHECKED by
@@ -2641,6 +2665,8 @@ def signpath_status_behaviour_violations(text: str | None = None) -> list[str]:
     for description, env, replies, expected_status, required, forbidden in (
         SIGNPATH_STATUS_TRUTH_TABLE
     ):
+        if only is not None and description not in only:
+            continue
         if not have_jq and any(reply.startswith("200|") for _, reply in replies):
             print(
                 f"UNCHECKED: SignPath status: {description}: this host has no jq, "
@@ -2698,29 +2724,214 @@ def signpath_status_behaviour_violations(text: str | None = None) -> list[str]:
                 check=False,
             )
             output = result.stdout + result.stderr
+            ran.add(description)
+            before = len(violations)
             if result.returncode != expected_status:
                 violations.append(
                     f"SignPath status: {description}: expected exit "
                     f"{expected_status}, got {result.returncode}; output="
                     f"{output.strip()[:600]!r}"
                 )
-                continue
-            for needle in required:
-                if needle not in output:
-                    violations.append(
-                        f"SignPath status: {description}: exited "
-                        f"{result.returncode} as expected but never said "
-                        f"{needle!r}; output={output.strip()[:600]!r}"
-                    )
-            for needle in forbidden:
-                if needle in output:
-                    violations.append(
-                        f"SignPath status: {description}: exited "
-                        f"{result.returncode} as expected but SAID {needle!r}, "
-                        "which is a claim this run did not earn; output="
-                        f"{output.strip()[:600]!r}"
-                    )
-    return violations
+            else:
+                for needle in required:
+                    if needle not in output:
+                        violations.append(
+                            f"SignPath status: {description}: exited "
+                            f"{result.returncode} as expected but never said "
+                            f"{needle!r}; output={output.strip()[:600]!r}"
+                        )
+                for needle in forbidden:
+                    if needle in output:
+                        violations.append(
+                            f"SignPath status: {description}: exited "
+                            f"{result.returncode} as expected but SAID {needle!r}, "
+                            "which is a claim this run did not earn; output="
+                            f"{output.strip()[:600]!r}"
+                        )
+            if len(violations) > before:
+                failed.add(description)
+    return SignPathStatusRun(violations, ran, failed)
+
+
+#: Every row whose verdict is COULD NOT MEASURE, derived rather than listed. The
+#: tri-state IS the exit status, so anything that collapses status 2 back into
+#: status 0 is visible from all of them -- and a row of that kind added later
+#: joins the catcher set instead of quietly narrowing it.
+_UNMEASURED_ROWS: frozenset[str] = frozenset(
+    description
+    for description, _, _, expected_status, _, _ in SIGNPATH_STATUS_TRUTH_TABLE
+    if expected_status == 2
+)
+
+#: The rows that reach the slug arm with something to say about it: the two that
+#: refute a slug 200 on its body, the two that cannot resolve a slug at all, and
+#: the two whose control probe decides the read was not a measurement.
+_SLUG_ROWS: frozenset[str] = frozenset({
+    "a server that rejects the control for its spelling and ignores the filters",
+    "a slug 200 that is a proxy page is not a signing-request list",
+    "a slug 200 whose items name a different slug refutes the filter",
+    "a slug probe whose transfer never completed cannot resolve the slug",
+    "a slug that rotates to itself is not its own control",
+    "the server ignores the slug filters, so the slugs stay unmeasured",
+})
+
+
+# Columns: the shipped text, what it is reverted to, the truth-table rows that
+# CAN catch that revert, and what is being reverted.
+#
+# The catcher column is measured, not guessed: each mutation was run against the
+# whole table once and the rows that failed are the rows named here. It buys two
+# things. A mutant now runs `catchers & baseline.ran` instead of all 21 rows --
+# 43 rows across the fourteen mutations rather than 294, each row a bash and a
+# stub curl -- and, because every named row must FAIL, the set is a claim about
+# which rows can see the revert rather than a bare "something went red".
+#
+# A mutation whose catchers all went unrun is a FAILURE here, not an UNCHECKED.
+# Unlike the Authenticode table these rows need no host capability beyond jq, so
+# "no live catcher" means the table changed under the mutation list, which is
+# the stale-fixture case this file exists to catch.
+SIGNPATH_STATUS_MUTATIONS: tuple[tuple[str, str, frozenset[str], str], ...] = (
+    (
+        'if [[ "$credential" == "ok" && "$active" != "true" ]]; then',
+        "if false; then",
+        frozenset({"accepted but not activated: everything resolves and the switch is off"}),
+        "the accepted-but-not-activated verdict",
+    ),
+    (
+        "                credential=unmeasured\n                note_unmeasured\n",
+        "                credential=ok\n",
+        frozenset({
+            "a 200 that does not parse is COULD NOT MEASURE, not a working credential",
+            "a 200 whose body is {}: valid JSON, countable, and not a list",
+        }),
+        "a 200 that does not parse being its own state, not a success",
+    ),
+    # THE SHAPE ASSERTION. A control that feeds HTML cannot catch this revert --
+    # HTML fails at the parser either way. The rows that catch it feed valid JSON
+    # that is not a list -- {}, a string, a number -- which is exactly what the
+    # reverted expression waves through.
+    (
+        '                    if type == "array" then length\n'
+        '                    elif type == "object" then\n'
+        '                      if (.values | type) == "array" then (.values | length)\n'
+        '                      elif (.items | type) == "array" then (.items | length)\n'
+        '                      else empty end\n'
+        '                    else empty end',
+        '                    if type == "object" then (.values // .items // [])\n'
+        '                    else . end | length',
+        frozenset({
+            "a 200 whose body is {}: valid JSON, countable, and not a list",
+            "a 200 whose body is a bare JSON string, whose length is its characters",
+            "a 200 whose body is a bare number, whose length is its own value",
+        }),
+        "the positive shape assertion on the credential response",
+    ),
+    (
+        '              if [[ "$real" == "1" && "$control" == "0" ]]; then',
+        '              if [[ "$real" == "1" ]]; then',
+        frozenset({
+            "a server that rejects the control for its spelling and ignores the filters",
+            "accepted, not activated, and the slugs could not be measured",
+            "the server ignores the slug filters, so the slugs stay unmeasured",
+        }),
+        "the control probe that makes a filtered read a measurement",
+    ),
+    # The two halves of the transfer status, mutated back to `|| true`: a curl
+    # whose status nobody reads makes an incomplete response indistinguishable
+    # from a complete one, at the credential and at each slug probe.
+    (
+        "          if (( curl_rc != 0 )); then\n",
+        "          if false; then\n",
+        frozenset({"a 200 whose transfer never completed is not a measurement"}),
+        "a failed credential transfer being distinguishable from a completed one",
+    ),
+    (
+        "              if (( rc != 0 )); then\n                echo 2\n",
+        "              if false; then\n                echo 2\n",
+        frozenset({
+            "a slug probe whose transfer never completed cannot resolve the slug",
+        }),
+        "a failed slug transfer being distinguishable from a completed one",
+    ),
+    # THE OUTERMOST BOUNDARY. A tri-state that collapses back to two at the exit
+    # is a tri-state nobody downstream can see: on a scheduled run the workflow
+    # result is the entire signal.
+    (
+        '            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then\n            note_unmeasured\n',
+        '            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then\n',
+        _SLUG_ROWS,
+        "an unmeasured slug having any consequence at all",
+    ),
+    (
+        "              status=2\n",
+        "              status=0\n",
+        _UNMEASURED_ROWS,
+        "could-not-measure exiting differently from measured-affirmative",
+    ),
+    (
+        '            && [[ "$project_state" != "resolved" || "$policy_state" != "resolved" ]]; then',
+        "            && false; then",
+        frozenset({"accepted, not activated, and the slugs could not be measured"}),
+        "refusing to recommend the switch on slugs that never resolved",
+    ),
+    (
+        '          describe SIGNPATH_PROJECT_SLUG "$project_state"',
+        '          echo "  SIGNPATH_PROJECT_SLUG: validated against the SignPath API"',
+        _SLUG_ROWS,
+        "the summary being derived from what the run measured",
+    ),
+    # ---- the three slug-arm remedies, each reverted on its own ----
+    #
+    # SEPARATELY and not as a block: a single mutation that undoes all three is
+    # caught by the first rule it happens to trip and says nothing about the
+    # other two.
+    #
+    # The rotation, back to the fixed impossible prefix. The control then differs
+    # from the configured slug in length, in content and in separator count as
+    # well as in whether it names anything, and `_SPELLING_RULE_SERVER` is a
+    # server that separates the two on the first of those and never applies a
+    # filter at all.
+    (
+        "rotate_slug() { printf '%s' \"$1\" | tr 'a-zA-Z0-9' 'b-zaB-ZA1-90'; }",
+        "rotate_slug() { printf '%s' \"wenlan-no-such-project-$$\"; }",
+        frozenset({
+            "a server that rejects the control for its spelling and ignores the filters",
+            "a slug that rotates to itself is not its own control",
+        }),
+        "a control slug that differs from the configured one in nothing but "
+        "whether it names something",
+    ),
+    (
+        '              if [[ "$4" == "$5" ]]; then\n',
+        "              if false; then\n",
+        frozenset({"a slug that rotates to itself is not its own control"}),
+        "refusing a differential whose two halves are the same request",
+    ),
+    # The slug body, back to the status line alone. `200) ;;` falls through to
+    # the envelope assertion and the item read below it; `200) echo 1` is the arm
+    # as it stood, where a 200 was affirmative whatever arrived with it. Narrower
+    # is not available here: an unparseable body cannot be admitted by any jq
+    # program, so the only revert that lets a proxy page through is the one that
+    # stops reading the body.
+    (
+        "                200)     ;;\n",
+        "                200)     echo 1; return 0 ;;\n",
+        frozenset({
+            "a slug 200 that is a proxy page is not a signing-request list",
+            "a slug 200 whose items name a different slug refutes the filter",
+        }),
+        "a slug 200 having to BE a signing-request list",
+    ),
+    # And the item read alone, with the envelope assertion left standing -- so
+    # the row that catches this one is refused by NOTHING else in the step: valid
+    # JSON, a real array, a completed transfer, a rejected control.
+    (
+        "              if (( wrong > 0 )); then\n",
+        "              if false; then\n",
+        frozenset({"a slug 200 whose items name a different slug refutes the filter"}),
+        "the returned items being read, and contradicting the filter",
+    ),
+)
 
 
 RESIGN_STEP = "Regenerate the updater signature over the signed installer"
@@ -3346,7 +3557,62 @@ def _authenticode_hashed_byte(data: bytes) -> tuple[int | None, str]:
     return offset, ""
 
 
+_FIXTURE_DIR: list[str] = []
+
+
+def _fixture_session_dir() -> str:
+    """One directory per process, holding the copied signature fixture."""
+    if not _FIXTURE_DIR:
+        path = tempfile.mkdtemp(prefix="wenlan-authenticode-")
+        atexit.register(shutil.rmtree, path, True)
+        _FIXTURE_DIR.append(path)
+    return _FIXTURE_DIR[0]
+
+
 def _signed_fixture(shell: str, work: str) -> FixtureResult:
+    """This host's Authenticode capability, measured once per shell and cached.
+
+    Eight callers ask for it in one run and nothing it measures can change
+    inside one, so it is measured once and the answer reused. The saving is
+    bounded by how long the search takes, which is a property of the host: it
+    stops at the first EMBEDDED signature it sees and costs 0.7s here, but its
+    ceiling is 60 `Get-AuthenticodeSignature` calls per system binary directory
+    on a host whose small binaries are all catalog-signed. `work` is the caller's
+    scratch directory and is no longer where the probe runs; it stays in the
+    signature because
+    scripts/negative-controls/authenticode-step-receipt.py calls this predicate
+    directly and rewrites its first body line to substitute a stub shell.
+
+    The binary it names is COPIED once into a session directory, because every
+    fixture row reads those bytes again and a file the suite owns cannot be
+    serviced out from under it mid-run.
+
+    The copy cannot change the CLASSIFICATION, only which path carries it. This
+    predicate answers "what can this host do", and
+    scripts/negative-controls/authenticode-step-receipt.py holds it to exactly
+    that by feeding it a stub shell that names a path which does not exist and
+    requiring `fixture` back. So a copy that fails hands back the path the probe
+    found -- what this returned before there was a copy -- and never downgrades a
+    measured capability to `probe-failed` on the strength of a file operation.
+    """
+    return _cached_signed_fixture(shell)
+
+
+@functools.lru_cache(maxsize=None)
+def _cached_signed_fixture(shell: str) -> FixtureResult:
+    with tempfile.TemporaryDirectory() as work:
+        capability, path, extra = _probe_signed_fixture(shell, work)
+    if capability != "fixture" or path is None:
+        return (capability, path, extra)
+    local = os.path.join(_fixture_session_dir(), "signed-" + os.path.basename(path))
+    try:
+        shutil.copyfile(path, local)
+    except OSError:
+        return (capability, path, extra)
+    return (capability, local, extra)
+
+
+def _probe_signed_fixture(shell: str, work: str) -> FixtureResult:
     """A real Authenticode-signed binary on this host, its publisher, and why not.
 
     `os.name == "nt"` is an OS proxy wearing a capability's name: it says where
@@ -3501,7 +3767,9 @@ class AuthenticodeRun(NamedTuple):
     capability: str = "fixture"
 
 
-def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
+def authenticode_behaviour_violations(
+    release: str, only: frozenset[str] | None = None
+) -> AuthenticodeRun:
     """Run the shipped Authenticode step against real signed and broken files.
 
     Nothing here is stubbed: Windows itself answers, over files whose signature
@@ -3524,6 +3792,13 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
     catches an early `exit 0`. The four signature-state rows need Windows. The
     caller is told which kinds ran so it can require exactly the mutations those
     rows can catch, and name the rest UNCHECKED rather than passing over them.
+
+    `only` restricts the pass to the named kinds. A mutation control already
+    knows which rows can catch its mutation, and the rows that cannot are pure
+    cost: each one builds a fixture and starts a shell to re-measure something
+    the baseline established. Restricting the pass cannot weaken the control,
+    because both of its demands -- that every catcher RAN, and that every catcher
+    FAILED -- are subsets of `only`.
     """
     script = authenticode_script(release)
     shell = _powershell()
@@ -3550,6 +3825,8 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
             f"({publisher}), which is a failed measurement, not an incapacity",
         }.get(capability, "")
         for description, kind, expected_status, required in AUTHENTICODE_TRUTH_TABLE:
+            if only is not None and kind not in only:
+                continue
             body = script
             staged = os.path.join(work, f"Wenlan_9.9.9_x64-setup-{kind}.exe")
             if kind == "missing":
@@ -4758,132 +5035,58 @@ def main() -> None:
     # states nobody can produce here -- an accepted application, a resolving
     # project slug -- so a stub server is the only way any of it is measured at
     # all before the day it matters.
-    status_violations = signpath_status_behaviour_violations()
-    if status_violations:
+    status_baseline = signpath_status_behaviour_violations()
+    if status_baseline.violations:
         raise AssertionError(
             "SignPath status behaviour contract failed:\n  "
-            + "\n  ".join(status_violations)
+            + "\n  ".join(status_baseline.violations)
         )
     status_text = SIGNPATH_STATUS_PATH.read_text(encoding="utf-8")
-    for old, new, why in (
-        (
-            'if [[ "$credential" == "ok" && "$active" != "true" ]]; then',
-            "if false; then",
-            "the accepted-but-not-activated verdict",
-        ),
-        (
-            "                credential=unmeasured\n                note_unmeasured\n",
-            "                credential=ok\n",
-            "a 200 that does not parse being its own state, not a success",
-        ),
-        # THE SHAPE ASSERTION. A control that feeds HTML cannot catch this
-        # revert -- HTML fails at the parser either way. The rows beside it feed
-        # valid JSON that is not a list -- {}, a string, a number -- which is
-        # exactly what the reverted expression waves through.
-        (
-            '                    if type == "array" then length\n'
-            '                    elif type == "object" then\n'
-            '                      if (.values | type) == "array" then (.values | length)\n'
-            '                      elif (.items | type) == "array" then (.items | length)\n'
-            '                      else empty end\n'
-            '                    else empty end',
-            '                    if type == "object" then (.values // .items // [])\n'
-            '                    else . end | length',
-            "the positive shape assertion on the credential response",
-        ),
-        (
-            '              if [[ "$real" == "1" && "$control" == "0" ]]; then',
-            '              if [[ "$real" == "1" ]]; then',
-            "the control probe that makes a filtered read a measurement",
-        ),
-        # The two halves of the transfer status, mutated back to `|| true`: a
-        # curl whose status nobody reads makes an incomplete response
-        # indistinguishable from a complete one, at the credential and at each
-        # slug probe.
-        (
-            "          if (( curl_rc != 0 )); then\n",
-            "          if false; then\n",
-            "a failed credential transfer being distinguishable from a completed one",
-        ),
-        (
-            "              if (( rc != 0 )); then\n                echo 2\n",
-            "              if false; then\n                echo 2\n",
-            "a failed slug transfer being distinguishable from a completed one",
-        ),
-        # THE OUTERMOST BOUNDARY. A tri-state that collapses back to two at
-        # the exit is a tri-state nobody downstream can see: on a scheduled
-        # run the workflow result is the entire signal.
-        (
-            '            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then\n            note_unmeasured\n',
-            '            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then\n',
-            "an unmeasured slug having any consequence at all",
-        ),
-        (
-            "              status=2\n",
-            "              status=0\n",
-            "could-not-measure exiting differently from measured-affirmative",
-        ),
-        (
-            '            && [[ "$project_state" != "resolved" || "$policy_state" != "resolved" ]]; then',
-            "            && false; then",
-            "refusing to recommend the switch on slugs that never resolved",
-        ),
-        (
-            '          describe SIGNPATH_PROJECT_SLUG "$project_state"',
-            '          echo "  SIGNPATH_PROJECT_SLUG: validated against the SignPath API"',
-            "the summary being derived from what the run measured",
-        ),
-        # ---- the three slug-arm remedies, each reverted on its own ----
-        #
-        # SEPARATELY and not as a block: a single mutation that undoes all three
-        # is caught by the first rule it happens to trip and says nothing about
-        # the other two.
-        #
-        # The rotation, back to the fixed impossible prefix. The control then
-        # differs from the configured slug in length, in content and in
-        # separator count as well as in whether it names anything, and
-        # `_SPELLING_RULE_SERVER` is a server that separates the two on the
-        # first of those and never applies a filter at all.
-        (
-            "rotate_slug() { printf '%s' \"$1\" | tr 'a-zA-Z0-9' 'b-zaB-ZA1-90'; }",
-            "rotate_slug() { printf '%s' \"wenlan-no-such-project-$$\"; }",
-            "a control slug that differs from the configured one in nothing but "
-            "whether it names something",
-        ),
-        (
-            '              if [[ "$4" == "$5" ]]; then\n',
-            "              if false; then\n",
-            "refusing a differential whose two halves are the same request",
-        ),
-        # The slug body, back to the status line alone. `200) ;;` falls through
-        # to the envelope assertion and the item read below it; `200) echo 1`
-        # is the arm as it stood, where a 200 was affirmative whatever arrived
-        # with it. Narrower is not available here: an unparseable body cannot
-        # be admitted by any jq program, so the only revert that lets a proxy
-        # page through is the one that stops reading the body.
-        (
-            "                200)     ;;\n",
-            "                200)     echo 1; return 0 ;;\n",
-            "a slug 200 having to BE a signing-request list",
-        ),
-        # And the item read alone, with the envelope assertion left standing --
-        # so the row that catches this one is refused by NOTHING else in the
-        # step: valid JSON, a real array, a completed transfer, a rejected
-        # control.
-        (
-            "              if (( wrong > 0 )); then\n",
-            "              if false; then\n",
-            "the returned items being read, and contradicting the filter",
-        ),
-    ):
+    status_rows = {row[0] for row in SIGNPATH_STATUS_TRUTH_TABLE}
+    for old, new, catchers, why in SIGNPATH_STATUS_MUTATIONS:
         if status_text.count(old) != 1:
             raise AssertionError(
                 f"signpath-status mutation fixture is stale "
                 f"({status_text.count(old)} matches): {old!r}"
             )
-        if not signpath_status_behaviour_violations(status_text.replace(old, new, 1)):
+        # The catcher set is checked before it is used, so a mutation cannot
+        # quietly stop being measured. An empty set, or one naming a row that no
+        # longer exists, is a stale table -- and a stale table that merely
+        # skipped would leave the mutation unmeasured while the suite still said
+        # PASS.
+        if not catchers:
+            raise AssertionError(f"the catcher set for {why} is empty")
+        unknown = catchers - status_rows
+        if unknown:
             raise AssertionError(
-                f"the SignPath status truth table did not notice a mutation of {why}"
+                f"the catcher set for {why} names {sorted(unknown)}, which is "
+                "not a row of the SignPath status truth table"
+            )
+        live = catchers & status_baseline.ran
+        if not live:
+            raise AssertionError(
+                f"no row that can catch a mutation of {why} ran here: catching "
+                f"it needs one of {sorted(catchers)} and this host ran "
+                f"{sorted(status_baseline.ran) or 'nothing'}"
+            )
+        mutant = signpath_status_behaviour_violations(
+            status_text.replace(old, new, 1), only=live
+        )
+        # Two demands, not one. "A violation appeared" is satisfied by a
+        # mutation that merely breaks a row; what is being claimed is that the
+        # rows named as catchers SAW this revert, so every one of them must have
+        # run and every one of them must have failed.
+        if not live <= mutant.ran:
+            raise AssertionError(
+                f"mutating {why} stopped {sorted(live - mutant.ran)} from "
+                "running; a row that never ran cannot be the row that caught it"
+            )
+        if not live <= mutant.failed:
+            raise AssertionError(
+                f"the SignPath status truth table did not notice a mutation of "
+                f"{why} in {sorted(live - mutant.failed)}, which the catcher set "
+                f"claims can see it (rows that did fail: "
+                f"{sorted(mutant.failed) or 'none'})"
             )
 
     # The re-signing step has the same shape of hole and none of the guard's
@@ -5040,7 +5243,9 @@ def main() -> None:
                 f"{sorted(catchers)} and this host ran {sorted(baseline.ran) or 'nothing'}"
             )
             continue
-        mutant = authenticode_behaviour_violations(release.replace(old, new, 1))
+        mutant = authenticode_behaviour_violations(
+            release.replace(old, new, 1), only=live
+        )
         # Two separate demands, because "a violation appeared" is not the same
         # claim as "the mutation was caught". Removing the publisher check, for
         # instance, also makes the `accepted` row unbuildable -- that violation

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -2180,16 +2180,15 @@ _FILTERING_SERVER = (
 #: a filtered read meaningless.
 _IGNORING_SERVER = (("SigningRequests", "200|[]"),)
 
-#: ROUND 7. A server that rejects the CONTROL for its SPELLING and applies no
-#: filter at all -- the shape the old fixed-prefix control could not tell apart
-#: from a real lookup. `wenlan-no-such-project-<epoch><pid>` differed from the
-#: configured slug in its length, its content and its number of separators as
-#: well as in the one property the probe is about, so a length cap, a charset
-#: rule or a reserved-word rule rejects it on sight: `real=1, control=0`,
-#: printed as `resolved`, for a project this server never looked up. The
-#: rotation control has the same length, the same separator positions and the
-#: same character class at every position, so no rule of that kind can separate
-#: the two, both probes come back 200, and the pair reads UNMEASURED.
+#: A server that rejects the CONTROL for its SPELLING and applies no filter at
+#: all. A fixed-prefix control such as `wenlan-no-such-project-<epoch><pid>`
+#: differs from the configured slug in its length, its content and its number of
+#: separators as well as in the one property the probe is about, so a length
+#: cap, a charset rule or a reserved-word rule rejects it on sight: `real=1,
+#: control=0`, printed as `resolved`, for a project this server never looked up.
+#: The rotation control has the same length, the same separator positions and
+#: the same character class at every position, so no rule of that kind can
+#: separate the two, both probes come back 200, and the pair reads UNMEASURED.
 #:
 #: `no-such-project` and not a length rule, because the stub matches on URL
 #: substrings: it is the same discrimination, expressed in the one vocabulary
@@ -2240,12 +2239,12 @@ def _filtering_server_but(project_reply: str) -> tuple[tuple[str, str], ...]:
 #:   1  something answered NEGATIVELY
 #:   2  something COULD NOT BE MEASURED
 #:
-#: Round 15 found the monitor recreating, at its own outermost boundary, the
-#: defect it was written to detect: with the credential good and both slugs
-#: coming back "NOT validated -- this run could not measure it", the script
-#: exited 0 -- the same result as both slugs resolving. This table said so too:
-#: the `_IGNORING_SERVER` row below USED to expect 0. A truth table that
-#: encodes the defect is worse than no truth table, because it certifies it.
+#: The monitor can recreate, at its own outermost boundary, the defect it was
+#: written to detect: with the credential good and both slugs coming back "NOT
+#: validated -- this run could not measure it", exiting 0 is the same result as
+#: both slugs resolving. The `_IGNORING_SERVER` row below is where that is
+#: pinned. A truth table that encodes the defect is worse than no truth table,
+#: because it certifies it.
 #:
 #: The last column exists for the same reason. Several of these rows are about
 #: what the run must NOT say -- a recommendation to switch signing on is a
@@ -2327,11 +2326,11 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
         ),
         (),
     ),
-    # ---- malformed but VALID JSON: the half the old control never tested ----
+    # ---- malformed but VALID JSON: the half an HTML control cannot reach ----
     #
-    # The expression that shipped was
+    # An expression such as
     #   if type == "object" then (.values // .items // []) else . end | length
-    # and it accepted anything countable. Measured on this host with jq 1.8.2:
+    # accepts anything countable. Measured on this host with jq 1.8.2:
     # `{}` yielded 0, `"proxy error"` yielded 11 (a string's length is its
     # characters), `42` yielded 42 (a number's length is its absolute value).
     # Each one set credential=ok and exited 0 while printing "the organization
@@ -2427,14 +2426,13 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
         ("COULD NOT MEASURE -- unexpected HTTP 500",),
         (),
     ),
-    # ROUND 5. THE ROW THE TABLE HAD NO SHAPE FOR: a request that received its
-    # status line and then did not complete. curl prints `200` through -w and
-    # exits 28 (timeout), 18 (body shorter than Content-Length) or 56 (reset),
-    # and the body that DID land here is a syntactically perfect `[]` -- so with
-    # curl's status discarded by `|| true`, jq accepted it, the credential read
-    # `ok`, both slug probes answered off the same swallowed failures, and with
-    # SIGNPATH_ACTIVE=true the workflow exited 0. Green, over a measurement that
-    # failed, from the monitor whose subject is that exact substitution.
+    # A request that received its status line and then did not complete. curl
+    # prints `200` through -w and exits 28 (timeout), 18 (body shorter than
+    # Content-Length) or 56 (reset), and the body that DID land here is a
+    # syntactically perfect `[]` -- so with curl's status discarded by
+    # `|| true`, jq accepts it, the credential reads `ok`, both slug probes
+    # answer off the same swallowed failures, and with SIGNPATH_ACTIVE=true the
+    # workflow exits 0 over a measurement that failed.
     #
     # The forbidden column is the half that matters: exiting 2 while still
     # printing "the organization id and the API token are both good" would be
@@ -2451,7 +2449,8 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
     # And the same failure on a SLUG probe, with the credential request whole.
     # The differential is only a measurement if both of its halves completed:
     # here the configured probe times out after printing 200 and the control is
-    # rejected for real, which is the exact pair that used to read `resolved`.
+    # rejected for real, which is the exact pair that reads `resolved` without
+    # the transfer status.
     (
         "a slug probe whose transfer never completed cannot resolve the slug",
         {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
@@ -2471,27 +2470,21 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
         ("COULD NOT MEASURE a configured slug",),
         ("SIGNPATH_PROJECT_SLUG: validated against the SignPath API",),
     ),
-    # ---- ROUND 7. THE THREE REMEDIES THAT NOTHING DEFENDED ----
-    #
-    # The step's slug arm was repaired in three places and every row above
-    # stayed green with any one of the three reverted. That is the exact state
-    # this file exists to make impossible: a suite that would not notice the bug
-    # is not evidence about the bug, and a green run over it certifies nothing.
+    # ---- one row per repair in the slug arm ----
     #
     # Each row below is refused by exactly ONE rule in the step, which is what
     # makes it a control for that rule rather than for the arm in general. The
     # mutation list at the bottom of main() names the revert each one catches.
     (
-        # 1. THE CONTROL'S SPELLING. The control used to be the fixed prefix
-        # `wenlan-no-such-project-` plus an epoch and a pid, and this server
-        # rejects exactly that spelling while ignoring the filters entirely --
-        # so with the rotation reverted it answers `real=1, control=0` and the
-        # step prints `resolved`, exit 0, for a project it never looked up. The
-        # differential would have measured SYNTAX and reported EXISTENCE. As
-        # shipped, the control is the configured slug with every alphanumeric
-        # rotated one place: same length, same separator positions, same
-        # character class throughout, nothing here can tell them apart, both
-        # probes answer 200, and the pair is UNMEASURED.
+        # 1. THE CONTROL'S SPELLING. A fixed-prefix control -- say
+        # `wenlan-no-such-project-` plus an epoch and a pid -- is rejected by
+        # this server for its spelling while the filters are ignored entirely,
+        # so the pair answers `real=1, control=0` and the step prints
+        # `resolved`, exit 0, for a project it never looked up: SYNTAX measured,
+        # EXISTENCE reported. As shipped the control is the configured slug with
+        # every alphanumeric rotated one place -- same length, same separator
+        # positions, same character class throughout -- so nothing here can tell
+        # them apart, both probes answer 200, and the pair is UNMEASURED.
         "a server that rejects the control for its spelling and ignores the filters",
         {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
         _SPELLING_RULE_SERVER,
@@ -2507,7 +2500,7 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
         ),
     ),
     (
-        # 1b. THE OTHER HALF OF THE SAME REMEDY, and it fails in the OTHER
+        # 1b. THE OTHER HALF OF THE SAME REMEDY, failing in the OTHER
         # direction. A slug with no alphanumeric in it rotates to itself, so
         # the two probes are the same URL and the "difference" between them is
         # zero by construction. Both are rejected here, and without
@@ -2538,11 +2531,11 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
     ),
     (
         # 2. A SLUG 200 THAT IS NOT A SIGNING-REQUEST LIST. The credential arm
-        # has refused this body since round 14; the slug probe reduced the
-        # reply to its status line and threw the payload away, so the very same
-        # proxy page that is COULD-NOT-MEASURE three screens above read as
-        # `resolved` down here. The policy pair still resolves and is REQUIRED
-        # to below, which is what keeps this row about the one reply rather
+        # refuses this body; a slug probe that reduces the reply to its status
+        # line and throws the payload away reads the very same proxy page that
+        # is COULD-NOT-MEASURE three screens above as `resolved` down here. The
+        # policy pair still resolves and is REQUIRED to below, which is what
+        # keeps this row about the one reply rather
         # than about the route: a row that went red because nothing resolved
         # would pass while measuring something else entirely.
         "a slug 200 that is a proxy page is not a signing-request list",
@@ -2560,7 +2553,7 @@ SIGNPATH_STATUS_TRUTH_TABLE: tuple[
         ),
     ),
     (
-        # 3. THE ITEMS, WHICH NOTHING HERE HAD EVER READ. A 200 that IS a list
+        # 3. THE ITEMS. A 200 that IS a list
         # -- of signing requests for `someone-else`, returned to a request that
         # filtered on projectSlug=wenlan. Every other rule in the step says
         # this resolved: the transfer completed, the status is 200, the
@@ -2960,15 +2953,15 @@ AUTHENTICODE_BODY_ENV = frozenset({"STAGED_SETUP"})
 def authenticode_body_env_violations(release: str) -> list[str]:
     """The body may read STAGED_SETUP and nothing else.
 
-    Round 13c, finding 1. The truth table runs the body in the harness's own
-    environment, so a body-level early-out keyed on a variable the harness does
-    not set is invisible to all five rows:
+    The truth table runs the body in the harness's own environment, so a
+    body-level early-out keyed on a variable the harness does not set is
+    invisible to all five rows:
 
         if ($env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }
 
     Green here, where SIGNPATH_CONFIGURED is unset; a no-op in the release,
-    where it is exactly 'true'. The harness now runs the body with the release
-    job's environment (see `AUTHENTICODE_STEP_ENV`), which catches that one
+    where it is exactly 'true'. Running the body with the release job's
+    environment (see `AUTHENTICODE_STEP_ENV`) catches that one
     variable -- but only that one, and the next such guard would key on CI,
     RUNNER_OS, GITHUB_REF or anything else the runner defines. Enumerating what
     the environment holds is unwinnable; enumerating what the body is allowed
@@ -2976,8 +2969,8 @@ def authenticode_body_env_violations(release: str) -> list[str]:
     to gate is not a gate.
     """
     script = authenticode_script(release)
-    # Round 13d, 13c finding 1 reopened. The rule used to be a case-sensitive
-    # regex for ONE spelling, `$env:NAME`. PowerShell has at least five:
+    # A case-sensitive regex for ONE spelling, `$env:NAME`, is not the rule:
+    # PowerShell has at least five more --
     # `$Env:NAME`, `${env:NAME}`, `Get-Item Env:NAME`, `dir env:`, and
     # `[System.Environment]::GetEnvironmentVariable(...)`. Enumerating spellings
     # is the same losing game as enumerating variables.
@@ -3026,8 +3019,8 @@ _ESCAPED_KEY = re.compile(r'^[ \t]*"[^"\n]*\\[^"\n]*"[ \t]*:', re.M)
 def continue_on_error_violations(release: str, job: str) -> list[str]:
     """`continue-on-error`, read as a DECODED property, not as a token.
 
-    Round 13e reopened finding 1. `re.finditer("continue-on-error", job)` is a
-    lexical net over the job's text. It is strictly conservative for what it can
+    `re.finditer("continue-on-error", job)` is a lexical net over the job's
+    text. It is strictly conservative for what it can
     see -- the token has no other business in this job -- but a property does
     not have to appear in a step's text to be on that step. A merge key pulls
     one in from an anchor defined anywhere else in the file:
@@ -3103,18 +3096,17 @@ def continue_on_error_violations(release: str, job: str) -> list[str]:
 def authenticode_step_metadata_violations(release: str) -> list[str]:
     """The step's YAML around the body, which no body-level test can see.
 
-    Round 13b: a five-row truth table over the extracted `run:` block proves
-    what the script does when it runs. `continue-on-error: true` on the step
-    leaves every row and every static marker passing while the release ignores
-    the failure and publishes anyway -- a gate that runs, fails, and is
-    discarded. The body is not the whole step.
+    A five-row truth table over the extracted `run:` block proves what the
+    script does when it runs. `continue-on-error: true` on the step leaves every
+    row and every static marker passing while the release ignores the failure
+    and publishes anyway -- a gate that runs, fails, and is discarded. The body
+    is not the whole step.
 
-    Round 13c reopened it twice over. `continue-on-error` was rejected on a
-    hand-listed four steps, and "Check SignPath configuration is
-    all-or-nothing" -- the guard that stops a half-configured repo from
-    publishing an unsigned installer under a configured-looking run -- was not
-    among them. A list of load-bearing steps is a list someone has to keep
-    right; the job has none that may swallow a failure, so the rule is the job.
+    The rule covers the JOB, not a hand-listed set of steps: a four-step list
+    omitted "Check SignPath configuration is all-or-nothing", the guard that
+    stops a half-configured repo from publishing an unsigned installer under a
+    configured-looking run. A list of load-bearing steps is a list someone has
+    to keep right; no step in this job may swallow a failure.
     """
     job = job_body(release, "app-bundle-windows")
     if not job:
@@ -3126,11 +3118,11 @@ def authenticode_step_metadata_violations(release: str) -> list[str]:
     # EVERY step, and the job itself. Attribution is by the nearest preceding
     # step name so the message still says which one, without the enumeration
     # being what decides whether the rule applies.
-    # Round 13d: the rule was `^\s*continue-on-error:`, which is one YAML
-    # spelling of the key. `"continue-on-error": true` and `{continue-on-error:
-    # true}` are the same key and were invisible. There is no other reason for
-    # that token to appear anywhere in this job, so the token IS the rule --
-    # no anchor, no quoting to enumerate, no place left to hide it.
+    # `^\s*continue-on-error:` is one YAML spelling of the key;
+    # `"continue-on-error": true` and `{continue-on-error: true}` are the same
+    # key and invisible to it. There is no other reason for that token to appear
+    # anywhere in this job, so the TOKEN is the rule -- no anchor, no quoting to
+    # enumerate, no place left to hide it.
     for match in re.finditer(r"continue-on-error", job):
         seen = re.findall(r"^      - name: (.+)$", job[: match.start()], re.MULTILINE)
         owner = repr(seen[-1]) if seen else "the app-bundle-windows job itself"
@@ -3155,19 +3147,18 @@ def authenticode_step_metadata_violations(release: str) -> list[str]:
 
 
 #: The environment the step runs in during a real release, as far as it can
-#: matter to the body. The harness used to supply STAGED_SETUP alone, so the
-#: body ran with SIGNPATH_CONFIGURED unset while the shipping job runs it with
-#: SIGNPATH_CONFIGURED == 'true' -- and a branch on that difference is a step
-#: that passes every row here and does nothing there (round 13c, finding 1).
+#: matter to the body. Supplying STAGED_SETUP alone runs the body with
+#: SIGNPATH_CONFIGURED unset while the shipping job runs it with
+#: SIGNPATH_CONFIGURED == 'true', and a branch on that difference is a step that
+#: passes every row here and does nothing there.
 #: `authenticode_body_env_violations` is the load-bearing half of that fix,
 #: since no list of variables can be complete; this one makes the variables the
 #: step is MOST likely to be branched on hold their release values anyway.
 #:
-#: Round 13e reopened this as new finding 3: the list was eleven names chosen
-#: by hand, and `GITHUB_WORKFLOW_REF` -- which GitHub documents as a default and
-#: which identifies the workflow file uniquely -- was not among them. A hand-
-#: picked list is exactly the shape this workstream keeps finding, so the list
-#: is now GitHub's own documented set of default environment variables, in full.
+#: The list is GitHub's own documented set of default environment variables, in
+#: full, rather than a hand-picked subset: an eleven-name selection omitted
+#: `GITHUB_WORKFLOW_REF`, which GitHub documents as a default and which
+#: identifies the workflow file uniquely.
 #: It still cannot be complete in principle: a step may branch on anything the
 #: job's `env:` supplies, or on a variable an action exported. That is why
 #: `authenticode_body_env_violations` -- which rejects ANY read of the
@@ -3194,8 +3185,8 @@ AUTHENTICODE_STEP_ENV = {
     "GITHUB_EVENT_PATH": "",
     "GITHUB_GRAPHQL_URL": "https://api.github.com/graphql",
     "GITHUB_HEAD_REF": "",
-    # Round 13d named this one: a branch that exits only when GITHUB_JOB is
-    # app-bundle-windows runs everywhere else and skips the gate where it counts.
+    # A branch that exits only when GITHUB_JOB is app-bundle-windows runs
+    # everywhere else and skips the gate where it counts.
     "GITHUB_JOB": "app-bundle-windows",
     "GITHUB_OUTPUT": "",
     "GITHUB_PATH": "",
@@ -3216,7 +3207,6 @@ AUTHENTICODE_STEP_ENV = {
     "GITHUB_STEP_SUMMARY": "",
     "GITHUB_TRIGGERING_ACTOR": "github-actions[bot]",
     "GITHUB_WORKFLOW": "release",
-    # Round 13e, new finding 3, by name.
     "GITHUB_WORKFLOW_REF": "7xuanlu/wenlan/.github/workflows/release.yml@refs/tags/v9.9.9",
     "GITHUB_WORKFLOW_SHA": "0" * 40,
     "GITHUB_WORKSPACE": "",
@@ -3249,16 +3239,12 @@ def _powershell() -> str | None:
 #: "probe-failed" the probe did not answer. PowerShell could not be started, or
 #:                it died on its own, or it printed something this cannot parse.
 #:
-#: Round 13e, new finding 4: the first three were read off the EXIT STATUS
-#: alone, so every way the probe could blow up with status 2 -- a PowerShell
-#: that refused the command line, a host policy that killed it, a syntax error
-#: introduced by an edit to the probe text below -- arrived here spelled
-#: "no-support", the one answer that is allowed to excuse an unmeasured row.
-#: A failed measurement wearing an incapacity's name is this workstream's
-#: signature defect, sitting in the predicate written to decide when a failed
-#: measurement may be excused. So the probe now PRINTS which arm it took, the
-#: status and the token have to agree, and anything else is `probe-failed`,
-#: which is a failure and never an excuse.
+#: Read off the EXIT STATUS alone, every way the probe can blow up with status
+#: 2 -- a PowerShell that refused the command line, a host policy that killed
+#: it, a syntax error in the probe text below -- arrives here spelled
+#: "no-support", the one answer allowed to excuse an unmeasured row. So the
+#: probe PRINTS which arm it took, the status and the token have to agree, and
+#: anything else is `probe-failed`, which is a failure and never an excuse.
 #:
 #: The third element is the publisher when the capability is "fixture", and the
 #: reason it could not answer when it is "probe-failed".
@@ -3363,13 +3349,12 @@ def _authenticode_hashed_byte(data: bytes) -> tuple[int | None, str]:
 def _signed_fixture(shell: str, work: str) -> FixtureResult:
     """A real Authenticode-signed binary on this host, its publisher, and why not.
 
-    Round 13c asked for a capability predicate and got `os.name == "nt"`, which
-    round 13d correctly called an OS proxy wearing a capability's name: it says
-    where the code is running, not what the host can do. It was propped up by a
-    probe that looked at three hard-coded paths, so "no signed binary on this
-    host" really meant "not one of these three files".
+    `os.name == "nt"` is an OS proxy wearing a capability's name: it says where
+    the code is running, not what the host can do. A probe that looks at three
+    hard-coded paths is the matching half, where "no signed binary on this host"
+    means "not one of these three files".
 
-    Both halves are replaced here. The probe SEARCHES the system binary
+    So the probe SEARCHES the system binary
     directories instead of naming files, and it distinguishes its two negative
     answers, which is the whole tri-state discipline applied to the capability
     question itself: a cmdlet that cannot run on this platform is an incapacity;
@@ -3512,7 +3497,7 @@ class AuthenticodeRun(NamedTuple):
     #: Why the unchecked rows went unchecked, as a HOST capability rather than
     #: an operating system: "fixture" (all rows buildable), "no-shell",
     #: "no-support" (a real incapacity), or "none-found" (a broken probe or
-    #: trust store, which is a failure anywhere). Round 13d.
+    #: trust store, which is a failure anywhere).
     capability: str = "fixture"
 
 
@@ -3532,7 +3517,7 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
     ships an unsigned installer -- the exact defect class this workstream exists
     to catch, in the gate that is supposed to catch it.
 
-    Coverage degrades by ROW, not all-or-nothing (round 13b, finding 1). The
+    Coverage degrades by ROW, not all-or-nothing. The
     `missing` row needs no Authenticode at all -- the step throws on Test-Path
     before it reaches the cmdlet -- so it runs anywhere pwsh exists, including
     the Ubuntu lane that actually runs this suite in CI, and it is the row that
@@ -3585,12 +3570,11 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
                     data[offset] ^= 0xFF
                     # Ask Authenticode about the fixture BEFORE the step does.
                     #
-                    # This check used to be `data[offset] != was` after
-                    # `data[offset] ^= 0xFF` -- true by arithmetic, and item
-                    # assignment cannot change a bytearray's length either. A
-                    # control that cannot fail, sitting inside the fixture
-                    # builder for the row whose whole purpose is to enforce
-                    # that controls can fail.
+                    # Not `data[offset] != was` after `data[offset] ^= 0xFF`:
+                    # that is true by arithmetic, and item assignment cannot
+                    # change a bytearray's length either. A control that cannot
+                    # fail, sitting inside the fixture builder for the row whose
+                    # whole purpose is to enforce that controls can fail.
                     #
                     # What can actually go wrong is that the chosen byte turns
                     # out not to be covered by the signature. Then the step
@@ -3742,9 +3726,9 @@ def _contrary_step_env() -> dict[str, str]:
 def authenticode_environment_invariance(release: str) -> InvarianceRun:
     """The step's outcome may not depend on the environment. A property, run.
 
-    Round 13e reopened finding 1 and new finding 3. Everything guarding this
-    until now was LEXICAL: `authenticode_body_env_violations` blanks the one
-    permitted read and rejects the surviving token `env`, case-insensitively,
+    Every other guard on this is LEXICAL: `authenticode_body_env_violations`
+    blanks the one permitted read and rejects the surviving token `env`,
+    case-insensitively,
     which is a good net and still only a net. PowerShell can assemble the drive
     name at runtime --
 
@@ -3826,12 +3810,12 @@ def authenticode_environment_invariance(release: str) -> InvarianceRun:
 # Columns: the shipped text, its replacement, the truth-table rows that can
 # catch the replacement, and why it matters.
 #
-# The catcher sets are the whole point of round 13b, finding 1. Coverage here is
-# host-dependent -- the four signature-state rows need an Authenticode-signed
-# file, which Ubuntu does not have -- and the previous shape skipped ALL of the
-# mutations whenever ANY row was unavailable, then printed PASS. Naming the
-# catchers per mutation means the rows that DID run still have to earn their
-# keep, and the rest are reported UNCHECKED by name rather than passed over.
+# The catcher sets exist because coverage here is host-dependent: the four
+# signature-state rows need an Authenticode-signed file, which Ubuntu does not
+# have, and skipping ALL of the mutations whenever ANY row is unavailable prints
+# PASS over nothing. Naming the catchers per mutation means the rows that DID
+# run still have to earn their keep, and the rest are reported UNCHECKED by name
+# rather than passed over.
 #
 # The first mutation is the one that matters on a fixture-free host: `exit 0`
 # above `$ErrorActionPreference` reaches nothing at all, so even the `missing`
@@ -4792,11 +4776,10 @@ def main() -> None:
             "                credential=ok\n",
             "a 200 that does not parse being its own state, not a success",
         ),
-        # THE SHAPE ASSERTION. Reverting it to the expression that shipped
-        # is the mutation the old control could not catch: that control fed
-        # HTML, which fails at the parser either way. The rows added beside
-        # it feed valid JSON that is not a list -- {} , a string, a number --
-        # which is exactly what the old expression waved through.
+        # THE SHAPE ASSERTION. A control that feeds HTML cannot catch this
+        # revert -- HTML fails at the parser either way. The rows beside it feed
+        # valid JSON that is not a list -- {}, a string, a number -- which is
+        # exactly what the reverted expression waves through.
         (
             '                    if type == "array" then length\n'
             '                    elif type == "object" then\n'
@@ -4813,10 +4796,10 @@ def main() -> None:
             '              if [[ "$real" == "1" ]]; then',
             "the control probe that makes a filtered read a measurement",
         ),
-        # ROUND 5. The two halves of the transfer status, mutated back to the
-        # `|| true` that stood here: a curl whose status nobody reads makes an
-        # incomplete response indistinguishable from a complete one, at the
-        # credential and at each slug probe.
+        # The two halves of the transfer status, mutated back to `|| true`: a
+        # curl whose status nobody reads makes an incomplete response
+        # indistinguishable from a complete one, at the credential and at each
+        # slug probe.
         (
             "          if (( curl_rc != 0 )); then\n",
             "          if false; then\n",
@@ -4850,13 +4833,11 @@ def main() -> None:
             '          echo "  SIGNPATH_PROJECT_SLUG: validated against the SignPath API"',
             "the summary being derived from what the run measured",
         ),
-        # ---- ROUND 7. The three slug-arm remedies, each reverted on its own.
+        # ---- the three slug-arm remedies, each reverted on its own ----
         #
-        # Every one of these left the whole table above green, which is why the
-        # four rows at the bottom of it exist. Reverted SEPARATELY and not as a
-        # block: a single mutation that undoes all three would be caught by the
-        # first rule it happens to trip and would say nothing about the other
-        # two.
+        # SEPARATELY and not as a block: a single mutation that undoes all three
+        # is caught by the first rule it happens to trip and says nothing about
+        # the other two.
         #
         # The rotation, back to the fixed impossible prefix. The control then
         # differs from the configured slug in length, in content and in
@@ -5087,12 +5068,11 @@ def main() -> None:
         # the line says so in the log the reviewer reads.
         for line in auth_unchecked:
             print(f"UNCHECKED: Authenticode step: {line}")
-        # Round 13c asked for a capability predicate; round 13c shipped
-        # `os.name == "nt"`, and round 13d called that what it was -- an OS
-        # proxy. The question is not which OS this is. It is whether the host
-        # COULD have measured what it did not measure, and the probe now answers
-        # that directly: "no-support" means Get-AuthenticodeSignature does not
-        # work here at all, which is a real incapacity on Linux and macOS;
+        # `os.name == "nt"` is an OS proxy, not a capability predicate. The
+        # question is not which OS this is; it is whether the host COULD have
+        # measured what it did not measure, which the probe answers directly:
+        # "no-support" means Get-AuthenticodeSignature does not work here at
+        # all, which is a real incapacity on Linux and macOS;
         # "none-found" means it works and a search of the system binary
         # directories still produced nothing signed, which is a broken probe or
         # a broken trust store on ANY operating system, and never a reason to

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -3265,6 +3265,61 @@ def _powershell() -> str | None:
 FixtureResult = tuple[str, str | None, str | None]
 
 
+def _authenticode_hashed_byte(data: bytes) -> tuple[int | None, str]:
+    """A file offset Authenticode covers, or why this fixture has none.
+
+    The first cut of the tampered-installer row wrote `data[4096:4100]`, which
+    is two assumptions wearing one line. Python slice assignment past the end
+    of a bytearray APPENDS, so on a host whose smallest signed binary is under
+    4 KiB -- and the probe sorts by size ascending, so it goes looking for one
+    -- the tampered-in-the-middle fixture silently became a second copy of the
+    byte-appended fixture: same bytes, same NotSigned, and the row that exists
+    to prove the HashMismatch branch is reachable was re-measuring the row
+    above it. A catalog-signed pick fails the same way for a different reason:
+    it carries no embedded certificate table, so nothing done to it can
+    produce a hash mismatch.
+
+    Both are answered from the file's own geometry instead of a constant.
+    Parse the PE header, find the certificate table, and return an offset that
+    is inside the hashed region and past the spans Authenticode excludes.
+    """
+    if len(data) < 0x40:
+        return None, f"the fixture is {len(data)} bytes, too short for a PE header"
+    pe = int.from_bytes(data[0x3C:0x40], "little")
+    if pe + 0x78 > len(data) or data[pe : pe + 4] != b"PE\0\0":
+        return None, "the fixture has no PE signature where its DOS header points"
+    magic = int.from_bytes(data[pe + 24 : pe + 26], "little")
+    if magic == 0x20B:  # PE32+
+        directories = pe + 24 + 112
+    elif magic == 0x10B:  # PE32
+        directories = pe + 24 + 96
+    else:
+        return None, f"unrecognised PE optional-header magic 0x{magic:x}"
+    # IMAGE_DIRECTORY_ENTRY_SECURITY is index 4, and it is the one directory
+    # whose first field is a FILE OFFSET rather than an RVA.
+    entry = directories + 4 * 8
+    if entry + 8 > len(data):
+        return None, "the PE data directory is truncated before the security entry"
+    table = int.from_bytes(data[entry : entry + 4], "little")
+    size = int.from_bytes(data[entry + 4 : entry + 8], "little")
+    if table == 0 or size == 0:
+        return None, (
+            "the fixture is catalog-signed -- it carries no embedded certificate "
+            "table -- so a modified copy of it reports NotSigned, and a hash "
+            "mismatch is not reachable through this file at all"
+        )
+    # Everything ahead of the certificate table is hashed except the checksum
+    # field and this directory entry, both of which live in the headers. The
+    # last byte before the table is past both.
+    offset = min(table, len(data)) - 1
+    if offset <= entry + 8:
+        return None, (
+            f"the certificate table starts at {table}, which leaves no hashed "
+            "byte after the header fields Authenticode excludes"
+        )
+    return offset, ""
+
+
 def _signed_fixture(shell: str, work: str) -> FixtureResult:
     """A real Authenticode-signed binary on this host, its publisher, and why not.
 
@@ -3293,6 +3348,19 @@ def _signed_fixture(shell: str, work: str) -> FixtureResult:
         "Write-Output 'NO-SUPPORT cmdlet-unusable'; exit 2 }\n"
         "$roots = @([System.Environment]::SystemDirectory, $PSHOME) |\n"
         "  Where-Object { $_ } | Select-Object -Unique\n"
+        # An embedded signature is PREFERRED, not required, so this is the
+        # first valid file seen rather than the answer. Measured on one
+        # Windows 11 host: 613 of the 622 validly signed .exe files under
+        # these roots are CATALOG-signed, which carries no certificate
+        # table of its own -- a modified copy of one reports NotSigned and
+        # can never report HashMismatch. Taking the first valid file made
+        # which kind the caller got a matter of luck, and the tampered
+        # -installer row then read that luck as a regression in the
+        # shipped step. Requiring an embedded one instead would answer
+        # NONE-FOUND on a host that has none in range, and this suite
+        # treats NONE-FOUND as a broken probe. Prefer, fall back, and let
+        # the one row that needs the certificate table say so itself.
+        "$fallback = $null\n"
         "foreach ($root in $roots) {\n"
         "  if (-not (Test-Path -LiteralPath $root)) { continue }\n"
         # Smallest first: the fixture gets read, patched and re-hashed five times.
@@ -3306,10 +3374,12 @@ def _signed_fixture(shell: str, work: str) -> FixtureResult:
         "      [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, "
         "$false)\n"
         "    if (-not $n) { continue }\n"
-        "    Write-Output \"FIXTURE`t$($f.FullName)`t$n\"\n"
-        "    exit 0\n"
+        "    $line = \"FIXTURE`t$($f.FullName)`t$n\"\n"
+        "    if ($s.SignatureType -eq 'Authenticode') { Write-Output $line; exit 0 }\n"
+        "    if (-not $fallback) { $fallback = $line }\n"
         "  }\n"
         "}\n"
+        "if ($fallback) { Write-Output $fallback; exit 0 }\n"
         "Write-Output 'NONE-FOUND'\n"
         "exit 1\n",
         encoding="utf-8",
@@ -3468,7 +3538,22 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
                 if kind == "notsigned":
                     data += b"X"
                 elif kind == "mismatch":
-                    data[4096:4100] = b"ZZZZ"
+                    offset, why = _authenticode_hashed_byte(bytes(data))
+                    if offset is None:
+                        unchecked.append(f"{description}: {why}")
+                        continue
+                    was, before = data[offset], len(data)
+                    data[offset] ^= 0xFF
+                    # Measured, not assumed. A fixture that did not actually
+                    # change is this branch's own version of the defect the
+                    # row exists to catch, and without this check it reaches
+                    # the runner looking like a signed file that stayed valid.
+                    if len(data) != before or data[offset] == was:
+                        violations.append(
+                            f"{description}: patching byte {offset} of the "
+                            f"{before}-byte fixture did not change it"
+                        )
+                        continue
                 elif kind in AUTHENTICODE_SUBSTITUTED_KINDS:
                     # The OPERATOR is matched, not assumed. A mutation that
                     # swaps -cne for -ne must leave both rows buildable, or the
@@ -3530,6 +3615,31 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
                     f"{output.strip()[:400]!r}"
                 )
             elif required not in output:
+                # A row can exit for the right reason and still not prove its
+                # own claim. The tampered-installer row asks for HashMismatch;
+                # if this host's signed binary refuses with some other status
+                # the gate did hold -- the installer was rejected -- but the
+                # HashMismatch branch went unexercised. That is the third
+                # state, and it is reported with the status that actually came
+                # back, so a reader can tell it from both a pass and a
+                # regression. The row also leaves `ran`, which is what stops
+                # the mutation loop below from crediting it with catching
+                # anything.
+                status = re.search(r"^Status: (\S+)", output, re.MULTILINE)
+                if (
+                    kind == "mismatch"
+                    and status is not None
+                    and status.group(1) != "HashMismatch"
+                    and "Authenticode status is" in output
+                ):
+                    unchecked.append(
+                        f"{description}: this host's fixture reports "
+                        f"{status.group(1)!r} when tampered rather than "
+                        "'HashMismatch'; the step refused it either way, but "
+                        "nothing here exercised the hash-mismatch branch"
+                    )
+                    ran.discard(kind)
+                    continue
                 failed.add(kind)
                 violations.append(
                     f"Authenticode step: {description}: exited {result.returncode} "

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -1986,8 +1986,8 @@ SIGNPATH_GUARD_TRUTH_TABLE: tuple[
     #
     # Rows 1 and 2 above already cover REQUIRED=false: unset behaves as false,
     # and the guard cannot tell an unset variable from an explicit one. These
-    # four make each combination explicit, because the matrix is the finding and
-    # a matrix that is only implied is a matrix nobody checked.
+    # four make each combination explicit, because a matrix that is only implied
+    # is a matrix nobody checked.
     (
         "not required, not configured: today's upstream state and every fork's",
         {"SIGNPATH_CONFIGURED": "false", "SIGNPATH_REQUIRED": "false"},
@@ -2234,8 +2234,8 @@ def _filtering_server_but(project_reply: str) -> tuple[tuple[str, str], ...]:
 #: Columns: description, env, stub replies, expected exit, text the output
 #: MUST contain, text it must NOT contain.
 #:
-#: The exit column carries three states, not two, and that is the finding this
-#: table exists to hold on to:
+#: The exit column carries three states, not two, and that is what this table
+#: exists to hold on to:
 #:
 #:   0  everything this run looked at answered affirmatively
 #:   1  something answered NEGATIVELY
@@ -2592,7 +2592,7 @@ def _stub_curl(directory: str, replies: tuple[tuple[str, str], ...]) -> None:
     shape a TRANSFER THAT FAILED has: curl prints the status line it had already
     received through `-w` and then exits non-zero (28 timeout, 18 short body, 56
     reset). Without it this stub could only ever produce completed requests, and
-    the round-5 finding is precisely about the ones that do not complete.
+    the rows that matter here are the ones that do not complete.
     """
     lines = [
         "#!/usr/bin/env bash",
@@ -3772,26 +3772,24 @@ def authenticode_behaviour_violations(
 ) -> AuthenticodeRun:
     """Run the shipped Authenticode step against real signed and broken files.
 
-    Nothing here is stubbed: Windows itself answers, over files whose signature
-    state was produced rather than asserted. One qualification, because round
-    13d was right that "nothing is mocked" overstated it -- the `accepted` row
-    substitutes the expected publisher, since no host running this has a
-    SignPath-signed file. It measures that a valid signature from the expected
-    publisher reaches PASS; the literal `SignPath Foundation` is pinned by a
-    separate static contract, and the publisher mutation below is what shows the
-    comparison is load-bearing. The static contract on this step is all
-    substring markers, so
-    an `exit 0` inserted at the top of the body satisfies every one of them and
-    ships an unsigned installer -- the exact defect class this workstream exists
-    to catch, in the gate that is supposed to catch it.
+    Windows itself answers, over files whose signature state was produced rather
+    than asserted. One qualification: the `accepted` row substitutes the expected
+    publisher, since no host running this has a SignPath-signed file. It measures
+    that a valid signature from the expected publisher reaches PASS; the literal
+    `SignPath Foundation` is pinned by a separate static contract, and the
+    publisher mutation below is what shows the comparison is load-bearing. That
+    static contract is all substring markers, so an `exit 0` inserted at the top
+    of the body satisfies every one of them and ships an unsigned installer --
+    the exact defect class this workstream exists to catch, in the gate that is
+    supposed to catch it.
 
-    Coverage degrades by ROW, not all-or-nothing. The
-    `missing` row needs no Authenticode at all -- the step throws on Test-Path
-    before it reaches the cmdlet -- so it runs anywhere pwsh exists, including
-    the Ubuntu lane that actually runs this suite in CI, and it is the row that
-    catches an early `exit 0`. The four signature-state rows need Windows. The
-    caller is told which kinds ran so it can require exactly the mutations those
-    rows can catch, and name the rest UNCHECKED rather than passing over them.
+    Coverage degrades by ROW, not all-or-nothing. The `missing` row needs no
+    Authenticode at all -- the step throws on Test-Path before it reaches the
+    cmdlet -- so it runs anywhere pwsh exists, including the Ubuntu lane that
+    actually runs this suite in CI, and it is the row that catches an early
+    `exit 0`. The four signature-state rows need Windows. The caller is told
+    which kinds ran so it can require exactly the mutations those rows can catch,
+    and name the rest UNCHECKED rather than passing over them.
 
     `only` restricts the pass to the named kinds. A mutation control already
     knows which rows can catch its mutation, and the rows that cannot are pure

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -3265,6 +3265,31 @@ def _powershell() -> str | None:
 FixtureResult = tuple[str, str | None, str | None]
 
 
+def _authenticode_status(shell: str, path: str) -> str | None:
+    """What this host's Authenticode makes of a file, or None if it could not
+    be asked. The path travels in the environment rather than inside the
+    command string, so a temp directory containing a quote cannot rewrite it.
+    """
+    try:
+        result = subprocess.run(
+            [
+                shell,
+                "-NoProfile",
+                "-Command",
+                "(Get-AuthenticodeSignature -LiteralPath "
+                "$env:AUTHENTICODE_PROBE_PATH).Status.ToString()",
+            ],
+            env={**os.environ, "AUTHENTICODE_PROBE_PATH": path},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    lines = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    return lines[0] if result.returncode == 0 and lines else None
+
+
 def _authenticode_hashed_byte(data: bytes) -> tuple[int | None, str]:
     """A file offset Authenticode covers, or why this fixture has none.
 
@@ -3311,7 +3336,22 @@ def _authenticode_hashed_byte(data: bytes) -> tuple[int | None, str]:
     # Everything ahead of the certificate table is hashed except the checksum
     # field and this directory entry, both of which live in the headers. The
     # last byte before the table is past both.
-    offset = min(table, len(data)) - 1
+    #
+    # A table that starts past the end of the file is one whose headers and
+    # contents disagree. The first cut clamped that case with
+    # `min(table, len(data)) - 1` and answered anyway -- and the last byte of
+    # an embedded-signed file is NOT hashed (measured: flipping it leaves the
+    # signature Valid), so the clamp hands back an offset that produces a
+    # still-valid fixture, and the row then reports the shipped step accepting
+    # a tampered installer. A parser error, wearing a product regression's
+    # clothes. A parser that cannot trust its input refuses instead.
+    if table > len(data):
+        return None, (
+            f"the certificate table claims to start at {table} in a "
+            f"{len(data)}-byte file, so its headers and its contents disagree "
+            "and no offset derived from them can be trusted"
+        )
+    offset = table - 1
     if offset <= entry + 8:
         return None, (
             f"the certificate table starts at {table}, which leaves no hashed "
@@ -3542,16 +3582,33 @@ def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
                     if offset is None:
                         unchecked.append(f"{description}: {why}")
                         continue
-                    was, before = data[offset], len(data)
                     data[offset] ^= 0xFF
-                    # Measured, not assumed. A fixture that did not actually
-                    # change is this branch's own version of the defect the
-                    # row exists to catch, and without this check it reaches
-                    # the runner looking like a signed file that stayed valid.
-                    if len(data) != before or data[offset] == was:
-                        violations.append(
-                            f"{description}: patching byte {offset} of the "
-                            f"{before}-byte fixture did not change it"
+                    # Ask Authenticode about the fixture BEFORE the step does.
+                    #
+                    # This check used to be `data[offset] != was` after
+                    # `data[offset] ^= 0xFF` -- true by arithmetic, and item
+                    # assignment cannot change a bytearray's length either. A
+                    # control that cannot fail, sitting inside the fixture
+                    # builder for the row whose whole purpose is to enforce
+                    # that controls can fail.
+                    #
+                    # What can actually go wrong is that the chosen byte turns
+                    # out not to be covered by the signature. Then the step
+                    # accepts the file, the row sees exit 0, and it reports a
+                    # shipped gate that waves through tampered installers --
+                    # when the truth is a fixture that could not pose the
+                    # question. Asking here attributes it correctly, and this
+                    # check CAN fail: it did, against a deliberately clamped
+                    # offset at the end of the file, which comes back 'Valid'.
+                    Path(staged).write_bytes(bytes(data))
+                    built = _authenticode_status(shell, staged)
+                    if built != "HashMismatch":
+                        unchecked.append(
+                            f"{description}: byte {offset} of this host's "
+                            f"fixture is not covered by its signature -- the "
+                            f"tampered copy reports {built!r} rather than "
+                            "'HashMismatch', so this row cannot ask its "
+                            "question here"
                         )
                         continue
                 elif kind in AUTHENTICODE_SUBSTITUTED_KINDS:
@@ -3820,6 +3877,23 @@ AUTHENTICODE_MUTATIONS: tuple[tuple[str, str, frozenset[str], str], ...] = (
         # exactly as the comment on the runner below says.
         frozenset({"signed"}),
         "the publisher check, which is what makes it SignPath's signature",
+    ),
+    (
+        # The one mutation `mismatch` alone can see, and the reason that row is
+        # worth the PE parsing it costs. Widening the status check to admit
+        # HashMismatch ships a gate that accepts an installer modified after
+        # signing, which is the whole threat this step exists for -- and every
+        # other row still passes: `notsigned` still throws (NotSigned is
+        # neither Valid nor HashMismatch), `missing` never reaches the check,
+        # and the three Valid rows are untouched. Without this entry the
+        # catcher sets only ever list `mismatch` alongside `notsigned`, so the
+        # mutation loop could never demand that the row catch anything by
+        # itself, and the row's unique claim was stated rather than enforced.
+        "          if ($signature.Status -ne 'Valid') {\n",
+        "          if ($signature.Status -ne 'Valid' -and "
+        "$signature.Status -ne 'HashMismatch') {\n",
+        frozenset({"mismatch"}),
+        "the status check's refusal of a file modified after signing",
     ),
     (
         # One operator, and the defect it hides is invisible to every other row

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -3,11 +3,17 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import re
+import shlex
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+from typing import NamedTuple
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -24,10 +30,18 @@ CLASSIFIER_PATH = REPO_ROOT / "scripts" / "classify-release-candidate.py"
 ARCHIVE_PATH = REPO_ROOT / "scripts" / "release_archive.py"
 PROMOTION_PATH = REPO_ROOT / "scripts" / "release-promotion.py"
 SYNC_RELEASE_PR_PATH = REPO_ROOT / "scripts" / "sync-release-pr.py"
+SIGNPATH_STATUS_PATH = REPO_ROOT / ".github" / "workflows" / "signpath-status.yml"
 RUNTIME_IMAGE_PATH = REPO_ROOT / "scripts" / "verify-release-runtime-image.py"
 PUBLISH_CRATE_TEST_PATH = REPO_ROOT / "scripts" / "publish-crate.test.py"
 
+# The Windows installer's Authenticode signer. It is in this allowlist because
+# the loop that reads the allowlist SKIPS any action missing from it, so an
+# action absent here is an action nobody checks the pin of.
+SIGNPATH_ACTION = "SignPath/github-action-submit-signing-request"
+SIGNPATH_ACTION_SHA = "c92b958760219087e01f8d67a1669ed57afe2627"
+
 EXPECTED_NODE24_ACTIONS = {
+    SIGNPATH_ACTION: SIGNPATH_ACTION_SHA,
     "actions/checkout": "d23441a48e516b6c34aea4fa41551a30e30af803",
     "actions/upload-artifact": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     "actions/download-artifact": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
@@ -457,7 +471,15 @@ def contract_violations(
         # notarize step past the job's own cap -- a hard kill that never prints
         # the submission id the operator needs.
         "app-bundle": 210,
-        "app-bundle-windows": 120,
+        # Raised to 165 when SignPath signing was wired in. A job timeout starts
+        # when the JOB starts, so this budgets the whole job, not the tail:
+        # ~40 minutes of measured pre-signing work (runs 33043452863,
+        # 33121699208, 33284603345 and 33291555184 took 38m21s to 39m00s end to
+        # end), 10 for moving a 62 MB installer to SignPath and back, the
+        # 5400-second wait the action is given for a human approver, 5 for
+        # replace/re-sign/stage/verify, and 20 of margin. Raise the action's
+        # wait and this moves with it.
+        "app-bundle-windows": 165,
     }.items():
         if not re.search(
             rf"^    timeout-minutes: {timeout}\s*$",
@@ -791,6 +813,473 @@ def contract_violations(
                 f"Node 24 action {action} uses mutable or unexpected reference {reference}"
             )
     violations.extend(release_cache_retry_contract_violations(ci))
+    violations.extend(signpath_signing_contract_violations(ci, release))
+    violations.extend(authenticode_lane_violations(ci))
+    return violations
+
+
+#: The job that runs THIS suite on a host that can answer the Authenticode
+#: half of it, and the variable that makes an unanswerable row fatal there.
+AUTHENTICODE_LANE_JOB = "windows-release-contract"
+AUTHENTICODE_LANE_FLAG = 'WENLAN_REQUIRE_AUTHENTICODE: "1"'
+
+
+def authenticode_lane_violations(ci: str) -> list[str]:
+    """A lane that CAN measure Authenticode must exist, and must be required.
+
+    Everything else in this file checks the release workflow. This checks the
+    only thing that decides whether the checks are ever run against a host that
+    can perform them.
+
+    The hole it closes: this suite reaches CI through
+    scripts/validate-versions.test.sh, which runs in ci.yml's `docs` job on
+    ubuntu-24.04. There is no Get-AuthenticodeSignature there, so the truth
+    table's signature rows and the mutations only those rows can catch print
+    UNCHECKED and the suite exits 0 -- a failed measurement wearing the same
+    exit status as a clean one. `WENLAN_REQUIRE_AUTHENTICODE=1` already turns
+    those lines fatal; until now nothing set it anywhere, so it was an opt-in
+    that nothing opted into.
+    """
+
+    violations: list[str] = []
+    job = job_body(ci, AUTHENTICODE_LANE_JOB)
+    if not job:
+        return [
+            f"ci.yml has no {AUTHENTICODE_LANE_JOB!r} job, so nothing runs this "
+            "suite on a host that can call Get-AuthenticodeSignature. Every "
+            "signature row would be UNCHECKED on the Ubuntu docs lane, and "
+            "UNCHECKED there exits 0"
+        ]
+    if "runs-on: windows-" not in job:
+        violations.append(
+            f"{AUTHENTICODE_LANE_JOB} does not run on Windows; the rows it exists "
+            "to make fatal cannot be measured anywhere else"
+        )
+    if AUTHENTICODE_LANE_FLAG not in job:
+        violations.append(
+            f"{AUTHENTICODE_LANE_JOB} does not set {AUTHENTICODE_LANE_FLAG}, so an "
+            "Authenticode row that could not be built stays a printed line and the "
+            "job exits 0 -- the lane exists and measures nothing"
+        )
+    if "scripts/release-workflow-contract.test.py" not in job:
+        violations.append(
+            f"{AUTHENTICODE_LANE_JOB} does not run this suite"
+        )
+    # Required, not merely present. `conclusion` is the aggregating check, and a
+    # job missing from its `needs` is a job whose failure nothing reads.
+    # Comments stripped here for a second reason: commenting the line out is
+    # how a required job stops being required, and a check that reads commented
+    # text is a check that cannot see that happen.
+    conclusion = "\n".join(
+        line
+        for line in job_body(ci, "conclusion").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    if AUTHENTICODE_LANE_JOB not in conclusion.split("steps:")[0]:
+        violations.append(
+            f"{AUTHENTICODE_LANE_JOB} is not in conclusion's needs, so the lane can "
+            "fail without failing CI"
+        )
+    if f"expect_job {AUTHENTICODE_LANE_JOB} " not in conclusion:
+        violations.append(
+            f"conclusion has no expect_job line for {AUTHENTICODE_LANE_JOB}; a job "
+            "in `needs` with `if: always()` above it is still not required until "
+            "its result is asserted"
+        )
+    # And NOT on a lane that cannot answer. Telling the Ubuntu docs job to
+    # require Authenticode would make it red for a capability it has never had,
+    # which ends with the flag being removed again.
+    # Comments stripped first: a job's body runs to the next job key, so the
+    # prose introducing the NEXT job -- which names this variable, because it
+    # explains why the variable is not set here -- would otherwise read as the
+    # docs lane setting it.
+    docs = "\n".join(
+        line
+        for line in job_body(ci, "docs").splitlines()
+        if not line.lstrip().startswith("#")
+    )
+    if "WENLAN_REQUIRE_AUTHENTICODE" in docs:
+        violations.append(
+            "the ubuntu docs lane sets WENLAN_REQUIRE_AUTHENTICODE; it cannot run "
+            "Get-AuthenticodeSignature at all, so this makes it permanently red "
+            "rather than making anything measured"
+        )
+    return violations
+
+
+# Steps that may only run when SignPath is fully configured. The
+# presence-consistency check is deliberately NOT in this list: guarding it would
+# reopen the exact hole it exists to close.
+SIGNPATH_GUARDED_STEPS = [
+    "Upload the unsigned installer for SignPath",
+    "Submit the installer to SignPath for signing",
+    "Replace the unsigned installer with the signed one",
+    "Regenerate the updater signature over the signed installer",
+    "Verify the installer carries a valid SignPath signature",
+]
+
+# The order these have to happen in, and the reason each edge exists:
+#   build -> upload           nothing to submit before the installer is built
+#   upload -> submit          the action takes a github-artifact-id
+#   submit -> replace         the bundle path still holds unsigned bytes
+#   replace -> re-sign        the .sig covers the bytes as they are now
+#   re-sign -> stage          staging copies and hashes both files
+#   stage -> Authenticode     the assertion runs on the bytes that ship
+#   Authenticode -> DLL/upload nothing publishes before both gates pass
+SIGNPATH_STEP_ORDER = [
+    "Build Windows desktop app bundle",
+    "Upload the unsigned installer for SignPath",
+    "Submit the installer to SignPath for signing",
+    "Replace the unsigned installer with the signed one",
+    "Regenerate the updater signature over the signed installer",
+    "Stage app bundle assets and checksums",
+    "Verify the installer carries a valid SignPath signature",
+    "Verify the runtime DLLs ship inside the installer",
+    "Upload Windows app bundle artifact",
+]
+
+
+def signpath_signing_contract_violations(ci: str, release: str) -> list[str]:
+    """Keep Windows Authenticode signing guarded, pinned, ordered, and asserted.
+
+    None of this is exercised by a run today: the SignPath Foundation
+    application is pending, no SIGNPATH_* secret exists, so every guarded step
+    below is skipped on every real release. That is precisely why the shape is
+    pinned statically -- the first time these steps run for real will be a tag
+    release, and the failure modes are all silent ones.
+    """
+
+    violations: list[str] = []
+    job = job_body(release, "app-bundle-windows")
+    if not job:
+        return ["release.yml no longer defines app-bundle-windows"]
+
+    # ---- the two sentinels and the permission the action needs ----
+    #
+    # SIGNPATH_CONFIGURED was pinned to the exact single-secret string
+    # `secrets.SIGNPATH_API_TOKEN != ''`, which was never a bypass -- the
+    # unconditional all-or-nothing step rejects every 1-to-3-of-4 combination --
+    # but it named one fifth of what it claimed to measure, and this contract
+    # actively REJECTED the clearer expression. The rule is now the property:
+    # all four required secrets have to appear in the sentinel, so no subset of
+    # them can be present while it reads true.
+    sentinel = re.search(r"^      SIGNPATH_CONFIGURED: (?P<expr>.+)$", job, re.MULTILINE)
+    if sentinel is None:
+        violations.append("app-bundle-windows no longer defines SIGNPATH_CONFIGURED")
+    else:
+        expression = sentinel.group("expr")
+        for secret in (
+            "SIGNPATH_API_TOKEN",
+            "SIGNPATH_ORGANIZATION_ID",
+            "SIGNPATH_PROJECT_SLUG",
+            "SIGNPATH_SIGNING_POLICY_SLUG",
+        ):
+            if f"secrets.{secret} != ''" not in expression:
+                violations.append(
+                    f"SIGNPATH_CONFIGURED does not require secrets.{secret}; the "
+                    "sentinel every signing step keys on would read true with that "
+                    "secret absent"
+                )
+    # SIGNPATH_REQUIRED is the other half, and the one that did not exist. With
+    # only SIGNPATH_CONFIGURED, a repository whose secrets were never installed
+    # is indistinguishable from a repository that is not supposed to sign: both
+    # skip all five signing steps, stage the unsigned installer, and finish
+    # green. That is correct while the SignPath Foundation application is
+    # pending, and it becomes the critical hole on the day it is accepted.
+    #
+    # Two properties, because either alone is satisfiable by the wrong thing: it
+    # must be scoped to the upstream repository (so no fork can be forced to
+    # sign) and it must key on an Actions VARIABLE (so the activation is a
+    # visible, auditable, single flip rather than a value nobody can read back).
+    required = re.search(r"^      SIGNPATH_REQUIRED: (?P<expr>.+)$", job, re.MULTILINE)
+    if required is None:
+        violations.append(
+            "app-bundle-windows defines no SIGNPATH_REQUIRED sentinel; without one "
+            "an accepted-but-unwired repository publishes an unsigned installer and "
+            "reports success, exactly as an intentionally unsigned one does"
+        )
+    else:
+        expression = required.group("expr")
+        if "github.repository == '7xuanlu/wenlan'" not in expression:
+            violations.append(
+                "SIGNPATH_REQUIRED is not scoped to the upstream repository; a fork "
+                "has no SignPath secrets and must still build green"
+            )
+        if "vars.SIGNPATH_ACTIVE" not in expression:
+            violations.append(
+                "SIGNPATH_REQUIRED does not key on vars.SIGNPATH_ACTIVE; the "
+                "activation must be an Actions variable a human can read back, not "
+                "a secret whose value nothing can audit"
+            )
+        if "secrets." in expression:
+            violations.append(
+                "SIGNPATH_REQUIRED reads a secret; then 'must this build be signed' "
+                "and 'are the secrets here' would answer the same question again "
+                "and the missing-secret case could never be detected"
+            )
+    permissions_block = re.search(
+        r"^    permissions:\n(?P<body>(?:      \S.*\n|      #.*\n)+)", job, re.MULTILINE
+    )
+    if permissions_block is None or "      actions: read\n" not in permissions_block.group("body"):
+        violations.append(
+            "app-bundle-windows does not grant actions: read; the SignPath action "
+            "cannot read job details or download the artifact it just uploaded"
+        )
+
+    # ---- the one step that must NOT be guarded ----
+    consistency = named_step_body(job, SIGNPATH_GUARD_STEP)
+    if not consistency:
+        violations.append(
+            "app-bundle-windows has no unconditional SignPath presence-consistency check"
+        )
+    else:
+        if "SIGNPATH_CONFIGURED" in consistency.split("run:")[0]:
+            violations.append(
+                "the SignPath presence-consistency check is guarded by the very "
+                "sentinel it exists to police; a missing API token would skip it "
+                "along with every signing step and publish an unsigned installer"
+            )
+        for marker in [
+            "must be all set or all unset",
+            "SECRET_SIGNPATH_API_TOKEN",
+            "SECRET_SIGNPATH_ORGANIZATION_ID",
+            "SECRET_SIGNPATH_PROJECT_SLUG",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG",
+            # The required-but-absent latch lives in this same step, because it
+            # needs the same property: it must run in the configuration it
+            # rejects. A step whose `if:` encoded the rule would skip exactly
+            # when the rule was about to fire.
+            "SIGNPATH_REQUIRED",
+        ]:
+            if marker not in consistency:
+                violations.append(
+                    f"SignPath presence-consistency check omits {marker!r}"
+                )
+        if "SIGNPATH_REQUIRED" in consistency.split("run:")[0].split("env:")[0]:
+            violations.append(
+                "the SignPath presence-consistency check is guarded by "
+                "SIGNPATH_REQUIRED; the latch that fails a required-but-unconfigured "
+                "build must not skip when signing is not required, or it can never "
+                "run in the state it exists to reject"
+            )
+
+    # ---- every signing step must be guarded ----
+    for step_name in SIGNPATH_GUARDED_STEPS:
+        body = named_step_body(job, step_name)
+        if not body:
+            violations.append(f"Windows release job omits SignPath step {step_name!r}")
+        elif "if: env.SIGNPATH_CONFIGURED == 'true'" not in body:
+            violations.append(
+                f"SignPath step {step_name!r} is not guarded; a fork with no "
+                "SignPath secret would fail instead of building"
+            )
+
+    # ---- the pin, and the reason the allowlist alone is not enough ----
+    signpath_references = [
+        (action, reference)
+        for action, reference in re.findall(r"uses:\s*([^@\s]+)@([^\s#]+)", job)
+        if action.lower().endswith("github-action-submit-signing-request")
+    ]
+    if not signpath_references:
+        violations.append("Windows release job no longer submits the installer to SignPath")
+    for action, reference in signpath_references:
+        if action != SIGNPATH_ACTION:
+            violations.append(
+                f"SignPath action is spelled {action!r}, not {SIGNPATH_ACTION!r}; the "
+                "Node 24 pin allowlist skips any action it does not recognise, so "
+                "this reference would be unpinned and nothing would say so"
+            )
+        if reference != SIGNPATH_ACTION_SHA:
+            violations.append(
+                f"SignPath action reference {reference!r} is not the pinned "
+                f"{SIGNPATH_ACTION_SHA}"
+            )
+
+    # ---- the submission itself ----
+    submit = named_step_body(job, "Submit the installer to SignPath for signing")
+    if submit:
+        if "output-artifact-directory:" not in submit:
+            violations.append(
+                "SignPath submission omits output-artifact-directory; the action's "
+                "own manifest says it then does not download the signed artifact, "
+                "the job stays green, and the release ships the unsigned installer"
+            )
+        if 'skip-decompress: "false"' not in submit:
+            violations.append(
+                'SignPath submission does not keep skip-decompress: "false"; the '
+                "upload is an archived artifact, so the returned ZIP has to be "
+                "extracted for the replacement step to find a bare installer"
+            )
+        wait = re.search(
+            r'wait-for-completion-timeout-in-seconds:\s*"?(\d+)"?', submit
+        )
+        if wait is None:
+            violations.append(
+                "SignPath submission does not set wait-for-completion-timeout-in-seconds"
+            )
+        elif int(wait.group(1)) <= 600:
+            violations.append(
+                f"SignPath wait timeout {wait.group(1)}s is not raised past the "
+                "600-second default; the Foundation requires a human to approve "
+                "each signing request"
+            )
+        if "github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}" not in submit:
+            violations.append(
+                "SignPath submission does not take its artifact id from the upload step"
+            )
+
+    # ---- the upload that feeds it ----
+    upload = named_step_body(job, "Upload the unsigned installer for SignPath")
+    if upload:
+        # Line-anchored, because the step explains both of these decisions in
+        # prose and a substring test would be satisfied by the comment.
+        if re.search(r"^\s*archive:\s*false\s*$", upload, re.MULTILINE):
+            violations.append(
+                "the unsigned installer upload uses archive: false, which makes the "
+                "artifact name the file's basename and breaks retry safety"
+            )
+        if not re.search(r"^\s*overwrite:\s*true\s*$", upload, re.MULTILINE):
+            violations.append(
+                "the unsigned installer upload is not retry-safe; a re-run collides "
+                "with the previous attempt's artifact of the same name"
+            )
+        if not re.search(r"^\s*if-no-files-found:\s*error\s*$", upload, re.MULTILINE):
+            violations.append(
+                "the unsigned installer upload does not fail on an empty match"
+            )
+
+    # ---- replacement is a content assertion, never a timestamp one ----
+    replace = named_step_body(job, "Replace the unsigned installer with the signed one")
+    if replace:
+        for marker in [
+            "Get-FileHash",
+            "if ($before -eq $after)",
+            "nothing was signed",
+        ]:
+            if marker not in replace:
+                violations.append(
+                    "the signed-installer replacement does not compare content: "
+                    f"{marker!r} is missing. ZIP extraction restores the archive "
+                    "entry's timestamp, so an mtime comparison passes and fails for "
+                    "the wrong reasons"
+                )
+        for marker in ["$unsigned.Count -ne 1", "$signed.Count -ne 1", ".Name -ne "]:
+            if marker not in replace:
+                violations.append(
+                    f"the signed-installer replacement omits a cardinality or "
+                    f"filename assertion: {marker!r}"
+                )
+        if "LastWriteTime" in replace:
+            violations.append(
+                "the signed-installer replacement gates on a file timestamp; "
+                "extraction restores the archive entry's mtime, so this is neither "
+                "necessary nor sufficient"
+            )
+
+    # ---- the updater signature covers the signed bytes ----
+    resign = named_step_body(job, "Regenerate the updater signature over the signed installer")
+    if resign:
+        for marker in [
+            "TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}",
+            "TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}",
+            "pnpm tauri signer sign",
+        ]:
+            if marker not in resign:
+                violations.append(
+                    "the updater re-signing step needs its own copy of the signing "
+                    f"key: {marker!r} is missing. Those secrets are env: on the "
+                    "bundle build step alone"
+                )
+        if 'before_sig' not in resign:
+            violations.append(
+                "the updater re-signing step does not prove the .sig changed; it "
+                "was computed over the unsigned bytes"
+            )
+
+    # ---- the publisher assertion ----
+    authenticode = named_step_body(job, "Verify the installer carries a valid SignPath signature")
+    if authenticode:
+        for marker in [
+            "Get-AuthenticodeSignature",
+            "$signature.Status -ne 'Valid'",
+            "GetNameInfo(",
+            # -cne, not -ne. PowerShell's -ne is case-INSENSITIVE, so the check
+            # this marker guards accepted 'signpath foundation' and every other
+            # casing of it. The case-sensitive operator is the assertion; the
+            # case-insensitive one only looks like it.
+            "$publisher -cne 'SignPath Foundation'",
+            "steps.stage.outputs.setup_filename",
+        ]:
+            if marker not in authenticode:
+                violations.append(
+                    "the Authenticode assertion is incomplete: "
+                    f"{marker!r} is missing. Status alone lets any publisher pass, "
+                    "and a skipped download must not read as a signed build"
+                )
+        if re.search(r"\$\w*[Cc]ertificate\.Subject\s+-(?:eq|like|match)", authenticode):
+            violations.append(
+                "the Authenticode assertion compares the raw certificate Subject; "
+                "that is a full distinguished name, so use GetNameInfo(SimpleName)"
+            )
+        # The marker above proves the case-SENSITIVE comparison is present; this
+        # proves the case-insensitive one has not been added back beside it. A
+        # second `-ne`/`-ine` against the publisher would make the -cne line
+        # decorative.
+        if re.search(r"\$publisher\s+-(?:ne|ine|eq|ieq|like|ilike)\b", authenticode):
+            violations.append(
+                "the Authenticode assertion compares $publisher with a "
+                "case-INSENSITIVE operator; PowerShell's -ne, -eq and -like all "
+                "ignore case, so 'signpath foundation' passes a check written to "
+                "demand one exact name. Use -cne"
+            )
+        # Nobody in this repository has seen SignPath Foundation's certificate --
+        # the application is pending -- so the first signed build's log is the
+        # only place the real Subject and Thumbprint will ever appear. Printed
+        # unconditionally, BEFORE the comparison: a run that fails the publisher
+        # check is exactly the run whose values someone needs, and a Write-Host
+        # placed after the throw prints on the passing runs only.
+        for marker in ["$($certificate.Subject)", "$($certificate.Thumbprint)"]:
+            if marker not in authenticode:
+                violations.append(
+                    f"the Authenticode assertion never logs {marker!r}; the "
+                    "publisher check compares a name nobody has verified against "
+                    "a certificate nobody has seen, and without this the only way "
+                    "to learn what it really says is to cut another release"
+                )
+        subject_log = authenticode.find("$($certificate.Subject)")
+        comparison = authenticode.find("$publisher -cne")
+        if -1 not in (subject_log, comparison) and subject_log > comparison:
+            violations.append(
+                "the certificate Subject is logged after the publisher "
+                "comparison, so the run that most needs the value -- the one "
+                "that failed -- is the one that does not print it"
+            )
+
+    # ---- order, which nothing else in this repository checks ----
+    positions: dict[str, int] = {}
+    for step_name in SIGNPATH_STEP_ORDER:
+        index = job.find(f"      - name: {step_name}\n")
+        if index < 0:
+            violations.append(f"Windows release job omits ordered step {step_name!r}")
+        else:
+            positions[step_name] = index
+    ordered = [name for name in SIGNPATH_STEP_ORDER if name in positions]
+    for earlier, later in zip(ordered, ordered[1:]):
+        if positions[earlier] >= positions[later]:
+            violations.append(
+                f"Windows release step order is wrong: {later!r} must come after "
+                f"{earlier!r}. Signing that lands after staging publishes unsigned "
+                "bytes or a digest that no longer matches the file"
+            )
+
+    # ---- the release job is the only Windows job allowed to talk to SignPath ----
+    ci_job = job_body(ci, "app-windows-bundle")
+    if ci_job and "signpath" in ci_job.lower():
+        violations.append(
+            "ci.yml app-windows-bundle references SignPath; that job publishes "
+            "nothing and must not consume the signing credentials, and its markers "
+            "are asserted in BOTH Windows recipes"
+        )
     return violations
 
 
@@ -1297,6 +1786,1945 @@ def trusted_candidate_gate_violations(
     return violations
 
 
+SIGNPATH_GUARD_STEP = (
+    "Check SignPath configuration is all-or-nothing, and present when required"
+)
+
+
+def posix_bash() -> str:
+    """A POSIX bash, never WSL's.
+
+    On any Windows machine with WSL installed the first `bash` on PATH is
+    C:\\Windows\\System32\\bash.exe, which is the Linux distro. Running a
+    workflow fragment there fails with an opaque RPC error that has nothing to
+    do with the fragment. Same resolution order as scripts/run-bash.mjs, which
+    exists for exactly this. Missing bash raises: a guard that cannot be run is
+    a guard that was not checked, not one that passed.
+    """
+    if sys.platform != "win32":
+        return "bash"
+    candidates = []
+    if os.environ.get("WENLAN_BASH"):
+        candidates.append(os.environ["WENLAN_BASH"])
+    roots = [
+        os.environ.get("ProgramFiles"),
+        os.environ.get("ProgramFiles(x86)"),
+        os.environ.get("ProgramW6432"),
+    ]
+    local = os.environ.get("LOCALAPPDATA")
+    if local:
+        roots.append(os.path.join(local, "Programs"))
+    for root in roots:
+        if root:
+            candidates.append(os.path.join(root, "Git", "bin", "bash.exe"))
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if re.search(r"[\\/]git[\\/](cmd|bin)$", entry, re.IGNORECASE):
+            candidates.append(os.path.join(entry, "..", "bin", "bash.exe"))
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    raise AssertionError(
+        "no Git Bash found; set WENLAN_BASH. The `bash` on PATH is WSL and "
+        "cannot run a Windows workflow fragment."
+    )
+
+
+def signpath_guard_script(release: str) -> str:
+    """The SHIPPED body of the all-or-nothing guard, ready to run under bash.
+
+    Keyed on the job and the step name, and required to appear exactly once. An
+    extractor that takes "the first `run: |` in the file" tests whichever block
+    happens to come first, so a decoy step added above it would leave this one
+    changing unwatched.
+    """
+    job = job_body(release, "app-bundle-windows")
+    if not job:
+        raise AssertionError("release.yml has no app-bundle-windows job")
+    occurrences = job.count(f"- name: {SIGNPATH_GUARD_STEP}\n")
+    if occurrences != 1:
+        raise AssertionError(
+            f"expected exactly one {SIGNPATH_GUARD_STEP!r} step, found {occurrences}"
+        )
+    step = named_step_body(job, SIGNPATH_GUARD_STEP)
+    match = re.search(r"^[ ]*run: \|\n(?P<body>.*)\Z", step, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"{SIGNPATH_GUARD_STEP!r} has no `run: |` block")
+    body = match.group("body").split("\n")
+    indent = len(body[0]) - len(body[0].lstrip())
+    script = "\n".join(line[indent:] if len(line) >= indent else line for line in body)
+    if "present=0" not in script:
+        raise AssertionError("the extracted guard is not the guard; shape changed")
+    return script
+
+
+# Every configuration this step can meet, and the status it must exit with.
+# The static contract below checks that the diagnostics and the secret names are
+# present; it cannot see the arithmetic. `present=$((present + 1))` mutated to
+# `+ 0` leaves every marker in place, passes the static contract, and lets a
+# release with three of four secrets ship an UNSIGNED installer. Only running
+# the step catches that.
+#
+# Columns: a description, the environment (the four secrets, the optional
+# artifact slug, SIGNPATH_CONFIGURED and SIGNPATH_REQUIRED), the exit status the
+# step must produce, and every string its output must contain.
+#
+# The output column exists because a status is not a diagnosis. The
+# required-but-unconfigured latch is the only thing standing between an accepted
+# SignPath application and a green unsigned release, and it will fire in front
+# of somebody who has never seen it before; "exit 1" with nothing naming the
+# missing secret sends them to read the workflow. Asserting the text is also the
+# only way to tell the latch apart from the all-or-nothing check, which exits 1
+# in some of the same rows for an entirely different reason.
+SIGNPATH_GUARD_TRUTH_TABLE: tuple[
+    tuple[str, dict[str, str], int, tuple[str, ...]], ...
+] = (
+    (
+        "nothing configured is the pending state, and every fork's state",
+        {"SIGNPATH_CONFIGURED": "false"},
+        0,
+        ("publishes an UNSIGNED Windows installer",),
+    ),
+    (
+        "all four present with the sentinel agreeing",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "true",
+        },
+        0,
+        ("The installer will be Authenticode-signed",),
+    ),
+    (
+        "all four present plus the optional artifact slug",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SECRET_SIGNPATH_ARTIFACT_CONFIGURATION_SLUG": "artifacts",
+            "SIGNPATH_CONFIGURED": "true",
+        },
+        0,
+        ("The installer will be Authenticode-signed",),
+    ),
+    (
+        "three of four: the token is missing and the guarded steps would skip",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SIGNPATH_CONFIGURED": "false",
+        },
+        1,
+        ("SIGNPATH_API_TOKEN is missing",),
+    ),
+    (
+        "the organization id alone is missing",
+        {
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "true",
+        },
+        1,
+        ("SIGNPATH_ORGANIZATION_ID is missing",),
+    ),
+    (
+        "the project slug alone is missing",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "true",
+        },
+        1,
+        ("SIGNPATH_PROJECT_SLUG is missing",),
+    ),
+    (
+        "the signing policy slug alone is missing",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "true",
+        },
+        1,
+        ("SIGNPATH_SIGNING_POLICY_SLUG is missing",),
+    ),
+    (
+        "the optional artifact slug set on its own, which signs nothing",
+        {
+            "SECRET_SIGNPATH_ARTIFACT_CONFIGURATION_SLUG": "artifacts",
+            "SIGNPATH_CONFIGURED": "false",
+        },
+        1,
+        ("ARTIFACT_CONFIGURATION_SLUG is set while none",),
+    ),
+    (
+        "all four present but the sentinel says false",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "false",
+        },
+        1,
+        ("SIGNPATH_CONFIGURED is 'false'",),
+    ),
+    (
+        "none present but the sentinel says true",
+        {"SIGNPATH_CONFIGURED": "true"},
+        1,
+        ("SIGNPATH_CONFIGURED is true but no SignPath secret is set",),
+    ),
+    # ---- the latch: the four combinations of REQUIRED x CONFIGURED ----
+    #
+    # Rows 1 and 2 above already cover REQUIRED=false: unset behaves as false,
+    # and the guard cannot tell an unset variable from an explicit one. These
+    # four make each combination explicit, because the matrix is the finding and
+    # a matrix that is only implied is a matrix nobody checked.
+    (
+        "not required, not configured: today's upstream state and every fork's",
+        {"SIGNPATH_CONFIGURED": "false", "SIGNPATH_REQUIRED": "false"},
+        0,
+        ("publishes an UNSIGNED Windows installer", "SIGNPATH_REQUIRED is 'false'"),
+    ),
+    (
+        "not required but configured anyway: signing happens, nothing fails",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "true",
+            "SIGNPATH_REQUIRED": "false",
+        },
+        0,
+        ("The installer will be Authenticode-signed", "SIGNPATH_REQUIRED is 'false'"),
+    ),
+    (
+        "required AND configured: the state this whole design is aiming at",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SECRET_SIGNPATH_API_TOKEN": "token",
+            "SIGNPATH_CONFIGURED": "true",
+            "SIGNPATH_REQUIRED": "true",
+        },
+        0,
+        ("The installer will be Authenticode-signed", "SIGNPATH_REQUIRED is 'true'"),
+    ),
+    (
+        "required and NOT configured: the hole. Zero of four is green today and "
+        "must be red the day signing is switched on",
+        {"SIGNPATH_CONFIGURED": "false", "SIGNPATH_REQUIRED": "true"},
+        1,
+        (
+            "has switched SignPath signing ON",
+            "MISSING: SIGNPATH_ORGANIZATION_ID",
+            "MISSING: SIGNPATH_PROJECT_SLUG",
+            "MISSING: SIGNPATH_SIGNING_POLICY_SLUG",
+            "MISSING: SIGNPATH_API_TOKEN",
+        ),
+    ),
+    (
+        "required and half configured: the all-or-nothing message wins, because "
+        "it names the one thing that is wrong",
+        {
+            "SECRET_SIGNPATH_ORGANIZATION_ID": "org",
+            "SECRET_SIGNPATH_PROJECT_SLUG": "proj",
+            "SECRET_SIGNPATH_SIGNING_POLICY_SLUG": "policy",
+            "SIGNPATH_CONFIGURED": "false",
+            "SIGNPATH_REQUIRED": "true",
+        },
+        1,
+        ("SIGNPATH_API_TOKEN is missing",),
+    ),
+    (
+        "only the literal 'true' arms the latch; a variable set to 1, yes or "
+        "TRUE is not the switch being thrown",
+        {"SIGNPATH_CONFIGURED": "false", "SIGNPATH_REQUIRED": "TRUE"},
+        0,
+        ("publishes an UNSIGNED Windows installer",),
+    ),
+)
+
+
+def signpath_guard_behaviour_violations(release: str) -> list[str]:
+    """Run the shipped guard against every configuration it can meet."""
+    script = signpath_guard_script(release)
+    violations: list[str] = []
+    for description, env, expected_status, required_text in SIGNPATH_GUARD_TRUTH_TABLE:
+        result = subprocess.run(
+            [posix_bash(), "-c", script],
+            env={"PATH": os.environ.get("PATH", ""), **env},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        output = result.stdout + result.stderr
+        if result.returncode != expected_status:
+            violations.append(
+                f"SignPath guard: {description}: expected exit {expected_status}, "
+                f"got {result.returncode}; stdout={result.stdout.strip()!r} "
+                f"stderr={result.stderr.strip()!r}"
+            )
+            continue
+        # Right status, wrong reason is still wrong. Several of these rows exit
+        # 1 through different checks, and a guard that reaches the right answer
+        # by the wrong route stops being the guard the next edit thinks it is.
+        for needle in required_text:
+            if needle not in output:
+                violations.append(
+                    f"SignPath guard: {description}: exited {result.returncode} as "
+                    f"expected but never said {needle!r}; output="
+                    f"{output.strip()[:600]!r}"
+                )
+    return violations
+
+
+# --------------------------------------------------------------------------
+# signpath-status.yml -- the activation monitor
+# --------------------------------------------------------------------------
+#
+# release.yml can only ever answer "are the secrets here". Whether SignPath
+# ACCEPTED the application, and whether this repository has been SWITCHED ON,
+# are questions only this workflow asks -- and the gap between those two is the
+# state that publishes a green unsigned installer. So it is contracted here,
+# statically and by running it.
+
+
+def signpath_status_script(text: str | None = None) -> str:
+    """The SHIPPED body of the status step, ready to run under bash.
+
+    `text` exists for the mutation controls below: they need to run a MODIFIED
+    workflow without writing it to disk, because a harness that mutates a
+    tracked file in place leaves it mutated the first time something crashes
+    between the write and the restore.
+    """
+    if text is None:
+        text = SIGNPATH_STATUS_PATH.read_text(encoding="utf-8")
+    match = re.search(r"^\s*run: \|\n(?P<body>.*)\Z", text, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError("signpath-status.yml has no `run: |` block")
+    body = match.group("body").split("\n")
+    indent = len(body[0]) - len(body[0].lstrip())
+    script = "\n".join(line[indent:] if len(line) >= indent else line for line in body)
+    if "== Configuration ==" not in script:
+        raise AssertionError("the extracted status script is not the status script")
+    return script
+
+
+def signpath_status_violations() -> list[str]:
+    """Static shape: the schedule, the switch, and the two-sentinel agreement."""
+    text = SIGNPATH_STATUS_PATH.read_text(encoding="utf-8")
+    violations: list[str] = []
+    # A monitor that only answers when asked cannot notice a state that arrives
+    # while nobody is asking, and "SignPath accepted us three weeks ago" is
+    # exactly such a state.
+    if not re.search(r"^on:\n(?:.*\n)*?  schedule:\n    - cron: ", text, re.MULTILINE):
+        violations.append(
+            "signpath-status.yml has no schedule; manual dispatch cannot notice "
+            "an application that was accepted while nobody was looking, which is "
+            "the one thing this workflow exists to notice"
+        )
+    if "workflow_dispatch:" not in text:
+        violations.append("signpath-status.yml can no longer be dispatched by hand")
+    # The switch has to be the SAME switch release.yml reads, and it has to be a
+    # variable: a secret cannot be read back, so a switch stored as one is a
+    # switch nobody can audit.
+    if "vars.SIGNPATH_ACTIVE" not in text:
+        violations.append(
+            "signpath-status.yml never reads vars.SIGNPATH_ACTIVE, so it cannot "
+            "report the accepted-but-not-activated state at all"
+        )
+    if "secrets.SIGNPATH_ACTIVE" in text:
+        violations.append(
+            "signpath-status.yml reads SIGNPATH_ACTIVE as a secret; release.yml "
+            "reads it as a variable, and the two would disagree about the switch"
+        )
+    return violations
+
+
+#: Columns: description, environment, the fake server's reply table, the exit
+#: status, and every string the output must contain.
+#:
+#: The reply table maps a URL substring to `<http status>|<body>`; the stub curl
+#: below walks it in order and takes the first match. A needle ending in `$`
+#: must match the END of the URL -- needed because the script's control probe
+#: derives its impossible slug from a fixed prefix, so a plain substring test
+#: for the configured slug would also match the control and the differential
+#: would silently be comparing a URL with itself. `""` as a status means curl
+#: itself produced nothing, which is not an HTTP outcome.
+_ALL_FOUR = {
+    "SIGNPATH_ORGANIZATION_ID": "org-guid",
+    "SIGNPATH_PROJECT_SLUG": "wenlan",
+    "SIGNPATH_SIGNING_POLICY_SLUG": "release-signing",
+    "SIGNPATH_API_TOKEN": "token",
+}
+#: A server that applies the filters: the configured slugs answer 200, anything
+#: else is 404. Ordered longest-first, since the stub takes the first match.
+_FILTERING_SERVER = (
+    ("signingPolicySlug=release-signing$", "200|[]"),
+    ("signingPolicySlug=", "404|{}"),
+    ("projectSlug=wenlan&", "200|[]"),
+    ("projectSlug=wenlan$", "200|[]"),
+    ("projectSlug=", "404|{}"),
+    ("SigningRequests", "200|[]"),
+)
+#: A server that ignores unknown query parameters, which is the shape that makes
+#: a filtered read meaningless.
+_IGNORING_SERVER = (("SigningRequests", "200|[]"),)
+
+#: ROUND 7. A server that rejects the CONTROL for its SPELLING and applies no
+#: filter at all -- the shape the old fixed-prefix control could not tell apart
+#: from a real lookup. `wenlan-no-such-project-<epoch><pid>` differed from the
+#: configured slug in its length, its content and its number of separators as
+#: well as in the one property the probe is about, so a length cap, a charset
+#: rule or a reserved-word rule rejects it on sight: `real=1, control=0`,
+#: printed as `resolved`, for a project this server never looked up. The
+#: rotation control has the same length, the same separator positions and the
+#: same character class at every position, so no rule of that kind can separate
+#: the two, both probes come back 200, and the pair reads UNMEASURED.
+#:
+#: `no-such-project` and not a length rule, because the stub matches on URL
+#: substrings: it is the same discrimination, expressed in the one vocabulary
+#: this stub has.
+_SPELLING_RULE_SERVER = (
+    ("no-such-project", "404|{}"),
+    ("SigningRequests", "200|[]"),
+)
+
+#: A server that rejects every slug-filtered read and answers the unfiltered
+#: credential route. Paired with slugs that contain no alphanumeric at all, so
+#: the rotation lands back on the configured slug and the two probes become the
+#: SAME request: both are rejected, and without `resolve_slug`'s refusal the
+#: pair reads `absent` -- a measured NEGATIVE about a slug, off a differential
+#: against itself.
+_SLUG_REJECTING_SERVER = (
+    ("projectSlug=", "404|{}"),
+    ("SigningRequests", "200|[]"),
+)
+
+
+def _filtering_server_but(project_reply: str) -> tuple[tuple[str, str], ...]:
+    """`_FILTERING_SERVER` with one different answer: the CONFIGURED project probe.
+
+    Ordered longest-first, since the stub takes the first match. Everything
+    except that single request still behaves like a server that applies its
+    filters -- the control is rejected, the policy pair resolves -- so a row
+    built on this is about the one reply and not about the route. Without that,
+    a row could go red because nothing resolved rather than because of the
+    reply it was written to be about.
+    """
+    return (
+        ("projectSlug=wenlan$", project_reply),
+        ("signingPolicySlug=release-signing$", "200|[]"),
+        ("signingPolicySlug=", "404|{}"),
+        ("projectSlug=wenlan&", "200|[]"),
+        ("projectSlug=", "404|{}"),
+        ("SigningRequests", "200|[]"),
+    )
+
+#: Columns: description, env, stub replies, expected exit, text the output
+#: MUST contain, text it must NOT contain.
+#:
+#: The exit column carries three states, not two, and that is the finding this
+#: table exists to hold on to:
+#:
+#:   0  everything this run looked at answered affirmatively
+#:   1  something answered NEGATIVELY
+#:   2  something COULD NOT BE MEASURED
+#:
+#: Round 15 found the monitor recreating, at its own outermost boundary, the
+#: defect it was written to detect: with the credential good and both slugs
+#: coming back "NOT validated -- this run could not measure it", the script
+#: exited 0 -- the same result as both slugs resolving. This table said so too:
+#: the `_IGNORING_SERVER` row below USED to expect 0. A truth table that
+#: encodes the defect is worse than no truth table, because it certifies it.
+#:
+#: The last column exists for the same reason. Several of these rows are about
+#: what the run must NOT say -- a recommendation to switch signing on is a
+#: claim about slugs that resolved, and a row where they did not resolve must
+#: not carry it. Requiring text can only catch a message that went missing; it
+#: cannot catch one that should never have been printed.
+SIGNPATH_STATUS_TRUTH_TABLE: tuple[
+    tuple[
+        str,
+        dict[str, str],
+        tuple[tuple[str, str], ...],
+        int,
+        tuple[str, ...],
+        tuple[str, ...],
+    ],
+    ...,
+] = (
+    (
+        "nothing wired and nothing switched on: today, and every fork",
+        {},
+        (),
+        0,
+        ("nothing is wired", "UNMEASURED here, not 'pending'"),
+        (),
+    ),
+    (
+        "switched on with nothing wired: the release would fail, so say so here",
+        {"SIGNPATH_ACTIVE": "true"},
+        (),
+        1,
+        ("SWITCHED ON WITH NOTHING WIRED",),
+        (),
+    ),
+    (
+        "half configured",
+        {"SIGNPATH_ORGANIZATION_ID": "org-guid", "SIGNPATH_API_TOKEN": "token"},
+        (),
+        1,
+        ("half-configured", "missing: SIGNPATH_PROJECT_SLUG"),
+        (),
+    ),
+    (
+        "accepted but not activated: everything resolves and the switch is off",
+        _ALL_FOUR,
+        _FILTERING_SERVER,
+        1,
+        (
+            "ACCEPTED BUT NOT ACTIVATED",
+            "SIGNPATH_PROJECT_SLUG: validated against the SignPath API",
+            "SIGNPATH_SIGNING_POLICY_SLUG: validated against the SignPath API",
+            "Set the repository variable SIGNPATH_ACTIVE",
+        ),
+        ("NOT FULLY VERIFIED",),
+    ),
+    (
+        # The ONLY row that may exit 0. Everything measured, and measured
+        # affirmatively.
+        "accepted and activated: the state this is all aiming at",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        _FILTERING_SERVER,
+        0,
+        ("the organization id and the API token are both good",
+         "SIGNPATH_ACTIVE is 'true'",
+         "VERDICT: everything this run looked at answered"),
+        ("COULD NOT MEASURE",),
+    ),
+    (
+        "a 200 that does not parse is COULD NOT MEASURE, not a working credential",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "200|<html>bad gateway</html>"),),
+        2,
+        (
+            "COULD NOT MEASURE the credential",
+            # A NAMED field, not the bare phrase: the slug lines say "NOT
+            # validated" whatever the credential did, so the bare phrase
+            # survives a mutation that credits the credential.
+            "SIGNPATH_API_TOKEN: NOT validated",
+            "VERDICT: something COULD NOT BE MEASURED",
+        ),
+        (),
+    ),
+    # ---- malformed but VALID JSON: the half the old control never tested ----
+    #
+    # The expression that shipped was
+    #   if type == "object" then (.values // .items // []) else . end | length
+    # and it accepted anything countable. Measured on this host with jq 1.8.2:
+    # `{}` yielded 0, `"proxy error"` yielded 11 (a string's length is its
+    # characters), `42` yielded 42 (a number's length is its absolute value).
+    # Each one set credential=ok and exited 0 while printing "the organization
+    # id and the API token are both good". The HTML row above is the easy half:
+    # it fails at the parser. These three get past the parser and are still not
+    # an answer, which is the whole distinction the verdict rests on.
+    (
+        "a 200 whose body is {}: valid JSON, countable, and not a list",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "200|{}"),),
+        2,
+        ("COULD NOT MEASURE the credential",
+         "SIGNPATH_API_TOKEN: NOT validated"),
+        ("the organization id and the API token are both good",),
+    ),
+    (
+        "a 200 whose body is a bare JSON string, whose length is its characters",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", '200|"proxy error"'),),
+        2,
+        ("COULD NOT MEASURE the credential",),
+        ("the organization id and the API token are both good",),
+    ),
+    (
+        "a 200 whose body is a bare number, whose length is its own value",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "200|42"),),
+        2,
+        ("COULD NOT MEASURE the credential",),
+        ("Signing requests visible to this token: 42",),
+    ),
+    (
+        # THE ROW THAT ENCODED THE DEFECT. It expected 0.
+        "the server ignores the slug filters, so the slugs stay unmeasured",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        _IGNORING_SERVER,
+        2,
+        (
+            "SIGNPATH_PROJECT_SLUG: NOT validated -- this run could not measure it",
+            "SIGNPATH_SIGNING_POLICY_SLUG: NOT validated -- this run could not measure it",
+            "COULD NOT MEASURE a configured slug",
+            "VERDICT: something COULD NOT BE MEASURED",
+        ),
+        ("VERDICT: everything this run looked at answered",),
+    ),
+    (
+        # Accepted, switched off, and the slugs unmeasured: the run must not
+        # tell anyone to throw the switch on the strength of what it could not
+        # resolve, because release.yml then REQUIRES signing and every release
+        # fails at the signing request, after the ~40-minute bundle build.
+        "accepted, not activated, and the slugs could not be measured",
+        _ALL_FOUR,
+        _IGNORING_SERVER,
+        1,
+        ("ACCEPTED, NOT ACTIVATED, AND NOT FULLY VERIFIED",
+         "Do NOT switch signing on yet",
+         "COULD NOT MEASURE a configured slug"),
+        ("Set the repository variable SIGNPATH_ACTIVE",),
+    ),
+    (
+        "a project slug that does not resolve, on a server that filters",
+        {**_ALL_FOUR, "SIGNPATH_PROJECT_SLUG": "typo", "SIGNPATH_ACTIVE": "true"},
+        _FILTERING_SERVER,
+        1,
+        (
+            "a configured slug does not resolve",
+            "SIGNPATH_PROJECT_SLUG does not name a project",
+            "VERDICT: something answered NEGATIVELY",
+        ),
+        (),
+    ),
+    (
+        "401 is a measured negative about the token",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "401|{}"),),
+        1,
+        ("401 Unauthorized", "REJECTED by the SignPath API"),
+        ("COULD NOT MEASURE the credential",),
+    ),
+    (
+        "curl produced no status at all: nothing was learned",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "|"),),
+        2,
+        ("COULD NOT MEASURE -- curl produced no HTTP status",),
+        (),
+    ),
+    (
+        "an undocumented HTTP status says nothing either way",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "500|{}"),),
+        2,
+        ("COULD NOT MEASURE -- unexpected HTTP 500",),
+        (),
+    ),
+    # ROUND 5. THE ROW THE TABLE HAD NO SHAPE FOR: a request that received its
+    # status line and then did not complete. curl prints `200` through -w and
+    # exits 28 (timeout), 18 (body shorter than Content-Length) or 56 (reset),
+    # and the body that DID land here is a syntactically perfect `[]` -- so with
+    # curl's status discarded by `|| true`, jq accepted it, the credential read
+    # `ok`, both slug probes answered off the same swallowed failures, and with
+    # SIGNPATH_ACTIVE=true the workflow exited 0. Green, over a measurement that
+    # failed, from the monitor whose subject is that exact substitution.
+    #
+    # The forbidden column is the half that matters: exiting 2 while still
+    # printing "the organization id and the API token are both good" would be
+    # the same claim in the channel a human reads.
+    (
+        "a 200 whose transfer never completed is not a measurement",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (("SigningRequests", "200|[]|28"),),
+        2,
+        ("COULD NOT MEASURE the credential -- curl exited 28",
+         "VERDICT: something COULD NOT BE MEASURED"),
+        ("the organization id and the API token are both good",),
+    ),
+    # And the same failure on a SLUG probe, with the credential request whole.
+    # The differential is only a measurement if both of its halves completed:
+    # here the configured probe times out after printing 200 and the control is
+    # rejected for real, which is the exact pair that used to read `resolved`.
+    (
+        "a slug probe whose transfer never completed cannot resolve the slug",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        (
+            # The filtering server, with the CONFIGURED project probe timing out
+            # after its status line. Longest-first, since the stub takes the
+            # first match: the policy pair still resolves, so this row is about
+            # the one probe that did not complete and not about the route.
+            ("projectSlug=wenlan$", "200|[]|28"),
+            ("signingPolicySlug=release-signing$", "200|[]"),
+            ("signingPolicySlug=", "404|{}"),
+            ("projectSlug=wenlan&", "200|[]"),
+            ("projectSlug=", "404|{}"),
+            ("SigningRequests", "200|[]"),
+        ),
+        2,
+        ("COULD NOT MEASURE a configured slug",),
+        ("SIGNPATH_PROJECT_SLUG: validated against the SignPath API",),
+    ),
+    # ---- ROUND 7. THE THREE REMEDIES THAT NOTHING DEFENDED ----
+    #
+    # The step's slug arm was repaired in three places and every row above
+    # stayed green with any one of the three reverted. That is the exact state
+    # this file exists to make impossible: a suite that would not notice the bug
+    # is not evidence about the bug, and a green run over it certifies nothing.
+    #
+    # Each row below is refused by exactly ONE rule in the step, which is what
+    # makes it a control for that rule rather than for the arm in general. The
+    # mutation list at the bottom of main() names the revert each one catches.
+    (
+        # 1. THE CONTROL'S SPELLING. The control used to be the fixed prefix
+        # `wenlan-no-such-project-` plus an epoch and a pid, and this server
+        # rejects exactly that spelling while ignoring the filters entirely --
+        # so with the rotation reverted it answers `real=1, control=0` and the
+        # step prints `resolved`, exit 0, for a project it never looked up. The
+        # differential would have measured SYNTAX and reported EXISTENCE. As
+        # shipped, the control is the configured slug with every alphanumeric
+        # rotated one place: same length, same separator positions, same
+        # character class throughout, nothing here can tell them apart, both
+        # probes answer 200, and the pair is UNMEASURED.
+        "a server that rejects the control for its spelling and ignores the filters",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        _SPELLING_RULE_SERVER,
+        2,
+        (
+            "SIGNPATH_PROJECT_SLUG: NOT validated -- this run could not measure it",
+            "SIGNPATH_SIGNING_POLICY_SLUG: NOT validated -- this run could not measure it",
+            "COULD NOT MEASURE a configured slug",
+        ),
+        (
+            "SIGNPATH_PROJECT_SLUG: validated against the SignPath API",
+            "VERDICT: everything this run looked at answered",
+        ),
+    ),
+    (
+        # 1b. THE OTHER HALF OF THE SAME REMEDY, and it fails in the OTHER
+        # direction. A slug with no alphanumeric in it rotates to itself, so
+        # the two probes are the same URL and the "difference" between them is
+        # zero by construction. Both are rejected here, and without
+        # `resolve_slug`'s refusal that pair reads `absent` -- a measured
+        # NEGATIVE, "this slug does not name a project", exit 1, off a
+        # comparison of a request with itself. A self-differential cannot
+        # produce a false `resolved` (real and control are always equal), which
+        # is why this needs its own row: the forbidden column, not the exit
+        # code, is the half the affirmative rows above would never have seen.
+        "a slug that rotates to itself is not its own control",
+        {
+            **_ALL_FOUR,
+            "SIGNPATH_PROJECT_SLUG": "---",
+            "SIGNPATH_SIGNING_POLICY_SLUG": "___",
+            "SIGNPATH_ACTIVE": "true",
+        },
+        _SLUG_REJECTING_SERVER,
+        2,
+        (
+            "SIGNPATH_PROJECT_SLUG: NOT validated -- this run could not measure it",
+            "SIGNPATH_SIGNING_POLICY_SLUG: NOT validated -- this run could not measure it",
+            "COULD NOT MEASURE a configured slug",
+        ),
+        (
+            "a configured slug does not resolve",
+            "SIGNPATH_PROJECT_SLUG does not name a project",
+        ),
+    ),
+    (
+        # 2. A SLUG 200 THAT IS NOT A SIGNING-REQUEST LIST. The credential arm
+        # has refused this body since round 14; the slug probe reduced the
+        # reply to its status line and threw the payload away, so the very same
+        # proxy page that is COULD-NOT-MEASURE three screens above read as
+        # `resolved` down here. The policy pair still resolves and is REQUIRED
+        # to below, which is what keeps this row about the one reply rather
+        # than about the route: a row that went red because nothing resolved
+        # would pass while measuring something else entirely.
+        "a slug 200 that is a proxy page is not a signing-request list",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        _filtering_server_but("200|<html>bad gateway</html>"),
+        2,
+        (
+            "SIGNPATH_PROJECT_SLUG: NOT validated -- this run could not measure it",
+            "SIGNPATH_SIGNING_POLICY_SLUG: validated against the SignPath API",
+            "COULD NOT MEASURE a configured slug",
+        ),
+        (
+            "SIGNPATH_PROJECT_SLUG: validated against the SignPath API",
+            "VERDICT: everything this run looked at answered",
+        ),
+    ),
+    (
+        # 3. THE ITEMS, WHICH NOTHING HERE HAD EVER READ. A 200 that IS a list
+        # -- of signing requests for `someone-else`, returned to a request that
+        # filtered on projectSlug=wenlan. Every other rule in the step says
+        # this resolved: the transfer completed, the status is 200, the
+        # envelope is an array, and the control was rejected. The server told
+        # us, in the field this request filtered on, that it did not apply the
+        # filter. The item read is the only thing that can refute that, and
+        # this row is the only place it is measured.
+        "a slug 200 whose items name a different slug refutes the filter",
+        {**_ALL_FOUR, "SIGNPATH_ACTIVE": "true"},
+        _filtering_server_but('200|[{"projectSlug":"someone-else"}]'),
+        2,
+        (
+            "SIGNPATH_PROJECT_SLUG: NOT validated -- this run could not measure it",
+            "SIGNPATH_SIGNING_POLICY_SLUG: validated against the SignPath API",
+            "COULD NOT MEASURE a configured slug",
+        ),
+        (
+            "SIGNPATH_PROJECT_SLUG: validated against the SignPath API",
+            "VERDICT: everything this run looked at answered",
+        ),
+    ),
+)
+
+
+def _stub_curl(directory: str, replies: tuple[tuple[str, str], ...]) -> None:
+    """A `curl` that answers from a table instead of from the network.
+
+    Only the flags the shipped script uses: -o for the body and -w for the
+    status. Anything the table does not name is a hard failure rather than a
+    default, so a script that starts calling a new URL is noticed here instead
+    of being answered with a plausible 200.
+
+    A reply may carry a third field, `<status>|<body>|<curl exit>`, which is the
+    shape a TRANSFER THAT FAILED has: curl prints the status line it had already
+    received through `-w` and then exits non-zero (28 timeout, 18 short body, 56
+    reset). Without it this stub could only ever produce completed requests, and
+    the round-5 finding is precisely about the ones that do not complete.
+    """
+    lines = [
+        "#!/usr/bin/env bash",
+        "url=\"${@: -1}\"",
+        "out=\"\"",
+        "prev=\"\"",
+        "for a in \"$@\"; do",
+        "  if [ \"$prev\" = -o ]; then out=\"$a\"; fi",
+        "  prev=\"$a\"",
+        "done",
+    ]
+    for needle, reply in replies:
+        code, _, rest = reply.partition("|")
+        body, _, curl_exit = rest.partition("|")
+        curl_exit = curl_exit or "0"
+        # The literal is double-quoted INSIDE the glob so that `&` and `=` stay
+        # ordinary characters; the `*`s outside the quotes are still wildcards.
+        if needle.endswith("$"):
+            pattern = '*"' + needle[:-1] + '"'
+        else:
+            pattern = '*"' + needle + '"*'
+        lines += [
+            f'case "$url" in {pattern})',
+            f'  [ -n "$out" ] && printf %s {shlex.quote(body)} > "$out"',
+            f'  printf %s {shlex.quote(code)}',
+            f"  exit {curl_exit} ;;",
+            "esac",
+        ]
+    lines += [
+        'echo "stub curl: no table entry for $url" >&2',
+        "exit 7",
+    ]
+    path = os.path.join(directory, "curl")
+    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    os.chmod(path, 0o755)
+
+
+def signpath_status_behaviour_violations(text: str | None = None) -> list[str]:
+    """Run the shipped status script against a fake SignPath."""
+    script = signpath_status_script(text)
+    violations: list[str] = []
+    bash = posix_bash()
+    # The script parses the API response with jq, so a host without jq can only
+    # ever reach the could-not-parse arm. Those rows are reported UNCHECKED by
+    # name rather than run against a stub jq: a stubbed parser would turn the
+    # "a 200 that does not parse" row into a test of the stub.
+    have_jq = shutil.which("jq") is not None
+    for description, env, replies, expected_status, required, forbidden in (
+        SIGNPATH_STATUS_TRUTH_TABLE
+    ):
+        if not have_jq and any(reply.startswith("200|") for _, reply in replies):
+            print(
+                f"UNCHECKED: SignPath status: {description}: this host has no jq, "
+                "so the script cannot reach any verdict but could-not-parse"
+            )
+            continue
+        with tempfile.TemporaryDirectory() as work:
+            stub_dir = os.path.join(work, "bin")
+            os.makedirs(stub_dir)
+            _stub_curl(stub_dir, replies)
+            child = {
+                "PATH": os.environ.get("PATH", ""),
+                "RUNNER_TEMP": work,
+                "WENLAN_STUB_DIR": stub_dir,
+                **env,
+            }
+            # PATH is prepended INSIDE the shell, not in the child environment.
+            # The MSYS runtime puts its own /usr/bin and /mingw64/bin ahead of
+            # whatever PATH it inherits, so a stub prepended from Python loses
+            # to the real curl -- silently, by making a real network call that
+            # then fails for its own reasons. Measured: `type curl` reported
+            # /mingw64/bin/curl with the stub directory first in the inherited
+            # PATH.
+            preamble = (
+                'if command -v cygpath >/dev/null 2>&1; then\n'
+                '  _wenlan_stub="$(cygpath -u "$WENLAN_STUB_DIR")"\n'
+                'else\n'
+                '  _wenlan_stub="$WENLAN_STUB_DIR"\n'
+                'fi\n'
+                'PATH="$_wenlan_stub:$PATH"\n'
+                'export PATH\n'
+                # And prove it took, rather than assuming: a stub that did not
+                # win the lookup would otherwise let every row below make real
+                # network calls and report their failures as the script's
+                # verdicts.
+                'case "$(command -v curl)" in\n'
+                '  "$_wenlan_stub"/*) : ;;\n'
+                '  *) echo "STUB CURL NOT IN EFFECT: $(command -v curl)" >&2; exit 97 ;;\n'
+                'esac\n'
+            )
+            # Written to a FILE, not passed to `bash -c`. Measured on this
+            # Windows host: `bash -c` with this ~14 KB script ran the first
+            # ~7.3 KB of it and then exited 0 as though it had reached the end,
+            # which is the same failure shape everything else here is about --
+            # a run that stopped early wearing the exit status of one that
+            # finished. A file has no argument-length limit to hit.
+            step_file = os.path.join(work, "status.sh")
+            with open(step_file, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(preamble + script)
+            result = subprocess.run(
+                [bash, step_file],
+                env=child,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            output = result.stdout + result.stderr
+            if result.returncode != expected_status:
+                violations.append(
+                    f"SignPath status: {description}: expected exit "
+                    f"{expected_status}, got {result.returncode}; output="
+                    f"{output.strip()[:600]!r}"
+                )
+                continue
+            for needle in required:
+                if needle not in output:
+                    violations.append(
+                        f"SignPath status: {description}: exited "
+                        f"{result.returncode} as expected but never said "
+                        f"{needle!r}; output={output.strip()[:600]!r}"
+                    )
+            for needle in forbidden:
+                if needle in output:
+                    violations.append(
+                        f"SignPath status: {description}: exited "
+                        f"{result.returncode} as expected but SAID {needle!r}, "
+                        "which is a claim this run did not earn; output="
+                        f"{output.strip()[:600]!r}"
+                    )
+    return violations
+
+
+RESIGN_STEP = "Regenerate the updater signature over the signed installer"
+
+
+def resign_script(release: str) -> str:
+    """The SHIPPED body of the updater re-signing step, ready to run under bash.
+
+    Keyed the same way as the guard above: job, step name, exactly one match.
+    """
+    job = job_body(release, "app-bundle-windows")
+    if not job:
+        raise AssertionError("release.yml has no app-bundle-windows job")
+    occurrences = job.count(f"- name: {RESIGN_STEP}\n")
+    if occurrences != 1:
+        raise AssertionError(
+            f"expected exactly one {RESIGN_STEP!r} step, found {occurrences}"
+        )
+    step = named_step_body(job, RESIGN_STEP)
+    match = re.search(r"^[ ]*run: \|\n(?P<body>.*)\Z", step, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"{RESIGN_STEP!r} has no `run: |` block")
+    body = match.group("body").split("\n")
+    indent = len(body[0]) - len(body[0].lstrip())
+    script = "\n".join(line[indent:] if len(line) >= indent else line for line in body)
+    if "pnpm tauri signer sign" not in script:
+        raise AssertionError("the extracted re-sign step is not the re-sign step")
+    return script
+
+
+# Stands in for `pnpm tauri signer sign <installer>`, so the step can be run
+# without a Tauri toolchain or a signing key. $4 is the installer path.
+#
+# `fresh` DERIVES the signature from the installer it was handed, rather than
+# writing a fixed string. That is what lets the caller assert the sidecar on
+# disk at the end of the step is the one produced over these bytes: a fixed
+# string can only be checked for "non-empty and different", which an
+# `printf x >> "$sig"` appended after the step's own assertion satisfies.
+#
+# What this still cannot catch, said plainly: a signer that signs the WRONG
+# file. The step has no key to verify against, so a real cryptographic check
+# belongs to the updater client, not here.
+RESIGN_SIGNER_STUB = """#!/bin/sh
+case "${STUB_MODE}" in
+  fresh)   printf 'sig:%s' "$(sha256sum < "$4" | cut -d' ' -f1)" > "$4.sig" ;;
+  same)    printf '%s' "${STUB_BEFORE}" > "$4.sig" ;;
+  missing) : ;;
+  empty)   : > "$4.sig" ;;
+  broken)  echo "signer exploded" >&2; exit 1 ;;
+  *)       echo "unknown STUB_MODE ${STUB_MODE}" >&2; exit 2 ;;
+esac
+"""
+
+# The .sig the bundle build produced covers the UNSIGNED installer. Every way
+# the re-signing can fail to replace it has to be non-zero, because the step
+# after this one uploads whatever is on disk: an Authenticode-signed installer
+# beside a signature over the bytes it no longer has is an update the client
+# rejects, and nothing downstream looks at the .sig again.
+#
+# The static contract cannot see any of this. `exit 0` inserted after
+# before_sig= leaves every marker in the file, passes the static contract, and
+# ships exactly that pair. Only running the step catches it.
+#
+# Columns: description, stub mode, installer present, .sig content before, exit.
+RESIGN_TRUTH_TABLE: tuple[tuple[str, str, bool, str | None, int], ...] = (
+    (
+        "the signer replaces the signature",
+        "fresh",
+        True,
+        "sig-over-unsigned-bytes",
+        0,
+    ),
+    (
+        "the signer leaves the signature over the unsigned bytes in place",
+        "same",
+        True,
+        "sig-over-unsigned-bytes",
+        1,
+    ),
+    (
+        "the signer writes no signature at all",
+        "missing",
+        True,
+        "sig-over-unsigned-bytes",
+        1,
+    ),
+    (
+        "the signer writes an empty signature",
+        "empty",
+        True,
+        "sig-over-unsigned-bytes",
+        1,
+    ),
+    (
+        "the signer itself fails",
+        "broken",
+        True,
+        "sig-over-unsigned-bytes",
+        1,
+    ),
+    (
+        "the bundle build left no .sig to replace",
+        "fresh",
+        True,
+        None,
+        1,
+    ),
+    (
+        "there is no installer under the nsis directory",
+        "fresh",
+        False,
+        None,
+        1,
+    ),
+)
+
+
+def resign_behaviour_violations(release: str) -> list[str]:
+    """Run the shipped re-signing step against a stub signer."""
+    script = resign_script(release)
+    violations: list[str] = []
+    for description, mode, installer, before, expected_status in RESIGN_TRUTH_TABLE:
+        with tempfile.TemporaryDirectory() as work:
+            nsis = os.path.join(
+                work, "target", "x86_64-pc-windows-msvc", "release", "bundle", "nsis"
+            )
+            os.makedirs(nsis)
+            setup = os.path.join(nsis, "Wenlan_9.9.9_x64-setup.exe")
+            installer_bytes = b"MZ authenticode-signed installer bytes"
+            expected_sig = "sig:" + hashlib.sha256(installer_bytes).hexdigest()
+            if installer:
+                Path(setup).write_bytes(installer_bytes)
+            if before is not None:
+                Path(setup + ".sig").write_text(before, encoding="utf-8")
+            stub_dir = os.path.join(work, "stub")
+            os.makedirs(stub_dir)
+            stub = os.path.join(stub_dir, "pnpm")
+            with open(stub, "w", encoding="utf-8", newline="\n") as handle:
+                handle.write(RESIGN_SIGNER_STUB)
+            os.chmod(stub, 0o755)
+            result = subprocess.run(
+                [posix_bash(), "-c", script],
+                cwd=work,
+                env={
+                    "PATH": stub_dir + os.pathsep + os.environ.get("PATH", ""),
+                    "STUB_MODE": mode,
+                    "STUB_BEFORE": before or "",
+                },
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != expected_status:
+                violations.append(
+                    f"re-sign step: {description}: expected exit {expected_status}, "
+                    f"got {result.returncode}; stdout={result.stdout.strip()!r} "
+                    f"stderr={result.stderr.strip()!r}"
+                )
+                continue
+            if expected_status != 0:
+                continue
+            # Exit 0 is not the claim. The claim is that the file on disk now
+            # covers the signed bytes, so the successful row asserts the
+            # replacement happened rather than trusting the status.
+            #
+            # "Non-empty and different from before" is too weak: a step that
+            # asserted correctly and THEN corrupted the file (`printf x >>
+            # "$sig"` after the check) satisfies both and still uploads a
+            # signature no client will accept. The sidecar must be byte-exact
+            # the one the signer produced over this installer, checked after
+            # the whole step has run.
+            after = Path(setup + ".sig")
+            if not after.exists() or not after.read_text(encoding="utf-8").strip():
+                violations.append(
+                    f"re-sign step: {description}: exited 0 with no signature on disk"
+                )
+            elif after.read_text(encoding="utf-8") == before:
+                violations.append(
+                    f"re-sign step: {description}: exited 0 with the signature over "
+                    "the unsigned bytes still on disk"
+                )
+            elif after.read_text(encoding="utf-8") != expected_sig:
+                violations.append(
+                    f"re-sign step: {description}: exited 0 but the sidecar on disk is "
+                    f"{after.read_text(encoding='utf-8')!r}, not the signature the "
+                    f"signer produced over the installer ({expected_sig!r}); the step "
+                    "changed it after checking it"
+                )
+    return violations
+
+
+AUTHENTICODE_STEP = "Verify the installer carries a valid SignPath signature"
+
+
+def authenticode_script(release: str) -> str:
+    """The SHIPPED body of the Authenticode verification step, as PowerShell."""
+    job = job_body(release, "app-bundle-windows")
+    if not job:
+        raise AssertionError("release.yml has no app-bundle-windows job")
+    occurrences = job.count(f"- name: {AUTHENTICODE_STEP}\n")
+    if occurrences != 1:
+        raise AssertionError(
+            f"expected exactly one {AUTHENTICODE_STEP!r} step, found {occurrences}"
+        )
+    step = named_step_body(job, AUTHENTICODE_STEP)
+    match = re.search(r"^[ ]*run: \|\n(?P<body>.*)\Z", step, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"{AUTHENTICODE_STEP!r} has no `run: |` block")
+    body = match.group("body").split("\n")
+    indent = len(body[0]) - len(body[0].lstrip())
+    script = "\n".join(line[indent:] if len(line) >= indent else line for line in body)
+    if "Get-AuthenticodeSignature" not in script:
+        raise AssertionError("the extracted verification step is not the verification step")
+    return script
+
+
+SIGNING_STEPS = (
+    "Submit the installer to SignPath for signing",
+    "Regenerate the updater signature over the signed installer",
+    AUTHENTICODE_STEP,
+    "Verify the runtime DLLs ship inside the installer",
+)
+
+
+#: The only environment variable the verification body may read. Everything
+#: else it needs is derived from the file it is pointed at.
+AUTHENTICODE_BODY_ENV = frozenset({"STAGED_SETUP"})
+
+
+def authenticode_body_env_violations(release: str) -> list[str]:
+    """The body may read STAGED_SETUP and nothing else.
+
+    Round 13c, finding 1. The truth table runs the body in the harness's own
+    environment, so a body-level early-out keyed on a variable the harness does
+    not set is invisible to all five rows:
+
+        if ($env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }
+
+    Green here, where SIGNPATH_CONFIGURED is unset; a no-op in the release,
+    where it is exactly 'true'. The harness now runs the body with the release
+    job's environment (see `AUTHENTICODE_STEP_ENV`), which catches that one
+    variable -- but only that one, and the next such guard would key on CI,
+    RUNNER_OS, GITHUB_REF or anything else the runner defines. Enumerating what
+    the environment holds is unwinnable; enumerating what the body is allowed
+    to read is one line. A gate that consults the environment to decide whether
+    to gate is not a gate.
+    """
+    script = authenticode_script(release)
+    # Round 13d, 13c finding 1 reopened. The rule used to be a case-sensitive
+    # regex for ONE spelling, `$env:NAME`. PowerShell has at least five:
+    # `$Env:NAME`, `${env:NAME}`, `Get-Item Env:NAME`, `dir env:`, and
+    # `[System.Environment]::GetEnvironmentVariable(...)`. Enumerating spellings
+    # is the same losing game as enumerating variables.
+    #
+    # So the rule is not a list of spellings. Every one of those forms contains
+    # the token `env`, case-insensitively, because that token IS how PowerShell
+    # names the environment -- the `Env:` drive and the `Environment` class both
+    # carry it. Blank out the single permitted read and any surviving `env` in
+    # the body is an unauthorised one, whatever it is spelled like. The cost is
+    # that a comment cannot say "environment"; that is a thirty-line body, and a
+    # loud false positive is the right side to be wrong on.
+    permitted = re.compile(r"\$env:(?:" + "|".join(sorted(AUTHENTICODE_BODY_ENV)) + r")\b")
+    masked = permitted.sub(lambda m: "_" * len(m.group(0)), script)
+    lines = script.splitlines()
+    stray = []
+    for match in re.finditer(r"(?i)env", masked):
+        number = masked[: match.start()].count("\n")
+        stray.append(f"line {number + 1}: {lines[number].strip()!r}")
+    if not stray:
+        return []
+    return [
+        f"{AUTHENTICODE_STEP!r} names the environment somewhere other than "
+        f"{sorted('$env:' + name for name in AUTHENTICODE_BODY_ENV)}: "
+        + "; ".join(stray)
+        + " -- a body-level branch on a variable the truth table does not set passes "
+        "here and skips the gate in the release, and it does not have to be spelled "
+        "`$env:` to do it"
+    ]
+
+
+#: A YAML alias used as a value, including the merge key. The only shapes that
+#: can put a property on a step without the property's name appearing in the
+#: step's own text.
+_ALIAS_VALUE = re.compile(r"^\s*(?:<<\s*:|[\w.\-\"']+\s*:)\s*\*[\w.\-]+\s*$", re.M)
+# The other presentation detail the token scan is blind to, and the one that
+# actually got past it: a double-quoted key carrying a backslash escape.
+# `"continue-on-error": true` decodes to the forbidden key and contains no
+# matching source token. YAML 1.2.2 SS5.7 makes escapes a presentation detail of
+# the double-quoted style, so only a parser can see through one. Listing both
+# classes here is what keeps the no-parser fallback from reporting "clean" about
+# an input it cannot read -- the same failed-measurement-as-negative rule the
+# rest of this file is about, applied to this file's own dependency.
+_ESCAPED_KEY = re.compile(r'^[ \t]*"[^"\n]*\\[^"\n]*"[ \t]*:', re.M)
+
+
+def continue_on_error_violations(release: str, job: str) -> list[str]:
+    """`continue-on-error`, read as a DECODED property, not as a token.
+
+    Round 13e reopened finding 1. `re.finditer("continue-on-error", job)` is a
+    lexical net over the job's text. It is strictly conservative for what it can
+    see -- the token has no other business in this job -- but a property does
+    not have to appear in a step's text to be on that step. A merge key pulls
+    one in from an anchor defined anywhere else in the file:
+
+        x-swallow: &swallow
+          continue-on-error: true
+        ...
+          - name: Verify the installer carries a valid SignPath signature
+            <<: *swallow
+
+    The token is in release.yml and not in `job_body(release, ...)`, the scan
+    sees nothing, and the gate's failure is discarded. Reading the key off the
+    decoded document is the only way to ask the question GitHub Actions will
+    answer. The token scan stays, as a second and independent net, and because
+    it is the one that still works when there is no parser here.
+    """
+    out: list[str] = []
+    try:
+        import yaml  # noqa: PLC0415  -- optional; the fallback below is measured
+    except ImportError:
+        # No parser. Rather than claim the coverage or fail blind, measure what
+        # is actually lost: with no alias and no escaped key anywhere in the job,
+        # every property a step carries IS written in the job's text as the token
+        # scan spells it, so that scan is complete for this input and nothing is
+        # unchecked. Both classes are named, because reporting only the one that
+        # happens to be checked is how a partial measurement becomes a clean bill
+        # of health.
+        blind: list[str] = []
+        if _ALIAS_VALUE.search(job):
+            blind.append("a YAML alias (a merge key can carry the property in)")
+        if _ESCAPED_KEY.search(job):
+            blind.append(
+                'a double-quoted key carrying a backslash escape '
+                '(`"continue-on-\\u0065rror"` decodes to the forbidden key)'
+            )
+        if blind:
+            out.append(
+                "app-bundle-windows contains " + " and ".join(blind) + ", and "
+                "PyYAML is not installed here, so `continue-on-error` could not be "
+                "read as a decoded property -- it can be carried onto a signing "
+                "step without the token appearing in the job. Install PyYAML or "
+                "remove the construct; this is unmeasured, not clean"
+            )
+        return out
+    try:
+        doc = yaml.safe_load(release)
+    except yaml.YAMLError as exc:
+        return [f"release.yml does not parse as YAML: {exc}"]
+    jobs = doc.get("jobs") if isinstance(doc, dict) else None
+    node = jobs.get("app-bundle-windows") if isinstance(jobs, dict) else None
+    if not isinstance(node, dict):
+        return ["release.yml has no app-bundle-windows job once decoded"]
+    swallow = (
+        "may not have its failure discarded; the installer it signs and verifies "
+        "is what a user runs"
+    )
+    if "continue-on-error" in node:
+        out.append(
+            "the app-bundle-windows job itself decodes with continue-on-error: "
+            f"{node['continue-on-error']!r}; a job that signs and verifies {swallow}"
+        )
+    steps = node.get("steps")
+    for index, step in enumerate(steps if isinstance(steps, list) else []):
+        if isinstance(step, dict) and "continue-on-error" in step:
+            owner = step.get("name") or f"the unnamed step #{index + 1}"
+            out.append(
+                f"{owner!r} decodes with continue-on-error: "
+                f"{step['continue-on-error']!r}; a step in this job {swallow}"
+            )
+    return out
+
+
+def authenticode_step_metadata_violations(release: str) -> list[str]:
+    """The step's YAML around the body, which no body-level test can see.
+
+    Round 13b: a five-row truth table over the extracted `run:` block proves
+    what the script does when it runs. `continue-on-error: true` on the step
+    leaves every row and every static marker passing while the release ignores
+    the failure and publishes anyway -- a gate that runs, fails, and is
+    discarded. The body is not the whole step.
+
+    Round 13c reopened it twice over. `continue-on-error` was rejected on a
+    hand-listed four steps, and "Check SignPath configuration is
+    all-or-nothing" -- the guard that stops a half-configured repo from
+    publishing an unsigned installer under a configured-looking run -- was not
+    among them. A list of load-bearing steps is a list someone has to keep
+    right; the job has none that may swallow a failure, so the rule is the job.
+    """
+    job = job_body(release, "app-bundle-windows")
+    if not job:
+        return ["release.yml has no app-bundle-windows job"]
+    violations = []
+    for name in SIGNING_STEPS:
+        if job.count(f"- name: {name}\n") != 1:
+            violations.append(f"expected exactly one {name!r} step in app-bundle-windows")
+    # EVERY step, and the job itself. Attribution is by the nearest preceding
+    # step name so the message still says which one, without the enumeration
+    # being what decides whether the rule applies.
+    # Round 13d: the rule was `^\s*continue-on-error:`, which is one YAML
+    # spelling of the key. `"continue-on-error": true` and `{continue-on-error:
+    # true}` are the same key and were invisible. There is no other reason for
+    # that token to appear anywhere in this job, so the token IS the rule --
+    # no anchor, no quoting to enumerate, no place left to hide it.
+    for match in re.finditer(r"continue-on-error", job):
+        seen = re.findall(r"^      - name: (.+)$", job[: match.start()], re.MULTILINE)
+        owner = repr(seen[-1]) if seen else "the app-bundle-windows job itself"
+        line = job[: match.start()].count("\n")
+        violations.append(
+            f"{owner} carries {job.splitlines()[line].strip()!r}; a step in the job "
+            "that signs and verifies the installer may not have its failure discarded"
+        )
+    # And the same question asked of the decoded document, which is the one
+    # GitHub Actions answers. The scan above cannot follow a merge key.
+    violations.extend(continue_on_error_violations(release, job))
+    violations.extend(authenticode_body_env_violations(release))
+    verify = named_step_body(job, AUTHENTICODE_STEP)
+    if not re.search(r"^\s*shell: pwsh\s*$", verify, re.MULTILINE):
+        violations.append(f"{AUTHENTICODE_STEP!r} must declare `shell: pwsh`")
+    if not re.search(r"^\s*if: env\.SIGNPATH_CONFIGURED == 'true'\s*$", verify, re.MULTILINE):
+        violations.append(
+            f"{AUTHENTICODE_STEP!r} must be guarded on SIGNPATH_CONFIGURED, like the "
+            "macOS steps, or a fork without secrets fails the build"
+        )
+    return violations
+
+
+#: The environment the step runs in during a real release, as far as it can
+#: matter to the body. The harness used to supply STAGED_SETUP alone, so the
+#: body ran with SIGNPATH_CONFIGURED unset while the shipping job runs it with
+#: SIGNPATH_CONFIGURED == 'true' -- and a branch on that difference is a step
+#: that passes every row here and does nothing there (round 13c, finding 1).
+#: `authenticode_body_env_violations` is the load-bearing half of that fix,
+#: since no list of variables can be complete; this one makes the variables the
+#: step is MOST likely to be branched on hold their release values anyway.
+#:
+#: Round 13e reopened this as new finding 3: the list was eleven names chosen
+#: by hand, and `GITHUB_WORKFLOW_REF` -- which GitHub documents as a default and
+#: which identifies the workflow file uniquely -- was not among them. A hand-
+#: picked list is exactly the shape this workstream keeps finding, so the list
+#: is now GitHub's own documented set of default environment variables, in full.
+#: It still cannot be complete in principle: a step may branch on anything the
+#: job's `env:` supplies, or on a variable an action exported. That is why
+#: `authenticode_body_env_violations` -- which rejects ANY read of the
+#: environment in the step's body -- is the load-bearing half and this is the
+#: belt, and why that rule is a LEXICAL net over the body's text rather than a
+#: semantic one: it matches the spellings of an environment read that are known
+#: today, and a sufficiently indirect read (a variable built from string
+#: fragments, a call through a helper defined elsewhere) is not caught by it.
+AUTHENTICODE_STEP_ENV = {
+    "SIGNPATH_CONFIGURED": "true",
+    "CI": "true",
+    # https://docs.github.com/actions/reference/workflows-and-actions/variables
+    # #default-environment-variables, in the order GitHub lists them.
+    "GITHUB_ACTION": "__run",
+    "GITHUB_ACTION_PATH": "",
+    "GITHUB_ACTION_REPOSITORY": "",
+    "GITHUB_ACTIONS": "true",
+    "GITHUB_ACTOR": "github-actions[bot]",
+    "GITHUB_ACTOR_ID": "41898282",
+    "GITHUB_API_URL": "https://api.github.com",
+    "GITHUB_BASE_REF": "",
+    "GITHUB_ENV": "",
+    "GITHUB_EVENT_NAME": "push",
+    "GITHUB_EVENT_PATH": "",
+    "GITHUB_GRAPHQL_URL": "https://api.github.com/graphql",
+    "GITHUB_HEAD_REF": "",
+    # Round 13d named this one: a branch that exits only when GITHUB_JOB is
+    # app-bundle-windows runs everywhere else and skips the gate where it counts.
+    "GITHUB_JOB": "app-bundle-windows",
+    "GITHUB_OUTPUT": "",
+    "GITHUB_PATH": "",
+    "GITHUB_REF": "refs/tags/v9.9.9",
+    "GITHUB_REF_NAME": "v9.9.9",
+    "GITHUB_REF_PROTECTED": "false",
+    "GITHUB_REF_TYPE": "tag",
+    "GITHUB_REPOSITORY": "7xuanlu/wenlan",
+    "GITHUB_REPOSITORY_ID": "0",
+    "GITHUB_REPOSITORY_OWNER": "7xuanlu",
+    "GITHUB_REPOSITORY_OWNER_ID": "0",
+    "GITHUB_RETENTION_DAYS": "90",
+    "GITHUB_RUN_ATTEMPT": "1",
+    "GITHUB_RUN_ID": "0",
+    "GITHUB_RUN_NUMBER": "0",
+    "GITHUB_SERVER_URL": "https://github.com",
+    "GITHUB_SHA": "0" * 40,
+    "GITHUB_STEP_SUMMARY": "",
+    "GITHUB_TRIGGERING_ACTOR": "github-actions[bot]",
+    "GITHUB_WORKFLOW": "release",
+    # Round 13e, new finding 3, by name.
+    "GITHUB_WORKFLOW_REF": "7xuanlu/wenlan/.github/workflows/release.yml@refs/tags/v9.9.9",
+    "GITHUB_WORKFLOW_SHA": "0" * 40,
+    "GITHUB_WORKSPACE": "",
+    "RUNNER_ARCH": "X64",
+    "RUNNER_DEBUG": "",
+    "RUNNER_ENVIRONMENT": "github-hosted",
+    "RUNNER_NAME": "GitHub Actions 1",
+    "RUNNER_OS": "Windows",
+    "RUNNER_TEMP": "",
+    "RUNNER_TOOL_CACHE": "",
+}
+
+
+def _powershell() -> str | None:
+    """A PowerShell that can run the step. pwsh first, Windows PowerShell after."""
+    import shutil
+
+    return shutil.which("pwsh") or shutil.which("powershell")
+
+
+#: What `_signed_fixture` found, which is also the host-capability answer.
+#: "fixture"      a signed binary was found; every row can be built.
+#: "no-support"   Get-AuthenticodeSignature is not usable here. A real
+#:                incapacity: PowerShell on Linux and macOS has no Authenticode
+#:                at all, and the probe SAYS so rather than merely exiting.
+#: "none-found"   the cmdlet works and a SEARCH of the system binary
+#:                directories turned up no validly signed file. That is not a
+#:                host that cannot measure; it is a probe or a trust store that
+#:                is broken, and it is reported as a failure wherever it happens.
+#: "probe-failed" the probe did not answer. PowerShell could not be started, or
+#:                it died on its own, or it printed something this cannot parse.
+#:
+#: Round 13e, new finding 4: the first three were read off the EXIT STATUS
+#: alone, so every way the probe could blow up with status 2 -- a PowerShell
+#: that refused the command line, a host policy that killed it, a syntax error
+#: introduced by an edit to the probe text below -- arrived here spelled
+#: "no-support", the one answer that is allowed to excuse an unmeasured row.
+#: A failed measurement wearing an incapacity's name is this workstream's
+#: signature defect, sitting in the predicate written to decide when a failed
+#: measurement may be excused. So the probe now PRINTS which arm it took, the
+#: status and the token have to agree, and anything else is `probe-failed`,
+#: which is a failure and never an excuse.
+#:
+#: The third element is the publisher when the capability is "fixture", and the
+#: reason it could not answer when it is "probe-failed".
+FixtureResult = tuple[str, str | None, str | None]
+
+
+def _signed_fixture(shell: str, work: str) -> FixtureResult:
+    """A real Authenticode-signed binary on this host, its publisher, and why not.
+
+    Round 13c asked for a capability predicate and got `os.name == "nt"`, which
+    round 13d correctly called an OS proxy wearing a capability's name: it says
+    where the code is running, not what the host can do. It was propped up by a
+    probe that looked at three hard-coded paths, so "no signed binary on this
+    host" really meant "not one of these three files".
+
+    Both halves are replaced here. The probe SEARCHES the system binary
+    directories instead of naming files, and it distinguishes its two negative
+    answers, which is the whole tri-state discipline applied to the capability
+    question itself: a cmdlet that cannot run on this platform is an incapacity;
+    a cmdlet that runs and finds nothing signed anywhere in System32 is a
+    failure, on any OS. The caller no longer has to ask what OS this is.
+    """
+    probe = os.path.join(work, "probe.ps1")
+    Path(probe).write_text(
+        # Support first, and by calling it rather than by asking what OS this is:
+        # on Linux and macOS the cmdlet exists and throws PlatformNotSupported.
+        "if (-not (Get-Command Get-AuthenticodeSignature "
+        "-ErrorAction SilentlyContinue)) { Write-Output 'NO-SUPPORT cmdlet-absent'; "
+        "exit 2 }\n"
+        "try { $null = Get-AuthenticodeSignature -LiteralPath "
+        "$PSCommandPath -ErrorAction Stop } catch { "
+        "Write-Output 'NO-SUPPORT cmdlet-unusable'; exit 2 }\n"
+        "$roots = @([System.Environment]::SystemDirectory, $PSHOME) |\n"
+        "  Where-Object { $_ } | Select-Object -Unique\n"
+        "foreach ($root in $roots) {\n"
+        "  if (-not (Test-Path -LiteralPath $root)) { continue }\n"
+        # Smallest first: the fixture gets read, patched and re-hashed five times.
+        "  $files = @(Get-ChildItem -LiteralPath $root -Filter *.exe -File "
+        "-ErrorAction SilentlyContinue |\n"
+        "    Sort-Object Length | Select-Object -First 60)\n"
+        "  foreach ($f in $files) {\n"
+        "    $s = Get-AuthenticodeSignature -LiteralPath $f.FullName\n"
+        "    if ($s.Status -ne 'Valid' -or $null -eq $s.SignerCertificate) { continue }\n"
+        "    $n = $s.SignerCertificate.GetNameInfo(\n"
+        "      [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName, "
+        "$false)\n"
+        "    if (-not $n) { continue }\n"
+        "    Write-Output \"FIXTURE`t$($f.FullName)`t$n\"\n"
+        "    exit 0\n"
+        "  }\n"
+        "}\n"
+        "Write-Output 'NONE-FOUND'\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    try:
+        result = subprocess.run(
+            [shell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", probe],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        return ("probe-failed", None, f"{shell} could not be started: {exc}")
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    token = lines[0].strip() if lines else ""
+    # Status AND token, together. Either one alone is a single witness, and the
+    # arm that matters -- "this host genuinely cannot do Authenticode" -- is the
+    # one an unrelated crash is most likely to be mistaken for.
+    if result.returncode == 2 and token.startswith("NO-SUPPORT"):
+        return ("no-support", None, None)
+    if result.returncode == 1 and token == "NONE-FOUND":
+        return ("none-found", None, None)
+    if result.returncode == 0 and token.startswith("FIXTURE\t"):
+        parts = token.split("\t")
+        if len(parts) == 3 and parts[1] and parts[2]:
+            return ("fixture", parts[1], parts[2])
+    return (
+        "probe-failed",
+        None,
+        f"exit {result.returncode} with first line {token[:120]!r}"
+        + (f"; stderr={result.stderr.strip()[:200]!r}" if result.stderr.strip() else ""),
+    )
+
+
+# Columns: description, fixture, expected exit, text the output must contain.
+#
+# "fixture" is how the staged installer is prepared:
+#   missing   - no file at all
+#   notsigned - a signed binary with a byte APPENDED, which breaks the
+#               certificate table and reports NotSigned
+#   mismatch  - a signed binary with a byte patched in the MIDDLE, which keeps
+#               the table and reports HashMismatch. Both are reachable and they
+#               are different statuses; a gate written against only one of them
+#               would ship the other.
+#   signed    - the untouched signed binary (publisher is not SignPath)
+#   accepted  - the untouched signed binary, with the step's expected publisher
+#               rewritten to this host's. The ONLY row that reaches the PASS.
+#   casefolded- the same substitution with the case swapped, which the
+#               case-sensitive comparison must reject. A publisher name differing
+#               only in case is a DIFFERENT publisher; PowerShell's -ne, -eq and
+#               -like are all case-insensitive, so the shipped check said -ne and
+#               meant nothing of the sort. This row is the only one that can see
+#               the difference between -ne and -cne.
+AUTHENTICODE_TRUTH_TABLE: tuple[tuple[str, str, int, str], ...] = (
+    ("no staged installer", "missing", 1, "staged installer missing"),
+    ("the download was skipped and the installer is unsigned", "notsigned", 1,
+     "Authenticode status is 'NotSigned'"),
+    ("the installer was modified after signing", "mismatch", 1,
+     "Authenticode status is 'HashMismatch'"),
+    ("someone else signed it", "signed", 1, "installer publisher is"),
+    ("SignPath signed it", "accepted", 0, "PASS"),
+    ("a publisher whose name differs from the expected one only in case",
+     "casefolded", 1, "installer publisher is"),
+)
+
+#: The fixtures above that DO NOT run the shipped step body verbatim: they
+#: rewrite the expected publisher name before running it. Exported because the
+#: receipt in scripts/negative-controls/authenticode-step-receipt.py reports how
+#: many rows ran verbatim and how many ran with a substitution, and a count
+#: restated by hand goes stale the moment a substituted row is added -- which is
+#: exactly the "a claim that no longer matches what was measured" defect this
+#: file exists to catch. Derive it from here instead.
+AUTHENTICODE_SUBSTITUTED_KINDS: frozenset[str] = frozenset({"accepted", "casefolded"})
+
+
+class AuthenticodeRun(NamedTuple):
+    """What one pass over the truth table actually measured.
+
+    `ran` and `failed` exist so a mutation control can say something stronger
+    than "some violation appeared": it can require that the violation came from
+    a row capable of catching THAT mutation, and that the row ran at all. A
+    mutation that merely makes a row unbuildable produces a violation too, and
+    without these two sets it is indistinguishable from a caught mutation.
+    """
+
+    violations: list[str]
+    unchecked: list[str]
+    ran: set[str]
+    failed: set[str]
+    #: Why the unchecked rows went unchecked, as a HOST capability rather than
+    #: an operating system: "fixture" (all rows buildable), "no-shell",
+    #: "no-support" (a real incapacity), or "none-found" (a broken probe or
+    #: trust store, which is a failure anywhere). Round 13d.
+    capability: str = "fixture"
+
+
+def authenticode_behaviour_violations(release: str) -> AuthenticodeRun:
+    """Run the shipped Authenticode step against real signed and broken files.
+
+    Nothing here is stubbed: Windows itself answers, over files whose signature
+    state was produced rather than asserted. One qualification, because round
+    13d was right that "nothing is mocked" overstated it -- the `accepted` row
+    substitutes the expected publisher, since no host running this has a
+    SignPath-signed file. It measures that a valid signature from the expected
+    publisher reaches PASS; the literal `SignPath Foundation` is pinned by a
+    separate static contract, and the publisher mutation below is what shows the
+    comparison is load-bearing. The static contract on this step is all
+    substring markers, so
+    an `exit 0` inserted at the top of the body satisfies every one of them and
+    ships an unsigned installer -- the exact defect class this workstream exists
+    to catch, in the gate that is supposed to catch it.
+
+    Coverage degrades by ROW, not all-or-nothing (round 13b, finding 1). The
+    `missing` row needs no Authenticode at all -- the step throws on Test-Path
+    before it reaches the cmdlet -- so it runs anywhere pwsh exists, including
+    the Ubuntu lane that actually runs this suite in CI, and it is the row that
+    catches an early `exit 0`. The four signature-state rows need Windows. The
+    caller is told which kinds ran so it can require exactly the mutations those
+    rows can catch, and name the rest UNCHECKED rather than passing over them.
+    """
+    script = authenticode_script(release)
+    shell = _powershell()
+    if shell is None:
+        return AuthenticodeRun(
+            [], ["no pwsh or powershell on this host"], set(), set(), "no-shell"
+        )
+    violations: list[str] = []
+    unchecked: list[str] = []
+    ran: set[str] = set()
+    failed: set[str] = set()
+    with tempfile.TemporaryDirectory() as work:
+        capability, signed_path, publisher = _signed_fixture(shell, work)
+        why_not = {
+            "no-support": "Get-AuthenticodeSignature is not usable on this host",
+            "none-found": "the search of this host's system binary directories found "
+            "no validly signed file, which is a broken probe or trust store, not an "
+            "incapacity",
+            # The reason travels in the publisher slot for this one arm; see
+            # FixtureResult. Naming it here is what keeps a crashed probe from
+            # reading, in the log a reviewer skims, like a platform that cannot
+            # do Authenticode.
+            "probe-failed": "the capability probe did not answer at all "
+            f"({publisher}), which is a failed measurement, not an incapacity",
+        }.get(capability, "")
+        for description, kind, expected_status, required in AUTHENTICODE_TRUTH_TABLE:
+            body = script
+            staged = os.path.join(work, f"Wenlan_9.9.9_x64-setup-{kind}.exe")
+            if kind == "missing":
+                pass
+            elif capability != "fixture":
+                unchecked.append(f"{description}: {why_not}")
+                continue
+            else:
+                assert signed_path is not None and publisher is not None
+                data = bytearray(Path(signed_path).read_bytes())
+                if kind == "notsigned":
+                    data += b"X"
+                elif kind == "mismatch":
+                    data[4096:4100] = b"ZZZZ"
+                elif kind in AUTHENTICODE_SUBSTITUTED_KINDS:
+                    # The OPERATOR is matched, not assumed. A mutation that
+                    # swaps -cne for -ne must leave both rows buildable, or the
+                    # row that exists to catch that swap reports "could not be
+                    # built" instead of "caught it" -- and the runner below can
+                    # tell those apart only because the row still runs.
+                    found = re.findall(
+                        r"-c?ne '(?:SignPath Foundation)'", body
+                    )
+                    if len(found) != 1:
+                        violations.append(
+                            "the expected-publisher comparison is no longer a "
+                            "single -cne/-ne against 'SignPath Foundation'; the "
+                            f"{kind} row cannot be built"
+                        )
+                        continue
+                    needle = found[0]
+                    operator = needle.split(" ", 1)[0]
+                    # The one documented substitution, made by exactly the rows
+                    # named in AUTHENTICODE_SUBSTITUTED_KINDS: this host has no
+                    # SignPath-signed file, so these rows swap the publisher the
+                    # step demands for the publisher this host can actually
+                    # produce (the casefolded row then re-cases it). Everything
+                    # else -- the Valid check, the null-certificate check, the
+                    # SimpleName parse, the PASS -- is the shipped code running
+                    # against a real signature.
+                    wanted = publisher
+                    if kind == "casefolded":
+                        # The same certificate, the same name, one different
+                        # casing. -cne rejects it; -ne, -eq, -like and -ine all
+                        # accept it, and this is the only row in the table that
+                        # can tell those two comparisons apart.
+                        wanted = publisher.swapcase()
+                        if wanted == publisher:
+                            unchecked.append(
+                                f"{description}: this host's fixture publisher "
+                                f"{publisher!r} has no cased letters, so a "
+                                "case-folded variant of it does not exist"
+                            )
+                            continue
+                    body = body.replace(needle, f"{operator} '{wanted}'")
+                Path(staged).write_bytes(bytes(data))
+            step_file = os.path.join(work, f"step-{kind}.ps1")
+            Path(step_file).write_text(body, encoding="utf-8")
+            result = subprocess.run(
+                [shell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", step_file],
+                env={**os.environ, **AUTHENTICODE_STEP_ENV, "STAGED_SETUP": staged},
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            output = result.stdout + result.stderr
+            ran.add(kind)
+            if result.returncode != expected_status:
+                failed.add(kind)
+                violations.append(
+                    f"Authenticode step: {description}: expected exit "
+                    f"{expected_status}, got {result.returncode}; output="
+                    f"{output.strip()[:400]!r}"
+                )
+            elif required not in output:
+                failed.add(kind)
+                violations.append(
+                    f"Authenticode step: {description}: exited {result.returncode} "
+                    f"without saying why; expected {required!r} in {output.strip()[:400]!r}"
+                )
+    return AuthenticodeRun(violations, unchecked, ran, failed, capability)
+
+
+class InvarianceRun(NamedTuple):
+    violations: list[str]
+    unchecked: list[str]
+    ran: list[str]
+
+
+def _contrary_step_env() -> dict[str, str]:
+    """Every variable the release supplies, set to something else entirely."""
+    contrary = {
+        "SIGNPATH_CONFIGURED": "false",
+        "CI": "false",
+        "GITHUB_ACTIONS": "false",
+        "RUNNER_OS": "Linux",
+        "RUNNER_ARCH": "ARM64",
+        "RUNNER_ENVIRONMENT": "self-hosted",
+        "GITHUB_JOB": "docs",
+        "GITHUB_EVENT_NAME": "pull_request",
+        "GITHUB_REF": "refs/heads/main",
+        "GITHUB_REF_TYPE": "branch",
+        "GITHUB_REF_NAME": "main",
+        "GITHUB_REF_PROTECTED": "true",
+        "GITHUB_WORKFLOW": "ci",
+        "GITHUB_WORKFLOW_REF": "someone/else/.github/workflows/ci.yml@refs/heads/main",
+        "GITHUB_REPOSITORY": "someone/else",
+        "GITHUB_REPOSITORY_OWNER": "someone",
+        "GITHUB_SERVER_URL": "https://example.invalid",
+        "GITHUB_API_URL": "https://example.invalid/api",
+    }
+    return {
+        name: contrary.get(name, "wrong-" + name.lower())
+        for name in AUTHENTICODE_STEP_ENV
+    }
+
+
+def authenticode_environment_invariance(release: str) -> InvarianceRun:
+    """The step's outcome may not depend on the environment. A property, run.
+
+    Round 13e reopened finding 1 and new finding 3. Everything guarding this
+    until now was LEXICAL: `authenticode_body_env_violations` blanks the one
+    permitted read and rejects the surviving token `env`, case-insensitively,
+    which is a good net and still only a net. PowerShell can assemble the drive
+    name at runtime --
+
+        if ((Get-Item ('E' + 'nv:GITHUB_WORKFLOW_REF')).Value) { exit 0 }
+
+    -- and the token never appears. Widening `AUTHENTICODE_STEP_ENV` to
+    GitHub's full documented set closes the other half of that particular
+    example, but "enumerate the variables" and "enumerate the spellings" are the
+    same losing game, one level apart.
+
+    So this asks the question directly, and by running the step rather than by
+    reading it: the same row, three times, under the release's own environment,
+    under none of it, and under every value replaced by a wrong one. A gate
+    whose answer depends on any of that is a gate that can be switched off from
+    the workflow, however it is spelled. Nothing here reads the body's text.
+
+    The `missing` row needs no fixture, so this property is measured even on a
+    lane with no Authenticode at all -- which is where a bypass would be least
+    likely to be noticed.
+    """
+    script = authenticode_script(release)
+    shell = _powershell()
+    if shell is None:
+        return InvarianceRun([], ["no pwsh or powershell on this host"], [])
+    violations: list[str] = []
+    unchecked: list[str] = []
+    ran: list[str] = []
+    with tempfile.TemporaryDirectory() as work:
+        capability, signed_path, reason = _signed_fixture(shell, work)
+        step_file = os.path.join(work, "invariance.ps1")
+        Path(step_file).write_text(script, encoding="utf-8")
+        rows = [("missing", os.path.join(work, "no-such-installer.exe"))]
+        if capability == "fixture" and signed_path is not None:
+            staged = os.path.join(work, "Wenlan_9.9.9_x64-setup-signed.exe")
+            Path(staged).write_bytes(Path(signed_path).read_bytes())
+            rows.append(("signed", staged))
+        else:
+            unchecked.append(
+                "the `signed` row needs a signed binary; the capability probe "
+                f"answered {capability!r}"
+                + (f" ({reason})" if capability == "probe-failed" else "")
+            )
+        # The base environment with every name the release supplies REMOVED, so
+        # "nothing at all" really is nothing rather than whatever this shell
+        # happens to be carrying.
+        base = {k: v for k, v in os.environ.items() if k not in AUTHENTICODE_STEP_ENV}
+        contrary = _contrary_step_env()
+        for kind, staged in rows:
+            outcomes: dict[str, tuple[int, str]] = {}
+            for label, extra in (
+                ("the release's own values", AUTHENTICODE_STEP_ENV),
+                ("none of them set", {}),
+                ("every one of them wrong", contrary),
+            ):
+                result = subprocess.run(
+                    [shell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", step_file],
+                    env={**base, **extra, "STAGED_SETUP": staged},
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                outcomes[label] = (
+                    result.returncode,
+                    (result.stdout + result.stderr).strip()[:300],
+                )
+            ran.append(kind)
+            if len(set(outcomes.values())) != 1:
+                violations.append(
+                    f"the {kind!r} row's outcome depends on the environment, and "
+                    "the step is allowed to read STAGED_SETUP and nothing else: "
+                    + "; ".join(
+                        f"{label} -> exit {rc} {out[:80]!r}"
+                        for label, (rc, out) in outcomes.items()
+                    )
+                )
+    return InvarianceRun(violations, unchecked, ran)
+
+
+# Columns: the shipped text, its replacement, the truth-table rows that can
+# catch the replacement, and why it matters.
+#
+# The catcher sets are the whole point of round 13b, finding 1. Coverage here is
+# host-dependent -- the four signature-state rows need an Authenticode-signed
+# file, which Ubuntu does not have -- and the previous shape skipped ALL of the
+# mutations whenever ANY row was unavailable, then printed PASS. Naming the
+# catchers per mutation means the rows that DID run still have to earn their
+# keep, and the rest are reported UNCHECKED by name rather than passed over.
+#
+# The first mutation is the one that matters on a fixture-free host: `exit 0`
+# above `$ErrorActionPreference` reaches nothing at all, so even the `missing`
+# row -- which needs no signature, only a Test-Path throw -- catches it. The
+# second sits below the Test-Path guard, so `missing` still exits 1 and only the
+# fixture rows can see it. Two different mutations because one of them is
+# checkable in the Ubuntu `docs` job that actually runs this suite in CI.
+AUTHENTICODE_MUTATIONS: tuple[tuple[str, str, frozenset[str], str], ...] = (
+    (
+        '          $ErrorActionPreference = "Stop"\n'
+        "          if (-not (Test-Path -LiteralPath $env:STAGED_SETUP)) {\n",
+        '          $ErrorActionPreference = "Stop"\n'
+        "          exit 0\n"
+        "          if (-not (Test-Path -LiteralPath $env:STAGED_SETUP)) {\n",
+        frozenset({"missing", "notsigned", "mismatch", "signed", "accepted"}),
+        "an early return above every one of the step's own assertions",
+    ),
+    (
+        "          $signature = Get-AuthenticodeSignature -LiteralPath $env:STAGED_SETUP\n",
+        "          exit 0\n"
+        "          $signature = Get-AuthenticodeSignature -LiteralPath $env:STAGED_SETUP\n",
+        frozenset({"notsigned", "mismatch", "signed", "accepted"}),
+        "an early return that reaches none of the signature assertions",
+    ),
+    (
+        "          if ($signature.Status -ne 'Valid') {\n"
+        "            throw \"Authenticode status is '$($signature.Status)',"
+        " expected 'Valid'. $($signature.StatusMessage)\"\n"
+        "          }\n",
+        "",
+        frozenset({"notsigned", "mismatch"}),
+        "the Authenticode status check",
+    ),
+    (
+        "          if ($publisher -cne 'SignPath Foundation') {\n"
+        "            throw \"installer publisher is '$publisher',"
+        " expected 'SignPath Foundation'\"\n"
+        "          }\n",
+        "",
+        # `signed` alone, deliberately. Deleting the comparison also deletes the
+        # line the `accepted` and `casefolded` rows rewrite, so those two rows
+        # become unbuildable rather than failing -- bookkeeping, not detection,
+        # exactly as the comment on the runner below says.
+        frozenset({"signed"}),
+        "the publisher check, which is what makes it SignPath's signature",
+    ),
+    (
+        # One operator, and the defect it hides is invisible to every other row
+        # in the table: -ne compares case-insensitively, so the check keeps
+        # rejecting a different name and quietly stops rejecting a different
+        # CASING of the right one. `casefolded` is the only catcher, which is
+        # exactly why that row exists.
+        "          if ($publisher -cne 'SignPath Foundation') {\n",
+        "          if ($publisher -ne 'SignPath Foundation') {\n",
+        frozenset({"casefolded"}),
+        "the case-SENSITIVE publisher comparison",
+    ),
+)
+
+
 def assert_mutation_detected(
     ci: str,
     release: str,
@@ -1447,6 +3875,7 @@ def main() -> None:
     violations.extend(windows_recipe_drift_violations(ci, release))
     violations.extend(candidate_observer_contract_violations(ci, observer, validator, archive))
     violations.extend(trusted_candidate_gate_violations(ci, classifier, validator))
+    violations.extend(signpath_status_violations())
     if violations:
         raise AssertionError("release workflow contract drift:\n" + "\n".join(violations))
 
@@ -1729,6 +4158,204 @@ def main() -> None:
             "still installs the CLI-only archive",
             "release",
         ),
+        # ---- Windows Authenticode signing ----------------------------------
+        # None of these steps runs today, and none of them will run until
+        # SignPath Foundation accepts the application. Every failure they guard
+        # against is silent, so each one gets a mutation that proves the check
+        # bites rather than merely existing.
+        (
+            "output-artifact-directory: ${{ runner.temp }}/signpath-signed",
+            "# output-artifact-directory removed",
+            "omits output-artifact-directory",
+            "release",
+        ),
+        (
+            "uses: SignPath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627",
+            "uses: SignPath/github-action-submit-signing-request@v2",
+            "mutable or unexpected reference",
+            "release",
+        ),
+        # Owner casing matters: the Node 24 pin allowlist looks the action up by
+        # its exact path and silently skips anything it does not recognise, so a
+        # lowercase spelling would leave the pin unenforced.
+        (
+            "uses: SignPath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627",
+            "uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627",
+            "the Node 24 pin allowlist skips any action it does not recognise",
+            "release",
+        ),
+        (
+            f"      - name: {SIGNPATH_GUARD_STEP}\n        shell: bash\n",
+            f"      - name: {SIGNPATH_GUARD_STEP}\n"
+            "        if: env.SIGNPATH_CONFIGURED == 'true'\n        shell: bash\n",
+            "guarded by the very sentinel it exists to police",
+            "release",
+        ),
+        # The same defect through the other sentinel. A latch that skips
+        # whenever signing is not required can never run in the state it exists
+        # to reject: SIGNPATH_REQUIRED true and the secrets absent is precisely
+        # the configuration this `if:` would evaluate as... true, and then the
+        # step runs -- but the reverse spelling, or a maintainer "optimising"
+        # the step away when signing is off, is one character from here.
+        (
+            f"      - name: {SIGNPATH_GUARD_STEP}\n        shell: bash\n",
+            f"      - name: {SIGNPATH_GUARD_STEP}\n"
+            "        if: env.SIGNPATH_REQUIRED == 'true'\n        shell: bash\n",
+            "must not skip when signing is not required",
+            "release",
+        ),
+        (
+            "      - name: Replace the unsigned installer with the signed one\n"
+            "        if: env.SIGNPATH_CONFIGURED == 'true'\n",
+            "      - name: Replace the unsigned installer with the signed one\n",
+            "is not guarded",
+            "release",
+        ),
+        (
+            "      actions: read\n      contents: read\n    env:\n"
+            "      # TWO questions",
+            "      contents: read\n    env:\n      # TWO questions",
+            "does not grant actions: read",
+            "release",
+        ),
+        (
+            'wait-for-completion-timeout-in-seconds: "5400"',
+            'wait-for-completion-timeout-in-seconds: "600"',
+            "is not raised past the",
+            "release",
+        ),
+        (
+            'skip-decompress: "false"',
+            'skip-decompress: "true"',
+            "skip-decompress",
+            "release",
+        ),
+        (
+            "    timeout-minutes: 165",
+            "    timeout-minutes: 120",
+            "165-minute bound",
+            "release",
+        ),
+        # Staging that lands before signing publishes unsigned bytes or a digest
+        # that no longer matches the file. Nothing else in this repository
+        # checks the order of these steps.
+        (
+            "      - name: Upload the unsigned installer for SignPath\n",
+            "      - name: Stage app bundle assets and checksums\n"
+            "      - name: Upload the unsigned installer for SignPath\n",
+            "must come after",
+            "release",
+        ),
+        (
+            "if ($before -eq $after) {",
+            "if ($false) {",
+            "does not compare content",
+            "release",
+        ),
+        (
+            "          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}\n"
+            "        run: |\n          set -euo pipefail\n          nsis_dir=",
+            "        run: |\n          set -euo pipefail\n          nsis_dir=",
+            "own copy of the signing",
+            "release",
+        ),
+        (
+            "$publisher -cne 'SignPath Foundation'",
+            "$false",
+            "Authenticode assertion is incomplete",
+            "release",
+        ),
+        # And the operator on its own. Losing the `c` leaves every marker in
+        # place, reads as a publisher check, and compares case-insensitively --
+        # which is no identity check at all.
+        (
+            "$publisher -cne 'SignPath Foundation'",
+            "$publisher -ne 'SignPath Foundation'",
+            "case-INSENSITIVE operator",
+            "release",
+        ),
+        # The certificate values are the whole record of what SignPath
+        # Foundation's certificate says, and nobody has seen it yet.
+        (
+            '          Write-Host "Subject:    $($certificate.Subject)"\n',
+            "",
+            "never logs",
+            "release",
+        ),
+        (
+            '          Write-Host "Thumbprint: $($certificate.Thumbprint)"\n',
+            "",
+            "never logs",
+            "release",
+        ),
+        # Logged, but after the comparison that throws: the failing run, which
+        # is the run whose values someone needs, prints nothing.
+        (
+            '          Write-Host "Publisher:  $publisher"\n',
+            "          if ($publisher -cne 'SignPath Foundation') { }\n"
+            '          Write-Host "Publisher:  $publisher"\n',
+            "logged after the publisher comparison",
+            "release",
+        ),
+        # SignerCertificate.Subject is a distinguished name, so bare-string
+        # equality against it is either always false or a substring match.
+        (
+            "          $publisher = $certificate.GetNameInfo(",
+            "          $publisher = ($certificate.Subject -eq 'SignPath Foundation') # (",
+            "compares the raw certificate Subject",
+            "release",
+        ),
+        # ci.yml's Windows bundle job publishes nothing and nobody installs its
+        # output, so it must not consume the signing credentials -- the same
+        # asymmetry that keeps it off the real updater key.
+        (
+            "  app-windows-bundle:\n    name: app-windows-bundle\n",
+            "  app-windows-bundle:\n    name: app-windows-bundle\n"
+            "    # borrow the SignPath credentials here too\n",
+            "ci.yml app-windows-bundle references SignPath",
+            "ci",
+        ),
+        # ---- the lane that makes the Authenticode rows fatal ----
+        # Each of these leaves a job that looks like coverage. The first deletes
+        # it outright; the second leaves it running on a host that can measure
+        # everything and requiring none of it; the third and fourth leave it
+        # green-or-red with nothing reading the answer.
+        (
+            "  windows-release-contract:\n    name: windows release contract\n",
+            "  windows-release-contract-disabled:\n    name: windows release contract\n",
+            "has no 'windows-release-contract' job",
+            "ci",
+        ),
+        (
+            '          WENLAN_REQUIRE_AUTHENTICODE: "1"\n',
+            "",
+            "does not set WENLAN_REQUIRE_AUTHENTICODE",
+            "ci",
+        ),
+        (
+            "docs, windows-release-contract, plugin,",
+            "docs, plugin,",
+            "is not in conclusion's needs",
+            "ci",
+        ),
+        (
+            "          expect_job windows-release-contract ",
+            "          # expect_job windows-release-contract ",
+            "no expect_job line for windows-release-contract",
+            "ci",
+        ),
+        # And the flag on a lane that cannot answer, which is the other way to
+        # end up with nothing measured: a permanently red Ubuntu job gets the
+        # flag removed again within a week.
+        (
+            "      - name: Validate README translations and eval provenance\n        run: |\n",
+            "      - name: Validate README translations and eval provenance\n"
+            "        env:\n"
+            '          WENLAN_REQUIRE_AUTHENTICODE: "1"\n'
+            "        run: |\n",
+            "ubuntu docs lane sets WENLAN_REQUIRE_AUTHENTICODE",
+            "ci",
+        ),
     ]
     for old, new, expected, owner in release_mutations:
         assert_mutation_detected(
@@ -1912,6 +4539,426 @@ def main() -> None:
             raise AssertionError(
                 f"candidate mutation did not exercise {expected!r}: {candidate_violations!r}"
             )
+    # The static contract above reads markers; this runs the guard. Both are
+    # needed: the markers survive a mutation of the arithmetic that decides
+    # whether a release ships signed.
+    guard_violations = signpath_guard_behaviour_violations(release)
+    if guard_violations:
+        raise AssertionError(
+            "SignPath guard behaviour contract failed:\n  "
+            + "\n  ".join(guard_violations)
+        )
+    # And the truth table has to be able to fail. A mutation the static contract
+    # cannot see must change at least one row's exit status, or the table is
+    # decoration.
+    for old, new, why in (
+        (
+            "              present=$((present + 1))",
+            "              present=$((present + 0))",
+            "the count that decides whether the guard fires",
+        ),
+        (
+            '          if [[ "$present" -eq 0 && -n "${SECRET_SIGNPATH_ARTIFACT_CONFIGURATION_SLUG:-}" ]]; then',
+            '          if [[ "$present" -eq -1 ]]; then',
+            "the optional-slug-alone check",
+        ),
+        # THE LATCH. Zero of four is a green release today and must be a red one
+        # the day signing is switched on; this condition is the entire
+        # difference between those two, and nothing else in the job can see it.
+        (
+            '          if [[ "${SIGNPATH_REQUIRED:-}" == "true" && "$present" -ne "${#names[@]}" ]]; then',
+            "          if false; then",
+            "the required-but-unconfigured latch",
+        ),
+        # And the diagnosis it prints. An operator meeting this failure has
+        # never seen it before -- it can only fire once, on the first release
+        # after the switch is thrown -- so a latch that fires without naming the
+        # missing secrets sends them to read the workflow instead.
+        (
+            '                echo "       MISSING: $name" >&2',
+            '                echo "       (something is missing)" >&2',
+            "the per-secret diagnosis the latch prints",
+        ),
+    ):
+        if old not in release:
+            raise AssertionError(f"SignPath guard mutation fixture is stale: {old!r}")
+        if not signpath_guard_behaviour_violations(release.replace(old, new, 1)):
+            raise AssertionError(
+                f"the SignPath guard truth table did not notice a mutation of {why}"
+            )
+    # The activation monitor, run against a fake SignPath. Its whole subject is
+    # states nobody can produce here -- an accepted application, a resolving
+    # project slug -- so a stub server is the only way any of it is measured at
+    # all before the day it matters.
+    status_violations = signpath_status_behaviour_violations()
+    if status_violations:
+        raise AssertionError(
+            "SignPath status behaviour contract failed:\n  "
+            + "\n  ".join(status_violations)
+        )
+    status_text = SIGNPATH_STATUS_PATH.read_text(encoding="utf-8")
+    for old, new, why in (
+        (
+            'if [[ "$credential" == "ok" && "$active" != "true" ]]; then',
+            "if false; then",
+            "the accepted-but-not-activated verdict",
+        ),
+        (
+            "                credential=unmeasured\n                note_unmeasured\n",
+            "                credential=ok\n",
+            "a 200 that does not parse being its own state, not a success",
+        ),
+        # THE SHAPE ASSERTION. Reverting it to the expression that shipped
+        # is the mutation the old control could not catch: that control fed
+        # HTML, which fails at the parser either way. The rows added beside
+        # it feed valid JSON that is not a list -- {} , a string, a number --
+        # which is exactly what the old expression waved through.
+        (
+            '                    if type == "array" then length\n'
+            '                    elif type == "object" then\n'
+            '                      if (.values | type) == "array" then (.values | length)\n'
+            '                      elif (.items | type) == "array" then (.items | length)\n'
+            '                      else empty end\n'
+            '                    else empty end',
+            '                    if type == "object" then (.values // .items // [])\n'
+            '                    else . end | length',
+            "the positive shape assertion on the credential response",
+        ),
+        (
+            '              if [[ "$real" == "1" && "$control" == "0" ]]; then',
+            '              if [[ "$real" == "1" ]]; then',
+            "the control probe that makes a filtered read a measurement",
+        ),
+        # ROUND 5. The two halves of the transfer status, mutated back to the
+        # `|| true` that stood here: a curl whose status nobody reads makes an
+        # incomplete response indistinguishable from a complete one, at the
+        # credential and at each slug probe.
+        (
+            "          if (( curl_rc != 0 )); then\n",
+            "          if false; then\n",
+            "a failed credential transfer being distinguishable from a completed one",
+        ),
+        (
+            "              if (( rc != 0 )); then\n                echo 2\n",
+            "              if false; then\n                echo 2\n",
+            "a failed slug transfer being distinguishable from a completed one",
+        ),
+        # THE OUTERMOST BOUNDARY. A tri-state that collapses back to two at
+        # the exit is a tri-state nobody downstream can see: on a scheduled
+        # run the workflow result is the entire signal.
+        (
+            '            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then\n            note_unmeasured\n',
+            '            && [[ "$project_state" == "unmeasured" || "$policy_state" == "unmeasured" ]]; then\n',
+            "an unmeasured slug having any consequence at all",
+        ),
+        (
+            "              status=2\n",
+            "              status=0\n",
+            "could-not-measure exiting differently from measured-affirmative",
+        ),
+        (
+            '            && [[ "$project_state" != "resolved" || "$policy_state" != "resolved" ]]; then',
+            "            && false; then",
+            "refusing to recommend the switch on slugs that never resolved",
+        ),
+        (
+            '          describe SIGNPATH_PROJECT_SLUG "$project_state"',
+            '          echo "  SIGNPATH_PROJECT_SLUG: validated against the SignPath API"',
+            "the summary being derived from what the run measured",
+        ),
+        # ---- ROUND 7. The three slug-arm remedies, each reverted on its own.
+        #
+        # Every one of these left the whole table above green, which is why the
+        # four rows at the bottom of it exist. Reverted SEPARATELY and not as a
+        # block: a single mutation that undoes all three would be caught by the
+        # first rule it happens to trip and would say nothing about the other
+        # two.
+        #
+        # The rotation, back to the fixed impossible prefix. The control then
+        # differs from the configured slug in length, in content and in
+        # separator count as well as in whether it names anything, and
+        # `_SPELLING_RULE_SERVER` is a server that separates the two on the
+        # first of those and never applies a filter at all.
+        (
+            "rotate_slug() { printf '%s' \"$1\" | tr 'a-zA-Z0-9' 'b-zaB-ZA1-90'; }",
+            "rotate_slug() { printf '%s' \"wenlan-no-such-project-$$\"; }",
+            "a control slug that differs from the configured one in nothing but "
+            "whether it names something",
+        ),
+        (
+            '              if [[ "$4" == "$5" ]]; then\n',
+            "              if false; then\n",
+            "refusing a differential whose two halves are the same request",
+        ),
+        # The slug body, back to the status line alone. `200) ;;` falls through
+        # to the envelope assertion and the item read below it; `200) echo 1`
+        # is the arm as it stood, where a 200 was affirmative whatever arrived
+        # with it. Narrower is not available here: an unparseable body cannot
+        # be admitted by any jq program, so the only revert that lets a proxy
+        # page through is the one that stops reading the body.
+        (
+            "                200)     ;;\n",
+            "                200)     echo 1; return 0 ;;\n",
+            "a slug 200 having to BE a signing-request list",
+        ),
+        # And the item read alone, with the envelope assertion left standing --
+        # so the row that catches this one is refused by NOTHING else in the
+        # step: valid JSON, a real array, a completed transfer, a rejected
+        # control.
+        (
+            "              if (( wrong > 0 )); then\n",
+            "              if false; then\n",
+            "the returned items being read, and contradicting the filter",
+        ),
+    ):
+        if status_text.count(old) != 1:
+            raise AssertionError(
+                f"signpath-status mutation fixture is stale "
+                f"({status_text.count(old)} matches): {old!r}"
+            )
+        if not signpath_status_behaviour_violations(status_text.replace(old, new, 1)):
+            raise AssertionError(
+                f"the SignPath status truth table did not notice a mutation of {why}"
+            )
+
+    # The re-signing step has the same shape of hole and none of the guard's
+    # coverage: its assertions are all reachable-only, so anything that returns
+    # early satisfies every one of them by never reaching them.
+    resign_violations = resign_behaviour_violations(release)
+    if resign_violations:
+        raise AssertionError(
+            "updater re-signing behaviour contract failed:\n  "
+            + "\n  ".join(resign_violations)
+        )
+    for old, new, why in (
+        (
+            '          before_sig="$(cat "$sig")"\n',
+            '          before_sig="$(cat "$sig")"\n          exit 0\n',
+            "an early return that reaches none of the step's own assertions",
+        ),
+        (
+            '          [[ "$(cat "$sig")" != "$before_sig" ]] || '
+            '{ echo "ERROR: $sig is unchanged; it still covers the unsigned bytes." >&2; exit 1; }\n',
+            "",
+            "the check that the signature actually changed",
+        ),
+        (
+            '          [[ -s "$sig" ]] || { echo "ERROR: re-signing produced no $sig." >&2; exit 1; }',
+            '          [[ -e "$sig" ]] || { echo "ERROR: re-signing produced no $sig." >&2; exit 1; }',
+            "the emptiness check on the regenerated signature",
+        ),
+        (
+            # Everything the step asserts is true at the moment it asserts it,
+            # and false by the time the next step uploads the file. A table that
+            # only asks "non-empty and changed" cannot see this; the sidecar has
+            # to be compared against what the signer actually produced.
+            '          echo "Regenerated $sig over the Authenticode-signed installer."',
+            '          printf x >> "$sig"\n'
+            '          echo "Regenerated $sig over the Authenticode-signed installer."',
+            "corruption of the sidecar after the step's own assertions passed",
+        ),
+    ):
+        if release.count(old) != 1:
+            raise AssertionError(
+                f"re-sign mutation fixture is stale ({release.count(old)} matches): {old!r}"
+            )
+        if not resign_behaviour_violations(release.replace(old, new, 1)):
+            raise AssertionError(
+                f"the re-sign truth table did not notice a mutation of {why}"
+            )
+    # The Authenticode gate is the last thing standing between a silently
+    # skipped SignPath download and a published unsigned installer, and until
+    # now it was held by substring markers alone.
+    #
+    # Two separate gates, because they fail in different places. The metadata
+    # gate reads the workflow: `continue-on-error: true` on a signing step is
+    # invisible to every body-level assertion above, and turns the gate into a
+    # log line. The behaviour gate runs the step.
+    meta_violations = authenticode_step_metadata_violations(release)
+    if meta_violations:
+        raise AssertionError(
+            "signing step metadata contract failed:\n  " + "\n  ".join(meta_violations)
+        )
+    for name in SIGNING_STEPS:
+        marker = f"- name: {name}\n"
+        if release.count(marker) != 1:
+            raise AssertionError(
+                f"metadata mutation fixture is stale for {name!r} "
+                f"({release.count(marker)} matches)"
+            )
+        mutated = release.replace(marker, marker + "        continue-on-error: true\n", 1)
+        if not authenticode_step_metadata_violations(mutated):
+            raise AssertionError(
+                f"the metadata contract did not notice continue-on-error on {name!r}"
+            )
+    # named_step_body strips, so the body it returns has lost the indentation of
+    # its first line; splice against the ORIGINAL slice of release.yml instead,
+    # or a whole-line removal silently becomes a partial one.
+    auth_header = f"      - name: {AUTHENTICODE_STEP}\n"
+    if release.count(auth_header) != 1:
+        raise AssertionError(
+            f"metadata mutation fixture is stale ({release.count(auth_header)} "
+            f"matches): {auth_header!r}"
+        )
+    auth_start = release.index(auth_header) + len(auth_header)
+    auth_body = named_step_body(job_body(release, "app-bundle-windows"), AUTHENTICODE_STEP)
+    auth_end = release.index(auth_body, auth_start) + len(auth_body)
+    auth_region = release[auth_start:auth_end]
+    for old, why in (
+        ("        shell: pwsh\n", "the `shell: pwsh` declaration"),
+        (
+            "        if: env.SIGNPATH_CONFIGURED == 'true'\n",
+            "the SIGNPATH_CONFIGURED guard",
+        ),
+    ):
+        if auth_region.count(old) != 1:
+            raise AssertionError(
+                f"metadata mutation fixture is stale "
+                f"({auth_region.count(old)} matches): {old!r}"
+            )
+        mutated = (
+            release[:auth_start] + auth_region.replace(old, "", 1) + release[auth_end:]
+        )
+        if not authenticode_step_metadata_violations(mutated):
+            raise AssertionError(f"the metadata contract did not notice removing {why}")
+    # And the insertions. An environment-keyed early-out is the one mutation the
+    # truth table structurally cannot see, because the table supplies the
+    # environment: `exit 0` under a branch on SIGNPATH_CONFIGURED is skipped
+    # here and taken in the release, so all five rows stay green while the gate
+    # does nothing. It is caught statically, on every host, fixture or not.
+    for anchor, inserted, why in (
+        (
+            '          $ErrorActionPreference = "Stop"\n',
+            "          if ($env:SIGNPATH_CONFIGURED -eq 'true') { exit 0 }\n",
+            "an early return taken only when the release's own guard variable is set",
+        ),
+        (
+            '          $ErrorActionPreference = "Stop"\n',
+            "          if ($env:CI -eq 'true') { exit 0 }\n",
+            "an early return taken only on a CI runner",
+        ),
+    ):
+        if auth_region.count(anchor) != 1:
+            raise AssertionError(
+                f"metadata insertion fixture is stale "
+                f"({auth_region.count(anchor)} matches): {anchor!r}"
+            )
+        mutated = (
+            release[:auth_start]
+            + auth_region.replace(anchor, anchor + inserted, 1)
+            + release[auth_end:]
+        )
+        if not authenticode_step_metadata_violations(mutated):
+            raise AssertionError(f"the metadata contract did not notice {why}")
+
+    baseline = authenticode_behaviour_violations(release)
+    auth_unchecked = list(baseline.unchecked)
+    if baseline.violations:
+        raise AssertionError(
+            "Authenticode verification behaviour contract failed:\n  "
+            + "\n  ".join(baseline.violations)
+        )
+    # Per-mutation, not all-or-nothing: whatever rows this host CAN run must
+    # still catch every mutation they are capable of catching. On a fixture-free
+    # host that is exactly one mutation -- and it is the one that guts the whole
+    # step -- so the Ubuntu lane stops being a free pass.
+    for old, new, catchers, why in AUTHENTICODE_MUTATIONS:
+        if release.count(old) != 1:
+            raise AssertionError(
+                "Authenticode mutation fixture is stale "
+                f"({release.count(old)} matches): {old!r}"
+            )
+        live = catchers & baseline.ran
+        if not live:
+            auth_unchecked.append(
+                f"mutation of {why} was not exercised; catching it needs one of "
+                f"{sorted(catchers)} and this host ran {sorted(baseline.ran) or 'nothing'}"
+            )
+            continue
+        mutant = authenticode_behaviour_violations(release.replace(old, new, 1))
+        # Two separate demands, because "a violation appeared" is not the same
+        # claim as "the mutation was caught". Removing the publisher check, for
+        # instance, also makes the `accepted` row unbuildable -- that violation
+        # is bookkeeping, not detection. So: every row that is supposed to catch
+        # this must still have RUN, and at least one of them must have FAILED.
+        if not live <= mutant.ran:
+            raise AssertionError(
+                f"mutating {why} stopped {sorted(live - mutant.ran)} from running; "
+                "a row that never ran cannot be the row that caught it"
+            )
+        # EVERY listed catcher must fail, not merely one of them. `catchers` is
+        # a claim about which rows can see this mutation, and it is the claim
+        # the UNCHECKED accounting rests on: an over-generous set makes a
+        # fixture-free host report "enforced" for a mutation nothing there could
+        # actually catch. Requiring the set to be exact is what keeps the claim
+        # honest; a set that is too small is safe and merely reports UNCHECKED.
+        if not live <= mutant.failed:
+            raise AssertionError(
+                f"the Authenticode truth table did not notice a mutation of {why} "
+                f"in {sorted(live - mutant.failed)}, which the catcher set claims "
+                f"can see it (rows that did fail: {sorted(mutant.failed) or 'none'})"
+            )
+    if auth_unchecked:
+        # Never silent. A gate that could not run is unchecked, not passed, and
+        # the line says so in the log the reviewer reads.
+        for line in auth_unchecked:
+            print(f"UNCHECKED: Authenticode step: {line}")
+        # Round 13c asked for a capability predicate; round 13c shipped
+        # `os.name == "nt"`, and round 13d called that what it was -- an OS
+        # proxy. The question is not which OS this is. It is whether the host
+        # COULD have measured what it did not measure, and the probe now answers
+        # that directly: "no-support" means Get-AuthenticodeSignature does not
+        # work here at all, which is a real incapacity on Linux and macOS;
+        # "none-found" means it works and a search of the system binary
+        # directories still produced nothing signed, which is a broken probe or
+        # a broken trust store on ANY operating system, and never a reason to
+        # pass over the rows it prevented.
+        if baseline.capability in ("none-found", "probe-failed"):
+            why = (
+                "Get-AuthenticodeSignature runs on this host, and a search of its "
+                "system binary directories still found no validly signed file"
+                if baseline.capability == "none-found"
+                else "the capability probe did not answer at all -- its exit status "
+                "and what it printed do not agree on any arm, so nothing here knows "
+                "whether this host can measure Authenticode or not"
+            )
+            raise AssertionError(
+                f"the Authenticode probe is broken. {why} -- so the rows below did "
+                "not go unmeasured for want of a capability, they failed to be "
+                "measured:\n  " + "\n  ".join(auth_unchecked)
+            )
+        if os.environ.get("WENLAN_REQUIRE_AUTHENTICODE") == "1":
+            raise AssertionError(
+                "the Authenticode contract is only partly measured on a lane that "
+                "declared it would measure all of it (WENLAN_REQUIRE_AUTHENTICODE=1):"
+                "\n  " + "\n  ".join(auth_unchecked)
+            )
+
+    # And the property no reading of the body can establish: run the step, and
+    # require the same answer under the release's environment, under none of it,
+    # and under all of it wrong. See `authenticode_environment_invariance`.
+    # Last, so that a lane which is only partly measured says which rows of the
+    # truth table it could not build BEFORE it says the same about this.
+    invariance = authenticode_environment_invariance(release)
+    if invariance.violations:
+        raise AssertionError(
+            "the Authenticode step's outcome depends on the environment:\n  "
+            + "\n  ".join(invariance.violations)
+        )
+    for line in invariance.unchecked:
+        print(f"UNCHECKED: Authenticode environment invariance: {line}")
+    if invariance.unchecked and os.environ.get("WENLAN_REQUIRE_AUTHENTICODE") == "1":
+        raise AssertionError(
+            "environment invariance is only partly measured on a lane that "
+            "declared it would measure all of it (WENLAN_REQUIRE_AUTHENTICODE=1):"
+            "\n  " + "\n  ".join(invariance.unchecked)
+        )
+    if not invariance.ran and not invariance.unchecked:
+        raise AssertionError(
+            "environment invariance measured nothing at all and said nothing "
+            "about why; the `missing` row needs no fixture and must always run"
+        )
+
     print("PASS: release promotion, Homebrew, and Node 24 action contracts")
 
 


### PR DESCRIPTION
Every commit on this branch is one defect, found again and again:

> **a failed measurement that is indistinguishable from a negative measurement**

A probe that crashes and is reported as "nothing is running". A check that could
not run and prints a pass. A fixture that failed to build and is graded clean. A
health poll that times out and returns `false`, meaning "unhealthy" rather than
"unknown". The remedy is the same shape every time: **pass / fail / unchecked,
with a named reason**, where `unchecked` is never a pass.

## What

Adds `.github/workflows/signpath-status.yml`, which watches the SignPath
Foundation application and fails when the signing secrets are absent rather than
quietly producing an unsigned build, and tightens the Authenticode verification
step in `release.yml` so it checks the parsed certificate common name instead of
substring-matching a distinguished name.

## The measurement problem it fixes

The release could produce an installer that nobody signed, and nothing in the
pipeline could tell that from an installer that was signed. `SIGNPATH_*` secrets
are still absent (0 of 14 secrets set, no repo variables at all), so
`vars.SIGNPATH_ACTIVE` is unset -- which is the correct current state while the
application is pending.

## What was measured

`scripts/release-workflow-contract.test.py` grows an Authenticode behaviour
contract: six rows that run the **shipped step body** against real signed and
deliberately broken files on the host, and a mutation loop that requires each
row to actually catch the mutations its catcher set claims it can see.

The second commit here fixes that contract after CI caught it being wrong in
exactly the way this branch is about -- the tampered-installer row assumed its
own fixture. Three assumptions, all measured rather than argued:

- `data[4096:4100] = b"ZZZZ"` is a patch only if the file is over 4 KiB; past
  the end, Python slice assignment **appends**, silently turning the tampered
  row into a second copy of the unsigned row.
- The probe took the first *valid* signed binary of either kind. Measured on a
  Windows 11 host: **613 of 622** validly signed `.exe` files under System32 and
  `$PSHOME` are catalog-signed, which carry no certificate table -- a modified
  copy reports `NotSigned` and can never report `HashMismatch`. Which kind the
  row got was luck. This host drew an embedded one; CI drew a catalog one.
- A row that exited for the right reason without proving its claim was graded a
  failure.

Now the offset comes from the file's own PE geometry, the patch is verified to
have landed, the probe *prefers* an embedded signature and falls back rather
than answering NONE-FOUND, and a mismatch row refused with another named status
is reported `unchecked` and drops out of `ran`.

Verified with the CI condition reproduced locally rather than argued: forcing
the probe to return a catalog-signed fixture gives 0 violations, `mismatch`
absent from `ran`, and one `unchecked` line naming the missing certificate
table -- while deleting the status check from the shipped step still produces a
violation, so the concession is a third state and not a hole.

## Review history since first pushed

- The SignPath mutation table in `release-workflow-contract.test.py` gained a
  per-mutation `catchers` set, so a mutant runs only the rows that can catch it
  (315 runs to 64). A wrong catcher set would report a mutation caught by a row
  that never ran; the second adversarial review checked the guards and held.
- The comment above the `windows-release-contract` CI job now says the suite ran
  in no lane before this job, which is the truth; it used to claim the docs lane.

---

Part of the `windows-track` stack, split out of #661 because 44,375 added lines
is not reviewable in one diff. Each PR below is based on the one above it, so
this diff shows only its own change. Merge in order.

| | PR | added | product | tests |
|---|---|---:|---:|---:|
| 01 | [#662](https://github.com/7xuanlu/wenlan/pull/662) SignPath watch | 5,656 | 1,206 | 4,450 |
| 02 | [#663](https://github.com/7xuanlu/wenlan/pull/663) host-process probes | 9,222 | 4,879 | 4,343 |
| 03 | [#664](https://github.com/7xuanlu/wenlan/pull/664) first-run ownership | 5,374 | 4,562 | 812 |
| 04 | [#665](https://github.com/7xuanlu/wenlan/pull/665) reading tri-state | 9,567 | 1,621 | 7,946 |
| 05 | [#666](https://github.com/7xuanlu/wenlan/pull/666) quick-capture halo | 460 | 182 | 278 |
| 06 | [#667](https://github.com/7xuanlu/wenlan/pull/667) negative controls | 14,096 | 41 | 14,055 |
| 07 | [#668](https://github.com/7xuanlu/wenlan/pull/668) Vulkan doc | 1 | 1 | 0 |

The stack's tip is byte-identical to `windows-track` (`git diff` between them is
empty), and every level was checked to route cleanly through drift_guard's
Windows paths-filter rule, so no intermediate PR here is red on it.

Reviewed twice by Codex Sol (adversarial) and once by a Fable gatekeeper on
the integrated tree; every finding was fixed in place and has a negative
control at level 6. The two Windows channels are never executed before merge:
their evidence is static reading, the 109-case Windows probe harness and the
35-case `lib.test.ps1` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH3nEZRDbNUeEzCrzfPuk8
