### PR TITLE
fix(app): drop the quick-capture halo where the platform draws no window shadow

### DIFF
--- a/src/components/QuickCapture.test.tsx
+++ b/src/components/QuickCapture.test.tsx
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import QuickCapture from "./QuickCapture";
+
+// Real user agents from the two webviews that matter here. The quick-capture
+// window is transparent and undecorated on both, but only macOS turns the
+// native window shadow off (app/src/lib.rs, `setHasShadow: NO`), so only macOS
+// has to paint one in CSS.
+const MACOS_WKWEBVIEW =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15";
+const WINDOWS_WEBVIEW2 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
+const LINUX_WEBKITGTK =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+/** Replace the ambient user agent, the way `needsCssWindowShadow` reads it. */
+function setPlatform(userAgent: string | undefined): void {
+  Object.defineProperty(globalThis, "navigator", {
+    value: userAgent === undefined ? undefined : { userAgent },
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, "navigator", originalNavigator);
+  } else {
+    Reflect.deleteProperty(globalThis, "navigator");
+  }
+});
+
+/**
+ * The card, found by IDENTITY rather than by presentation.
+ *
+ * This used to be `container.querySelector(".rounded-xl")`, and that is not a
+ * selection, it is a coincidence that keeps working. `querySelector` returns
+ * the FIRST match and never says how many there were, so a second element
+ * picking up the same utility class -- a Tailwind class, present for its corner
+ * radius and nothing else -- silently redirects every assertion below onto the
+ * wrong node. And the assertions are all `expect(...).toBe("none")`: an element
+ * with no inline shadow at all satisfies them for the wrong reason, so the test
+ * would keep passing while the card it was written about lost its shadow. A
+ * control that cannot fail is worse than no control.
+ *
+ * Preferred hook: `data-testid="quick-capture-card"`. It does NOT exist yet --
+ * `src/components/QuickCapture.tsx` is owned by another agent in this
+ * workstream and is not mine to edit, so adding it is a REQUIRED FOLLOW-UP and
+ * this helper is written to use it the moment it lands.
+ *
+ * Until then the identity used is SEMANTIC and asserted UNIQUE: the card is the
+ * one element whose inline style carries BOTH a `border-color` and a
+ * `box-shadow`. That pair is exactly the decision under test -- `borderAccent`
+ * plus the platform-scoped `boxShadow` -- and it distinguishes the card from
+ * the Save button, which sets an inline `box-shadow` but no `border-color`.
+ * `toHaveLength(1)` is what makes it able to fail: if the component changes so
+ * that two elements match, or none does, this throws instead of quietly
+ * measuring something else.
+ */
+function findCard(container: HTMLElement): HTMLElement {
+  const tagged = container.querySelectorAll('[data-testid="quick-capture-card"]');
+  if (tagged.length > 0) {
+    expect(tagged).toHaveLength(1);
+    return tagged[0] as HTMLElement;
+  }
+  const byIdentity = Array.from(container.querySelectorAll<HTMLElement>("[style]")).filter(
+    (el) => el.style.borderColor !== "" && el.style.boxShadow !== "",
+  );
+  // Exactly one, or the identity this test relies on no longer holds and the
+  // right outcome is a loud failure rather than a silent redirect.
+  expect(byIdentity).toHaveLength(1);
+  return byIdentity[0];
+}
+
+/**
+ * Renders and hands back the two elements the platform scoping touches: the
+ * standalone window's outer wrapper (which owns the transparent inset) and the
+ * card itself (which owns the shadow).
+ */
+function renderCapture(standalone: boolean) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const { container } = render(
+    <QueryClientProvider client={client}>
+      <QuickCapture isOpen onClose={() => {}} standalone={standalone} />
+    </QueryClientProvider>,
+  );
+  const wrapper = container.firstElementChild as HTMLElement;
+  expect(wrapper).toBeTruthy();
+  const card = findCard(container);
+  // The card is INSIDE the wrapper whose inset is asserted alongside it. Both
+  // halves of every test below are then known to be about one window rather
+  // than about two elements that happen to be in the same container.
+  expect(wrapper.contains(card)).toBe(true);
+  expect(wrapper).not.toBe(card);
+  return { wrapper, card };
+}
+
+/** Inset in px, whichever way React and jsdom chose to serialise a zero. */
+function insetPx(el: HTMLElement): number {
+  return parseInt(el.style.padding || "0", 10);
+}
+
+describe("QuickCapture standalone window shadow is platform-scoped", () => {
+  it("keeps the CSS shadow on macOS, where the NSWindow draws none", () => {
+    setPlatform(MACOS_WKWEBVIEW);
+    const { wrapper, card } = renderCapture(true);
+
+    // app/src/lib.rs sets setHasShadow:NO on this NSWindow, so removing the CSS
+    // shadow would flatten the card against the desktop behind it.
+    expect(card.style.boxShadow).not.toBe("none");
+    expect(card.style.boxShadow).toContain("32px");
+    // And the shadow needs somewhere to render: an outer shadow is clipped at
+    // the viewport edge without a transparent margin.
+    expect(insetPx(wrapper)).toBe(12);
+  });
+
+  it("drops the shadow and the inset on a Windows layered window", () => {
+    setPlatform(WINDOWS_WEBVIEW2);
+    const { wrapper, card } = renderCapture(true);
+
+    // The reported bug: this shadow composites as a flat grey band, not a halo
+    // that fades into the desktop.
+    expect(card.style.boxShadow).toBe("none");
+    expect(insetPx(wrapper)).toBe(0);
+  });
+
+  it("treats Linux like Windows -- layered windows composite the same way", () => {
+    setPlatform(LINUX_WEBKITGTK);
+    const { wrapper, card } = renderCapture(true);
+
+    expect(card.style.boxShadow).toBe("none");
+    expect(insetPx(wrapper)).toBe(0);
+  });
+
+  it("defaults an unknown platform to no shadow, which cannot look broken", () => {
+    // No navigator at all is the real first-paint / unknown-host case. A card
+    // missing its shadow reads as plain; a shadow the compositor cannot blend
+    // reads as a rendering artifact, so the unknown side takes the former.
+    setPlatform(undefined);
+    const { wrapper, card } = renderCapture(true);
+
+    expect(card.style.boxShadow).toBe("none");
+    expect(insetPx(wrapper)).toBe(0);
+  });
+
+  it("leaves the modal's shadow alone on every platform", () => {
+    // The modal floats over the app on an opaque backdrop with room around it.
+    // Nothing about the host window applies, so it must not be scoped at all.
+    for (const ua of [MACOS_WKWEBVIEW, WINDOWS_WEBVIEW2, LINUX_WEBKITGTK]) {
+      setPlatform(ua);
+      const { card } = renderCapture(false);
+      expect(card.style.boxShadow).not.toBe("none");
+      expect(card.style.boxShadow).toContain("32px");
+    }
+  });
+});

--- a/src/components/QuickCapture.tsx
+++ b/src/components/QuickCapture.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { quickCapture } from "../lib/tauri";
+import { cssWindowShadowInset, needsCssWindowShadow } from "../lib/windowChrome";
 
 interface QuickCaptureProps {
   isOpen: boolean;
@@ -95,6 +96,12 @@ export default function QuickCapture({ isOpen, onClose, standalone }: QuickCaptu
         ? "var(--mem-accent-indigo)"
         : "var(--mem-border)";
 
+  // The modal is unconditional; only the standalone window asks the platform.
+  // `needsCssWindowShadow` reads the three-valued `hostPlatform()` and applies
+  // the documented visual default for `unknown` at its own named site, so the
+  // answer here is always a decided one.
+  const paintsOwnShadow = !standalone || needsCssWindowShadow();
+
   const card = (
     <div
       className="flex-1 flex flex-col overflow-hidden rounded-xl"
@@ -102,9 +109,20 @@ export default function QuickCapture({ isOpen, onClose, standalone }: QuickCaptu
         backgroundColor: "var(--mem-surface)",
         border: "1px solid var(--mem-border)",
         borderColor: borderAccent,
-        boxShadow: !isEmpty && !saved
-          ? "0 0 20px var(--mem-shimmer-color), 0 8px 32px rgba(0,0,0,0.25)"
-          : "0 8px 32px rgba(0,0,0,0.25)",
+        // The modal always keeps its shadow: it floats over the app, on an
+        // opaque backdrop with room around it. The standalone window IS the
+        // card, so whether the shadow can be drawn at all is a platform
+        // question -- see `needsCssWindowShadow`. On macOS the NSWindow has
+        // `setHasShadow: NO`, so this shadow is the only thing lifting the card
+        // off the desktop and it must stay. On a Windows/Linux layered window
+        // the same shadow composites as a flat grey band, so it goes; state is
+        // still carried by `borderAccent`, the header dot and label, and the
+        // Save button, all of which paint inside the card's opaque surface.
+        boxShadow: !paintsOwnShadow
+          ? "none"
+          : !isEmpty && !saved
+            ? "0 0 20px var(--mem-shimmer-color), 0 8px 32px rgba(0,0,0,0.25)"
+            : "0 8px 32px rgba(0,0,0,0.25)",
         transition: "border-color 0.3s ease, box-shadow 0.3s ease",
       }}
     >
@@ -237,8 +255,16 @@ export default function QuickCapture({ isOpen, onClose, standalone }: QuickCaptu
   );
 
   if (standalone) {
+    // The inset exists only to give the shadow somewhere to render. Where no
+    // shadow is drawn it is a transparent margin the compositor fills with a
+    // halo instead, so it collapses to 0 on exactly the platforms that skip the
+    // shadow. Corners stay rounded either way -- the few pixels outside the
+    // radius are the only transparency left when the inset is gone.
     return (
-      <div className="w-full h-screen p-[12px] flex flex-col" style={{ background: "transparent" }}>
+      <div
+        className="w-full h-screen flex flex-col"
+        style={{ background: "transparent", padding: cssWindowShadowInset() }}
+      >
         {card}
       </div>
     );

--- a/src/lib/windowChrome.test.ts
+++ b/src/lib/windowChrome.test.ts
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import { describe, expect, it } from "vitest";
 
+import * as windowChrome from "./windowChrome";
 import {
+  CSS_WINDOW_SHADOW_INSET,
   MACOS_TRAFFIC_LIGHT_INSET,
   NATIVE_TITLE_BAR_INSET,
+  cssWindowShadowInset,
   dragStripHeight,
-  isMacOS,
+  hostPlatform,
+  needsCssWindowShadow,
   topBarLeftInset,
 } from "./windowChrome";
 
@@ -16,6 +20,12 @@ const WINDOWS_WEBVIEW2 =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0";
 const LINUX_WEBKITGTK =
   "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+// A WebView whose UA the app or an embedder has customised past recognition.
+// This is not a hypothetical: it is what a real Mac looks like to this module
+// once anything rewrites the UA string, and it is the case every one of the
+// three questions below used to answer as "not macOS".
+const UNRECOGNISED_UA = "Wenlan/1.0";
 
 /** Runs `body` with `globalThis.navigator` replaced, then puts it back. */
 function withNavigator(replacement: { userAgent: string } | undefined, body: () => void): void {
@@ -36,52 +46,133 @@ function withNavigator(replacement: { userAgent: string } | undefined, body: () 
 }
 
 describe("window chrome", () => {
-  it("recognises the macOS webview and nothing else", () => {
-    expect(isMacOS(MACOS_WKWEBVIEW)).toBe(true);
-    expect(isMacOS(WINDOWS_WEBVIEW2)).toBe(false);
-    expect(isMacOS(LINUX_WEBKITGTK)).toBe(false);
-  });
+  // The three states, and the two that used to be one. "Windows" is a
+  // measurement that says not-macOS; a missing or unplaceable user agent is
+  // not a measurement at all.
+  it("tells an unrecognised platform apart from a measured non-macOS one", () => {
+    expect(hostPlatform(MACOS_WKWEBVIEW)).toBe("macos");
+    expect(hostPlatform(WINDOWS_WEBVIEW2)).toBe("other");
+    expect(hostPlatform(LINUX_WEBKITGTK)).toBe("other");
 
-  it("treats a missing user agent as not macOS", () => {
-    expect(isMacOS("")).toBe(false);
-
+    expect(hostPlatform("")).toBe("unknown");
+    expect(hostPlatform(UNRECOGNISED_UA)).toBe("unknown");
     // The real missing-user-agent path is no navigator at all. Passing
     // `undefined` explicitly would re-trigger the default parameter and read
-    // jsdom's own user agent instead, so it would pass for the wrong reason.
+    // the ambient user agent instead, so it would pass for the wrong reason.
     withNavigator(undefined, () => {
-      expect(isMacOS()).toBe(false);
+      expect(hostPlatform()).toBe("unknown");
     });
+
+    expect(hostPlatform(UNRECOGNISED_UA)).not.toBe(hostPlatform(WINDOWS_WEBVIEW2));
+  });
+
+  // "Mac" alone appears in unrelated tokens; only the platform strings count.
+  it("does not match a stray Mac substring", () => {
+    expect(hostPlatform("Mozilla/5.0 (Windows NT 10.0) MacGyver/1.0")).toBe("other");
+    expect(hostPlatform("MacGyver/1.0")).toBe("unknown");
+  });
+
+  it("measures the two platforms it can place", () => {
+    expect(topBarLeftInset(MACOS_WKWEBVIEW)).toBe(82);
+    expect(topBarLeftInset(WINDOWS_WEBVIEW2)).toBe(20);
+    expect(topBarLeftInset(LINUX_WEBKITGTK)).toBe(20);
+
+    expect(dragStripHeight(MACOS_WKWEBVIEW)).toBe(32);
+    expect(dragStripHeight(WINDOWS_WEBVIEW2)).toBe(0);
+    expect(dragStripHeight(LINUX_WEBKITGTK)).toBe(0);
+
+    expect(needsCssWindowShadow(MACOS_WKWEBVIEW)).toBe(true);
+    expect(needsCssWindowShadow(WINDOWS_WEBVIEW2)).toBe(false);
+    expect(needsCssWindowShadow(LINUX_WEBKITGTK)).toBe(false);
   });
 
   // How the components actually call these: no argument, so the values come
   // from the webview the app is running in.
   it("reads the ambient user agent when called with no argument", () => {
     withNavigator({ userAgent: MACOS_WKWEBVIEW }, () => {
-      expect(isMacOS()).toBe(true);
-      expect(topBarLeftInset()).toBe(MACOS_TRAFFIC_LIGHT_INSET);
+      expect(topBarLeftInset()).toBe(82);
       expect(dragStripHeight()).toBe(32);
+      expect(needsCssWindowShadow()).toBe(true);
     });
 
     withNavigator({ userAgent: WINDOWS_WEBVIEW2 }, () => {
-      expect(isMacOS()).toBe(false);
-      expect(topBarLeftInset()).toBe(NATIVE_TITLE_BAR_INSET);
+      expect(topBarLeftInset()).toBe(20);
       expect(dragStripHeight()).toBe(0);
+      expect(needsCssWindowShadow()).toBe(false);
     });
   });
 
-  // "Mac" alone appears in unrelated tokens; only the platform strings count.
-  it("does not match a stray Mac substring", () => {
-    expect(isMacOS("Mozilla/5.0 (Windows NT 10.0) MacGyver/1.0")).toBe(false);
+  // ---------------------------------------------------------------------
+  // The three unknown-platform DECISIONS. Each is pinned to a literal, so an
+  // edit that flips one fails here rather than shipping. They deliberately do
+  // not all take the same side; the last assertion in this block is what makes
+  // "three separate decisions" rather than "one shared boolean" testable.
+  // ---------------------------------------------------------------------
+
+  it("DECISION: an unmeasured platform gets the macOS top-bar inset, not the native one", () => {
+    // Guessing "not macOS" on a real Mac paints the sidebar toggle under the
+    // traffic lights, which sit on top of the webview and take the click --
+    // aiming at the toggle presses Close. Guessing "macOS" off macOS indents a
+    // full-width header by 62px. Destructive loses to cosmetic.
+    expect(topBarLeftInset(UNRECOGNISED_UA)).toBe(82);
+    expect(topBarLeftInset("")).toBe(82);
+    withNavigator(undefined, () => {
+      expect(topBarLeftInset()).toBe(82);
+    });
+
+    // The defect this replaces: `unknown` and a measured "Windows" produced the
+    // same number, so the failed measurement was invisible.
+    expect(topBarLeftInset(UNRECOGNISED_UA)).not.toBe(topBarLeftInset(WINDOWS_WEBVIEW2));
+    expect(topBarLeftInset(UNRECOGNISED_UA)).toBe(MACOS_TRAFFIC_LIGHT_INSET);
+    expect(topBarLeftInset(UNRECOGNISED_UA)).not.toBe(NATIVE_TITLE_BAR_INSET);
   });
 
-  it("insets the top bar past the traffic lights only on macOS", () => {
-    expect(topBarLeftInset(MACOS_WKWEBVIEW)).toBe(MACOS_TRAFFIC_LIGHT_INSET);
-    expect(topBarLeftInset(WINDOWS_WEBVIEW2)).toBe(NATIVE_TITLE_BAR_INSET);
-    expect(topBarLeftInset(LINUX_WEBKITGTK)).toBe(NATIVE_TITLE_BAR_INSET);
+  it("DECISION: an unmeasured platform gets the macOS drag strip, not a zero one", () => {
+    // Guessing "not macOS" on a real Mac leaves the setup wizard -- no top bar
+    // of its own, `titleBarStyle: "Overlay"` so no native bar either -- with no
+    // drag target at all. The window cannot be moved. Guessing "macOS" off
+    // macOS costs 32px of dead space above the content. Unmovable loses.
+    expect(dragStripHeight(UNRECOGNISED_UA)).toBe(32);
+    expect(dragStripHeight("")).toBe(32);
+    withNavigator(undefined, () => {
+      expect(dragStripHeight()).toBe(32);
+    });
+
+    expect(dragStripHeight(UNRECOGNISED_UA)).not.toBe(dragStripHeight(WINDOWS_WEBVIEW2));
+    expect(dragStripHeight(UNRECOGNISED_UA)).toBe(dragStripHeight(MACOS_WKWEBVIEW));
   });
 
-  it("only reserves a drag strip where the title bar is overlaid", () => {
-    expect(dragStripHeight(MACOS_WKWEBVIEW)).toBe(32);
-    expect(dragStripHeight(WINDOWS_WEBVIEW2)).toBe(0);
+  it("DECISION: an unmeasured platform paints no CSS window shadow", () => {
+    // The one question whose asymmetry runs the other way: both mistakes are
+    // cosmetic, so the tie goes to the one that cannot render as an artifact. A
+    // missing shadow looks plain; a shadow the compositor cannot blend is the
+    // flat grey band that was actually reported.
+    expect(needsCssWindowShadow(UNRECOGNISED_UA)).toBe(false);
+    expect(needsCssWindowShadow("")).toBe(false);
+    withNavigator(undefined, () => {
+      expect(needsCssWindowShadow()).toBe(false);
+    });
+
+    expect(cssWindowShadowInset(UNRECOGNISED_UA)).toBe(0);
+    expect(cssWindowShadowInset(MACOS_WKWEBVIEW)).toBe(CSS_WINDOW_SHADOW_INSET);
+    expect(cssWindowShadowInset(MACOS_WKWEBVIEW)).toBe(12);
+  });
+
+  it("makes the three decisions separately -- they do not all take the macOS side", () => {
+    // If a future edit reunifies these behind one boolean, whichever side that
+    // boolean picks, this fails: geometry sides with macOS and the shadow does
+    // not, so no single answer satisfies all three.
+    expect(topBarLeftInset(UNRECOGNISED_UA)).toBe(topBarLeftInset(MACOS_WKWEBVIEW));
+    expect(dragStripHeight(UNRECOGNISED_UA)).toBe(dragStripHeight(MACOS_WKWEBVIEW));
+    expect(needsCssWindowShadow(UNRECOGNISED_UA)).not.toBe(needsCssWindowShadow(MACOS_WKWEBVIEW));
+  });
+
+  // `isMacOS` was the shared boolean all three questions used to route through,
+  // and it collapsed `unknown` to `false` for every one of them without saying
+  // so. Removing it is the fix; this keeps it removed, because a re-added
+  // helper with that name is what a future caller would reach for.
+  it("exports no boolean isMacOS for a caller to collapse unknown through", () => {
+    expect(Object.keys(windowChrome)).not.toContain("isMacOS");
+    expect(Object.keys(windowChrome)).toContain("hostPlatform");
   });
 });

--- a/src/lib/windowChrome.ts
+++ b/src/lib/windowChrome.ts
@@ -14,9 +14,45 @@
  * get_system_info: both are async, and these values are needed for the first
  * paint. The webview's user agent is the platform's own, so it reports the host
  * rather than anything the app configured.
+ *
+ * `hostPlatform` is three-valued, because two values were being spent on three
+ * states: a UA that says "Windows" and a UA that is missing or unrecognised are
+ * different measurements, and a boolean `isMacOS` answered `false` to both.
+ * Every caller here still wants a number or a boolean in the end -- these values
+ * decide pixel offsets at first paint, so nothing may wait on an async platform
+ * lookup -- but the collapse happens at a named site *per question*, because the
+ * three questions do not have the same answer for `unknown`:
+ *
+ *   - "how much left inset?"   -> `UNKNOWN_PLATFORM_TOP_BAR_INSET`     (macOS's)
+ *   - "how tall a drag strip?" -> `UNKNOWN_PLATFORM_DRAG_STRIP_HEIGHT` (macOS's)
+ *   - "who paints the shadow?" -> `UNKNOWN_PLATFORM_PAINTS_SHADOW`     (not macOS's)
+ *
+ * Each is a DECISION about an unmeasured platform, justified where it is
+ * declared, and each is pinned by a test so flipping one fails loudly. They do
+ * not agree with each other, which is the whole reason they are three sites and
+ * not one shared boolean.
+ *
+ * There is deliberately no exported `isMacOS`. It existed; all three of these
+ * questions were answered by calling it; and every one of them therefore
+ * inherited `unknown -> false` invisibly -- the exact
+ * failed-measurement-as-a-negative this module was split up to remove. Anything
+ * new that needs the platform asks `hostPlatform()` and handles all three
+ * states, or calls a function below that has already decided.
  */
-export function isMacOS(ua: string | undefined = globalThis.navigator?.userAgent): boolean {
-  return /\b(Macintosh|Mac OS X)\b/.test(ua ?? "");
+export type HostPlatform = "macos" | "other" | "unknown";
+
+export function hostPlatform(
+  ua: string | undefined = globalThis.navigator?.userAgent,
+): HostPlatform {
+  // No navigator, or an empty UA: nothing was measured. A WebView whose UA the
+  // app or the host has customised lands here too.
+  if (!ua) return "unknown";
+  if (/\b(Macintosh|Mac OS X)\b/.test(ua)) return "macos";
+  // A UA that names one of the other two platforms the app ships to is a
+  // measured "not macOS". Anything else is a UA we cannot place, and saying
+  // "not macOS" about it would be the same failed-measurement-as-negative.
+  if (/\b(Windows|Linux|X11|CrOS|Android)\b/.test(ua)) return "other";
+  return "unknown";
 }
 
 /** Room for the overlaid traffic lights, matched to their x=16 origin. */
@@ -25,10 +61,65 @@ export const MACOS_TRAFFIC_LIGHT_INSET = 82;
 /** The inset used everywhere else, matched to the top bars' right padding. */
 export const NATIVE_TITLE_BAR_INSET = 20;
 
+/**
+ * What an unmeasured platform gets for the top bar's left padding: the macOS
+ * inset.
+ *
+ * This is a DECISION about an unmeasured platform, not a measurement of one.
+ * The two ways of being wrong are not symmetrical.
+ *
+ * Wrong as "not macOS" on a real Mac (a WebView whose UA has been customised
+ * past recognition): the header's leftmost control -- the sidebar toggle --
+ * gets 20px of inset and paints underneath traffic lights that start at x=16.
+ * Those buttons are composited *over* the webview and take the click, so the
+ * user does not merely lose the toggle; aiming at it presses Close. Functional,
+ * and destructive.
+ *
+ * Wrong as "macOS" on Windows or Linux: `MACOS_TRAFFIC_LIGHT_INSET -
+ * NATIVE_TITLE_BAR_INSET` = 62px of extra padding at the left of a header that
+ * spans the window anyway. Nothing is covered, nothing is unreachable, the row
+ * is just indented. Cosmetic.
+ *
+ * Cosmetic beats destructive, so `unknown` takes the macOS side here. Note that
+ * this is the opposite side from `UNKNOWN_PLATFORM_PAINTS_SHADOW`, whose
+ * asymmetry genuinely runs the other way -- see there.
+ */
+const UNKNOWN_PLATFORM_TOP_BAR_INSET = MACOS_TRAFFIC_LIGHT_INSET;
+
 /** Left padding for a top bar that shares its row with the window controls. */
 export function topBarLeftInset(ua?: string): number {
-  return isMacOS(ua) ? MACOS_TRAFFIC_LIGHT_INSET : NATIVE_TITLE_BAR_INSET;
+  const platform = hostPlatform(ua);
+  if (platform === "unknown") return UNKNOWN_PLATFORM_TOP_BAR_INSET;
+  return platform === "macos" ? MACOS_TRAFFIC_LIGHT_INSET : NATIVE_TITLE_BAR_INSET;
 }
+
+/** Drag target macOS needs above content that has no top bar of its own. */
+export const MACOS_DRAG_STRIP_HEIGHT = 32;
+
+/** None needed where the platform draws a real, draggable title bar itself. */
+export const NATIVE_DRAG_STRIP_HEIGHT = 0;
+
+/**
+ * What an unmeasured platform gets for the drag strip: the macOS height.
+ *
+ * This is a DECISION about an unmeasured platform, not a measurement of one,
+ * and it is the same asymmetry as the inset above in a sharper form.
+ *
+ * Wrong as "not macOS" on a real Mac: the setup wizard gets a strip of zero. It
+ * has no top bar of its own, and its window is `titleBarStyle: "Overlay"`, so
+ * there is no native bar to grab either. The window cannot be moved. There is
+ * no other drag handle on that screen, so the failure is not merely functional
+ * but unrecoverable from inside the app.
+ *
+ * Wrong as "macOS" on Windows or Linux: a 32px transparent strip sits above the
+ * wizard's content, under a native title bar that already drags, and the
+ * content starts 32px lower. Cosmetic -- and the strip is, if anything, a
+ * second working drag target.
+ *
+ * An unmovable window beats 32px of dead space, so `unknown` takes the macOS
+ * side here too.
+ */
+const UNKNOWN_PLATFORM_DRAG_STRIP_HEIGHT = MACOS_DRAG_STRIP_HEIGHT;
 
 /**
  * Height of the drag strip above content that has no top bar of its own, such
@@ -36,5 +127,62 @@ export function topBarLeftInset(ua?: string): number {
  * drag target and the clearance.
  */
 export function dragStripHeight(ua?: string): number {
-  return isMacOS(ua) ? 32 : 0;
+  const platform = hostPlatform(ua);
+  if (platform === "unknown") return UNKNOWN_PLATFORM_DRAG_STRIP_HEIGHT;
+  return platform === "macos" ? MACOS_DRAG_STRIP_HEIGHT : NATIVE_DRAG_STRIP_HEIGHT;
+}
+
+/**
+ * Whether an undecorated, transparent window must paint its own drop shadow.
+ *
+ * macOS: app/src/lib.rs sets `setHasShadow: NO` on the quick-capture NSWindow,
+ * alongside `setBackgroundColor: clearColor` and `setOpaque: NO`. The window
+ * server therefore draws no shadow at all, so the CSS one is the only thing
+ * separating the floating card from the desktop behind it. It also needs a
+ * transparent inset to render into, because an outer shadow is clipped at the
+ * viewport edge.
+ *
+ * Windows and Linux: there is no equivalent block. The window is a plain
+ * layered `transparent(true)` surface, and a shadow drawn into its transparent
+ * margin composites as a flat grey band around the card instead of fading into
+ * the desktop -- the "weird semi-transparent outer layer" this scoping removes.
+ *
+ * Unknown platform (no navigator, an empty user agent, or a WebView whose UA
+ * has been customised past recognition): `UNKNOWN_PLATFORM_PAINTS_SHADOW`
+ * below.
+ */
+export function needsCssWindowShadow(ua?: string): boolean {
+  const platform = hostPlatform(ua);
+  if (platform === "unknown") return UNKNOWN_PLATFORM_PAINTS_SHADOW;
+  return platform === "macos";
+}
+
+/**
+ * What an unmeasured platform gets for the window shadow: `false`.
+ *
+ * This is a DECISION about an unmeasured platform, not a measurement of one,
+ * and it is the one place where the asymmetry runs *against* guessing macOS.
+ *
+ * Wrong as "not macOS" on a real Mac: the card loses the only shadow it has and
+ * reads as plain against the desktop. It still has its own opaque surface, its
+ * border, and its accent, so it is legible and fully usable. Cosmetic.
+ *
+ * Wrong as "macOS" on Windows or Linux: the shadow is drawn into a transparent
+ * margin the compositor cannot blend, and renders as the flat grey band around
+ * the card -- the "weird semi-transparent outer layer" that was actually
+ * reported. That looks broken rather than plain.
+ *
+ * Both mistakes are cosmetic here, so unlike the two decisions above there is
+ * no functional failure to avoid; the tie is broken by which one cannot render
+ * as an artifact. The residual is stated: a macOS WebView running a customised
+ * UA loses its shadow.
+ */
+const UNKNOWN_PLATFORM_PAINTS_SHADOW = false;
+
+/** Transparent margin an undecorated window leaves for its own CSS shadow. */
+export const CSS_WINDOW_SHADOW_INSET = 12;
+
+/** Room for that shadow, and none where the platform draws no shadow at all. */
+export function cssWindowShadowInset(ua?: string): number {
+  return needsCssWindowShadow(ua) ? CSS_WINDOW_SHADOW_INSET : 0;
 }


### PR DESCRIPTION
Every commit on this branch is one defect, found again and again:

> **a failed measurement that is indistinguishable from a negative measurement**

A probe that crashes and is reported as "nothing is running". A check that could
not run and prints a pass. A fixture that failed to build and is graded clean. A
health poll that times out and returns `false`, meaning "unhealthy" rather than
"unknown". The remedy is the same shape every time: **pass / fail / unchecked,
with a named reason**, where `unchecked` is never a pass.

## What

The quick-capture window drew a CSS halo to fake a drop shadow. On platforms
that already draw a real window shadow it doubled up; on platforms that draw
none it was the only shadow and had to stay. `src/lib/windowChrome.ts` asks the
platform instead of assuming.

The smallest PR in the stack, and the only one that is purely cosmetic.

## Review history since first pushed

- Unchanged by the review rounds.

---

Part of the `windows-track` stack, split out of #661 because 44,375 added lines
is not reviewable in one diff. Each PR below is based on the one above it, so
this diff shows only its own change. Merge in order.

| | PR | added | product | tests |
|---|---|---:|---:|---:|
| 01 | [#662](https://github.com/7xuanlu/wenlan/pull/662) SignPath watch | 5,656 | 1,206 | 4,450 |
| 02 | [#663](https://github.com/7xuanlu/wenlan/pull/663) host-process probes | 9,222 | 4,879 | 4,343 |
| 03 | [#664](https://github.com/7xuanlu/wenlan/pull/664) first-run ownership | 5,374 | 4,562 | 812 |
| 04 | [#665](https://github.com/7xuanlu/wenlan/pull/665) reading tri-state | 9,567 | 1,621 | 7,946 |
| 05 | [#666](https://github.com/7xuanlu/wenlan/pull/666) quick-capture halo | 460 | 182 | 278 |
| 06 | [#667](https://github.com/7xuanlu/wenlan/pull/667) negative controls | 14,096 | 41 | 14,055 |
| 07 | [#668](https://github.com/7xuanlu/wenlan/pull/668) Vulkan doc | 1 | 1 | 0 |

The stack's tip is byte-identical to `windows-track` (`git diff` between them is
empty), and every level was checked to route cleanly through drift_guard's
Windows paths-filter rule, so no intermediate PR here is red on it.

Reviewed twice by Codex Sol (adversarial) and once by a Fable gatekeeper on
the integrated tree; every finding was fixed in place and has a negative
control at level 6. The two Windows channels are never executed before merge:
their evidence is static reading, the 109-case Windows probe harness and the
35-case `lib.test.ps1` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH3nEZRDbNUeEzCrzfPuk8
