### PR TITLE
ci(app): type-check the e2e, preview, review, and script TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
               - 'pnpm-workspace.yaml'
               - 'index.html'
               - 'tsconfig.json'
+              - 'tsconfig.tools.json'
               - 'vite.config.ts'
               - 'vite.preview.config.ts'
               - 'vite.review.config.ts'
@@ -2389,6 +2390,8 @@ jobs:
         run: bash scripts/test-install-macos-app.sh
       - name: TypeScript check
         run: pnpm exec tsc -b
+      - name: TypeScript check (tools)
+        run: pnpm exec tsc -p tsconfig.tools.json
       - name: i18n gates
         run: pnpm test:i18n
       - name: Frontend unit tests

--- a/e2e/tauriMock.self-test.spec.ts
+++ b/e2e/tauriMock.self-test.spec.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import { expect, test } from "@playwright/test";
+import type { Page as KnowledgePage, Space } from "../src/lib/tauri";
 import { installTauriMock } from "./tauriMock";
 
 test("models detail reads and mutations while rejecting unknown commands", async ({ page }) => {
@@ -154,9 +155,9 @@ test("models Page draft identity, replay, Space validation, and rename versionin
       space: null,
     });
 
-    const activeBeforeRename = await invoke("get_page", { id: "page-architecture" });
+    const activeBeforeRename = await invoke("get_page", { id: "page-architecture" }) as KnowledgePage;
     await invoke("accept_refinement", { id: "refinement-page-history-cleanup" });
-    const archivedBeforeRename = await invoke("get_page", { id: "page-history" });
+    const archivedBeforeRename = await invoke("get_page", { id: "page-history" }) as KnowledgePage;
     const renameClockDraft = await invoke("create_page_draft", {
       clientDraftId: "page_66666666-6666-4666-8666-666666666666",
       title: "Rename clock",
@@ -169,14 +170,14 @@ test("models Page draft identity, replay, Space validation, and rename versionin
       title: "Rename clock",
       content: "After update",
       space: "Wenlan",
-    });
+    }) as KnowledgePage;
     const renameCollisionError = await errorMessage("update_space", {
       name: "Wenlan",
       newName: "Research",
       description: "Must not apply",
     });
     const draftAfterRenameCollision = await invoke("get_page", { id: renameClockDraft.id });
-    const spacesAfterRenameCollision = await invoke("list_spaces", {});
+    const spacesAfterRenameCollision = await invoke("list_spaces", {}) as Space[];
 
     await invoke("update_space", {
       name: "Wenlan",
@@ -184,9 +185,9 @@ test("models Page draft identity, replay, Space validation, and rename versionin
       description: "Renamed",
     });
     const moved = await invoke("get_page", { id: original.clientDraftId });
-    const updatedAfterRename = await invoke("get_page", { id: renameClockDraft.id });
-    const activeAfterRename = await invoke("get_page", { id: "page-architecture" });
-    const archivedAfterRename = await invoke("get_page", { id: "page-history" });
+    const updatedAfterRename = await invoke("get_page", { id: renameClockDraft.id }) as KnowledgePage;
+    const activeAfterRename = await invoke("get_page", { id: "page-architecture" }) as KnowledgePage;
+    const archivedAfterRename = await invoke("get_page", { id: "page-history" }) as KnowledgePage;
     const replayedAfterRename = await invoke("create_page_draft", original);
     const staleAfterRenameError = await errorMessage("update_page_draft", {
       id: original.clientDraftId,
@@ -200,7 +201,7 @@ test("models Page draft identity, replay, Space validation, and rename versionin
       newName: "Wenlan Foundation",
       description: null,
     });
-    const updatedAfterSecondRename = await invoke("get_page", { id: renameClockDraft.id });
+    const updatedAfterSecondRename = await invoke("get_page", { id: renameClockDraft.id }) as KnowledgePage;
 
     return {
       invalidIdError,
@@ -246,7 +247,7 @@ test("models Page draft identity, replay, Space validation, and rename versionin
   expect(results.renameCollisionError).toContain('Space "Research" already exists');
   expect(results.draftAfterRenameCollision).toEqual(results.updatedBeforeRename);
   expect(results.spacesAfterRenameCollision.filter(
-    (space: { name: string }) => space.name === "Research",
+    (space) => space.name === "Research",
   )).toHaveLength(1);
   for (const [before, after] of [
     [results.activeBeforeRename, results.activeAfterRename],

--- a/e2e/tauriMock.ts
+++ b/e2e/tauriMock.ts
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 import type { Page } from "@playwright/test";
-import { APP_LOCALE_STORAGE_KEY, type AppLocale } from "../src/i18n/locales";
-import type { MemoryItem } from "../src/lib/tauri";
+import { APP_LOCALE_STORAGE_KEY } from "../src/i18n/locales";
 import { createSpacesNavigationFixture } from "./fixtures/spacesNavigation";
 import { TauriMockRuntime } from "./tauriMock/runtime";
 import type {
   BrowserErrorCapture,
   InstallTauriMockOptions,
   MockCommandCall,
-  TauriMockPageScenario,
 } from "./tauriMock/types";
 
 export type { TauriMockPageScenario } from "./tauriMock/types";
@@ -110,7 +108,7 @@ declare global {
       transformCallback: (callback: (...args: unknown[]) => unknown, once?: boolean) => number;
       unregisterCallback: (id: number) => void;
     };
-    __TAURI_EVENT_PLUGIN_INTERNALS__?: {
+    __TAURI_EVENT_PLUGIN_INTERNALS__: {
       unregisterListener: (event: string, eventId: number) => void;
     };
     __wenlanTauriInvoke: (command: string, args?: unknown) => Promise<unknown>;

--- a/e2e/wiki-visual.spec.ts
+++ b/e2e/wiki-visual.spec.ts
@@ -25,7 +25,7 @@ function wikiPages() {
 async function openWiki(page: BrowserPage, locale: "en" | "zh-Hant", theme: "dark" | "light") {
   const browserErrors = collectBrowserErrors(page);
   await installTauriMock(page, {
-    fixture: { pages: wikiPages() },
+    fixture: { ...createSpacesNavigationFixture(), pages: wikiPages() },
     locale,
     localStorage: { "wenlan-theme": theme },
     rawActions: [],

--- a/preview/main.tsx
+++ b/preview/main.tsx
@@ -124,7 +124,7 @@ function Harness() {
       "general",
     ),
   );
-  const applyTheme = (next: string) => {
+  const applyTheme = (next: "dark" | "light") => {
     document.documentElement.setAttribute("data-theme", next);
     setTheme(next);
   };

--- a/preview/mocks/live-invoke.test.ts
+++ b/preview/mocks/live-invoke.test.ts
@@ -122,7 +122,7 @@ describe("liveInvoke authored Page preview", () => {
   });
 
   it("models partial draft snapshots, CAS updates, publish, discard, and title conflicts in memory", async () => {
-    const fetch = vi.fn(async (input) =>
+    const fetch = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) =>
       new Response(JSON.stringify(
         String(input).endsWith("/api/spaces")
           ? [{ name: "Wenlan" }]

--- a/preview/mocks/live-invoke.ts
+++ b/preview/mocks/live-invoke.ts
@@ -183,7 +183,7 @@ function spaceRows(wire: any): Record<string, unknown>[] {
       ? wire.spaces
       : [];
   return rows.filter(
-    (candidate): candidate is Record<string, unknown> =>
+    (candidate: unknown): candidate is Record<string, unknown> =>
       candidate !== null && typeof candidate === "object",
   );
 }

--- a/scripts/ci_test_plan.py
+++ b/scripts/ci_test_plan.py
@@ -138,6 +138,7 @@ APP_JOB_FILES = {
     "pnpm-workspace.yaml",
     "index.html",
     "tsconfig.json",
+    "tsconfig.tools.json",
     "vite.config.ts",
     "vite.preview.config.ts",
     "vite.review.config.ts",

--- a/tsconfig.tools.json
+++ b/tsconfig.tools.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true
+  },
+  "include": [
+    "e2e",
+    "preview",
+    "review",
+    "scripts/**/*.ts",
+    "vite.config.ts",
+    "vite.preview.config.ts",
+    "vite.review.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "playwright.review.config.ts",
+    "src/vite-env.d.ts"
+  ]
+}


### PR DESCRIPTION
Adds a dedicated `tsconfig.tools.json` and wires `pnpm exec tsc -p tsconfig.tools.json` so the e2e, preview, review, and script TypeScript is type-checked in CI, closing a gap where those trees had no compile-time check. No runtime behavior changes.

Verified: `pnpm exec tsc -p tsconfig.tools.json` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
