### PR TITLE
fix(cli): keep launchd env vars, read launchd state before backfills, warn on a temp data root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9035,6 +9035,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 6.0.0",
+ "plist",
  "predicates",
  "reqwest 0.12.28",
  "serde",

--- a/crates/wenlan-cli/Cargo.toml
+++ b/crates/wenlan-cli/Cargo.toml
@@ -34,6 +34,11 @@ uuid = { workspace = true }
 # only auto-appends `.exe`; .cmd / .bat live behind explicit-extension paths.
 which = "4"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# `background on` reads the existing LaunchAgent plist so it can keep the
+# user's keys; already a transitive dependency through service-manager.
+plist = "1"
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/crates/wenlan-cli/src/commands/service.rs
+++ b/crates/wenlan-cli/src/commands/service.rs
@@ -275,6 +275,116 @@ fn build_launchd_plist(
     buf
 }
 
+/// The data root this CLI run was told to use, if any: `WENLAN_DATA_DIR` (or
+/// its legacy `ORIGIN_DATA_DIR` spelling) in the CLI's own environment, which
+/// is also how the desktop app hands over its selected store.
+#[cfg(target_os = "macos")]
+fn explicit_data_root() -> Option<PathBuf> {
+    wenlan_core::env_compat::var_compat("WENLAN_DATA_DIR").map(PathBuf::from)
+}
+
+/// The plist `background on` registers: a fresh one when none exists, else
+/// the existing file with the CLI-owned keys brought up to date.
+///
+/// Ownership rule for an existing `com.wenlan.server.plist` (re-registering
+/// over one is the upgrade path, and the user or the desktop app may have
+/// edited it since):
+/// - The CLI owns the launch mechanics and rewrites them every time: `Label`,
+///   `ProgramArguments`, `KeepAlive`, `RunAtLoad`, `Disabled`,
+///   `StandardOutPath`, `StandardErrorPath`.
+/// - Every other top-level key and every `EnvironmentVariables` entry belongs
+///   to whoever put it there and is kept as is (a full rewrite on 2026-08-16
+///   dropped the user's `WENLAN_ENABLE_EDGE_GROUNDING_PROMOTE=1`).
+/// - `RUST_LOG` is seeded to `info` only when absent.
+/// - `WENLAN_DATA_DIR` is written only when this run was given one explicitly
+///   (see [`explicit_data_root`]); otherwise an existing value stays and a
+///   missing one stays missing, so a plist that relies on the platform
+///   default keeps doing so instead of gaining a pinned copy of it.
+///
+/// A file that does not parse as a plist dictionary carries nothing worth
+/// keeping and is replaced by a fresh one; the CLI says so on stderr.
+#[cfg(target_os = "macos")]
+fn launchd_plist_contents(
+    existing: Option<&str>,
+    program: &Path,
+    stderr_log: &Path,
+    data_root: &Path,
+    explicit_data_root: Option<&Path>,
+) -> String {
+    let stdout = Path::new("/dev/null");
+    let fresh = || build_launchd_plist(program, stdout, stderr_log, "info", data_root);
+    let Some(existing) = existing else {
+        return fresh();
+    };
+    match merge_launchd_plist(existing, program, stdout, stderr_log, explicit_data_root) {
+        Ok(merged) => merged,
+        Err(error) => {
+            eprintln!(
+                "The existing {SERVICE_LABEL} plist could not be read ({error:#}); writing a fresh one."
+            );
+            fresh()
+        }
+    }
+}
+
+/// Applies the ownership rule in [`launchd_plist_contents`] to an existing
+/// plist and renders the result.
+#[cfg(target_os = "macos")]
+fn merge_launchd_plist(
+    existing: &str,
+    program: &Path,
+    stdout_path: &Path,
+    stderr_path: &Path,
+    explicit_data_root: Option<&Path>,
+) -> Result<String> {
+    use plist::{Dictionary, Value};
+
+    let path_value = |path: &Path| Value::String(path.to_string_lossy().into_owned());
+    let mut root = match Value::from_reader_xml(existing.as_bytes()).context("parse plist")? {
+        Value::Dictionary(root) => root,
+        _ => anyhow::bail!("plist root is not a dictionary"),
+    };
+    root.insert("Label".into(), Value::String(SERVICE_LABEL.into()));
+    root.insert(
+        "ProgramArguments".into(),
+        Value::Array(vec![path_value(program)]),
+    );
+    let mut keep_alive = Dictionary::new();
+    keep_alive.insert("SuccessfulExit".into(), Value::Boolean(false));
+    root.insert("KeepAlive".into(), Value::Dictionary(keep_alive));
+    root.insert("RunAtLoad".into(), Value::Boolean(true));
+    root.insert("Disabled".into(), Value::Boolean(true));
+    root.insert("StandardOutPath".into(), path_value(stdout_path));
+    root.insert("StandardErrorPath".into(), path_value(stderr_path));
+
+    if root
+        .get("EnvironmentVariables")
+        .and_then(Value::as_dictionary)
+        .is_none()
+    {
+        root.insert(
+            "EnvironmentVariables".into(),
+            Value::Dictionary(Dictionary::new()),
+        );
+    }
+    let env = root
+        .get_mut("EnvironmentVariables")
+        .and_then(Value::as_dictionary_mut)
+        .context("EnvironmentVariables is not a dictionary")?;
+    if !env.contains_key("RUST_LOG") {
+        env.insert("RUST_LOG".into(), Value::String("info".into()));
+    }
+    if let Some(data_root) = explicit_data_root {
+        env.insert("WENLAN_DATA_DIR".into(), path_value(data_root));
+    }
+
+    let mut rendered = Vec::new();
+    Value::Dictionary(root)
+        .to_writer_xml(&mut rendered)
+        .context("render plist")?;
+    String::from_utf8(rendered).context("rendered plist is not UTF-8")
+}
+
 pub async fn install() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
@@ -363,12 +473,20 @@ pub async fn install() -> Result<()> {
                     format!("create the daemon log directory {}", log_dir.display())
                 })?;
             }
-            Some(build_launchd_plist(
+            let plist_path = service_unit_path()?;
+            let existing = match std::fs::read_to_string(&plist_path) {
+                Ok(existing) => Some(existing),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => {
+                    return Err(error).with_context(|| format!("read {}", plist_path.display()))
+                }
+            };
+            Some(launchd_plist_contents(
+                existing.as_deref(),
                 &program,
-                Path::new("/dev/null"),
                 &stderr_log,
-                "info",
                 &data_root,
+                explicit_data_root().as_deref(),
             ))
         }
         #[cfg(not(target_os = "macos"))]
@@ -1118,6 +1236,227 @@ mod tests {
         assert!(plist.contains(
             "<key>WENLAN_DATA_DIR</key>\n\t\t<string>/tmp/wenlan-plist-test-root</string>"
         ));
+    }
+
+    /// A plist as a user leaves it: an older binary path and stderr path, a
+    /// tuning key the CLI knows nothing about, a `RUST_LOG` they changed, and
+    /// an extra environment variable — with no `WENLAN_DATA_DIR`.
+    #[cfg(target_os = "macos")]
+    const USER_EDITED_PLIST: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.wenlan.server</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/old/bin/wenlan-server</string>
+	</array>
+	<key>StandardErrorPath</key>
+	<string>/old/root/logs/launchd-stderr.log</string>
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>RUST_LOG</key>
+		<string>debug</string>
+		<key>WENLAN_ENABLE_EDGE_GROUNDING_PROMOTE</key>
+		<string>1</string>
+	</dict>
+</dict>
+</plist>
+"#;
+
+    #[cfg(target_os = "macos")]
+    fn plist_dict(rendered: &str) -> plist::Dictionary {
+        match plist::Value::from_reader_xml(rendered.as_bytes()).expect("rendered plist parses") {
+            plist::Value::Dictionary(root) => root,
+            other => panic!("plist root is not a dictionary: {other:?}"),
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn plist_env(root: &plist::Dictionary) -> &plist::Dictionary {
+        root.get("EnvironmentVariables")
+            .and_then(plist::Value::as_dictionary)
+            .expect("EnvironmentVariables dictionary")
+    }
+
+    #[cfg(target_os = "macos")]
+    fn plist_string<'a>(dict: &'a plist::Dictionary, key: &str) -> Option<&'a str> {
+        dict.get(key).and_then(plist::Value::as_string)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn merged_user_plist(explicit_data_root: Option<&Path>) -> plist::Dictionary {
+        plist_dict(&launchd_plist_contents(
+            Some(USER_EDITED_PLIST),
+            Path::new("/new/bin/wenlan-server"),
+            Path::new("/new/root/logs/launchd-stderr.log"),
+            Path::new("/new/root"),
+            explicit_data_root,
+        ))
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_without_an_existing_file_is_the_fresh_template() {
+        let program = Path::new("/opt/wenlan/wenlan-server");
+        let stderr_log = Path::new("/data/logs/launchd-stderr.log");
+        let data_root = Path::new("/data");
+        assert_eq!(
+            launchd_plist_contents(None, program, stderr_log, data_root, Some(data_root)),
+            build_launchd_plist(
+                program,
+                Path::new("/dev/null"),
+                stderr_log,
+                "info",
+                data_root
+            )
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_merge_keeps_user_keys_and_updates_cli_owned_ones() {
+        let root = merged_user_plist(None);
+        let env = plist_env(&root);
+        assert_eq!(
+            plist_string(env, "WENLAN_ENABLE_EDGE_GROUNDING_PROMOTE"),
+            Some("1"),
+            "user environment variables survive re-registration"
+        );
+        assert_eq!(
+            plist_string(env, "RUST_LOG"),
+            Some("debug"),
+            "a RUST_LOG the user changed is theirs"
+        );
+        assert_eq!(
+            env.get("WENLAN_DATA_DIR"),
+            None,
+            "no default WENLAN_DATA_DIR is added when the CLI was not given one"
+        );
+        assert_eq!(
+            root.get("ThrottleInterval")
+                .and_then(plist::Value::as_signed_integer),
+            Some(30),
+            "unknown top-level keys survive"
+        );
+        assert_eq!(
+            root.get("ProgramArguments")
+                .and_then(plist::Value::as_array)
+                .and_then(|args| args.first())
+                .and_then(plist::Value::as_string),
+            Some("/new/bin/wenlan-server"),
+            "the program path is CLI-owned and moves with the binary"
+        );
+        assert_eq!(
+            plist_string(&root, "StandardErrorPath"),
+            Some("/new/root/logs/launchd-stderr.log")
+        );
+        assert_eq!(plist_string(&root, "StandardOutPath"), Some("/dev/null"));
+        assert_eq!(plist_string(&root, "Label"), Some(SERVICE_LABEL));
+        assert_eq!(
+            root.get("KeepAlive")
+                .and_then(plist::Value::as_dictionary)
+                .and_then(|keep_alive| keep_alive.get("SuccessfulExit"))
+                .and_then(plist::Value::as_boolean),
+            Some(false)
+        );
+        assert_eq!(
+            root.get("RunAtLoad").and_then(plist::Value::as_boolean),
+            Some(true)
+        );
+        assert_eq!(
+            root.get("Disabled").and_then(plist::Value::as_boolean),
+            Some(true)
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_merge_writes_only_an_explicit_data_root() {
+        let root = merged_user_plist(Some(Path::new("/explicit/root")));
+        assert_eq!(
+            plist_string(plist_env(&root), "WENLAN_DATA_DIR"),
+            Some("/explicit/root")
+        );
+        assert_eq!(
+            plist_string(plist_env(&root), "WENLAN_ENABLE_EDGE_GROUNDING_PROMOTE"),
+            Some("1")
+        );
+
+        let pinned = USER_EDITED_PLIST.replace(
+            "\t\t<key>RUST_LOG</key>",
+            "\t\t<key>WENLAN_DATA_DIR</key>\n\t\t<string>/private/tmp/scratch</string>\n\t\t<key>RUST_LOG</key>",
+        );
+        let program = Path::new("/new/bin/wenlan-server");
+        let stderr_log = Path::new("/new/root/logs/launchd-stderr.log");
+        let data_root = Path::new("/new/root");
+        let kept = plist_dict(&launchd_plist_contents(
+            Some(&pinned),
+            program,
+            stderr_log,
+            data_root,
+            None,
+        ));
+        assert_eq!(
+            plist_string(plist_env(&kept), "WENLAN_DATA_DIR"),
+            Some("/private/tmp/scratch"),
+            "an existing WENLAN_DATA_DIR is kept when the CLI was not given one"
+        );
+        let replaced = plist_dict(&launchd_plist_contents(
+            Some(&pinned),
+            program,
+            stderr_log,
+            data_root,
+            Some(data_root),
+        ));
+        assert_eq!(
+            plist_string(plist_env(&replaced), "WENLAN_DATA_DIR"),
+            Some("/new/root"),
+            "an explicit data root replaces the existing one"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn launchd_plist_merge_seeds_rust_log_and_replaces_an_unreadable_file() {
+        let no_env = USER_EDITED_PLIST.replace(
+            "\t<key>EnvironmentVariables</key>\n\t<dict>\n\t\t<key>RUST_LOG</key>\n\t\t<string>debug</string>\n\t\t<key>WENLAN_ENABLE_EDGE_GROUNDING_PROMOTE</key>\n\t\t<string>1</string>\n\t</dict>\n",
+            "",
+        );
+        assert!(!no_env.contains("EnvironmentVariables"), "{no_env}");
+        let program = Path::new("/new/bin/wenlan-server");
+        let stderr_log = Path::new("/new/root/logs/launchd-stderr.log");
+        let data_root = Path::new("/new/root");
+        let seeded = plist_dict(&launchd_plist_contents(
+            Some(&no_env),
+            program,
+            stderr_log,
+            data_root,
+            None,
+        ));
+        assert_eq!(plist_string(plist_env(&seeded), "RUST_LOG"), Some("info"));
+        assert_eq!(plist_env(&seeded).get("WENLAN_DATA_DIR"), None);
+
+        assert_eq!(
+            launchd_plist_contents(
+                Some("fake registered launch agent"),
+                program,
+                stderr_log,
+                data_root,
+                None
+            ),
+            build_launchd_plist(
+                program,
+                Path::new("/dev/null"),
+                stderr_log,
+                "info",
+                data_root
+            ),
+            "a file that is not a plist has nothing to keep"
+        );
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/wenlan-cli/src/commands/setup.rs
+++ b/crates/wenlan-cli/src/commands/setup.rs
@@ -3,6 +3,7 @@
 
 use clap::{Subcommand, ValueEnum};
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use wenlan_core::{config, on_device_models};
 
 use crate::client::origin_host_from_env;
@@ -244,6 +245,7 @@ pub async fn run_reranker(mode: RerankerModeArg) -> anyhow::Result<()> {
 pub async fn run_doctor() -> anyhow::Result<()> {
     println!("Wenlan doctor");
     println!();
+    print_data_root();
     print_daemon_health().await;
     #[cfg(target_os = "macos")]
     print_daemon_log_paths();
@@ -259,6 +261,41 @@ pub async fn run_doctor() -> anyhow::Result<()> {
     print_space_resolution(&cwd);
 
     Ok(())
+}
+
+/// The store the daemon and CLI resolve to — the same `WENLAN_DATA_DIR`-aware
+/// lookup the daemon uses at startup.
+fn print_data_root() {
+    let root = config::data_root();
+    println!("Data root: {}", root.display());
+    let tmpdir = std::env::var_os("TMPDIR").map(PathBuf::from);
+    if let Some(warning) = scratch_data_root_warning(&root, tmpdir.as_deref()) {
+        println!("{warning}");
+    }
+}
+
+/// Warns when the data root sits in a directory the OS may empty on its own.
+/// A daemon pointed at scratch space comes up serving an empty store while the
+/// real memories stay where they were, and nothing else says so: on 2026-08-09
+/// a `WENLAN_DATA_DIR` under `/private/tmp` served 0 memories and 0 spaces
+/// against a store holding about 3,000.
+///
+/// An empty or root `TMPDIR` is ignored — every path starts with those.
+fn scratch_data_root_warning(root: &Path, tmpdir: Option<&Path>) -> Option<String> {
+    let mut scratch_roots = vec![Path::new("/tmp"), Path::new("/private/tmp")];
+    if let Some(tmpdir) = tmpdir.filter(|dir| dir.parent().is_some()) {
+        scratch_roots.push(tmpdir);
+    }
+    scratch_roots
+        .iter()
+        .any(|scratch| root.starts_with(scratch))
+        .then(|| {
+            "  WARNING: that is a temporary directory. The OS can empty it at any time, so the \
+             daemon can come up serving an empty store while your real memories stay where they \
+             were.\n  WENLAN_DATA_DIR is what points here: clear it from your shell and from the \
+             background service registration to go back to the default store."
+                .to_string()
+        })
 }
 
 /// Where the daemon logs when its data root is not writable (mirrors
@@ -992,7 +1029,10 @@ fn prompt_secret(prompt: &str) -> anyhow::Result<String> {
 
 #[cfg(test)]
 mod doctor_tests {
-    use super::{last_daemon_error, last_daemon_error_since, strip_ansi};
+    use super::{
+        last_daemon_error, last_daemon_error_since, scratch_data_root_warning, strip_ansi,
+    };
+    use std::path::Path;
 
     #[test]
     fn last_daemon_error_since_ignores_errors_written_before_the_mark() {
@@ -1085,5 +1125,49 @@ mod doctor_tests {
     fn strip_ansi_leaves_plain_text_alone() {
         assert_eq!(strip_ansi("plain ERROR line"), "plain ERROR line");
         assert_eq!(strip_ansi("\x1b[31mred\x1b[0m"), "red");
+    }
+
+    #[test]
+    fn a_scratch_data_root_is_warned_about() {
+        for root in ["/tmp/wenlan", "/private/tmp/wenlan-scratch"] {
+            let warning = scratch_data_root_warning(Path::new(root), None)
+                .unwrap_or_else(|| panic!("{root} must be warned about"));
+            assert!(warning.contains("temporary directory"), "{warning}");
+            assert!(warning.contains("WENLAN_DATA_DIR"), "{warning}");
+        }
+        assert!(
+            scratch_data_root_warning(
+                Path::new("/var/folders/ab/T/wenlan"),
+                Some(Path::new("/var/folders/ab/T")),
+            )
+            .is_some(),
+            "a data root under $TMPDIR is scratch space too"
+        );
+    }
+
+    #[test]
+    fn a_real_data_root_is_not_warned_about() {
+        assert_eq!(
+            scratch_data_root_warning(
+                Path::new("/Users/someone/Library/Application Support/wenlan"),
+                Some(Path::new("/var/folders/ab/T")),
+            ),
+            None
+        );
+    }
+
+    /// An unset or degenerate TMPDIR must not turn every store into a warning.
+    #[test]
+    fn an_empty_or_root_tmpdir_matches_nothing() {
+        for tmpdir in ["", "/"] {
+            assert_eq!(
+                scratch_data_root_warning(
+                    Path::new("/Users/someone/Library/Application Support/wenlan"),
+                    Some(Path::new(tmpdir)),
+                ),
+                None,
+                "TMPDIR={tmpdir:?}"
+            );
+        }
     }
 }

--- a/crates/wenlan-server/src/cmd_backfill.rs
+++ b/crates/wenlan-server/src/cmd_backfill.rs
@@ -149,7 +149,7 @@ fn service_unit_path() -> Result<std::path::PathBuf> {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 fn check_service_unit_absent(unit: &std::path::Path) -> Result<()> {
     if unit.exists() {
         Err(anyhow!(
@@ -163,8 +163,86 @@ fn check_service_unit_absent(unit: &std::path::Path) -> Result<()> {
     }
 }
 
-/// Returns Ok if no service manager has the origin daemon registered.
-/// Returns Err with instructions if a service unit file is present.
+/// Exit status `launchctl print` uses for a target launchd does not have.
+#[cfg(target_os = "macos")]
+const LAUNCHCTL_NO_SUCH_SERVICE: i32 = 113;
+
+/// The current user's launchd domain id, for `gui/<uid>/<label>` targets.
+/// Mirrors `current_user_id` in wenlan-cli's `commands::service`; the CLI is a
+/// separate crate this daemon does not depend on, so the lookup is repeated
+/// rather than shared.
+#[cfg(target_os = "macos")]
+fn current_user_id() -> Result<String> {
+    let output = std::process::Command::new("id")
+        .arg("-u")
+        .output()
+        .context("run id -u for the launchd user domain")?;
+    if !output.status.success() {
+        anyhow::bail!("id -u failed (exit {})", output.status.code().unwrap_or(-1));
+    }
+    let uid = std::str::from_utf8(&output.stdout)
+        .context("id -u returned non-UTF-8 output")?
+        .trim()
+        .to_owned();
+    if uid.is_empty() || !uid.bytes().all(|byte| byte.is_ascii_digit()) {
+        anyhow::bail!("id -u returned invalid user id: {uid:?}");
+    }
+    Ok(uid)
+}
+
+#[cfg(target_os = "macos")]
+fn launchctl_print_exit_code(target: &str) -> Result<Option<i32>> {
+    let output = std::process::Command::new("launchctl")
+        .args(["print", target])
+        .output()
+        .context("spawn launchctl print")?;
+    Ok(output.status.code())
+}
+
+/// Refuses while launchd still has the daemon job loaded.
+///
+/// The plist file is not the answer on macOS: `wenlan background off` boots the
+/// job out and deliberately keeps
+/// `~/Library/LaunchAgents/com.wenlan.server.plist`, so a file check refused
+/// precisely after the command this error tells the user to run.
+/// `launchctl print gui/<uid>/<label>` exits 113 for a target launchd does not
+/// have — the same signal `wenlan background off` itself reads (wenlan-cli
+/// `commands::service::stop_registered_service`).
+///
+/// `print_exit_code` is injected so tests can drive every launchd answer
+/// without loading or unloading the real service.
+#[cfg(target_os = "macos")]
+fn check_launchd_job_unloaded(
+    uid: &str,
+    print_exit_code: impl FnOnce(&str) -> Result<Option<i32>>,
+) -> Result<()> {
+    let target = format!("gui/{uid}/{SERVICE_LABEL}");
+    match print_exit_code(&target)? {
+        Some(LAUNCHCTL_NO_SUCH_SERVICE) => Ok(()),
+        Some(0) => Err(anyhow!(
+            "launchd still has the Wenlan daemon loaded as '{}', so it can restart in the \
+             middle of this command.\nIts LaunchAgent is at:\n  {}\n\
+             Turn it off first to prevent auto-restart:\n  wenlan background off\n\
+             Then re-run this command. (Restart after with `wenlan background on`.)",
+            target,
+            service_unit_path()?.display()
+        )),
+        other => Err(anyhow!(
+            "Could not read launchd state for '{}': launchctl print exit status {}. \
+             Refusing while it is unknown whether the daemon can restart mid-run.\n\
+             Turn it off first:\n  wenlan background off\n\
+             Then re-run this command. (Restart after with `wenlan background on`.)",
+            target,
+            match other {
+                Some(code) => code.to_string(),
+                None => "killed by a signal".to_string(),
+            }
+        )),
+    }
+}
+
+/// Returns Ok when nothing can restart the daemon under this command.
+/// Returns Err with instructions when something can.
 pub(crate) fn check_service_unloaded() -> Result<()> {
     #[cfg(target_os = "windows")]
     {
@@ -186,7 +264,11 @@ pub(crate) fn check_service_unloaded() -> Result<()> {
             Ok(())
         }
     }
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
+    {
+        check_launchd_job_unloaded(&current_user_id()?, launchctl_print_exit_code)
+    }
+    #[cfg(target_os = "linux")]
     {
         let unit = service_unit_path()?;
         check_service_unit_absent(&unit)
@@ -228,13 +310,49 @@ pub(crate) async fn check_daemon_not_running() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     #[test]
     fn check_service_unloaded_returns_ok_when_no_service_installed() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let unit = tmp.path().join("com.wenlan.server.plist");
+        let unit = tmp.path().join("wenlan-server.service");
 
         super::check_service_unit_absent(&unit).expect("expected Ok for absent test unit");
+    }
+
+    /// `wenlan background off` boots the launchd job out and keeps the plist on
+    /// disk, so an unloaded job must let the command run even though the file
+    /// is still there.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_unloaded_launchd_job_lets_the_command_run() {
+        let mut asked = Vec::new();
+        super::check_launchd_job_unloaded("501", |target| {
+            asked.push(target.to_string());
+            Ok(Some(113))
+        })
+        .expect("an unloaded launchd job must not block the command");
+        assert_eq!(asked, vec!["gui/501/com.wenlan.server".to_string()]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_loaded_launchd_job_blocks_and_names_background_off() {
+        let error = super::check_launchd_job_unloaded("501", |_| Ok(Some(0)))
+            .expect_err("a loaded launchd job must block the command");
+        let message = format!("{error}");
+        assert!(message.contains("gui/501/com.wenlan.server"), "{message}");
+        assert!(message.contains("wenlan background off"), "{message}");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn an_unreadable_launchd_state_blocks() {
+        let error = super::check_launchd_job_unloaded("501", |_| Ok(Some(2)))
+            .expect_err("an unknown launchd state must block the command");
+        assert!(
+            format!("{error}").contains("Could not read launchd state"),
+            "{error}"
+        );
     }
 
     /// Pin both copies (CLI + server) to the on-disk paths `service-manager`

--- a/crates/wenlan-server/src/main.rs
+++ b/crates/wenlan-server/src/main.rs
@@ -729,7 +729,14 @@ async fn run_daemon(startup_repair_claim: Option<StartupRepairClaim>) -> anyhow:
     // Data directory. `WENLAN_DATA_DIR` (set by `--data-dir` flag) overrides the
     // default, enabling isolated dev/demo runs (e.g. `--data-dir /tmp/wenlan-demo`).
     let data_dir = wenlan_root.join("memorydb");
-    tracing::info!("Wenlan data root: {}", wenlan_root.display());
+    // First thing after the version banner, and the line `wenlan doctor` sends
+    // people to: a daemon pointed at the wrong store looks healthy otherwise.
+    // The file name mirrors `MemoryDB` in wenlan-core (`db.rs`).
+    tracing::info!(
+        "Wenlan data root: {} (database {})",
+        wenlan_root.display(),
+        data_dir.join("origin_memory.db").display()
+    );
     let _data_root_lock = DaemonDataLock::acquire(&wenlan_root, startup_repair_claimed)?;
 
     let startup::PreparedStartupState {


### PR DESCRIPTION
Keeps launchd-supplied environment variables intact instead of dropping them, reads launchd state before running backfills so it isn't stale, and adds a warning when a temp data root is in use. These close a set of CLI/daemon environment-handling gaps found during CLI review.

Verified: 10 tests across `wenlan-cli` and `wenlan-server` pass; drift guard 156 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
