### PR TITLE
fix(cli): exit non-zero from status when unreachable and fix the brief and distill hints

### DIFF
--- a/crates/wenlan-cli/src/commands/brief.rs
+++ b/crates/wenlan-cli/src/commands/brief.rs
@@ -134,7 +134,8 @@ fn format_brief(response: &BriefReadResponse) -> String {
             "No Space resolved. Use --space or configure a project mapping.\n".into()
         }
         BriefReadState::BriefNotCreated => format!(
-            "No Brief exists for Space '{}'. The first handoff will create it.\n",
+            "No Brief exists for Space '{}'. Run `wenlan brief update --file <json>` \
+             (or the /handoff plugin command) to create it.\n",
             response.space.as_deref().unwrap_or("unknown")
         ),
         BriefReadState::Ready => response
@@ -263,5 +264,22 @@ mod tests {
         assert!(output.contains("Related Context: release"));
         assert!(!output.contains("secret-space-id"));
         assert!(!output.contains("secret-item-id"));
+    }
+
+    #[test]
+    fn no_brief_hint_names_a_command_the_cli_actually_has() {
+        let response = BriefReadResponse {
+            state: BriefReadState::BriefNotCreated,
+            space: Some("work".into()),
+            brief: None,
+            related_context: None,
+        };
+
+        let output = format_brief(&response);
+
+        // The CLI has no `handoff` subcommand; the hint must point at
+        // something a CLI user can actually run.
+        assert!(!output.contains("The first handoff"));
+        assert!(output.contains("wenlan brief update"));
     }
 }

--- a/crates/wenlan-cli/src/commands/status.rs
+++ b/crates/wenlan-cli/src/commands/status.rs
@@ -10,6 +10,9 @@ use crate::output::{print_json, ResolvedFormat};
 /// `format` is the resolved output format (Auto already collapsed in main).
 /// `quiet` suppresses success output; errors still propagate via `?` to stderr.
 /// We still hit the daemon under `quiet` to surface connection failures via exit code.
+/// The JSON branch prints the same `"status": "unreachable"` body either way,
+/// then returns the connect error so the process exits non-zero like every
+/// other command does on a connect failure.
 pub async fn run(client: &WenlanClient, format: ResolvedFormat, quiet: bool) -> Result<()> {
     if quiet {
         let _health = client.health().await?;
@@ -26,6 +29,9 @@ pub async fn run(client: &WenlanClient, format: ResolvedFormat, quiet: bool) -> 
                     "error": format!("{err:#}"),
                 });
                 print_json(&status)?;
+                // Print the JSON scripts parse, but still exit non-zero like
+                // every other command does on a connect failure.
+                return Err(err);
             }
         },
         ResolvedFormat::Table => {

--- a/crates/wenlan-cli/tests/cli_integration.rs
+++ b/crates/wenlan-cli/tests/cli_integration.rs
@@ -961,13 +961,13 @@ fn agents_edit_no_flags_bails() {
 }
 
 #[test]
-fn status_json_succeeds_when_daemon_is_unreachable() {
+fn status_json_prints_unreachable_but_exits_non_zero_when_daemon_is_unreachable() {
     cli()
         .env("WENLAN_HOST", "http://127.0.0.1:9")
         .env("WENLAN_NO_AUTOSTART", "1")
         .args(["status", "--format", "json"])
         .assert()
-        .success()
+        .failure()
         .stdout(predicate::str::contains("\"status\": \"unreachable\""));
 }
 
@@ -1316,7 +1316,7 @@ fn setup_background_status_roundtrip_isolated() {
     cli_with_isolated_runtime(&runtime)
         .args(["status", "--format", "json"])
         .assert()
-        .success()
+        .failure()
         .stdout(predicate::str::contains("\"status\": \"unreachable\""));
 
     let launchctl_log = runtime.data.path().join("background-off-launchctl.log");

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -870,12 +870,21 @@ pub async fn handle_distill(
     });
     if no_clusters_and_no_pages {
         if let serde_json::Value::Object(ref mut map) = response {
-            map.insert(
-                "hint".into(),
-                serde_json::json!(
-                    "No page-sized cluster formed in this scope: nothing grouped into 3 or more related memories that fit one page. Capture more related memories, or check the daemon log for dropped clusters."
-                ),
-            );
+            // Distinguish "nothing to synthesize" from "nothing CAN
+            // synthesize" -- on a fresh install with no on-device model or
+            // API key configured, telling the user to capture more memories
+            // sends them the wrong way.
+            let prefer_llm = api_llm.as_ref().or(llm.as_ref());
+            let model_available = prefer_llm
+                .as_ref()
+                .map(|provider| provider.is_available())
+                .unwrap_or(false);
+            let hint = if model_available {
+                "No page-sized cluster formed in this scope: nothing grouped into 3 or more related memories that fit one page. Capture more related memories, or check the daemon log for dropped clusters."
+            } else {
+                "No synthesis model is configured or reachable: install an on-device model or set an Anthropic key via `wenlan setup` / `/origin:doctor` before distilling."
+            };
+            map.insert("hint".into(), serde_json::json!(hint));
         }
     }
     Ok(Json(response))
@@ -1788,6 +1797,48 @@ mod distill_sweep_route_tests {
             db.count().await.unwrap(),
         );
         assert_eq!(after, before, "sweep route must not write rows");
+    }
+
+    #[tokio::test]
+    async fn distill_with_no_model_and_no_clusters_hints_at_model_setup_not_more_memories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let emitter: Arc<dyn wenlan_core::events::EventEmitter> =
+            Arc::new(wenlan_core::events::NoopEmitter);
+        let db = Arc::new(
+            wenlan_core::db::MemoryDB::new(tmp.path(), emitter)
+                .await
+                .expect("MemoryDB::new"),
+        );
+        // Fresh DB, no memories, and (via `..Default::default()`) no llm/api_llm
+        // configured -- the fresh-install case the hint must diagnose correctly.
+        let state = Arc::new(RwLock::new(ServerState {
+            db: Some(db),
+            ..Default::default()
+        }));
+        let app = crate::router::build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/distill")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let hint = payload["hint"].as_str().expect("hint present");
+        assert!(
+            hint.contains("wenlan setup"),
+            "with no model configured, the hint should point at setup, not more memories: {hint}"
+        );
+        assert!(!hint.contains("Capture more related memories"));
     }
 
     #[tokio::test]

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -617,7 +617,7 @@ pub async fn handle_distill(
                         "force": true,
                         "page_id": page_id,
                         "updated": false,
-                        "hint": "force rebuild needs an LLM in the daemon — install an on-device model or set an Anthropic key via `wenlan setup` / `/origin:doctor`",
+                        "hint": "force rebuild needs an LLM in the daemon — install an on-device model or set an Anthropic key via `wenlan setup` / `/wenlan:setup`",
                     })));
                 }
                 db.clear_user_edited(page_id)
@@ -882,7 +882,7 @@ pub async fn handle_distill(
             let hint = if model_available {
                 "No page-sized cluster formed in this scope: nothing grouped into 3 or more related memories that fit one page. Capture more related memories, or check the daemon log for dropped clusters."
             } else {
-                "No synthesis model is configured or reachable: install an on-device model or set an Anthropic key via `wenlan setup` / `/origin:doctor` before distilling."
+                "No synthesis model is configured or reachable: install an on-device model or set an Anthropic key via `wenlan setup` / `/wenlan:setup` before distilling."
             };
             map.insert("hint".into(), serde_json::json!(hint));
         }
@@ -953,7 +953,7 @@ pub async fn handle_redistill(
         Ok(Json(serde_json::json!({
             "status": "skipped",
             "updated": false,
-            "hint": "page re-distill needs an LLM in the daemon — install an on-device model or set an Anthropic key via `wenlan setup` / `/origin:doctor`",
+            "hint": "page re-distill needs an LLM in the daemon — install an on-device model or set an Anthropic key via `wenlan setup` / `/wenlan:setup`",
         })))
     }
 }

--- a/scripts/first-run/cli-roundtrip.ps1
+++ b/scripts/first-run/cli-roundtrip.ps1
@@ -25,8 +25,8 @@ $bin = $env:WENLAN_BIN
 $sentinel = "kumquat-lighthouse-8231"
 
 Write-Host "==> wenlan status"
-# `status --format json` prints {"status":"unreachable"} with exit 0 when the
-# daemon is down, so require the health payload's version field, not just rc=0.
+# `status --format json` now exits non-zero when the daemon is unreachable,
+# but check the health payload's version field too, not just rc=0.
 Check -Name "cli-status" -Expect '"version"' -Script { & $bin --format json status }
 
 Write-Host "==> wenlan capture (sentinel)"

--- a/scripts/first-run/cli-roundtrip.sh
+++ b/scripts/first-run/cli-roundtrip.sh
@@ -34,8 +34,8 @@ SENTINEL="kumquat-lighthouse-8231"
 CLI=("$WENLAN_BIN" --format json)
 
 echo "==> wenlan status"
-# `status --format json` prints {"status":"unreachable"} with exit 0 when the
-# daemon is down, so require the health payload's version field, not just rc=0.
+# `status --format json` now exits non-zero when the daemon is unreachable,
+# but check the health payload's version field too, not just rc=0.
 check_output cli-status '"version"' -- "${CLI[@]}" status
 
 echo "==> wenlan capture (sentinel)"


### PR DESCRIPTION
Makes `wenlan status` exit non-zero when the daemon is unreachable instead of reporting success, and fixes the brief and distill command hints so they point at the right commands. Also renames the stale `/origin:doctor` hint to `/wenlan:setup`.

Verified: `cli_integration` status 4 pass, brief 2 pass, server distill 14 pass, drift guard 156 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
