### PR TITLE
fix(core): fence page writes on an immutable incarnation token and guard db commits

### DIFF
--- a/crates/wenlan-core/src/citations.rs
+++ b/crates/wenlan-core/src/citations.rs
@@ -339,9 +339,11 @@ pub(crate) fn attempt_key(page_id: &str) -> String {
 /// `source_revision`, leaving `version` unchanged, so matching on `version`
 /// alone would let failed attempts against the OLD evidence set carry over
 /// and poison-pill a page that has since gained fresh, never-tried
-/// evidence.
-fn attempt_generation(page_version: i64, source_revision: i64) -> String {
-    format!("v{page_version}:s{source_revision}:")
+/// evidence. Keyed on the page `incarnation` too: a page deleted and
+/// re-created under the same id restarts both counters, so without it the
+/// old row's failures would count toward poison-pilling the new one.
+fn attempt_generation(incarnation: &str, page_version: i64, source_revision: i64) -> String {
+    format!("i{incarnation}:v{page_version}:s{source_revision}:")
 }
 
 /// Parse the attempt count out of a stored `app_metadata` value, but only
@@ -392,12 +394,13 @@ async fn build_backfill_changelog(
 async fn record_annotate_failure(
     db: &MemoryDB,
     page_id: &str,
+    incarnation: &str,
     page_version: i64,
     expected_source_revision: i64,
     giveup_reason: &str,
 ) -> Result<(), WenlanError> {
     let key = attempt_key(page_id);
-    let generation = attempt_generation(page_version, expected_source_revision);
+    let generation = attempt_generation(incarnation, page_version, expected_source_revision);
     let attempts = db
         .get_app_metadata(&key)
         .await?
@@ -413,6 +416,7 @@ async fn record_annotate_failure(
                 &changelog,
                 page_version,
                 expected_source_revision,
+                incarnation,
             )
             .await?;
         if landed {
@@ -496,10 +500,14 @@ async fn run_citation_backfill_with_page_limit(
         // deleted between selection (`get_pages_missing_citations`, above)
         // and this read must skip like the `get_page` miss right below it,
         // not abort the whole slice with `get_page_source_revision`'s
-        // does-not-exist error.
-        let Some(source_revision) = db.try_get_page_source_revision(&page_id).await? else {
+        // does-not-exist error. The fence also carries the row's
+        // incarnation: a page deleted and re-created under this id between
+        // here and the write restarts both counters, and only the token
+        // tells the new row from the old.
+        let Some(fence) = db.try_get_page_fence(&page_id).await? else {
             continue;
         };
+        let source_revision = fence.source_revision;
         let Some(page) = db.get_page(&page_id).await? else {
             continue;
         };
@@ -532,6 +540,7 @@ async fn run_citation_backfill_with_page_limit(
                     &changelog,
                     page.version,
                     source_revision,
+                    &fence.incarnation,
                 )
                 .await?;
             if landed {
@@ -545,7 +554,7 @@ async fn run_citation_backfill_with_page_limit(
                 let _ = db
                     .delete_app_metadata_if_value_starts_with(
                         &attempt_key(&page_id),
-                        &attempt_generation(page.version, source_revision),
+                        &attempt_generation(&fence.incarnation, page.version, source_revision),
                     )
                     .await;
             }
@@ -610,6 +619,7 @@ async fn run_citation_backfill_with_page_limit(
                     &changelog,
                     page.version,
                     source_revision,
+                    &fence.incarnation,
                 )
                 .await?;
             if landed {
@@ -618,7 +628,7 @@ async fn run_citation_backfill_with_page_limit(
                 let _ = db
                     .delete_app_metadata_if_value_starts_with(
                         &attempt_key(&page_id),
-                        &attempt_generation(page.version, source_revision),
+                        &attempt_generation(&fence.incarnation, page.version, source_revision),
                     )
                     .await;
             }
@@ -647,6 +657,7 @@ async fn run_citation_backfill_with_page_limit(
                 record_annotate_failure(
                     db,
                     &page_id,
+                    &fence.incarnation,
                     page.version,
                     source_revision,
                     "citation backfill gave up: provider error after 3 attempts",
@@ -674,6 +685,7 @@ async fn run_citation_backfill_with_page_limit(
                 record_annotate_failure(
                     db,
                     &page_id,
+                    &fence.incarnation,
                     page.version,
                     source_revision,
                     "citation backfill gave up: zero markers after 3 attempts",
@@ -703,6 +715,7 @@ async fn run_citation_backfill_with_page_limit(
                         Some(&json),
                         page.version,
                         source_revision,
+                        &fence.incarnation,
                         None,
                     )
                     .await?;
@@ -715,7 +728,7 @@ async fn run_citation_backfill_with_page_limit(
                     let _ = db
                         .delete_app_metadata_if_value_starts_with(
                             &attempt_key(&page_id),
-                            &attempt_generation(page.version, source_revision),
+                            &attempt_generation(&fence.incarnation, page.version, source_revision),
                         )
                         .await;
                 }
@@ -724,6 +737,7 @@ async fn run_citation_backfill_with_page_limit(
             record_annotate_failure(
                 db,
                 &page_id,
+                &fence.incarnation,
                 page.version,
                 source_revision,
                 "citation backfill gave up: annotate guard rejected 3x",
@@ -977,6 +991,14 @@ mod tests {
 
     const BACKFILL_BODY: &str = "The daemon binds to port 7878 by default.";
     const BACKFILL_MEM_CONTENT: &str = "The daemon binds to port 7878 by default";
+
+    async fn incarnation_of(db: &crate::db::MemoryDB, page_id: &str) -> String {
+        db.try_get_page_fence(page_id)
+            .await
+            .unwrap()
+            .expect("page exists")
+            .incarnation
+    }
 
     async fn seed_backfill_page(db: &crate::db::MemoryDB, page_id: &str, with_evidence: bool) {
         let now = chrono::Utc::now().to_rfc3339();
@@ -1301,7 +1323,17 @@ mod tests {
         let attempts = db.get_app_metadata(&attempt_key("p_guard")).await.unwrap();
         assert_eq!(
             attempts.as_deref(),
-            Some(format!("{}1", attempt_generation(version, source_revision)).as_str())
+            Some(
+                format!(
+                    "{}1",
+                    attempt_generation(
+                        &incarnation_of(&db, "p_guard").await,
+                        version,
+                        source_revision
+                    )
+                )
+                .as_str()
+            )
         );
     }
 
@@ -1421,7 +1453,14 @@ mod tests {
         // than deleting nothing.
         db.set_app_metadata(
             &attempt_key("p_cleanup_success"),
-            &format!("{}1", attempt_generation(version, source_revision)),
+            &format!(
+                "{}1",
+                attempt_generation(
+                    &incarnation_of(&db, "p_cleanup_success").await,
+                    version,
+                    source_revision
+                )
+            ),
         )
         .await
         .unwrap();
@@ -1531,7 +1570,8 @@ mod tests {
         // generation -- the call below is the 3rd, reaching the poison
         // threshold and attempting the terminal CAS write.
         let key = attempt_key("p_poison_cas_rejected");
-        let generation = attempt_generation(version, stale_source_revision);
+        let incarnation = incarnation_of(&db, "p_poison_cas_rejected").await;
+        let generation = attempt_generation(&incarnation, version, stale_source_revision);
         db.set_app_metadata(&key, &format!("{generation}2"))
             .await
             .unwrap();
@@ -1555,6 +1595,7 @@ mod tests {
         record_annotate_failure(
             &db,
             "p_poison_cas_rejected",
+            &incarnation,
             version,
             stale_source_revision,
             "citation backfill gave up: test",
@@ -1594,7 +1635,14 @@ mod tests {
             .unwrap();
         db.set_app_metadata(
             &attempt_key("p_giveup_cleanup"),
-            &format!("{}1", attempt_generation(page.version, source_revision)),
+            &format!(
+                "{}1",
+                attempt_generation(
+                    &incarnation_of(&db, "p_giveup_cleanup").await,
+                    page.version,
+                    source_revision
+                )
+            ),
         )
         .await
         .unwrap();
@@ -1658,10 +1706,36 @@ mod tests {
                 .await
                 .unwrap()
                 .as_deref(),
-            Some(format!("{}1", attempt_generation(version, new_source_revision)).as_str()),
+            Some(
+                format!(
+                    "{}1",
+                    attempt_generation(
+                        &incarnation_of(&db, "p_rollover").await,
+                        version,
+                        new_source_revision
+                    )
+                )
+                .as_str()
+            ),
             "the rolled-over generation's count must start fresh at 1, overwriting the old \
              generation's value in place"
         );
+    }
+
+    /// Delete-and-recreate ABA at the counter: a re-created page restarts at
+    /// the same `version`/`source_revision` the old row started at, so the
+    /// generation prefix must carry the incarnation too, or failures
+    /// recorded against the OLD row would count toward poison-pilling the
+    /// NEW one. A pre-127 value (no incarnation) is a foreign generation for
+    /// the same reason.
+    #[test]
+    fn attempts_recorded_against_a_previous_incarnation_count_as_zero() {
+        let old = attempt_generation("0123", 1, 0);
+        let new = attempt_generation("89ab", 1, 0);
+        assert_ne!(old, new);
+        assert_eq!(parse_attempts(&format!("{old}2"), &new), 0);
+        assert_eq!(parse_attempts(&format!("{new}2"), &new), 2);
+        assert_eq!(parse_attempts("v1:s0:2", &new), 0);
     }
 
     /// Round-5 finding F2/F3, citations-level: the same guarantee
@@ -1672,8 +1746,8 @@ mod tests {
     async fn terminal_cleanup_does_not_touch_a_newer_generation() {
         let (db, _dir) = crate::db::tests::test_db().await;
         let key = attempt_key("p_generation_race");
-        let older = attempt_generation(1, 1);
-        let newer = attempt_generation(1, 2);
+        let older = attempt_generation("same", 1, 1);
+        let newer = attempt_generation("same", 1, 2);
         db.set_app_metadata(&key, &format!("{newer}1"))
             .await
             .unwrap();
@@ -1720,7 +1794,14 @@ mod tests {
         let key = attempt_key("p_provider_error");
         db.set_app_metadata(
             &key,
-            &format!("{}2", attempt_generation(version, source_revision)),
+            &format!(
+                "{}2",
+                attempt_generation(
+                    &incarnation_of(&db, "p_provider_error").await,
+                    version,
+                    source_revision
+                )
+            ),
         )
         .await
         .unwrap();
@@ -1820,7 +1901,17 @@ mod tests {
         let attempts = db.get_app_metadata(&attempt_key("p_zero")).await.unwrap();
         assert_eq!(
             attempts.as_deref(),
-            Some(format!("{}1", attempt_generation(version, source_revision)).as_str())
+            Some(
+                format!(
+                    "{}1",
+                    attempt_generation(
+                        &incarnation_of(&db, "p_zero").await,
+                        version,
+                        source_revision
+                    )
+                )
+                .as_str()
+            )
         );
 
         // Two more zero-marker ticks trigger the poison-pill.
@@ -1882,7 +1973,17 @@ mod tests {
                 .await
                 .unwrap()
                 .as_deref(),
-            Some(format!("{}2", attempt_generation(version, original_source_revision)).as_str()),
+            Some(
+                format!(
+                    "{}2",
+                    attempt_generation(
+                        &incarnation_of(&db, "p_budget_reset").await,
+                        version,
+                        original_source_revision
+                    )
+                )
+                .as_str()
+            ),
             "sanity: two consecutive rejections must have recorded 2 attempts \
              against the original generation"
         );
@@ -1925,7 +2026,17 @@ mod tests {
             .unwrap();
         assert_eq!(
             attempts_after.as_deref(),
-            Some(format!("{}1", attempt_generation(version, new_source_revision)).as_str()),
+            Some(
+                format!(
+                    "{}1",
+                    attempt_generation(
+                        &incarnation_of(&db, "p_budget_reset").await,
+                        version,
+                        new_source_revision
+                    )
+                )
+                .as_str()
+            ),
             "the new generation's attempt count must start fresh at 1, overwriting the old \
              generation's value in place -- exactly one app_metadata row for this page, ever"
         );

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -1156,7 +1156,8 @@ pub const EMBEDDING_DIM: usize = 768;
 /// `observations`/`memory_entities`/`entity_minhash_bands` without their
 /// `REFERENCES entities(id)` foreign key. Migration 123 (G6 Stage 3) drops
 /// `entities` and `entity_aliases` outright. Migration 127 adds
-/// `pages.refresh_blocked_reason` (citation-gate surfacing).
+/// `pages.refresh_blocked_reason` (citation-gate surfacing). Migration 128
+/// adds `pages.incarnation` (delete-and-recreate ABA fencing).
 ///
 /// This constant is also the **downgrade barrier**. `run_migrations` refuses
 /// to open a database whose `user_version` exceeds it, so a build that
@@ -1164,7 +1165,7 @@ pub const EMBEDDING_DIM: usize = 768;
 /// `entities` table, skip every `version < N` branch, and quietly operate
 /// against a schema it cannot see. Refusing to open is recoverable; writing is
 /// not.
-pub const SCHEMA_VERSION: u32 = 127;
+pub const SCHEMA_VERSION: u32 = 128;
 
 /// Reserved id AND name of the uncategorized-page sentinel space (M1 honest
 /// columns). Uncategorized pages store this value in `pages.space`/`workspace`
@@ -1175,6 +1176,18 @@ pub const SCHEMA_VERSION: u32 = 127;
 /// sentinel on the name-unique constraint. `create_space`/`update_space` reject
 /// this exact string as a user-supplied name, keeping the reservation closed.
 pub(crate) const UNFILED_SPACE_ID: &str = "00000000-0000-4000-8000-000000000001";
+
+/// The row-level fences a machine writer snapshots BEFORE reading evidence,
+/// read in one statement so they describe the same row state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageFence {
+    /// Immutable per-row token minted at page creation (migration 127). A
+    /// page deleted and re-created under the same id gets a new one, so a
+    /// CAS carrying the old token cannot match the new row even though
+    /// `version` and `source_revision` restart at their initial values.
+    pub incarnation: String,
+    pub source_revision: i64,
+}
 
 /// A retry receipt to commit alongside a mutation.
 ///
@@ -9814,6 +9827,15 @@ impl MemoryDB {
                 self.migrate_127_page_refresh_blocked_reason(version)
                     .await?;
             }
+
+            // Migration 128 (2026-08-29 page incarnation): every page row
+            // carries an immutable, never-reused `incarnation` token so a
+            // CAS captured against a page that was since deleted and
+            // re-created under the same id cannot match the new row. See
+            // migrate_128_page_incarnation.
+            if version < 128 {
+                self.migrate_128_page_incarnation(version).await?;
+            }
         }
 
         // Private M4 builds could already have stamped user_version=95 before
@@ -11349,13 +11371,13 @@ impl MemoryDB {
                 id, title, summary, content, kind, entity_type, confidence, entity_confirmed,
                 embedding, space, workspace, source_memory_ids, version, status,
                 created_at, last_compiled, last_modified, creation_kind, review_status,
-                aliases, source_agent, entity_created_at, entity_updated_at
+                aliases, source_agent, entity_created_at, entity_updated_at, incarnation
              )
              VALUES (?1, ?2, NULL, '', 'entity', ?3, ?4, ?5,
                      CASE WHEN ?6 IS NULL THEN NULL ELSE vector32(?6) END,
                      COALESCE(?7, ?8), COALESCE(?7, ?8), '[]', 1, 'active',
                      ?9, ?9, ?9, 'entity', 'unconfirmed',
-                     ?10, ?11, ?12, ?13)",
+                     ?10, ?11, ?12, ?13, lower(hex(randomblob(16))))",
             libsql::params![
                 page_id,
                 name,
@@ -16902,6 +16924,78 @@ impl MemoryDB {
             .await
             .map_err(|e| WenlanError::VectorDb(format!("m127 bump: {e}")))?;
         log::info!("[migration] Migration 127 applied: pages.refresh_blocked_reason column added");
+        Ok(())
+    }
+
+    /// Migration 128 (2026-08-29): add `pages.incarnation`, an opaque token
+    /// minted once per row at creation and never rewritten.
+    ///
+    /// `version` and `source_revision` both restart at their initial values
+    /// when a page is deleted and re-created under the same id, so a machine
+    /// writer that captured both fences against the OLD row still matches
+    /// the NEW one (delete-and-recreate ABA). Carrying the incarnation in the
+    /// CAS closes that: the re-created row gets a fresh token, so the stale
+    /// write matches nothing. Existing rows are backfilled with fresh tokens
+    /// here; every production page INSERT stamps its own from the same
+    /// expression. The column check keeps a replay on a store that already
+    /// has the column from failing on the ALTER.
+    async fn migrate_128_page_incarnation(&self, prior_version: i64) -> Result<(), WenlanError> {
+        self.backup_before_migration(128, prior_version).await?;
+        let conn = self.conn.lock().await;
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m128 begin: {e}")))?;
+
+        let result: Result<u64, WenlanError> = async {
+            let has_incarnation = {
+                let mut rows = conn
+                    .query(
+                        "SELECT COUNT(*) FROM pragma_table_info('pages') WHERE name = 'incarnation'",
+                        (),
+                    )
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m128 column check: {e}")))?;
+                rows.next()
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m128 column row: {e}")))?
+                    .is_some_and(|row| row.get::<i64>(0).unwrap_or(0) > 0)
+            };
+            if !has_incarnation {
+                conn.execute(
+                    "ALTER TABLE pages ADD COLUMN incarnation TEXT NOT NULL DEFAULT ''",
+                    (),
+                )
+                .await
+                .map_err(|e| WenlanError::VectorDb(format!("m128 add incarnation: {e}")))?;
+            }
+            conn.execute(
+                "UPDATE pages SET incarnation = lower(hex(randomblob(16))) WHERE incarnation = ''",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m128 backfill: {e}")))
+        }
+        .await;
+
+        let stamped = match result {
+            Ok(value) => {
+                commit_or_rollback(&conn)
+                    .await
+                    .map_err(|e| WenlanError::VectorDb(format!("m128 commit: {e}")))?;
+                value
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                return Err(e);
+            }
+        };
+
+        conn.execute("PRAGMA user_version = 128", ())
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("m128 bump: {e}")))?;
+        log::info!(
+            "[migration] Migration 128 applied: {stamped} page row(s) stamped with an incarnation token"
+        );
         Ok(())
     }
 
@@ -31616,7 +31710,7 @@ impl MemoryDB {
                      (id,title,summary,content,entity_id,space,source_memory_ids,
                       version,status,embedding,created_at,last_compiled,last_modified,
                       sources_updated_count,stale_reason,user_edited,changelog,
-                      creation_kind,review_status,workspace,citations,kind)
+                      creation_kind,review_status,workspace,citations,kind,incarnation)
                  SELECT ?1,title,summary,content,entity_id,space,source_memory_ids,
                         version,status,embedding,created_at,last_compiled,last_modified,
                         sources_updated_count,stale_reason,user_edited,changelog,
@@ -31625,7 +31719,8 @@ impl MemoryDB {
                              WHEN creation_kind = 'authored' THEN 'authored'
                              WHEN creation_kind IN ('imported', 'source') THEN 'source'
                              WHEN creation_kind = 'entity' THEN 'entity'
-                             ELSE 'concept' END
+                             ELSE 'concept' END,
+                        lower(hex(randomblob(16)))
                  FROM pages
                  WHERE id = ?2 AND creation_kind = 'source'",
                 libsql::params![new_page_id, old_page_id],
@@ -48223,15 +48318,15 @@ impl MemoryDB {
         let concept_result = match &embedding_sql {
             Some(emb) => {
                 conn.execute(
-                    "INSERT INTO pages (id, title, summary, content, entity_id, space, source_memory_ids, version, status, embedding, created_at, last_compiled, last_modified, creation_kind, review_status, workspace, citations, kind)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1, 'active', vector32(?8), ?9, ?9, ?9, ?10, ?11, ?12, ?13, ?14)",
+                    "INSERT INTO pages (id, title, summary, content, entity_id, space, source_memory_ids, version, status, embedding, created_at, last_compiled, last_modified, creation_kind, review_status, workspace, citations, kind, incarnation)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1, 'active', vector32(?8), ?9, ?9, ?9, ?10, ?11, ?12, ?13, ?14, lower(hex(randomblob(16))))",
                     libsql::params![id, title, summary, content, entity_id, space, source_ids_json, emb.as_str(), now, creation_kind, review_status, workspace, citations_json, kind],
                 ).await
             }
             None => {
                 conn.execute(
-                    "INSERT INTO pages (id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, creation_kind, review_status, workspace, citations, kind)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1, 'active', ?8, ?8, ?8, ?9, ?10, ?11, ?12, ?13)",
+                    "INSERT INTO pages (id, title, summary, content, entity_id, space, source_memory_ids, version, status, created_at, last_compiled, last_modified, creation_kind, review_status, workspace, citations, kind, incarnation)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1, 'active', ?8, ?8, ?8, ?9, ?10, ?11, ?12, ?13, lower(hex(randomblob(16))))",
                     libsql::params![id, title, summary, content, entity_id, space, source_ids_json, now, creation_kind, review_status, workspace, citations_json, kind],
                 ).await
             }
@@ -49069,6 +49164,7 @@ impl MemoryDB {
             None,
             None,
             None,
+            None,
             false,
         )
         .await
@@ -49095,6 +49191,7 @@ impl MemoryDB {
             source_memory_ids,
             link_reason,
             true,
+            None,
             None,
             None,
             None,
@@ -49133,6 +49230,7 @@ impl MemoryDB {
             citations_json,
             None,
             Some(expected_source_revision),
+            None,
             None,
             receipt,
             None,
@@ -49179,6 +49277,7 @@ impl MemoryDB {
             expected_version,
             None,
             None,
+            None,
             receipt,
             None,
             false,
@@ -49210,6 +49309,7 @@ impl MemoryDB {
             Some(changelog),
             citations_json,
             Some(expected_version),
+            None,
             None,
             None,
             receipt,
@@ -49244,6 +49344,7 @@ impl MemoryDB {
         citations_json: Option<&str>,
         expected_version: i64,
         expected_source_revision: i64,
+        expected_incarnation: &str,
         receipt: Option<OperationReceipt<'_>>,
     ) -> Result<bool, WenlanError> {
         self.try_update_page_content(
@@ -49256,6 +49357,7 @@ impl MemoryDB {
             citations_json,
             Some(expected_version),
             Some(expected_source_revision),
+            Some(expected_incarnation),
             None,
             receipt,
             None,
@@ -49299,6 +49401,7 @@ impl MemoryDB {
             Some(expected_source_revision),
             None,
             None,
+            None,
             Some((source_id, expected_memory_version)),
             true,
         )
@@ -49329,6 +49432,7 @@ impl MemoryDB {
             None,
             expected_version,
             expected_source_revision,
+            None,
             Some(revision_source_id),
             None,
             None,
@@ -49357,6 +49461,7 @@ impl MemoryDB {
         citations_json: Option<&str>,
         expected_version: Option<i64>,
         expected_source_revision: Option<i64>,
+        expected_incarnation: Option<&str>,
         consume_revision_id: Option<&str>,
         receipt: Option<OperationReceipt<'_>>,
         page_growth_guard: Option<(&str, i64)>,
@@ -49381,6 +49486,20 @@ impl MemoryDB {
         {
             return Err(WenlanError::Validation(
                 "only page growth, citation backfill, and revision accept may combine version and source-revision CAS".to_string(),
+            ));
+        }
+        // The incarnation fence only rides with a fully fenced changelog
+        // write (the citation backfill's shape): that is the one SQL builder
+        // below that binds it, so accepting it anywhere else would silently
+        // drop the fence.
+        if expected_incarnation.is_some()
+            && (expected_version.is_none()
+                || expected_source_revision.is_none()
+                || changelog.is_none())
+        {
+            return Err(WenlanError::Validation(
+                "the page incarnation fence requires version, source-revision, and changelog"
+                    .to_string(),
             ));
         }
         let citations_bind = citations_json;
@@ -49536,6 +49655,9 @@ impl MemoryDB {
                     sql.push_str(" AND COALESCE(source_revision, 0) = ?8 AND status = 'active'");
                 }
             }
+            if expected_incarnation.is_some() {
+                sql.push_str(" AND incarnation = ?10");
+            }
             let update_result = match (expected_version, expected_source_revision) {
                 (Some(version), None) => {
                     conn.execute(
@@ -49584,23 +49706,43 @@ impl MemoryDB {
                     )
                     .await
                 }
-                (Some(version), Some(revision)) => {
-                    conn.execute(
-                        &sql,
-                        libsql::params![
-                            content,
-                            source_ids_json,
-                            now,
-                            link_reason,
-                            id,
-                            cl,
-                            citations_bind,
-                            version,
-                            revision
-                        ],
-                    )
-                    .await
-                }
+                (Some(version), Some(revision)) => match expected_incarnation {
+                    Some(incarnation) => {
+                        conn.execute(
+                            &sql,
+                            libsql::params![
+                                content,
+                                source_ids_json,
+                                now,
+                                link_reason,
+                                id,
+                                cl,
+                                citations_bind,
+                                version,
+                                revision,
+                                incarnation
+                            ],
+                        )
+                        .await
+                    }
+                    None => {
+                        conn.execute(
+                            &sql,
+                            libsql::params![
+                                content,
+                                source_ids_json,
+                                now,
+                                link_reason,
+                                id,
+                                cl,
+                                citations_bind,
+                                version,
+                                revision
+                            ],
+                        )
+                        .await
+                    }
+                },
             };
             match update_result {
                 Ok(n) => n,
@@ -52833,6 +52975,11 @@ impl MemoryDB {
     /// give-up `[]`), permanently dropping it out of the citations-missing
     /// queue. Same `COALESCE(source_revision, 0) = ?N` pattern as
     /// `try_update_page_content_with_changelog_at_source_revision`.
+    ///
+    /// `expected_incarnation` closes the third window: a page deleted and
+    /// re-created under the same id restarts BOTH counters, so a writer that
+    /// captured them against the old row would match the new one. The token
+    /// is minted per row and never reused (migration 127).
     pub async fn set_page_citations_with_changelog_at_version(
         &self,
         page_id: &str,
@@ -52840,6 +52987,7 @@ impl MemoryDB {
         changelog_json: &str,
         expected_version: i64,
         expected_source_revision: i64,
+        expected_incarnation: &str,
     ) -> Result<bool, WenlanError> {
         let conn = self.conn.lock().await;
         conn.execute("BEGIN", ()).await.map_err(|e| {
@@ -52852,13 +53000,15 @@ impl MemoryDB {
                 .execute(
                     "UPDATE pages SET citations = ?1, changelog = ?2
                      WHERE id = ?3 AND version = ?4 AND status = 'active'
-                       AND citations IS NULL AND COALESCE(source_revision, 0) = ?5",
+                       AND citations IS NULL AND COALESCE(source_revision, 0) = ?5
+                       AND incarnation = ?6",
                     libsql::params![
                         citations_json,
                         changelog_json,
                         page_id,
                         expected_version,
-                        expected_source_revision
+                        expected_source_revision,
+                        expected_incarnation
                     ],
                 )
                 .await?;
@@ -53874,6 +54024,40 @@ impl MemoryDB {
         row.get::<i64>(0)
             .map(Some)
             .map_err(|e| WenlanError::VectorDb(format!("try_get_page_source_revision: {e}")))
+    }
+
+    /// [`Self::try_get_page_source_revision`] plus the row's incarnation
+    /// token, read together. `Ok(None)` when the page is missing. The
+    /// citation backfill carries both into its terminal CAS writes: the
+    /// source revision catches a re-arm, the incarnation catches a
+    /// delete-and-recreate under the same id.
+    pub async fn try_get_page_fence(
+        &self,
+        page_id: &str,
+    ) -> Result<Option<PageFence>, WenlanError> {
+        let conn = self.conn.lock().await;
+        let mut rows = conn
+            .query(
+                "SELECT incarnation, COALESCE(source_revision, 0) FROM pages WHERE id = ?1",
+                libsql::params![page_id],
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("try_get_page_fence: {e}")))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("try_get_page_fence: {e}")))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(PageFence {
+            incarnation: row
+                .get::<String>(0)
+                .map_err(|e| WenlanError::VectorDb(format!("try_get_page_fence: {e}")))?,
+            source_revision: row
+                .get::<i64>(1)
+                .map_err(|e| WenlanError::VectorDb(format!("try_get_page_fence: {e}")))?,
+        }))
     }
 
     /// A verified refresh can produce byte-identical prose and sources. In

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -16831,7 +16831,10 @@ impl MemoryDB {
     /// keys (`citation_backfill_attempts:<page_id>:v...`), predating the
     /// one-row-per-page redesign (`citations::attempt_key`) -- a dead key a
     /// live page can never match again, since every read is gated on the
-    /// current `v{version}:s{source_revision}:` generation prefix. See
+    /// current generation prefix. The `LIKE` pattern cannot say that on its
+    /// own: a page id that itself contains `:v` makes the page's *live* key
+    /// `citation_backfill_attempts:<id>` match the pattern too. So the delete
+    /// also excludes, by exact value, every key a current page owns. See
     /// migrate_126_rearm_empty_citations_and_drop_legacy_attempt_keys.
     async fn migrate_126_rearm_empty_citations_and_drop_legacy_attempt_keys(
         &self,
@@ -16853,7 +16856,11 @@ impl MemoryDB {
                 .map_err(|e| WenlanError::VectorDb(format!("m126 rearm: {e}")))?;
             let legacy_attempt_keys_dropped = conn
                 .execute(
-                    "DELETE FROM app_metadata WHERE key LIKE 'citation_backfill_attempts:%:v%'",
+                    "DELETE FROM app_metadata \
+                     WHERE key LIKE 'citation_backfill_attempts:%:v%' \
+                       AND key NOT IN (\
+                           SELECT 'citation_backfill_attempts:' || id FROM pages\
+                       )",
                     (),
                 )
                 .await

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -33770,6 +33770,14 @@ async fn user_version(db: &MemoryDB) -> i64 {
     rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
 }
 
+async fn incarnation_of(db: &MemoryDB, page_id: &str) -> String {
+    db.try_get_page_fence(page_id)
+        .await
+        .unwrap()
+        .expect("page exists")
+        .incarnation
+}
+
 async fn pages_has_column(db: &MemoryDB, column: &str) -> bool {
     let conn = db.conn.lock().await;
     let mut rows = conn
@@ -53620,6 +53628,7 @@ async fn set_page_citations_with_changelog_at_version_rejects_stale_source_revis
 
     // The stale writer's CAS must not match: version still matches, but
     // source_revision has moved on.
+    let incarnation = incarnation_of(&db, "page_source_cas").await;
     let stale_changelog =
         r#"[{"edited_by":"citation_backfill","at":1,"citations_summary":"stale write"}]"#;
     let wrote_stale = db
@@ -53629,6 +53638,7 @@ async fn set_page_citations_with_changelog_at_version_rejects_stale_source_revis
             stale_changelog,
             version,
             stale_source_revision,
+            &incarnation,
         )
         .await
         .unwrap();
@@ -53667,6 +53677,7 @@ async fn set_page_citations_with_changelog_at_version_rejects_stale_source_revis
             current_changelog,
             version,
             current_source_revision,
+            &incarnation,
         )
         .await
         .unwrap();
@@ -53735,6 +53746,7 @@ async fn combine_version_and_source_revision_cas_rejected_for_non_growth_non_bac
             None,
             Some(version),
             Some(source_revision),
+            None,
             None,
             None,
             None,
@@ -53828,6 +53840,7 @@ async fn citation_backfill_combined_cas_writes_on_match_and_rejects_stale_source
         .unwrap();
     let stale_source_revision = current_source_revision + 1;
 
+    let incarnation = incarnation_of(&db, "page_combine_backfill").await;
     let wrote_stale = db
         .try_update_page_content_with_changelog_at_versions(
             "page_combine_backfill",
@@ -53837,6 +53850,7 @@ async fn citation_backfill_combined_cas_writes_on_match_and_rejects_stale_source
             None,
             version,
             stale_source_revision,
+            &incarnation,
             None,
         )
         .await
@@ -53864,6 +53878,7 @@ async fn citation_backfill_combined_cas_writes_on_match_and_rejects_stale_source
             None,
             version,
             current_source_revision,
+            &incarnation,
             None,
         )
         .await
@@ -53948,6 +53963,7 @@ async fn combined_cas_read_order_rejects_write_racing_a_mid_read_attach() {
             Some("[]"),
             page.version,
             source_revision,
+            &incarnation_of(&db, "page_read_order").await,
             None,
         )
         .await
@@ -56966,6 +56982,211 @@ async fn migration_126_rearms_empty_citations_to_null_exactly_once() {
     assert_eq!(
         citations_of(&db, "m126-archived-pill").await,
         Some("[]".to_string())
+    );
+}
+
+/// Migration 128: every existing page row is stamped with a distinct
+/// incarnation token; a row that already carries one keeps it (idempotent
+/// replay), and a fresh insert mints its own without the migration.
+#[tokio::test]
+async fn migration_128_stamps_every_existing_page_with_a_distinct_incarnation() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    for id in ["m127-a", "m127-b", "m127-keep"] {
+        db.insert_page(id, "T", None, "body", None, None, &[], &now)
+            .await
+            .unwrap();
+    }
+    assert!(pages_has_column(&db, "incarnation").await);
+    let keep_before = incarnation_of(&db, "m127-keep").await;
+    assert_eq!(
+        keep_before.len(),
+        32,
+        "a fresh insert mints its own token: {keep_before:?}"
+    );
+
+    // Pre-127 shape: rows carrying only the column DEFAULT.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "UPDATE pages SET incarnation = '' WHERE id IN ('m127-a', 'm127-b')",
+            (),
+        )
+        .await
+        .unwrap();
+        conn.execute("PRAGMA user_version = 126", ()).await.unwrap();
+    }
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .unwrap();
+    assert_eq!(user_version(&db).await, i64::from(SCHEMA_VERSION));
+
+    let a = incarnation_of(&db, "m127-a").await;
+    let b = incarnation_of(&db, "m127-b").await;
+    assert_eq!(a.len(), 32, "16 random bytes as lower-case hex: {a:?}");
+    assert!(
+        a.bytes()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "lower-case hex: {a:?}"
+    );
+    assert_ne!(a, b, "every row must get its own token");
+    assert_eq!(
+        incarnation_of(&db, "m127-keep").await,
+        keep_before,
+        "an already-stamped row keeps its token"
+    );
+
+    // Replay: nothing left to stamp, every token unchanged.
+    {
+        let conn = db.conn.lock().await;
+        conn.execute("PRAGMA user_version = 126", ()).await.unwrap();
+    }
+    db.run_migrations(&crate::events::NoopEmitter)
+        .await
+        .expect("re-running migration 128 must be a no-op");
+    assert_eq!(incarnation_of(&db, "m127-a").await, a);
+    assert_eq!(incarnation_of(&db, "m127-b").await, b);
+    assert_eq!(incarnation_of(&db, "m127-keep").await, keep_before);
+}
+
+/// Delete-and-recreate ABA: `version` and `source_revision` both restart at
+/// their initial values when a page is deleted and re-created under the same
+/// id, so both fences a backfill writer captured against the OLD row still
+/// match the NEW row. The incarnation token is what tells them apart: a
+/// write carrying the old token must be refused at both terminal CAS entry
+/// points, and the same write carrying the new token must land.
+#[tokio::test]
+async fn page_cas_writes_carrying_a_previous_incarnation_are_refused_after_delete_and_recreate() {
+    let (db, _dir) = test_db().await;
+    let now = chrono::Utc::now().to_rfc3339();
+    db.insert_page(
+        "page_aba",
+        "T",
+        None,
+        "body",
+        None,
+        None,
+        &["mem_seed"],
+        &now,
+    )
+    .await
+    .unwrap();
+    let old = db.try_get_page_fence("page_aba").await.unwrap().unwrap();
+    let old_version = db.get_page("page_aba").await.unwrap().unwrap().version;
+
+    db.delete_page("page_aba").await.unwrap();
+    assert!(
+        db.try_get_page_fence("page_aba").await.unwrap().is_none(),
+        "sanity: the row is gone"
+    );
+    db.insert_page(
+        "page_aba",
+        "T",
+        None,
+        "body",
+        None,
+        None,
+        &["mem_seed"],
+        &now,
+    )
+    .await
+    .unwrap();
+    let new = db.try_get_page_fence("page_aba").await.unwrap().unwrap();
+    let new_version = db.get_page("page_aba").await.unwrap().unwrap().version;
+    assert_eq!(
+        (new_version, new.source_revision),
+        (old_version, old.source_revision),
+        "sanity: both counters restart on re-create -- that IS the ABA hazard"
+    );
+    assert_ne!(
+        new.incarnation, old.incarnation,
+        "sanity: the re-created row must carry a fresh token"
+    );
+
+    // Citation-only terminal write (the give-up / poison-pill path).
+    let wrote_stale = db
+        .set_page_citations_with_changelog_at_version(
+            "page_aba",
+            Some("[]"),
+            "[]",
+            old_version,
+            old.source_revision,
+            &old.incarnation,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !wrote_stale,
+        "a citations write carrying the old incarnation must be refused"
+    );
+    assert!(
+        db.get_pages_missing_citations(10)
+            .await
+            .unwrap()
+            .contains(&"page_aba".to_string()),
+        "the refused write must not have knocked the re-created page out of the queue"
+    );
+    let wrote_current = db
+        .set_page_citations_with_changelog_at_version(
+            "page_aba",
+            Some("[]"),
+            "[]",
+            new_version,
+            new.source_revision,
+            &new.incarnation,
+        )
+        .await
+        .unwrap();
+    assert!(
+        wrote_current,
+        "the same write with the current token must land"
+    );
+
+    // Content-rewriting terminal write (the annotate path).
+    let wrote_stale = db
+        .try_update_page_content_with_changelog_at_versions(
+            "page_aba",
+            "stale body",
+            &["mem_seed"],
+            "[]",
+            Some("[]"),
+            old_version,
+            old.source_revision,
+            &old.incarnation,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        !wrote_stale,
+        "a content write carrying the old incarnation must be refused"
+    );
+    assert_eq!(
+        db.get_page("page_aba").await.unwrap().unwrap().content,
+        "body",
+        "the refused write must not have landed"
+    );
+    let wrote_current = db
+        .try_update_page_content_with_changelog_at_versions(
+            "page_aba",
+            "annotated body",
+            &["mem_seed"],
+            "[]",
+            Some("[]"),
+            new_version,
+            new.source_revision,
+            &new.incarnation,
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(
+        wrote_current,
+        "the same write with the current token must land"
+    );
+    assert_eq!(
+        db.get_page("page_aba").await.unwrap().unwrap().content,
+        "annotated body"
     );
 }
 

--- a/crates/wenlan-core/src/db/main_tests.rs
+++ b/crates/wenlan-core/src/db/main_tests.rs
@@ -56898,6 +56898,25 @@ async fn migration_126_rearms_empty_citations_to_null_exactly_once() {
         .await
         .unwrap();
 
+    // A page id that itself contains `:v` makes the page's *live* attempt key
+    // match the legacy `LIKE` pattern. It is still read by the backfill, so
+    // the sweep must exclude it by exact key.
+    db.insert_page(
+        "m126:v-odd-id",
+        "Page whose id contains a colon-v",
+        None,
+        "body",
+        None,
+        None,
+        &[],
+        &now,
+    )
+    .await
+    .unwrap();
+    db.set_app_metadata(&crate::citations::attempt_key("m126:v-odd-id"), "v2:s1:1")
+        .await
+        .unwrap();
+
     {
         let conn = db.conn.lock().await;
         conn.execute("PRAGMA user_version = 125", ()).await.unwrap();
@@ -56966,6 +56985,16 @@ async fn migration_126_rearms_empty_citations_to_null_exactly_once() {
             .unwrap(),
         Some("v1:s0:2".to_string()),
         "a current-format attempt key (no `:v` suffix) must survive the migration"
+    );
+
+    assert_eq!(
+        db.get_app_metadata(&crate::citations::attempt_key("m126:v-odd-id"))
+            .await
+            .unwrap(),
+        Some("v2:s1:1".to_string()),
+        "a live attempt key whose page id contains `:v` matches the legacy LIKE \
+         pattern, so the sweep must exclude it by exact key or it deletes a \
+         counter the backfill is still reading"
     );
 
     // Idempotency: rewind and replay finds nothing left to re-arm (the

--- a/crates/wenlan-core/src/db/page_drafts.rs
+++ b/crates/wenlan-core/src/db/page_drafts.rs
@@ -292,12 +292,14 @@ impl MemoryDB {
                     id, title, summary, content, entity_id, space, source_memory_ids,
                     version, status, embedding, created_at, last_compiled,
                     last_modified, sources_updated_count, stale_reason, user_edited,
-                    changelog, creation_kind, review_status, workspace, citations, kind
+                    changelog, creation_kind, review_status, workspace, citations, kind,
+                    incarnation
                  ) VALUES (
                     ?1, ?2, NULL, ?3, NULL, ?4, '[]',
                     1, 'draft', NULL, ?5, ?5,
                     ?5, 0, NULL, 1,
-                    '[]', 'authored', 'unconfirmed', ?4, '[]', ?6
+                    '[]', 'authored', 'unconfirmed', ?4, '[]', ?6,
+                    lower(hex(randomblob(16)))
                  )",
             libsql::params![
                 id,

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -12568,3 +12568,321 @@ fn retired_parity_machinery_guard_detects_a_live_reference() {
     let hits = live_references_to_retired_symbols_in_source(source, &re);
     assert_eq!(hits, vec![(1, "SCOPED_ENTITIES_CONSUMER".to_string())]);
 }
+
+// ── Teeth #17: every db-layer COMMIT rolls back when the COMMIT itself fails ──
+
+/// Bytes of source after a `COMMIT` execute in which its error handling must
+/// begin. Every real shape in the db layer opens that block within a few dozen
+/// bytes of the literal (`…await {`, or the `match …await {` head); this is
+/// wide enough to survive rustfmt splitting the call across lines and narrow
+/// enough that an unrelated block further down the function cannot be mistaken
+/// for the commit's own.
+const COMMIT_ERROR_ARM_REACH: usize = 240;
+
+/// Names of db-layer helpers that perform the `ROLLBACK` for their caller. A
+/// commit whose error arm calls one is recovered even though the SQL word
+/// appears only inside the helper. The list is checked, not trusted:
+/// `every_db_commit_rolls_back_when_the_commit_fails` asserts each name is a
+/// real function in a scanned file whose own body executes `"ROLLBACK"`, so a
+/// rename or a gutted helper cannot quietly turn this into a blanket
+/// exemption. `commit_or_rollback` is deliberately absent — it rolls back in
+/// its own error arm, so it satisfies the guard like any other site.
+const ROLLBACK_HELPERS: &[&str] = &["rollback_repair_transaction"];
+
+/// The db layer: the one file that owns the writer connection plus its child
+/// modules, which reach the same connection through `super::`. A `COMMIT` that
+/// fails anywhere else does not wedge this process's only writer.
+fn is_db_layer_module(path: &str) -> bool {
+    path == "crates/wenlan-core/src/db.rs" || path.starts_with("crates/wenlan-core/src/db/")
+}
+
+/// True when a commit's error-handling block reaches a rollback — either the
+/// SQL statement itself or one of the named helpers that runs it.
+fn error_arm_rolls_back(arm: &str) -> bool {
+    arm.contains("ROLLBACK") || ROLLBACK_HELPERS.iter().any(|helper| arm.contains(helper))
+}
+
+/// Offset of the `}` closing the `{` at `open`, on brace-masked text.
+fn matching_brace(masked: &str, open: usize) -> Option<usize> {
+    let bytes = masked.as_bytes();
+    let mut depth = 0usize;
+    for (offset, byte) in bytes[open..].iter().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(open + offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Name of the function a byte offset sits in, for a readable site label.
+/// Read off the brace-masked text so an `fn ` inside a string or comment
+/// cannot claim the site.
+fn enclosing_fn_name(masked: &str, at: usize) -> String {
+    masked[..at]
+        .match_indices("fn ")
+        .filter(|(start, _)| {
+            *start == 0
+                || !masked[..*start]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| c.is_alphanumeric() || c == '_')
+        })
+        .last()
+        .map(|(start, _)| {
+            masked[start + 3..]
+                .trim_start()
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect::<String>()
+        })
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "<unknown fn>".to_string())
+}
+
+/// Body of `fn <name>` in `source`, literals kept, or `None` when the file
+/// does not define it.
+fn fn_body(source: &str, name: &str) -> Option<String> {
+    let braces = mask_lexical(source, false);
+    let strings = mask_lexical(source, true);
+    let needle = format!("fn {name}");
+    let at = braces.find(&needle)?;
+    let after = at + needle.len();
+    if braces[after..]
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_alphanumeric() || c == '_')
+    {
+        return None;
+    }
+    let open = after + braces[after..].find('{')?;
+    let close = matching_brace(&braces, open)?;
+    Some(strings[open..close].to_string())
+}
+
+/// Production `COMMIT` executes whose error handling does not roll back,
+/// reported as `path::fn`.
+///
+/// SQLite leaves the transaction **open** when `COMMIT` fails (the
+/// `SQLITE_BUSY` case), so a site that returns the commit error without a
+/// `ROLLBACK` wedges the process's single writer connection: every later write
+/// fails with "cannot start a transaction within a transaction" until the
+/// daemon restarts. PR #611 fixed the sites that existed then; this guard is
+/// what stops the twenty-second one from being written.
+///
+/// Two masked copies of the same source are read at the same offsets, which is
+/// exactly the split `mask_lexical` was built for: braces are counted on the
+/// copy with literals blanked, so a `{e}` inside a `format!` cannot move the
+/// depth counter, while `"COMMIT"` and `"ROLLBACK"` are read on the copy that
+/// keeps literals.
+fn commit_sites_without_rollback(path: &str, source: &str) -> Vec<String> {
+    let production = strip_cfg_test_items(source);
+    let strings = mask_lexical(&production, true);
+    let braces = mask_lexical(&production, false);
+    assert_eq!(
+        strings.len(),
+        braces.len(),
+        "mask_lexical must preserve byte length so one offset indexes both copies"
+    );
+
+    let mut sites = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(found) = strings[cursor..].find("\"COMMIT") {
+        let at = cursor + found;
+        cursor = at + "\"COMMIT".len();
+
+        // Only an executed statement counts. `conn.execute("COMMIT", ())`
+        // reads as `…execute(` before the literal; rustfmt may put the literal
+        // on its own line, so whitespace is skipped.
+        let head = strings[..at].trim_end();
+        let head = head.strip_suffix('(').unwrap_or(head).trim_end();
+        if !head.ends_with("execute") && !head.ends_with("execute_batch") {
+            continue;
+        }
+
+        // Back the window off to a char boundary: the reach is a byte count,
+        // and code outside blanked literals and comments is not guaranteed
+        // ASCII.
+        let mut reach = braces.len().min(at + COMMIT_ERROR_ARM_REACH);
+        while reach > at && !braces.is_char_boundary(reach) {
+            reach -= 1;
+        }
+        let arm = braces[at..reach]
+            .find('{')
+            .map(|offset| at + offset)
+            .and_then(|open| matching_brace(&braces, open).map(|close| (open, close)));
+        match arm {
+            Some((open, close)) if error_arm_rolls_back(&strings[open..close]) => {}
+            _ => sites.push(format!("{path}::{}", enclosing_fn_name(&braces, at))),
+        }
+    }
+    sites
+}
+
+#[test]
+fn every_db_commit_rolls_back_when_the_commit_fails() {
+    let root = repo_root();
+    let db_layer: Vec<String> = git_ls_files(&root, "*.rs")
+        .into_iter()
+        .filter(|path| is_db_layer_module(path) && !is_test_only_module(path))
+        .collect();
+    // A scan over nothing passes for free. `db.rs` plus its production child
+    // modules are always more than one file, so a smaller result means the
+    // pathspec stopped resolving rather than that the layer got clean.
+    assert!(
+        db_layer.len() > 1,
+        "the db layer resolved to {} file(s), so the scan cannot have run",
+        db_layer.len()
+    );
+
+    // The allow-list is only worth what its members do. Each named helper must
+    // be a real function in a scanned file whose own body executes a ROLLBACK.
+    for helper in ROLLBACK_HELPERS {
+        let found = db_layer.iter().find_map(|path| {
+            let source = std::fs::read_to_string(root.join(path)).expect("read Rust source");
+            fn_body(&source, helper).map(|body| (path.clone(), body))
+        });
+        let (path, body) = found.unwrap_or_else(|| {
+            panic!("rollback helper `{helper}` is not defined in any scanned db-layer file")
+        });
+        assert!(
+            body.contains("\"ROLLBACK\""),
+            "rollback helper `{helper}` in {path} no longer executes a ROLLBACK, so every \
+             commit error arm that calls it is unguarded"
+        );
+    }
+
+    let mut sites = Vec::new();
+    for path in &db_layer {
+        let source = std::fs::read_to_string(root.join(path)).expect("read Rust source");
+        sites.extend(commit_sites_without_rollback(path, &source));
+    }
+    assert!(
+        sites.is_empty(),
+        "a db-layer COMMIT returns its error without a ROLLBACK: {sites:?}. \
+         SQLite leaves the transaction open when COMMIT fails, so this wedges the \
+         process's only writer connection and every later write dies with \
+         \"cannot start a transaction within a transaction\". Roll back in the \
+         error arm, or call `commit_or_rollback`, which does it for you"
+    );
+}
+
+#[test]
+fn commit_rollback_guard_detects_the_wedge_and_ignores_recovered_shapes() {
+    // Positive control: the exact shape PR #611 removed -- commit, map the
+    // error, return it, transaction still open.
+    assert_eq!(
+        commit_sites_without_rollback(
+            "crates/wenlan-core/src/db.rs",
+            "impl MemoryDB { async fn wedge(&self, conn: &Connection) -> Result<()> { \
+             conn.execute(\"COMMIT\", ()).await.map_err(|e| Error::Db(format!(\"x: {e}\")))?; \
+             Ok(()) } }",
+        ),
+        ["crates/wenlan-core/src/db.rs::wedge"],
+        "a commit whose error is returned without a rollback must be caught"
+    );
+
+    // The `{e}` in that `format!` is why braces are counted on the
+    // literals-blanked copy: read on the other copy it opens a block that
+    // never closes.
+    for (label, source) in [
+        (
+            "if-let error arm",
+            "async fn ok_if_let(conn: &Connection) -> Result<()> { \
+             if let Err(error) = conn.execute(\"COMMIT\", ()).await { \
+             let _ = conn.execute(\"ROLLBACK\", ()).await; \
+             return Err(Error::Db(format!(\"commit: {error}\"))); } Ok(()) }",
+        ),
+        (
+            "match with both arms",
+            "async fn ok_match(conn: &Connection) -> Result<u64> { \
+             match conn.execute(\"COMMIT\", ()).await { Ok(rows) => Ok(rows), \
+             Err(e) => { let _ = conn.execute(\"ROLLBACK\", ()).await; \
+             Err(Error::Db(format!(\"commit: {e}\"))) } } }",
+        ),
+        (
+            "shared rollback helper",
+            "async fn ok_helper(conn: &Connection) -> Result<()> { \
+             if let Err(error) = conn.execute(\"COMMIT\", ()).await { \
+             let commit_error = Error::Db(format!(\"commit: {error}\")); \
+             rollback_repair_transaction(conn, &commit_error, false).await?; \
+             return Err(commit_error); } Ok(()) }",
+        ),
+        (
+            "rustfmt split across lines",
+            "async fn ok_split(conn: &Connection) -> Result<()> {\n    if let Err(error) = conn\n\
+             \x20       .execute(\n            \"COMMIT\",\n            (),\n        )\n\
+             \x20       .await\n    {\n        let _ = conn.execute(\"ROLLBACK\", ()).await;\n\
+             \x20       return Err(Error::Db(format!(\"commit: {error}\")));\n    }\n    Ok(())\n}",
+        ),
+    ] {
+        assert!(
+            commit_sites_without_rollback("crates/wenlan-core/src/db.rs", source).is_empty(),
+            "{label}: a commit that already rolls back is not a violation"
+        );
+    }
+
+    // Not executes at all: a doc comment naming COMMIT, and a literal that is
+    // never handed to the connection.
+    for (label, source) in [
+        (
+            "doc comment",
+            "/// Runs conn.execute(\"COMMIT\") for the caller.\n\
+             async fn documented(conn: &Connection) { let _ = conn; }",
+        ),
+        (
+            "literal that is never executed",
+            "async fn labelled(conn: &Connection) { let stage = \"COMMIT\"; \
+             let _ = (conn, stage); }",
+        ),
+    ] {
+        assert!(
+            commit_sites_without_rollback("crates/wenlan-core/src/db.rs", source).is_empty(),
+            "{label}: only an executed COMMIT statement is a site"
+        );
+    }
+
+    // Test-only code is out of scope both ways: by path, and by cfg attribute
+    // inside a production file.
+    assert!(
+        !is_db_layer_module("crates/wenlan-core/src/post_ingest.rs"),
+        "the guard covers the db layer, which is where the writer connection lives"
+    );
+    assert!(
+        is_test_only_module("crates/wenlan-core/src/db/main_tests.rs"),
+        "db test modules must be out of scope -- their bare COMMITs are fixtures"
+    );
+    assert!(
+        commit_sites_without_rollback(
+            "crates/wenlan-core/src/db.rs",
+            "#[cfg(test)]\nmod tests {\n    async fn fixture(conn: &Connection) {\n\
+             \x20       conn.execute(\"COMMIT\", ()).await.unwrap();\n    }\n}",
+        )
+        .is_empty(),
+        "a cfg(test) module inside a production file is not a production writer"
+    );
+
+    // `fn_body` is what makes the allow-list checkable, so it must actually
+    // read a body and stop at its close.
+    let body = fn_body(
+        "async fn helper(conn: &Connection) { conn.execute(\"ROLLBACK\", ()).await; }\n\
+         async fn after() { let _ = \"COMMIT\"; }",
+        "helper",
+    )
+    .expect("fn_body must find a defined function");
+    assert!(body.contains("\"ROLLBACK\""));
+    assert!(
+        !body.contains("\"COMMIT\""),
+        "fn_body must stop at the function's closing brace"
+    );
+    assert!(
+        fn_body("async fn helper_two() {}", "helper").is_none(),
+        "a longer name must not answer for the one asked about"
+    );
+}

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_api_manifest.txt
@@ -833,6 +833,11 @@ crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::
 crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_legacy_page_write_card_without_version_still_accepts|TestDbSession::execute|1
 crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_legacy_page_write_card_without_version_still_accepts|TestDbSession::query|1
 crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_legacy_page_write_card_without_version_still_accepts|test_primary_session|1
+crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing|TestDbRow::get|1
+crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing|TestDbRows::next|1
+crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing|TestDbSession::execute|1
+crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing|TestDbSession::query|1
+crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing|test_primary_session|1
 crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::create_entity_minhash_disabled_is_noop|TestDbRow::get|1
 crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::create_entity_minhash_disabled_is_noop|TestDbRows::next|1
 crates/wenlan-core/src/post_write/post_write_tests.rs|crate::post_write::tests::create_entity_minhash_disabled_is_noop|TestDbSession::query|1

--- a/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
+++ b/crates/wenlan-core/src/drift_guard/r4_test_support_test.rs
@@ -3229,7 +3229,7 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
     );
     assert_eq!(
         analysis.support_calls.len(),
-        1041,
+        1046,
         "PR-D integration must expose the frozen 967 support calls, the 6 PR-D test identities, \
          the 5 M5 derivation-marker fixture calls, the 10 M6 shadow-promoter fixture calls, \
          the 7 G6 BindPageLink repair-test calls (G6 Stage 2 PR 2b, item 3: \
@@ -3348,7 +3348,13 @@ fn repository_module_graph_matches_r4_25_group_6_census() {
          synthesis/distill.rs's new refresh_page_rebuilds_the_summary_from_the_new_body \
          contributes test_primary_session|1 and TestDbSession::execute|1 (the raw UPDATE that \
          plants an old first-bullet summary on the page before the refresh re-derives it from \
-         the new body)"
+         the new body); plus the 5 PR #598 follow-up calls in \
+         post_write::tests::\
+         accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing, \
+         which ages a staged page card back to its pre-#598 shape to prove the accept path \
+         refuses it: test_primary_session|1, TestDbSession::query|1, TestDbRows::next|1 and \
+         TestDbRow::get|1 read the card's structured_fields, TestDbSession::execute|1 writes \
+         them back with source_revision removed"
     );
 }
 

--- a/crates/wenlan-core/src/post_ingest.rs
+++ b/crates/wenlan-core/src/post_ingest.rs
@@ -163,6 +163,28 @@ pub async fn run_title_enrichment_slice(
     })
 }
 
+/// A memory that matches no growable page is finished for this generation:
+/// record the step as ok at the input's version and report the terminal
+/// no-match. Reached three ways -- nothing matched at all, the matched page
+/// vanished before the reload, and the reloaded page no longer satisfies the
+/// match -- which is why it is one function rather than three copies.
+async fn terminal_no_match(
+    db: &MemoryDB,
+    source_id: &str,
+    version: i64,
+) -> Result<PageGrowthSliceReport, WenlanError> {
+    let committed = db
+        .record_enrichment_step_at_version(source_id, "page_growth", "ok", None, version)
+        .await?;
+    Ok(PageGrowthSliceReport {
+        selected: true,
+        matched: false,
+        terminal_no_match: true,
+        committed,
+        llm_calls: 0,
+    })
+}
+
 /// Advance one restart-safe Page-growth item. Matching is CPU-only and occurs
 /// before admission to the model. A no-match result is terminal for the
 /// current memory generation; a match gets exactly one model request and a
@@ -227,22 +249,7 @@ pub async fn run_page_growth_slice(
         )
         .await?
     else {
-        let committed = db
-            .record_enrichment_step_at_version(
-                &input.source_id,
-                "page_growth",
-                "ok",
-                None,
-                input.version,
-            )
-            .await?;
-        return Ok(PageGrowthSliceReport {
-            selected: true,
-            matched: false,
-            terminal_no_match: true,
-            committed,
-            llm_calls: 0,
-        });
+        return terminal_no_match(db, &input.source_id, input.version).await;
     };
     pause_after_match(&page.id).await;
     let expected_source_revision = db.get_page_source_revision(&page.id).await?;
@@ -254,23 +261,28 @@ pub async fn run_page_growth_slice(
     // or a detach that landed just before the counter read gets baked back
     // into the write it is supposed to prevent.
     let Some(page) = db.get_page(&page.id).await? else {
-        let committed = db
-            .record_enrichment_step_at_version(
-                &input.source_id,
-                "page_growth",
-                "ok",
-                None,
-                input.version,
-            )
-            .await?;
-        return Ok(PageGrowthSliceReport {
-            selected: true,
-            matched: false,
-            terminal_no_match: true,
-            committed,
-            llm_calls: 0,
-        });
+        return terminal_no_match(db, &input.source_id, input.version).await;
     };
+
+    // The reload refreshes the row, not the decision. `find_matching_page_scoped`
+    // also reads `review_status`, `space` and page ownership, and any of those can
+    // move in the match-to-reload window: a human takes the page over, it is sent
+    // back for review, it is moved to another space. Ask the same question again
+    // against the current rows and stop when this page is no longer the answer,
+    // rather than spending a model call on a write the fences would refuse.
+    if db
+        .find_matching_page_scoped(
+            input.entity_id.as_deref(),
+            &mem_embedding,
+            growth_threshold,
+            input.space.as_deref(),
+            false,
+        )
+        .await?
+        .is_none_or(|matched| matched.id != page.id)
+    {
+        return terminal_no_match(db, &input.source_id, input.version).await;
+    }
 
     let clean_current = crate::citations::strip_markers(&page.content);
     let evidence = db.get_page_evidence(&page.id).await.unwrap_or_default();
@@ -917,6 +929,17 @@ pub(crate) async fn grow_page(
     let Some(page) = db.get_page(&page.id).await? else {
         return Ok(false);
     };
+
+    // Same recheck as `run_page_growth_slice`, same reason: the reload refreshes
+    // the row but not the decision, and a page that stopped being a legal dedup
+    // target in the match-to-reload window must not reach the model.
+    if db
+        .find_matching_page_scoped(entity_id, mem_embedding, growth_threshold, space, true)
+        .await?
+        .is_none_or(|matched| matched.id != page.id)
+    {
+        return Ok(false);
+    }
 
     // (a) Input hygiene — strip stale [N] markers from the current body before
     // it goes into the prompt (⚖ §4). The old markers pointed at a numbered
@@ -2249,6 +2272,108 @@ mod tests {
             .contains(&"match-reload-a".to_string()));
     }
 
+    /// The reload after the counter read refreshes the matched row but never
+    /// re-asks whether that row is still a legal growth target. A human taking
+    /// the page over in the match-to-reload window leaves a page
+    /// `find_matching_page_scoped` would now refuse, and the slice would still
+    /// spend a model call on it. Mutation check: delete the post-reload match
+    /// recheck and this test sees `llm_calls == 1`.
+    #[tokio::test]
+    async fn page_growth_slice_skips_a_page_that_stopped_matching_before_the_reload() {
+        let (db, _dir) = test_db().await;
+        let db = Arc::new(db);
+        let entity_id = db
+            .create_entity("Post Reload Recheck", "Topic", Some("work"))
+            .await
+            .unwrap();
+        insert_growth_page(
+            &db,
+            "recheck-page",
+            &entity_id,
+            "work",
+            "page before the human took it over",
+        )
+        .await;
+        seed_page_growth_memory(
+            &db,
+            "recheck-source",
+            "source evidence for the post-reload recheck",
+            Some(&entity_id),
+            Some("work"),
+        )
+        .await;
+        db.link_page_source("recheck-page", "recheck-source", "test_source")
+            .await
+            .unwrap();
+        seed_page_growth_memory(
+            &db,
+            "recheck-trigger",
+            "new evidence that triggers page growth",
+            Some(&entity_id),
+            Some("work"),
+        )
+        .await;
+
+        let stub = Arc::new(CapturingStubProvider {
+            response: "growth that must never be generated.[1][2]".to_string(),
+            captured_prompt: std::sync::Mutex::new(None),
+        });
+        let llm: Arc<dyn LlmProvider> = stub.clone();
+
+        let (parked_tx, parked_rx) = tokio::sync::oneshot::channel();
+        let (go_tx, go_rx) = tokio::sync::oneshot::channel();
+        *POST_MATCH_PAUSE_GATE.lock().unwrap() =
+            Some(("recheck-page".to_string(), parked_tx, go_rx));
+
+        let prompts = PromptRegistry::default();
+        let slice = run_page_growth_slice(&db, &llm, &prompts, 2.0, None);
+        let take_over = async {
+            parked_rx
+                .await
+                .expect("growth slice must reach the post-match pause");
+            let page = db.get_page("recheck-page").await.unwrap().unwrap();
+            assert!(db
+                .try_update_page_content_with_changelog_at_version(
+                    "recheck-page",
+                    "the human owns this page now",
+                    &["recheck-source"],
+                    "fs_edit",
+                    "[]",
+                    None,
+                    page.version,
+                    None,
+                )
+                .await
+                .unwrap());
+            go_tx.send(()).expect("growth slice must still be parked");
+        };
+
+        let (report, _) = tokio::join!(slice, take_over);
+        let report = report.unwrap();
+
+        assert!(report.selected);
+        assert!(
+            !report.matched,
+            "a page that no longer satisfies the match predicate is not a match"
+        );
+        assert!(report.terminal_no_match);
+        assert!(
+            report.committed,
+            "the memory is done for this generation, so its receipt must land"
+        );
+        assert_eq!(
+            report.llm_calls, 0,
+            "the recheck must land before the model call, not after it"
+        );
+        assert!(
+            stub.captured_prompt.lock().unwrap().is_none(),
+            "no prompt may be built for a page that stopped matching"
+        );
+        let page = db.get_page("recheck-page").await.unwrap().unwrap();
+        assert_eq!(page.content, "the human owns this page now");
+        assert!(page.user_edited);
+    }
+
     #[tokio::test]
     async fn page_growth_slice_rejects_page_changed_during_inference() {
         let (db, _dir) = test_db().await;
@@ -2668,6 +2793,91 @@ mod tests {
         assert!(page
             .source_memory_ids
             .contains(&"grow-page-match-reload-a".to_string()));
+    }
+
+    /// The same post-reload recheck on the legacy `grow_page` entrypoint.
+    /// `grow_page` matches with `allow_user_edited = true`, so what bites there
+    /// is a page sent back for review: `review_status` leaves `confirmed` in the
+    /// match-to-reload window and the page stops being a dedup target. Mutation
+    /// check: delete the recheck and `grow_page` generates and writes anyway.
+    #[tokio::test]
+    async fn grow_page_skips_a_page_that_stopped_matching_before_the_reload() {
+        let (db, _dir) = test_db().await;
+        let entity_id = db
+            .create_entity("Grow Page Post Reload Recheck", "Topic", Some("work"))
+            .await
+            .unwrap();
+        insert_growth_page(
+            &db,
+            "grow-recheck-page",
+            &entity_id,
+            "work",
+            "page before it left the confirmed set",
+        )
+        .await;
+        seed_page_growth_memory(
+            &db,
+            "grow-recheck-source",
+            "source evidence for the grow_page recheck",
+            Some(&entity_id),
+            Some("work"),
+        )
+        .await;
+        db.link_page_source("grow-recheck-page", "grow-recheck-source", "test_source")
+            .await
+            .unwrap();
+        seed_page_growth_memory(
+            &db,
+            "grow-recheck-trigger",
+            "new evidence that triggers page growth",
+            Some(&entity_id),
+            Some("work"),
+        )
+        .await;
+
+        let stub = std::sync::Arc::new(CapturingStubProvider {
+            response: "growth that must never be generated.[1][2]".to_string(),
+            captured_prompt: std::sync::Mutex::new(None),
+        });
+        let llm: std::sync::Arc<dyn LlmProvider> = stub.clone();
+
+        let (parked_tx, parked_rx) = tokio::sync::oneshot::channel();
+        let (go_tx, go_rx) = tokio::sync::oneshot::channel();
+        *POST_MATCH_PAUSE_GATE.lock().unwrap() =
+            Some(("grow-recheck-page".to_string(), parked_tx, go_rx));
+
+        let prompts = crate::prompts::PromptRegistry::default();
+        let grow = grow_page(
+            &db,
+            "grow-recheck-trigger",
+            "new evidence that triggers page growth",
+            Some(&entity_id),
+            Some("work"),
+            Some(&llm),
+            &prompts,
+            2.0,
+        );
+        let unconfirm = async {
+            parked_rx
+                .await
+                .expect("grow_page must reach the post-match pause");
+            db.set_page_review_status("grow-recheck-page", "unconfirmed")
+                .await
+                .unwrap();
+            go_tx.send(()).expect("grow_page must still be parked");
+        };
+
+        let (grew, _) = tokio::join!(grow, unconfirm);
+        assert!(
+            !grew.unwrap(),
+            "a page that left the confirmed set must not be grown"
+        );
+        assert!(
+            stub.captured_prompt.lock().unwrap().is_none(),
+            "no prompt may be built for a page that stopped matching"
+        );
+        let page = db.get_page("grow-recheck-page").await.unwrap().unwrap();
+        assert_eq!(page.content, "page before it left the confirmed set");
     }
 
     /// Spec §5.1 (True source kinds): `grow_page`'s numbered-source list must

--- a/crates/wenlan-core/src/post_write/page_revision.rs
+++ b/crates/wenlan-core/src/post_write/page_revision.rs
@@ -66,9 +66,9 @@ async fn resolve_page_revision_card(
     // only decodes two legacy shapes: cards staged before the field existed
     // at all (missing key), and cards staged in the window where the field
     // existed but callers could still pass `None` through it (a literal JSON
-    // `null`). Both are treated the same as a pre-versioning `page_version`:
-    // accepted on the version fence alone rather than inventing a base to
-    // check.
+    // `null`). Both are stale by construction, and
+    // `accept_page_revision_card` refuses them -- see the rejection there for
+    // why a missing base cannot be substituted with the version fence.
     let source_revision = structured.get("source_revision").and_then(|v| v.as_i64());
 
     Ok(Some(PageRevisionCard {
@@ -81,15 +81,40 @@ async fn resolve_page_revision_card(
     }))
 }
 
-// Current PageWrite cards record the Page version they were staged from, and
-// `try_accept_page_revision` checks it atomically with card consumption.
-// Legacy cards without `page_version` remain accepted for compatibility; their
-// missing base is explicit in `PageRevisionCard` rather than silently invented.
+// Current PageWrite cards record the Page version *and* the source revision
+// they were staged from, and `try_accept_page_revision` checks both atomically
+// with card consumption. A card carrying no `source_revision` is refused
+// outright and its page re-queued; a card carrying no `page_version` still
+// accepts on the source-revision fence, which is the stronger of the two.
 async fn accept_page_revision_card(
     db: &MemoryDB,
     card: PageRevisionCard,
     knowledge_path: Option<&Path>,
 ) -> Result<wenlan_types::RevisionAcceptResponse, WenlanError> {
+    // A card staged before source-revision fencing (PR #598) records no base
+    // to check its evidence against. `version` alone cannot stand in: it does
+    // not move when a source is attached to or detached from the page, so a
+    // card compiled from evidence the page no longer holds would still pass
+    // the version fence and write prose citing sources that are gone. Nothing
+    // on the row can tell us whether that happened. So refuse the card,
+    // delete it, and mark the page stale -- `"source_updated"` is the reason
+    // string every stale-page consumer queries -- so the refresh lane
+    // regenerates a fenced card from the evidence the page holds now.
+    //
+    // Stale first, delete second: if the delete fails the page is merely
+    // re-queued twice, whereas the other order can drop the card while
+    // leaving the page unqueued, with nothing left to rebuild it from.
+    if card.source_revision.is_none() {
+        db.set_page_stale(&card.page_id, "source_updated").await?;
+        db.delete_by_source_id("memory", &card.revision_id).await?;
+        return Err(WenlanError::Conflict(format!(
+            "revision card {} for page {} was staged before source-revision fencing, so it \
+             cannot be checked against the page's current sources. The card has been \
+             discarded and the page re-queued to be regenerated from the sources it holds now.",
+            card.revision_id, card.page_id
+        )));
+    }
+
     let current = db
         .get_page(&card.page_id)
         .await?

--- a/crates/wenlan-core/src/post_write/post_write_tests.rs
+++ b/crates/wenlan-core/src/post_write/post_write_tests.rs
@@ -5262,6 +5262,133 @@ async fn accept_pending_revision_legacy_page_write_card_without_version_still_ac
     );
 }
 
+/// A card staged before source-revision fencing (PR #598) records no base to
+/// check its evidence against, and `version` cannot stand in for one: attaching
+/// or detaching a source leaves `version` untouched. Accepting such a card on
+/// the version fence alone would write prose citing sources the page may no
+/// longer hold. It is refused, deleted, and the page re-queued instead.
+#[tokio::test]
+async fn accept_pending_revision_discards_a_page_card_staged_before_source_revision_fencing() {
+    let (db, _dir) = test_db().await;
+    let mem_id = "mem_page_accept_prefence_original";
+    let new_mem_id = "mem_page_accept_prefence_new";
+    let original_content = "Rust ownership keeps memory safety rules explicit";
+    let human_content = "Rust ownership keeps memory safety rules explicit, with human notes";
+    let proposed_content =
+        "Rust ownership lets the compiler enforce memory safety during page refresh";
+
+    seed_memory(&db, mem_id, original_content).await;
+    seed_memory(&db, new_mem_id, proposed_content).await;
+    let page_id = seed_page(&db, mem_id, original_content).await;
+    update_page(
+        &db,
+        &page_id,
+        UpdatePageRequest {
+            content: human_content.to_string(),
+            source_memory_ids: vec![mem_id.to_string()],
+            expected_version: None,
+            caller_id: None,
+            operation_id: None,
+        },
+        "fs_edit",
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let staged_source_revision = db.get_page_source_revision(&page_id).await.unwrap();
+    let card = stage_page_revision_card(
+        &db,
+        &before,
+        proposed_content,
+        &[mem_id.to_string(), new_mem_id.to_string()],
+        staged_source_revision,
+        "page_growth",
+        None,
+    )
+    .await
+    .unwrap();
+    let card_id = card
+        .revision_card_id
+        .as_deref()
+        .expect("staged page card must return an id")
+        .to_string();
+
+    // Age the card back to a pre-#598 staging: the field is gone entirely,
+    // which is what the cards already sitting in real queues look like.
+    {
+        let conn = db.test_primary_session().await;
+        let mut rows = conn
+            .query(
+                "SELECT structured_fields FROM memories WHERE source_id = ?1",
+                libsql::params![card_id.clone()],
+            )
+            .await
+            .unwrap();
+        let row = rows
+            .next()
+            .await
+            .unwrap()
+            .expect("revision card row must exist");
+        let structured_fields = row.get::<String>(0).unwrap();
+        drop(rows);
+
+        let mut structured: serde_json::Value = serde_json::from_str(&structured_fields).unwrap();
+        structured
+            .as_object_mut()
+            .expect("structured_fields must be an object")
+            .remove("source_revision");
+        conn.execute(
+            "UPDATE memories SET structured_fields = ?1 WHERE source_id = ?2",
+            libsql::params![structured.to_string(), card_id.clone()],
+        )
+        .await
+        .unwrap();
+    }
+
+    let err = accept_pending_revision(&db, &card_id, "test-agent")
+        .await
+        .unwrap_err();
+    let WenlanError::Conflict(message) = err else {
+        panic!("a card carrying no source_revision must be refused as a conflict: {err:?}");
+    };
+    assert!(
+        message.contains(&card_id) && message.contains(&page_id),
+        "the refusal must name the card and the page: {message}"
+    );
+    assert!(
+        message.contains("discarded") && message.contains("re-queued"),
+        "the refusal is permanent, so it must say the card is gone and the page will be \
+         regenerated rather than invite a retry that can never succeed: {message}"
+    );
+
+    let after = db.get_page(&page_id).await.unwrap().unwrap();
+    assert_eq!(
+        after.content, human_content,
+        "the stale card's prose must not reach the page"
+    );
+    assert_eq!(
+        after.stale_reason.as_deref(),
+        Some("source_updated"),
+        "the page must be re-queued for regeneration"
+    );
+    assert!(
+        db.get_page_source_revision(&page_id).await.unwrap() > staged_source_revision,
+        "re-queueing must bump the source revision so no other card staged against the \
+         old evidence can win a later race"
+    );
+    assert!(
+        db.pending_memory_revision_payload(&card_id)
+            .await
+            .unwrap()
+            .is_none(),
+        "the discarded card must be gone from the pending queue"
+    );
+}
+
 #[tokio::test]
 async fn accept_pending_revision_returns_not_found_on_missing_id() {
     let (db, _tmp) = crate::db::tests::test_db().await;

--- a/src/components/memory/ReviewDialog.tsx
+++ b/src/components/memory/ReviewDialog.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import {
+  daemonErrorMessage,
   getEntityDetail,
   getMemoryDetail,
   getPage,
@@ -535,7 +536,12 @@ export default function ReviewDialog({
   const [showDone, setShowDone] = useState(false);
   const [sideBySide, setSideBySide] = useState(false);
   const [flash, setFlash] = useState<string | null>(null);
-  const [resolveError, setResolveError] = useState(false);
+  // The sentence shown when a resolve fails, not just a flag. Some refusals
+  // are permanent and say so — a revision card staged before source-revision
+  // fencing is discarded and its page re-queued, so "Try again" would be an
+  // instruction to do something that can never work. Falls back to the
+  // generic wording when the daemon sent no explanation.
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const [resolvingLocally, setResolvingLocally] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
   const navigationVersionRef = useRef(0);
@@ -657,7 +663,7 @@ export default function ReviewDialog({
 
   useEffect(() => {
     navigationVersionRef.current += 1;
-    setResolveError(false);
+    setResolveError(null);
   }, [openId]);
 
   const resolveCurrent = async (approve: boolean) => {
@@ -677,16 +683,16 @@ export default function ReviewDialog({
     const next = items[index + 1] ?? (index > 0 ? items[index - 1] : null);
     const navigationVersion = navigationVersionRef.current;
     const requestId = ++resolveRequestRef.current;
-    setResolveError(false);
+    setResolveError(null);
     setResolvingLocally(true);
     try {
       await onResolve({ item, approve });
-    } catch {
+    } catch (error) {
       if (
         resolveRequestRef.current === requestId &&
         navigationVersionRef.current === navigationVersion
       ) {
-        setResolveError(true);
+        setResolveError(daemonErrorMessage(error) ?? t("review.actionError"));
       }
       return;
     } finally {
@@ -1462,7 +1468,7 @@ export default function ReviewDialog({
                   padding: "9px 11px",
                 }}
               >
-                {t("review.actionError")}
+                {resolveError}
               </p>
             )}
 

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -1088,3 +1088,34 @@ describe("daemonMeetsFloor", () => {
     expect(daemonMeetsFloor("0.13.0", "0.13.0")).toBe(true);
   });
 });
+
+describe("daemonErrorMessage", () => {
+  it("pulls the daemon's sentence out of a rejected command string", () => {
+    expect(
+      tauri.daemonErrorMessage(
+        "HTTP POST /api/memory/revision/mem_1/accept returned 409 Conflict: "
+        + '{"error":"page revision card mem_1 for page page_a was staged before '
+        + 'source-revision fencing; it has been discarded and the page re-queued"}',
+      ),
+    ).toBe(
+      "page revision card mem_1 for page page_a was staged before "
+      + "source-revision fencing; it has been discarded and the page re-queued",
+    );
+  });
+
+  it("reads an Error's message the same way as a raw string rejection", () => {
+    expect(
+      tauri.daemonErrorMessage(new Error('returned 409 Conflict: {"error":"stale card"}')),
+    ).toBe("stale card");
+  });
+
+  it("returns null when the rejection carries no daemon body", () => {
+    // A transport failure never reaches a route, so the caller keeps its own
+    // wording rather than showing the reader a socket error.
+    expect(tauri.daemonErrorMessage("HTTP POST /api/x: connection refused")).toBeNull();
+    expect(tauri.daemonErrorMessage("returned 500: {not json")).toBeNull();
+    expect(tauri.daemonErrorMessage('returned 500: {"error":"  "}')).toBeNull();
+    expect(tauri.daemonErrorMessage('returned 500: {"detail":"no error key"}')).toBeNull();
+    expect(tauri.daemonErrorMessage(undefined)).toBeNull();
+  });
+});

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -1152,6 +1152,32 @@ function pageDraftErrorText(error: unknown): string {
   return String(error);
 }
 
+/**
+ * The daemon's own sentence out of a rejected Tauri command.
+ *
+ * A rejected command carries a formatted string, not an Error:
+ * `HTTP POST /api/... returned 409 Conflict: {"error":"..."}` (app/src/api.rs
+ * `post_empty`). The URL and the status are ours; the part worth showing a
+ * person is the `error` field of the JSON body the daemon sent, which is where
+ * a route explains what it refused and what it did instead. Returns null when
+ * the rejection carries no daemon body, so callers keep their own wording for
+ * transport failures.
+ */
+export function daemonErrorMessage(error: unknown): string | null {
+  const text = pageDraftErrorText(error);
+  const objectStart = text.indexOf("{");
+  if (objectStart < 0) return null;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(text.slice(objectStart));
+  } catch {
+    return null;
+  }
+  if (typeof payload !== "object" || payload === null) return null;
+  const message = Reflect.get(payload, "error");
+  return typeof message === "string" && message.trim() !== "" ? message : null;
+}
+
 function parsePageDraftError(error: unknown): PageDraftApiError | null {
   const message = pageDraftErrorText(error);
   const objectStart = message.indexOf("{");


### PR DESCRIPTION
## Summary

- `fix(core): fence page writes on an immutable incarnation token` — stamps each page with an incarnation token at creation and rejects writes that target a stale incarnation.
- `fix(core): refuse page revision cards staged before source-revision fencing` — rejects revision cards staged before the source-revision fence was in place, so stale cards can't slip through.
- `fix(core): recompute the growth match after the post-counter-read reload` — recomputes the growth match after the counter is reloaded, instead of reusing a value read before the reload.
- `fix(core): match migration 126's legacy attempt keys exactly` — matches migration 126's legacy attempt keys exactly rather than by prefix, avoiding accidental matches.
- `test(core): guard every db-layer COMMIT against the open-transaction wedge` — adds a guard test that catches any db-layer COMMIT issued while a transaction is still open.

Adds schema migration 128 and bumps SCHEMA_VERSION. Verified against main (schema version 127, no migration 128) before rebasing — no renumbering was needed.

## Test plan

- `WENLAN_NO_AUTOSTART=1 cargo test -p wenlan-core migration` — rc=0, 184 passed, 1 ignored
- `WENLAN_NO_AUTOSTART=1 cargo test -p wenlan-core incarnation` — rc=0, 3 passed
- `WENLAN_NO_AUTOSTART=1 cargo test -p wenlan-core drift_guard` — rc=0, 158 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
