### PR TITLE
fix(ci): stop requiring a version bump in a file that no longer has one

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -69,14 +69,6 @@ else
 fi
 echo "  Updated $CODEX_PLUGIN_MCP_RUNNER (wenlan-mcp pin)"
 
-CODEX_PLUGIN_README="plugin-codex/README.md"
-if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_README"
-else
-    sed -i -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_README"
-fi
-echo "  Updated $CODEX_PLUGIN_README (wenlan-mcp pin)"
-
 # 5. /setup skill install.sh URL pinned to current tag (not `main`), so the
 # install one-liner is reproducible at the release boundary.
 SETUP_SKILL="plugin/skills/setup/SKILL.md"

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -50,10 +50,6 @@ cat > "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" <<EOF
 exec npx -y wenlan-mcp@^0.4.1 --agent-name "\${agent_name}" "\$@"
 EOF
 
-cat > "$TMPDIR_TEST/plugin-codex/README.md" <<EOF
-Falls back to npx -y wenlan-mcp@^0.4.1 when no local runtime exists.
-EOF
-
 cat > "$TMPDIR_TEST/app/Cargo.toml" <<EOF
 [package]
 name = "wenlan-app"
@@ -151,7 +147,6 @@ APP_PKG_VER=$(jq -r .version "$TMPDIR_TEST/package.json")
 grep -q '# x-release-please-version' "$TMPDIR_TEST/app/Cargo.toml" || { echo "FAIL: app/Cargo.toml lost its x-release-please-version marker"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin/skills/setup/SKILL.md" || { echo "FAIL: setup skill installer not bumped"; exit 1; }
 grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" || { echo "FAIL: Codex runner pin not bumped"; exit 1; }
-grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin-codex/README.md" || { echo "FAIL: Codex README runner pin not bumped"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" || { echo "FAIL: Codex setup skill installer not bumped"; exit 1; }
 
 # Cargo.lock: all five workspace members bumped to 0.5.0, exactly as

--- a/scripts/ci_measure_plan.py
+++ b/scripts/ci_measure_plan.py
@@ -35,7 +35,6 @@ RELEASE_MANAGED_PATHS = frozenset(
         "crates/wenlan-mcp/npm/package.json",
         "package.json",
         "plugin-codex/.codex-plugin/plugin.json",
-        "plugin-codex/README.md",
         "plugin-codex/bin/wenlan-mcp-runner.sh",
         "plugin-codex/skills/setup/SKILL.md",
         "plugin/.claude-plugin/plugin.json",

--- a/scripts/validate-release-candidate.py
+++ b/scripts/validate-release-candidate.py
@@ -65,7 +65,6 @@ RELEASE_MANAGED_PATHS = frozenset(
         "crates/wenlan-mcp/npm/package.json",
         "package.json",
         "plugin-codex/.codex-plugin/plugin.json",
-        "plugin-codex/README.md",
         "plugin-codex/bin/wenlan-mcp-runner.sh",
         "plugin-codex/skills/setup/SKILL.md",
         "plugin/.claude-plugin/plugin.json",

--- a/scripts/validate-release-candidate.test.py
+++ b/scripts/validate-release-candidate.test.py
@@ -1168,7 +1168,7 @@ class ValidateReleaseCandidateTests(unittest.TestCase):
         self.assertEqual((version, base_sha), ("0.15.4", BASE_SHA))
         self.assertEqual(paths, VALIDATOR.REQUIRED_RELEASE_PATHS)
 
-        new["plugin-codex/README.md"] += "unrelated executable instruction\n"
+        new["plugin-codex/skills/setup/SKILL.md"] += "unrelated executable instruction\n"
         with self.assertRaisesRegex(VALIDATOR.CandidateError, "exact version-only"):
             VALIDATOR.validate_release_pr_content(
                 FakeContentApi(old, new), "7xuanlu/wenlan", candidate_pr()

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -34,7 +34,6 @@ PLUGIN_VER=$(jq -r .version plugin/.claude-plugin/plugin.json)
 CODEX_PLUGIN_VER_RAW=$(jq -r .version plugin-codex/.codex-plugin/plugin.json)
 CODEX_PLUGIN_VER="${CODEX_PLUGIN_VER_RAW%%+*}"
 CODEX_RUNNER_PINS=$(grep -Eo 'wenlan-mcp@\^[0-9]+\.[0-9]+\.[0-9]+' plugin-codex/bin/wenlan-mcp-runner.sh | sed -E 's/.*@\^//' | sort -u || true)
-CODEX_README_PINS=$(grep -Eo 'wenlan-mcp@\^[0-9]+\.[0-9]+\.[0-9]+' plugin-codex/README.md | sed -E 's/.*@\^//' | sort -u || true)
 CODEX_SETUP_TAGS=$(grep -Eo '/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' plugin-codex/skills/setup/SKILL.md | sed -E 's|/v([^/]+)/install\.sh|\1|' | sort -u || true)
 
 echo "Tag:         $TAG_VER"
@@ -53,8 +52,6 @@ echo "Plugin:      $PLUGIN_VER"
 echo "Codex plugin: $CODEX_PLUGIN_VER_RAW"
 echo "Codex runner pins:"
 printf '%s\n' "$CODEX_RUNNER_PINS" | sed 's/^/  /'
-echo "Codex README pins:"
-printf '%s\n' "$CODEX_README_PINS" | sed 's/^/  /'
 echo "Codex setup tags:"
 printf '%s\n' "$CODEX_SETUP_TAGS" | sed 's/^/  /'
 
@@ -63,14 +60,14 @@ if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$WENLAN_TYPES_DEP
     exit 1
 fi
 
-for pin in $CODEX_RUNNER_PINS $CODEX_README_PINS $CODEX_SETUP_TAGS; do
+for pin in $CODEX_RUNNER_PINS $CODEX_SETUP_TAGS; do
     if [[ "$pin" != "$TAG_VER" ]]; then
         echo "ERROR: Codex plugin release pin drift — ${pin} is not ${TAG_VER}"
         exit 1
     fi
 done
 
-if [[ -z "$CODEX_RUNNER_PINS" || -z "$CODEX_README_PINS" || -z "$CODEX_SETUP_TAGS" ]]; then
+if [[ -z "$CODEX_RUNNER_PINS" || -z "$CODEX_SETUP_TAGS" ]]; then
     echo "ERROR: Codex plugin release pin missing"
     exit 1
 fi

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -61,9 +61,6 @@ echo '{"name": "wenlan-app", "version": "0.5.0"}' > "$TMPDIR_TEST/package.json"
 cat > "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" <<EOF
 exec npx -y wenlan-mcp@^0.5.0 --agent-name "\${agent_name}" "\$@"
 EOF
-cat > "$TMPDIR_TEST/plugin-codex/README.md" <<EOF
-Fallbacks to npx -y wenlan-mcp@^0.5.0 when no local runtime exists.
-EOF
 cat > "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" <<EOF
 curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.5.0/install.sh | bash
 EOF
@@ -156,28 +153,6 @@ if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-ver
     exit 1
 fi
 echo "PASS test 7: Codex setup install tag drift detected"
-
-perl -0pi -e 's|/v0\.4\.9/install\.sh|/v0.5.0/install.sh|g' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md"
-perl -0pi -e 's/wenlan-mcp@\^0\.5\.0/wenlan-mcp@^0.4.9/g' "$TMPDIR_TEST/plugin-codex/README.md"
-if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
-    echo "FAIL test 8: should have detected Codex README runner pin drift"
-    exit 1
-fi
-echo "PASS test 8: Codex README runner pin drift detected"
-
-cat > "$TMPDIR_TEST/plugin-codex/README.md" <<EOF
-No package fallback is documented here.
-EOF
-if output=$(cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh" 2>&1); then
-    echo "FAIL test 9: should have detected missing Codex README runner pin"
-    exit 1
-fi
-if ! printf '%s\n' "$output" | grep -q "Codex plugin release pin missing"; then
-    echo "FAIL test 9: missing pin error was not reported"
-    printf '%s\n' "$output"
-    exit 1
-fi
-echo "PASS test 9: Codex README runner pin missing detected"
 
 assert_release_job_pins_release_sha() {
     local workflow="$1"

--- a/scripts/verify-release-merge.py
+++ b/scripts/verify-release-merge.py
@@ -37,7 +37,6 @@ RELEASE_MANAGED_PATHS = frozenset(
         "crates/wenlan-mcp/npm/package.json",
         "package.json",
         "plugin-codex/.codex-plugin/plugin.json",
-        "plugin-codex/README.md",
         "plugin-codex/bin/wenlan-mcp-runner.sh",
         "plugin-codex/skills/setup/SKILL.md",
         "plugin/.claude-plugin/plugin.json",

--- a/scripts/verify-release-merge.test.py
+++ b/scripts/verify-release-merge.test.py
@@ -25,7 +25,6 @@ RELEASE_FILES = (
     "crates/wenlan-cli/npm/package.json",
     "crates/wenlan-mcp/npm/package.json",
     "plugin-codex/.codex-plugin/plugin.json",
-    "plugin-codex/README.md",
     "plugin-codex/bin/wenlan-mcp-runner.sh",
     "plugin-codex/skills/setup/SKILL.md",
     "plugin/.claude-plugin/plugin.json",


### PR DESCRIPTION
## What

`plugin-codex/README.md` is listed as a release-managed path in three scripts, but nothing changes it during a release any more.

PR #674 replaced its `npx -y wenlan-mcp@^X.Y.Z` line with a link to `plugin-codex/bin/wenlan-mcp-runner.sh`, where the pin actually lives (line 32). The README now contains no version string at all.

## Why main is red

`scripts/validate-release-candidate.py:603` compares the release pull request's file list against `REQUIRED_RELEASE_PATHS` with exact set equality, so `plugin-codex/README.md` shows up as permanently missing. That is the release-candidate observer failure on main.

Two more breaks are fixed alongside it, neither of which anyone has hit yet:

- `scripts/ci_measure_plan.py:218` has the same exact-equality shape and would have failed identically at the next release.
- `scripts/validate-versions.sh` built `CODEX_README_PINS` by grepping the README for a pin that is gone, then failed on the empty result with `ERROR: Codex plugin release pin missing`. That would have blocked the next real release outright.

`scripts/verify-release-merge.py` uses its copy of the set as an allow-list rather than an equality check, so it was not failing. It is updated too, to keep the three sets identical.

`scripts/bump-version.sh` carried a `sed` for the README that can no longer match anything; it is removed. The `CODEX_PLUGIN_MCP_RUNNER` block directly above it is untouched and still live.

## Verification

Test scripts, all exit 0:

- `bash scripts/bump-version.test.sh`
- `bash scripts/validate-versions.test.sh` (tests 1 through 12 pass)
- `python3 scripts/validate-release-candidate.test.py` — Ran 40 tests, OK
- `python3 scripts/verify-release-merge.test.py` — Ran 10 tests, OK
- `python3 scripts/ci_measure_plan.test.py` — Ran 15 tests, OK
- `bash scripts/validate-plugin-contract.test.sh` — all pass, unchanged by this PR

End-to-end proof, in a scratch copy of the tree: set `version.txt` to `9.9.9`, ran `scripts/bump-version.sh`, and listed the files it touched. Exactly 13, matching the trimmed managed-path set of 15 minus `CHANGELOG.md` and `.release-please-manifest.json`, which release-please writes itself. Set difference computed both ways: nothing missing, nothing extra. `RELEASE_TAG=v9.9.9 bash scripts/validate-versions.sh` then printed `All versions consistent: 9.9.9`.

`scripts/ci_measure_plan.test.py` already contains `test_release_managed_paths_equals_validator_required_paths`, which asserts the planner and validator sets match exactly. It passes untouched, because both were edited identically.

`scripts/release-version-sync.test.ts` was not run locally: this worktree has no `node_modules`. Reading it, its assertions cover only `app/Cargo.toml`, `app/tauri.conf.json` and `package.json`, all still present, and its `RELEASE_MANAGED_PATHS` regex still matches. CI runs it.

## Not fixed here

`scripts/verify-release-merge.py:43` also lists `plugin/bin/wenlan-mcp-runner.sh`, which the other two sets lack. Pre-existing divergence, left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
