### PR TITLE
ci: fill a FastEmbed cache miss instead of failing the job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,13 +79,20 @@ jobs:
           # create branch-scoped entries that no other ref can reuse.
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      # Cache service availability is only an optimization. The pinned
+      # preparer verifies a hit or fills a miss, so a cache-service outage
+      # cannot fail this job.
       - name: Restore portable FastEmbed model
+        id: fastembed-restore
+        continue-on-error: true
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: .fastembed_cache
           key: fastembed-bge-base-en-v1.5-q-v3-portable
           enableCrossOsArchive: "true"
-          fail-on-cache-miss: "true"
+
+      - name: Prepare portable FastEmbed model
+        run: python3 scripts/prepare-fastembed-cache.py --cache-dir .fastembed_cache
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2

--- a/.github/workflows/main-canary.yml
+++ b/.github/workflows/main-canary.yml
@@ -74,13 +74,19 @@ jobs:
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2
         with:
           tool: cargo-nextest
+      # Cache service availability is only an optimization. The pinned
+      # preparer verifies a hit or fills a miss, so a cache-service outage
+      # cannot fail this job.
       - name: Restore portable FastEmbed model
+        id: fastembed-restore
+        continue-on-error: true
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: .fastembed_cache
           key: fastembed-bge-base-en-v1.5-q-v3-portable
           enableCrossOsArchive: "true"
-          fail-on-cache-miss: "true"
+      - name: Prepare portable FastEmbed model
+        run: python3 scripts/prepare-fastembed-cache.py --cache-dir .fastembed_cache
       - name: Verify exact canary inventory
         env:
           CANARY_FILTER: test(=eval::retrieval::tests::test_run_quality_cost_eval_basic) | test(=eval::retrieval_drift::tests::ranking_drift_vs_golden)

--- a/crates/wenlan-core/src/drift_guard.rs
+++ b/crates/wenlan-core/src/drift_guard.rs
@@ -451,6 +451,10 @@ fn fastembed_ci_cache_violations(workflow: &str) -> Vec<String> {
 
 fn coverage_fastembed_cache_violations(workflow: &str) -> Vec<String> {
     const CACHE_STEP: &str = "Restore portable FastEmbed model";
+    const PREPARE_STEP: &str = "Prepare portable FastEmbed model";
+    const PREPARE_RUN: &str =
+        "python3 scripts/prepare-fastembed-cache.py --cache-dir .fastembed_cache";
+    const CONSUMER_STEP: &str = "Run Rust coverage (wenlan-core + wenlan-server)";
     const CACHE_DIR: &str = "${{ github.workspace }}/.fastembed_cache";
     const CACHE_PATH: &str = ".fastembed_cache";
     const CACHE_KEY: &str = "fastembed-bge-base-en-v1.5-q-v3-portable";
@@ -468,18 +472,20 @@ fn coverage_fastembed_cache_violations(workflow: &str) -> Vec<String> {
         violations.push("coverage job has no steps".into());
         return violations;
     };
-    let cache_steps: Vec<&serde_yaml::Value> = steps
+    let cache_indexes: Vec<usize> = steps
         .iter()
-        .filter(|step| step["name"].as_str() == Some(CACHE_STEP))
+        .enumerate()
+        .filter_map(|(index, step)| (step["name"].as_str() == Some(CACHE_STEP)).then_some(index))
         .collect();
-    if cache_steps.len() != 1 {
+    if cache_indexes.len() != 1 {
         violations.push(format!(
             "coverage has {} {CACHE_STEP:?} steps, expected 1",
-            cache_steps.len()
+            cache_indexes.len()
         ));
         return violations;
     }
-    let cache_step = cache_steps[0];
+    let cache_index = cache_indexes[0];
+    let cache_step = &steps[cache_index];
     let actual_path = cache_step["with"]["path"].as_str();
     if actual_path != Some(CACHE_PATH) {
         violations.push(format!(
@@ -500,9 +506,43 @@ fn coverage_fastembed_cache_violations(workflow: &str) -> Vec<String> {
         violations
             .push("coverage does not restore the cross-OS portable FastEmbed v3 cache".into());
     }
-    if cache_step["with"]["fail-on-cache-miss"].as_str() != Some("true") {
+    // Cache-service availability is an optimization, not a correctness input.
+    // A restore failure must not fail the job; the pinned preparer verifies a
+    // hit or fills a miss with byte-identical, SHA-256-checked files.
+    if cache_step["with"].get("fail-on-cache-miss").is_some()
+        || cache_step["continue-on-error"].as_bool() != Some(true)
+    {
+        violations.push(
+            "coverage FastEmbed cache restore does not treat cache-service availability as \
+             optional"
+                .into(),
+        );
+    }
+    let prepare_indexes: Vec<usize> = steps
+        .iter()
+        .enumerate()
+        .filter_map(|(index, step)| (step["name"].as_str() == Some(PREPARE_STEP)).then_some(index))
+        .collect();
+    if prepare_indexes.len() != 1 || steps[prepare_indexes[0]]["run"].as_str() != Some(PREPARE_RUN)
+    {
         violations
-            .push("coverage FastEmbed cache restore is not fail-closed on a cache miss".into());
+            .push("coverage does not fill a FastEmbed cache miss with the pinned preparer".into());
+    }
+    let consumer_index = steps
+        .iter()
+        .position(|step| step["name"].as_str() == Some(CONSUMER_STEP));
+    if prepare_indexes
+        .first()
+        .zip(consumer_index)
+        .is_none_or(|(&prepare_index, consumer_index)| {
+            prepare_index <= cache_index || prepare_index >= consumer_index
+        })
+    {
+        violations.push(
+            "coverage does not prepare the FastEmbed model between the restore and the coverage \
+             run"
+            .into(),
+        );
     }
     if steps.iter().any(|step| {
         step["uses"].as_str().is_some_and(|uses| {
@@ -745,7 +785,9 @@ jobs:
         "coverage caches",
         "cache key",
         "cross-OS portable FastEmbed v3",
-        "fail-closed",
+        "cache-service availability as optional",
+        "pinned preparer",
+        "between the restore and the coverage run",
         "FastEmbed cache writer",
     ] {
         assert!(
@@ -780,6 +822,53 @@ fn coverage_fastembed_cache_contract_rejects_absolute_action_path() {
         violations[0].contains("coverage caches"),
         "absolute cache action path must fail the shared-version contract: {violations:?}"
     );
+}
+
+#[test]
+fn coverage_fastembed_cache_contract_rejects_fail_closed_restore_or_missing_preparer() {
+    const PREPARE_BLOCK: &str = "      - name: Prepare portable FastEmbed model\n        run: \
+                                 python3 scripts/prepare-fastembed-cache.py --cache-dir \
+                                 .fastembed_cache\n";
+    let workflow = std::fs::read_to_string(repo_root().join(".github/workflows/coverage.yml"))
+        .expect("read coverage.yml");
+
+    let fail_closed = workflow.replacen(
+        "          enableCrossOsArchive: \"true\"\n",
+        "          enableCrossOsArchive: \"true\"\n          fail-on-cache-miss: \"true\"\n",
+        1,
+    );
+    assert_ne!(
+        fail_closed, workflow,
+        "fixture must re-add the fail-closed cache restore"
+    );
+    let violations = coverage_fastembed_cache_violations(&fail_closed);
+    assert_eq!(
+        violations.len(),
+        1,
+        "a re-added fail-on-cache-miss must be the only mutation: {violations:?}"
+    );
+    assert!(
+        violations[0].contains("cache-service availability as optional"),
+        "a cache-service outage must not be a correctness failure: {violations:?}"
+    );
+
+    let unprepared = workflow.replacen(PREPARE_BLOCK, "", 1);
+    assert_ne!(
+        unprepared, workflow,
+        "fixture must remove the pinned preparer step"
+    );
+    let violations = coverage_fastembed_cache_violations(&unprepared);
+    for expected in [
+        "pinned preparer",
+        "between the restore and the coverage run",
+    ] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "dropping the preparer must exercise {expected:?}: {violations:?}"
+        );
+    }
 }
 
 #[test]
@@ -7512,11 +7601,41 @@ fn main_canary_contract_violations(ci_workflow: &str, canary_workflow: &str) -> 
             "main canary FastEmbed cache is not the restore-only cross-OS portable v3 cache".into(),
         );
     }
-    if fastembed_restore.and_then(|step| step["with"]["fail-on-cache-miss"].as_str())
-        != Some("true")
+    // Cache-service availability is an optimization, not a correctness input.
+    // A restore failure must not turn main red; the pinned preparer verifies a
+    // hit or fills a miss with byte-identical, SHA-256-checked files.
+    if fastembed_restore.is_some_and(|step| step["with"].get("fail-on-cache-miss").is_some())
+        || fastembed_restore.and_then(|step| step["continue-on-error"].as_bool()) != Some(true)
     {
-        violations
-            .push("main canary FastEmbed cache restore is not fail-closed on a cache miss".into());
+        violations.push(
+            "main canary FastEmbed cache restore does not treat cache-service availability as \
+             optional"
+                .into(),
+        );
+    }
+    let canary_step_index = |name: &str| {
+        canary_steps
+            .clone()
+            .position(|step| step["name"].as_str() == Some(name))
+    };
+    let fastembed_prepare = job_step(&canary, "main-canary", "Prepare portable FastEmbed model");
+    if fastembed_prepare.and_then(|step| step["run"].as_str())
+        != Some("python3 scripts/prepare-fastembed-cache.py --cache-dir .fastembed_cache")
+    {
+        violations.push(
+            "main canary does not fill a FastEmbed cache miss with the pinned preparer".into(),
+        );
+    }
+    if canary_step_index("Restore portable FastEmbed model")
+        .zip(canary_step_index("Prepare portable FastEmbed model"))
+        .zip(canary_step_index("Run embedding-only eval"))
+        .is_none_or(|((restore, prepare), eval)| restore >= prepare || prepare >= eval)
+    {
+        violations.push(
+            "main canary does not prepare the FastEmbed model between the restore and the eval \
+             run"
+            .into(),
+        );
     }
     if canary_steps
         .clone()
@@ -7668,7 +7787,9 @@ jobs:
         "FastEmbed cache directory",
         "rust-cache is not restore-only",
         "portable v3 cache",
-        "fail-closed",
+        "cache-service availability as optional",
+        "pinned preparer",
+        "between the restore and the eval run",
         "FastEmbed cache writer",
         "exact two-test ignored inventory",
         "exact two-test eval contract",
@@ -7705,6 +7826,52 @@ fn main_canary_contract_rejects_absolute_cache_action_path() {
         violations[0].contains("portable v3 cache"),
         "absolute cache action path must fail the shared-version contract: {violations:?}"
     );
+}
+
+#[test]
+fn main_canary_contract_rejects_fail_closed_restore_or_missing_preparer() {
+    const PREPARE_BLOCK: &str = "      - name: Prepare portable FastEmbed model\n        run: \
+                                 python3 scripts/prepare-fastembed-cache.py --cache-dir \
+                                 .fastembed_cache\n";
+    let root = repo_root();
+    let ci = std::fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let canary = std::fs::read_to_string(root.join(".github/workflows/main-canary.yml"))
+        .expect("read main-canary.yml");
+
+    let fail_closed = canary.replacen(
+        "          enableCrossOsArchive: \"true\"\n",
+        "          enableCrossOsArchive: \"true\"\n          fail-on-cache-miss: \"true\"\n",
+        1,
+    );
+    assert_ne!(
+        fail_closed, canary,
+        "fixture must re-add the fail-closed cache restore"
+    );
+    let violations = main_canary_contract_violations(&ci, &fail_closed);
+    assert_eq!(
+        violations.len(),
+        1,
+        "a re-added fail-on-cache-miss must be the only mutation: {violations:?}"
+    );
+    assert!(
+        violations[0].contains("cache-service availability as optional"),
+        "a cache-service outage must not turn main red: {violations:?}"
+    );
+
+    let unprepared = canary.replacen(PREPARE_BLOCK, "", 1);
+    assert_ne!(
+        unprepared, canary,
+        "fixture must remove the pinned preparer step"
+    );
+    let violations = main_canary_contract_violations(&ci, &unprepared);
+    for expected in ["pinned preparer", "between the restore and the eval run"] {
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.contains(expected)),
+            "dropping the preparer must exercise {expected:?}: {violations:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Why

`main-canary.yml` and `coverage.yml` restored the portable FastEmbed model with `fail-on-cache-miss: "true"` and no fallback, so any failure to hand back the entry killed the job and turned main red. Three such failures landed in about 40 minutes.

**These were not evictions.** The `refs/heads/main` entry for `fastembed-bge-base-en-v1.5-q-v3-portable` existed throughout the incident — created `2026-09-03T16:43:18Z`, last accessed `17:31:52Z`, i.e. *after* the failures — and unchanged reruns passed. The cache service transiently failed to return an entry that was present.

## What changed

Both workflows now use the shape `ci-benchmark.yml` already uses (lines 309-324): restore without `fail-on-cache-miss`, `continue-on-error: true`, then `python3 scripts/prepare-fastembed-cache.py --cache-dir .fastembed_cache`.

That preparer verifies a hit or fills a miss against pinned revision `738cad1c108e2f23649db9e44b2eab988626493b`, with a SHA-256 check on each of five files and five retries with exponential backoff. It is idempotent, so a cache hit costs a hash check and nothing else. A cache-service outage becomes slow instead of fatal — and so does a real eviction, which matters because the repo sits near GitHub's 10 GiB cache limit.

### Constraints preserved

- Neither workflow gains a cache writer. The rule that only `ci.yml` seeds and saves this cache is intact, so no branch-scoped entries are created.
- `coverage.yml`'s `Swatinem/rust-cache` `save-if: ${{ github.ref == 'refs/heads/main' }}` is untouched.
- The cache `path:` and `--cache-dir` stay the relative `.fastembed_cache`, because `actions/cache` treats the path spelling as part of cache identity. `prepare-fastembed-cache.py` takes an explicit `--cache-dir` over the `FASTEMBED_CACHE_DIR` env var rather than combining them, and both resolve to the same workspace directory the consumers read.

## Guards

`drift_guard.rs` deliberately pinned the old fail-closed behaviour, so both contract functions now assert the new one: `fail-on-cache-miss` absent, `continue-on-error: true`, and exactly one prepare step with the pinned command positioned between the restore and the model consumer.

Two existing control lists were updated and two positive controls added. Each new control runs two independent mutations on the real workflow text, each guarded by `assert_ne!`, so a fixture that silently stops mutating fails rather than passing.

## Receipts

```
cargo nextest run -p wenlan-core --lib -E 'test(drift_guard)'
Summary [  10.628s] 160 tests run: 160 passed, 4065 skipped
```

RED control — both real workflows mutated back to `fail-on-cache-miss: "true"` with the prepare step deleted:

```
    FAIL drift_guard::coverage_and_ci_share_the_fastembed_cache_contract
coverage FastEmbed cache restore does not treat cache-service availability as optional
coverage does not fill a FastEmbed cache miss with the pinned preparer
coverage does not prepare the FastEmbed model between the restore and the coverage run
    FAIL drift_guard::main_canary_is_independent_and_read_only
main canary FastEmbed cache restore does not treat cache-service availability as optional
main canary does not fill a FastEmbed cache miss with the pinned preparer
main canary does not prepare the FastEmbed model between the restore and the eval run
Summary 2 tests run: 0 passed, 2 failed
```

`cargo fmt -p wenlan-core -- --check` clean; `cargo clippy -p wenlan-core --lib --tests --all-features` reported no issues.

## Note

The YAML files are proved to parse by `serde_yaml::from_str(...).expect(...)` inside the guards themselves (`drift_guard.rs:462` and `:7404`), which panics the test on malformed YAML. A standalone pyyaml check was not available on the machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
