### PR TITLE
fix(core): accept the whole staged body when a page revision card chunks

### DIFF
--- a/crates/wenlan-cli/src/commands/curate.rs
+++ b/crates/wenlan-cli/src/commands/curate.rs
@@ -165,12 +165,17 @@ fn print_table(groups: &[GroupedRevision]) {
     println!("accept/dismiss: wenlan curate accept|dismiss <revision_source_id>");
 }
 
-/// Group per-chunk `PendingRevisionItem` rows into one logical revision each.
+/// Turn `PendingRevisionItem` rows into one `GroupedRevision` each.
 ///
-/// `list_pending_revisions` returns one row per chunk; a long revision spans
-/// several rows sharing the same `revision_source_id`. Join their content in the
-/// order received (the daemon sorts by `last_modified DESC`) so each card is ONE
-/// logical revision, not a mid-sentence fragment.
+/// The daemon now returns exactly one row per revision: it reads chunk zero and,
+/// for a page card, previews the whole staged body from `source_text` (issue
+/// #650). The join below therefore folds nothing against a current daemon.
+///
+/// It stays because the CLI and the daemon are separately installed binaries and
+/// need not be the same build. An older daemon still returns one row per chunk,
+/// and joining them in the order received (sorted by `last_modified DESC`) is
+/// what keeps such a card one logical revision rather than a mid-sentence
+/// fragment.
 fn group_revisions(items: Vec<PendingRevisionItem>) -> Vec<GroupedRevision> {
     use std::collections::HashMap;
     let mut order: Vec<String> = Vec::new();

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -41943,11 +41943,17 @@ impl MemoryDB {
         let mut rows = conn
             .query(
                 "SELECT supersedes, source_id, content, source_agent, last_modified, structured_fields, \
-                        EXISTS (SELECT 1 FROM pages page WHERE page.id = memories.supersedes) \
+                        EXISTS (SELECT 1 FROM pages page WHERE page.id = memories.supersedes), \
+                        source_text, \
+                        EXISTS (SELECT 1 FROM memories sibling \
+                                WHERE sibling.source_id = memories.source_id \
+                                  AND sibling.source = 'memory' \
+                                  AND sibling.chunk_index > 0) \
                  FROM memories \
                  WHERE pending_revision = 1 \
                    AND supersedes IS NOT NULL \
                    AND source = 'memory' \
+                   AND chunk_index = 0 \
                  ORDER BY last_modified DESC \
                  LIMIT ?1",
                 libsql::params![limit as i64],
@@ -41970,6 +41976,31 @@ impl MemoryDB {
                         .and_then(|g| g.as_str())
                         .map(str::to_string)
                 });
+            let targets_a_page = row.get::<i64>(6).unwrap_or(0) != 0;
+            let chunk = row
+                .get::<String>(2)
+                .map_err(|e| WenlanError::VectorDb(format!("col 2: {e}")))?;
+            let last_modified = row
+                .get::<i64>(4)
+                .map_err(|e| WenlanError::VectorDb(format!("col 4: {e}")))?;
+            // A page card previews the whole staged body; `content` on one row
+            // is a single chunk of it (issue #650). Only a card that actually
+            // chunked needs `source_text`: once a human edits a staged card,
+            // `apply_memory_update` leaves one row holding the edited body and
+            // a `source_text` from before the edit, and previewing that would
+            // show the human their own edit reverted.
+            //
+            // A memory card keeps previewing `content` whatever its shape,
+            // because there `source_text` is the pre-distillation prose rather
+            // than the body its accept stores.
+            let chunked = row.get::<i64>(8).unwrap_or(0) != 0;
+            let revision_content =
+                match (targets_a_page && chunked, row.get::<Option<String>>(7).ok()) {
+                    (true, Some(Some(staged))) => {
+                        memory_point_reads::rehydrate_staged_body(&staged, last_modified)
+                    }
+                    _ => chunk,
+                };
             out.push(wenlan_types::responses::PendingRevisionItem {
                 target_source_id: row
                     .get::<String>(0)
@@ -41977,13 +42008,9 @@ impl MemoryDB {
                 revision_source_id: row
                     .get::<String>(1)
                     .map_err(|e| WenlanError::VectorDb(format!("col 1: {e}")))?,
-                revision_content: row
-                    .get::<String>(2)
-                    .map_err(|e| WenlanError::VectorDb(format!("col 2: {e}")))?,
+                revision_content,
                 source_agent: row.get::<Option<String>>(3).unwrap_or(None),
-                last_modified: row
-                    .get::<i64>(4)
-                    .map_err(|e| WenlanError::VectorDb(format!("col 4: {e}")))?,
+                last_modified,
                 target_kind: revision_target_kind(row.get::<i64>(6).unwrap_or(0)),
                 grounded_in,
             });
@@ -42077,21 +42104,19 @@ impl MemoryDB {
             ),
         };
         let limit_param = values.len();
+        // `source_text` rides along so a page card can preview the body an
+        // accept would actually write. Which column wins is decided in Rust
+        // below, off the page flag this query already selects, so the page
+        // lookup still runs once per row.
         let sql = format!(
-            // A page card's preview comes from `source_text`, which carries the
-            // whole staged body on every chunk row, while `content` holds one
-            // chunk. Without this the human reviews the card's first ~1,500
-            // characters and cannot see what accepting it would write (issue
-            // #650). A memory card keeps reading `content` on purpose: there
-            // `source_text` is the pre-distillation prose, not the body the
-            // accept path writes, so previewing it would show text the accept
-            // never stores.
-            "SELECT revision.supersedes, revision.source_id,
-                    CASE WHEN EXISTS (SELECT 1 FROM pages page WHERE page.id = revision.supersedes)
-                         THEN COALESCE(revision.source_text, revision.content)
-                         ELSE revision.content END,
+            "SELECT revision.supersedes, revision.source_id, revision.content,
                     revision.source_agent, revision.last_modified, revision.structured_fields,
-                    EXISTS (SELECT 1 FROM pages page WHERE page.id = revision.supersedes)
+                    EXISTS (SELECT 1 FROM pages page WHERE page.id = revision.supersedes),
+                    revision.source_text,
+                    EXISTS (SELECT 1 FROM memories sibling
+                            WHERE sibling.source_id = revision.source_id
+                              AND sibling.source = 'memory'
+                              AND sibling.chunk_index > 0)
              FROM memories revision
              WHERE revision.pending_revision = 1
                AND revision.supersedes IS NOT NULL
@@ -42122,6 +42147,31 @@ impl MemoryDB {
                         .and_then(|ground| ground.as_str())
                         .map(str::to_string)
                 });
+            let targets_a_page = row.get::<i64>(6).unwrap_or(0) != 0;
+            let chunk = row
+                .get::<String>(2)
+                .map_err(|e| WenlanError::VectorDb(format!("col 2: {e}")))?;
+            let last_modified = row
+                .get::<i64>(4)
+                .map_err(|e| WenlanError::VectorDb(format!("col 4: {e}")))?;
+            // A page card previews the whole staged body; `content` on one row
+            // is a single chunk of it (issue #650). Only a card that actually
+            // chunked needs `source_text`: once a human edits a staged card,
+            // `apply_memory_update` leaves one row holding the edited body and
+            // a `source_text` from before the edit, and previewing that would
+            // show the human their own edit reverted.
+            //
+            // A memory card keeps previewing `content` whatever its shape,
+            // because there `source_text` is the pre-distillation prose rather
+            // than the body its accept stores.
+            let chunked = row.get::<i64>(8).unwrap_or(0) != 0;
+            let revision_content =
+                match (targets_a_page && chunked, row.get::<Option<String>>(7).ok()) {
+                    (true, Some(Some(staged))) => {
+                        memory_point_reads::rehydrate_staged_body(&staged, last_modified)
+                    }
+                    _ => chunk,
+                };
             out.push(wenlan_types::responses::PendingRevisionItem {
                 target_source_id: row
                     .get::<String>(0)
@@ -42129,13 +42179,9 @@ impl MemoryDB {
                 revision_source_id: row
                     .get::<String>(1)
                     .map_err(|e| WenlanError::VectorDb(format!("col 1: {e}")))?,
-                revision_content: row
-                    .get::<String>(2)
-                    .map_err(|e| WenlanError::VectorDb(format!("col 2: {e}")))?,
+                revision_content,
                 source_agent: row.get::<Option<String>>(3).unwrap_or(None),
-                last_modified: row
-                    .get::<i64>(4)
-                    .map_err(|e| WenlanError::VectorDb(format!("col 4: {e}")))?,
+                last_modified,
                 target_kind: revision_target_kind(row.get::<i64>(6).unwrap_or(0)),
                 grounded_in,
             });

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -41945,6 +41945,7 @@ impl MemoryDB {
                 "SELECT supersedes, source_id, content, source_agent, last_modified, structured_fields, \
                         EXISTS (SELECT 1 FROM pages page WHERE page.id = memories.supersedes), \
                         source_text, \
+                        COALESCE(created_at, last_modified), \
                         EXISTS (SELECT 1 FROM memories sibling \
                                 WHERE sibling.source_id = memories.source_id \
                                   AND sibling.source = 'memory' \
@@ -41993,11 +41994,14 @@ impl MemoryDB {
             // A memory card keeps previewing `content` whatever its shape,
             // because there `source_text` is the pre-distillation prose rather
             // than the body its accept stores.
-            let chunked = row.get::<i64>(8).unwrap_or(0) != 0;
+            let chunked = row.get::<i64>(9).unwrap_or(0) != 0;
+            // Grounding anchors on `created_at`, the staging date, because
+            // `last_modified` moves on any later metadata edit to the card.
+            let staged_at = row.get::<i64>(8).unwrap_or(last_modified);
             let revision_content =
                 match (targets_a_page && chunked, row.get::<Option<String>>(7).ok()) {
                     (true, Some(Some(staged))) => {
-                        memory_point_reads::rehydrate_staged_body(&staged, last_modified)
+                        memory_point_reads::rehydrate_staged_body(&staged, staged_at)
                     }
                     _ => chunk,
                 };
@@ -42113,6 +42117,7 @@ impl MemoryDB {
                     revision.source_agent, revision.last_modified, revision.structured_fields,
                     EXISTS (SELECT 1 FROM pages page WHERE page.id = revision.supersedes),
                     revision.source_text,
+                    COALESCE(revision.created_at, revision.last_modified),
                     EXISTS (SELECT 1 FROM memories sibling
                             WHERE sibling.source_id = revision.source_id
                               AND sibling.source = 'memory'
@@ -42164,11 +42169,14 @@ impl MemoryDB {
             // A memory card keeps previewing `content` whatever its shape,
             // because there `source_text` is the pre-distillation prose rather
             // than the body its accept stores.
-            let chunked = row.get::<i64>(8).unwrap_or(0) != 0;
+            let chunked = row.get::<i64>(9).unwrap_or(0) != 0;
+            // Grounding anchors on `created_at`, the staging date, because
+            // `last_modified` moves on any later metadata edit to the card.
+            let staged_at = row.get::<i64>(8).unwrap_or(last_modified);
             let revision_content =
                 match (targets_a_page && chunked, row.get::<Option<String>>(7).ok()) {
                     (true, Some(Some(staged))) => {
-                        memory_point_reads::rehydrate_staged_body(&staged, last_modified)
+                        memory_point_reads::rehydrate_staged_body(&staged, staged_at)
                     }
                     _ => chunk,
                 };

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -42078,7 +42078,18 @@ impl MemoryDB {
         };
         let limit_param = values.len();
         let sql = format!(
-            "SELECT revision.supersedes, revision.source_id, revision.content,
+            // A page card's preview comes from `source_text`, which carries the
+            // whole staged body on every chunk row, while `content` holds one
+            // chunk. Without this the human reviews the card's first ~1,500
+            // characters and cannot see what accepting it would write (issue
+            // #650). A memory card keeps reading `content` on purpose: there
+            // `source_text` is the pre-distillation prose, not the body the
+            // accept path writes, so previewing it would show text the accept
+            // never stores.
+            "SELECT revision.supersedes, revision.source_id,
+                    CASE WHEN EXISTS (SELECT 1 FROM pages page WHERE page.id = revision.supersedes)
+                         THEN COALESCE(revision.source_text, revision.content)
+                         ELSE revision.content END,
                     revision.source_agent, revision.last_modified, revision.structured_fields,
                     EXISTS (SELECT 1 FROM pages page WHERE page.id = revision.supersedes)
              FROM memories revision

--- a/crates/wenlan-core/src/db/memory_point_reads.rs
+++ b/crates/wenlan-core/src/db/memory_point_reads.rs
@@ -42,8 +42,16 @@ pub(crate) struct PendingMemoryRevisionPayload {
 ///
 /// Kept beside the read rather than at the call site: every consumer of a
 /// recovered body needs both transforms, and a caller that forgot the first
-/// one would publish PII. `observed_at` is the row's `last_modified`, the same
-/// anchor the write path used.
+/// one would publish PII.
+///
+/// `observed_at` must be the row's `created_at`, not its `last_modified`.
+/// `upsert_documents` grounds against the document's `last_modified` and stores
+/// that same value in both columns, so at insert the two agree. They stop
+/// agreeing afterwards: `apply_memory_update` bumps `last_modified` on every
+/// call, including a metadata-only one that changes no text and deletes no
+/// sibling chunks -- confirming a card, or moving it to another space, is
+/// enough. Anchoring on `last_modified` would then ground "yesterday" against
+/// the date of that unrelated edit instead of the date the card was staged.
 pub(super) fn rehydrate_staged_body(raw: &str, observed_at: i64) -> String {
     let redacted = crate::privacy::redact_pii(raw);
     if crate::db::temporal_grounding_enabled() {
@@ -110,7 +118,8 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT source_id, supersedes, content, structured_fields, source_text, last_modified, \
+                "SELECT source_id, supersedes, content, structured_fields, source_text, \
+                        COALESCE(created_at, last_modified), \
                         EXISTS (SELECT 1 FROM memories sibling \
                                 WHERE sibling.source_id = memories.source_id \
                                   AND sibling.source = 'memory' \

--- a/crates/wenlan-core/src/db/memory_point_reads.rs
+++ b/crates/wenlan-core/src/db/memory_point_reads.rs
@@ -7,8 +7,52 @@ use std::collections::HashMap;
 pub(crate) struct PendingMemoryRevisionPayload {
     pub(crate) revision_id: String,
     pub(crate) supersedes: String,
+    /// One chunk of the staged text, exactly as `memories` stores it. This is
+    /// what a memory-target revision accept has always used, and it stays that
+    /// way: for a memory card `source_text` is the pre-distillation prose, not
+    /// the body an accept writes.
     pub(crate) content: String,
+    /// The whole staged body, for a card whose `content` is only part of it:
+    /// several chunk rows and a `source_text` to recover the rest from. `None`
+    /// whenever this row's own `content` is already the whole body, so a
+    /// caller can take `full_body` when it is there and `content` otherwise.
+    ///
+    /// A page card needs this and `content` cannot supply it: past the
+    /// chunker's budget the staged body becomes several rows and no single one
+    /// holds all of it (issue #650).
+    ///
+    /// Two things make the raw column wrong to hand straight to a caller, and
+    /// both are silent:
+    ///
+    /// - `upsert_documents` redacts `content` before chunking (`redact_pii`)
+    ///   and grounds relative dates in it, but copies `source_text` in
+    ///   verbatim, so the raw column would write PII into a page and into its
+    ///   exported markdown. `rehydrate_staged_body` re-applies both.
+    /// - `apply_memory_update` rewrites chunk zero's `content` and deletes the
+    ///   rest, never touching `source_text`. An edited card is therefore one
+    ///   row whose `source_text` is the body before the edit, so `full_body`
+    ///   is `None` there and the edit is what an accept writes.
+    pub(crate) full_body: Option<String>,
     pub(crate) structured_fields: Option<String>,
+}
+
+/// Re-applies the write-time text transforms that `upsert_documents` runs on
+/// `content` before chunking, so a body recovered from `source_text` matches
+/// what the chunk rows hold.
+///
+/// Kept beside the read rather than at the call site: every consumer of a
+/// recovered body needs both transforms, and a caller that forgot the first
+/// one would publish PII. `observed_at` is the row's `last_modified`, the same
+/// anchor the write path used.
+pub(super) fn rehydrate_staged_body(raw: &str, observed_at: i64) -> String {
+    let redacted = crate::privacy::redact_pii(raw);
+    if crate::db::temporal_grounding_enabled() {
+        let anchor =
+            chrono::DateTime::from_timestamp(observed_at, 0).unwrap_or_else(chrono::Utc::now);
+        crate::temporal_query::ground_relative_dates(&redacted, anchor)
+    } else {
+        redacted
+    }
 }
 
 impl MemoryDB {
@@ -39,25 +83,26 @@ impl MemoryDB {
     /// An exact `source_id` match wins over the legacy `supersedes` fallback;
     /// otherwise the newest eligible legacy row wins.
     ///
-    /// The returned `content` comes from `source_text`, and only the
-    /// `chunk_index = 0` row is eligible. Both halves matter. A staged
-    /// card is written through the ordinary document upsert, so a body over
-    /// roughly 1,500 characters becomes several `memories` rows sharing one
-    /// `source_id` and one `last_modified` -- the ordering above cannot break
-    /// that tie, so the old unrestricted `LIMIT 1` returned an arbitrary
-    /// fragment. The accept path writes what this read returns as the page's
-    /// complete new body, which destroyed two real pages on 2026-08-30
-    /// (21,038 characters down to 1,814, and 9,142 down to 1,428; issue
-    /// #650). `content` on any single row is one chunk by construction;
-    /// `source_text` carries the whole staged body on every chunk row,
-    /// because `stage_page_revision_card` passes the full string in both and
-    /// the chunk loop copies `source_text` verbatim onto each row. Pinning
-    /// chunk zero also makes the row choice deterministic and agrees with
-    /// `list_pending_revisions_scoped`, which already pins it, so the queue a
-    /// human reviews and the body an accept writes come from the same row.
-    /// `COALESCE` keeps a row whose `source_text` is NULL readable; the only
-    /// cards that predate the column also predate source-revision fencing,
-    /// and `accept_page_revision_card` refuses those outright.
+    /// Only the `chunk_index = 0` row is eligible. When sibling chunks exist
+    /// its `content` is a fragment, so the whole staged body comes back
+    /// alongside it as `full_body`; with no siblings `content` is already the
+    /// whole body and `full_body` is `None`.
+    ///
+    /// A staged card goes through the ordinary document upsert, so a body past
+    /// the chunker's size budget becomes several `memories` rows sharing one
+    /// `source_id` and one `last_modified`. The ordering below cannot break
+    /// that tie, so an unrestricted `LIMIT 1` returned an arbitrary fragment,
+    /// and the page accept path wrote that fragment as a page's complete new
+    /// body -- 21,038 characters down to 1,814 on a real page (issue #650).
+    /// Pinning chunk zero makes the row deterministic, which is what the
+    /// `full_body`-is-`None` fallback rests on, and matches
+    /// `list_pending_revisions_scoped`, so the queue a human reviews and the
+    /// body an accept writes come from one row.
+    ///
+    /// The budget that decides whether a card chunks at all is not one number:
+    /// the markdown splitter caps a chunk at 1,500 characters, the plain-text
+    /// splitter at 512, and with a tokenizer loaded the cap is 510 BGE tokens.
+    /// A few hundred characters of unstructured prose is already enough.
     pub(crate) async fn pending_memory_revision_payload(
         &self,
         id: &str,
@@ -65,7 +110,11 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT source_id, supersedes, COALESCE(source_text, content), structured_fields \
+                "SELECT source_id, supersedes, content, structured_fields, source_text, last_modified, \
+                        EXISTS (SELECT 1 FROM memories sibling \
+                                WHERE sibling.source_id = memories.source_id \
+                                  AND sibling.source = 'memory' \
+                                  AND sibling.chunk_index > 0) \
                  FROM memories \
                  WHERE pending_revision = 1 \
                    AND source = 'memory' \
@@ -96,6 +145,10 @@ impl MemoryDB {
                 .get::<String>(2)
                 .map_err(|e| WenlanError::VectorDb(format!("revision content: {e}")))?,
             structured_fields: row.get::<Option<String>>(3).unwrap_or(None),
+            full_body: (row.get::<i64>(6).unwrap_or(0) != 0)
+                .then(|| row.get::<Option<String>>(4).unwrap_or(None))
+                .flatten()
+                .map(|raw| rehydrate_staged_body(&raw, row.get::<i64>(5).unwrap_or(0))),
         }))
     }
 

--- a/crates/wenlan-core/src/db/memory_point_reads.rs
+++ b/crates/wenlan-core/src/db/memory_point_reads.rs
@@ -38,6 +38,26 @@ impl MemoryDB {
     ///
     /// An exact `source_id` match wins over the legacy `supersedes` fallback;
     /// otherwise the newest eligible legacy row wins.
+    ///
+    /// The returned `content` comes from `source_text`, and only the
+    /// `chunk_index = 0` row is eligible. Both halves matter. A staged
+    /// card is written through the ordinary document upsert, so a body over
+    /// roughly 1,500 characters becomes several `memories` rows sharing one
+    /// `source_id` and one `last_modified` -- the ordering above cannot break
+    /// that tie, so the old unrestricted `LIMIT 1` returned an arbitrary
+    /// fragment. The accept path writes what this read returns as the page's
+    /// complete new body, which destroyed two real pages on 2026-08-30
+    /// (21,038 characters down to 1,814, and 9,142 down to 1,428; issue
+    /// #650). `content` on any single row is one chunk by construction;
+    /// `source_text` carries the whole staged body on every chunk row,
+    /// because `stage_page_revision_card` passes the full string in both and
+    /// the chunk loop copies `source_text` verbatim onto each row. Pinning
+    /// chunk zero also makes the row choice deterministic and agrees with
+    /// `list_pending_revisions_scoped`, which already pins it, so the queue a
+    /// human reviews and the body an accept writes come from the same row.
+    /// `COALESCE` keeps a row whose `source_text` is NULL readable; the only
+    /// cards that predate the column also predate source-revision fencing,
+    /// and `accept_page_revision_card` refuses those outright.
     pub(crate) async fn pending_memory_revision_payload(
         &self,
         id: &str,
@@ -45,10 +65,11 @@ impl MemoryDB {
         let conn = self.conn.lock().await;
         let mut rows = conn
             .query(
-                "SELECT source_id, supersedes, content, structured_fields \
+                "SELECT source_id, supersedes, COALESCE(source_text, content), structured_fields \
                  FROM memories \
                  WHERE pending_revision = 1 \
                    AND source = 'memory' \
+                   AND chunk_index = 0 \
                    AND (source_id = ?1 OR supersedes = ?1) \
                  ORDER BY CASE WHEN source_id = ?1 THEN 0 ELSE 1 END, last_modified DESC \
                  LIMIT 1",

--- a/crates/wenlan-core/src/post_write/page_revision.rs
+++ b/crates/wenlan-core/src/post_write/page_revision.rs
@@ -77,10 +77,14 @@ async fn resolve_page_revision_card(
         page_version,
         source_revision,
         // The staged body, not the one chunk of it this row happens to
-        // carry. `full_body` is `None` only for a row written before
-        // `source_text` existed, and such a card also predates source-revision
-        // fencing, so `accept_page_revision_card` refuses it below before its
-        // content is ever written.
+        // carry. `full_body` is `Some` exactly when the card spans several
+        // chunk rows, which is the only case where `content` is a fragment.
+        //
+        // The `content` fallback is the ordinary path, not a legacy one: it
+        // carries every page short enough to stage as a single row, and every
+        // card a human has edited, since editing collapses a card to one row
+        // holding the whole edited body. Do not turn this into an `expect` --
+        // it would panic on both.
         content: payload.full_body.unwrap_or(payload.content),
         source_memory_ids,
     }))

--- a/crates/wenlan-core/src/post_write/page_revision.rs
+++ b/crates/wenlan-core/src/post_write/page_revision.rs
@@ -76,7 +76,12 @@ async fn resolve_page_revision_card(
         revision_id: payload.revision_id,
         page_version,
         source_revision,
-        content: payload.content,
+        // The staged body, not the one chunk of it this row happens to
+        // carry. `full_body` is `None` only for a row written before
+        // `source_text` existed, and such a card also predates source-revision
+        // fencing, so `accept_page_revision_card` refuses it below before its
+        // content is ever written.
+        content: payload.full_body.unwrap_or(payload.content),
         source_memory_ids,
     }))
 }

--- a/crates/wenlan-core/src/post_write/post_write_tests.rs
+++ b/crates/wenlan-core/src/post_write/post_write_tests.rs
@@ -5082,6 +5082,148 @@ async fn accept_pending_revision_page_write_card_with_matching_source_revision_w
     );
 }
 
+/// Issue #650: a page long enough to chunk must survive its own accept.
+///
+/// `memories` stores one row per chunk, and every chunk of a staged card
+/// shares the card's `source_id` and `last_modified`. A read that takes one
+/// row therefore returns an arbitrary fragment, which the accept path then
+/// writes as the page's complete new body -- observed live turning a 21,038
+/// character page into 1,814. The staged card is not at fault:
+/// `stage_page_revision_card` puts the whole body in `source_text` on every
+/// chunk row, so the whole body is always there to be read.
+///
+/// The multi-chunk assertion below is the test's own gate. Under the
+/// character fallback splitter a body has to clear roughly 1,500 characters
+/// to split at all, so a shorter fixture would pass against the broken read
+/// and prove nothing.
+#[tokio::test]
+async fn accepting_a_multi_chunk_page_card_keeps_the_whole_body() {
+    let (db, _dir) = test_db().await;
+    let mem_id = "mem_650_multi_chunk";
+    let new_mem_id = "mem_650_multi_chunk_source";
+    let original_content = "Ownership rules make Rust memory safety explicit";
+    // Kept close to the cited source: the human write runs through the same
+    // hallucination guard, and an unrelated sentence fails it before the test
+    // reaches the behaviour under test.
+    let human_content =
+        "Ownership rules make Rust memory safety explicit. A human maintains this page.";
+
+    // Long enough to split, and structured so the split lands on section
+    // boundaries the way a real wiki page does.
+    let proposed_content = (1..=8)
+        .map(|section| {
+            format!(
+                "## Section {section}\n\n{}\n",
+                format!(
+                    "Paragraph {section} of the proposed revision carries enough prose to \
+                     push this page past the chunker's size budget so the write lands as \
+                     several rows rather than one. "
+                )
+                .repeat(4)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        proposed_content.len() > 1500,
+        "fixture must exceed the character splitter's budget, got {} chars",
+        proposed_content.len()
+    );
+
+    seed_memory(&db, mem_id, original_content).await;
+    // The staging path checks the proposed prose against its cited sources,
+    // so the card needs a source that actually carries this body.
+    seed_memory(&db, new_mem_id, &proposed_content).await;
+    let page_id = seed_page(&db, mem_id, original_content).await;
+    update_page(
+        &db,
+        &page_id,
+        UpdatePageRequest {
+            content: human_content.to_string(),
+            source_memory_ids: vec![mem_id.to_string()],
+            expected_version: None,
+            caller_id: None,
+            operation_id: None,
+        },
+        "fs_edit",
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let staged_source_revision = db.get_page_source_revision(&page_id).await.unwrap();
+    let card = stage_page_revision_card(
+        &db,
+        &before,
+        &proposed_content,
+        &[mem_id.to_string(), new_mem_id.to_string()],
+        staged_source_revision,
+        "page_growth",
+        None,
+    )
+    .await
+    .unwrap();
+    let card_id = card
+        .revision_card_id
+        .as_deref()
+        .expect("staged page card must return an id");
+
+    // Gate: without more than one chunk row the broken read cannot truncate,
+    // so the assertion below would pass on unfixed code.
+    let chunk_rows: i64 = {
+        let conn = db.test_primary_session().await;
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM memories WHERE source = 'memory' AND source_id = ?1",
+                libsql::params![card_id.to_string()],
+            )
+            .await
+            .unwrap();
+        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
+    };
+    assert!(
+        chunk_rows > 1,
+        "fixture must stage a card that actually chunked, got {chunk_rows} row(s)"
+    );
+
+    // The queue a human reads before clicking accept must show the same body
+    // the accept will write. Previewing one chunk hides what is about to
+    // happen at the exact moment the human is deciding.
+    let queued = db
+        .list_pending_revisions_scoped(10, &crate::read_scope::ReadScope::Global)
+        .await
+        .unwrap();
+    let queued_card = queued
+        .iter()
+        .find(|item| item.revision_source_id == card_id)
+        .expect("the staged card must appear in the pending queue");
+    assert_eq!(
+        queued_card.revision_content,
+        proposed_content,
+        "the review queue must preview the whole staged body, not one chunk \
+         (got {} chars, staged {} chars)",
+        queued_card.revision_content.len(),
+        proposed_content.len()
+    );
+
+    accept_pending_revision(&db, card_id, "test-agent")
+        .await
+        .unwrap();
+
+    let after = db.get_page(&page_id).await.unwrap().unwrap();
+    assert_eq!(
+        after.content,
+        proposed_content,
+        "accepting a chunked card must write the whole staged body, not one chunk \
+         (got {} chars, staged {} chars)",
+        after.content.len(),
+        proposed_content.len()
+    );
+}
+
 /// Proves the source_revision fence is actually wired end-to-end through
 /// the daemon-internal path a machine refresh uses to reach a human-owned
 /// page's gate: `update_page_at_source_revision` (the same wrapper

--- a/crates/wenlan-core/src/post_write/post_write_tests.rs
+++ b/crates/wenlan-core/src/post_write/post_write_tests.rs
@@ -5290,6 +5290,19 @@ async fn accepting_a_chunked_page_card_keeps_the_redaction_its_chunks_carry() {
         .as_deref()
         .expect("staged page card must return an id");
 
+    // Gate: the card must have chunked, or the accept reads `content` and this
+    // test stops covering the recovered-body path it exists for.
+    let payload = db
+        .pending_memory_revision_payload(card_id)
+        .await
+        .unwrap()
+        .expect("the staged card must resolve");
+    assert!(
+        payload.full_body.is_some(),
+        "fixture must stage a card that actually chunked, or the redaction \
+         under test is never reached"
+    );
+
     accept_pending_revision(&db, card_id, "test-agent")
         .await
         .unwrap();
@@ -5447,6 +5460,193 @@ async fn accepting_an_edited_page_card_writes_the_edit_not_the_staged_body() {
     );
 }
 
+/// A recovered body must be grounded against the date the card was staged,
+/// which is not the date of the last edit to its row.
+///
+/// `upsert_documents` grounds `content` against the document's `last_modified`
+/// and stores that same value in `created_at`, so at insert the two agree.
+/// They stop agreeing afterwards: `apply_memory_update` bumps `last_modified`
+/// on every call, and its sibling-chunk delete sits inside the content branch,
+/// so a metadata-only edit -- confirming the card, or moving it to another
+/// space -- moves the timestamp while leaving the card chunked. Anchoring the
+/// recovered body on `last_modified` would then ground "yesterday" against the
+/// date of that unrelated edit, and the page would get a date that was never
+/// staged.
+///
+/// This is also the only coverage of the grounding branch at all: it is off by
+/// default, so every other test here exercises redaction alone.
+#[tokio::test]
+async fn a_recovered_body_grounds_against_the_staging_date_not_a_later_edit() {
+    let (db, _dir) = test_db().await;
+    let target_id = "mem_650_grounding_target";
+    let card_id = "mem_650_grounding_card";
+
+    // Far enough back that "yesterday" resolves to a different calendar day
+    // than it would today, so the two anchors cannot coincide.
+    let staged_at = chrono::Utc::now() - chrono::Duration::days(90);
+    let expected_day = (staged_at - chrono::Duration::days(1))
+        .date_naive()
+        .to_string();
+    let wrong_day = (chrono::Utc::now() - chrono::Duration::days(1))
+        .date_naive()
+        .to_string();
+
+    // Long enough to chunk, so the body is only reachable through the
+    // recovered-body path this test is about.
+    let body = format!(
+        "We agreed on the retention rule yesterday. {}",
+        "Supporting prose that pushes this card past the chunker's budget. ".repeat(60)
+    );
+
+    temp_env::async_with_vars([("WENLAN_ENABLE_TEMPORAL_GROUNDING", Some("1"))], async {
+        seed_memory(&db, target_id, "The retention rule is under discussion").await;
+
+        let card = crate::sources::RawDocument {
+            source: "memory".to_string(),
+            source_id: card_id.to_string(),
+            title: "Revision: retention".to_string(),
+            content: body.clone(),
+            last_modified: staged_at.timestamp(),
+            memory_type: Some("fact".to_string()),
+            source_agent: Some("test".to_string()),
+            confidence: Some(0.9),
+            supersedes: Some(target_id.to_string()),
+            pending_revision: true,
+            source_text: Some(body.clone()),
+            ..Default::default()
+        };
+        db.upsert_documents(vec![card]).await.unwrap();
+
+        // A metadata-only edit: it bumps `last_modified` to now and leaves
+        // every sibling chunk in place.
+        update_memory(
+            &db,
+            card_id,
+            MemoryUpdate {
+                content: None,
+                space: None,
+                confirm: true,
+                memory_type: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let payload = db
+            .pending_memory_revision_payload(card_id)
+            .await
+            .unwrap()
+            .expect("the staged card must resolve");
+        let full_body = payload
+            .full_body
+            .expect("a chunked card must expose its whole staged body");
+
+        assert!(
+            full_body.contains(&format!("yesterday ({expected_day})")),
+            "the recovered body must ground against the staging date; got: {}",
+            &full_body[..full_body.len().min(120)]
+        );
+        assert!(
+            !full_body.contains(&wrong_day),
+            "the recovered body must not ground against the date of the \
+                 later metadata edit ({wrong_day})"
+        );
+    })
+    .await;
+}
+
+/// The whole staged body must survive an accept at every length, not just the
+/// one the other tests happen to use.
+///
+/// Issue #650 is a chunk-boundary bug, so a single fixture size proves the fix
+/// only at that size. This sweeps lengths across both budgets that decide
+/// whether a card chunks at all -- 1,500 characters for markdown, 512 for
+/// plain text -- and past them, so the crossing itself is covered rather than
+/// approximated. A staged card takes the plain-text splitter, because
+/// `upsert_documents` hands the chunker the card's `source_id` as its path and
+/// that has no markdown extension.
+///
+/// Compared after `trim_end`: `text_splitter` trims chunk edges, so a
+/// single-chunk body ending in a newline round-trips without it. That is
+/// pre-existing and whitespace-only, and no rule requires a trailing newline.
+#[tokio::test]
+async fn a_page_card_survives_its_accept_at_every_length() {
+    let (db, _dir) = test_db().await;
+
+    for (case, filler_repeats) in [
+        ("tiny", 1),
+        ("under", 6),
+        ("at", 8),
+        ("over", 10),
+        ("wide", 60),
+    ] {
+        let mem_id = format!("mem_650_sweep_{case}");
+        let original_content = "Ownership rules make Rust memory safety explicit";
+        let human_content =
+            "Ownership rules make Rust memory safety explicit. A human maintains this page.";
+        let proposed_content = format!(
+            "## Section for {case}\n\n{}Reach the maintainer at sweep@example.com.\n",
+            "Prose that lengthens this body one repeat at a time. ".repeat(filler_repeats)
+        );
+
+        seed_memory(&db, &mem_id, original_content).await;
+        let page_id = seed_page(&db, &mem_id, original_content).await;
+        update_page(
+            &db,
+            &page_id,
+            UpdatePageRequest {
+                content: human_content.to_string(),
+                source_memory_ids: vec![mem_id.clone()],
+                expected_version: None,
+                caller_id: None,
+                operation_id: None,
+            },
+            "fs_edit",
+            false,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let before = db.get_page(&page_id).await.unwrap().unwrap();
+        let staged_source_revision = db.get_page_source_revision(&page_id).await.unwrap();
+        let card = stage_page_revision_card(
+            &db,
+            &before,
+            &proposed_content,
+            std::slice::from_ref(&mem_id),
+            staged_source_revision,
+            "page_growth",
+            None,
+        )
+        .await
+        .unwrap();
+        let card_id = card
+            .revision_card_id
+            .as_deref()
+            .expect("staged page card must return an id");
+
+        accept_pending_revision(&db, card_id, "test-agent")
+            .await
+            .unwrap();
+
+        let after = db.get_page(&page_id).await.unwrap().unwrap();
+        let expected = crate::privacy::redact_pii(&proposed_content);
+        assert_eq!(
+            after.content.trim_end(),
+            expected.trim_end(),
+            "case {case} ({} chars staged) came back as {} chars",
+            proposed_content.len(),
+            after.content.len()
+        );
+        assert!(
+            !after.content.contains("sweep@example.com"),
+            "case {case} leaked the raw address into the page"
+        );
+    }
+}
+
 /// The queue must keep previewing a memory card's stored `content`.
 ///
 /// Only a page card previews `source_text`. On a memory card `source_text` is
@@ -5458,23 +5658,45 @@ async fn a_memory_revision_card_still_previews_its_stored_content() {
     let target_id = "mem_650_memory_target";
     seed_memory(&db, target_id, "Postgres stores JSON in a JSONB column").await;
 
-    let stored = "Postgres stores JSON in a JSONB column, which is indexable";
-    let pre_distillation = "So anyway I looked it up and Postgres has this JSONB thing";
+    // Both bodies are long enough to chunk. A single-chunk fixture would take
+    // the not-chunked arm whatever the page flag said, so deleting the page
+    // check from the preview would leave this test green while a real chunked
+    // memory card started previewing prose its accept never stores.
+    let stored = format!(
+        "CANONICAL-CLAIM-MARKER. {}",
+        "Postgres stores JSON in a JSONB column, which is indexable. ".repeat(40)
+    );
+    let pre_distillation = format!(
+        "PRE-DISTILLATION-MARKER. {}",
+        "So anyway I looked it up and Postgres has this JSONB thing. ".repeat(40)
+    );
     let card = crate::sources::RawDocument {
         source: "memory".to_string(),
         source_id: "mem_650_memory_card".to_string(),
         title: "Revision: Postgres".to_string(),
-        content: stored.to_string(),
+        content: stored.clone(),
         last_modified: chrono::Utc::now().timestamp(),
         memory_type: Some("fact".to_string()),
         source_agent: Some("test".to_string()),
         confidence: Some(0.9),
         supersedes: Some(target_id.to_string()),
         pending_revision: true,
-        source_text: Some(pre_distillation.to_string()),
+        source_text: Some(pre_distillation.clone()),
         ..Default::default()
     };
     db.upsert_documents(vec![card]).await.unwrap();
+
+    // Gate: the card really chunked, so the page check is the only thing
+    // keeping its preview off `source_text`.
+    let payload = db
+        .pending_memory_revision_payload("mem_650_memory_card")
+        .await
+        .unwrap()
+        .expect("the memory card must resolve");
+    assert!(
+        payload.content.len() < stored.len(),
+        "fixture must stage a memory card that actually chunked"
+    );
 
     let queued = db
         .list_pending_revisions_scoped(10, &crate::read_scope::ReadScope::Global)
@@ -5484,10 +5706,14 @@ async fn a_memory_revision_card_still_previews_its_stored_content() {
         .iter()
         .find(|item| item.revision_source_id == "mem_650_memory_card")
         .expect("the memory card must appear in the pending queue");
-    assert_eq!(
-        item.revision_content, stored,
-        "a memory card previews the text its accept stores, not the prose it \
-         was distilled from"
+    assert!(
+        item.revision_content.contains("CANONICAL-CLAIM-MARKER"),
+        "a memory card previews the text its accept stores"
+    );
+    assert!(
+        !item.revision_content.contains("PRE-DISTILLATION-MARKER"),
+        "a memory card must never preview the prose it was distilled from: \
+         accepting it would not write that text"
     );
 }
 

--- a/crates/wenlan-core/src/post_write/post_write_tests.rs
+++ b/crates/wenlan-core/src/post_write/post_write_tests.rs
@@ -5092,15 +5092,15 @@ async fn accept_pending_revision_page_write_card_with_matching_source_revision_w
 /// `stage_page_revision_card` puts the whole body in `source_text` on every
 /// chunk row, so the whole body is always there to be read.
 ///
-/// The multi-chunk assertion below is the test's own gate. Under the
-/// character fallback splitter a body has to clear roughly 1,500 characters
-/// to split at all, so a shorter fixture would pass against the broken read
-/// and prove nothing.
+/// The chunking assertion below is the test's own gate: a fixture that never
+/// split would pass against the broken read and prove nothing. The splitters
+/// cap a chunk at 1,500 characters for markdown, 512 for plain text, or 510
+/// BGE tokens with a tokenizer loaded, so this fixture is sized past all of
+/// them.
 #[tokio::test]
 async fn accepting_a_multi_chunk_page_card_keeps_the_whole_body() {
     let (db, _dir) = test_db().await;
     let mem_id = "mem_650_multi_chunk";
-    let new_mem_id = "mem_650_multi_chunk_source";
     let original_content = "Ownership rules make Rust memory safety explicit";
     // Kept close to the cited source: the human write runs through the same
     // hallucination guard, and an unrelated sentence fails it before the test
@@ -5131,9 +5131,6 @@ async fn accepting_a_multi_chunk_page_card_keeps_the_whole_body() {
     );
 
     seed_memory(&db, mem_id, original_content).await;
-    // The staging path checks the proposed prose against its cited sources,
-    // so the card needs a source that actually carries this body.
-    seed_memory(&db, new_mem_id, &proposed_content).await;
     let page_id = seed_page(&db, mem_id, original_content).await;
     update_page(
         &db,
@@ -5159,7 +5156,7 @@ async fn accepting_a_multi_chunk_page_card_keeps_the_whole_body() {
         &db,
         &before,
         &proposed_content,
-        &[mem_id.to_string(), new_mem_id.to_string()],
+        &[mem_id.to_string()],
         staged_source_revision,
         "page_growth",
         None,
@@ -5171,22 +5168,24 @@ async fn accepting_a_multi_chunk_page_card_keeps_the_whole_body() {
         .as_deref()
         .expect("staged page card must return an id");
 
-    // Gate: without more than one chunk row the broken read cannot truncate,
-    // so the assertion below would pass on unfixed code.
-    let chunk_rows: i64 = {
-        let conn = db.test_primary_session().await;
-        let mut rows = conn
-            .query(
-                "SELECT COUNT(*) FROM memories WHERE source = 'memory' AND source_id = ?1",
-                libsql::params![card_id.to_string()],
-            )
-            .await
-            .unwrap();
-        rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap()
-    };
+    // Gate: the card must really have chunked, or the assertions below would
+    // pass against the broken read and prove nothing. The chunk this row
+    // carries being shorter than what was staged is exactly that proof.
+    let payload = db
+        .pending_memory_revision_payload(card_id)
+        .await
+        .unwrap()
+        .expect("the staged card must resolve");
     assert!(
-        chunk_rows > 1,
-        "fixture must stage a card that actually chunked, got {chunk_rows} row(s)"
+        payload.content.len() < proposed_content.len(),
+        "fixture must stage a card that actually chunked: one row already holds \
+         all {} characters",
+        proposed_content.len()
+    );
+    assert_eq!(
+        payload.full_body.as_deref(),
+        Some(proposed_content.as_str()),
+        "the row must expose the whole staged body beside its chunk"
     );
 
     // The queue a human reads before clicking accept must show the same body
@@ -5221,6 +5220,274 @@ async fn accepting_a_multi_chunk_page_card_keeps_the_whole_body() {
          (got {} chars, staged {} chars)",
         after.content.len(),
         proposed_content.len()
+    );
+}
+
+/// Recovering the whole staged body must not smuggle raw personal data past
+/// the redaction the chunk rows already carry.
+///
+/// `upsert_documents` runs `redact_pii` on `content` before chunking but copies
+/// `source_text` in verbatim, so a read that recovers the body from
+/// `source_text` and hands it straight to the accept path would write an email
+/// address or a card number into the page and into its exported markdown --
+/// worse than the truncation of issue #650, and silent in the same way.
+#[tokio::test]
+async fn accepting_a_chunked_page_card_keeps_the_redaction_its_chunks_carry() {
+    let (db, _dir) = test_db().await;
+    let mem_id = "mem_650_redaction";
+    let original_content = "Ownership rules make Rust memory safety explicit";
+    let human_content =
+        "Ownership rules make Rust memory safety explicit. A human maintains this page.";
+
+    let leak = "alice@example.com";
+    let proposed_content = (1..=8)
+        .map(|section| {
+            format!(
+                "## Section {section}\n\n{}Reach the maintainer at {leak} for details.\n",
+                "Paragraph of the proposed revision, long enough that this page \
+                 splits into several rows rather than one. "
+                    .repeat(4)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    seed_memory(&db, mem_id, original_content).await;
+    let page_id = seed_page(&db, mem_id, original_content).await;
+    update_page(
+        &db,
+        &page_id,
+        UpdatePageRequest {
+            content: human_content.to_string(),
+            source_memory_ids: vec![mem_id.to_string()],
+            expected_version: None,
+            caller_id: None,
+            operation_id: None,
+        },
+        "fs_edit",
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let staged_source_revision = db.get_page_source_revision(&page_id).await.unwrap();
+    let card = stage_page_revision_card(
+        &db,
+        &before,
+        &proposed_content,
+        &[mem_id.to_string()],
+        staged_source_revision,
+        "page_growth",
+        None,
+    )
+    .await
+    .unwrap();
+    let card_id = card
+        .revision_card_id
+        .as_deref()
+        .expect("staged page card must return an id");
+
+    accept_pending_revision(&db, card_id, "test-agent")
+        .await
+        .unwrap();
+
+    let after = db.get_page(&page_id).await.unwrap().unwrap();
+    assert!(
+        !after.content.contains(leak),
+        "the raw address must never reach the page body"
+    );
+    assert!(
+        after.content.contains("[REDACTED:EMAIL]"),
+        "the page must carry the same redaction marker the chunk rows do"
+    );
+    assert_eq!(
+        after.content,
+        crate::privacy::redact_pii(&proposed_content),
+        "the page must equal the staged body with exactly the write-time \
+         redaction applied, nothing more and nothing less"
+    );
+}
+
+/// A human edit to a staged card is what its accept must write.
+///
+/// `apply_memory_update` rewrites chunk zero and deletes the rest without
+/// touching `source_text`, so an edited card is one row whose `source_text`
+/// still holds the body from before the edit. Recovering the body from that
+/// column unconditionally would revert the edit at the moment of accepting it
+/// -- the same silent wrong-body write as issue #650, pointed the other way.
+#[tokio::test]
+async fn accepting_an_edited_page_card_writes_the_edit_not_the_staged_body() {
+    let (db, _dir) = test_db().await;
+    let mem_id = "mem_650_edited";
+    let original_content = "Ownership rules make Rust memory safety explicit";
+    let human_content =
+        "Ownership rules make Rust memory safety explicit. A human maintains this page.";
+
+    // Staged long enough to chunk, so the row starts out in exactly the shape
+    // issue #650 is about.
+    let proposed_content = (1..=8)
+        .map(|section| {
+            format!(
+                "## Section {section}\n\n{}\n",
+                "Paragraph of the proposed revision, long enough that this page \
+                 splits into several rows rather than one. "
+                    .repeat(4)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    seed_memory(&db, mem_id, original_content).await;
+    let page_id = seed_page(&db, mem_id, original_content).await;
+    update_page(
+        &db,
+        &page_id,
+        UpdatePageRequest {
+            content: human_content.to_string(),
+            source_memory_ids: vec![mem_id.to_string()],
+            expected_version: None,
+            caller_id: None,
+            operation_id: None,
+        },
+        "fs_edit",
+        false,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let before = db.get_page(&page_id).await.unwrap().unwrap();
+    let staged_source_revision = db.get_page_source_revision(&page_id).await.unwrap();
+    let card = stage_page_revision_card(
+        &db,
+        &before,
+        &proposed_content,
+        &[mem_id.to_string()],
+        staged_source_revision,
+        "page_growth",
+        None,
+    )
+    .await
+    .unwrap();
+    let card_id = card
+        .revision_card_id
+        .as_deref()
+        .expect("staged page card must return an id");
+
+    // Gate: the card chunked, so before the edit the whole body is only
+    // reachable through `source_text`.
+    let staged = db
+        .pending_memory_revision_payload(card_id)
+        .await
+        .unwrap()
+        .expect("the staged card must resolve");
+    assert_eq!(
+        staged.full_body.as_deref(),
+        Some(proposed_content.as_str()),
+        "a chunked card must expose its whole staged body"
+    );
+
+    let edited_content = format!("{proposed_content}\n## Reviewed\n\nA human rewrote the end.\n");
+    update_memory(
+        &db,
+        card_id,
+        MemoryUpdate {
+            content: Some(&edited_content),
+            space: None,
+            confirm: false,
+            memory_type: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    // The edit collapsed the card to one row, so `content` is authoritative
+    // again and the stale `source_text` must be left alone.
+    let edited = db
+        .pending_memory_revision_payload(card_id)
+        .await
+        .unwrap()
+        .expect("the edited card must resolve");
+    assert_eq!(
+        edited.content, edited_content,
+        "the edited card's own row must hold the whole edited body"
+    );
+    assert_eq!(
+        edited.full_body, None,
+        "an unchunked card must not offer a body recovered from the stale \
+         `source_text` it kept from before the edit"
+    );
+
+    let queued = db
+        .list_pending_revisions_scoped(10, &crate::read_scope::ReadScope::Global)
+        .await
+        .unwrap();
+    let queued_card = queued
+        .iter()
+        .find(|item| item.revision_source_id == card_id)
+        .expect("the edited card must appear in the pending queue");
+    assert_eq!(
+        queued_card.revision_content, edited_content,
+        "the review queue must preview the edit, not the body staged before it"
+    );
+
+    accept_pending_revision(&db, card_id, "test-agent")
+        .await
+        .unwrap();
+
+    let after = db.get_page(&page_id).await.unwrap().unwrap();
+    assert_eq!(
+        after.content, edited_content,
+        "accepting an edited card must write the edit, not the staged body it \
+         replaced"
+    );
+}
+
+/// The queue must keep previewing a memory card's stored `content`.
+///
+/// Only a page card previews `source_text`. On a memory card `source_text` is
+/// the prose the row was distilled from, which its accept never writes, so
+/// previewing it would show the human text that accepting cannot produce.
+#[tokio::test]
+async fn a_memory_revision_card_still_previews_its_stored_content() {
+    let (db, _dir) = test_db().await;
+    let target_id = "mem_650_memory_target";
+    seed_memory(&db, target_id, "Postgres stores JSON in a JSONB column").await;
+
+    let stored = "Postgres stores JSON in a JSONB column, which is indexable";
+    let pre_distillation = "So anyway I looked it up and Postgres has this JSONB thing";
+    let card = crate::sources::RawDocument {
+        source: "memory".to_string(),
+        source_id: "mem_650_memory_card".to_string(),
+        title: "Revision: Postgres".to_string(),
+        content: stored.to_string(),
+        last_modified: chrono::Utc::now().timestamp(),
+        memory_type: Some("fact".to_string()),
+        source_agent: Some("test".to_string()),
+        confidence: Some(0.9),
+        supersedes: Some(target_id.to_string()),
+        pending_revision: true,
+        source_text: Some(pre_distillation.to_string()),
+        ..Default::default()
+    };
+    db.upsert_documents(vec![card]).await.unwrap();
+
+    let queued = db
+        .list_pending_revisions_scoped(10, &crate::read_scope::ReadScope::Global)
+        .await
+        .unwrap();
+    let item = queued
+        .iter()
+        .find(|item| item.revision_source_id == "mem_650_memory_card")
+        .expect("the memory card must appear in the pending queue");
+    assert_eq!(
+        item.revision_content, stored,
+        "a memory card previews the text its accept stores, not the prose it \
+         was distilled from"
     );
 }
 


### PR DESCRIPTION
Fixes #650.

## The bug

A page revision card long enough to chunk lost everything but one chunk when
accepted. Observed live: a 21,038-character page became 1,814.

`memories` stores one row per chunk, and every chunk of a staged card shares the
card's `source_id` **and** its `last_modified`. The read behind
`accept_page_revision_card` ordered by `last_modified DESC` and took `LIMIT 1`,
so the sort key was tied across every chunk and the row it got was arbitrary.
The accept path then wrote that fragment as the page's complete new body.

Two things made it silent. The pending-revisions queue previewed the same single
chunk, so the human reviewing the card could not see what accepting it would do.
And the page's markdown export was rewritten from the truncated body, so the
loss reached disk.

The staged card was never at fault: `stage_page_revision_card` puts the whole
body in `source_text` on every chunk row, so the whole body was always there.

## The fix

`pending_memory_revision_payload` pins `chunk_index = 0`, so the row is
deterministic instead of arbitrary, and returns the whole staged body beside the
chunk as a new `full_body` field. `resolve_page_revision_card` writes
`full_body` when it is there and `content` otherwise.

Both pending-revision listers get the same treatment, so the queue a human reads
and the body an accept writes now come from one row. The unscoped
`list_pending_revisions` had no chunk filter at all and was returning one queue
item per chunk; it is pinned to chunk zero too.

Two things make `source_text` wrong to read raw, and this PR handles both. They
are what the first version of this fix got wrong.

**Redaction and grounding.** `upsert_documents` runs `redact_pii` on `content`
and grounds relative dates in it *before* chunking, but copies `source_text` in
verbatim. Handing the raw column to the accept path would write an email address
or a card number into a page and into its exported markdown — worse than the
truncation, and silent in the same way. `rehydrate_staged_body` re-applies both
transforms against the row's own `last_modified` anchor.

**Human edits.** `apply_memory_update` rewrites chunk zero's `content` and
deletes the sibling chunks without touching `source_text`, so an edited card is
a single row whose `source_text` holds the body from *before* the edit. Reading
that column unconditionally would revert the human's edit at the moment they
accepted it. So `full_body` is `Some` only when sibling chunks actually exist —
the exact condition under which `content` is a fragment. With no siblings,
`content` is already the whole body and it wins.

A memory card keeps previewing and accepting `content` whatever its shape:
there `source_text` is the pre-distillation prose, not the body an accept
stores.

## Evidence

End-to-end against an isolated daemon — its own port (17878), its own
`WENLAN_DATA_DIR`, its own pages directory written into a scratch `config.json`
before spawn, and `WENLAN_NO_AUTOSTART=1`, with the daemon's reported knowledge
path checked against the scratch directory before the drive proceeds. Store a
memory, create a page citing it, edit the page by hand so machine writes gate,
refresh with a 5,215-character body, review the queue, accept, read the page
back.

| leg | before | after |
|---|---|---|
| queue preview | 1,301 of 5,215 chars | 5,215 of 5,215 |
| page after accept | 1,301 chars | 5,215 chars, exact match |
| accept after a human edits the card | — | writes the edit, not the staged body |

Six new tests in `post_write_tests.rs`. Each is proved load-bearing by a
mutation control that failed exactly it and left the others green, with both
edited source files checksummed back to their pre-mutation bytes afterwards:

| test | control that breaks it |
|---|---|
| `accepting_a_multi_chunk_page_card_keeps_the_whole_body` | the original single-chunk read |
| `accepting_a_chunked_page_card_keeps_the_redaction_its_chunks_carry` | drop `redact_pii` from `rehydrate_staged_body` |
| `accepting_an_edited_page_card_writes_the_edit_not_the_staged_body` | remove the sibling-chunk gate |
| `a_memory_revision_card_still_previews_its_stored_content` | drop the page check from the preview |
| `a_recovered_body_grounds_against_the_staging_date_not_a_later_edit` | anchor grounding on `last_modified` |
| `a_page_card_survives_its_accept_at_every_length` | (a length sweep, not a single mutation) |

The sweep runs the whole stage-and-accept cycle at five lengths spanning both
budgets that decide whether a card chunks, because a chunk-boundary bug proved
at one fixture size is proved only at that size.

`cargo clippy -p wenlan-core -p wenlan --all-targets` is clean. CI is green on
this commit: all three Linux test slices, all three macOS slices, formatting,
lint, contract integration, and canonical acceptance.

The local `cargo test -p wenlan-core --lib` run is 4195 passed, 1 failed. The one
failure is `lint::serving::tests::the_model_source_pin_reaches_only_the_graph_channel_through_the_runner`
("runtime.provider_inventory lost its finding"), which is pre-existing and not
reachable from this diff. Its helper `run_with_kg_config`
(`crates/wenlan-core/src/lint/serving_test.rs:134`) sets four
`WENLAN_ENABLE_*_CHANNEL` variables through `temp_env`, and environment variables
are process-wide, so a test running beside it can change the provider inventory
between the two runs the assertion compares. It passes on its own, and CI's
per-process test runner passes it on every slice. This is its second observed
occurrence, so by `docs/ci-flake-policy.md` it wants an owner and a fix of its
own -- separately from this PR, which touches nothing in the lint module.

## Known and not fixed here

- `src/lib/wordDiff.ts` bails out of the word-level diff past a million cells and
  falls back to a whole-block replace. Full bodies now reach that code where
  chunks used to, so a long page's review diff will collapse more often. That is
  a UI budget question, separate from the data loss.
- `/api/memory/pending-revisions` now returns whole bodies rather than first
  chunks, with a default limit of 50 and a maximum of 500. Worth watching.
- `crates/wenlan-cli/src/commands/curate.rs` joins per-chunk rows. Against a
  current daemon it folds nothing; it is kept for daemon/CLI version skew and its
  comment now says so rather than asserting the old shape.

## Review closure

An independent review of the integrated diff returned **ship**, confirmed both
subtleties above by reading every production writer of a `pending_revision` row,
and raised four low findings. All four are fixed here.

The one real code bug: `rehydrate_staged_body` anchored grounding on the row's
`last_modified`, which matches the write path only at insert.
`apply_memory_update` bumps `last_modified` on every call, and its sibling-chunk
delete sits inside the content branch, so a metadata-only edit -- confirming a
card, or moving it to another space -- moves the timestamp while leaving the card
chunked. A card staged in January and confirmed in March would have had
"yesterday" grounded to the day before the confirmation. All three reads now
anchor on `COALESCE(created_at, last_modified)`, written once at insert and never
moved. Latent rather than live, since grounding is off by default -- and now
covered by the first test of that branch.

The other three: the comment above the accept path's `full_body.unwrap_or(content)`
described the fallback as legacy-only when it is the ordinary path for short
pages and edited cards; the redaction test had no chunking gate, so a raised
budget would have silently stopped it exercising redaction; and the
memory-preview card was a single chunk, so deleting the page check from the
preview left every test green.

## Note on the earlier red CI

The Linux nextest slices failed on the first push with the two
`drift_guard::r4_test_support_test` census tests: the test added then used raw
`TestDbSession` calls, which that census freezes by exact count and manifest.
The test now gates on `pending_memory_revision_payload` instead, which both
clears the census and exercises the new field directly.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
