### PR TITLE
fix(harness): close shared Claude/Codex hook and runner gaps

### DIFF
--- a/.claude/hooks/block-no-verify.sh
+++ b/.claude/hooks/block-no-verify.sh
@@ -30,8 +30,21 @@ CMD="$(printf '%s' "$INPUT" | "$PYTHON_BIN" -c 'import sys,json; d=json.load(sys
 # mentions "--no-verify" gets blocked.
 case "$CMD" in
   *git\ *)
+    # Normalize whitespace so `-c commit.gpgsign = false` (spaced =) can't bypass
+    # the literal `-c commit.gpgsign=false` match.
+    NORM_CMD="$(printf '%s' "$CMD" | tr -d '[:space:]')"
     case "$CMD" in
-      *"--no-verify"*|*"--no-gpg-sign"*|*"-c commit.gpgsign=false"*)
+      *"--no-verify"*|*"--no-gpg-sign"*)
+        {
+          echo "🛑 Blocked: git command uses --no-verify / --no-gpg-sign / signing-bypass."
+          echo "    Command: $CMD"
+          echo "    Per project policy hooks must run. Fix the underlying issue."
+        } >&2
+        exit 2
+        ;;
+    esac
+    case "$NORM_CMD" in
+      *"-ccommit.gpgsign=false"*)
         {
           echo "🛑 Blocked: git command uses --no-verify / --no-gpg-sign / signing-bypass."
           echo "    Command: $CMD"

--- a/.claude/hooks/block-release-please-files.sh
+++ b/.claude/hooks/block-release-please-files.sh
@@ -29,10 +29,23 @@ fi
 
 # Block Cargo.toml ONLY if it has release-please version marker
 if [[ "$file_path" == */Cargo.toml || "$file_path" == Cargo.toml ]]; then
-  if [[ -f "$file_path" ]] && grep -q 'x-release-please-version' "$file_path" 2>/dev/null; then
-    echo "BLOCKED: $file_path has release-please-managed version line. Bump via release-please PR, not direct edit." >&2
-    exit 2
+  # Resolve relative paths against the repo root so a bare `Cargo.toml` or
+  # `app/Cargo.toml` can't bypass the marker check when the hook's cwd is
+  # not the repo root.
+  REPO_DIR="${CLAUDE_PROJECT_DIR:-}"
+  if [[ -z "$REPO_DIR" ]]; then
+    REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   fi
+  candidates=("$file_path")
+  if [[ "$file_path" != /* ]]; then
+    candidates+=("$REPO_DIR/$file_path")
+  fi
+  for cand in "${candidates[@]}"; do
+    if [[ -f "$cand" ]] && grep -q 'x-release-please-version' "$cand" 2>/dev/null; then
+      echo "BLOCKED: $file_path has release-please-managed version line. Bump via release-please PR, not direct edit." >&2
+      exit 2
+    fi
+  done
 fi
 
 exit 0

--- a/.claude/hooks/pre-stop-gate.sh
+++ b/.claude/hooks/pre-stop-gate.sh
@@ -36,7 +36,7 @@ if [ "${#FILES[@]}" -gt 0 ]; then
     'assert_eq!\s*\(\s*true\s*,\s*true\s*\)'
     'todo!\s*\('
     'unimplemented!\s*\('
-    '^\s*//.*FIXME'
+    '^[+ ]*\s*//.*FIXME'
     'assert[[:space:]]*\([[:space:]]*true[[:space:]]*\)'
     'expect[[:space:]]*\([[:space:]]*true[[:space:]]*\)[[:space:]]*\.toBe[[:space:]]*\([[:space:]]*true[[:space:]]*\)'
     '(^|[^[:alnum:]_])(it|test)\.skip[[:space:]]*\('

--- a/.claude/hooks/test-hooks.sh
+++ b/.claude/hooks/test-hooks.sh
@@ -21,6 +21,9 @@ t() { # desc script stdin want-exit
 }
 
 t "no-verify: block --no-verify"           block-no-verify.sh '{"tool_input":{"command":"git commit --no-verify -m x"}}' 2
+t "no-verify: block --no-gpg-sign"         block-no-verify.sh '{"tool_input":{"command":"git commit --no-gpg-sign -m x"}}' 2
+t "no-verify: block -c gpgsign=false"      block-no-verify.sh '{"tool_input":{"command":"git -c commit.gpgsign=false commit -m x"}}' 2
+t "no-verify: block spaced gpgsign=false"  block-no-verify.sh '{"tool_input":{"command":"git -c commit.gpgsign = false commit -m x"}}' 2
 t "no-verify: allow plain git"             block-no-verify.sh '{"tool_input":{"command":"git status"}}' 0
 t "no-verify: allow innocent mention"      block-no-verify.sh '{"tool_input":{"command":"grep -- --no-verify README.md"}}' 0
 t "no-verify: malformed JSON fails closed" block-no-verify.sh 'not json' 2
@@ -28,6 +31,18 @@ t "release-please: block CHANGELOG.md"     block-release-please-files.sh '{"tool
 t "release-please: allow normal file"      block-release-please-files.sh '{"tool_input":{"file_path":"/x/src/main.rs"}}' 0
 t "release-please: allow no file_path"     block-release-please-files.sh '{"tool_input":{}}' 0
 t "release-please: malformed JSON fails closed" block-release-please-files.sh '{{{' 2
+
+RP_TMP="$(mktemp -d "${TMPDIR:-/tmp}/wenlan-rp.XXXXXX")"
+mkdir -p "$RP_TMP/marked" "$RP_TMP/unmarked"
+printf '[package]\nversion = "0.1.0" # x-release-please-version\n' > "$RP_TMP/marked/Cargo.toml"
+printf '[package]\nversion = "0.1.0"\n' > "$RP_TMP/unmarked/Cargo.toml"
+t "release-please: block Cargo.toml with marker" block-release-please-files.sh "{\"tool_input\":{\"file_path\":\"$RP_TMP/marked/Cargo.toml\"}}" 2
+t "release-please: allow Cargo.toml without marker" block-release-please-files.sh "{\"tool_input\":{\"file_path\":\"$RP_TMP/unmarked/Cargo.toml\"}}" 0
+rp_got="$(printf '{"tool_input":{"file_path":"Cargo.toml"}}' | CLAUDE_PROJECT_DIR="$RP_TMP/marked" bash block-release-please-files.sh >/dev/null 2>&1; echo $?)"
+if [ "$rp_got" -eq 2 ]; then echo "PASS  release-please: relative Cargo.toml resolves via CLAUDE_PROJECT_DIR"; else echo "FAIL  release-please: relative Cargo.toml resolves via CLAUDE_PROJECT_DIR (want exit 2, got $rp_got)"; fails=$((fails + 1)); fi
+rp_got="$(printf '{"tool_input":{"file_path":"Cargo.toml"}}' | CLAUDE_PROJECT_DIR="$RP_TMP/unmarked" bash block-release-please-files.sh >/dev/null 2>&1; echo $?)"
+if [ "$rp_got" -eq 0 ]; then echo "PASS  release-please: relative unmarked Cargo.toml allows"; else echo "FAIL  release-please: relative unmarked Cargo.toml allows (want exit 0, got $rp_got)"; fails=$((fails + 1)); fi
+rm -rf "$RP_TMP"
 
 stop_t() { # desc fixture want-exit
   local tmp got filename
@@ -41,9 +56,41 @@ stop_t() { # desc fixture want-exit
       filename=canary.rs
       printf 'fn main() { todo!(); }\n' > "$tmp/$filename"
       ;;
+    rust-assert-true)
+      filename=canary.rs
+      printf 'fn main() { assert!(true); }\n' > "$tmp/$filename"
+      ;;
+    rust-assert-eq)
+      filename=canary.rs
+      printf 'fn main() { assert_eq!(true, true); }\n' > "$tmp/$filename"
+      ;;
+    rust-unimplemented)
+      filename=canary.rs
+      printf 'fn main() { unimplemented!(); }\n' > "$tmp/$filename"
+      ;;
+    rust-fixme)
+      filename=canary.rs
+      printf '// FIXME: finish this\nfn main() {}\n' > "$tmp/$filename"
+      ;;
+    ts-assert)
+      filename=canary.ts
+      printf 'assert(true);\n' > "$tmp/$filename"
+      ;;
+    ts-expect)
+      filename=canary.ts
+      printf 'expect(true).toBe(true);\n' > "$tmp/$filename"
+      ;;
     ts-skip)
       filename=canary.ts
       printf 'it.skip("pending", () => {});\n' > "$tmp/$filename"
+      ;;
+    ts-test-skip)
+      filename=canary.ts
+      printf 'test.skip("pending", () => {});\n' > "$tmp/$filename"
+      ;;
+    ts-xit)
+      filename=canary.ts
+      printf 'xit("pending", () => {});\n' > "$tmp/$filename"
       ;;
     clean)
       ;;
@@ -63,7 +110,15 @@ stop_t() { # desc fixture want-exit
 }
 
 stop_t "pre-stop: block staged todo!" rust-todo 2
+stop_t "pre-stop: block staged assert!(true)" rust-assert-true 2
+stop_t "pre-stop: block staged assert_eq!(true,true)" rust-assert-eq 2
+stop_t "pre-stop: block staged unimplemented!" rust-unimplemented 2
+stop_t "pre-stop: block staged FIXME" rust-fixme 2
+stop_t "pre-stop: block staged assert(true)" ts-assert 2
+stop_t "pre-stop: block staged expect(true).toBe(true)" ts-expect 2
 stop_t "pre-stop: block staged TS skip" ts-skip 2
+stop_t "pre-stop: block staged test.skip" ts-test-skip 2
+stop_t "pre-stop: block staged xit" ts-xit 2
 stop_t "pre-stop: allow clean tree" clean 0
 
 # ---- wrapper-level cases: exercise the REAL settings.json command strings, not
@@ -126,9 +181,22 @@ rm -rf "$D"
 J="$(jq -n --arg cwd "$ROOT" --arg fp "$ROOT/CHANGELOG.md" '{cwd:$cwd, tool_input:{file_path:$fp}}')"
 wt "wrapper write: CLAUDE_PROJECT_DIR resolves, inner blocks CHANGELOG.md" "$W_WRITE" "$J" "$ROOT" 2
 
+# Inside a repo that's just missing the script: still fail closed.
+D="$(mktemp -d "${TMPDIR:-/tmp}/wenlan-wrap.XXXXXX")"
+git init -q "$D"
+J="$(jq -n --arg cwd "$D" --arg fp "$D/CHANGELOG.md" '{cwd:$cwd, tool_input:{file_path:$fp}}')"
+wt "wrapper write: cwd inside a repo missing the script -> fail closed" "$W_WRITE" "$J" "/nonexistent/path" 2 "inside a repo"
+rm -rf "$D"
+
 D="$(mktemp -d "${TMPDIR:-/tmp}/wenlan-wrap.XXXXXX")"
 J="$(jq -n --arg cwd "$D" '{cwd:$cwd}')"
 wt "wrapper stop: cwd outside any git repo -> allow" "$W_STOP" "$J" "/nonexistent" 0
+rm -rf "$D"
+
+D="$(mktemp -d "${TMPDIR:-/tmp}/wenlan-wrap.XXXXXX")"
+git init -q "$D"
+J="$(jq -n --arg cwd "$D" '{cwd:$cwd}')"
+wt "wrapper stop: cwd inside a repo missing the script -> gate did not run" "$W_STOP" "$J" "/nonexistent/path" 1 "did not run"
 rm -rf "$D"
 
 echo "----"

--- a/.claude/rules/app-eval.md
+++ b/.claude/rules/app-eval.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "app/eval/**"
+---
+
+Before editing files here, read `app/eval/AGENTS.md`. It holds the instructions for eval fixtures and artifacts.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/app.md
+++ b/.claude/rules/app.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "app/**"
+---
+
+Before editing files here, read `app/AGENTS.md`. It holds the instructions for the Tauri desktop app.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/e2e.md
+++ b/.claude/rules/e2e.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "e2e/**"
+---
+
+Before editing files here, read `e2e/AGENTS.md`. It holds the instructions for browser e2e tests.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/frontend-memory.md
+++ b/.claude/rules/frontend-memory.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "src/components/memory/**"
+---
+
+Before editing files here, read `src/components/memory/AGENTS.md`. It holds the instructions for the memory components.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "src/**"
+---
+
+Before editing files here, read `src/AGENTS.md`. It holds the instructions for the React frontend.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/preview.md
+++ b/.claude/rules/preview.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "preview/**"
+---
+
+Before editing files here, read `preview/AGENTS.md`. It holds the instructions for the browser-only preview harness.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "scripts/**"
+---
+
+Before editing files here, read `scripts/AGENTS.md`. It holds the instructions for release, sidecar, and repo-inventory scripts.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/wenlan-core-eval.md
+++ b/.claude/rules/wenlan-core-eval.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "crates/wenlan-core/src/eval/**"
+---
+
+Before editing files here, read `crates/wenlan-core/src/eval/AGENTS.md`. It holds the instructions for Rust eval runners and experiment design.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/wenlan-core-retrieval.md
+++ b/.claude/rules/wenlan-core-retrieval.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "crates/wenlan-core/src/retrieval/**"
+---
+
+Before editing files here, read `crates/wenlan-core/src/retrieval/AGENTS.md`. It holds the instructions for retrieval channels and ranking.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/wenlan-core.md
+++ b/.claude/rules/wenlan-core.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "crates/wenlan-core/**"
+---
+
+Before editing files here, read `crates/wenlan-core/AGENTS.md`. It holds the instructions for business logic, storage, retrieval, enrichment, and the core invariants.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/rules/wenlan-server.md
+++ b/.claude/rules/wenlan-server.md
@@ -1,0 +1,7 @@
+---
+paths:
+  - "crates/wenlan-server/**"
+---
+
+Before editing files here, read `crates/wenlan-server/AGENTS.md`. It holds the instructions for the HTTP daemon, runtime workers, and the single database writer.
+Claude Code auto-loads this rule by path; the nested `AGENTS.md` itself is not auto-loaded.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "alwaysThinkingEnabled": true,
   "autoUpdatesChannel": "stable",
   "effortLevel": "xhigh",
-  "env": {
-    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
-    "MAX_THINKING_TOKENS": "16384"
-  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ crates/*/.fastembed_cache
 !.claude/settings.json
 !.claude/hooks/
 !.claude/agents/
+!.claude/rules/
 # Skills are tracked selectively: verification skills ship with the repo,
 # personal/local skills stay local.
 !.claude/skills/

--- a/plugin-codex/bin/wenlan-mcp-runner.sh
+++ b/plugin-codex/bin/wenlan-mcp-runner.sh
@@ -5,7 +5,10 @@
 #   1. Sibling file `bin/wenlan-mcp.local` next to this script.
 #   2. WENLAN_MCP_DEV_BIN env var, for local development.
 #   3. ~/.wenlan/bin/wenlan-mcp, installed by install.sh.
-#   4. npx -y wenlan-mcp@^0.18.0, package fallback.
+#   4. npx -y wenlan-mcp@^<.codex-plugin/plugin.json version>, package fallback.
+#      The version is derived from the sibling plugin.json (the single source
+#      of truth kept on the release train) rather than a hardcoded pin that
+#      silently drifts — same approach as the Claude runner.
 #
 # The explicit agent name is a Codex plugin requirement: stdio MCP clients may
 # send a client name during initialize, but the fallback must not mislabel
@@ -29,4 +32,15 @@ if [ -x "${installed_bin}" ]; then
   exec "${installed_bin}" --agent-name "${agent_name}" "$@"
 fi
 
-exec npx -y wenlan-mcp@^0.18.0 --agent-name "${agent_name}" "$@"
+# Derive the npm version from the sibling plugin.json (single source of truth on
+# the release train) so the fallback can't drift from a hardcoded pin; @latest if
+# it can't be read. Strip any pre-release/build suffix (e.g. "0.17.0+codex").
+# ponytail: sed-parse the one "version" key — no python/jq dep in the MCP host shell.
+plugin_json="${here}/../.codex-plugin/plugin.json"
+ver="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${plugin_json}" 2>/dev/null | head -1)"
+ver="${ver%%+*}"
+ver="${ver%%-*}"
+if [ -n "${ver}" ]; then
+  exec npx -y "wenlan-mcp@^${ver}" --agent-name "${agent_name}" "$@"
+fi
+exec npx -y wenlan-mcp@latest --agent-name "${agent_name}" "$@"


### PR DESCRIPTION
Closes the five gaps from the shared-harness audit (Claude/Codex/Muse md, hooks, skills, plugins):

- pre-stop-gate: FIXME pattern now tolerates the '+' diff prefix; staged '// FIXME' blocks (was silent allow)
- block-no-verify: gpgsign match is whitespace-insensitive; '-c commit.gpgsign = false' blocks
- block-release-please: relative Cargo.toml paths resolve against repo root before the marker grep
- test-hooks canary: gpg-sign cases, all 9 stop-gate patterns, marker allow-vs-block, Write (exit 2) / Stop (exit 1) missing-script fail-closed cases
- plugin-codex runner: npx fallback version derived from .codex-plugin/plugin.json (strips +codex suffix), mirroring the Claude runner. Rebased over main's 0.17 to 0.18 pin bump; the derived value now reads 0.18.0.

Second commit (b80df578, from the 2026-09-04 Fable harness audit):

- `.claude/settings.json`: remove `alwaysThinkingEnabled`, `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING` and `MAX_THINKING_TOKENS`. Claude 5 models always use adaptive reasoning and ignore them; `effortLevel` stays the control.
- `.claude/rules/<area>.md` (11 files) with `paths:` globs, each pointing at the nested `AGENTS.md` for that subtree. Claude Code auto-loads nested `CLAUDE.md` and path rules, not nested `AGENTS.md`, so a session that skipped the root "Start here" table never saw them. `.gitignore` un-ignores `.claude/rules/`.

Evidence (at b80df578, rebased on main 4e4e05c2):
- 'bash .claude/hooks/test-hooks.sh' -> hook canary: ALL PASS
- 'bash scripts/git-hooks.test.sh' -> git hook routing contracts: PASS
- Runner version parse from plugin.json -> 0.18.0
- Path-rule auto-load is unchecked until a fresh session touches a covered subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUUSFLHk7LrKPWVZ27nG1z