### PR TITLE
fix(app): stop the Windows window starting blank and link the desktop app from the release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,14 @@ jobs:
               - 'scripts/validate-versions.test.sh'
               - 'scripts/bump-version.sh'
               - 'scripts/bump-version.test.sh'
+              # validate-versions.test.sh runs the release contract suite, and
+              # this is its only LINUX lane. One of that suite's mutations --
+              # dropping the CR strip from the release-note link step -- can
+              # only be seen where awk keeps the CR of a CRLF line, which the
+              # Windows lane's MSYS awk does not, so it prints UNCHECKED there.
+              # Without this entry a change to the truth table alone would be
+              # measured only on the host that cannot measure that row.
+              - 'scripts/release-workflow-contract.test.py'
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
             # The release workflow's shipped contracts. `docs` already routes
@@ -298,9 +306,10 @@ jobs:
             # feeds the Windows lane that runs the same suite with
             # WENLAN_REQUIRE_AUTHENTICODE=1, where UNCHECKED is fatal.
             #
-            # The suite's own file is listed, which `docs` does not do: a change
-            # to release-workflow-contract.test.py alone currently runs nothing
-            # at all.
+            # The suite's own file is listed here too, so a change to it alone
+            # reaches BOTH lanes: this one, where Authenticode is required, and
+            # the Ubuntu provenance lane, which is the only host where the
+            # release-note step's CRLF mutation can bite.
             release-contract:
               - '.github/workflows/ci.yml'
               - '.github/workflows/release.yml'
@@ -2463,6 +2472,17 @@ jobs:
         run: pnpm test:i18n
       - name: Frontend unit tests
         run: pnpm test
+      # index.html's first-paint style and script sit outside the module graph,
+      # so the unit run above can only check the source. dist/ is gitignored and
+      # nothing before this point builds it, which left the assertions about the
+      # shipped file skipped on every run. This builds, then re-runs that one
+      # file with WENLAN_REQUIRE_DIST set so an absent dist/ fails instead of
+      # skipping. The build on the same line is what makes the artifact current;
+      # the test's own mtime check only catches a local edit-without-rebuild.
+      - name: First paint survives the production bundle
+        run: pnpm build && pnpm vitest run src/__tests__/firstPaint.test.ts
+        env:
+          WENLAN_REQUIRE_DIST: "1"
       - name: Build + verify fixture-only Review app
         run: pnpm review:build && pnpm review:verify
       - name: Install Playwright Chromium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2281,6 +2281,16 @@ jobs:
       # promoted the release, leaving v0.15.5 stable but still labelled pending.
       pull-requests: write
     steps:
+      # The Install section prepare-release writes is entirely command line:
+      # three `npx`, two `curl | bash`. A Windows user has none of those, so the
+      # one artifact built for them was reachable only by expanding a collapsed
+      # list of fifteen assets. The links belong in the notes — but not in
+      # prepare-release, which creates the prerelease publicly and in parallel
+      # with the two bundle jobs, so a link written there points at nothing for
+      # the 40-210 minutes they run, and forever if either one fails. This job
+      # needs promote-app-assets, so by here the installers are really on the
+      # release; the step still checks rather than assuming, and refuses to
+      # write a link it cannot see the target of.
       - name: Publish SHA256SUMS
         run: |
           set -euo pipefail
@@ -2408,6 +2418,131 @@ jobs:
             <<<"$labels" >/dev/null
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # After Promote, before the cleanup PR. Publish SHA256SUMS and
+      # Promote are load-bearing and this step is cosmetic, so a filename
+      # it cannot match must never be what leaves a release unpromoted or
+      # unchecksummed. It sits ahead of the cleanup PR because that step
+      # can fail after creating its branch and then exit 0 on the re-run,
+      # so putting the links behind it would let a release keep the notes
+      # it shipped with.
+      - name: Link the desktop app from the release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same derivation as app-bundle-windows: all four secrets, not one.
+          # Whether the installer is signed decides whether the notes should
+          # warn about SmartScreen, and hardcoding "unsigned" would quietly
+          # become a lie the day signing is switched on. Nothing is claimed
+          # about macOS, which is Developer ID signed and notarized from
+          # v0.17.4 (docs/code-signing.md) and needs no warning at all.
+          SIGNPATH_CONFIGURED: ${{ secrets.SIGNPATH_API_TOKEN != '' && secrets.SIGNPATH_ORGANIZATION_ID != '' && secrets.SIGNPATH_PROJECT_SLUG != '' && secrets.SIGNPATH_SIGNING_POLICY_SLUG != '' }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          win="Wenlan_${version}_x64-setup.exe"
+          dmg="Wenlan_${version}_aarch64.dmg"
+
+          names="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[].name')"
+          for asset in "$win" "$dmg"; do
+            grep -Fxq "$asset" <<<"$names" || {
+              echo "ERROR: $asset is not on $RELEASE_TAG; refusing to link it." >&2
+              exit 1
+            }
+          done
+
+          base="https://github.com/$GITHUB_REPOSITORY/releases/download/$RELEASE_TAG"
+          {
+            echo "**Desktop app:**"
+            echo
+            echo "- Windows: [$win]($base/$win)"
+            echo "- macOS (Apple silicon): [$dmg]($base/$dmg)"
+            echo
+            # Signing does not simply switch the warning off. Microsoft weighs
+            # the file's hash as well as the publisher certificate, so a newly
+            # signed binary can still warn until one of the two accumulates
+            # reputation, and the Foundation certificate names SignPath rather
+            # than Wenlan (docs/code-signing.md). Dropping this the day signing
+            # lands would take the instructions away from users who still need
+            # them; only the reason changes. Both branches say "may": SmartScreen
+            # can be off, and reputation can already have accumulated.
+            if [[ "$SIGNPATH_CONFIGURED" == "true" ]]; then
+              echo "Windows may still show \"Windows protected your PC\" until this download's hash or its publisher has built up enough reputation — choose **More info → Run anyway**."
+            else
+              echo "The Windows installer is not code-signed yet, so Windows may show \"Windows protected your PC\" on first run — choose **More info → Run anyway**."
+            fi
+            echo
+          } > "$RUNNER_TEMP/desktop.md"
+
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json body --jq .body > "$RUNNER_TEMP/body.md"
+
+          # GitHub stores whatever line endings the writer used, and anything
+          # edited through the web UI comes back CRLF. Left alone, awk's
+          # `$0 == "## Install"` would be comparing against "## Install\r" and
+          # the step would report a missing heading on a release that has one.
+          # Stripping CR changes no rendered character.
+          sed -i 's/\r$//' "$RUNNER_TEMP/body.md"
+
+          # Only the Install section counts as "already linked". A bullet
+          # identical to ours can sit in a changelog entry or a fenced example
+          # elsewhere in the notes, and treating that as the real section would
+          # exit green having linked nothing. Trailing whitespace is ignored
+          # here but preserved in the body that gets written back.
+          awk '/^## /{ inside = ($0 == "## Install") } inside' "$RUNNER_TEMP/body.md" \
+            | sed 's/[[:space:]]*$//' > "$RUNNER_TEMP/install.md"
+
+          # Both link lines or neither. Matching one would call a half-repaired
+          # note finished, and exiting green there restores the very defect this
+          # step exists to fix, so a partial state stops the step instead.
+          #
+          # The markers are the two rendered list items, matched whole-line with
+          # -Fx, and deliberately not the "**Desktop app:**" heading or a bare
+          # URL. The heading is what release-please renders for an ordinary
+          # `fix(Desktop app):` commit, so keying on it would make a normal
+          # changelog look half-linked. A bare URL is worse in both directions:
+          # a changelog that merely mentions the installer URL would fail the
+          # job, and a body that happened to carry both URLs somewhere else
+          # would be declared done while the Install section still had nothing
+          # in it. A whole line of the exact form written below is the section
+          # itself, not a substring that can wander in from prose.
+          present=0
+          while IFS= read -r marker; do
+            [[ -n "$marker" ]] || continue
+            # -- because every marker starts with "- ", which grep would
+            # otherwise read as a bundle of short options.
+            if grep -Fxq -- "$marker" "$RUNNER_TEMP/install.md"; then
+              present=$((present + 1))
+            fi
+          done <<<"$(grep '^- ' "$RUNNER_TEMP/desktop.md")"
+          if [[ "$present" -eq 2 ]]; then
+            echo "Desktop links already present on $RELEASE_TAG; nothing to do."
+            exit 0
+          fi
+          if [[ "$present" -ne 0 ]]; then
+            echo "ERROR: the $RELEASE_TAG notes already carry $present of the 2 desktop links; refusing to guess at the rest." >&2
+            exit 1
+          fi
+
+          # Insert under the Install heading so the desktop app is the first
+          # thing a reader of that section sees.
+          awk -v block="$RUNNER_TEMP/desktop.md" '
+            { print }
+            !inserted && $0 == "## Install" {
+              print ""
+              while ((getline line < block) > 0) print line
+              inserted = 1
+            }
+            END { if (!inserted) exit 3 }
+          ' "$RUNNER_TEMP/body.md" > "$RUNNER_TEMP/body.new.md" || {
+            echo "ERROR: no '## Install' heading in the $RELEASE_TAG notes; left unchanged." >&2
+            exit 1
+          }
+
+          gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --notes-file "$RUNNER_TEMP/body.new.md"
+          echo "---- desktop section ----"
+          cat "$RUNNER_TEMP/desktop.md"
+
       - name: Open the release-as override cleanup PR
         # A deliberate minor/major is steered by a one-shot `release-as`
         # override in release-please-config.json (docs/RELEASING.md,

--- a/app/tauri.conf.json
+++ b/app/tauri.conf.json
@@ -69,7 +69,12 @@
       "binaries/wenlan-server",
       "binaries/wenlan-mcp",
       "binaries/cloudflared"
-    ]
+    ],
+    "windows": {
+      "nsis": {
+        "installerIcon": "icons/icon.ico"
+      }
+    }
   },
   "plugins": {
     "updater": {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,109 @@
     <!-- Served from public/fonts, not from Google. See that directory's fonts.css. -->
     <link rel="stylesheet" href="/fonts/fonts.css" />
     <title>Wenlan</title>
+    <style>
+      /*
+        First paint, before index.css or React exist.
+
+        index.css keeps `html` and `body` transparent so the toast and
+        quick-capture webviews can float over the desktop, and the main window
+        inherits that: from the moment it is shown until React's first render it
+        paints nothing at all. macOS never revealed this because app/src/lib.rs
+        gives the main window a native NSColor background; there is no such call
+        on Windows or Linux, and app/tauri.conf.json shows the window from
+        config on purpose ("launch cannot depend on a frontend event to
+        appear"), so a cold start there is a blank rectangle for as long as the
+        bundle, the fonts and the daemon health check take. On a version upgrade
+        that also waits on database migrations, which is tens of seconds.
+
+        Painting the app's own base colour costs two rules and closes that
+        window — from the first parse of this file until React renders —
+        without weakening the guarantee. Scoped to the main window: the overlay
+        webviews must stay transparent.
+
+        It does not cover the frame before that. The main window declares no
+        backgroundColor, so Wry leaves WebView2's controller background unset
+        and Windows paints its default white until this file is parsed. That is
+        a much shorter flash than the one above, but it is a real one for a
+        dark-theme user, and closing it means setting a window background
+        colour from Rust. A static one cannot be right for both themes, and
+        Rust cannot read the theme from localStorage before the webview exists,
+        so it needs the OS preference instead. Deliberately left alone here.
+
+        `html[data-window="main"]` is (0,1,1) against index.css's `html, body`
+        at (0,0,1), so this wins on specificity whatever order the bundler emits
+        the stylesheets in.
+      */
+      html[data-window="main"] {
+        background: #11131a;
+      }
+      html[data-window="main"][data-theme="light"] {
+        background: #fcfcfb;
+      }
+    </style>
+    <script>
+      // A classic script, so it runs to completion before the module below and
+      // its attributes land on the first frame.
+      (function () {
+        // Tauri injects __TAURI_INTERNALS__ ahead of any page script, and
+        // getCurrentWindow() reads currentWindow.label straight out of it. That
+        // label is the window's real identity. The URL fragment is only a
+        // routing convention, and reading it instead gets this wrong twice:
+        // `index.html#` has an empty `location.hash`, and a fragment added
+        // after parsing arrives too late. So ask the window what it is, and
+        // fall back to the fragment only where there are no internals to ask —
+        // `pnpm dev` in a plain browser and the preview harness, neither of
+        // which creates an overlay window.
+        var label;
+        try {
+          label = window.__TAURI_INTERNALS__.metadata.currentWindow.label;
+        } catch (e) {
+          label = undefined;
+        }
+        var isMain =
+          typeof label === "string"
+            ? label === "main"
+            : !window.location.hash.replace(/^#/, "");
+        if (!isMain) return;
+
+        document.documentElement.setAttribute("data-window", "main");
+
+        // Resolve the theme to the same value src/lib/theme.ts would, so what
+        // applyTheme() writes a moment later is already on screen and nothing
+        // flashes: readPreference()'s key order — current key, then the legacy
+        // key only when the current one is absent — and resolveTheme(), which
+        // sends only "system" to the media query and passes every other value
+        // through untouched, including one this file would not recognise.
+        //
+        // It departs from those two in exactly two ways, both because an
+        // exception here would abort the script and leave the window
+        // transparent, which is the defect this is here to fix.
+        // readPreference() copies a legacy value into the current key as it
+        // reads; a first-paint script has no business writing to storage, and
+        // not writing cannot change what is painted because applyTheme()
+        // migrates it moments later. And resolveTheme() calls matchMedia
+        // unconditionally, which throws where it does not exist, so the call
+        // is guarded here and the light default stands in.
+        var stored = null;
+        try {
+          stored = localStorage.getItem("wenlan-theme");
+          if (stored === null) stored = localStorage.getItem("origin-theme");
+        } catch (e) {
+          // Storage can be unavailable; the media query below decides instead.
+        }
+
+        var theme = stored === null ? "system" : stored;
+        var resolved =
+          theme === "system"
+            ? !!window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light"
+            : theme;
+
+        document.documentElement.setAttribute("data-theme", resolved);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/release-workflow-contract.test.py
+++ b/scripts/release-workflow-contract.test.py
@@ -2090,6 +2090,461 @@ def signpath_guard_behaviour_violations(release: str) -> list[str]:
 
 
 # --------------------------------------------------------------------------
+# finalize-release -- the desktop links in the published notes
+# --------------------------------------------------------------------------
+#
+# The Install section prepare-release writes is entirely command line, so the
+# one artifact built for Windows users is reachable only by expanding a
+# collapsed list of fifteen assets. finalize-release links it into the notes.
+#
+# Everything that step decides is arithmetic and whole-line matching that no
+# reading of the YAML can check: whether both assets are really on the release,
+# whether the Install section already carries the links, whether one link is a
+# finished re-run or a half-written section. Both defects found while writing it
+# were found by running it, not by reading it -- `grep -Fxq` read a marker
+# beginning "- " as a bundle of short options and never matched anything, and
+# matching the whole body instead of the Install section declared a release
+# already linked when the only copy of the links was in a changelog line.
+
+DESKTOP_LINK_STEP = "Link the desktop app from the release notes"
+
+# Deliberately not a version that exists. The step derives both filenames from
+# RELEASE_TAG, and a fixture reusing a shipped version would pass just as well
+# against a step that had them hardcoded.
+DESKTOP_LINK_TAG = "v9.9.9"
+DESKTOP_LINK_REPO = "7xuanlu/wenlan"
+DESKTOP_LINK_WIN = "Wenlan_9.9.9_x64-setup.exe"
+DESKTOP_LINK_DMG = "Wenlan_9.9.9_aarch64.dmg"
+DESKTOP_LINK_BASE = (
+    f"https://github.com/{DESKTOP_LINK_REPO}/releases/download/{DESKTOP_LINK_TAG}"
+)
+
+# `gh` as a shell FUNCTION, not an executable on a doctored PATH. An
+# extensionless stub in a scratch directory does not shadow gh.exe on Windows:
+# PATHEXT resolution walks straight past it to the real binary, which answers
+# the asset query with "401 Bad credentials" and turns rows green for a reason
+# that has nothing to do with the step. A function is resolved before PATH is
+# consulted at all, on every platform.
+DESKTOP_LINK_GH_STUB = """
+gh() {
+  case "$*" in
+    *"--json assets"*) cat "$WORK/assets.txt"; return 0 ;;
+    *"--json body"*)   cat "$WORK/body.txt";   return 0 ;;
+  esac
+  if [[ "$1" == "release" && "$2" == "edit" ]]; then
+    local arg
+    for arg in "$@"; do [[ -f "$arg" ]] && cp "$arg" "$WORK/edited.md"; done
+    echo GH-RELEASE-EDIT-CALLED
+    return 0
+  fi
+  echo "gh stub: unexpected $*" >&2
+  return 9
+}
+"""
+
+DESKTOP_LINK_EDITED = "GH-RELEASE-EDIT-CALLED"
+
+DESKTOP_LINK_NOTES = """## What's Changed
+
+### Bug Fixes
+
+* **app:** something
+
+## Install
+
+**Wenlan setup (local runtime + daemon):**
+
+```
+npx -y wenlan setup
+```
+"""
+
+DESKTOP_LINK_NO_INSTALL = "## What's Changed\n\nNothing here.\n"
+
+DESKTOP_LINK_SECTION = (
+    "## Install\n\n**Desktop app:**\n\n"
+    f"- Windows: [{DESKTOP_LINK_WIN}]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN})\n"
+    f"- macOS (Apple silicon): [{DESKTOP_LINK_DMG}]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_DMG})\n"
+)
+# A release whose notes the step has already edited.
+DESKTOP_LINK_DONE = DESKTOP_LINK_NOTES.replace("## Install", DESKTOP_LINK_SECTION, 1)
+# One of the two rendered items, which is damage and not a completed run.
+DESKTOP_LINK_HALF = DESKTOP_LINK_NOTES.replace(
+    "## Install",
+    "## Install\n\n**Desktop app:**\n\n"
+    f"- Windows: [{DESKTOP_LINK_WIN}]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN})\n",
+    1,
+)
+
+
+class DesktopLinkCase(NamedTuple):
+    """One release-note shape, and what the step must do with it.
+
+    `expect` and `forbid` are matched against the step's own output AND the
+    notes it wrote back; `ordered` only against the notes, and in sequence, so
+    a block inserted in the right file but the wrong place still fails.
+    """
+
+    description: str
+    assets: tuple[str, ...]
+    body: str
+    signpath: str
+    status: int
+    expect: tuple[str, ...] = ()
+    forbid: tuple[str, ...] = ()
+    ordered: tuple[str, ...] = ()
+
+
+# Not in the table, and deliberately: a body carrying TWO `## Install` headings.
+# awk's `inside` toggles on each, so the extracted section is both of them
+# concatenated, and links under the second would report the first as done. That
+# is a real wrong answer, but prepare-release composes exactly one Install
+# heading and nothing else writes to these notes before this step runs, so there
+# is no shape to assert against without first inventing the release that
+# produces it. Named here rather than left to be discovered as a silent gap.
+DESKTOP_LINK_TRUTH_TABLE: tuple[DesktopLinkCase, ...] = (
+    DesktopLinkCase(
+        "links both installers, under the Install heading and above the CLI methods",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG, "SHA256SUMS"),
+        DESKTOP_LINK_NOTES,
+        "false",
+        0,
+        expect=(
+            "**Desktop app:**",
+            f"- Windows: [{DESKTOP_LINK_WIN}]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN})",
+            f"- macOS (Apple silicon): [{DESKTOP_LINK_DMG}]"
+            f"({DESKTOP_LINK_BASE}/{DESKTOP_LINK_DMG})",
+            "Windows protected your PC",
+        ),
+        ordered=("## Install", "**Desktop app:**", "npx -y wenlan setup"),
+    ),
+    # The whole point of checking rather than assuming. promote-app-assets is a
+    # `needs`, so the assets should be there -- but "should" is what published
+    # the dead link this step exists to avoid.
+    DesktopLinkCase(
+        "refuses when the Windows installer is not on the release",
+        (DESKTOP_LINK_DMG, "SHA256SUMS"),
+        DESKTOP_LINK_NOTES,
+        "false",
+        1,
+        expect=(f"ERROR: {DESKTOP_LINK_WIN} is not on {DESKTOP_LINK_TAG}",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    DesktopLinkCase(
+        "refuses when the macOS dmg is not on the release",
+        (DESKTOP_LINK_WIN, "SHA256SUMS"),
+        DESKTOP_LINK_NOTES,
+        "false",
+        1,
+        expect=(f"ERROR: {DESKTOP_LINK_DMG} is not on {DESKTOP_LINK_TAG}",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    DesktopLinkCase(
+        "refuses notes with no Install heading instead of editing them blindly",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_NO_INSTALL,
+        "false",
+        1,
+        expect=("no '## Install' heading",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    # `--jq .body` on a release with no notes returns an empty string. Refusing
+    # is the only safe answer: the alternative is a release whose entire body is
+    # the desktop block, written over whatever prepare-release failed to write.
+    DesktopLinkCase(
+        "refuses a release with no notes at all",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        "",
+        "false",
+        1,
+        expect=("no '## Install' heading",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    # Install last, with no following `## ` to switch awk's `inside` back off,
+    # so the extracted section runs to end of file. The insert still has to land
+    # directly under the heading and not at the end of it.
+    DesktopLinkCase(
+        "links notes whose Install section is the last one",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        "## What's Changed\n\n* **app:** something\n\n"
+        "## Install\n\n```\nnpx -y wenlan setup\n```\n",
+        "false",
+        0,
+        expect=(DESKTOP_LINK_EDITED,),
+        ordered=("## Install", "**Desktop app:**", "npx -y wenlan setup"),
+    ),
+    # Signing changes the reason, never the click path: the user still meets
+    # SmartScreen while the hash or the publisher accumulates reputation.
+    DesktopLinkCase(
+        "keeps the SmartScreen instructions once signed, and changes only the reason",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_NOTES,
+        "true",
+        0,
+        expect=(
+            "**Desktop app:**",
+            "hash or its publisher has built up enough reputation",
+            "More info → Run anyway",
+        ),
+        forbid=("is not code-signed yet",),
+    ),
+    DesktopLinkCase(
+        "is a no-op on a re-run rather than appending a second block",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_DONE,
+        "false",
+        0,
+        expect=("already present",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    DesktopLinkCase(
+        "stops on a half-written section instead of calling it finished",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_HALF,
+        "false",
+        1,
+        expect=("1 of the 2 desktop links",),
+        forbid=(DESKTOP_LINK_EDITED, "already present"),
+    ),
+    # Why the markers are the rendered list items and not bare URLs: a changelog
+    # line that merely mentions the installer must not stop the release.
+    DesktopLinkCase(
+        "inserts normally when a changelog entry mentions the installer URL",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_NOTES.replace(
+            "* **app:** something",
+            f"* **app:** stop shipping a broken {DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN}",
+            1,
+        ),
+        "false",
+        0,
+        expect=(DESKTOP_LINK_EDITED, "- macOS (Apple silicon): ["),
+        forbid=("refusing to guess", "already present"),
+    ),
+    # And why they are not the heading: release-please renders a
+    # `fix(Desktop app):` scope as exactly the bold string this step writes.
+    DesktopLinkCase(
+        "is not fooled by a changelog entry scoped 'Desktop app'",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_NOTES.replace(
+            "* **app:** something",
+            "* **Desktop app:** stop the window flashing on cold start",
+            1,
+        ),
+        "false",
+        0,
+        expect=(DESKTOP_LINK_EDITED, f"- Windows: [{DESKTOP_LINK_WIN}]"),
+        forbid=("refusing to guess", "already present"),
+    ),
+    # GitHub hands back whatever line endings the body was stored with, and
+    # anything edited through the web UI comes back CRLF.
+    DesktopLinkCase(
+        "links a CRLF release body",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_NOTES.replace("\n", "\r\n"),
+        "false",
+        0,
+        expect=(DESKTOP_LINK_EDITED, f"- Windows: [{DESKTOP_LINK_WIN}]"),
+        forbid=("no '## Install' heading",),
+    ),
+    DesktopLinkCase(
+        "treats an already-linked CRLF body as done",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_DONE.replace("\n", "\r\n"),
+        "false",
+        0,
+        expect=("already present",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    DesktopLinkCase(
+        "ignores trailing whitespace on links that are already there",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_DONE.replace(
+            f"]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN})",
+            f"]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN})  ",
+            1,
+        ),
+        "false",
+        0,
+        expect=("already present",),
+        forbid=(DESKTOP_LINK_EDITED,),
+    ),
+    # The row that made whole-body matching wrong. Both bullets are present, but
+    # quoted in a later section; the Install section still has nothing in it, and
+    # a step that reported "already present" here would leave it that way.
+    DesktopLinkCase(
+        "does not count links quoted outside the Install section",
+        (DESKTOP_LINK_WIN, DESKTOP_LINK_DMG),
+        DESKTOP_LINK_NOTES
+        + "\n## Notes for maintainers\n\nThe release should end up with:\n\n"
+        f"- Windows: [{DESKTOP_LINK_WIN}]({DESKTOP_LINK_BASE}/{DESKTOP_LINK_WIN})\n"
+        f"- macOS (Apple silicon): [{DESKTOP_LINK_DMG}]"
+        f"({DESKTOP_LINK_BASE}/{DESKTOP_LINK_DMG})\n",
+        "false",
+        0,
+        expect=(DESKTOP_LINK_EDITED,),
+        forbid=("already present", "refusing to guess"),
+    ),
+)
+
+
+def desktop_link_script(release: str) -> str:
+    """The SHIPPED body of the release-note link step, ready to run under bash.
+
+    Keyed on the job and the step name, and required to appear exactly once, for
+    the same reason as `signpath_guard_script`: an extractor that takes the
+    first `run: |` it finds tests whichever block happens to come first.
+    """
+    job = job_body(release, "finalize-release")
+    if not job:
+        raise AssertionError("release.yml has no finalize-release job")
+    occurrences = job.count(f"- name: {DESKTOP_LINK_STEP}\n")
+    if occurrences != 1:
+        raise AssertionError(
+            f"expected exactly one {DESKTOP_LINK_STEP!r} step, found {occurrences}"
+        )
+    step = named_step_body(job, DESKTOP_LINK_STEP)
+    match = re.search(r"^[ ]*run: \|\n(?P<body>.*)\Z", step, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise AssertionError(f"{DESKTOP_LINK_STEP!r} has no `run: |` block")
+    body = match.group("body").split("\n")
+    indent = len(body[0]) - len(body[0].lstrip())
+    script = "\n".join(line[indent:] if len(line) >= indent else line for line in body)
+    for shape in ('gh release edit "$RELEASE_TAG"', "$RUNNER_TEMP/desktop.md"):
+        if shape not in script:
+            raise AssertionError(
+                f"the extracted step is not the link step; {shape!r} is gone"
+            )
+    return script
+
+
+def desktop_link_order_violations(release: str) -> list[str]:
+    """Where the step sits in finalize-release is part of what it promises.
+
+    It edits prose and nothing else in the release depends on it. `Publish
+    SHA256SUMS` and `Promote` are load-bearing, so an asset filename this step
+    cannot match must never be what leaves a release unchecksummed or
+    unpromoted -- which is exactly what happens if it runs ahead of them and
+    exits 1. It must equally stay AHEAD of the cleanup PR, which can fail after
+    creating its branch and then exit 0 on the re-run: behind it, a release that
+    met that failure would keep the unlinked notes it shipped with for good.
+    """
+    job = job_body(release, "finalize-release")
+    if not job:
+        return ["release.yml has no finalize-release job"]
+    order = re.findall(r"^      - name: (.+)$", job, re.MULTILINE)
+    violations: list[str] = []
+    if DESKTOP_LINK_STEP not in order:
+        return [f"finalize-release has no {DESKTOP_LINK_STEP!r} step"]
+    here = order.index(DESKTOP_LINK_STEP)
+    for earlier in ("Publish SHA256SUMS", "Promote"):
+        if earlier not in order:
+            violations.append(f"finalize-release no longer has a {earlier!r} step")
+        elif order.index(earlier) > here:
+            violations.append(
+                f"{DESKTOP_LINK_STEP!r} runs before {earlier!r}; a filename it "
+                "cannot match would leave the release unpromoted or unchecksummed"
+            )
+    later = "Open the release-as override cleanup PR"
+    if later in order and order.index(later) < here:
+        violations.append(
+            f"{DESKTOP_LINK_STEP!r} runs after {later!r}, which can fail after "
+            "creating its branch and then exit 0 on the re-run, so the links "
+            "would never be written"
+        )
+    return violations
+
+
+def desktop_link_behaviour_violations(release: str) -> list[str]:
+    """Run the shipped step against every note shape it can be handed."""
+    script = desktop_link_script(release)
+    violations: list[str] = []
+    for case in DESKTOP_LINK_TRUTH_TABLE:
+        with tempfile.TemporaryDirectory() as work:
+            runner_temp = os.path.join(work, "runner_temp")
+            os.makedirs(runner_temp)
+            # Bytes, so the CRLF rows carry the line endings they say they do
+            # and nothing on the way in normalises them back.
+            Path(work, "body.txt").write_bytes(case.body.encode("utf-8"))
+            Path(work, "assets.txt").write_bytes(
+                "".join(f"{name}\n" for name in case.assets).encode("utf-8")
+            )
+            result = subprocess.run(
+                [posix_bash(), "-c", DESKTOP_LINK_GH_STUB + script],
+                env={
+                    "PATH": os.environ.get("PATH", ""),
+                    "WORK": work.replace("\\", "/"),
+                    "RUNNER_TEMP": runner_temp.replace("\\", "/"),
+                    "RELEASE_TAG": DESKTOP_LINK_TAG,
+                    "GITHUB_REPOSITORY": DESKTOP_LINK_REPO,
+                    "SIGNPATH_CONFIGURED": case.signpath,
+                    "GH_TOKEN": "stub-token-the-real-gh-never-sees",
+                },
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+            output = (result.stdout or "") + (result.stderr or "")
+            edited = Path(work, "edited.md")
+            written = edited.read_text(encoding="utf-8") if edited.exists() else ""
+
+        label = f"desktop links: {case.description}"
+        if result.returncode != case.status:
+            violations.append(
+                f"{label}: expected exit {case.status}, got {result.returncode}; "
+                f"output={output.strip()[:600]!r}"
+            )
+            continue
+        # Right status, wrong reason is still wrong: three rows exit 1 and three
+        # exit 0, each through a different branch, and a step that reaches the
+        # right answer by the wrong route is not the step the next edit reads.
+        haystack = f"{written}\n{output}"
+        for needle in case.expect:
+            if needle not in haystack:
+                violations.append(
+                    f"{label}: exited {result.returncode} as expected but never "
+                    f"said {needle!r}; output={haystack.strip()[:600]!r}"
+                )
+        for needle in case.forbid:
+            if needle in haystack:
+                violations.append(f"{label}: should not have said {needle!r}")
+        cursor = -1
+        for needle in case.ordered:
+            found = written.find(needle, cursor + 1)
+            if found < 0:
+                violations.append(
+                    f"{label}: the notes it wrote back have no {needle!r} after "
+                    "the text that must precede it"
+                )
+                break
+            cursor = found
+    return violations
+
+
+def awk_compares_crlf_lines_intact() -> bool:
+    """Whether this machine's awk sees the CR at the end of a CRLF line.
+
+    GNU Awk under MSYS reads in text mode and strips it, so `$0 == "## Install"`
+    matches a CRLF heading there and the CR-stripping `sed` in the step looks
+    like dead code. On GitHub's Ubuntu runners it does not, and dropping that
+    `sed` makes the step report a missing heading on a release that has one.
+    This is the difference between the two, asked directly rather than assumed,
+    so the mutation below is enforced where it is real and reported as
+    unchecked where it cannot be.
+    """
+    probe = subprocess.run(
+        [posix_bash(), "-c", "printf '## Install\\r\\n' | awk '$0 == \"## Install\"'"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    # awk echoes the line only if the comparison held, i.e. only if the CR was
+    # already gone. No output means the CR was still there to be compared.
+    return not probe.stdout.strip()
+
+
+# --------------------------------------------------------------------------
 # signpath-status.yml -- the activation monitor
 # --------------------------------------------------------------------------
 #
@@ -4316,6 +4771,7 @@ def main() -> None:
         sync_release_pr,
     )
     violations.extend(windows_recipe_drift_violations(ci, release))
+    violations.extend(desktop_link_order_violations(release))
     violations.extend(candidate_observer_contract_violations(ci, observer, validator, archive))
     violations.extend(trusted_candidate_gate_violations(ci, classifier, validator))
     violations.extend(signpath_status_violations())
@@ -4995,8 +5451,14 @@ def main() -> None:
     # cannot see must change at least one row's exit status, or the table is
     # decoration.
     for old, new, why in (
+        # Anchored on the line above it as well: finalize-release's link step
+        # counts with an identically indented `present=$((present + 1))`, and a
+        # bare fixture would depend on which job happens to come first in the
+        # file for the mutation to land in this one.
         (
+            '            if [[ -n "${!var:-}" ]]; then\n'
             "              present=$((present + 1))",
+            '            if [[ -n "${!var:-}" ]]; then\n'
             "              present=$((present + 0))",
             "the count that decides whether the guard fires",
         ),
@@ -5029,6 +5491,75 @@ def main() -> None:
             raise AssertionError(
                 f"the SignPath guard truth table did not notice a mutation of {why}"
             )
+    # The other step in this file whose whole job is a decision no reading of
+    # the YAML can check: the desktop links in the published release notes.
+    link_violations = desktop_link_behaviour_violations(release)
+    if link_violations:
+        raise AssertionError(
+            "desktop release-note link behaviour contract failed:\n  "
+            + "\n  ".join(link_violations)
+        )
+    # Same rule as above: a truth table that cannot fail is decoration. Each
+    # mutation below is a way the step has actually been wrong, or a way it
+    # would silently go wrong; every one must turn at least one row red.
+    desktop_link_unchecked: list[str] = []
+    for old, new, why, needs_strict_awk in (
+        (
+            'for asset in "$win" "$dmg"; do',
+            'for asset in "$win"; do',
+            "the check that BOTH installers are on the release before linking",
+            False,
+        ),
+        # The `--` was missing once. Every marker starts with "- ", so grep read
+        # it as a bundle of short options, matched nothing, and the step
+        # re-inserted the section on a release that already had it.
+        (
+            'grep -Fxq -- "$marker" "$RUNNER_TEMP/install.md"',
+            'grep -Fxq "$marker" "$RUNNER_TEMP/install.md"',
+            "the -- that stops a marker being read as grep options",
+            False,
+        ),
+        # And matching the whole body was the first version. Both links quoted
+        # in a maintainers' note made it report success having linked nothing.
+        (
+            'grep -Fxq -- "$marker" "$RUNNER_TEMP/install.md"',
+            'grep -Fxq -- "$marker" "$RUNNER_TEMP/body.md"',
+            "scoping the already-linked check to the Install section",
+            False,
+        ),
+        (
+            '          if [[ "$present" -eq 2 ]]; then',
+            '          if [[ "$present" -ge 1 ]]; then',
+            "the refusal to call a half-written section finished",
+            False,
+        ),
+        (
+            "          sed -i 's/\\r$//' \"$RUNNER_TEMP/body.md\"\n",
+            "",
+            "the CR strip that lets a CRLF body find its own Install heading",
+            True,
+        ),
+    ):
+        if release.count(old) != 1:
+            raise AssertionError(
+                f"desktop link mutation fixture is stale or ambiguous: {old!r}"
+            )
+        if needs_strict_awk and not awk_compares_crlf_lines_intact():
+            # MSYS awk strips the CR before comparing, so removing the `sed`
+            # changes nothing here. Saying so beats a row that quietly passes:
+            # on Linux, where the release actually runs, this mutation bites.
+            desktop_link_unchecked.append(
+                f"{why}: this machine's awk strips CR from a CRLF line before "
+                "comparing it, so the mutation is invisible here; it is checked "
+                "on the Linux runners this workflow ships from"
+            )
+            continue
+        if not desktop_link_behaviour_violations(release.replace(old, new, 1)):
+            raise AssertionError(
+                f"the desktop link truth table did not notice a mutation of {why}"
+            )
+    for line in desktop_link_unchecked:
+        print(f"UNCHECKED: desktop release-note links: {line}")
     # The activation monitor, run against a fake SignPath. Its whole subject is
     # states nobody can produce here -- an accepted application, a resolving
     # project slug -- so a stub server is the only way any of it is measured at

--- a/src/__tests__/firstPaint.test.ts
+++ b/src/__tests__/firstPaint.test.ts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/**
+ * The first-paint background in index.html.
+ *
+ * index.css keeps `html` and `body` transparent so the toast and quick-capture
+ * webviews can float over the desktop. The main window inherits that, and
+ * app/tauri.conf.json shows it from config on purpose, so between the window
+ * appearing and React's first render it paints nothing. macOS hides this by
+ * giving the window a native NSColor background (app/src/lib.rs); Windows and
+ * Linux have no such call, so the window is blank for as long as the bundle,
+ * the fonts and the daemon health check take -- tens of seconds on an upgrade
+ * that runs database migrations.
+ *
+ * index.html closes that with two CSS rules and one classic inline script.
+ * Those live outside the module graph, so nothing else in the suite covers
+ * them: this file executes the real script from the real file, and then the
+ * real script from the built file.
+ *
+ * What this file does NOT do: parse HTML in a real engine, apply a CSP, or
+ * model browser scheduling. It is a behavioural test of one script.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SOURCE_HTML_PATH = path.join(ROOT, "index.html");
+const DIST_HTML_PATH = path.join(ROOT, "dist/index.html");
+const INDEX_HTML = readFileSync(SOURCE_HTML_PATH, "utf-8");
+const INDEX_CSS = readFileSync(path.join(ROOT, "src/index.css"), "utf-8");
+
+/** The one classic <script> in index.html: the module entry carries a src. */
+function inlineScript(html: string): string {
+  const matches = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)];
+  expect(
+    matches,
+    "index.html should carry exactly one inline classic script",
+  ).toHaveLength(1);
+  return matches[0][1];
+}
+
+/**
+ * The inline <style>'s rules, with comments removed and spacing flattened.
+ *
+ * Removing the comments is the point. That block explains itself by quoting
+ * the very selectors it defines, so a bare `toContain` on the html is
+ * satisfied by the prose alone and would still pass if the rules were deleted.
+ */
+function styleRules(html: string): string {
+  const match = html.match(/<style>([\s\S]*?)<\/style>/);
+  expect(match, "index.html should carry exactly one inline <style>").not.toBeNull();
+  return match![1]
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s*([{}:;])\s*/g, "$1")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Run a first-paint script against a throwaway document, and report what it set.
+ *
+ * `storage` undefined means localStorage throws, which is what a webview with
+ * site data disabled does. `label` undefined means Tauri injected no
+ * internals, which is `pnpm dev` in a plain browser.
+ */
+function runFirstPaint(
+  opts: {
+    hash: string;
+    label?: string;
+    storage?: Record<string, string>;
+    prefersDark?: boolean;
+    matchMedia?: boolean;
+  },
+  script: string = inlineScript(INDEX_HTML),
+): { window: string | null; theme: string | null } {
+  const el: Record<string, string> = {};
+  const documentElement = {
+    setAttribute: (k: string, v: string) => {
+      el[k] = v;
+    },
+  };
+  const storage = opts.storage;
+  const fakeWindow: Record<string, unknown> = {
+    location: { hash: opts.hash },
+    matchMedia:
+      opts.matchMedia === false
+        ? undefined
+        : (query: string) => ({
+            matches: query.includes("dark")
+              ? !!opts.prefersDark
+              : !opts.prefersDark,
+          }),
+  };
+  if (opts.label !== undefined) {
+    fakeWindow.__TAURI_INTERNALS__ = {
+      metadata: { currentWindow: { label: opts.label } },
+    };
+  }
+  const localStorage = {
+    getItem: (k: string) => {
+      if (!storage) throw new DOMException("denied", "SecurityError");
+      return k in storage ? storage[k] : null;
+    },
+  };
+
+  new Function(
+    "window",
+    "document",
+    "localStorage",
+    "DOMException",
+    script,
+  )(fakeWindow, { documentElement }, localStorage, DOMException);
+
+  return { window: el["data-window"] ?? null, theme: el["data-theme"] ?? null };
+}
+
+describe("which window gets a background", () => {
+  // The label is the window's real identity. Tauri prepends the currentWindow
+  // metadata to the webview's initialization scripts and WebView2 runs those
+  // before HTML parsing, so it is already there when this script runs.
+  // Trusting it means a fragment added after parsing, or an overlay opened at
+  // `index.html#` (whose location.hash is the empty string), can no longer be
+  // mistaken for main.
+  it("trusts the Tauri window label over the fragment", () => {
+    expect(runFirstPaint({ hash: "", label: "main" }).window).toBe("main");
+    expect(runFirstPaint({ hash: "#toast", label: "main" }).window).toBe("main");
+  });
+
+  it.each(["toast", "quick-capture"])(
+    "leaves the %s window transparent even with no fragment",
+    (label) => {
+      const r = runFirstPaint({ hash: "", label });
+      expect(r.window).toBeNull();
+      expect(r.theme).toBeNull();
+    },
+  );
+
+  // Without Tauri there are no overlay windows to confuse it with, so the
+  // fragment is enough. This is `pnpm dev` and the preview harness.
+  it("falls back to the fragment when Tauri injected no internals", () => {
+    expect(runFirstPaint({ hash: "" }).window).toBe("main");
+    expect(runFirstPaint({ hash: "#toast" }).window).toBeNull();
+    expect(runFirstPaint({ hash: "#quick-capture" }).window).toBeNull();
+  });
+});
+
+describe("the early theme resolves as theme.ts would", () => {
+  // readPreference() returns the current key, falling back to the legacy key
+  // only when the current one is absent; resolveTheme() sends "system" to the
+  // media query and passes every other value through untouched. A value this
+  // file does not recognise must therefore survive, or applyTheme() would
+  // replace what was painted and the window would flash.
+  const cases: Array<[string, Record<string, string>, boolean, string]> = [
+    ["nothing stored, dark OS", {}, true, "dark"],
+    ["nothing stored, light OS", {}, false, "light"],
+    ["system, dark OS", { "wenlan-theme": "system" }, true, "dark"],
+    ["system, light OS", { "wenlan-theme": "system" }, false, "light"],
+    ["light beats a dark OS", { "wenlan-theme": "light" }, true, "light"],
+    ["dark beats a light OS", { "wenlan-theme": "dark" }, false, "dark"],
+    ["legacy key when current is absent", { "origin-theme": "light" }, true, "light"],
+    [
+      "current key wins over legacy",
+      { "wenlan-theme": "dark", "origin-theme": "light" },
+      false,
+      "dark",
+    ],
+    ["an unrecognised value passes through", { "wenlan-theme": "bogus" }, false, "bogus"],
+    ["an empty value passes through", { "wenlan-theme": "" }, true, ""],
+  ];
+
+  it.each(cases)("%s", (_name, storage, prefersDark, expected) => {
+    expect(runFirstPaint({ hash: "", label: "main", storage, prefersDark }).theme).toBe(
+      expected,
+    );
+  });
+
+  // Two deliberate departures from theme.ts. Both exist because this script
+  // runs before anything can catch it: an exception here leaves the window
+  // transparent, which is the defect it was written to fix.
+  describe("and departs from it deliberately, in two places", () => {
+    // readPreference() copies a legacy value into the current key as it reads.
+    // A first-paint script has no business writing to storage, and skipping
+    // the write cannot change what is painted: the value returned is the same
+    // either way, and applyTheme() performs the migration moments later.
+    it("reads the legacy key without migrating it", () => {
+      const storage = { "origin-theme": "light" };
+      expect(runFirstPaint({ hash: "", label: "main", storage }).theme).toBe("light");
+      expect(storage).toEqual({ "origin-theme": "light" });
+    });
+
+    // resolveTheme() calls window.matchMedia unconditionally and would throw
+    // where it does not exist. Here that would abort the script before it set
+    // anything, so the call is guarded and the light default stands in.
+    it("treats a missing matchMedia as light instead of throwing", () => {
+      const r = runFirstPaint({
+        hash: "",
+        label: "main",
+        storage: {},
+        prefersDark: true,
+        matchMedia: false,
+      });
+      expect(r.window).toBe("main");
+      expect(r.theme).toBe("light");
+    });
+  });
+
+  it("still resolves a theme when localStorage throws", () => {
+    const r = runFirstPaint({ hash: "", label: "main", prefersDark: false });
+    expect(r.window).toBe("main");
+    expect(r.theme).toBe("light");
+  });
+});
+
+describe("first-paint colours track index.css", () => {
+  let darkBg: string;
+  let lightBg: string;
+
+  beforeAll(() => {
+    const dark = INDEX_CSS.match(/:root\s*\{[^}]*?--bg-primary:\s*(#[0-9a-fA-F]{6})/);
+    const light = INDEX_CSS.match(
+      /html\[data-theme="light"\]\s*\{[^}]*?--bg-primary:\s*(#[0-9a-fA-F]{6})/,
+    );
+    expect(dark, "index.css should declare a dark --bg-primary").not.toBeNull();
+    expect(light, "index.css should declare a light --bg-primary").not.toBeNull();
+    darkBg = dark![1].toLowerCase();
+    lightBg = light![1].toLowerCase();
+  });
+
+  // index.html cannot use a CSS variable here: the variables live in
+  // index.css, which the module graph loads well after this paints. The hex is
+  // therefore duplicated on purpose, and this test is what keeps the duplicate
+  // honest when the palette moves.
+  it("uses the same dark background as --bg-primary", () => {
+    expect(styleRules(INDEX_HTML)).toContain(
+      `html[data-window="main"]{background:${darkBg};`,
+    );
+  });
+
+  it("uses the same light background as --bg-primary", () => {
+    expect(styleRules(INDEX_HTML)).toContain(
+      `html[data-window="main"][data-theme="light"]{background:${lightBg};`,
+    );
+  });
+
+  it("still keeps html and body transparent for the overlays", () => {
+    expect(INDEX_CSS).toMatch(/html,\s*body\s*\{\s*background:\s*transparent/);
+  });
+});
+
+/**
+ * Everything above reads index.html. All of it passes if Vite drops the inline
+ * script on its way to dist/, because none of it looks at what ships.
+ *
+ * dist/ is gitignored and `pnpm test` runs before any build, so on a fresh
+ * checkout there is nothing here to read, and skipping quietly in that state
+ * is how this block came to run nowhere at all. WENLAN_REQUIRE_DIST turns the
+ * skip into a failure; the CI step that sets it builds immediately first, and
+ * that build -- not the mtime below -- is what makes the artifact current
+ * there.
+ *
+ * The mtime comparison is a convenience, not a proof: it catches the common
+ * local mistake of editing index.html and forgetting to rebuild. A dist/
+ * restored from a cache or another revision can carry a newer timestamp than
+ * the source and would pass it. Do not read it as a guarantee that what is
+ * checked is what this revision builds.
+ */
+function distStatus(): { ok: boolean; reason: string } {
+  if (!existsSync(DIST_HTML_PATH)) {
+    return { ok: false, reason: "dist/index.html does not exist; run pnpm build" };
+  }
+  if (statSync(DIST_HTML_PATH).mtimeMs < statSync(SOURCE_HTML_PATH).mtimeMs) {
+    return { ok: false, reason: "dist/index.html is older than index.html; run pnpm build" };
+  }
+  return { ok: true, reason: "" };
+}
+
+const dist = distStatus();
+const distIsMandatory = !!process.env.WENLAN_REQUIRE_DIST;
+
+describe.skipIf(!dist.ok && !distIsMandatory)("survives the bundler", () => {
+  let built: string;
+
+  beforeAll(() => {
+    // Only a WENLAN_REQUIRE_DIST run reaches this unsatisfied; without it the
+    // block is skipped instead.
+    if (!dist.ok) throw new Error(`cannot check the built output: ${dist.reason}`);
+    built = readFileSync(DIST_HTML_PATH, "utf-8");
+  });
+
+  // The point of the whole block: not that the text survived, but that the
+  // code did. Vite copies index.html's inline blocks through verbatim, so a
+  // substring check is answered by the explanatory comments whether or not the
+  // script still works. This runs the shipped script instead.
+  it("still paints the main window and still leaves the overlays alone", () => {
+    const script = inlineScript(built);
+    expect(
+      runFirstPaint({ hash: "", label: "main", storage: {}, prefersDark: true }, script),
+    ).toEqual({ window: "main", theme: "dark" });
+    expect(
+      runFirstPaint({ hash: "", label: "main", storage: { "wenlan-theme": "light" } }, script),
+    ).toEqual({ window: "main", theme: "light" });
+    expect(runFirstPaint({ hash: "", label: "toast" }, script)).toEqual({
+      window: null,
+      theme: null,
+    });
+  });
+
+  it("still carries both first-paint rules, and not just the comment", () => {
+    const rules = styleRules(built);
+    expect(rules).toContain('html[data-window="main"]{background:');
+    expect(rules).toContain('html[data-window="main"][data-theme="light"]{background:');
+    expect(rules).toBe(styleRules(INDEX_HTML));
+  });
+
+  // Vite hoists the module entry into <head>. Module scripts are deferred, so
+  // ordering would hold either way, but asserting it keeps the guarantee from
+  // resting on that one fact alone.
+  it("keeps the classic script ahead of the module entry, and undeferred", () => {
+    const doc = new DOMParser().parseFromString(built, "text/html");
+    const scripts = [...doc.querySelectorAll("script")];
+    const classicAt = scripts.findIndex((s) => !s.hasAttribute("src"));
+    const moduleAt = scripts.findIndex((s) => s.getAttribute("type") === "module");
+    expect(classicAt, "no inline classic script in dist/index.html").toBeGreaterThanOrEqual(0);
+    expect(moduleAt, "no module entry in dist/index.html").toBeGreaterThanOrEqual(0);
+    expect(classicAt).toBeLessThan(moduleAt);
+
+    const classic = scripts[classicAt];
+    expect(classic.hasAttribute("defer")).toBe(false);
+    expect(classic.hasAttribute("async")).toBe(false);
+    expect(classic.getAttribute("type")).toBeNull();
+  });
+});


### PR DESCRIPTION
Three defects found by installing and running the published **v0.17.7 Windows build on real hardware**, rather than by reading the release job log.

## 1. The window was blank on a cold start

For seconds to half a minute. `index.css` keeps `html` and `body` transparent so the toast and quick-capture webviews can float over the desktop, and those webviews load the same `index.html` through hash routes — so the rule has to stay, and the main window inherits it. macOS never showed the gap because `app/src/lib.rs` gives that window a native `NSColor` background; there is no equivalent call on Windows or Linux, and the whole app-ready reveal path in that file is inside `cfg(target_os = "macos")`.

`tauri.conf.json` shows the window from config on purpose, so launch can never depend on a frontend event — which also guarantees the window appears before anything paints in it. That guarantee is worth keeping, so this paints the app's own base colour **as soon as the document is parsed** instead: two CSS rules and one classic inline script, scoped to the main window so the overlays stay transparent.

It does **not** cover the frame before that. The main window declares no `backgroundColor`, so Wry leaves WebView2's controller background unset and Windows paints its default white until the file is parsed. That flash is far shorter than the one being fixed, but it is real for a dark-theme user. Closing it means setting a window background from Rust off the OS preference — `localStorage` does not exist yet, and one static colour cannot be right for both themes. **Left alone here rather than guessed at.**

## 2. The installer carried NSIS's stock icon

`bundle.icon` already lists `icons/icon.ico`, which is why the installed app and the Start Menu entry are right — but Tauri does not derive `nsis.installerIcon` from it, and that key was absent.

## 3. The release notes never linked the desktop app

The Install section offered five methods, all command line, two of them `curl | bash`, which does not exist on a stock Windows machine. The one artifact built for Windows users was reachable only by expanding a collapsed list of fifteen assets.

The links are written in `finalize-release`, not when the notes are composed: `prepare-release` creates the public prerelease *in parallel* with the bundle jobs, so a link written there points at nothing for the 40–210 minutes they run, and forever if either fails. `finalize-release` needs `promote-app-assets`, so by then the installers are really on the release — and the step checks that rather than assuming it.

It runs **after** `Publish SHA256SUMS` and `Promote` (it is cosmetic; a filename it cannot match must never leave a release unpromoted or unchecksummed) and **ahead of** the cleanup PR (which can fail after creating its branch and then exit 0 on the re-run).

## Coverage

None of what that step decides is visible in the YAML, so `release-workflow-contract.test.py` now **runs** it: the shipped body is extracted keyed on job + step name, `gh` is stubbed as a shell *function* (an extensionless stub does not shadow `gh.exe` on Windows — PATHEXT walks past it to the real binary, which answers 401 and turns rows green for the wrong reason), and 15 note shapes are driven through it.

Five mutations establish the table can fail. Four turn rows red. The fifth — deleting the CR strip — cannot be measured on a Windows dev machine, because GNU Awk under MSYS strips the CR before comparing and the bug is unreproducible there. **That row prints `UNCHECKED` rather than passing**, and `ci.yml` now routes this suite's own file to the Ubuntu lane as well, which is the only host where the mutation bites.

`src/__tests__/firstPaint.test.ts` executes the real inline script from the real file, and a final block runs it out of the **built** `index.html` — because Vite copies inline blocks through verbatim, comments included, so a substring check there would pass on the prose alone. That block previously skipped on every CI run (`dist/` is gitignored and `pnpm test` precedes every build); a new `app-check` step builds and re-runs it with `WENLAN_REQUIRE_DIST=1`, which turns a missing `dist/` into a failure instead of a skip.

Reverting `index.html` turns 19 of the 20 source cases red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH3nEZRDbNUeEzCrzfPuk8
