### PR TITLE
fix(app): keep starting when a global shortcut is already taken

### DIFF
--- a/app/src/global_shortcuts.rs
+++ b/app/src/global_shortcuts.rs
@@ -18,10 +18,11 @@
 //! the app appeared, showed "Starting the local runtime…", and vanished with no
 //! error UI.
 //!
-//! A shortcut is a convenience; the app is not. So each shortcut is registered
-//! on its own, every failure is a WARN naming the shortcut and the OS error,
-//! and the outcome is recorded in [`GlobalShortcutStatus`] so a surface can
-//! tell the user which keys are dead this session.
+//! A shortcut is a convenience; the app is not. So [`register_all`] attempts
+//! every shortcut on its own, logs a WARN for each refusal, and returns a
+//! [`GlobalShortcutStatus`] a surface can read to say which keys are dead this
+//! session. It takes the registrar as a closure, so the "keep going" rule is
+//! provable without a Tauri app: see the tests at the bottom of this file.
 //!
 //! ## Reading the status from the UI
 //!
@@ -33,13 +34,13 @@
 //! present but not working), and copy in all three locales in
 //! `src/i18n/resources.ts`. Until then the WARN in the app log is the record.
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tauri_plugin_global_shortcut::Shortcut;
 
 /// Which of the app's shortcuts a spec is. An id rather than a comparison
 /// against the parsed `Shortcut`, so a shortcut that failed to register (and
 /// therefore has no parsed value to compare against) is still nameable.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ShortcutId {
     /// Summon the main window and focus the search field.
@@ -69,7 +70,7 @@ impl std::fmt::Display for ShortcutId {
 }
 
 /// One shortcut the app wants: what it is for, and the accelerator to ask for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub struct ShortcutSpec {
     pub id: ShortcutId,
     /// The accelerator exactly as Tauri parses it.
@@ -78,10 +79,11 @@ pub struct ShortcutSpec {
 
 /// Every global shortcut the app registers, in registration order.
 ///
-/// The accelerators are load-bearing history: `toggle-spotlight` and
-/// `show-memory` are still the event names the frontend listens for even though
-/// spotlight mode is retired (see `src/App.tsx`), so changing these changes what
-/// users' fingers already know.
+/// The accelerators are load-bearing: changing one changes what users' fingers
+/// already know. They are not the same names as the Tauri events the handlers
+/// emit in `lib.rs` — `toggle-spotlight` and `show-memory` are event names,
+/// kept from the retired spotlight mode because `src/App.tsx` still listens for
+/// them.
 pub const SHORTCUTS: [ShortcutSpec; 3] = [
     ShortcutSpec {
         id: ShortcutId::ToggleSearch,
@@ -98,7 +100,7 @@ pub const SHORTCUTS: [ShortcutSpec; 3] = [
 ];
 
 /// A shortcut the app holds this session.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ActiveShortcut {
     pub id: ShortcutId,
     pub accelerator: String,
@@ -108,7 +110,7 @@ pub struct ActiveShortcut {
 /// the OS/plugin message verbatim (`HotKey already registered: ...`) — a
 /// summarised version would lose the only detail that distinguishes "someone
 /// else holds it" from "this accelerator is not parseable".
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct UnavailableShortcut {
     pub id: ShortcutId,
     pub accelerator: String,
@@ -117,25 +119,16 @@ pub struct UnavailableShortcut {
 
 /// What the app got when it asked the OS for its hotkeys. Recorded at startup
 /// and never updated: registration is attempted once, in `setup()`.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct GlobalShortcutStatus {
     pub active: Vec<ActiveShortcut>,
     pub unavailable: Vec<UnavailableShortcut>,
 }
 
-impl GlobalShortcutStatus {
-    /// True when every shortcut the app asked for is live. False the moment one
-    /// is not — including when nothing was asked for, which is not a state this
-    /// app reaches but is not "all registered" either.
-    pub fn all_registered(&self) -> bool {
-        !self.active.is_empty() && self.unavailable.is_empty()
-    }
-}
-
 /// Parse a spec's accelerator. Separated from registration so a malformed
 /// accelerator is the same kind of recoverable failure as a taken one, rather
 /// than the `unwrap()` panic it used to be.
-pub fn parse(spec: &ShortcutSpec) -> Result<Shortcut, String> {
+pub fn parse(spec: ShortcutSpec) -> Result<Shortcut, String> {
     spec.accelerator
         .parse::<Shortcut>()
         .map_err(|e| e.to_string())
@@ -143,36 +136,50 @@ pub fn parse(spec: &ShortcutSpec) -> Result<Shortcut, String> {
 
 /// The WARN line for a shortcut the app could not register. Explicit by
 /// construction: it names the shortcut's id, the accelerator the user would
-/// press, the fact that the key is dead for this session, and the OS error.
-pub fn registration_warning(spec: &ShortcutSpec, error: &str) -> String {
+/// press, the fact that the key is dead for this session, and the error.
+///
+/// It offers no cause of its own. The same path carries both "another process
+/// holds this hotkey" and "this accelerator does not parse", and a guess
+/// appended to the second one would be a fabrication — the verbatim error
+/// already says which happened.
+pub fn registration_warning(spec: ShortcutSpec, error: &str) -> String {
     format!(
-        "[shortcuts] global shortcut {} ({}) could not be registered and is unavailable this session; \
-         another application or another Wenlan instance is likely holding it: {error}",
+        "[shortcuts] global shortcut {} ({}) could not be registered and is unavailable this session: {error}",
         spec.id, spec.accelerator
     )
 }
 
-/// Split per-shortcut registration outcomes into what the app holds and what it
-/// lost. Order follows [`SHORTCUTS`] so both lists read the same way every run.
+/// Ask for every shortcut in `specs`, one at a time, and report what came back.
 ///
-/// Takes outcomes rather than doing the registering, so the partition is
-/// testable without a Tauri app or a real hotkey manager.
-pub fn partition_registrations<I>(outcomes: I) -> GlobalShortcutStatus
-where
-    I: IntoIterator<Item = (ShortcutSpec, Result<(), String>)>,
-{
+/// `register` is the caller's registrar — in the app it parses the accelerator
+/// and calls `on_shortcut`; in tests it is a closure. Injecting it is the point:
+/// the rule this function exists to hold is "a refusal never skips the shortcuts
+/// after it", and that rule is only observable from the sequence of calls made,
+/// not from a status computed out of outcomes someone else already gathered.
+///
+/// So: no early return, no `?`, no `break`. Every spec is attempted, every
+/// failure is logged, and the caller gets a status instead of an error.
+pub fn register_all(
+    specs: &[ShortcutSpec],
+    mut register: impl FnMut(ShortcutSpec) -> Result<(), String>,
+) -> GlobalShortcutStatus {
     let mut status = GlobalShortcutStatus::default();
-    for (spec, outcome) in outcomes {
-        match outcome {
+    for &spec in specs {
+        match register(spec) {
             Ok(()) => status.active.push(ActiveShortcut {
                 id: spec.id,
                 accelerator: spec.accelerator.to_string(),
             }),
-            Err(error) => status.unavailable.push(UnavailableShortcut {
-                id: spec.id,
-                accelerator: spec.accelerator.to_string(),
-                error,
-            }),
+            Err(error) => {
+                // Explicit, never swallowed. Logged here rather than at the
+                // call site so no caller can register without reporting.
+                log::warn!("{}", registration_warning(spec, &error));
+                status.unavailable.push(UnavailableShortcut {
+                    id: spec.id,
+                    accelerator: spec.accelerator.to_string(),
+                    error,
+                });
+            }
         }
     }
     status
@@ -193,6 +200,8 @@ pub fn global_shortcut_status(
 mod tests {
     use super::*;
 
+    const TAKEN: &str = "HotKey already registered: HotKey { mods: CONTROL, key: KeyK }";
+
     fn spec(id: ShortcutId) -> ShortcutSpec {
         SHORTCUTS
             .iter()
@@ -208,7 +217,7 @@ mod tests {
         // where it costs nothing.
         for spec in SHORTCUTS {
             assert!(
-                parse(&spec).is_ok(),
+                parse(spec).is_ok(),
                 "{} accelerator {:?} does not parse",
                 spec.id,
                 spec.accelerator
@@ -217,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_list_is_the_three_bindings_the_frontend_listens_for() {
+    fn shortcut_list_is_the_three_bindings_the_app_registers() {
         assert_eq!(
             SHORTCUTS.map(|s| (s.id, s.accelerator)),
             [
@@ -239,17 +248,31 @@ mod tests {
 
     #[test]
     fn a_taken_shortcut_does_not_cost_the_others() {
-        // The regression in one assertion: `Ctrl+K` refused, the other two
-        // still held. `on_shortcuts` used to abort the whole batch instead.
-        let status = partition_registrations([
-            (
-                spec(ShortcutId::ToggleSearch),
-                Err("HotKey already registered: HotKey { mods: CONTROL, key: KeyK }".to_string()),
-            ),
-            (spec(ShortcutId::ShowMemory), Ok(())),
-            (spec(ShortcutId::QuickCapture), Ok(())),
-        ]);
+        // The regression itself. The FIRST shortcut is refused — the exact
+        // shape of the crash, where `Ctrl+K` was already held — and the test
+        // watches the registrar, not just the result: `on_shortcuts` used to
+        // abandon the batch on the first refusal, so the other two were never
+        // even attempted. An early `break` here fails this test.
+        let mut attempted: Vec<ShortcutId> = Vec::new();
 
+        let status = register_all(&SHORTCUTS, |spec| {
+            attempted.push(spec.id);
+            if spec.id == ShortcutId::ToggleSearch {
+                Err(TAKEN.to_string())
+            } else {
+                Ok(())
+            }
+        });
+
+        assert_eq!(
+            attempted,
+            vec![
+                ShortcutId::ToggleSearch,
+                ShortcutId::ShowMemory,
+                ShortcutId::QuickCapture,
+            ],
+            "every shortcut must be attempted, including the ones after a refusal"
+        );
         assert_eq!(
             status.active,
             vec![
@@ -268,64 +291,59 @@ mod tests {
             vec![UnavailableShortcut {
                 id: ShortcutId::ToggleSearch,
                 accelerator: "CmdOrCtrl+K".to_string(),
-                error: "HotKey already registered: HotKey { mods: CONTROL, key: KeyK }".to_string(),
+                error: TAKEN.to_string(),
             }]
         );
-        assert!(!status.all_registered());
     }
 
     #[test]
     fn every_failure_keeps_its_own_error() {
-        let status = partition_registrations([
-            (
-                spec(ShortcutId::ToggleSearch),
-                Err("taken by A".to_string()),
-            ),
-            (spec(ShortcutId::ShowMemory), Err("taken by B".to_string())),
-            (spec(ShortcutId::QuickCapture), Ok(())),
-        ]);
+        let status = register_all(&SHORTCUTS, |spec| match spec.id {
+            ShortcutId::ToggleSearch => Err("taken by A".to_string()),
+            ShortcutId::ShowMemory => Err("taken by B".to_string()),
+            ShortcutId::QuickCapture => Ok(()),
+        });
 
         assert_eq!(
             status
                 .unavailable
                 .iter()
-                .map(|u| u.error.as_str())
+                .map(|u| (u.id, u.error.as_str()))
                 .collect::<Vec<_>>(),
-            vec!["taken by A", "taken by B"],
+            vec![
+                (ShortcutId::ToggleSearch, "taken by A"),
+                (ShortcutId::ShowMemory, "taken by B"),
+            ],
         );
         assert_eq!(status.active.len(), 1);
     }
 
     #[test]
-    fn all_registered_only_when_nothing_failed() {
-        let all_ok = partition_registrations(SHORTCUTS.map(|spec| (spec, Ok(()))));
-        assert!(all_ok.all_registered());
-        assert!(all_ok.unavailable.is_empty());
+    fn nothing_is_unavailable_when_every_registration_succeeds() {
+        let status = register_all(&SHORTCUTS, |_| Ok(()));
 
-        // Nothing asked for is not the same claim as nothing refused.
-        assert!(!GlobalShortcutStatus::default().all_registered());
+        assert_eq!(status.active.len(), SHORTCUTS.len());
+        assert!(status.unavailable.is_empty());
     }
 
     #[test]
     fn warning_names_the_shortcut_the_key_and_the_error() {
-        let warning = registration_warning(
-            &spec(ShortcutId::ToggleSearch),
-            "HotKey already registered: HotKey { mods: CONTROL, key: KeyK }",
-        );
+        let warning = registration_warning(spec(ShortcutId::ToggleSearch), TAKEN);
 
         assert!(warning.contains("toggle-search"), "{warning}");
         assert!(warning.contains("CmdOrCtrl+K"), "{warning}");
         assert!(warning.contains("unavailable this session"), "{warning}");
-        assert!(
-            warning.contains("HotKey already registered: HotKey { mods: CONTROL, key: KeyK }"),
-            "{warning}"
-        );
+        assert!(warning.contains(TAKEN), "{warning}");
+        // No invented cause: the same line carries parse failures too, where
+        // "something else is holding it" would be false.
+        assert!(!warning.contains("likely"), "{warning}");
     }
 
     #[test]
     fn status_serializes_with_the_stable_kebab_ids() {
-        let status =
-            partition_registrations([(spec(ShortcutId::QuickCapture), Err("nope".to_string()))]);
+        let status = register_all(&[spec(ShortcutId::QuickCapture)], |_| {
+            Err("nope".to_string())
+        });
         let json = serde_json::to_value(&status).expect("status serializes");
 
         assert_eq!(json["unavailable"][0]["id"], "quick-capture");

--- a/app/src/global_shortcuts.rs
+++ b/app/src/global_shortcuts.rs
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! The global shortcuts the app asks the OS for, and what happens when the OS
+//! says no.
+//!
+//! A global hotkey belongs to whichever process grabbed it first, desktop-wide.
+//! So registration is a request that can be refused, and it is refused often:
+//! another app already owns `Ctrl+K`, or a second Wenlan is running. The
+//! single-instance plugin does NOT cover the second case — it keys on the
+//! bundle identifier, so a build with a different identifier (a dev build, a
+//! side-by-side install, a renamed bundle) is a different "instance" to the
+//! plugin and reaches this code with the first instance's hotkeys still held.
+//!
+//! That refusal used to be fatal. `setup()` called `on_shortcuts([..])?`, which
+//! stops at the FIRST failing shortcut — so one taken hotkey both aborted the
+//! remaining registrations and propagated out of `setup()`, where Tauri turns
+//! it into `Failed to setup app: HotKey already registered: HotKey { mods:
+//! CONTROL, key: KeyK }` and panics. The window was already on screen by then:
+//! the app appeared, showed "Starting the local runtime…", and vanished with no
+//! error UI.
+//!
+//! A shortcut is a convenience; the app is not. So each shortcut is registered
+//! on its own, every failure is a WARN naming the shortcut and the OS error,
+//! and the outcome is recorded in [`GlobalShortcutStatus`] so a surface can
+//! tell the user which keys are dead this session.
+//!
+//! ## Reading the status from the UI
+//!
+//! `global_shortcut_status` (registered in `lib.rs`) returns the recorded
+//! outcome. Nothing renders it yet — deliberately, because inventing that
+//! surface is a separate change: it needs a wrapper in `src/lib/tauri.ts`, a
+//! block in `src/components/memory/settings/sections/DiagnosticsSection.tsx`
+//! (Settings → Diagnostics is where the app already explains wiring that is
+//! present but not working), and copy in all three locales in
+//! `src/i18n/resources.ts`. Until then the WARN in the app log is the record.
+
+use serde::{Deserialize, Serialize};
+use tauri_plugin_global_shortcut::Shortcut;
+
+/// Which of the app's shortcuts a spec is. An id rather than a comparison
+/// against the parsed `Shortcut`, so a shortcut that failed to register (and
+/// therefore has no parsed value to compare against) is still nameable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ShortcutId {
+    /// Summon the main window and focus the search field.
+    ToggleSearch,
+    /// Show/hide the main window.
+    ShowMemory,
+    /// Show/hide the quick-capture popup.
+    QuickCapture,
+}
+
+impl ShortcutId {
+    /// The stable wire name. Matches the serde representation; used in logs so
+    /// a log line and a status payload name the same thing the same way.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ToggleSearch => "toggle-search",
+            Self::ShowMemory => "show-memory",
+            Self::QuickCapture => "quick-capture",
+        }
+    }
+}
+
+impl std::fmt::Display for ShortcutId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One shortcut the app wants: what it is for, and the accelerator to ask for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShortcutSpec {
+    pub id: ShortcutId,
+    /// The accelerator exactly as Tauri parses it.
+    pub accelerator: &'static str,
+}
+
+/// Every global shortcut the app registers, in registration order.
+///
+/// The accelerators are load-bearing history: `toggle-spotlight` and
+/// `show-memory` are still the event names the frontend listens for even though
+/// spotlight mode is retired (see `src/App.tsx`), so changing these changes what
+/// users' fingers already know.
+pub const SHORTCUTS: [ShortcutSpec; 3] = [
+    ShortcutSpec {
+        id: ShortcutId::ToggleSearch,
+        accelerator: "CmdOrCtrl+K",
+    },
+    ShortcutSpec {
+        id: ShortcutId::ShowMemory,
+        accelerator: "CmdOrCtrl+Shift+K",
+    },
+    ShortcutSpec {
+        id: ShortcutId::QuickCapture,
+        accelerator: "CmdOrCtrl+Shift+N",
+    },
+];
+
+/// A shortcut the app holds this session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActiveShortcut {
+    pub id: ShortcutId,
+    pub accelerator: String,
+}
+
+/// A shortcut the app asked for and did not get, with the reason. `error` is
+/// the OS/plugin message verbatim (`HotKey already registered: ...`) — a
+/// summarised version would lose the only detail that distinguishes "someone
+/// else holds it" from "this accelerator is not parseable".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnavailableShortcut {
+    pub id: ShortcutId,
+    pub accelerator: String,
+    pub error: String,
+}
+
+/// What the app got when it asked the OS for its hotkeys. Recorded at startup
+/// and never updated: registration is attempted once, in `setup()`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GlobalShortcutStatus {
+    pub active: Vec<ActiveShortcut>,
+    pub unavailable: Vec<UnavailableShortcut>,
+}
+
+impl GlobalShortcutStatus {
+    /// True when every shortcut the app asked for is live. False the moment one
+    /// is not — including when nothing was asked for, which is not a state this
+    /// app reaches but is not "all registered" either.
+    pub fn all_registered(&self) -> bool {
+        !self.active.is_empty() && self.unavailable.is_empty()
+    }
+}
+
+/// Parse a spec's accelerator. Separated from registration so a malformed
+/// accelerator is the same kind of recoverable failure as a taken one, rather
+/// than the `unwrap()` panic it used to be.
+pub fn parse(spec: &ShortcutSpec) -> Result<Shortcut, String> {
+    spec.accelerator
+        .parse::<Shortcut>()
+        .map_err(|e| e.to_string())
+}
+
+/// The WARN line for a shortcut the app could not register. Explicit by
+/// construction: it names the shortcut's id, the accelerator the user would
+/// press, the fact that the key is dead for this session, and the OS error.
+pub fn registration_warning(spec: &ShortcutSpec, error: &str) -> String {
+    format!(
+        "[shortcuts] global shortcut {} ({}) could not be registered and is unavailable this session; \
+         another application or another Wenlan instance is likely holding it: {error}",
+        spec.id, spec.accelerator
+    )
+}
+
+/// Split per-shortcut registration outcomes into what the app holds and what it
+/// lost. Order follows [`SHORTCUTS`] so both lists read the same way every run.
+///
+/// Takes outcomes rather than doing the registering, so the partition is
+/// testable without a Tauri app or a real hotkey manager.
+pub fn partition_registrations<I>(outcomes: I) -> GlobalShortcutStatus
+where
+    I: IntoIterator<Item = (ShortcutSpec, Result<(), String>)>,
+{
+    let mut status = GlobalShortcutStatus::default();
+    for (spec, outcome) in outcomes {
+        match outcome {
+            Ok(()) => status.active.push(ActiveShortcut {
+                id: spec.id,
+                accelerator: spec.accelerator.to_string(),
+            }),
+            Err(error) => status.unavailable.push(UnavailableShortcut {
+                id: spec.id,
+                accelerator: spec.accelerator.to_string(),
+                error,
+            }),
+        }
+    }
+    status
+}
+
+/// Which global shortcuts this session holds, and which it could not get.
+///
+/// Present so a taken hotkey is answerable rather than only logged; see the
+/// module docs for the UI wiring this is waiting for.
+#[tauri::command]
+pub fn global_shortcut_status(
+    status: tauri::State<'_, GlobalShortcutStatus>,
+) -> GlobalShortcutStatus {
+    status.inner().clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(id: ShortcutId) -> ShortcutSpec {
+        SHORTCUTS
+            .iter()
+            .copied()
+            .find(|s| s.id == id)
+            .expect("every id has a spec")
+    }
+
+    #[test]
+    fn every_declared_shortcut_parses() {
+        // The old code `unwrap()`ed these three parses in `setup()`, so a typo
+        // in an accelerator was a startup panic. This is that guard, moved to
+        // where it costs nothing.
+        for spec in SHORTCUTS {
+            assert!(
+                parse(&spec).is_ok(),
+                "{} accelerator {:?} does not parse",
+                spec.id,
+                spec.accelerator
+            );
+        }
+    }
+
+    #[test]
+    fn shortcut_list_is_the_three_bindings_the_frontend_listens_for() {
+        assert_eq!(
+            SHORTCUTS.map(|s| (s.id, s.accelerator)),
+            [
+                (ShortcutId::ToggleSearch, "CmdOrCtrl+K"),
+                (ShortcutId::ShowMemory, "CmdOrCtrl+Shift+K"),
+                (ShortcutId::QuickCapture, "CmdOrCtrl+Shift+N"),
+            ]
+        );
+    }
+
+    #[test]
+    fn shortcut_ids_are_distinct() {
+        let mut ids: Vec<&str> = SHORTCUTS.iter().map(|s| s.id.as_str()).collect();
+        ids.sort_unstable();
+        let count = ids.len();
+        ids.dedup();
+        assert_eq!(ids.len(), count, "two specs share an id");
+    }
+
+    #[test]
+    fn a_taken_shortcut_does_not_cost_the_others() {
+        // The regression in one assertion: `Ctrl+K` refused, the other two
+        // still held. `on_shortcuts` used to abort the whole batch instead.
+        let status = partition_registrations([
+            (
+                spec(ShortcutId::ToggleSearch),
+                Err("HotKey already registered: HotKey { mods: CONTROL, key: KeyK }".to_string()),
+            ),
+            (spec(ShortcutId::ShowMemory), Ok(())),
+            (spec(ShortcutId::QuickCapture), Ok(())),
+        ]);
+
+        assert_eq!(
+            status.active,
+            vec![
+                ActiveShortcut {
+                    id: ShortcutId::ShowMemory,
+                    accelerator: "CmdOrCtrl+Shift+K".to_string(),
+                },
+                ActiveShortcut {
+                    id: ShortcutId::QuickCapture,
+                    accelerator: "CmdOrCtrl+Shift+N".to_string(),
+                },
+            ]
+        );
+        assert_eq!(
+            status.unavailable,
+            vec![UnavailableShortcut {
+                id: ShortcutId::ToggleSearch,
+                accelerator: "CmdOrCtrl+K".to_string(),
+                error: "HotKey already registered: HotKey { mods: CONTROL, key: KeyK }".to_string(),
+            }]
+        );
+        assert!(!status.all_registered());
+    }
+
+    #[test]
+    fn every_failure_keeps_its_own_error() {
+        let status = partition_registrations([
+            (
+                spec(ShortcutId::ToggleSearch),
+                Err("taken by A".to_string()),
+            ),
+            (spec(ShortcutId::ShowMemory), Err("taken by B".to_string())),
+            (spec(ShortcutId::QuickCapture), Ok(())),
+        ]);
+
+        assert_eq!(
+            status
+                .unavailable
+                .iter()
+                .map(|u| u.error.as_str())
+                .collect::<Vec<_>>(),
+            vec!["taken by A", "taken by B"],
+        );
+        assert_eq!(status.active.len(), 1);
+    }
+
+    #[test]
+    fn all_registered_only_when_nothing_failed() {
+        let all_ok = partition_registrations(SHORTCUTS.map(|spec| (spec, Ok(()))));
+        assert!(all_ok.all_registered());
+        assert!(all_ok.unavailable.is_empty());
+
+        // Nothing asked for is not the same claim as nothing refused.
+        assert!(!GlobalShortcutStatus::default().all_registered());
+    }
+
+    #[test]
+    fn warning_names_the_shortcut_the_key_and_the_error() {
+        let warning = registration_warning(
+            &spec(ShortcutId::ToggleSearch),
+            "HotKey already registered: HotKey { mods: CONTROL, key: KeyK }",
+        );
+
+        assert!(warning.contains("toggle-search"), "{warning}");
+        assert!(warning.contains("CmdOrCtrl+K"), "{warning}");
+        assert!(warning.contains("unavailable this session"), "{warning}");
+        assert!(
+            warning.contains("HotKey already registered: HotKey { mods: CONTROL, key: KeyK }"),
+            "{warning}"
+        );
+    }
+
+    #[test]
+    fn status_serializes_with_the_stable_kebab_ids() {
+        let status =
+            partition_registrations([(spec(ShortcutId::QuickCapture), Err("nope".to_string()))]);
+        let json = serde_json::to_value(&status).expect("status serializes");
+
+        assert_eq!(json["unavailable"][0]["id"], "quick-capture");
+        assert_eq!(json["unavailable"][0]["accelerator"], "CmdOrCtrl+Shift+N");
+        assert_eq!(json["unavailable"][0]["error"], "nope");
+        assert_eq!(json["active"].as_array().map(Vec::len), Some(0));
+    }
+}

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 mod daemon_start;
 pub mod error;
 pub mod events;
+pub mod global_shortcuts;
 #[cfg(target_os = "macos")]
 mod handover;
 mod identity_paths;
@@ -906,19 +907,10 @@ pub fn run() {
                 }
             }
 
-            // Register global shortcuts
+            // Register global shortcuts. The accelerators live in
+            // `global_shortcuts::SHORTCUTS`.
             use tauri::Manager;
             use tauri_plugin_global_shortcut::GlobalShortcutExt;
-
-            let toggle_shortcut = "CmdOrCtrl+K"
-                .parse::<tauri_plugin_global_shortcut::Shortcut>()
-                .unwrap();
-            let spotlight_shortcut = "CmdOrCtrl+Shift+K"
-                .parse::<tauri_plugin_global_shortcut::Shortcut>()
-                .unwrap();
-            let quick_capture_shortcut = "CmdOrCtrl+Shift+N"
-                .parse::<tauri_plugin_global_shortcut::Shortcut>()
-                .unwrap();
 
             let state: tauri::State<Arc<RwLock<AppState>>> = app.state();
             let state_clone = state.inner().clone();
@@ -936,83 +928,113 @@ pub fn run() {
                 });
             }
 
-            // Register all global shortcuts
-            {
-                let handle_for_shortcuts = handle.clone();
-                let toggle = toggle_shortcut;
-                let spotlight = spotlight_shortcut;
-                let quick_capture = quick_capture_shortcut;
-                app.global_shortcut().on_shortcuts(
-                    [toggle, spotlight, quick_capture],
-                    move |_app, shortcut, event| {
-                        use tauri::Emitter;
-                        use tauri_plugin_global_shortcut::ShortcutState;
-                        if event.state != ShortcutState::Pressed {
-                            return;
-                        }
-                        if *shortcut == toggle {
-                            let _ = handle_for_shortcuts.emit("toggle-spotlight", ());
-                        } else if *shortcut == spotlight {
-                            if let Some(window) = handle_for_shortcuts.get_webview_window("main") {
-                                if window.is_visible().unwrap_or(false) {
-                                    let _ = window.hide();
-                                    set_main_window_dock_visibility(&handle_for_shortcuts, false);
-                                } else {
-                                    set_main_window_dock_visibility(&handle_for_shortcuts, true);
-                                    let _ = window.show();
-                                    let _ = window.set_focus();
-                                    let _ = handle_for_shortcuts.emit("show-memory", ());
+            // Register the global shortcuts — one at a time, and never fatally.
+            //
+            // A hotkey belongs to whichever process grabbed it first, desktop
+            // wide, so "already registered" is an ordinary answer: another app
+            // holds Ctrl+K, or a second Wenlan does. The single-instance plugin
+            // does not prevent the second case; it keys on the bundle
+            // identifier, so a build with a different identifier is not "the
+            // same instance" to it and arrives here with the running app's
+            // hotkeys still held.
+            //
+            // This used to be one `on_shortcuts([..])?` call. That helper stops
+            // at the first refusal — so one taken hotkey also cost the other
+            // two — and the `?` carried the error out of `setup()`, which Tauri
+            // turns into `Failed to setup app: HotKey already registered: ...`
+            // and a panic, seconds after the window was already visible. See
+            // `global_shortcuts` for the whole story.
+            let shortcut_status = {
+                use crate::global_shortcuts::ShortcutId;
+
+                let mut outcomes = Vec::with_capacity(global_shortcuts::SHORTCUTS.len());
+                for spec in global_shortcuts::SHORTCUTS {
+                    let handle_for_shortcuts = handle.clone();
+                    let outcome = global_shortcuts::parse(&spec).and_then(|shortcut| {
+                        app.global_shortcut()
+                            .on_shortcut(shortcut, move |_app, _shortcut, event| {
+                                use tauri::Emitter;
+                                use tauri_plugin_global_shortcut::ShortcutState;
+                                if event.state != ShortcutState::Pressed {
+                                    return;
                                 }
-                            }
-                        } else if *shortcut == quick_capture {
-                            if let Some(window) =
-                                handle_for_shortcuts.get_webview_window("quick-capture")
-                            {
-                                #[cfg(target_os = "macos")]
-                                #[allow(deprecated)]
-                                {
-                                    use cocoa::base::id;
-                                    use raw_window_handle::HasWindowHandle;
-                                    if let Ok(raw_handle) = window.window_handle() {
-                                        if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
-                                            let ns_view = appkit.ns_view.as_ptr() as id;
-                                            unsafe {
-                                                let ns_win: id = objc::msg_send![ns_view, window];
-                                                let visible: bool = objc::msg_send![ns_win, isVisible];
-                                                if visible {
-                                                    // orderOut removes the window without
-                                                    // triggering macOS window promotion
-                                                    let _: () = objc::msg_send![ns_win, orderOut: ns_win];
-                                                } else {
-                                                    // makeKeyAndOrderFront shows + focuses
-                                                    // without activating the app (main stays put)
-                                                    let _: () = objc::msg_send![ns_win, setLevel: 3_i64]; // NSFloatingWindowLevel
-                                                    let _: () = objc::msg_send![ns_win, makeKeyAndOrderFront: ns_win];
-                                                    tauri::async_runtime::spawn({
-                                                        let h = handle_for_shortcuts.clone();
-                                                        async move {
-                                                            let _ = crate::search::position_quick_capture(h).await;
+                                if spec.id == ShortcutId::ToggleSearch {
+                                    let _ = handle_for_shortcuts.emit("toggle-spotlight", ());
+                                } else if spec.id == ShortcutId::ShowMemory {
+                                    if let Some(window) = handle_for_shortcuts.get_webview_window("main") {
+                                        if window.is_visible().unwrap_or(false) {
+                                            let _ = window.hide();
+                                            set_main_window_dock_visibility(&handle_for_shortcuts, false);
+                                        } else {
+                                            set_main_window_dock_visibility(&handle_for_shortcuts, true);
+                                            let _ = window.show();
+                                            let _ = window.set_focus();
+                                            let _ = handle_for_shortcuts.emit("show-memory", ());
+                                        }
+                                    }
+                                } else if spec.id == ShortcutId::QuickCapture {
+                                    if let Some(window) =
+                                        handle_for_shortcuts.get_webview_window("quick-capture")
+                                    {
+                                        #[cfg(target_os = "macos")]
+                                        #[allow(deprecated)]
+                                        {
+                                            use cocoa::base::id;
+                                            use raw_window_handle::HasWindowHandle;
+                                            if let Ok(raw_handle) = window.window_handle() {
+                                                if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
+                                                    let ns_view = appkit.ns_view.as_ptr() as id;
+                                                    unsafe {
+                                                        let ns_win: id = objc::msg_send![ns_view, window];
+                                                        let visible: bool = objc::msg_send![ns_win, isVisible];
+                                                        if visible {
+                                                            // orderOut removes the window without
+                                                            // triggering macOS window promotion
+                                                            let _: () = objc::msg_send![ns_win, orderOut: ns_win];
+                                                        } else {
+                                                            // makeKeyAndOrderFront shows + focuses
+                                                            // without activating the app (main stays put)
+                                                            let _: () = objc::msg_send![ns_win, setLevel: 3_i64]; // NSFloatingWindowLevel
+                                                            let _: () = objc::msg_send![ns_win, makeKeyAndOrderFront: ns_win];
+                                                            tauri::async_runtime::spawn({
+                                                                let h = handle_for_shortcuts.clone();
+                                                                async move {
+                                                                    let _ = crate::search::position_quick_capture(h).await;
+                                                                }
+                                                            });
                                                         }
-                                                    });
+                                                    }
                                                 }
+                                            }
+                                        }
+                                        #[cfg(not(target_os = "macos"))]
+                                        {
+                                            if window.is_visible().unwrap_or(false) {
+                                                let _ = window.hide();
+                                            } else {
+                                                let _ = window.show();
+                                                let _ = window.set_focus();
                                             }
                                         }
                                     }
                                 }
-                                #[cfg(not(target_os = "macos"))]
-                                {
-                                    if window.is_visible().unwrap_or(false) {
-                                        let _ = window.hide();
-                                    } else {
-                                        let _ = window.show();
-                                        let _ = window.set_focus();
-                                    }
-                                }
-                            }
-                        }
-                    },
-                )?;
-            }
+                            })
+                            .map_err(|e| e.to_string())
+                    });
+
+                    // Explicit, never swallowed: the shortcut, the keys the
+                    // user would press, and the OS error, in the app log.
+                    if let Err(ref error) = outcome {
+                        log::warn!("{}", global_shortcuts::registration_warning(&spec, error));
+                    }
+                    outcomes.push((spec, outcome));
+                }
+
+                global_shortcuts::partition_registrations(outcomes)
+            };
+            // Recorded so a surface can answer "why does Ctrl+K do nothing?".
+            // Read it with the `global_shortcut_status` command.
+            app.manage(shortcut_status);
 
             // Tray icon: left-click toggles window, right-click menu with Show / Status / Quit
             {
@@ -1518,6 +1540,8 @@ pub fn run() {
             acknowledge_guarded_quit_request,
             cancel_guarded_quit_request,
             daemon_start::start_daemon_sidecar,
+            // Which global hotkeys this session actually holds
+            global_shortcuts::global_shortcut_status,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -942,15 +942,17 @@ pub fn run() {
             // at the first refusal — so one taken hotkey also cost the other
             // two — and the `?` carried the error out of `setup()`, which Tauri
             // turns into `Failed to setup app: HotKey already registered: ...`
-            // and a panic, seconds after the window was already visible. See
-            // `global_shortcuts` for the whole story.
+            // and a panic, seconds after the window was already visible.
+            //
+            // `register_all` owns the keep-going rule and the WARN for each
+            // refusal; this closure is only the registrar it drives. See
+            // `global_shortcuts` for the whole story and its tests.
             let shortcut_status = {
                 use crate::global_shortcuts::ShortcutId;
 
-                let mut outcomes = Vec::with_capacity(global_shortcuts::SHORTCUTS.len());
-                for spec in global_shortcuts::SHORTCUTS {
+                global_shortcuts::register_all(&global_shortcuts::SHORTCUTS, |spec| {
                     let handle_for_shortcuts = handle.clone();
-                    let outcome = global_shortcuts::parse(&spec).and_then(|shortcut| {
+                    global_shortcuts::parse(spec).and_then(|shortcut| {
                         app.global_shortcut()
                             .on_shortcut(shortcut, move |_app, _shortcut, event| {
                                 use tauri::Emitter;
@@ -958,79 +960,74 @@ pub fn run() {
                                 if event.state != ShortcutState::Pressed {
                                     return;
                                 }
-                                if spec.id == ShortcutId::ToggleSearch {
-                                    let _ = handle_for_shortcuts.emit("toggle-spotlight", ());
-                                } else if spec.id == ShortcutId::ShowMemory {
-                                    if let Some(window) = handle_for_shortcuts.get_webview_window("main") {
-                                        if window.is_visible().unwrap_or(false) {
-                                            let _ = window.hide();
-                                            set_main_window_dock_visibility(&handle_for_shortcuts, false);
-                                        } else {
-                                            set_main_window_dock_visibility(&handle_for_shortcuts, true);
-                                            let _ = window.show();
-                                            let _ = window.set_focus();
-                                            let _ = handle_for_shortcuts.emit("show-memory", ());
+                                match spec.id {
+                                    ShortcutId::ToggleSearch => {
+                                        let _ = handle_for_shortcuts.emit("toggle-spotlight", ());
+                                    }
+                                    ShortcutId::ShowMemory => {
+                                        if let Some(window) = handle_for_shortcuts.get_webview_window("main") {
+                                            if window.is_visible().unwrap_or(false) {
+                                                let _ = window.hide();
+                                                set_main_window_dock_visibility(&handle_for_shortcuts, false);
+                                            } else {
+                                                set_main_window_dock_visibility(&handle_for_shortcuts, true);
+                                                let _ = window.show();
+                                                let _ = window.set_focus();
+                                                let _ = handle_for_shortcuts.emit("show-memory", ());
+                                            }
                                         }
                                     }
-                                } else if spec.id == ShortcutId::QuickCapture {
-                                    if let Some(window) =
-                                        handle_for_shortcuts.get_webview_window("quick-capture")
-                                    {
-                                        #[cfg(target_os = "macos")]
-                                        #[allow(deprecated)]
+                                    ShortcutId::QuickCapture => {
+                                        if let Some(window) =
+                                            handle_for_shortcuts.get_webview_window("quick-capture")
                                         {
-                                            use cocoa::base::id;
-                                            use raw_window_handle::HasWindowHandle;
-                                            if let Ok(raw_handle) = window.window_handle() {
-                                                if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
-                                                    let ns_view = appkit.ns_view.as_ptr() as id;
-                                                    unsafe {
-                                                        let ns_win: id = objc::msg_send![ns_view, window];
-                                                        let visible: bool = objc::msg_send![ns_win, isVisible];
-                                                        if visible {
-                                                            // orderOut removes the window without
-                                                            // triggering macOS window promotion
-                                                            let _: () = objc::msg_send![ns_win, orderOut: ns_win];
-                                                        } else {
-                                                            // makeKeyAndOrderFront shows + focuses
-                                                            // without activating the app (main stays put)
-                                                            let _: () = objc::msg_send![ns_win, setLevel: 3_i64]; // NSFloatingWindowLevel
-                                                            let _: () = objc::msg_send![ns_win, makeKeyAndOrderFront: ns_win];
-                                                            tauri::async_runtime::spawn({
-                                                                let h = handle_for_shortcuts.clone();
-                                                                async move {
-                                                                    let _ = crate::search::position_quick_capture(h).await;
-                                                                }
-                                                            });
+                                            #[cfg(target_os = "macos")]
+                                            #[allow(deprecated)]
+                                            {
+                                                use cocoa::base::id;
+                                                use raw_window_handle::HasWindowHandle;
+                                                if let Ok(raw_handle) = window.window_handle() {
+                                                    if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
+                                                        let ns_view = appkit.ns_view.as_ptr() as id;
+                                                        unsafe {
+                                                            let ns_win: id = objc::msg_send![ns_view, window];
+                                                            let visible: bool = objc::msg_send![ns_win, isVisible];
+                                                            if visible {
+                                                                // orderOut removes the window without
+                                                                // triggering macOS window promotion
+                                                                let _: () = objc::msg_send![ns_win, orderOut: ns_win];
+                                                            } else {
+                                                                // makeKeyAndOrderFront shows + focuses
+                                                                // without activating the app (main stays put)
+                                                                let _: () = objc::msg_send![ns_win, setLevel: 3_i64]; // NSFloatingWindowLevel
+                                                                let _: () = objc::msg_send![ns_win, makeKeyAndOrderFront: ns_win];
+                                                                tauri::async_runtime::spawn({
+                                                                    let h = handle_for_shortcuts.clone();
+                                                                    async move {
+                                                                        let _ = crate::search::position_quick_capture(h).await;
+                                                                    }
+                                                                });
+                                                            }
                                                         }
                                                     }
                                                 }
                                             }
-                                        }
-                                        #[cfg(not(target_os = "macos"))]
-                                        {
-                                            if window.is_visible().unwrap_or(false) {
-                                                let _ = window.hide();
-                                            } else {
-                                                let _ = window.show();
-                                                let _ = window.set_focus();
+                                            #[cfg(not(target_os = "macos"))]
+                                            {
+                                                if window.is_visible().unwrap_or(false) {
+                                                    let _ = window.hide();
+                                                } else {
+                                                    let _ = window.show();
+                                                    let _ = window.set_focus();
+                                                }
                                             }
                                         }
                                     }
                                 }
                             })
                             .map_err(|e| e.to_string())
-                    });
-
-                    // Explicit, never swallowed: the shortcut, the keys the
-                    // user would press, and the OS error, in the app log.
-                    if let Err(ref error) = outcome {
-                        log::warn!("{}", global_shortcuts::registration_warning(&spec, error));
-                    }
-                    outcomes.push((spec, outcome));
-                }
-
-                global_shortcuts::partition_registrations(outcomes)
+                    })
+                })
             };
             // Recorded so a surface can answer "why does Ctrl+K do nothing?".
             // Read it with the `global_shortcut_status` command.


### PR DESCRIPTION
## The crash

Launching Wenlan while another process held `Ctrl+K` panicked about 2.5 seconds
after the window was already on screen:

```
Failed to setup app: HotKey already registered: HotKey { mods: CONTROL, key: KeyK }
```

The panic names no process, only the hotkey. In practice that is another Wenlan
instance or any other application holding the same combination.

What the user saw: the window appeared, showed "Starting the local runtime…",
and then vanished. No dialog, no toast, no tray message — nothing that named a
keyboard shortcut as the reason.

## Root cause

`app/src/lib.rs:945` at `6602e29c` registered all three global shortcuts —
`CmdOrCtrl+K`, `CmdOrCtrl+Shift+K`, `CmdOrCtrl+Shift+N` — in a single
`app.global_shortcut().on_shortcuts([..])?` call, and treated a refusal as
fatal. Two things followed from that:

- `on_shortcuts` registers in a loop and returns on the **first** failure, so
  one taken hotkey also cost the other two, which were never attempted.
- The `?` carried the error out of `setup()`, and Tauri turns a failed setup
  into a panic — by which point the window was already visible.

A global hotkey belongs to whichever process grabbed it first, desktop-wide, so
"already registered" is an ordinary answer rather than an exceptional one. Any
other application holding `Ctrl+K` reaches the same path. The single-instance
plugin does not prevent the second-Wenlan case either: it keys on the bundle
identifier, so a build with a different identifier (a dev build, a side-by-side
install, a renamed bundle) is a different instance to the plugin and arrives
here with the running app's hotkeys still held.

The three accelerators were also `unwrap()`ed at parse time, so a typo in one
would have been a startup panic of its own.

## The change

New module `app/src/global_shortcuts.rs` owns the shortcut list and the failure
handling. `global_shortcuts::register_all(specs, register)` attempts every spec
in turn and returns a status; `lib.rs` passes it a closure that parses the
accelerator and calls `on_shortcut`. No registration error leaves `setup()`.

- Registration is per-shortcut with no early exit, so a refused `Ctrl+K` leaves
  `Ctrl+Shift+K` and `Ctrl+Shift+N` working.
- Every failure logs a WARN — inside `register_all`, so no caller can register
  without reporting — naming the shortcut id, the keys the user would press,
  that the key is dead for this session, and the verbatim OS error.
- The outcome is recorded as a `GlobalShortcutStatus` (active / unavailable,
  each unavailable entry carrying its own error) and managed in Tauri state.
- New command `global_shortcut_status` returns it.
- The handler dispatches on an exhaustive `match spec.id`, so adding a fourth
  `ShortcutId` is a compile error rather than a shortcut that registers and
  silently does nothing.

## What the user sees now

The app starts and stays up. The shortcuts that could be registered work; the
ones that were taken do nothing, and the app log says exactly which and why:

```
WARN [shortcuts] global shortcut toggle-search (CmdOrCtrl+K) could not be
registered and is unavailable this session: HotKey already registered: HotKey
{ mods: CONTROL, key: KeyK }
```

The line offers no cause of its own. The same path carries "another process
holds this hotkey" and "this accelerator does not parse", and a guess appended
to the second would be a fabrication — the verbatim error already says which.

No UI renders the status yet — deliberately, and it is called out in the module
doc rather than invented here. Wiring it would mean a wrapper in
`src/lib/tauri.ts`, a block in
`src/components/memory/settings/sections/DiagnosticsSection.tsx` (Settings →
Diagnostics is where the app already explains wiring that is present but not
working), and copy in all three locales in `src/i18n/resources.ts`. Until then
the WARN is the record.

## Tests

Eight unit tests in `app/src/global_shortcuts.rs`, all pure — no Tauri app and
no real hotkey manager needed:

- `a_taken_shortcut_does_not_cost_the_others` — the regression. The registrar
  closure refuses the FIRST spec and records every call, so the test asserts all
  three were attempted, not just that the status came out right. An early
  `break` in `register_all` (the old batch semantics) fails it; verified by
  mutation, then restored.
- `every_failure_keeps_its_own_error`
- `nothing_is_unavailable_when_every_registration_succeeds`
- `every_declared_shortcut_parses` — replaces the three `unwrap()`s that used to
  live in `setup()`
- `shortcut_list_is_the_three_bindings_the_app_registers`
- `shortcut_ids_are_distinct`
- `warning_names_the_shortcut_the_key_and_the_error`
- `status_serializes_with_the_stable_kebab_ids`

The exhaustive `match` was checked the same way: adding a probe `ShortcutId`
variant makes `app/src/lib.rs:960` fail with E0004, then it was removed.

`cargo test -p wenlan-app --lib` on Windows: all 8 of the above pass, and the
only failures in the crate are pre-existing Windows-only ones — five constant
`api::tests` presence failures (they mint a presence capability, which
`presence.rs` refuses on non-unix by design: "owner-only secret protection is
not implemented on this platform") plus one intermittent, none of them in this
module. The app-check CI lane runs on macOS, where they pass.

`cargo clippy -p wenlan-app --all-targets` on Windows reports only the
pre-existing Windows-only `NO_TRUTH` dead-code constant at
`app/src/page_review.rs:282`; nothing from the changed or added code, so the
`-D warnings` form fails on that alone. `cargo fmt --all --check` is clean. No
frontend files were touched, so `tsc -b` was not run.

Not verified: a live two-instance conflict was not reproduced against the
running app, since that would mean launching a second build against the user's
real daemon and data. The keep-going rule and the warning text are covered by
the tests above; the actual OS refusal is produced only by the plugin call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NH3nEZRDbNUeEzCrzfPuk8
