### PR TITLE
chore(release): steer the next release to 0.18.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "simple",
       "always-update": true,
-      "versioning": "always-bump-patch"
+      "versioning": "always-bump-patch",
+      "release-as": "0.18.0"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Steers the next release to **0.18.0** instead of the 0.17.9 that release-please proposed in #694.

The repo pins `versioning: always-bump-patch`, so a deliberate minor is a config change, not a commit footer (`docs/RELEASING.md`, "Version-steering policy"). Main since 0.17.8 carries the app launch fixes (#692, #695, #696, #698) and the new home page (#693); this is the launch build.

What happens next, automatically: release-please retitles #694 to 0.18.0 and syncs `version.txt`. After the tag lands, `finalize-release` opens the cleanup PR that removes this override. That cleanup PR must be merged, or the candidate validator rejects the following release as stale.

Local check: `python3 scripts/validate-release-candidate.test.py` ran 40 tests, all OK. The validator accepts this override because 0.18.0 advances past the released base 0.17.8 (`scripts/validate-release-candidate.py:570-577`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7
