### PR TITLE
chore: drop the release-as override now that 0.18.0 is cut

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,7 @@
     ".": {
       "release-type": "simple",
       "always-update": true,
-      "versioning": "always-bump-patch",
-      "release-as": "0.18.0"
+      "versioning": "always-bump-patch"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Automated follow-up from the v0.18.0 release: the one-shot release-as override has been consumed, and release-please would otherwise keep proposing 0.18.0 (see docs/RELEASING.md, version-steering policy). The candidate validator rejects a stale override, so merging this unblocks the next release.