### PR TITLE
docs: give the README launch video its soundtrack

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=7c7d6c8fba5ea5036d603ad2670082ab97e41a3629c9fee2b1d790fd98384738 -->
+<!-- README_SYNC: source=README.md sha256=e8b2ae58b31176519b022dc30f37a0f728d5f19a1ba28c16a4937865053228a7 -->
 
 <p align="center">
   <picture>
@@ -28,7 +28,7 @@ El trabajo útil con IA no debería desaparecer cuando termina una conversación
   <a href="#learn-more">Leer&nbsp;más</a>
 </p>
 
-https://github.com/user-attachments/assets/77272089-84ea-4eb0-a074-c9cc8b7b28fd
+https://github.com/user-attachments/assets/24364236-6c19-41f8-baf8-6982fe72663e
 
 <p align="center">
   <sub>Una Página mantenida en la aplicación de escritorio: abre cualquier cita para inspeccionar la Fuente o Memoria detrás de la afirmación.</sub>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Useful work with AI shouldn't disappear when a conversation ends. Wenlan builds 
   <a href="#learn-more">Learn&nbsp;more</a>
 </p>
 
-https://github.com/user-attachments/assets/77272089-84ea-4eb0-a074-c9cc8b7b28fd
+https://github.com/user-attachments/assets/24364236-6c19-41f8-baf8-6982fe72663e
 
 <p align="center">
   <sub>A maintained Page in the desktop app: open any citation to inspect the Source or Memory behind the claim.</sub>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=7c7d6c8fba5ea5036d603ad2670082ab97e41a3629c9fee2b1d790fd98384738 -->
+<!-- README_SYNC: source=README.md sha256=e8b2ae58b31176519b022dc30f37a0f728d5f19a1ba28c16a4937865053228a7 -->
 
 <p align="center">
   <picture>
@@ -28,7 +28,7 @@
   <a href="#learn-more">进&#8288;一&#8288;步&#8288;了&#8288;解</a>
 </p>
 
-https://github.com/user-attachments/assets/fd1631cd-8fe3-4f7e-9334-c7772f5d1ed7
+https://github.com/user-attachments/assets/26fd756f-5825-4f06-9dac-082361edaebc
 
 <p align="center">
   <sub>桌面 app 中持续维护的页面：打开任意引用，就能检查这条结论背后的来源或记忆。</sub>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=7c7d6c8fba5ea5036d603ad2670082ab97e41a3629c9fee2b1d790fd98384738 -->
+<!-- README_SYNC: source=README.md sha256=e8b2ae58b31176519b022dc30f37a0f728d5f19a1ba28c16a4937865053228a7 -->
 
 <p align="center">
   <picture>
@@ -28,7 +28,7 @@
   <a href="#learn-more">進&#8288;一&#8288;步&#8288;了&#8288;解</a>
 </p>
 
-https://github.com/user-attachments/assets/c18bcad8-2bf8-4150-8c7a-1f6d7ec439ab
+https://github.com/user-attachments/assets/b7bb11c7-77a8-4f20-ba73-ad55e8410cb7
 
 <p align="center">
   <sub>桌面 app 中持續維護的頁面：開啟任一引用，就能檢查這項結論背後的來源或記憶。</sub>


### PR DESCRIPTION
The four READMEs embedded a silent render of the launch demo. Verified: the served attachment has no audio stream at all, while the same footage on wenlan.app and YouTube carries the licensed track.

This swaps in the v0.18.0 cut with music, re-encoded to about 8.7 MB so it stays inside GitHub's attachment limit. Same footage (identical video stream hash against the master), 84.096 s, 1920x1200. Music: Leva - Eternity by lemonmusicstudio from Pixabay, credited in the video and in the YouTube descriptions.

| README | New attachment |
|---|---|
| README.md, README.es-ES.md | 24364236-6c19-41f8-baf8-6982fe72663e |
| README.zh-Hant.md | b7bb11c7-77a8-4f20-ba73-ad55e8410cb7 |
| README.zh-Hans.md | 26fd756f-5825-4f06-9dac-082361edaebc |

Old links kept here for rollback: 77272089-84ea-4eb0-a074-c9cc8b7b28fd (en/es), c18bcad8-2bf8-4150-8c7a-1f6d7ec439ab (zh-Hant), fd1631cd-8fe3-4f7e-9334-c7772f5d1ed7 (zh-Hans).

`scripts/check-readme-translations.py` reports translations in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7