### PR TITLE
docs: restore the README video's opening frame

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=e8b2ae58b31176519b022dc30f37a0f728d5f19a1ba28c16a4937865053228a7 -->
+<!-- README_SYNC: source=README.md sha256=f1b5462c72ffd262f62a3ec6e38a3574588d3b600a72e7742ed086cd1dd31439 -->
 
 <p align="center">
   <picture>
@@ -28,7 +28,7 @@ El trabajo útil con IA no debería desaparecer cuando termina una conversación
   <a href="#learn-more">Leer&nbsp;más</a>
 </p>
 
-https://github.com/user-attachments/assets/24364236-6c19-41f8-baf8-6982fe72663e
+https://github.com/user-attachments/assets/d8b2ad4a-f97a-4a15-97a8-9105478de18a
 
 <p align="center">
   <sub>Una Página mantenida en la aplicación de escritorio: abre cualquier cita para inspeccionar la Fuente o Memoria detrás de la afirmación.</sub>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Useful work with AI shouldn't disappear when a conversation ends. Wenlan builds 
   <a href="#learn-more">Learn&nbsp;more</a>
 </p>
 
-https://github.com/user-attachments/assets/24364236-6c19-41f8-baf8-6982fe72663e
+https://github.com/user-attachments/assets/d8b2ad4a-f97a-4a15-97a8-9105478de18a
 
 <p align="center">
   <sub>A maintained Page in the desktop app: open any citation to inspect the Source or Memory behind the claim.</sub>

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=e8b2ae58b31176519b022dc30f37a0f728d5f19a1ba28c16a4937865053228a7 -->
+<!-- README_SYNC: source=README.md sha256=f1b5462c72ffd262f62a3ec6e38a3574588d3b600a72e7742ed086cd1dd31439 -->
 
 <p align="center">
   <picture>
@@ -28,7 +28,7 @@
   <a href="#learn-more">进&#8288;一&#8288;步&#8288;了&#8288;解</a>
 </p>
 
-https://github.com/user-attachments/assets/26fd756f-5825-4f06-9dac-082361edaebc
+https://github.com/user-attachments/assets/418c9006-80bd-4250-b28a-f3914e47749c
 
 <p align="center">
   <sub>桌面 app 中持续维护的页面：打开任意引用，就能检查这条结论背后的来源或记忆。</sub>

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,4 +1,4 @@
-<!-- README_SYNC: source=README.md sha256=e8b2ae58b31176519b022dc30f37a0f728d5f19a1ba28c16a4937865053228a7 -->
+<!-- README_SYNC: source=README.md sha256=f1b5462c72ffd262f62a3ec6e38a3574588d3b600a72e7742ed086cd1dd31439 -->
 
 <p align="center">
   <picture>
@@ -28,7 +28,7 @@
   <a href="#learn-more">進&#8288;一&#8288;步&#8288;了&#8288;解</a>
 </p>
 
-https://github.com/user-attachments/assets/b7bb11c7-77a8-4f20-ba73-ad55e8410cb7
+https://github.com/user-attachments/assets/78818f74-3e68-4a45-83d5-f0302a9eb177
 
 <p align="center">
   <sub>桌面 app 中持續維護的頁面：開啟任一引用，就能檢查這項結論背後的來源或記憶。</sub>


### PR DESCRIPTION
Follow-up to #702. The v0.18.0 cut opens on a 0.6 second fade from black. GitHub's inline player has no poster attribute, so the browser shows frame zero, which meant a black box where the previous render showed the desktop app.

Measured: first frame of the previous README video was near white (f3f4f0); first frame of the #702 upload was pure black. The three README copies are re-cut to start after the fade.

| Property | Before | After |
|---|---|---|
| First frame | black | app UI (f2f2f3) |
| Duration | 84.096 s | 83.496 s |
| Audio | music, -23.3 dB | unchanged |
| Size | ~8.7 MB | ~8.6 MB |

New attachments: en/es d8b2ad4a-f97a-4a15-97a8-9105478de18a, zh-Hant 78818f74-3e68-4a45-83d5-f0302a9eb177, zh-Hans 418c9006-80bd-4250-b28a-f3914e47749c. The #702 links stay valid for rollback.

The YouTube uploads and wenlan.app keep the full cut with its fade; only the GitHub copies are trimmed, because only they use frame zero as the thumbnail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MD4BnpxmKKCnQsL6BZ2dy7