### PR TITLE
fix(release): stop requiring the codex runner script in release PRs

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -56,18 +56,9 @@ jq ".version = \"${NEW_VERSION}+codex\"" "$CODEX_PLUGIN_MANIFEST" > "${CODEX_PLU
 mv "${CODEX_PLUGIN_MANIFEST}.tmp" "$CODEX_PLUGIN_MANIFEST"
 echo "  Updated $CODEX_PLUGIN_MANIFEST"
 
-# 4. Plugin's MCP server pin — the wrapper script falls back to
-# `npx -y wenlan-mcp@^X.Y.Z` so a floating tag can't auto-RCE on every
-# Claude Code session. The pin lives in the runner shell script, not
-# .mcp.json, so dev users can override the wenlan-mcp binary via
-# WENLAN_MCP_DEV_BIN.
-CODEX_PLUGIN_MCP_RUNNER="plugin-codex/bin/wenlan-mcp-runner.sh"
-if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_MCP_RUNNER"
-else
-    sed -i -E "s|(wenlan-mcp@\\^)[0-9]+\\.[0-9]+\\.[0-9]+|\\1${NEW_VERSION}|g" "$CODEX_PLUGIN_MCP_RUNNER"
-fi
-echo "  Updated $CODEX_PLUGIN_MCP_RUNNER (wenlan-mcp pin)"
+# 4. The plugin MCP runner scripts (plugin/bin, plugin-codex/bin) derive their
+# `npx -y wenlan-mcp@^X.Y.Z` fallback pin from the sibling plugin.json at run
+# time, so they carry no version string and are not touched by the release PR.
 
 # 5. /setup skill install.sh URL pinned to current tag (not `main`), so the
 # install one-liner is reproducible at the release boundary.
@@ -131,4 +122,4 @@ awk -v ver="$NEW_VERSION" '
 echo "  Updated Cargo.lock (workspace member versions)"
 
 echo ""
-echo "Versions synced from version.txt (${NEW_VERSION}) to Cargo.toml + npm + plugin manifests + plugin MCP/skills + desktop app trio + Cargo.lock."
+echo "Versions synced from version.txt (${NEW_VERSION}) to Cargo.toml + npm + plugin manifests + plugin skills + desktop app trio + Cargo.lock."

--- a/scripts/bump-version.test.sh
+++ b/scripts/bump-version.test.sh
@@ -47,7 +47,8 @@ cat > "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json" <<EOF
 EOF
 
 cat > "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" <<EOF
-exec npx -y wenlan-mcp@^0.4.1 --agent-name "\${agent_name}" "\$@"
+plugin_json="\${here}/../.codex-plugin/plugin.json"
+exec npx -y "wenlan-mcp@^\${ver}" --agent-name "\${agent_name}" "\$@"
 EOF
 
 cat > "$TMPDIR_TEST/app/Cargo.toml" <<EOF
@@ -146,7 +147,8 @@ APP_PKG_VER=$(jq -r .version "$TMPDIR_TEST/package.json")
 [[ "$APP_PKG_VER" == "0.5.0" ]] || { echo "FAIL: package.json not bumped (got $APP_PKG_VER)"; exit 1; }
 grep -q '# x-release-please-version' "$TMPDIR_TEST/app/Cargo.toml" || { echo "FAIL: app/Cargo.toml lost its x-release-please-version marker"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin/skills/setup/SKILL.md" || { echo "FAIL: setup skill installer not bumped"; exit 1; }
-grep -q 'wenlan-mcp@\^0.5.0' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" || { echo "FAIL: Codex runner pin not bumped"; exit 1; }
+grep -q 'wenlan-mcp@\^\${ver}' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" || { echo "FAIL: Codex runner must keep deriving its pin from plugin.json"; exit 1; }
+grep -Eq 'wenlan-mcp@\^[0-9]' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" && { echo "FAIL: bump-version.sh must not hardcode a Codex runner pin"; exit 1; }
 grep -q '/v0.5.0/install.sh' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" || { echo "FAIL: Codex setup skill installer not bumped"; exit 1; }
 
 # Cargo.lock: all five workspace members bumped to 0.5.0, exactly as

--- a/scripts/ci_measure_plan.py
+++ b/scripts/ci_measure_plan.py
@@ -35,7 +35,6 @@ RELEASE_MANAGED_PATHS = frozenset(
         "crates/wenlan-mcp/npm/package.json",
         "package.json",
         "plugin-codex/.codex-plugin/plugin.json",
-        "plugin-codex/bin/wenlan-mcp-runner.sh",
         "plugin-codex/skills/setup/SKILL.md",
         "plugin/.claude-plugin/plugin.json",
         "plugin/skills/setup/SKILL.md",

--- a/scripts/validate-release-candidate.py
+++ b/scripts/validate-release-candidate.py
@@ -65,7 +65,6 @@ RELEASE_MANAGED_PATHS = frozenset(
         "crates/wenlan-mcp/npm/package.json",
         "package.json",
         "plugin-codex/.codex-plugin/plugin.json",
-        "plugin-codex/bin/wenlan-mcp-runner.sh",
         "plugin-codex/skills/setup/SKILL.md",
         "plugin/.claude-plugin/plugin.json",
         "plugin/skills/setup/SKILL.md",

--- a/scripts/validate-release-candidate.test.py
+++ b/scripts/validate-release-candidate.test.py
@@ -73,17 +73,12 @@ class FakeContentApi:
         records = []
         for name in sorted(VALIDATOR.REQUIRED_RELEASE_PATHS):
             raw = contents[name].encode()
-            default_mode = (
-                "100755"
-                if name == "plugin-codex/bin/wenlan-mcp-runner.sh"
-                else "100644"
-            )
             records.append(
                 {
                     "path": name,
-                    "mode": self.head_mode_overrides.get(name, default_mode)
+                    "mode": self.head_mode_overrides.get(name, "100644")
                     if head
-                    else default_mode,
+                    else "100644",
                     "type": "blob",
                     "sha": git_blob_sha(raw),
                     "size": len(raw),
@@ -1456,16 +1451,14 @@ class ValidateReleaseCandidateTests(unittest.TestCase):
                 ):
                     transform(qualified, "0.15.3", "0.15.4")
 
-    def test_release_runner_mode_change_is_rejected(self) -> None:
+    def test_release_managed_mode_change_is_rejected(self) -> None:
         old, new = release_contents()
         with self.assertRaisesRegex(VALIDATOR.CandidateError, "mode/type changed"):
             VALIDATOR.validate_release_pr_content(
                 FakeContentApi(
                     old,
                     new,
-                    head_mode_overrides={
-                        "plugin-codex/bin/wenlan-mcp-runner.sh": "100644"
-                    },
+                    head_mode_overrides={"version.txt": "100755"},
                 ),
                 "7xuanlu/wenlan",
                 candidate_pr(),

--- a/scripts/validate-versions.sh
+++ b/scripts/validate-versions.sh
@@ -33,7 +33,10 @@ WENLAN_NPM_VER=$(jq -r .version crates/wenlan-cli/npm/package.json)
 PLUGIN_VER=$(jq -r .version plugin/.claude-plugin/plugin.json)
 CODEX_PLUGIN_VER_RAW=$(jq -r .version plugin-codex/.codex-plugin/plugin.json)
 CODEX_PLUGIN_VER="${CODEX_PLUGIN_VER_RAW%%+*}"
-CODEX_RUNNER_PINS=$(grep -Eo 'wenlan-mcp@\^[0-9]+\.[0-9]+\.[0-9]+' plugin-codex/bin/wenlan-mcp-runner.sh | sed -E 's/.*@\^//' | sort -u || true)
+# The Codex runner derives its `npx wenlan-mcp@^X.Y.Z` fallback from the sibling
+# plugin.json at run time, so it must carry no hardcoded pin that could drift.
+CODEX_RUNNER_HARDCODED_PINS=$(grep -Eo 'wenlan-mcp@\^[0-9]+\.[0-9]+\.[0-9]+' plugin-codex/bin/wenlan-mcp-runner.sh | sed -E 's/.*@\^//' | sort -u || true)
+CODEX_RUNNER_DERIVES_PIN=$(grep -c '\.codex-plugin/plugin\.json' plugin-codex/bin/wenlan-mcp-runner.sh || true)
 CODEX_SETUP_TAGS=$(grep -Eo '/v[0-9]+\.[0-9]+\.[0-9]+/install\.sh' plugin-codex/skills/setup/SKILL.md | sed -E 's|/v([^/]+)/install\.sh|\1|' | sort -u || true)
 
 echo "Tag:         $TAG_VER"
@@ -50,8 +53,7 @@ echo "wenlan-mcp npm: $MCP_NPM_VER"
 echo "wenlan npm: $WENLAN_NPM_VER"
 echo "Plugin:      $PLUGIN_VER"
 echo "Codex plugin: $CODEX_PLUGIN_VER_RAW"
-echo "Codex runner pins:"
-printf '%s\n' "$CODEX_RUNNER_PINS" | sed 's/^/  /'
+echo "Codex runner hardcoded pins: ${CODEX_RUNNER_HARDCODED_PINS:-none}"
 echo "Codex setup tags:"
 printf '%s\n' "$CODEX_SETUP_TAGS" | sed 's/^/  /'
 
@@ -60,15 +62,25 @@ if [[ "$VTXT_VER" != "$TAG_VER" || "$WS_VER" != "$TAG_VER" || "$WENLAN_TYPES_DEP
     exit 1
 fi
 
-for pin in $CODEX_RUNNER_PINS $CODEX_SETUP_TAGS; do
+for pin in $CODEX_SETUP_TAGS; do
     if [[ "$pin" != "$TAG_VER" ]]; then
         echo "ERROR: Codex plugin release pin drift — ${pin} is not ${TAG_VER}"
         exit 1
     fi
 done
 
-if [[ -z "$CODEX_RUNNER_PINS" || -z "$CODEX_SETUP_TAGS" ]]; then
+if [[ -z "$CODEX_SETUP_TAGS" ]]; then
     echo "ERROR: Codex plugin release pin missing"
+    exit 1
+fi
+
+if [[ -n "$CODEX_RUNNER_HARDCODED_PINS" ]]; then
+    echo "ERROR: Codex runner carries a hardcoded wenlan-mcp pin (${CODEX_RUNNER_HARDCODED_PINS//$'\n'/ }); it must derive the pin from plugin.json"
+    exit 1
+fi
+
+if [[ "$CODEX_RUNNER_DERIVES_PIN" == "0" ]]; then
+    echo "ERROR: Codex runner does not derive its wenlan-mcp pin from .codex-plugin/plugin.json"
     exit 1
 fi
 

--- a/scripts/validate-versions.test.sh
+++ b/scripts/validate-versions.test.sh
@@ -59,7 +59,8 @@ EOF
 echo '{"version": "0.5.0"}' > "$TMPDIR_TEST/app/tauri.conf.json"
 echo '{"name": "wenlan-app", "version": "0.5.0"}' > "$TMPDIR_TEST/package.json"
 cat > "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" <<EOF
-exec npx -y wenlan-mcp@^0.5.0 --agent-name "\${agent_name}" "\$@"
+plugin_json="\${here}/../.codex-plugin/plugin.json"
+exec npx -y "wenlan-mcp@^\${ver}" --agent-name "\${agent_name}" "\$@"
 EOF
 cat > "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md" <<EOF
 curl -fsSL https://raw.githubusercontent.com/7xuanlu/wenlan/v0.5.0/install.sh | bash
@@ -139,14 +140,22 @@ fi
 echo "PASS test 5: Codex plugin manifest drift detected"
 
 echo '{"version": "0.5.0+codex"}' > "$TMPDIR_TEST/plugin-codex/.codex-plugin/plugin.json"
-perl -0pi -e 's/wenlan-mcp@\^0\.5\.0/wenlan-mcp@^0.4.9/g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+perl -0pi -e 's/\^\$\{ver\}/^0.5.0/g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+grep -q 'wenlan-mcp@\^0\.5\.0' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh" || { echo "FAIL test 6: fixture mutation did not apply"; exit 1; }
 if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
-    echo "FAIL test 6: should have detected Codex runner pin drift"
+    echo "FAIL test 6: should have rejected a hardcoded Codex runner pin (even a matching one)"
     exit 1
 fi
-echo "PASS test 6: Codex runner pin drift detected"
+echo "PASS test 6: hardcoded Codex runner pin rejected"
 
-perl -0pi -e 's/wenlan-mcp@\^0\.4\.9/wenlan-mcp@^0.5.0/g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+perl -0pi -e 's/\^0\.5\.0/^\${ver}/g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+perl -0pi -e 's|\.codex-plugin/plugin\.json|.codex-plugin/other.json|g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
+if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
+    echo "FAIL test 6b: should have rejected a Codex runner that does not read plugin.json"
+    exit 1
+fi
+echo "PASS test 6b: Codex runner without plugin.json derivation rejected"
+perl -0pi -e 's|\.codex-plugin/other\.json|.codex-plugin/plugin.json|g' "$TMPDIR_TEST/plugin-codex/bin/wenlan-mcp-runner.sh"
 perl -0pi -e 's|/v0\.5\.0/install\.sh|/v0.4.9/install.sh|g' "$TMPDIR_TEST/plugin-codex/skills/setup/SKILL.md"
 if (cd "$TMPDIR_TEST" && RELEASE_TAG="v0.5.0" bash "$OLDPWD/scripts/validate-versions.sh") 2>/dev/null; then
     echo "FAIL test 7: should have detected Codex setup install tag drift"

--- a/scripts/verify-release-merge.py
+++ b/scripts/verify-release-merge.py
@@ -37,10 +37,8 @@ RELEASE_MANAGED_PATHS = frozenset(
         "crates/wenlan-mcp/npm/package.json",
         "package.json",
         "plugin-codex/.codex-plugin/plugin.json",
-        "plugin-codex/bin/wenlan-mcp-runner.sh",
         "plugin-codex/skills/setup/SKILL.md",
         "plugin/.claude-plugin/plugin.json",
-        "plugin/bin/wenlan-mcp-runner.sh",
         "plugin/skills/setup/SKILL.md",
         "version.txt",
     }

--- a/scripts/verify-release-merge.test.py
+++ b/scripts/verify-release-merge.test.py
@@ -25,7 +25,6 @@ RELEASE_FILES = (
     "crates/wenlan-cli/npm/package.json",
     "crates/wenlan-mcp/npm/package.json",
     "plugin-codex/.codex-plugin/plugin.json",
-    "plugin-codex/bin/wenlan-mcp-runner.sh",
     "plugin-codex/skills/setup/SKILL.md",
     "plugin/.claude-plugin/plugin.json",
     "plugin/skills/setup/SKILL.md",
@@ -360,8 +359,8 @@ class ReleaseManagedPathsConsistencyTests(unittest.TestCase):
     """A stale copy of RELEASE_MANAGED_PATHS must not silently drift.
 
     validate-release-candidate.py is the canonical source of REQUIRED_RELEASE_PATHS.
-    This copy legitimately carries extra entries (e.g. "plugin/bin/wenlan-mcp-runner.sh"),
-    so the contract is superset, not equality.
+    This copy may carry extra entries, so the contract is superset, not
+    equality.
     """
 
     def test_release_managed_paths_is_superset_of_validator_required_paths(self) -> None:


### PR DESCRIPTION
## What this PR does
Repairs two latent breaks in the release chain left by #689, which made `plugin-codex/bin/wenlan-mcp-runner.sh` derive its `npx wenlan-mcp@^X.Y.Z` fallback from the sibling `plugin.json` at run time instead of carrying a stamped pin.

**1. Release-candidate observer.** `bump-version.sh` no longer changes the runner, so release-please's PR no longer stages it, but `REQUIRED_RELEASE_PATHS` still listed it. The 0.18.1 candidate (#704) failed in observer run 33994894323:

```
release candidate validation failed: CandidateError: release PR paths mismatch: missing=['plugin-codex/bin/wenlan-mcp-runner.sh'] extra=[]
```

- drop the runner from the path lists in `validate-release-candidate.py`, `ci_measure_plan.py` and `verify-release-merge.py` (the Claude runner entry in the last one was equally stale)
- drop the dead `sed` step from `bump-version.sh`
- retarget the mode-change test at `version.txt`; trim the fixtures

**2. Tag-time version validation.** `validate-versions.sh` (run by `release.yml` on the tag) grepped the runner for a pin and failed closed with `Codex plugin release pin missing` when there is none, so v0.18.1 would have died at tagging even with the observer fixed. It now asserts the inverse contract: no hardcoded `wenlan-mcp@^X.Y.Z` in the runner, and a `.codex-plugin/plugin.json` reference present. Fixtures in `validate-versions.test.sh` and `bump-version.test.sh` follow; test 6 now covers both rejections.

## How to test
Unit suites on this branch (macOS):

```
python3 scripts/validate-release-candidate.test.py   -> OK
python3 scripts/ci_measure_plan.test.py              -> Ran 15 tests, OK
python3 scripts/verify-release-merge.test.py         -> OK
bash scripts/bump-version.test.sh                    -> PASS: bump-version.sh syncs all manifests
bash scripts/validate-versions.test.sh               -> PASS test 1 .. test 10, including:
  ERROR: Codex runner carries a hardcoded wenlan-mcp pin (0.5.0); it must derive the pin from plugin.json
  PASS test 6: hardcoded Codex runner pin rejected
  ERROR: Codex runner does not derive its wenlan-mcp pin from .codex-plugin/plugin.json
  PASS test 6b: Codex runner without plugin.json derivation rejected
```

`validate-versions.test.sh` chains `release-workflow-contract.test.py` as test 11, which shows the same 10 pre-existing "desktop links" BSD-sed failures on this branch and on unmodified main (`af646ddc`); nothing else fails, and CI runs it on Ubuntu.

Tag-time check against the real tree at the current version:

```
$ RELEASE_TAG=v0.18.0 bash scripts/validate-versions.sh
...
Codex runner hardcoded pins: none
Codex setup tags:
  0.18.0
All versions consistent: 0.18.0
```

Dry run of the stamping path with `version.txt` set to `0.18.1`:

```
$ bash scripts/bump-version.sh
...
Versions synced from version.txt (0.18.1) to Cargo.toml + npm + plugin manifests + plugin skills + desktop app trio + Cargo.lock.
$ git status --short
 M Cargo.lock  M Cargo.toml  M app/Cargo.toml  M app/tauri.conf.json
 M crates/wenlan-cli/npm/package.json  M crates/wenlan-mcp/npm/package.json
 M package.json  M plugin-codex/.codex-plugin/plugin.json
 M plugin-codex/skills/setup/SKILL.md  M plugin/.claude-plugin/plugin.json
 M plugin/skills/setup/SKILL.md  M version.txt
```

Those 12 files plus `CHANGELOG.md` and `.release-please-manifest.json` are exactly the 14 files in #704 and exactly the new `REQUIRED_RELEASE_PATHS`.

Once this lands, release-please refreshes #704, its CI re-runs, and the observer should produce the receipt.

## Checklist
- [x] Tests pass (script suites above; no Rust changes)
- [x] `cargo clippy` and `cargo fmt` pass (no Rust changes)
- [x] New files use the appropriate SPDX header (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GuU2xyENzLENFPvtmrmiC
