### PR TITLE
fix(release): scope the Cargo.toml release transform to the marker and member pins

### DIFF
--- a/scripts/validate-release-candidate.py
+++ b/scripts/validate-release-candidate.py
@@ -433,6 +433,58 @@ def _reject_qualified_workspace_refs(value: object) -> None:
 
 _APP_CARGO_MARKER_RE = re.compile(r'^version = "([^"]+)"(.*x-release-please-version.*)$')
 
+# The root workspace manifest pins its two publishable members by version so
+# `cargo publish` resolves them against the registry. bump-version.sh rewrites
+# exactly these lines plus the marker line, and nothing else.
+_ROOT_CARGO_MEMBER_PIN_RE = re.compile(
+    r'^((?P<member>wenlan-types|wenlan-core)\s+= \{ path = "crates/(?P=member)",\s+version = ")'
+    r'([^"]+)(".*)$'
+)
+ROOT_CARGO_MEMBER_PINS = frozenset({"wenlan-types", "wenlan-core"})
+
+
+def _expected_root_cargo_transform(old: str, old_version: str, new_version: str) -> str:
+    """Bump the marker line and the two workspace-member pins in Cargo.toml.
+
+    Every other line stays byte-identical. The root manifest carries
+    third-party dependency literals that can land on the workspace version
+    string (`lru = "0.18.2"` collided with the 0.18.2 -> 0.18.3 release and
+    failed the candidate), so the generic whole-file
+    `old.replace(old_version, new_version)` transform is unsafe here -- the
+    same collision class app/Cargo.toml and Cargo.lock already guard against.
+    The marker line and each member pin must appear exactly once and sit at
+    the base version; anything else fails closed.
+    """
+    lines = old.split("\n")
+    marker_rows = [i for i, line in enumerate(lines) if _APP_CARGO_MARKER_RE.match(line)]
+    if len(marker_rows) != 1:
+        raise CandidateError(
+            "Cargo.toml does not pin exactly one x-release-please-version marker line"
+        )
+    row = marker_rows[0]
+    match = _APP_CARGO_MARKER_RE.match(lines[row])
+    assert match is not None
+    if match.group(1) != old_version:
+        raise CandidateError("Cargo.toml marker line is not at the base version")
+    lines[row] = f'version = "{new_version}"{match.group(2)}'
+
+    seen: dict[str, int] = {}
+    for index, line in enumerate(lines):
+        pin = _ROOT_CARGO_MEMBER_PIN_RE.match(line)
+        if pin is None:
+            continue
+        member = pin.group("member")
+        if member in seen:
+            raise CandidateError(f"Cargo.toml pins workspace member {member!r} more than once")
+        if pin.group(3) != old_version:
+            raise CandidateError(f"Cargo.toml pin for {member!r} is not at the base version")
+        seen[member] = index
+        lines[index] = f"{pin.group(1)}{new_version}{pin.group(4)}"
+    missing = sorted(ROOT_CARGO_MEMBER_PINS - seen.keys())
+    if missing:
+        raise CandidateError(f"Cargo.toml is missing workspace member pins: {missing}")
+    return "\n".join(lines)
+
 
 def _expected_app_cargo_transform(old: str, old_version: str, new_version: str) -> str:
     """Bump only the `# x-release-please-version` marker line in app/Cargo.toml,
@@ -510,14 +562,21 @@ def _validate_content_delta(path: str, old: str, new: str, old_version: str, new
     if path == "Cargo.lock":
         if new != _expected_lock_transform(old, old_version, new_version):
             raise CandidateError(
-                "release-managed file 'Cargo.lock' is not the exact"
+                "release-managed file 'Cargo.lock' is not the exact version-only"
                 " workspace-stanza version-only transform"
+            )
+        return
+    if path == "Cargo.toml":
+        if new != _expected_root_cargo_transform(old, old_version, new_version):
+            raise CandidateError(
+                "release-managed file 'Cargo.toml' is not the exact version-only"
+                " marker-and-member-pin transform"
             )
         return
     if path == "app/Cargo.toml":
         if new != _expected_app_cargo_transform(old, old_version, new_version):
             raise CandidateError(
-                "release-managed file 'app/Cargo.toml' is not the exact"
+                "release-managed file 'app/Cargo.toml' is not the exact version-only"
                 " marker-line-only transform"
             )
         return

--- a/scripts/validate-release-candidate.test.py
+++ b/scripts/validate-release-candidate.test.py
@@ -186,6 +186,24 @@ def lock_contents(
     return "\n\n".join(stanzas) + "\n"
 
 
+def root_cargo_contents(version: str, *, decoy_version: str | None = None) -> str:
+    """Root Cargo.toml in the shape bump-version.sh rewrites: the marker line and
+    both workspace-member pins move together; an optional third-party literal
+    (the `lru = "0.18.2"` collision) sits wherever `decoy_version` says."""
+    lines = [
+        "[workspace.package]",
+        f'version = "{version}"   # x-release-please-version',
+        'edition = "2021"',
+        "",
+        "[workspace.dependencies]",
+        f'wenlan-types = {{ path = "crates/wenlan-types", version = "{version}" }}',
+        f'wenlan-core  = {{ path = "crates/wenlan-core",  version = "{version}" }}',
+    ]
+    if decoy_version is not None:
+        lines.append(f'lru = "{decoy_version}"')
+    return "\n".join(lines) + "\n"
+
+
 def release_contents() -> tuple[dict[str, str], dict[str, str]]:
     old_version = "0.15.3"
     new_version = "0.15.4"
@@ -211,8 +229,8 @@ def release_contents() -> tuple[dict[str, str], dict[str, str]]:
     codex = "plugin-codex/.codex-plugin/plugin.json"
     old[codex] = json.dumps({"version": f"{old_version}+codex"})
     new[codex] = json.dumps({"version": f"{new_version}+codex"})
-    old["Cargo.toml"] = f'version = "{old_version}"   # x-release-please-version\n'
-    new["Cargo.toml"] = f'version = "{new_version}"   # x-release-please-version\n'
+    old["Cargo.toml"] = root_cargo_contents(old_version)
+    new["Cargo.toml"] = root_cargo_contents(new_version)
     old["app/Cargo.toml"] = f'version = "{old_version}" # x-release-please-version\n'
     new["app/Cargo.toml"] = f'version = "{new_version}" # x-release-please-version\n'
     for path in ("app/tauri.conf.json", "package.json"):
@@ -1219,6 +1237,55 @@ class ValidateReleaseCandidateTests(unittest.TestCase):
             VALIDATOR.validate_release_pr_content(
                 FakeContentApi(old, hostile_new), "7xuanlu/wenlan", candidate_pr()
             )
+
+    def test_root_cargo_transform_leaves_a_colliding_dependency_literal_alone(self) -> None:
+        # Positive: the 0.18.2 -> 0.18.3 shape. `lru = "0.18.2"` sits at the
+        # base version and must survive untouched while the marker line and
+        # both member pins move.
+        old, new = release_contents()
+        old["Cargo.toml"] = root_cargo_contents("0.15.3", decoy_version="0.15.3")
+        new["Cargo.toml"] = root_cargo_contents("0.15.4", decoy_version="0.15.3")
+        version, _, _ = VALIDATOR.validate_release_pr_content(
+            FakeContentApi(old, new), "7xuanlu/wenlan", candidate_pr()
+        )
+        self.assertEqual(version, "0.15.4")
+
+        # Collision-negative: the decoy moving with the release is exactly what
+        # the whole-file replace would have demanded, and must be rejected.
+        hostile_new = dict(new)
+        hostile_new["Cargo.toml"] = root_cargo_contents("0.15.4", decoy_version="0.15.4")
+        with self.assertRaisesRegex(VALIDATOR.CandidateError, "marker-and-member-pin"):
+            VALIDATOR.validate_release_pr_content(
+                FakeContentApi(old, hostile_new), "7xuanlu/wenlan", candidate_pr()
+            )
+
+        # A member pin left at the base version is a broken `cargo publish`,
+        # not a version-only release; the transform refuses it.
+        stale_pin = dict(new)
+        stale_pin["Cargo.toml"] = root_cargo_contents("0.15.4", decoy_version="0.15.3").replace(
+            'wenlan-core  = { path = "crates/wenlan-core",  version = "0.15.4" }',
+            'wenlan-core  = { path = "crates/wenlan-core",  version = "0.15.3" }',
+        )
+        with self.assertRaisesRegex(VALIDATOR.CandidateError, "marker-and-member-pin"):
+            VALIDATOR.validate_release_pr_content(
+                FakeContentApi(old, stale_pin), "7xuanlu/wenlan", candidate_pr()
+            )
+
+        # The base itself must carry both pins exactly once, or the validator
+        # fails closed instead of guessing which lines bump-version.sh touched.
+        for broken_base in (
+            root_cargo_contents("0.15.3").replace(
+                'wenlan-core  = { path = "crates/wenlan-core",  version = "0.15.3" }\n', ""
+            ),
+            root_cargo_contents("0.15.3")
+            + 'wenlan-core  = { path = "crates/wenlan-core",  version = "0.15.3" }\n',
+        ):
+            broken_old = dict(old)
+            broken_old["Cargo.toml"] = broken_base
+            with self.assertRaisesRegex(VALIDATOR.CandidateError, "Cargo.toml"):
+                VALIDATOR.validate_release_pr_content(
+                    FakeContentApi(broken_old, new), "7xuanlu/wenlan", candidate_pr()
+                )
 
     def test_json_trio_transforms_reject_extra_field_changes(self) -> None:
         # Positive + collision-negative for the shared JSON scoped transform,


### PR DESCRIPTION
## What this PR does
Unblocks Release PR #714 (0.18.2 → 0.18.3). Its release-candidate observer failed with `release-managed file 'Cargo.toml' is not the exact version-only transform` because the root manifest pins `lru = "0.18.2"`: the validator's whole-file `old.replace(old_version, new_version)` demanded a dependency bump that `bump-version.sh` correctly never makes.

The validator now expects for `Cargo.toml` exactly what `bump-version.sh` rewrites: the `x-release-please-version` marker line plus the `wenlan-types` / `wenlan-core` workspace-member pins, each exactly once and at the base version, with every other line byte-identical. A colliding third-party literal survives; any other edit, a stale pin, or a base missing/duplicating a pin still fails closed. Same collision class `app/Cargo.toml` and `Cargo.lock` already guard against.

## How to test
- `python3 scripts/validate-release-candidate.test.py` — 41 tests, all pass locally on this branch (new: `test_root_cargo_transform_leaves_a_colliding_dependency_literal_alone`; the fixture now carries both member pins).
- Proof on real data: `_expected_root_cargo_transform(<main Cargo.toml>, "0.18.2", "0.18.3")` reproduces #714's `Cargo.toml` at `b4f12e0a` byte for byte, and the old whole-file replace of the same input is rejected.
- After merge: release-please refreshes #714; the observer (which runs default-branch code) should then emit the `validated-release-receipt-*` artifact for the new head.

## Checklist
- [x] Tests pass (Python script suite; no Rust change, `cargo test --workspace` not applicable)
- [x] `cargo clippy` and `cargo fmt` pass (no Rust change)
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GuU2xyENzLENFPvtmrmiC