### PR TITLE
feat(entities): archive idle detected entities by default

### DIFF
--- a/crates/wenlan-core/src/tuning.rs
+++ b/crates/wenlan-core/src/tuning.rs
@@ -174,6 +174,9 @@ fn d_15_u64() -> u64 {
 fn d_90_i64() -> i64 {
     90
 }
+fn d_90_u64() -> u64 {
+    90
+}
 fn d_01_f64() -> f64 {
     0.1
 }
@@ -263,10 +266,10 @@ pub struct RefineryConfig {
     /// detected entity once it has been in the index for this many days and
     /// none of its linked memories is dated within the window (an imported
     /// memory keeps its original conversation date, so the entity's own age
-    /// is the floor). `0` (the default) turns the rule off. Only detected
-    /// entities are eligible; established and already-archived ones are never
-    /// touched, and archiving is reversible from the Entities view.
-    #[serde(default)]
+    /// is the floor). Defaults to 90 days; `0` turns the rule off. Only
+    /// detected entities are eligible; established and already-archived ones
+    /// are never touched, and archiving is reversible from the Entities view.
+    #[serde(default = "d_90_u64")]
     pub entity_archive_idle_days: u64,
 }
 
@@ -547,7 +550,7 @@ impl Default for RefineryConfig {
             kg_rethink_interval_hours: d_168_u64(),
             entity_backfill_batch_size: d_5_usize(),
             entity_establish_min_memories: d_3_usize(),
-            entity_archive_idle_days: 0,
+            entity_archive_idle_days: d_90_u64(),
         }
     }
 }
@@ -719,7 +722,7 @@ mod tests {
         assert_eq!(cfg.refinery.batch_window_secs, 30);
         assert_eq!(cfg.refinery.kg_rethink_interval_hours, 168);
         assert_eq!(cfg.refinery.entity_establish_min_memories, 3);
-        assert_eq!(cfg.refinery.entity_archive_idle_days, 0);
+        assert_eq!(cfg.refinery.entity_archive_idle_days, 90);
         // Narrative
         assert_eq!(cfg.narrative.stale_secs, 86400);
         assert_eq!(cfg.narrative.max_memories, 12);
@@ -779,10 +782,11 @@ score_threshold = 0.25
         assert_eq!(cfg.refinery.max_proposals_per_steep, 5);
     }
 
-    /// `entity_archive_idle_days` is off unless the file names it, and a file
-    /// that sets only it leaves the rest of the refinery block alone.
+    /// `entity_archive_idle_days` defaults to 90 unless the file names it, `0`
+    /// in the file is the opt-out, and a file that sets only it leaves the
+    /// rest of the refinery block alone.
     #[test]
-    fn entity_archive_idle_days_reads_from_toml_and_defaults_off() {
+    fn entity_archive_idle_days_reads_from_toml_and_defaults_to_90() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("intelligence.toml");
         std::fs::write(&path, "[refinery]\nentity_archive_idle_days = 30\n").unwrap();
@@ -792,6 +796,11 @@ score_threshold = 0.25
         assert_eq!(cfg.refinery.entity_establish_min_memories, 3);
 
         std::fs::write(&path, "[refinery]\nentity_establish_min_memories = 4\n").unwrap();
+        let cfg = TuningConfig::load(&path);
+        assert_eq!(cfg.refinery.entity_archive_idle_days, 90);
+        assert_eq!(cfg.refinery.entity_establish_min_memories, 4);
+
+        std::fs::write(&path, "[refinery]\nentity_archive_idle_days = 0\n").unwrap();
         let cfg = TuningConfig::load(&path);
         assert_eq!(cfg.refinery.entity_archive_idle_days, 0);
     }

--- a/crates/wenlan-server/src/scheduler/ambient.rs
+++ b/crates/wenlan-server/src/scheduler/ambient.rs
@@ -106,7 +106,8 @@ impl AmbientAvailability {
                 && wenlan_core::db::edge_grounding_promote_enabled(),
             // Deterministic housekeeping: no model involved, so it runs
             // whether or not a provider is pinned. The tuning key itself
-            // (`entity_archive_idle_days`, default 0) is the on/off switch,
+            // (`entity_archive_idle_days`, default 90; `0` opts out) is the
+            // on/off switch,
             // checked inside the job arm.
             entity_idle_archive: true,
         }

--- a/crates/wenlan-server/src/scheduler/scheduler_tests.rs
+++ b/crates/wenlan-server/src/scheduler/scheduler_tests.rs
@@ -2274,9 +2274,10 @@ async fn ambient_status_records_last_run_after_force_ambient_sweep() {
     );
 }
 
-/// #708: with `entity_archive_idle_days = 0` (the default) the idle-archive
-/// job reports an unselected turn without database work, and the attempt is
-/// still recorded so `/api/ambient/status` shows the lane is alive.
+/// #708: with `entity_archive_idle_days = 0` (the opt-out; the default is 90)
+/// the idle-archive job reports an unselected turn without database work, and
+/// the attempt is still recorded so `/api/ambient/status` shows the lane is
+/// alive.
 #[tokio::test]
 async fn entity_idle_archive_tick_with_zero_days_is_not_selected() {
     let _lock = crate::TEST_DATA_DIR_LOCK
@@ -2285,8 +2286,10 @@ async fn entity_idle_archive_tick_with_zero_days_is_not_selected() {
         .await;
     let _env = DataDirGuard::new();
     let (db, _db_dir) = new_test_db().await;
-    let refinery = wenlan_core::tuning::RefineryConfig::default();
-    assert_eq!(refinery.entity_archive_idle_days, 0);
+    let refinery = wenlan_core::tuning::RefineryConfig {
+        entity_archive_idle_days: 0,
+        ..Default::default()
+    };
 
     let report = run_ambient_job_safe(
         AmbientJob::EntityIdleArchive,


### PR DESCRIPTION
## What

`[refinery] entity_archive_idle_days` now defaults to **90** days instead of `0` (off). Setting `0` in `intelligence.toml` remains the opt-out.

Follow-up to #708 / #715: the idle-archive housekeeping rule shipped opt-in; the user decided to turn it on for everyone now, since the detected-entity clutter (empty Wiki pages, crowded Entities tab) is the symptom people actually report and the rule is reversible.

## Behaviour

- Daily ambient job `entity_idle_archive` now runs with a 90-day window by default.
- Only **detected** entities are eligible. Established and already-archived entities are never touched.
- Both clocks must be past the window: newest linked memory AND the entity's own `created_at`, so freshly imported old conversations are not archived on the first night.
- Archive is reversible from Entities → Archived → Restore, and a sticky-archived entity restores itself at the establish threshold (3 memories).

## Changes

- `crates/wenlan-core/src/tuning.rs`: `d_90_u64` serde default, `Default` impl, doc comment; defaults test asserts 90; the toml round-trip test now covers default-90, file-set-30, and explicit `0` opt-out.
- `crates/wenlan-server/src/scheduler/ambient.rs`: comment only.
- `crates/wenlan-server/src/scheduler/scheduler_tests.rs`: the "zero days is not selected" test sets `0` explicitly instead of relying on the default.

## Proof

Pushed via the GitHub contents API from a session whose local git is blocked, so the compile and test gates are CI on this PR (`cargo test` for `wenlan-core` and `wenlan-server`, fmt, clippy). The diff is limited to the default value, its doc comments, and the tests that pinned the old default.

Not in this PR: a Settings switch/picker for the window. That remains config-file only (`intelligence.toml`), tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GuU2xyENzLENFPvtmrmiC