### PR TITLE
fix(distill): let re-distill and force rebuild use a connected local server

### DIFF
--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -117,11 +117,11 @@ pub struct MoveSpaceResponse {
 // material.
 
 /// Resolved route for one job class: which source serves it, the model, and how
-/// it was chosen. `mode`: "pinned" | "pinned_degraded" | "auto". `source`
+/// it was chosen. `mode`: "pinned" | "pinned_unavailable" | "auto". `source`
 /// (everyday): "anthropic"|"external"|"on_device"|"basic"; (synthesis):
 /// "anthropic"|"external"|"on_device"|"none". `pin`: the raw configured source
 /// pin, or `None` when unpinned — distinct from `source` (the RESOLVED
-/// source): on a `pinned_degraded` result the two differ, letting the app say
+/// source): on a `pinned_unavailable` result the two differ, letting the app say
 /// "Pinned to X — using Y". `#[serde(default)]` so a daemon that predates the
 /// field (pre-#357) still deserializes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/wenlan-server/src/routes.rs
+++ b/crates/wenlan-server/src/routes.rs
@@ -549,6 +549,24 @@ pub struct DistillRequest {
     pub sweep: bool,
 }
 
+/// Provider for an explicit, user-triggered page rebuild (re-distill,
+/// force distill, and the "nothing can synthesize" hint). A foreground
+/// call is the user's own consent, so unlike background routing
+/// (`resolve_synthesis`, which needs a pin) it crosses sources in the
+/// legacy foreground order: Anthropic routine slot → external
+/// OpenAI-compatible server (Ollama, LM Studio) → on-device model.
+/// Only a provider that reports `is_available()` counts.
+fn foreground_rebuild_llm<'a>(
+    api_llm: Option<&'a Arc<dyn wenlan_core::llm_provider::LlmProvider>>,
+    external_llm: Option<&'a Arc<dyn wenlan_core::llm_provider::LlmProvider>>,
+    on_device: Option<&'a Arc<dyn wenlan_core::llm_provider::LlmProvider>>,
+) -> Option<&'a Arc<dyn wenlan_core::llm_provider::LlmProvider>> {
+    [api_llm, external_llm, on_device]
+        .into_iter()
+        .flatten()
+        .find(|slot| slot.is_available())
+}
+
 /// POST /api/distill
 /// The write half of this route is gated downstream, but the RESPONSE is a page
 /// reader three times over: stale pages carry title/summary/stale_reason and
@@ -622,7 +640,7 @@ async fn handle_distill_inner(
     // background refinery calls `distill_pages_scoped` directly with the
     // daemon LLM; that path is the one that synthesizes inline. Two
     // triggers, one shared function, no behavior drift inside the function.
-    let (db, prompts, tuning, llm, api_llm) = {
+    let (db, prompts, tuning, llm, api_llm, external_llm) = {
         let s = state.read().await;
         (
             s.db.clone(),
@@ -630,6 +648,7 @@ async fn handle_distill_inner(
             s.tuning.distillation.clone(),
             s.llm.clone(),
             s.api_llm.clone(),
+            s.external_llm.clone(),
         )
     };
     let db = db.ok_or(ServerError::Internal("DB not initialized".into()))?;
@@ -663,7 +682,8 @@ async fn handle_distill_inner(
     if req.force {
         match &target {
             Some(wenlan_core::synthesis::distill::DistillTarget::Page(page_id)) => {
-                let prefer_llm = api_llm.as_ref().or(llm.as_ref());
+                let prefer_llm =
+                    foreground_rebuild_llm(api_llm.as_ref(), external_llm.as_ref(), llm.as_ref());
                 if !prefer_llm
                     .as_ref()
                     .map(|provider| provider.is_available())
@@ -674,7 +694,7 @@ async fn handle_distill_inner(
                         "force": true,
                         "page_id": page_id,
                         "updated": false,
-                        "hint": "force rebuild needs an LLM in the daemon — install an on-device model or set an Anthropic key via `wenlan setup` / `/wenlan:setup`",
+                        "hint": "force rebuild needs an LLM in the daemon — install an on-device model, connect a local server (Ollama, LM Studio), or set an Anthropic key via `wenlan setup` / `/wenlan:setup`",
                     })));
                 }
                 db.clear_user_edited(page_id)
@@ -931,7 +951,8 @@ async fn handle_distill_inner(
             // synthesize" -- on a fresh install with no on-device model or
             // API key configured, telling the user to capture more memories
             // sends them the wrong way.
-            let prefer_llm = api_llm.as_ref().or(llm.as_ref());
+            let prefer_llm =
+                foreground_rebuild_llm(api_llm.as_ref(), external_llm.as_ref(), llm.as_ref());
             let model_available = prefer_llm
                 .as_ref()
                 .map(|provider| provider.is_available())
@@ -939,7 +960,7 @@ async fn handle_distill_inner(
             let hint = if model_available {
                 "No page-sized cluster formed in this scope: nothing grouped into 3 or more related memories that fit one page. Capture more related memories, or check the daemon log for dropped clusters."
             } else {
-                "No synthesis model is configured or reachable: install an on-device model or set an Anthropic key via `wenlan setup` / `/wenlan:setup` before distilling."
+                "No synthesis model is configured or reachable: install an on-device model, connect a local server (Ollama, LM Studio), or set an Anthropic key via `wenlan setup` / `/wenlan:setup` before distilling."
             };
             map.insert("hint".into(), serde_json::json!(hint));
         }
@@ -950,7 +971,7 @@ async fn handle_distill_inner(
 /// POST /api/distill/{page_id}
 ///
 /// Re-distill a single page. Requires the daemon to have an LLM available
-/// (on-device or Anthropic key). When no model/key is configured (local memory
+/// (on-device, external server, or Anthropic key). When no model/key is configured (local memory
 /// mode) the route returns a 200 with a hint payload instead of a 500 —
 /// the caller's intent (refresh this page) can't be honored, but the
 /// failure mode is documented in the response so the skill can surface
@@ -975,12 +996,13 @@ async fn handle_redistill_inner(
     State(state): State<Arc<RwLock<ServerState>>>,
     Path(page_id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ServerError> {
-    let (db, llm, api_llm, prompts) = {
+    let (db, llm, api_llm, external_llm, prompts) = {
         let s = state.read().await;
         (
             s.db.clone(),
             s.llm.clone(),
             s.api_llm.clone(),
+            s.external_llm.clone(),
             s.prompts.clone(),
         )
     };
@@ -991,7 +1013,7 @@ async fn handle_redistill_inner(
         Some(config.knowledge_path_or_default())
     };
 
-    let prefer_llm = api_llm.as_ref().or(llm.as_ref());
+    let prefer_llm = foreground_rebuild_llm(api_llm.as_ref(), external_llm.as_ref(), llm.as_ref());
     if prefer_llm
         .as_ref()
         .map(|provider| provider.is_available())
@@ -1026,7 +1048,7 @@ async fn handle_redistill_inner(
         Ok(Json(serde_json::json!({
             "status": "skipped",
             "updated": false,
-            "hint": "page re-distill needs an LLM in the daemon — install an on-device model or set an Anthropic key via `wenlan setup` / `/wenlan:setup`",
+            "hint": "page re-distill needs an LLM in the daemon — install an on-device model, connect a local server (Ollama, LM Studio), or set an Anthropic key via `wenlan setup` / `/wenlan:setup`",
         })))
     }
 }
@@ -1186,7 +1208,10 @@ pub async fn handle_test_llm(
         user_prompt: req
             .prompt
             .unwrap_or_else(|| "Say 'hello' and nothing else.".into()),
-        max_tokens: 10,
+        // Thinking models (e.g. qwen3 on LM Studio) spend a tiny budget
+        // inside <think>, leaving the card empty; 256 buys room for the
+        // reasoning plus the visible reply below.
+        max_tokens: 256,
         temperature: 0.0,
         label: None,
         timeout_secs: None,
@@ -1201,6 +1226,15 @@ pub async fn handle_test_llm(
         }
         other => ServerError::Internal(format!("test_llm: {other}")),
     })?;
+    // Show the answer, not the reasoning: strip <think> blocks so the card
+    // never renders a model's private planning as its reply.
+    let text = wenlan_core::llm_provider::strip_think_tags(&response);
+    let text = text.trim().to_string();
+    let response = if text.is_empty() && !response.trim().is_empty() {
+        "(connected; the model used its whole reply on reasoning)".to_string()
+    } else {
+        text
+    };
     Ok(Json(wenlan_types::requests::TestLlmResponse { response }))
 }
 
@@ -1762,8 +1796,37 @@ mod distill_sweep_route_tests {
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use tower::ServiceExt;
+    use wenlan_core::llm_provider::{LlmBackend, LlmError, LlmProvider, LlmRequest};
 
     use crate::state::ServerState;
+
+    /// Stands in for an external OpenAI-compatible server (Ollama, LM Studio).
+    /// `generate` is never reached on the no-cluster path; availability is
+    /// what the hint branch reads.
+    struct RebuildMockProvider;
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RebuildMockProvider {
+        async fn generate(&self, _request: LlmRequest) -> Result<String, LlmError> {
+            Ok("rebuilt body".into())
+        }
+
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        fn name(&self) -> &str {
+            "rebuild-mock"
+        }
+
+        fn backend(&self) -> LlmBackend {
+            LlmBackend::Api
+        }
+
+        fn kind(&self) -> &'static str {
+            "mock"
+        }
+    }
 
     async fn seeded_sweep_app() -> (
         crate::router::AppRouter,
@@ -1921,6 +1984,54 @@ mod distill_sweep_route_tests {
     }
 
     #[tokio::test]
+    async fn distill_with_only_external_llm_and_no_clusters_hints_at_more_memories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let emitter: Arc<dyn wenlan_core::events::EventEmitter> =
+            Arc::new(wenlan_core::events::NoopEmitter);
+        let db = Arc::new(
+            wenlan_core::db::MemoryDB::new(tmp.path(), emitter)
+                .await
+                .expect("MemoryDB::new"),
+        );
+        // Fresh DB with no memories, but an external server (Ollama / LM
+        // Studio) IS configured — the hint must diagnose "nothing grouped",
+        // not "no model configured".
+        let mock: Arc<dyn LlmProvider> = Arc::new(RebuildMockProvider);
+        let state = Arc::new(RwLock::new(ServerState {
+            db: Some(db),
+            external_llm: Some(mock),
+            ..Default::default()
+        }));
+        let app = crate::router::build_router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/distill")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        let hint = payload["hint"].as_str().expect("hint present");
+        assert!(
+            hint.contains("Capture more related memories"),
+            "with an external model reachable, the hint should point at more memories: {hint}"
+        );
+        assert!(
+            !hint.contains("wenlan setup"),
+            "with an external model reachable, the hint must not point at setup: {hint}"
+        );
+    }
+
+    #[tokio::test]
     async fn distill_sweep_with_target_or_force_returns_hint_payload() {
         let (app, _db, _tmp) = seeded_sweep_app().await;
 
@@ -1962,12 +2073,44 @@ mod redistill_contract_tests {
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use tower::ServiceExt;
+    use wenlan_core::llm_provider::{LlmBackend, LlmError, LlmProvider, LlmRequest};
     use wenlan_types::requests::CreateConceptRequest;
 
     use crate::state::ServerState;
 
+    /// Mock foreground-rebuild provider: stands in for an external
+    /// OpenAI-compatible server (Ollama, LM Studio), so `backend()` reports
+    /// `Api` exactly like the real external slot does.
+    struct RebuildMockProvider {
+        available: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmProvider for RebuildMockProvider {
+        async fn generate(&self, _request: LlmRequest) -> Result<String, LlmError> {
+            Ok("rebuilt body".into())
+        }
+
+        fn is_available(&self) -> bool {
+            self.available
+        }
+
+        fn name(&self) -> &str {
+            "rebuild-mock"
+        }
+
+        fn backend(&self) -> LlmBackend {
+            LlmBackend::Api
+        }
+
+        fn kind(&self) -> &'static str {
+            "mock"
+        }
+    }
+
     async fn seeded_user_edited_page() -> (
         crate::router::AppRouter,
+        Arc<RwLock<ServerState>>,
         Arc<wenlan_core::db::MemoryDB>,
         String,
         tempfile::TempDir,
@@ -2012,12 +2155,13 @@ mod redistill_contract_tests {
             db: Some(db.clone()),
             ..Default::default()
         }));
-        (crate::router::build_router(state), db, page_id, tmp)
+        let app = crate::router::build_router(state.clone());
+        (app, state, db, page_id, tmp)
     }
 
     #[tokio::test]
     async fn page_redistill_without_llm_does_not_clear_user_edited() {
-        let (app, db, page_id, _tmp) = seeded_user_edited_page().await;
+        let (app, _state, db, page_id, _tmp) = seeded_user_edited_page().await;
 
         let response = app
             .oneshot(
@@ -2035,6 +2179,12 @@ mod redistill_contract_tests {
             .unwrap();
         let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(payload["status"], "skipped");
+        assert!(
+            payload["hint"]
+                .as_str()
+                .is_some_and(|hint| hint.contains("Ollama")),
+            "skip hint must name the local-server option, not just keys/models: {payload}"
+        );
 
         let page = db
             .get_page(&page_id)
@@ -2054,7 +2204,7 @@ mod redistill_contract_tests {
 
     #[tokio::test]
     async fn force_target_redistill_without_llm_does_not_clear_user_edited() {
-        let (app, db, page_id, _tmp) = seeded_user_edited_page().await;
+        let (app, _state, db, page_id, _tmp) = seeded_user_edited_page().await;
 
         let response = app
             .oneshot(
@@ -2076,6 +2226,12 @@ mod redistill_contract_tests {
         let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(payload["status"], "skipped");
         assert_eq!(payload["force"], true);
+        assert!(
+            payload["hint"]
+                .as_str()
+                .is_some_and(|hint| hint.contains("Ollama")),
+            "skip hint must name the local-server option, not just keys/models: {payload}"
+        );
 
         let page = db
             .get_page(&page_id)
@@ -2090,6 +2246,142 @@ mod redistill_contract_tests {
             page.stale_reason.as_deref(),
             Some("manual_force"),
             "skipped no-LLM force re-distill must not mark a manual force rewrite"
+        );
+    }
+
+    #[tokio::test]
+    async fn page_redistill_with_only_external_llm_runs_the_rebuild() {
+        let (app, state, db, page_id, _tmp) = seeded_user_edited_page().await;
+        // Only the external slot (Ollama / LM Studio) is populated; the
+        // on-device (`llm`) and Anthropic routine (`api_llm`) slots stay None.
+        let mock: Arc<dyn LlmProvider> = Arc::new(RebuildMockProvider { available: true });
+        {
+            let mut guard = state.write().await;
+            guard.external_llm = Some(mock);
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/distill/{page_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            payload["status"], "ok",
+            "external-only server must run the rebuild, not skip: {payload}"
+        );
+        assert!(
+            payload.get("hint").is_none(),
+            "a completed rebuild carries no skip hint: {payload}"
+        );
+
+        let page = db
+            .get_page(&page_id)
+            .await
+            .expect("get page")
+            .expect("page exists");
+        assert!(
+            !page.user_edited,
+            "completed external rebuild must clear user_edited"
+        );
+        // NOTE: `updated` may be false with a `reason` (the citation gate can
+        // discard the mock body), so this test asserts only on `status` and
+        // the `user_edited` flip.
+    }
+
+    #[tokio::test]
+    async fn force_target_redistill_with_only_external_llm_runs_the_rebuild() {
+        let (app, state, db, page_id, _tmp) = seeded_user_edited_page().await;
+        let mock: Arc<dyn LlmProvider> = Arc::new(RebuildMockProvider { available: true });
+        {
+            let mut guard = state.write().await;
+            guard.external_llm = Some(mock);
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/distill")
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"target":"{page_id}","force":true}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(
+            payload["status"], "ok",
+            "external-only server must run the force rebuild, not skip: {payload}"
+        );
+        assert_eq!(payload["force"], true);
+
+        let page = db
+            .get_page(&page_id)
+            .await
+            .expect("get page")
+            .expect("page exists");
+        assert!(
+            !page.user_edited,
+            "completed external force rebuild must clear user_edited"
+        );
+        // NOTE: `updated` may be false with a `reason` (the citation gate can
+        // discard the mock body), so this test asserts only on `status`,
+        // `force`, and the `user_edited` flip.
+    }
+
+    #[tokio::test]
+    async fn page_redistill_with_unavailable_external_llm_stays_skipped() {
+        let (app, state, db, page_id, _tmp) = seeded_user_edited_page().await;
+        // An external server that reports `is_available() == false` must not
+        // count as a rebuild provider.
+        let mock: Arc<dyn LlmProvider> = Arc::new(RebuildMockProvider { available: false });
+        {
+            let mut guard = state.write().await;
+            guard.external_llm = Some(mock);
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/distill/{page_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["status"], "skipped");
+        assert_eq!(payload["updated"], false);
+
+        let page = db
+            .get_page(&page_id)
+            .await
+            .expect("get page")
+            .expect("page exists");
+        assert!(
+            page.user_edited,
+            "skipped unavailable-external re-distill must not unlock user-edited prose"
         );
     }
 }
@@ -2408,6 +2700,35 @@ mod test_llm_bearer_tests {
 
     /// Mock server that refuses every request the way LM Studio does with
     /// "Require Authentication" on and no bearer token supplied.
+    /// Mock OpenAI-compatible server returning a fixed `content` and
+    /// recording every request body it receives.
+    async fn spawn_content_mock(
+        content: &str,
+    ) -> (std::net::SocketAddr, Arc<Mutex<Vec<serde_json::Value>>>) {
+        let bodies: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+        let cap = bodies.clone();
+        let content = content.to_string();
+        let app = axum::Router::new().route(
+            "/chat/completions",
+            axum::routing::post(move |body: axum::body::Bytes| {
+                let cap = cap.clone();
+                let content = content.clone();
+                async move {
+                    if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&body) {
+                        cap.lock().unwrap().push(json);
+                    }
+                    axum::Json(serde_json::json!({
+                        "choices": [{"message": {"content": content}}]
+                    }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        (addr, bodies)
+    }
+
     async fn spawn_unauthorized_mock() -> std::net::SocketAddr {
         let app = axum::Router::new().route(
             "/chat/completions",
@@ -2518,6 +2839,50 @@ mod test_llm_bearer_tests {
             captured.lock().unwrap().as_slice(),
             &[Some("Bearer sk-x".to_string())],
             "trailing whitespace/newline in a pasted key must not reach the wire"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_llm_strips_think_tags_from_probe_response() {
+        let content = r#"<think>
+planning
+</think>
+
+Hello."#;
+        let (addr, _bodies) = spawn_content_mock(content).await;
+        let (status, body) = probe_response(addr, serde_json::json!({})).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(json["response"], "Hello.", "{body}");
+    }
+
+    #[tokio::test]
+    async fn test_llm_reasoning_only_probe_reports_connected() {
+        // Truncated thinking-model reply: no close tag, so stripping leaves
+        // nothing. The connection works, so the card must say so instead of
+        // showing an empty answer.
+        let content = r#"<think>
+still thinking"#;
+        let (addr, _bodies) = spawn_content_mock(content).await;
+        let (status, body) = probe_response(addr, serde_json::json!({})).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            json["response"], "(connected; the model used its whole reply on reasoning)",
+            "{body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_llm_probe_requests_enough_tokens_for_thinking_models() {
+        let (addr, bodies) = spawn_content_mock("hello").await;
+        let (status, body) = probe_response(addr, serde_json::json!({})).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let bodies = bodies.lock().unwrap();
+        assert_eq!(bodies.len(), 1, "probe must send exactly one request");
+        assert_eq!(
+            bodies[0]["max_tokens"], 256,
+            "a 10-token cap strands thinking models inside <think>"
         );
     }
 }

--- a/preview/fixtures.ts
+++ b/preview/fixtures.ts
@@ -878,7 +878,7 @@ export const GRAPH_MEMORIES: MemoryItem[] = [
   {
     source_id: "gm-5",
     title: "Anthropic model routing prefers pinned sources over auto fallback",
-    content: "A pinned_degraded result means the pin isn't configured yet and the chain fell back.",
+    content: "A pinned_unavailable result means the pin isn't configured yet and the chain fell back.",
     summary: null,
     memory_type: "fact",
     domain: "engineering",

--- a/preview/mocks/core.ts
+++ b/preview/mocks/core.ts
@@ -48,6 +48,7 @@ export async function invoke(
     case "record_page_editor_diagnostic":
       return null;
     case "get_page":
+    case "get_page_explicit_browse":
       return PAGES[args?.id as string] ?? null;
     case "get_page_sources": {
       const pageId = args?.pageId as string;
@@ -279,7 +280,7 @@ export async function invoke(
     case "get_resolved_routing":
       return {
         everyday: { source: "on_device", model: "qwen3-4b", mode: "pinned", pin: "on_device" },
-        synthesis: { source: "external", model: "gpt-5.2", mode: "pinned_degraded", pin: "anthropic" },
+        synthesis: { source: "external", model: "gpt-5.2", mode: "pinned_unavailable", pin: "anthropic" },
         pool: {
           anthropic: { configured: false, everyday_model: null, synthesis_model: null },
           external: { endpoint: "https://api.openai.com/v1", model: "gpt-5.2" },

--- a/src/components/ChatImport/ImportFlow.tsx
+++ b/src/components/ChatImport/ImportFlow.tsx
@@ -111,7 +111,7 @@ export function ImportFlow({ onBusyChange, onImportAccepted }: ImportFlowProps =
     try {
       await operation();
     } catch (e: unknown) {
-      setLocalAction({ kind: "error", message: String(e) });
+      setLocalAction({ kind: "error", message: e instanceof Error ? e.message : String(e) });
     } finally {
       busyRef.current = false;
       setBusy(false);

--- a/src/components/ChatImport/__tests__/ImportFlow.test.tsx
+++ b/src/components/ChatImport/__tests__/ImportFlow.test.tsx
@@ -202,6 +202,23 @@ describe("ImportFlow", () => {
     expect(chooseFile).toBeEnabled();
   });
 
+  it("renders a rejected importChatExport message without the Error: prefix", async () => {
+    const mockOpen = open as ReturnType<typeof vi.fn>;
+    mockOpen.mockResolvedValue("/tmp/export.zip");
+    mockImportChatExport.mockRejectedValue(new Error("boom"));
+
+    const { getByRole, queryByText } = render(<ImportFlow />);
+    const chooseFile = getByRole("button", { name: /choose file/i });
+    await act(async () => {
+      chooseFile.click();
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    expect(getByRole("button", { name: /choose file/i })).toBeEnabled();
+    expect(queryByText("Error: boom")).toBeNull();
+    expect(queryByText("boom")).toBeInTheDocument();
+  });
+
   it("surfaces File.arrayBuffer failures so the user can retry", async () => {
     const file = new File(["zip bytes"], "export.zip", { type: "application/zip" });
     Object.defineProperty(file, "arrayBuffer", {

--- a/src/components/intelligence/AnyProviderCard.test.tsx
+++ b/src/components/intelligence/AnyProviderCard.test.tsx
@@ -148,6 +148,7 @@ describe("AnyProviderCard — the Local-server card (spec §5.2)", () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["external-llm"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["external-llm-key-configured"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["resolvedRouting"] });
   });
 
   it("shows the Anthropic precedence warning when an Anthropic key is configured", async () => {

--- a/src/components/intelligence/AnyProviderCard.tsx
+++ b/src/components/intelligence/AnyProviderCard.tsx
@@ -317,6 +317,7 @@ export default function AnyProviderCard({
       // own prefill query — otherwise the rows keep showing stale state.
       queryClient.invalidateQueries({ queryKey: ["external-llm"] });
       queryClient.invalidateQueries({ queryKey: ["external-llm-key-configured"] });
+      queryClient.invalidateQueries({ queryKey: ["resolvedRouting"] });
     } catch (err) {
       setSaveState(`error:${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/components/intelligence/IntelligenceSetup.test.tsx
+++ b/src/components/intelligence/IntelligenceSetup.test.tsx
@@ -59,6 +59,7 @@ describe("AnthropicFields", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["apiKey"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["external-llm"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["external-llm-key-configured"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["resolvedRouting"] });
   });
 
   it("invalidates the same keys after clearing a configured key", async () => {
@@ -73,6 +74,7 @@ describe("AnthropicFields", () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["apiKey"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["external-llm"] });
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["external-llm-key-configured"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["resolvedRouting"] });
   });
 
   it("offers a Get-a-key link to the Anthropic console when no key is set", async () => {

--- a/src/components/intelligence/IntelligenceSetup.tsx
+++ b/src/components/intelligence/IntelligenceSetup.tsx
@@ -71,6 +71,7 @@ export function AnthropicFields({
     queryClient.invalidateQueries({ queryKey: ["apiKey"] });
     queryClient.invalidateQueries({ queryKey: ["external-llm"] });
     queryClient.invalidateQueries({ queryKey: ["external-llm-key-configured"] });
+    queryClient.invalidateQueries({ queryKey: ["resolvedRouting"] });
   };
 
   const handleSave = async () => {

--- a/src/components/memory/PageDetail.test.tsx
+++ b/src/components/memory/PageDetail.test.tsx
@@ -553,6 +553,9 @@ describe("PageDetail", () => {
     await user.click(screen.getByTitle("Re-distill page"));
     await waitFor(() => expect(redistillPage).toHaveBeenCalledWith("concept_abc"));
 
+    // While the re-distill promise is still unresolved the button is busy.
+    expect(screen.getByRole("button", { name: "Re-distilling page" })).toHaveAttribute("aria-busy", "true");
+
     rerender(
       <QueryClientProvider client={queryClient}>
         <PageDetail {...defaultProps} pageId="concept_next" />

--- a/src/components/memory/PageDetail.tsx
+++ b/src/components/memory/PageDetail.tsx
@@ -640,14 +640,16 @@ export default function PageDetail({
       }
       setRedistillNotice({
         kind: "success",
-        message: result.updated ? "Page re-distilled." : "Page already up to date.",
+        message: result.updated ? t("pageDetail.redistilled") : t("pageDetail.redistillUpToDate"),
       });
     },
     onError: (error, id) => {
       if (activePageIdRef.current !== id) return;
       setRedistillNotice({
         kind: "error",
-        message: error instanceof Error ? error.message : "Page re-distill failed.",
+        message: t("pageDetail.redistillFailed", {
+          message: error instanceof Error ? error.message : String(error),
+        }),
       });
     },
   });
@@ -1495,6 +1497,7 @@ export default function PageDetail({
                 <button
                   onClick={handleRedistillClick}
                   disabled={redistillMutation.isPending}
+                  aria-busy={redistillMutation.isPending}
                   className="mem-icon-action"
                   aria-label={
                     redistillMutation.isPending
@@ -1516,6 +1519,7 @@ export default function PageDetail({
                     fill="none"
                     stroke="currentColor"
                     strokeWidth="2"
+                    className={redistillMutation.isPending ? "animate-spin motion-reduce:animate-none" : undefined}
                   >
                     <path d="M21 12a9 9 0 11-2.64-6.36" />
                     <path d="M21 3v6h-6" />

--- a/src/components/memory/settings/sections/IntelligenceSection.test.tsx
+++ b/src/components/memory/settings/sections/IntelligenceSection.test.tsx
@@ -244,11 +244,11 @@ describe("IntelligenceSection", () => {
     expect(mocks.setSourcePin).toHaveBeenCalledWith("external", null);
   });
 
-  // ── Headline (c): PINNED_DEGRADED — the pinned source is unavailable, so the
+  // ── Headline (c): PINNED_UNAVAILABLE — the pinned source is unavailable, so the
   // amber hint names it: "Pinned to X — using Y for now". Mutation proof:
   // removing the `isPinned && degraded` branch drops the hint and fails this
   // assertion.
-  it("pinned_degraded mode: renders the amber hint naming the pinned source", async () => {
+  it("pinned_unavailable mode: renders the amber hint naming the pinned source", async () => {
     mocks.getResolvedRouting.mockResolvedValue(
       pinnedRouting({
         everyday: { source: "on_device", model: "qwen3-4b-instruct-2507", mode: "pinned" },
@@ -256,7 +256,7 @@ describe("IntelligenceSection", () => {
         // route fell back to the connected external provider (OpenAI). The
         // component trusts the wire values as-is — see the next test for the
         // no-pin (pre-#357 daemon) fallback case.
-        synthesis: { source: "external", model: "gpt-5.2", mode: "pinned_degraded", pin: "anthropic" },
+        synthesis: { source: "external", model: "gpt-5.2", mode: "pinned_unavailable", pin: "anthropic" },
       })
     );
     renderSection();
@@ -267,16 +267,16 @@ describe("IntelligenceSection", () => {
     expect(await screen.findByText("Pinned to Anthropic — currently unavailable, using OpenAI for now.")).toBeInTheDocument();
   });
 
-  // ── Headline (d): PINNED_DEGRADED with no pin on the wire (a daemon that
+  // ── Headline (d): PINNED_UNAVAILABLE with no pin on the wire (a daemon that
   // predates #357's pin field) — falls back to the generic, unnamed hint
   // rather than rendering "Pinned to null". Mutation proof: forcing
   // `pinnedDisplay` to always resolve from `pin` (dropping the `pin ?` guard)
   // renders the named hint here and fails the generic-hint assertion.
-  it("pinned_degraded mode with no pin on the wire: falls back to the generic hint", async () => {
+  it("pinned_unavailable mode with no pin on the wire: falls back to the generic hint", async () => {
     mocks.getResolvedRouting.mockResolvedValue(
       pinnedRouting({
         everyday: { source: "on_device", model: "qwen3-4b-instruct-2507", mode: "pinned" },
-        synthesis: { source: "external", model: "gpt-5.2", mode: "pinned_degraded", pin: null },
+        synthesis: { source: "external", model: "gpt-5.2", mode: "pinned_unavailable", pin: null },
       })
     );
     renderSection();

--- a/src/components/memory/settings/sections/IntelligenceSection.tsx
+++ b/src/components/memory/settings/sections/IntelligenceSection.tsx
@@ -502,7 +502,7 @@ export default function IntelligenceSection({ delay }: { delay: number }) {
       sourceDisplay: sourceLabel(source),
       meta: routeMeta(job, source, model),
       connected: source !== "basic" && source !== "none",
-      degraded: mode === "pinned_degraded",
+      degraded: mode === "pinned_unavailable",
       pinnedDisplay: pin ? sourceLabel(pin) : null,
       sourceOptions: buildOptions(job),
       external: routedExternal,

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -529,6 +529,9 @@ const en = {
     redistillingPage: "Re-distilling page",
     redistillPage: "Re-distill page",
     redistillBlocked: "Page not updated: {{reason}}",
+    redistilled: "Page re-distilled.",
+    redistillUpToDate: "Page already up to date.",
+    redistillFailed: "Page re-distill failed: {{message}}",
   },
   pageCanvas: {
     newSectionPlaceholder: "Name this section",
@@ -2356,6 +2359,9 @@ const zhHans = {
     redistillingPage: "正在重新精炼页面",
     redistillPage: "重新精炼页面",
     redistillBlocked: "页面未更新：{{reason}}",
+    redistilled: "页面已重新提炼。",
+    redistillUpToDate: "页面已是最新。",
+    redistillFailed: "页面重新提炼失败：{{message}}",
   },
   pageCanvas: {
     newSectionPlaceholder: "为这个章节命名",
@@ -4158,6 +4164,9 @@ const zhHant = {
     redistillingPage: "正在重新精煉頁面",
     redistillPage: "重新精煉頁面",
     redistillBlocked: "頁面未更新：{{reason}}",
+    redistilled: "頁面已重新提煉。",
+    redistillUpToDate: "頁面已是最新。",
+    redistillFailed: "頁面重新提煉失敗：{{message}}",
   },
   pageCanvas: {
     newSectionPlaceholder: "為這個章節命名",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -389,11 +389,11 @@ export async function setModelChoice(
 // predates the endpoint (the live 0.13.2 daemon) — callers render LEGACY mode.
 // Never contains key material.
 
-/** How one job resolves. `mode`: "pinned" | "pinned_degraded" | "auto".
+/** How one job resolves. `mode`: "pinned" | "pinned_unavailable" | "auto".
  *  `source` (everyday): "anthropic"|"external"|"on_device"|"basic";
  *  (synthesis): "anthropic"|"external"|"on_device"|"none". `pin`: the raw
  *  configured source pin, or `null` when unpinned — distinct from `source`
- *  (the RESOLVED source): on a `pinned_degraded` result the two differ,
+ *  (the RESOLVED source): on a `pinned_unavailable` result the two differ,
  *  letting the app say "Pinned to X — using Y". */
 export interface JobRoute {
   source: string;


### PR DESCRIPTION
## What this PR does

Closes #727. The foreground distill routes (page Re-distill, force rebuild, and the "nothing can synthesize" hint) picked only the Anthropic or on-device slot, so a daemon with only LM Studio or Ollama connected answered "needs an LLM in the daemon". A shared `foreground_rebuild_llm` helper now takes the first present and available slot in the legacy foreground order (Anthropic, external, on-device). The three hints name local servers as an option. Background routing (`resolve_synthesis`) is untouched.

Also in this PR, from the first-use UX sweep the issue asked for:

- Provider Test probe asks for 256 tokens and strips `<think>` blocks, so thinking models (qwen3 on LM Studio) no longer show an empty "Response:".
- Intelligence settings matched `pinned_degraded` while the daemon emits `pinned_unavailable`, so the amber "Pinned to X, using Y for now" hint never rendered. Fixed, with the doc comments in `src/lib/tauri.ts` and `app/src/api.rs`.
- Saving a local server or an Anthropic key now invalidates the resolved-routing query, so the job rows refresh without a remount.
- Re-distill success and failure notices are localized (en, zh-CN, zh-TW); the button shows `aria-busy` and a spinner while pending.
- Chat import errors render the message without the `Error:` prefix.
- Preview harness: mocks `get_page_explicit_browse` so page mode renders again, and its routing fixture uses the real mode string.

Not changed on purpose: the setup wizard still pins on-device when a model is merely selected. That is the user's stated intent, and with the mode-string fix the daemon's unavailable state now surfaces honestly while the model loads.

## How to test

Connect LM Studio or Ollama with no Anthropic key and no on-device model, open a wiki page, click Re-distill: the page rebuilds instead of returning the hint. In Settings > Intelligence, pin a job to a source that is not configured: the amber hint appears under the job row.

Verified at 702dffc3:

```
WENLAN_NO_AUTOSTART=1 cargo test -p wenlan-server --lib -- test_llm redistill distill_with
test result: ok. 16 passed; 0 failed
cargo fmt -p wenlan-server -- --check   (clean)
cargo clippy -p wenlan-server --tests   (no new warnings)
pnpm exec tsc -b                        (exit 0)
pnpm exec vitest run <touched suites>   Test Files 12 passed, Tests 238 passed
pnpm test:i18n                          Tests 55 passed
```

Mutation check: reverting the mode string to `pinned_degraded` fails two IntelligenceSection tests. Rendered check in headless Chromium against the preview harness: the amber hint renders under the Synthesis row, and "Page re-distilled." renders after clicking Re-distill (screenshots kept locally, not attached).

Independent review: Muse Spark read-only session, verdict approve, no blockers. Its one should-fix (the reasoning-only probe string is English inside the daemon) is accepted as-is because every daemon hint is English and the card renders responses verbatim.

## Checklist
- [x] Tests pass (targeted suites above; CI runs the closure)
- [x] `cargo clippy` and `cargo fmt` pass
- [x] New files use the appropriate SPDX header for their package, even if nearby legacy files have not been normalized yet (no new files)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3mnLzAyZVszRSzJF6wwrz