### PR TITLE
feat(quick-capture): center the window over the app and dim it when opened from the toolbar

### DIFF
--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -30,6 +30,7 @@ pub mod plugin_install;
 // outside tests. See the module doc comment.
 #[allow(dead_code)]
 mod presence;
+mod quick_capture;
 pub mod remote_access;
 mod search;
 pub mod sources;
@@ -767,6 +768,9 @@ pub fn run() {
         .manage(Arc::new(tokio::sync::Mutex::new(
             None::<indexer::FileWatcher>,
         )))
+        .manage(quick_capture::QuickCapturePlacementState(
+            std::sync::Mutex::new(Default::default()),
+        ))
         .setup(|app| {
             let handle = app.handle().clone();
 
@@ -1129,45 +1133,26 @@ pub fn run() {
                                         if let Some(window) =
                                             handle_for_shortcuts.get_webview_window("quick-capture")
                                         {
-                                            #[cfg(target_os = "macos")]
-                                            #[allow(deprecated)]
-                                            {
-                                                use cocoa::base::id;
-                                                use raw_window_handle::HasWindowHandle;
-                                                if let Ok(raw_handle) = window.window_handle() {
-                                                    if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
-                                                        let ns_view = appkit.ns_view.as_ptr() as id;
-                                                        unsafe {
-                                                            let ns_win: id = objc::msg_send![ns_view, window];
-                                                            let visible: bool = objc::msg_send![ns_win, isVisible];
-                                                            if visible {
-                                                                // orderOut removes the window without
-                                                                // triggering macOS window promotion
-                                                                let _: () = objc::msg_send![ns_win, orderOut: ns_win];
-                                                            } else {
-                                                                // makeKeyAndOrderFront shows + focuses
-                                                                // without activating the app (main stays put)
-                                                                let _: () = objc::msg_send![ns_win, setLevel: 3_i64]; // NSFloatingWindowLevel
-                                                                let _: () = objc::msg_send![ns_win, makeKeyAndOrderFront: ns_win];
-                                                                tauri::async_runtime::spawn({
-                                                                    let h = handle_for_shortcuts.clone();
-                                                                    async move {
-                                                                        let _ = crate::search::position_quick_capture(h).await;
-                                                                    }
-                                                                });
-                                                            }
-                                                        }
+                                            if window.is_visible().unwrap_or(false) {
+                                                // Safe on the main thread: `run_on_main_thread`
+                                                // executes synchronously when already there
+                                                // (see `schedule_main_window_traffic_lights_alignment`).
+                                                let _ = crate::quick_capture::hide_quietly(&window);
+                                                crate::quick_capture::notify_closed(
+                                                    &handle_for_shortcuts,
+                                                );
+                                            } else {
+                                                crate::quick_capture::set_placement(
+                                                    &handle_for_shortcuts,
+                                                    crate::quick_capture::QuickCapturePlacement::BottomRight,
+                                                );
+                                                crate::quick_capture::show_floating(&window);
+                                                tauri::async_runtime::spawn({
+                                                    let h = handle_for_shortcuts.clone();
+                                                    async move {
+                                                        let _ = crate::search::position_quick_capture(h).await;
                                                     }
-                                                }
-                                            }
-                                            #[cfg(not(target_os = "macos"))]
-                                            {
-                                                if window.is_visible().unwrap_or(false) {
-                                                    let _ = window.hide();
-                                                } else {
-                                                    let _ = window.show();
-                                                    let _ = window.set_focus();
-                                                }
+                                                });
                                             }
                                         }
                                     }
@@ -1559,6 +1544,7 @@ pub fn run() {
             search::suggest_tags,
             search::dismiss_quick_capture,
             search::position_quick_capture,
+            quick_capture::open_quick_capture,
             search::get_session_snapshots,
             search::get_snapshot_captures,
             search::get_snapshot_captures_with_content,

--- a/app/src/quick_capture.rs
+++ b/app/src/quick_capture.rs
@@ -241,7 +241,14 @@ pub async fn open_quick_capture(
         set_placement(&app, QuickCapturePlacement::BottomRight);
         return Err(e);
     }
-    show_floating(&window);
+    // This command runs on a tokio thread; AppKit traps when a window's level
+    // or ordering changes off the main thread, so hop over before showing.
+    let to_show = window.clone();
+    window
+        .run_on_main_thread(move || {
+            show_floating(&to_show);
+        })
+        .map_err(|e| e.to_string())?;
     app.emit_to("main", QC_OPENED_EVENT, placement)
         .map_err(|e| e.to_string())
 }

--- a/app/src/quick_capture.rs
+++ b/app/src/quick_capture.rs
@@ -2,7 +2,7 @@
 //! Placement and show/hide plumbing for the quick-capture window.
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
-use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
 
 pub const QC_WIDTH: f64 = 400.0;
 pub const QC_HEIGHT: f64 = 160.0;
@@ -52,21 +52,32 @@ pub fn apply_placement(app: &AppHandle) -> Result<(), String> {
             if !main_visible || main_minimized {
                 return position_bottom_right(&win);
             }
+            // Physical pixels end to end: `outer_position`/`outer_size` are
+            // physical, and `set_position(LogicalPosition)` would reconvert
+            // with the capture window's scale, which differs on mixed-scale
+            // monitors.
+            let pos = main.outer_position().map_err(|e| e.to_string())?;
+            let size = main.outer_size().map_err(|e| e.to_string())?;
             let scale = main.scale_factor().map_err(|e| e.to_string())?;
-            let pos = main
-                .outer_position()
-                .map_err(|e| e.to_string())?
-                .to_logical::<f64>(scale);
-            let size = main
-                .outer_size()
-                .map_err(|e| e.to_string())?
-                .to_logical::<f64>(scale);
-            let (x, y) =
-                centered_origin(pos.x, pos.y, size.width, size.height, QC_WIDTH, QC_HEIGHT);
-            win.set_size(LogicalSize::new(QC_WIDTH, QC_HEIGHT))
-                .map_err(|e| e.to_string())?;
-            win.set_position(LogicalPosition::new(x, y))
-                .map_err(|e| e.to_string())?;
+            let (qw, qh) = (QC_WIDTH * scale, QC_HEIGHT * scale);
+            let (x, y) = centered_origin(
+                pos.x as f64,
+                pos.y as f64,
+                size.width as f64,
+                size.height as f64,
+                qw,
+                qh,
+            );
+            win.set_size(tauri::PhysicalSize::new(
+                qw.round() as u32,
+                qh.round() as u32,
+            ))
+            .map_err(|e| e.to_string())?;
+            win.set_position(tauri::PhysicalPosition::new(
+                x.round() as i32,
+                y.round() as i32,
+            ))
+            .map_err(|e| e.to_string())?;
             Ok(())
         }
         QuickCapturePlacement::BottomRight => {
@@ -80,7 +91,32 @@ pub fn apply_placement(app: &AppHandle) -> Result<(), String> {
 
 fn position_bottom_right(win: &WebviewWindow) -> Result<(), String> {
     #[cfg(not(target_os = "macos"))]
-    let _ = &win;
+    {
+        let monitor = win
+            .current_monitor()
+            .map_err(|e| e.to_string())?
+            .or_else(|| win.primary_monitor().ok().flatten())
+            .ok_or("no monitor available")?;
+        let scale = monitor.scale_factor();
+        let (qw, qh, pad) = (
+            QC_WIDTH * scale,
+            QC_HEIGHT * scale,
+            QC_CORNER_PADDING * scale,
+        );
+        let area = monitor.work_area();
+        let x = area.position.x as f64 + area.size.width as f64 - qw - pad;
+        let y = area.position.y as f64 + area.size.height as f64 - qh - pad;
+        win.set_size(tauri::PhysicalSize::new(
+            qw.round() as u32,
+            qh.round() as u32,
+        ))
+        .map_err(|e| e.to_string())?;
+        win.set_position(tauri::PhysicalPosition::new(
+            x.round() as i32,
+            y.round() as i32,
+        ))
+        .map_err(|e| e.to_string())?;
+    }
 
     #[cfg(target_os = "macos")]
     #[allow(deprecated)]
@@ -201,7 +237,10 @@ pub async fn open_quick_capture(
         .get_webview_window("quick-capture")
         .ok_or("quick-capture window not found")?;
     set_placement(&app, placement);
-    apply_placement(&app)?;
+    if let Err(e) = apply_placement(&app) {
+        set_placement(&app, QuickCapturePlacement::BottomRight);
+        return Err(e);
+    }
     show_floating(&window);
     app.emit_to("main", QC_OPENED_EVENT, placement)
         .map_err(|e| e.to_string())

--- a/app/src/quick_capture.rs
+++ b/app/src/quick_capture.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Placement and show/hide plumbing for the quick-capture window.
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use tauri::{AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, WebviewWindow};
+
+pub const QC_WIDTH: f64 = 400.0;
+pub const QC_HEIGHT: f64 = 160.0;
+pub const QC_CORNER_PADDING: f64 = 16.0;
+pub const QC_OPENED_EVENT: &str = "quick-capture-opened";
+pub const QC_CLOSED_EVENT: &str = "quick-capture-closed";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum QuickCapturePlacement {
+    #[default]
+    BottomRight,
+    CenteredOverMain,
+}
+
+pub struct QuickCapturePlacementState(pub Mutex<QuickCapturePlacement>);
+
+/// Top-left origin that centers a `w` x `h` window over a rectangle at (`x`, `y`) of `mw` x `mh`.
+pub fn centered_origin(x: f64, y: f64, mw: f64, mh: f64, w: f64, h: f64) -> (f64, f64) {
+    (x + (mw - w) / 2.0, y + (mh - h) / 2.0)
+}
+
+pub fn set_placement(app: &AppHandle, placement: QuickCapturePlacement) {
+    if let Some(state) = app.try_state::<QuickCapturePlacementState>() {
+        let mut guard = state.0.lock().unwrap_or_else(|e| e.into_inner());
+        *guard = placement;
+    }
+}
+
+pub fn placement(app: &AppHandle) -> QuickCapturePlacement {
+    app.try_state::<QuickCapturePlacementState>()
+        .map(|state| *state.0.lock().unwrap_or_else(|e| e.into_inner()))
+        .unwrap_or_default()
+}
+
+pub fn apply_placement(app: &AppHandle) -> Result<(), String> {
+    match placement(app) {
+        QuickCapturePlacement::CenteredOverMain => {
+            let win = app
+                .get_webview_window("quick-capture")
+                .ok_or("quick-capture window not found")?;
+            let Some(main) = app.get_webview_window("main") else {
+                return position_bottom_right(&win);
+            };
+            let main_visible = main.is_visible().unwrap_or(false);
+            let main_minimized = main.is_minimized().unwrap_or(false);
+            if !main_visible || main_minimized {
+                return position_bottom_right(&win);
+            }
+            let scale = main.scale_factor().map_err(|e| e.to_string())?;
+            let pos = main
+                .outer_position()
+                .map_err(|e| e.to_string())?
+                .to_logical::<f64>(scale);
+            let size = main
+                .outer_size()
+                .map_err(|e| e.to_string())?
+                .to_logical::<f64>(scale);
+            let (x, y) =
+                centered_origin(pos.x, pos.y, size.width, size.height, QC_WIDTH, QC_HEIGHT);
+            win.set_size(LogicalSize::new(QC_WIDTH, QC_HEIGHT))
+                .map_err(|e| e.to_string())?;
+            win.set_position(LogicalPosition::new(x, y))
+                .map_err(|e| e.to_string())?;
+            Ok(())
+        }
+        QuickCapturePlacement::BottomRight => {
+            let win = app
+                .get_webview_window("quick-capture")
+                .ok_or("quick-capture window not found")?;
+            position_bottom_right(&win)
+        }
+    }
+}
+
+fn position_bottom_right(win: &WebviewWindow) -> Result<(), String> {
+    #[cfg(not(target_os = "macos"))]
+    let _ = &win;
+
+    #[cfg(target_os = "macos")]
+    #[allow(deprecated)]
+    {
+        use cocoa::base::id;
+        use cocoa::foundation::NSRect;
+        use raw_window_handle::HasWindowHandle;
+        use tauri::{LogicalPosition, LogicalSize};
+
+        let raw_handle = win.window_handle().map_err(|e| e.to_string())?;
+        if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
+            let ns_view = appkit.ns_view.as_ptr() as id;
+
+            let (visible, screen_h) = unsafe {
+                let ns_win: id = objc::msg_send![ns_view, window];
+                if ns_win.is_null() {
+                    return Err("NSWindow not attached".into());
+                }
+                let screen: id = objc::msg_send![ns_win, screen];
+                if screen.is_null() {
+                    return Err("NSScreen not available".into());
+                }
+                let visible: NSRect = objc::msg_send![screen, visibleFrame];
+                let frame: NSRect = objc::msg_send![screen, frame];
+                (visible, frame.size.height)
+            };
+
+            let width = QC_WIDTH;
+            let height = QC_HEIGHT;
+            let padding = QC_CORNER_PADDING;
+
+            win.set_size(LogicalSize::new(width, height))
+                .map_err(|e| e.to_string())?;
+
+            let x = visible.origin.x + visible.size.width - width - padding;
+            let y = screen_h - visible.origin.y - padding - height;
+
+            log::debug!("[qc-pos] visible=({:.0},{:.0} {:.0}x{:.0}) screen_h={:.0} → size=({:.0},{:.0}) pos=({:.0},{:.0})",
+                visible.origin.x, visible.origin.y, visible.size.width, visible.size.height,
+                screen_h, width, height, x, y);
+
+            win.set_position(LogicalPosition::new(x, y))
+                .map_err(|e| e.to_string())?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn show_floating(window: &WebviewWindow) {
+    #[cfg(target_os = "macos")]
+    #[allow(deprecated)]
+    {
+        use cocoa::base::id;
+        use raw_window_handle::HasWindowHandle;
+
+        if let Ok(raw_handle) = window.window_handle() {
+            if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
+                let ns_view = appkit.ns_view.as_ptr() as id;
+                unsafe {
+                    let ns_win: id = objc::msg_send![ns_view, window];
+                    let _: () = objc::msg_send![ns_win, setLevel: 3_i64]; // NSFloatingWindowLevel
+                    let _: () = objc::msg_send![ns_win, makeKeyAndOrderFront: ns_win];
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+/// Hide without triggering macOS window promotion (which would show main).
+/// `orderOut:` removes the window; `hide()` would auto-activate the next app window.
+pub fn hide_quietly(window: &WebviewWindow) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    #[allow(deprecated)]
+    {
+        let qc_for_main_thread = window.clone();
+        window
+            .run_on_main_thread(move || {
+                use cocoa::base::id;
+                use raw_window_handle::HasWindowHandle;
+
+                if let Ok(raw_handle) = qc_for_main_thread.window_handle() {
+                    if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw()
+                    {
+                        let ns_view = appkit.ns_view.as_ptr() as id;
+                        unsafe {
+                            let ns_win: id = objc::msg_send![ns_view, window];
+                            let _: () = objc::msg_send![ns_win, orderOut: ns_win];
+                        }
+                    }
+                }
+            })
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = window.hide();
+    }
+    Ok(())
+}
+
+pub fn notify_closed(app: &AppHandle) {
+    set_placement(app, QuickCapturePlacement::BottomRight);
+    let _ = app.emit_to("main", QC_CLOSED_EVENT, ());
+}
+
+#[tauri::command]
+pub async fn open_quick_capture(
+    app: AppHandle,
+    placement: QuickCapturePlacement,
+) -> Result<(), String> {
+    let window = app
+        .get_webview_window("quick-capture")
+        .ok_or("quick-capture window not found")?;
+    set_placement(&app, placement);
+    apply_placement(&app)?;
+    show_floating(&window);
+    app.emit_to("main", QC_OPENED_EVENT, placement)
+        .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn centered_origin_centers_exactly() {
+        assert_eq!(
+            centered_origin(100.0, 50.0, 1200.0, 800.0, 400.0, 160.0),
+            (500.0, 370.0)
+        );
+    }
+
+    #[test]
+    fn placement_serde_round_trip() {
+        assert_eq!(
+            serde_json::to_string(&QuickCapturePlacement::BottomRight).unwrap(),
+            "\"bottom-right\""
+        );
+        assert_eq!(
+            serde_json::to_string(&QuickCapturePlacement::CenteredOverMain).unwrap(),
+            "\"centered-over-main\""
+        );
+        assert_eq!(
+            serde_json::from_str::<QuickCapturePlacement>("\"bottom-right\"").unwrap(),
+            QuickCapturePlacement::BottomRight
+        );
+        assert_eq!(
+            serde_json::from_str::<QuickCapturePlacement>("\"centered-over-main\"").unwrap(),
+            QuickCapturePlacement::CenteredOverMain
+        );
+    }
+
+    #[test]
+    fn default_placement_is_bottom_right() {
+        assert_eq!(
+            QuickCapturePlacement::default(),
+            QuickCapturePlacement::BottomRight
+        );
+    }
+}

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -125,94 +125,16 @@ pub async fn dismiss_quick_capture(app: tauri::AppHandle) -> Result<(), String> 
     use tauri::Manager;
 
     if let Some(qc) = app.get_webview_window("quick-capture") {
-        // Use orderOut instead of hide() to remove the window without
-        // triggering macOS window promotion (which would show main).
-        #[cfg(target_os = "macos")]
-        #[allow(deprecated)]
-        {
-            let qc_for_main_thread = qc.clone();
-            qc.run_on_main_thread(move || {
-                use cocoa::base::id;
-                use raw_window_handle::HasWindowHandle;
-
-                if let Ok(raw_handle) = qc_for_main_thread.window_handle() {
-                    if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw()
-                    {
-                        let ns_view = appkit.ns_view.as_ptr() as id;
-                        unsafe {
-                            let ns_win: id = objc::msg_send![ns_view, window];
-                            let _: () = objc::msg_send![ns_win, orderOut: ns_win];
-                        }
-                    }
-                }
-            })
-            .map_err(|e| e.to_string())?;
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            let _ = qc.hide();
-        }
+        crate::quick_capture::hide_quietly(&qc)?;
     }
+    crate::quick_capture::notify_closed(&app);
 
     Ok(())
 }
 
 #[tauri::command]
 pub async fn position_quick_capture(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::Manager;
-
-    let win = app
-        .get_webview_window("quick-capture")
-        .ok_or("quick-capture window not found")?;
-    #[cfg(not(target_os = "macos"))]
-    let _ = &win;
-
-    #[cfg(target_os = "macos")]
-    #[allow(deprecated)]
-    {
-        use cocoa::base::id;
-        use cocoa::foundation::NSRect;
-        use raw_window_handle::HasWindowHandle;
-        use tauri::{LogicalPosition, LogicalSize};
-
-        let raw_handle = win.window_handle().map_err(|e| e.to_string())?;
-        if let raw_window_handle::RawWindowHandle::AppKit(appkit) = raw_handle.as_raw() {
-            let ns_view = appkit.ns_view.as_ptr() as id;
-
-            let (visible, screen_h) = unsafe {
-                let ns_win: id = objc::msg_send![ns_view, window];
-                if ns_win.is_null() {
-                    return Err("NSWindow not attached".into());
-                }
-                let screen: id = objc::msg_send![ns_win, screen];
-                if screen.is_null() {
-                    return Err("NSScreen not available".into());
-                }
-                let visible: NSRect = objc::msg_send![screen, visibleFrame];
-                let frame: NSRect = objc::msg_send![screen, frame];
-                (visible, frame.size.height)
-            };
-
-            let width = 400.0;
-            let height = 160.0;
-            let padding = 16.0;
-
-            win.set_size(LogicalSize::new(width, height))
-                .map_err(|e| e.to_string())?;
-
-            let x = visible.origin.x + visible.size.width - width - padding;
-            let y = screen_h - visible.origin.y - padding - height;
-
-            log::debug!("[qc-pos] visible=({:.0},{:.0} {:.0}x{:.0}) screen_h={:.0} → size=({:.0},{:.0}) pos=({:.0},{:.0})",
-                visible.origin.x, visible.origin.y, visible.size.width, visible.size.height,
-                screen_h, width, height, x, y);
-
-            win.set_position(LogicalPosition::new(x, y))
-                .map_err(|e| e.to_string())?;
-        }
-    }
-
-    Ok(())
+    crate::quick_capture::apply_placement(&app)
 }
 
 #[tauri::command]

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -125,7 +125,7 @@ pub async fn dismiss_quick_capture(app: tauri::AppHandle) -> Result<(), String> 
     use tauri::Manager;
 
     if let Some(qc) = app.get_webview_window("quick-capture") {
-        crate::quick_capture::hide_quietly(&qc)?;
+        let _ = crate::quick_capture::hide_quietly(&qc);
     }
     crate::quick_capture::notify_closed(&app);
 

--- a/src/components/memory/Main.tsx
+++ b/src/components/memory/Main.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import {
@@ -50,6 +51,7 @@ import { deleteRecentSpace, recordRecentSpaceVisit, renameRecentSpace } from "..
 import { createSpaceDetailCopy, createSpacesOverviewLabels } from "./navigation/copy";
 import { activeNavigationForView, type View } from "./navigation/viewState";
 import { ReviewEnvironmentBadge } from "./navigation/ReviewEnvironmentBadge";
+import QuickCaptureScrim from "./QuickCaptureScrim";
 import { useResponsiveSidebar } from "./navigation/useResponsiveSidebar";
 import "./navigation/navigation-shell.css";
 
@@ -592,13 +594,7 @@ export default function Main({
             </button>
             {/* Quick Capture */}
             <button
-              onClick={async () => {
-                const { WebviewWindow } = await import("@tauri-apps/api/webviewWindow");
-                const win = await WebviewWindow.getByLabel("quick-capture");
-                if (!win) return;
-                await win.show();
-                await win.setFocus();
-              }}
+              onClick={() => void invoke("open_quick_capture", { placement: "centered-over-main" })}
               className="p-1.5 rounded-md transition-colors duration-150 hover:bg-[var(--mem-hover-strong)]"
               style={{ color: "var(--mem-text-secondary)" }}
               title={t("main.quickCaptureTitle")}
@@ -1063,6 +1059,7 @@ export default function Main({
       </div>
 
       <AboutWenlanDialog open={aboutOpen} onClose={() => setAboutOpen(false)} />
+      <QuickCaptureScrim />
     </div>
   );
 }

--- a/src/components/memory/Main.tsx
+++ b/src/components/memory/Main.tsx
@@ -485,6 +485,7 @@ export default function Main({
         searchInputRef.current?.focus();
       }
       if (e.key === "Escape") {
+        if (e.defaultPrevented) return;
         if (responsiveSidebar.presentation === "overlay" && responsiveSidebar.open) return;
         if (query) {
           setQuery("");

--- a/src/components/memory/QuickCaptureScrim.test.tsx
+++ b/src/components/memory/QuickCaptureScrim.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import QuickCaptureScrim from "./QuickCaptureScrim";
+
+type Handler = (event: { payload: unknown }) => void;
+
+const listeners = vi.hoisted(() => new Map<string, Handler>());
+const unlistenOpened = vi.hoisted(() => vi.fn());
+const unlistenClosed = vi.hoisted(() => vi.fn());
+const listenMock = vi.hoisted(() => vi.fn());
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: listenMock,
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+function fireOpened(payload: unknown): void {
+  const handler = listeners.get("quick-capture-opened");
+  expect(handler).toBeDefined();
+  act(() => {
+    handler?.({ payload });
+  });
+}
+
+function fireClosed(): void {
+  const handler = listeners.get("quick-capture-closed");
+  expect(handler).toBeDefined();
+  act(() => {
+    handler?.({ payload: undefined });
+  });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  listenMock.mockReset();
+  invokeMock.mockReset();
+  unlistenOpened.mockReset();
+  unlistenClosed.mockReset();
+  listenMock.mockImplementation((event: string, handler: Handler) => {
+    listeners.set(event, handler);
+    if (event === "quick-capture-opened") return Promise.resolve(unlistenOpened);
+    return Promise.resolve(unlistenClosed);
+  });
+});
+
+describe("QuickCaptureScrim", () => {
+  it("renders nothing initially", () => {
+    render(<QuickCaptureScrim />);
+    expect(screen.queryByTestId("quick-capture-scrim")).toBeNull();
+  });
+
+  it("shows the scrim when opened centered over main", () => {
+    render(<QuickCaptureScrim />);
+    fireOpened("centered-over-main");
+    expect(screen.getByTestId("quick-capture-scrim")).toBeTruthy();
+  });
+
+  it("stays hidden when opened at the bottom-right shortcut position", () => {
+    render(<QuickCaptureScrim />);
+    fireOpened("bottom-right");
+    expect(screen.queryByTestId("quick-capture-scrim")).toBeNull();
+  });
+
+  it("removes the scrim when the capture window closes", () => {
+    render(<QuickCaptureScrim />);
+    fireOpened("centered-over-main");
+    expect(screen.getByTestId("quick-capture-scrim")).toBeTruthy();
+    fireClosed();
+    expect(screen.queryByTestId("quick-capture-scrim")).toBeNull();
+  });
+
+  it("dismisses the capture window on scrim click", () => {
+    render(<QuickCaptureScrim />);
+    fireOpened("centered-over-main");
+    fireEvent.click(screen.getByTestId("quick-capture-scrim"));
+    expect(invokeMock).toHaveBeenCalledWith("dismiss_quick_capture");
+  });
+
+  it("dismisses the capture window on Escape while open", () => {
+    render(<QuickCaptureScrim />);
+    fireOpened("centered-over-main");
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(invokeMock).toHaveBeenCalledWith("dismiss_quick_capture");
+  });
+
+  it("ignores non-Escape keys while open", () => {
+    render(<QuickCaptureScrim />);
+    fireOpened("centered-over-main");
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it("unlistens both events on unmount", async () => {
+    const { unmount } = render(<QuickCaptureScrim />);
+    expect(listenMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      unmount();
+    });
+    expect(unlistenOpened).toHaveBeenCalledTimes(1);
+    expect(unlistenClosed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/memory/QuickCaptureScrim.test.tsx
+++ b/src/components/memory/QuickCaptureScrim.test.tsx
@@ -82,18 +82,26 @@ describe("QuickCaptureScrim", () => {
     expect(invokeMock).toHaveBeenCalledWith("dismiss_quick_capture");
   });
 
-  it("dismisses the capture window on Escape while open", () => {
+  it("dismisses the capture window on Escape while open and marks it handled", () => {
     render(<QuickCaptureScrim />);
     fireOpened("centered-over-main");
-    fireEvent.keyDown(window, { key: "Escape" });
+    const event = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+    act(() => {
+      window.dispatchEvent(event);
+    });
     expect(invokeMock).toHaveBeenCalledWith("dismiss_quick_capture");
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("ignores non-Escape keys while open", () => {
     render(<QuickCaptureScrim />);
     fireOpened("centered-over-main");
-    fireEvent.keyDown(window, { key: "Enter" });
+    const event = new KeyboardEvent("keydown", { key: "Enter", cancelable: true });
+    act(() => {
+      window.dispatchEvent(event);
+    });
     expect(invokeMock).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it("unlistens both events on unmount", async () => {

--- a/src/components/memory/QuickCaptureScrim.tsx
+++ b/src/components/memory/QuickCaptureScrim.tsx
@@ -15,9 +15,18 @@ export default function QuickCaptureScrim() {
   }, []);
   useEffect(() => {
     if (!open) return;
-    const onKey = (event: KeyboardEvent) => { if (event.key === "Escape") void invoke("dismiss_quick_capture"); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    // Capture phase so this runs before Main's bubble-phase Escape branch
+    // regardless of subscription order; preventDefault marks the event as
+    // handled so Main skips its own Escape handling (clearing search, back
+    // navigation) for the same keypress.
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        void invoke("dismiss_quick_capture");
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [open]);
   if (!open) return null;
   return <div className="quick-capture-scrim" data-testid="quick-capture-scrim" onClick={() => void invoke("dismiss_quick_capture")} />;

--- a/src/components/memory/QuickCaptureScrim.tsx
+++ b/src/components/memory/QuickCaptureScrim.tsx
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import "./quickCaptureScrim.css";
+
+type Placement = "bottom-right" | "centered-over-main";
+
+export default function QuickCaptureScrim() {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    const opened = listen<Placement>("quick-capture-opened", (event) => setOpen(event.payload === "centered-over-main"));
+    const closed = listen("quick-capture-closed", () => setOpen(false));
+    return () => { opened.then((fn) => fn()); closed.then((fn) => fn()); };
+  }, []);
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => { if (event.key === "Escape") void invoke("dismiss_quick_capture"); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+  if (!open) return null;
+  return <div className="quick-capture-scrim" data-testid="quick-capture-scrim" onClick={() => void invoke("dismiss_quick_capture")} />;
+}

--- a/src/components/memory/quickCaptureScrim.css
+++ b/src/components/memory/quickCaptureScrim.css
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: AGPL-3.0-only */
+.quick-capture-scrim {
+  animation: quick-capture-scrim-in 150ms ease-out both;
+  background: rgb(0 0 0 / 45%);
+  cursor: default;
+  inset: 0;
+  position: fixed;
+  z-index: 70;
+}
+
+@keyframes quick-capture-scrim-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quick-capture-scrim { animation: none; }
+}

--- a/src/lib/reviewCommandContract.test.ts
+++ b/src/lib/reviewCommandContract.test.ts
@@ -100,6 +100,7 @@ const OUTSIDE_THE_REVIEW_SURFACE: readonly string[] = [
   "move_space",
   "on_device_model_download_bytes",
   "open_file",
+  "open_quick_capture",
   "open_search_result",
   "position_quick_capture",
   "quick_capture",


### PR DESCRIPTION
## What

The toolbar pencil button now opens Quick Capture centered over the main window and shows a dimming scrim in the main webview. Clicking the scrim or pressing Escape in the main window dismisses the capture window. The global shortcut (`CmdOrCtrl+Shift+N`) keeps its bottom-right placement with no scrim.

## How

- New `app/src/quick_capture.rs`: placement enum (`bottom-right` / `centered-over-main`) in a managed `std::sync::Mutex`, `centered_origin` math, `apply_placement` (centered branch works in physical pixels from main's `outer_position` / `outer_size` / `scale_factor`, falls back to bottom-right when main is hidden or minimized), `show_floating`, `hide_quietly`, `notify_closed`, and the `open_quick_capture` command.
- Bottom-right placement now also works on Windows and Linux via `current_monitor().work_area()`; the macOS Cocoa path is unchanged.
- `search.rs`: `dismiss_quick_capture` and `position_quick_capture` delegate to the new module, so the capture window's focus handler re-applies the active placement instead of always jumping to the corner. Every dismiss resets placement to bottom-right and emits `quick-capture-closed` to main.
- `lib.rs`: shortcut arm collapsed onto the shared helpers; command registered.
- New `QuickCaptureScrim` component mounted in `Main.tsx`, listening to `quick-capture-opened` / `quick-capture-closed`; 150ms fade, reduced-motion respected, z-index 70. The scrim owns Escape (capture phase + `preventDefault`) so main's own Escape branch does not also fire.
- 4a753518: `open_quick_capture` runs on a tokio thread, and `show_floating` sent `setLevel:` / `makeKeyAndOrderFront:` from there. AppKit trapped (EXC_BREAKPOINT in `-[_WMWindow setWindowLevel:]`) and the app died the first time the pencil button was pressed. The show now hops to the main thread first. The shortcut path was never affected because its handler already runs on the main thread.

## Review

Pass one (Muse, read-only, at 438273d3): nothing blocking; two medium findings (mixed-scale monitor math, Windows/Linux corner no-op) and four low ones. All six fixed in ae3debef.

## Verification (4a753518, macOS arm64)

- `cargo fmt --all --check`, `cargo clippy -p wenlan-app --all-targets -- -D warnings`: clean.
- `cargo test -p wenlan-app quick_capture`: 3 passed.
- `pnpm exec vitest run src/components/memory/QuickCaptureScrim.test.tsx src/components/QuickCapture.test.tsx`: 13 passed (ae3debef; no frontend change since).
- `pnpm exec tsc --noEmit -p tsconfig.json`: clean (ae3debef).
- Live check in an isolated dev build (`open_quick_capture` with `centered-over-main` triggered from the app runtime): before the fix, crash report `wenlan-app-2026-09-10-235440.ips`; after the fix, the capture window is on screen at the floating level, 400x160 at (664,495), exactly centered over the 1280x720 main window at (224,215). Screenshots were not possible in this session (screen capture permission denied), so the scrim and the click/Escape dismiss remain **unchecked** live; they are covered by the vitest suite.
- The non-macOS `position_bottom_right` block is not compiled locally; CI's Windows/Linux app-check lane covers it.

Implemented by Muse Spark (acpx session qc-impl1, two turns) from lead-written briefs; the main-thread fix is a lead edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3mnLzAyZVszRSzJF6wwrz