### PR TITLE
feat(activity): add GET /api/activity background-work summary route

### DIFF
--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -766,6 +766,10 @@ impl WenlanClient {
         self.get_json("/api/debug/pipeline").await
     }
 
+    pub async fn activity(&self) -> Result<wenlan_types::activity::ActivityResponse, String> {
+        self.get_json("/api/activity").await
+    }
+
     pub async fn list_tags(&self) -> Result<Vec<String>, String> {
         Ok(self.list_tag_inventory().await?.tags)
     }
@@ -2303,6 +2307,39 @@ mod tests {
         assert_eq!(
             request.lines().next().unwrap_or_default(),
             "GET /api/debug/pipeline HTTP/1.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn activity_uses_daemon_activity_endpoint() {
+        let body = r#"{"state":"organizing","last_activity_at":1700000100,"assets":[{"kind":"memories","state":"running","done":7,"total":10,"blocked":0,"steps":[]}],"everyday":{"job":"everyday","lane":"on_device","model":"qwen3-4b","mode":"pinned","available":true},"synthesis":{"job":"synthesis","lane":"none","model":null,"mode":"unconfigured","available":false}}"#;
+        let (base_url, request) = serve_json_once(body).await;
+        let client = WenlanClient {
+            client: reqwest::Client::new(),
+            base_url,
+        };
+
+        let activity = client.activity().await.unwrap();
+
+        assert_eq!(
+            activity.state,
+            wenlan_types::activity::ActivityState::Organizing
+        );
+        assert_eq!(activity.last_activity_at, Some(1_700_000_100));
+        assert_eq!(activity.assets.len(), 1);
+        assert_eq!(
+            activity.assets[0].kind,
+            wenlan_types::activity::ActivityAssetKind::Memories
+        );
+        assert_eq!(
+            activity.everyday.lane,
+            wenlan_types::activity::ActivityLane::OnDevice
+        );
+        assert!(!activity.synthesis.available);
+        let request = request.await.unwrap();
+        assert_eq!(
+            request.lines().next().unwrap_or_default(),
+            "GET /api/activity HTTP/1.1"
         );
     }
 

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1538,6 +1538,7 @@ pub fn run() {
             search::rebuild_activities,
             search::get_capture_stats,
             search::get_pipeline_status,
+            search::get_activity,
             search::list_all_tags,
             search::set_document_tags,
             search::delete_tag,

--- a/app/src/search.rs
+++ b/app/src/search.rs
@@ -430,6 +430,17 @@ pub async fn get_pipeline_status(
     client.pipeline_status().await
 }
 
+#[tauri::command]
+pub async fn get_activity(
+    state: tauri::State<'_, State>,
+) -> Result<wenlan_types::activity::ActivityResponse, String> {
+    let client = {
+        let s = state.read().await;
+        s.client.clone()
+    };
+    client.activity().await
+}
+
 #[cfg(test)]
 mod pipeline_status_command_type_tests {
     use super::*;

--- a/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
+++ b/crates/wenlan-core/contracts/m5-reader-manifest-inventory.md
@@ -541,6 +541,7 @@ load-bearing: the shape gate holds even when this one is bypassed.
 
 | Method | Path | Builder | Page-bearing | Class | Marker-shape | Adapter | Evidence |
 |---|---|---|---|---|---|---|---|
+| `GET` | `/api/activity` | main | no | not_applicable | `none` | — | no prose fields |
 | `GET` | `/api/activities` | main | yes | automatic | `none` | `handle_list_activities` | AgentActivityRow.detail = title={page.title} |
 | `GET` | `/api/agents` | main | no | not_applicable | `none` | — | DEMOTED — proof in the inventory doc |
 | `DELETE` | `/api/agents/{name}` | main | yes | automatic | `none` | `handle_delete_agent` | opaque response type — fail-closed |

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -69,7 +69,7 @@ mod repair_receipt;
 pub(crate) mod repair_stale_projection;
 pub(crate) mod repair_target_receipt;
 pub(crate) mod repair_verification;
-pub use activity_counts::{ActivityCounts, StepBacklog, StepCount};
+pub use activity_counts::{ActivityCounts, AssetBacklog, DetectTally, StepBacklog, StepCount};
 mod scoped_entities;
 mod scoped_pages;
 mod source_sync;

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -69,7 +69,7 @@ mod repair_receipt;
 pub(crate) mod repair_stale_projection;
 pub(crate) mod repair_target_receipt;
 pub(crate) mod repair_verification;
-pub use activity_counts::{ActivityCounts, StepCount};
+pub use activity_counts::{ActivityCounts, StepBacklog, StepCount};
 mod scoped_entities;
 mod scoped_pages;
 mod source_sync;

--- a/crates/wenlan-core/src/db.rs
+++ b/crates/wenlan-core/src/db.rs
@@ -42,6 +42,7 @@ mod genesis_schema;
 /// real substrate. Text, not a `libsql` handle — see the constant's own note.
 #[cfg(test)]
 pub(crate) use genesis_schema::GENESIS_SUBSTRATE_DDL;
+mod activity_counts;
 mod kg_quality_diagnostics;
 mod kg_quality_duplicate_candidates;
 mod kg_quality_embedding_refresh;
@@ -68,6 +69,7 @@ mod repair_receipt;
 pub(crate) mod repair_stale_projection;
 pub(crate) mod repair_target_receipt;
 pub(crate) mod repair_verification;
+pub use activity_counts::{ActivityCounts, StepCount};
 mod scoped_entities;
 mod scoped_pages;
 mod source_sync;

--- a/crates/wenlan-core/src/db/activity_counts.rs
+++ b/crates/wenlan-core/src/db/activity_counts.rs
@@ -16,6 +16,14 @@ pub struct StepCount {
     pub count: u64,
 }
 
+/// Memories a step has not started: distinct `source_id`s with `source =
+/// 'memory'` and no `enrichment_steps` row for `step_name`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepBacklog {
+    pub step_name: String,
+    pub count: u64,
+}
+
 /// Every count `GET /api/activity` composes into an `ActivityResponse`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActivityCounts {
@@ -23,9 +31,11 @@ pub struct ActivityCounts {
     pub memories_total: u64,
     /// `(step_name, status, count)` cells from `enrichment_steps`.
     pub step_counts: Vec<StepCount>,
-    /// The "raw" count from `pipeline_status`: distinct memory `source_id`s
-    /// with no `enrichment_steps` row at all.
-    pub memories_without_steps: u64,
+    /// Memories (source = 'memory') with no `enrichment_steps` row for this
+    /// step name. Keyed by step name: the backlog a step has not started.
+    /// One entry each for `title_enrich`, `page_growth`, `entity_extract`
+    /// and `entity_link`, even when the count is zero.
+    pub memories_without_step: Vec<StepBacklog>,
     /// Entity shadow pages that are live but unconfirmed.
     pub entities_detected: u64,
     /// Entity shadow pages that are live and confirmed.
@@ -85,14 +95,44 @@ impl MemoryDB {
         }
         drop(step_rows);
 
-        // Same SQL as the "raw" count in `pipeline_status`.
-        let memories_without_steps = scalar_u64(
-            &conn,
-            "SELECT COUNT(DISTINCT source_id) FROM memories WHERE source = 'memory' \
-             AND source_id NOT IN (SELECT DISTINCT source_id FROM enrichment_steps)",
-            "activity_counts memories_without_steps",
-        )
-        .await?;
+        // Per-step backlog: memories with no row for that step at all. The
+        // `pipeline_status` "raw" count cannot answer this per step — a
+        // memory with only a `title_enrich` row is still waiting on
+        // `page_growth` — so each step gets its own correlated subquery.
+        let mut backlog_rows = conn
+            .query(
+                "SELECT s.name, (SELECT COUNT(*) FROM memories m WHERE m.source = 'memory' \
+                 AND NOT EXISTS (SELECT 1 FROM enrichment_steps e \
+                 WHERE e.source_id = m.source_id AND e.step_name = s.name)) \
+                 FROM (SELECT 'title_enrich' AS name UNION ALL SELECT 'page_growth' \
+                 UNION ALL SELECT 'entity_extract' UNION ALL SELECT 'entity_link') s",
+                (),
+            )
+            .await
+            .map_err(|e| {
+                WenlanError::VectorDb(format!("activity_counts memories_without_step: {e}"))
+            })?;
+        let mut memories_without_step = Vec::new();
+        while let Some(row) = backlog_rows.next().await.map_err(|e| {
+            WenlanError::VectorDb(format!("activity_counts memories_without_step row: {e}"))
+        })? {
+            memories_without_step.push(StepBacklog {
+                step_name: row.get::<String>(0).map_err(|e| {
+                    WenlanError::VectorDb(format!(
+                        "activity_counts memories_without_step name: {e}"
+                    ))
+                })?,
+                count: row
+                    .get::<i64>(1)
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!(
+                            "activity_counts memories_without_step count: {e}"
+                        ))
+                    })?
+                    .max(0) as u64,
+            });
+        }
+        drop(backlog_rows);
 
         // Entity lifecycle predicates mirror `entity_status_predicate` in
         // db.rs, over the same `entity_page_map`/`pages` shadow shape the
@@ -161,7 +201,7 @@ impl MemoryDB {
         Ok(ActivityCounts {
             memories_total,
             step_counts,
-            memories_without_steps,
+            memories_without_step,
             entities_detected,
             entities_confirmed,
             pages_active,
@@ -222,7 +262,24 @@ mod tests {
             ActivityCounts {
                 memories_total: 0,
                 step_counts: vec![],
-                memories_without_steps: 0,
+                memories_without_step: vec![
+                    StepBacklog {
+                        step_name: "title_enrich".to_string(),
+                        count: 0,
+                    },
+                    StepBacklog {
+                        step_name: "page_growth".to_string(),
+                        count: 0,
+                    },
+                    StepBacklog {
+                        step_name: "entity_extract".to_string(),
+                        count: 0,
+                    },
+                    StepBacklog {
+                        step_name: "entity_link".to_string(),
+                        count: 0,
+                    },
+                ],
                 entities_detected: 0,
                 entities_confirmed: 0,
                 pages_active: 0,
@@ -245,22 +302,24 @@ mod tests {
             .await
             .unwrap();
         }
-        // One memory with a done + a failed step, one raw memory, one
-        // non-memory row the reader must ignore.
-        seed_memory(
-            &db,
-            "row-1",
-            "mem-1",
-            &[("title_enrich", "ok", 100), ("page_growth", "failed", 200)],
-        )
-        .await;
-        seed_memory(&db, "row-2", "mem-2", &[]).await;
+        // Eight memories: one with a done `title_enrich` row, none with a
+        // `page_growth` row, plus one non-memory row the reader must ignore.
+        for index in 1..=8 {
+            let id = format!("row-{index}");
+            let source_id = format!("mem-{index}");
+            let steps: &[(&str, &str, i64)] = if index == 1 {
+                &[("title_enrich", "ok", 100)]
+            } else {
+                &[]
+            };
+            seed_memory(&db, &id, &source_id, steps).await;
+        }
         {
             let conn = db.conn.lock().await;
             conn.execute(
                 "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
                  last_modified, chunk_type, space) \
-                 VALUES ('row-3', 'content', 'note', 'note-1', 'title', 0, 0, 'text', 'work')",
+                 VALUES ('row-note-1', 'content', 'note', 'note-1', 'title', 0, 0, 'text', 'work')",
                 (),
             )
             .await
@@ -299,23 +358,32 @@ mod tests {
         .unwrap();
 
         let counts = db.activity_counts().await.unwrap();
-        assert_eq!(counts.memories_total, 2);
-        assert_eq!(counts.memories_without_steps, 1);
+        assert_eq!(counts.memories_total, 8);
         let mut cells: Vec<(&str, &str, u64)> = counts
             .step_counts
             .iter()
             .map(|cell| (cell.step_name.as_str(), cell.status.as_str(), cell.count))
             .collect();
         cells.sort();
-        assert_eq!(
-            cells,
-            vec![("page_growth", "failed", 1), ("title_enrich", "ok", 1)]
-        );
+        assert_eq!(cells, vec![("title_enrich", "ok", 1)]);
+        let backlog = |step_name: &str| {
+            counts
+                .memories_without_step
+                .iter()
+                .find(|entry| entry.step_name == step_name)
+                .map(|entry| entry.count)
+        };
+        // The one memory with a `title_enrich` row is still waiting on every
+        // other step; the seven without any row wait on all four.
+        assert_eq!(backlog("title_enrich"), Some(7));
+        assert_eq!(backlog("page_growth"), Some(8));
+        assert_eq!(backlog("entity_extract"), Some(8));
+        assert_eq!(backlog("entity_link"), Some(8));
         assert_eq!(counts.entities_detected, 1);
         assert_eq!(counts.entities_confirmed, 1);
         assert_eq!(counts.pages_active, 3);
         assert_eq!(counts.pages_stale, 1);
         assert_eq!(counts.pages_refresh_blocked, 1);
-        assert_eq!(counts.last_step_updated_at, Some(200));
+        assert_eq!(counts.last_step_updated_at, Some(100));
     }
 }

--- a/crates/wenlan-core/src/db/activity_counts.rs
+++ b/crates/wenlan-core/src/db/activity_counts.rs
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Counts backing `GET /api/activity`: one read-only pass over the memories,
+//! enrichment-step, entity-shadow and page tables.
+//!
+//! Same shape as the other `impl MemoryDB` reader files (e.g.
+//! `scoped_entities.rs`): pure counts, no prose, one held connection guard.
+
+use super::MemoryDB;
+use crate::WenlanError;
+
+/// One `(step_name, status)` cell of the `enrichment_steps` table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StepCount {
+    pub step_name: String,
+    pub status: String,
+    pub count: u64,
+}
+
+/// Every count `GET /api/activity` composes into an `ActivityResponse`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActivityCounts {
+    /// Distinct `source_id`s in `memories` with `source = 'memory'`.
+    pub memories_total: u64,
+    /// `(step_name, status, count)` cells from `enrichment_steps`.
+    pub step_counts: Vec<StepCount>,
+    /// The "raw" count from `pipeline_status`: distinct memory `source_id`s
+    /// with no `enrichment_steps` row at all.
+    pub memories_without_steps: u64,
+    /// Entity shadow pages that are live but unconfirmed.
+    pub entities_detected: u64,
+    /// Entity shadow pages that are live and confirmed.
+    pub entities_confirmed: u64,
+    /// Live non-entity pages.
+    pub pages_active: u64,
+    /// Live non-entity pages with `stale_reason` set and refreshable.
+    pub pages_stale: u64,
+    /// Live non-entity pages whose refresh is blocked.
+    pub pages_refresh_blocked: u64,
+    /// `MAX(updated_at)` over `enrichment_steps`; `None` on an empty table.
+    pub last_step_updated_at: Option<i64>,
+}
+
+impl MemoryDB {
+    /// Read every count `GET /api/activity` needs in one pass. Holds the
+    /// connection guard for the whole function like `pipeline_status` does;
+    /// every query is read-only.
+    pub async fn activity_counts(&self) -> Result<ActivityCounts, WenlanError> {
+        let conn = self.conn.lock().await;
+
+        let memories_total = scalar_u64(
+            &conn,
+            "SELECT COUNT(DISTINCT source_id) FROM memories WHERE source = 'memory'",
+            "activity_counts memories_total",
+        )
+        .await?;
+
+        let mut step_rows = conn
+            .query(
+                "SELECT step_name, status, COUNT(*) FROM enrichment_steps \
+                 GROUP BY step_name, status",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("activity_counts step_counts: {e}")))?;
+        let mut step_counts = Vec::new();
+        while let Some(row) = step_rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("activity_counts step_counts row: {e}")))?
+        {
+            step_counts.push(StepCount {
+                step_name: row.get::<String>(0).map_err(|e| {
+                    WenlanError::VectorDb(format!("activity_counts step_counts name: {e}"))
+                })?,
+                status: row.get::<String>(1).map_err(|e| {
+                    WenlanError::VectorDb(format!("activity_counts step_counts status: {e}"))
+                })?,
+                count: row
+                    .get::<i64>(2)
+                    .map_err(|e| {
+                        WenlanError::VectorDb(format!("activity_counts step_counts count: {e}"))
+                    })?
+                    .max(0) as u64,
+            });
+        }
+        drop(step_rows);
+
+        // Same SQL as the "raw" count in `pipeline_status`.
+        let memories_without_steps = scalar_u64(
+            &conn,
+            "SELECT COUNT(DISTINCT source_id) FROM memories WHERE source = 'memory' \
+             AND source_id NOT IN (SELECT DISTINCT source_id FROM enrichment_steps)",
+            "activity_counts memories_without_steps",
+        )
+        .await?;
+
+        // Entity lifecycle predicates mirror `entity_status_predicate` in
+        // db.rs, over the same `entity_page_map`/`pages` shadow shape the
+        // scoped entity readers use.
+        let entities_detected = scalar_u64(
+            &conn,
+            "SELECT COUNT(*) FROM entity_page_map epm JOIN pages p ON p.id = epm.page_id \
+             WHERE p.kind = 'entity' \
+             AND (p.status != 'archived' AND COALESCE(p.entity_confirmed, 0) = 0)",
+            "activity_counts entities_detected",
+        )
+        .await?;
+        let entities_confirmed = scalar_u64(
+            &conn,
+            "SELECT COUNT(*) FROM entity_page_map epm JOIN pages p ON p.id = epm.page_id \
+             WHERE p.kind = 'entity' \
+             AND (p.status != 'archived' AND COALESCE(p.entity_confirmed, 0) = 1)",
+            "activity_counts entities_confirmed",
+        )
+        .await?;
+
+        // Same SQL as `count_active_pages`.
+        let pages_active = scalar_u64(
+            &conn,
+            "SELECT COUNT(*) FROM pages \
+             WHERE status = 'active' AND COALESCE(kind, 'concept') != 'entity'",
+            "activity_counts pages_active",
+        )
+        .await?;
+        // Stale-page predicates follow `list_stale_pages_scoped`'s base shape
+        // (live non-entity pages with `stale_reason` set), split by whether a
+        // refresh is blocked.
+        let pages_stale = scalar_u64(
+            &conn,
+            "SELECT COUNT(*) FROM pages \
+             WHERE status = 'active' AND COALESCE(kind, 'concept') != 'entity' \
+             AND stale_reason IS NOT NULL AND refresh_blocked_reason IS NULL",
+            "activity_counts pages_stale",
+        )
+        .await?;
+        let pages_refresh_blocked = scalar_u64(
+            &conn,
+            "SELECT COUNT(*) FROM pages \
+             WHERE status = 'active' AND COALESCE(kind, 'concept') != 'entity' \
+             AND stale_reason IS NOT NULL AND refresh_blocked_reason IS NOT NULL",
+            "activity_counts pages_refresh_blocked",
+        )
+        .await?;
+
+        let mut updated_rows = conn
+            .query("SELECT MAX(updated_at) FROM enrichment_steps", ())
+            .await
+            .map_err(|e| {
+                WenlanError::VectorDb(format!("activity_counts last_step_updated_at: {e}"))
+            })?;
+        let last_step_updated_at = match updated_rows.next().await.map_err(|e| {
+            WenlanError::VectorDb(format!("activity_counts last_step_updated_at row: {e}"))
+        })? {
+            Some(row) => row.get::<Option<i64>>(0).map_err(|e| {
+                WenlanError::VectorDb(format!("activity_counts last_step_updated_at get: {e}"))
+            })?,
+            None => None,
+        };
+        drop(updated_rows);
+
+        Ok(ActivityCounts {
+            memories_total,
+            step_counts,
+            memories_without_steps,
+            entities_detected,
+            entities_confirmed,
+            pages_active,
+            pages_stale,
+            pages_refresh_blocked,
+            last_step_updated_at,
+        })
+    }
+}
+
+async fn scalar_u64(conn: &libsql::Connection, sql: &str, what: &str) -> Result<u64, WenlanError> {
+    let mut rows = conn
+        .query(sql, ())
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("{what} query: {e}")))?;
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| WenlanError::VectorDb(format!("{what} next: {e}")))?
+        .ok_or_else(|| WenlanError::Generic(format!("{what}: no rows")))?;
+    Ok(row
+        .get::<i64>(0)
+        .map_err(|e| WenlanError::VectorDb(format!("{what} get: {e}")))?
+        .max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn seed_memory(db: &MemoryDB, id: &str, source_id: &str, steps: &[(&str, &str, i64)]) {
+        let conn = db.conn.lock().await;
+        conn.execute(
+            "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+             last_modified, chunk_type, space) \
+             VALUES (?1, 'content', 'memory', ?2, 'title', 0, 0, 'text', 'work')",
+            libsql::params![id, source_id],
+        )
+        .await
+        .unwrap();
+        for (step_name, status, updated_at) in steps {
+            conn.execute(
+                "INSERT INTO enrichment_steps (source_id, step_name, status, attempts, updated_at) \
+                 VALUES (?1, ?2, ?3, 1, ?4)",
+                libsql::params![source_id, *step_name, *status, *updated_at],
+            )
+            .await
+            .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn activity_counts_empty_db_is_all_zero() {
+        let (db, _tmp) = super::super::tests::test_db().await;
+        let counts = db.activity_counts().await.unwrap();
+        assert_eq!(
+            counts,
+            ActivityCounts {
+                memories_total: 0,
+                step_counts: vec![],
+                memories_without_steps: 0,
+                entities_detected: 0,
+                entities_confirmed: 0,
+                pages_active: 0,
+                pages_stale: 0,
+                pages_refresh_blocked: 0,
+                last_step_updated_at: None,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn activity_counts_groups_steps_and_splits_pages_and_entities() {
+        let (db, _tmp) = super::super::tests::test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute_batch(
+                "INSERT INTO spaces (id, name, created_at, updated_at) \
+                 VALUES ('space-work', 'work', 1, 1);",
+            )
+            .await
+            .unwrap();
+        }
+        // One memory with a done + a failed step, one raw memory, one
+        // non-memory row the reader must ignore.
+        seed_memory(
+            &db,
+            "row-1",
+            "mem-1",
+            &[("title_enrich", "ok", 100), ("page_growth", "failed", 200)],
+        )
+        .await;
+        seed_memory(&db, "row-2", "mem-2", &[]).await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute(
+                "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                 last_modified, chunk_type, space) \
+                 VALUES ('row-3', 'content', 'note', 'note-1', 'title', 0, 0, 'text', 'work')",
+                (),
+            )
+            .await
+            .unwrap();
+            conn.execute(
+                "INSERT INTO pages (id, title, content, created_at, last_compiled, last_modified) \
+                 VALUES ('page-active', 'Active', 'body', 0, 0, 0)",
+                (),
+            )
+            .await
+            .unwrap();
+            conn.execute(
+                "INSERT INTO pages (id, title, content, created_at, last_compiled, last_modified, \
+                 stale_reason) \
+                 VALUES ('page-stale', 'Stale', 'body', 0, 0, 0, 'source_updated')",
+                (),
+            )
+            .await
+            .unwrap();
+            conn.execute(
+                "INSERT INTO pages (id, title, content, created_at, last_compiled, last_modified, \
+                 stale_reason, refresh_blocked_reason) \
+                 VALUES ('page-blocked', 'Blocked', 'body', 0, 0, 0, 'source_updated', 'citations')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+        db.test_seed_entity_shadow_page(crate::db::TestEntity::new("ent-1", "One", "concept"))
+            .await
+            .unwrap();
+        db.test_seed_entity_shadow_page(
+            crate::db::TestEntity::new("ent-2", "Two", "concept").confirmed(true),
+        )
+        .await
+        .unwrap();
+
+        let counts = db.activity_counts().await.unwrap();
+        assert_eq!(counts.memories_total, 2);
+        assert_eq!(counts.memories_without_steps, 1);
+        let mut cells: Vec<(&str, &str, u64)> = counts
+            .step_counts
+            .iter()
+            .map(|cell| (cell.step_name.as_str(), cell.status.as_str(), cell.count))
+            .collect();
+        cells.sort();
+        assert_eq!(
+            cells,
+            vec![("page_growth", "failed", 1), ("title_enrich", "ok", 1)]
+        );
+        assert_eq!(counts.entities_detected, 1);
+        assert_eq!(counts.entities_confirmed, 1);
+        assert_eq!(counts.pages_active, 3);
+        assert_eq!(counts.pages_stale, 1);
+        assert_eq!(counts.pages_refresh_blocked, 1);
+        assert_eq!(counts.last_step_updated_at, Some(200));
+    }
+}

--- a/crates/wenlan-core/src/db/activity_counts.rs
+++ b/crates/wenlan-core/src/db/activity_counts.rs
@@ -24,6 +24,25 @@ pub struct StepBacklog {
     pub count: u64,
 }
 
+/// Memories (distinct `source_id`, `source = 'memory'`) by how their entity
+/// detection stands: `done` has BOTH `entity_extract` and `entity_link` in a
+/// done status, `failed` has EITHER in a failed status and is not done.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectTally {
+    pub done: u64,
+    pub failed: u64,
+}
+
+/// Exact distinct-memory counts for one asset's two steps: `failed` is
+/// distinct memories with at least one step in a failed status;
+/// `unfinished` is distinct memories not fully done — at least one step
+/// failed, pending, or with no row at all. A superset of `failed`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetBacklog {
+    pub failed: u64,
+    pub unfinished: u64,
+}
+
 /// Every count `GET /api/activity` composes into an `ActivityResponse`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActivityCounts {
@@ -36,12 +55,22 @@ pub struct ActivityCounts {
     /// One entry each for `title_enrich`, `page_growth`, `entity_extract`
     /// and `entity_link`, even when the count is zero.
     pub memories_without_step: Vec<StepBacklog>,
+    /// Exact entity-detection standing over distinct memories.
+    pub detect: DetectTally,
+    /// Exact distinct-memory counts for the Memories steps
+    /// (`title_enrich`, `page_growth`).
+    pub memories_backlog: AssetBacklog,
+    /// Exact distinct-memory counts for the Entities steps
+    /// (`entity_extract`, `entity_link`).
+    pub entities_backlog: AssetBacklog,
     /// Entity shadow pages that are live but unconfirmed.
     pub entities_detected: u64,
     /// Entity shadow pages that are live and confirmed.
     pub entities_confirmed: u64,
-    /// Live non-entity pages.
-    pub pages_active: u64,
+    /// The whole live non-entity page population. `pages_stale` and
+    /// `pages_refresh_blocked` are SUBSETS of this count, not a separate
+    /// population: derive current/blocked from it, never add to it.
+    pub pages_total: u64,
     /// Live non-entity pages with `stale_reason` set and refreshable.
     pub pages_stale: u64,
     /// Live non-entity pages whose refresh is blocked.
@@ -101,7 +130,10 @@ impl MemoryDB {
         // `page_growth` — so each step gets its own correlated subquery.
         let mut backlog_rows = conn
             .query(
-                "SELECT s.name, (SELECT COUNT(*) FROM memories m WHERE m.source = 'memory' \
+                // DISTINCT: `memories` holds one row per chunk, so a bare
+                // COUNT(*) would count chunks, not memories.
+                "SELECT s.name, (SELECT COUNT(DISTINCT m.source_id) FROM memories m \
+                 WHERE m.source = 'memory' \
                  AND NOT EXISTS (SELECT 1 FROM enrichment_steps e \
                  WHERE e.source_id = m.source_id AND e.step_name = s.name)) \
                  FROM (SELECT 'title_enrich' AS name UNION ALL SELECT 'page_growth' \
@@ -134,6 +166,65 @@ impl MemoryDB {
         }
         drop(backlog_rows);
 
+        // Exact per-memory standing for both two-step lanes in one pass over
+        // distinct memories. The inner DISTINCT collapses chunks so each
+        // memory counts once; the outer CASE sums use only portable SQL (no
+        // FILTER clause). `ok`/`bad` count ROWS in a done/failed status for
+        // the lane's two steps; a memory is finished only when both are ok.
+        let mut tally_rows = conn
+            .query(
+                "SELECT \
+                 COALESCE(SUM(CASE WHEN ent_ok = 2 THEN 1 ELSE 0 END), 0), \
+                 COALESCE(SUM(CASE WHEN ent_ok < 2 AND ent_bad > 0 THEN 1 ELSE 0 END), 0), \
+                 COALESCE(SUM(CASE WHEN mem_bad > 0 THEN 1 ELSE 0 END), 0), \
+                 COALESCE(SUM(CASE WHEN mem_ok < 2 THEN 1 ELSE 0 END), 0), \
+                 COALESCE(SUM(CASE WHEN ent_bad > 0 THEN 1 ELSE 0 END), 0), \
+                 COALESCE(SUM(CASE WHEN ent_ok < 2 THEN 1 ELSE 0 END), 0) \
+                 FROM ( \
+                   SELECT m.source_id, \
+                     SUM(CASE WHEN e.step_name IN ('title_enrich', 'page_growth') \
+                              AND e.status IN ('ok', 'skipped') THEN 1 ELSE 0 END) AS mem_ok, \
+                     SUM(CASE WHEN e.step_name IN ('title_enrich', 'page_growth') \
+                              AND e.status IN ('failed', 'abandoned') THEN 1 ELSE 0 END) AS mem_bad, \
+                     SUM(CASE WHEN e.step_name IN ('entity_extract', 'entity_link') \
+                              AND e.status IN ('ok', 'skipped') THEN 1 ELSE 0 END) AS ent_ok, \
+                     SUM(CASE WHEN e.step_name IN ('entity_extract', 'entity_link') \
+                              AND e.status IN ('failed', 'abandoned') THEN 1 ELSE 0 END) AS ent_bad \
+                   FROM (SELECT DISTINCT source_id FROM memories WHERE source = 'memory') m \
+                   LEFT JOIN enrichment_steps e ON e.source_id = m.source_id \
+                   GROUP BY m.source_id \
+                 )",
+                (),
+            )
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("activity_counts tallies: {e}")))?;
+        let tally_row = tally_rows
+            .next()
+            .await
+            .map_err(|e| WenlanError::VectorDb(format!("activity_counts tallies row: {e}")))?
+            .ok_or_else(|| WenlanError::Generic("activity_counts tallies: no rows".into()))?;
+        let tally_cell = |index: i32| {
+            tally_row
+                .get::<i64>(index)
+                .map(|value| value.max(0) as u64)
+                .map_err(|e| {
+                    WenlanError::VectorDb(format!("activity_counts tallies cell {index}: {e}"))
+                })
+        };
+        let detect = DetectTally {
+            done: tally_cell(0)?,
+            failed: tally_cell(1)?,
+        };
+        let memories_backlog = AssetBacklog {
+            failed: tally_cell(2)?,
+            unfinished: tally_cell(3)?,
+        };
+        let entities_backlog = AssetBacklog {
+            failed: tally_cell(4)?,
+            unfinished: tally_cell(5)?,
+        };
+        drop(tally_rows);
+
         // Entity lifecycle predicates mirror `entity_status_predicate` in
         // db.rs, over the same `entity_page_map`/`pages` shadow shape the
         // scoped entity readers use.
@@ -154,12 +245,14 @@ impl MemoryDB {
         )
         .await?;
 
-        // Same SQL as `count_active_pages`.
-        let pages_active = scalar_u64(
+        // Same SQL as `count_active_pages`: the WHOLE live non-entity page
+        // population. Stale and refresh-blocked pages are subsets of this
+        // count — compose derives current/blocked from it, never adds to it.
+        let pages_total = scalar_u64(
             &conn,
             "SELECT COUNT(*) FROM pages \
              WHERE status = 'active' AND COALESCE(kind, 'concept') != 'entity'",
-            "activity_counts pages_active",
+            "activity_counts pages_total",
         )
         .await?;
         // Stale-page predicates follow `list_stale_pages_scoped`'s base shape
@@ -202,9 +295,12 @@ impl MemoryDB {
             memories_total,
             step_counts,
             memories_without_step,
+            detect,
+            memories_backlog,
+            entities_backlog,
             entities_detected,
             entities_confirmed,
-            pages_active,
+            pages_total,
             pages_stale,
             pages_refresh_blocked,
             last_step_updated_at,
@@ -280,9 +376,18 @@ mod tests {
                         count: 0,
                     },
                 ],
+                detect: DetectTally { done: 0, failed: 0 },
+                memories_backlog: AssetBacklog {
+                    failed: 0,
+                    unfinished: 0,
+                },
+                entities_backlog: AssetBacklog {
+                    failed: 0,
+                    unfinished: 0,
+                },
                 entities_detected: 0,
                 entities_confirmed: 0,
-                pages_active: 0,
+                pages_total: 0,
                 pages_stale: 0,
                 pages_refresh_blocked: 0,
                 last_step_updated_at: None,
@@ -379,11 +484,117 @@ mod tests {
         assert_eq!(backlog("page_growth"), Some(8));
         assert_eq!(backlog("entity_extract"), Some(8));
         assert_eq!(backlog("entity_link"), Some(8));
+        assert_eq!(counts.detect, DetectTally { done: 0, failed: 0 });
+        assert_eq!(
+            counts.memories_backlog,
+            AssetBacklog {
+                failed: 0,
+                unfinished: 8,
+            }
+        );
+        assert_eq!(
+            counts.entities_backlog,
+            AssetBacklog {
+                failed: 0,
+                unfinished: 8,
+            }
+        );
         assert_eq!(counts.entities_detected, 1);
         assert_eq!(counts.entities_confirmed, 1);
-        assert_eq!(counts.pages_active, 3);
+        assert_eq!(counts.pages_total, 3);
         assert_eq!(counts.pages_stale, 1);
         assert_eq!(counts.pages_refresh_blocked, 1);
         assert_eq!(counts.last_step_updated_at, Some(100));
+    }
+
+    #[tokio::test]
+    async fn backlog_counts_memories_not_chunks() {
+        let (db, _tmp) = super::super::tests::test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute_batch(
+                "INSERT INTO spaces (id, name, created_at, updated_at) \
+                 VALUES ('space-work', 'work', 1, 1);",
+            )
+            .await
+            .unwrap();
+            // One memory in three chunks, no step rows: every backlog is 1,
+            // not 3.
+            for chunk_index in 0..3i64 {
+                conn.execute(
+                    "INSERT INTO memories (id, content, source, source_id, title, chunk_index, \
+                     last_modified, chunk_type, space) \
+                     VALUES (?1, 'content', 'memory', 'mem-chunked', 'title', ?2, 0, 'text', 'work')",
+                    libsql::params![format!("row-chunk-{chunk_index}"), chunk_index],
+                )
+                .await
+                .unwrap();
+            }
+        }
+
+        let counts = db.activity_counts().await.unwrap();
+        assert_eq!(counts.memories_total, 1);
+        for step_name in [
+            "title_enrich",
+            "page_growth",
+            "entity_extract",
+            "entity_link",
+        ] {
+            let backlog = counts
+                .memories_without_step
+                .iter()
+                .find(|entry| entry.step_name == step_name)
+                .map(|entry| entry.count);
+            assert_eq!(backlog, Some(1), "backlog for {step_name}");
+        }
+        assert_eq!(
+            counts.memories_backlog,
+            AssetBacklog {
+                failed: 0,
+                unfinished: 1,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_counts_memories_with_both_steps_done() {
+        let (db, _tmp) = super::super::tests::test_db().await;
+        {
+            let conn = db.conn.lock().await;
+            conn.execute_batch(
+                "INSERT INTO spaces (id, name, created_at, updated_at) \
+                 VALUES ('space-work', 'work', 1, 1);",
+            )
+            .await
+            .unwrap();
+        }
+        // Two memories with both entity steps done, one with only extract
+        // done, one with link failed.
+        seed_memory(
+            &db,
+            "row-a",
+            "mem-a",
+            &[("entity_extract", "ok", 10), ("entity_link", "ok", 11)],
+        )
+        .await;
+        seed_memory(
+            &db,
+            "row-b",
+            "mem-b",
+            &[("entity_extract", "ok", 12), ("entity_link", "skipped", 13)],
+        )
+        .await;
+        seed_memory(&db, "row-c", "mem-c", &[("entity_extract", "ok", 14)]).await;
+        seed_memory(&db, "row-d", "mem-d", &[("entity_link", "failed", 15)]).await;
+
+        let counts = db.activity_counts().await.unwrap();
+        assert_eq!(counts.detect, DetectTally { done: 2, failed: 1 });
+        assert_eq!(
+            counts.entities_backlog,
+            AssetBacklog {
+                failed: 1,
+                unfinished: 2,
+            }
+        );
     }
 }

--- a/crates/wenlan-core/src/lint/serving/routes/records.rs
+++ b/crates/wenlan-core/src/lint/serving/routes/records.rs
@@ -15,6 +15,7 @@ pub(super) const ROUTES: &[SensitiveReadRoute] = &[
     row!(Get,"/api/import/state","import_state",NoSelector,UnauthenticatedLocal,Global,NoGate,NotApplicable,GlobalRead),
     row!(Get,"/api/import/batches/active","import_batches_active",NoSelector,UnauthenticatedLocal,Global,NoGate,NotApplicable,GlobalRead),
     row!(Get,"/api/import/batches/{batch_id}/status","import_batch_status",NoSelector,UnauthenticatedLocal,Global,SingleId404,NotApplicable,GlobalRead),
+    row!(Get,"/api/activity","background_work_counts",NoSelector,UnauthenticatedLocal,Global,NoGate,NotApplicable,AggregateOnly),
     row!(Get,"/api/memory/{source_id}/enrichment-status","memory_detail",HeaderOnly,UnauthenticatedLocal,MemorySpace,SingleId404,Rejected,Forbidden),
     row!(Get,"/api/memory/{id}/revisions","memory_revisions",HeaderOnly,UnauthenticatedLocal,MemorySpace,SingleId404,Rejected,Forbidden),
     row!(Get,"/api/memory/rejections","memory_rejections",NoSelector,UnauthenticatedLocal,Global,NoGate,NotApplicable,GlobalRead),

--- a/crates/wenlan-core/src/lint/serving_review_test.rs
+++ b/crates/wenlan-core/src/lint/serving_review_test.rs
@@ -70,6 +70,7 @@ fn route_catalog_freezes_exact_global_and_scoped_keys() {
         (Method::Get, "/api/memory/rejections"),
         (Method::Get, "/api/refinery/queue"),
         (Method::Get, "/api/capture-stats"),
+        (Method::Get, "/api/activity"),
         (Method::Get, "/api/decisions/domains"),
         (Method::Get, "/api/snapshots"),
     ];

--- a/crates/wenlan-core/src/truth_manifest.rs
+++ b/crates/wenlan-core/src/truth_manifest.rs
@@ -172,12 +172,13 @@ pub struct CliReader {
     pub adapter: &'static str,
 }
 
-/// All 177 registered `(method, path, handler)` triples.
+/// All 178 registered `(method, path, handler)` triples.
 ///
-/// 62 page-bearing, 115 not. Expands to 181 `(builder, method, path)`
-/// runtime entries: 175 in `main`, 6 in `repair`.
+/// 62 page-bearing, 116 not. Expands to 182 `(builder, method, path)`
+/// runtime entries: 176 in `main`, 6 in `repair`.
 #[rustfmt::skip]
 pub const HTTP_READERS: &[HttpReader] = &[
+    HttpReader { method: ReaderMethod::Get, path: "/api/activity", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "no prose fields" },
     HttpReader { method: ReaderMethod::Get, path: "/api/activities", builder: Builder::Main, page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "handle_list_activities", evidence: "AgentActivityRow.detail = title={page.title}" },
     HttpReader { method: ReaderMethod::Get, path: "/api/agents", builder: Builder::Main, page_bearing: PageBearing::No, class: TruthClass::NotApplicable, marker_shape: MarkerShape::None, adapter: "—", evidence: "DEMOTED — proof in the inventory doc" },
     HttpReader { method: ReaderMethod::Delete, path: "/api/agents/{name}", builder: Builder::Main, page_bearing: PageBearing::Yes, class: TruthClass::Automatic, marker_shape: MarkerShape::None, adapter: "handle_delete_agent", evidence: "opaque response type — fail-closed" },

--- a/crates/wenlan-core/src/truth_manifest_test.rs
+++ b/crates/wenlan-core/src/truth_manifest_test.rs
@@ -211,10 +211,11 @@ fn manifest_counts_match_the_spec() {
     // Then 173 after #708 added POST `/api/memory/entities/query`, `/archive`
     // and `/restore` (detected-entities index). Then 175 after the import
     // batch-status lane added GET `/api/import/batches/active` and GET
-    // `/api/import/batches/{batch_id}/status`.
+    // `/api/import/batches/{batch_id}/status`. Then 178 after the activity
+    // status lane added GET `/api/activity` (counts-only, not page-bearing).
     assert_eq!(
         HTTP_READERS.len(),
-        177,
+        178,
         "registered (method, path, handler) triples"
     );
     assert_eq!(MCP_READERS.len(), 29, "#[tool( declarations");
@@ -225,7 +226,7 @@ fn manifest_counts_match_the_spec() {
     let entries: Vec<_> = runtime_entries().collect();
     assert_eq!(
         entries.len(),
-        181,
+        182,
         "(builder, method, path) runtime entries"
     );
     assert_eq!(
@@ -233,7 +234,7 @@ fn manifest_counts_match_the_spec() {
             .iter()
             .filter(|(b, _, _)| *b == Builder::Main)
             .count(),
-        175,
+        176,
         "main builder entries"
     );
     assert_eq!(
@@ -409,7 +410,7 @@ fn marker_shape_allowlist_is_fail_closed() {
             .iter()
             .filter(|r| r.marker_shape == MarkerShape::None)
             .count(),
-        171 // includes the GET/PUT telemetry consent routes, which carry no page markers
+        172 // includes the GET/PUT telemetry consent routes and GET /api/activity, which carry no page markers
     );
 }
 

--- a/crates/wenlan-server/src/activity_routes.rs
+++ b/crates/wenlan-server/src/activity_routes.rs
@@ -621,7 +621,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn stale_pages_with_synthesis_lane_are_organizing() {
         let (everyday, _) = pinned_local();
         let synthesis = job_route("anthropic", Some("claude-sonnet-4-6"), "pinned");

--- a/crates/wenlan-server/src/activity_routes.rs
+++ b/crates/wenlan-server/src/activity_routes.rs
@@ -72,6 +72,18 @@ fn tally(counts: &ActivityCounts, step_names: &[&str]) -> StepTally {
     tally
 }
 
+/// Memories with no `enrichment_steps` row for this step name: work the step
+/// has not started. Zero when the reader has no entry (defensive; the reader
+/// always emits all four).
+fn backlog(counts: &ActivityCounts, step_name: &str) -> u64 {
+    counts
+        .memories_without_step
+        .iter()
+        .find(|entry| entry.step_name == step_name)
+        .map(|entry| entry.count)
+        .unwrap_or(0)
+}
+
 /// Per-step liveness from its backlog and its lane: failed work blocks even
 /// when the lane is healthy; waiting work blocks only when no lane serves it.
 fn step_state(pending: u64, failed: u64, lane_available: bool) -> ActivityStepState {
@@ -92,6 +104,52 @@ fn rollup(states: &[ActivityStepState]) -> ActivityStepState {
     } else {
         ActivityStepState::Idle
     }
+}
+
+/// The asset's headline numbers follow the first step that is doing or
+/// waiting on work, so the bar and the blocked count describe the same
+/// thing. When every step is idle the asset rests on its settled step:
+/// Summarize for Memories, Confirm for Entities, Write for Pages.
+fn headline(steps: &[ActivityStep], resting: ActivityStepName) -> (u64, u64) {
+    steps
+        .iter()
+        .find(|step| {
+            matches!(
+                step.state,
+                ActivityStepState::Running | ActivityStepState::Blocked
+            )
+        })
+        .or_else(|| steps.iter().find(|step| step.name == resting))
+        .map(|step| (step.done, step.total))
+        .unwrap_or((0, 0))
+}
+
+/// One step's share of its asset's blocked count: failed work, plus waiting
+/// work when this step's lane cannot serve it. Steps with no lane (Store,
+/// Confirm) contribute failed work only — their backlog is someone else's
+/// turn (the import request, the user), never a missing model.
+fn blocked_contribution(step: &ActivityStep, lane_available: bool) -> u64 {
+    let pending = step.total.saturating_sub(step.done + step.failed);
+    step.failed
+        + if step.job.is_some() && !lane_available {
+            pending
+        } else {
+            0
+        }
+}
+
+/// An asset's blocked count is the maximum across its steps, not the sum:
+/// the number is shown as a count of items ("12 pages blocked"), and one
+/// memory pending in two steps is still one item. A floor, stated honestly:
+/// distinct memories may be blocked in different steps, so the true item
+/// count is at least the max and at most the sum — the max is the claim we
+/// can prove.
+fn blocked_max(steps: &[ActivityStep], lane_available: bool) -> u64 {
+    steps
+        .iter()
+        .map(|step| blocked_contribution(step, lane_available))
+        .max()
+        .unwrap_or(0)
 }
 
 /// Map a `JobRoute.source` string onto its lane. Unknown sources fall to
@@ -137,10 +195,10 @@ pub(crate) fn compose_activity(
         failed: 0,
         job: ActivityStepName::Store.job(),
     };
-    // Summarize (Enrich) is `title_enrich`; memories with no step row at all
-    // are still waiting for it, so they count as pending here.
+    // Summarize (Enrich) is `title_enrich`; memories with no row for it are
+    // still waiting on it, so the per-step backlog counts as pending here.
     let summarize_tally = tally(&counts, &["title_enrich"]);
-    let summarize_pending = summarize_tally.pending + counts.memories_without_steps;
+    let summarize_pending = summarize_tally.pending + backlog(&counts, "title_enrich");
     let summarize = ActivityStep {
         name: ActivityStepName::Summarize,
         state: step_state(
@@ -153,40 +211,41 @@ pub(crate) fn compose_activity(
         failed: summarize_tally.failed,
         job: ActivityStepName::Summarize.job(),
     };
-    // Link is `page_growth`.
+    // Link is `page_growth`, with the same per-step backlog treatment as
+    // Summarize: a memory with no `page_growth` row is waiting on Link even
+    // when it already has rows for other steps.
     let link_tally = tally(&counts, &["page_growth"]);
+    let link_pending = link_tally.pending + backlog(&counts, "page_growth");
     let link = ActivityStep {
         name: ActivityStepName::Link,
-        state: step_state(
-            link_tally.pending,
-            link_tally.failed,
-            everyday_route.available,
-        ),
+        state: step_state(link_pending, link_tally.failed, everyday_route.available),
         done: link_tally.done,
-        total: link_tally.done + link_tally.failed + link_tally.pending,
+        total: link_tally.done + link_tally.failed + link_pending,
         failed: link_tally.failed,
         job: ActivityStepName::Link.job(),
     };
+    let memory_steps = vec![store, summarize, link];
+    let (memories_done, memories_total) = headline(&memory_steps, ActivityStepName::Summarize);
     let memories = ActivityAssetStatus {
         kind: ActivityAssetKind::Memories,
-        state: rollup(&[store.state, summarize.state, link.state]),
-        done: summarize.done,
-        total: summarize.total,
-        blocked: summarize.failed
-            + link.failed
-            + if everyday_route.available {
-                0
-            } else {
-                summarize_pending + link_tally.pending
-            },
-        steps: vec![store, summarize, link],
+        state: rollup(&[
+            memory_steps[0].state,
+            memory_steps[1].state,
+            memory_steps[2].state,
+        ]),
+        done: memories_done,
+        total: memories_total,
+        blocked: blocked_max(&memory_steps, everyday_route.available),
+        steps: memory_steps,
     };
 
     // ── Entities ────────────────────────────────────────────────────
     // Detect is `entity_extract` + `entity_link`: a memory is done only when
     // both are done. The reader returns counts, not pairs, so `done` is the
     // overlap lower bound (`min`) and `failed` the union upper bound (`max`);
-    // pending is the rest of the memory population.
+    // pending is the rest of the memory population. That total already covers
+    // every memory, so memories with no row for either step are pending here
+    // without a backlog term (adding one would double-count).
     let extract = tally(&counts, &["entity_extract"]);
     let entity_link = tally(&counts, &["entity_link"]);
     let detect_done = extract.done.min(entity_link.done);
@@ -210,18 +269,17 @@ pub(crate) fn compose_activity(
         failed: 0,
         job: ActivityStepName::Confirm.job(),
     };
+    let entity_steps = vec![detect, confirm];
+    let (entities_done, entities_total) = headline(&entity_steps, ActivityStepName::Confirm);
     let entities = ActivityAssetStatus {
         kind: ActivityAssetKind::Entities,
-        state: rollup(&[detect.state, confirm.state]),
-        done: confirm.done,
-        total: confirm.total,
-        blocked: detect.failed
-            + if everyday_route.available {
-                0
-            } else {
-                detect_pending
-            },
-        steps: vec![detect, confirm],
+        state: rollup(&[entity_steps[0].state, entity_steps[1].state]),
+        done: entities_done,
+        total: entities_total,
+        // Detect's share is already a memory count (min/max over the memory
+        // population), so the max keeps it exact.
+        blocked: blocked_max(&entity_steps, everyday_route.available),
+        steps: entity_steps,
     };
 
     // ── Pages ───────────────────────────────────────────────────────
@@ -242,18 +300,15 @@ pub(crate) fn compose_activity(
         failed: counts.pages_refresh_blocked,
         job: ActivityStepName::Write.job(),
     };
+    let page_steps = vec![write];
+    let (pages_done, pages_total) = headline(&page_steps, ActivityStepName::Write);
     let pages = ActivityAssetStatus {
         kind: ActivityAssetKind::Pages,
-        state: write.state,
-        done: write.done,
-        total: write.total,
-        blocked: write.failed
-            + if synthesis_route.available {
-                0
-            } else {
-                write_pending
-            },
-        steps: vec![write],
+        state: page_steps[0].state,
+        done: pages_done,
+        total: pages_total,
+        blocked: blocked_max(&page_steps, synthesis_route.available),
+        steps: page_steps,
     };
 
     // ── Overall ─────────────────────────────────────────────────────
@@ -292,7 +347,7 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use tower::ServiceExt;
-    use wenlan_core::db::StepCount;
+    use wenlan_core::db::{StepBacklog, StepCount};
 
     fn job_route(source: &str, model: Option<&str>, mode: &str) -> JobRoute {
         JobRoute {
@@ -314,7 +369,7 @@ mod tests {
         ActivityCounts {
             memories_total: 0,
             step_counts: vec![],
-            memories_without_steps: 0,
+            memories_without_step: vec![],
             entities_detected: 0,
             entities_confirmed: 0,
             pages_active: 0,
@@ -344,6 +399,36 @@ mod tests {
 
     fn memories_asset(response: &ActivityResponse) -> &ActivityAssetStatus {
         &response.assets[0]
+    }
+
+    fn entities_asset(response: &ActivityResponse) -> &ActivityAssetStatus {
+        &response.assets[1]
+    }
+
+    /// Eight memories with no step row for any step: every lane-served step
+    /// has the whole population as backlog.
+    fn unstarted_backlog() -> Vec<StepBacklog> {
+        [
+            "title_enrich",
+            "page_growth",
+            "entity_extract",
+            "entity_link",
+        ]
+        .into_iter()
+        .map(|step_name| StepBacklog {
+            step_name: step_name.to_string(),
+            count: 8,
+        })
+        .collect()
+    }
+
+    fn eight_memories_no_rows() -> ActivityCounts {
+        ActivityCounts {
+            memories_total: 8,
+            step_counts: vec![],
+            memories_without_step: unstarted_backlog(),
+            ..empty_counts()
+        }
     }
 
     fn pages_asset(response: &ActivityResponse) -> &ActivityAssetStatus {
@@ -388,7 +473,6 @@ mod tests {
                 status: "pending".to_string(),
                 count: 10,
             }],
-            memories_without_steps: 0,
             ..empty_counts()
         };
         let response = compose_activity(counts, &[], &everyday, &synthesis);
@@ -410,7 +494,6 @@ mod tests {
                 status: "pending".to_string(),
                 count: 10,
             }],
-            memories_without_steps: 0,
             ..empty_counts()
         };
         let response = compose_activity(counts, &[], &everyday, &synthesis);
@@ -430,7 +513,6 @@ mod tests {
                 status: "failed".to_string(),
                 count: 2,
             }],
-            memories_without_steps: 0,
             ..empty_counts()
         };
         let response = compose_activity(counts, &[], &everyday, &synthesis);
@@ -481,6 +563,74 @@ mod tests {
         assert_eq!(response.state, ActivityState::Organizing);
         // The batch's write is newer than any step row: it wins the timestamp.
         assert_eq!(response.last_activity_at, Some(1_700_000_100));
+    }
+
+    #[test]
+    fn link_counts_memories_with_no_step_row() {
+        let (everyday, synthesis) = pinned_local();
+        let response = compose_activity(eight_memories_no_rows(), &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Organizing);
+        let memories = memories_asset(&response);
+        let link = memories
+            .steps
+            .iter()
+            .find(|step| step.name == ActivityStepName::Link)
+            .expect("Link step");
+        assert_eq!(link.state, ActivityStepState::Running);
+        assert_eq!((link.done, link.total, link.failed), (0, 8, 0));
+        assert_eq!((memories.done, memories.total), (0, 8));
+    }
+
+    #[test]
+    fn asset_headline_follows_the_live_step() {
+        let everyday = job_route("basic", None, "unconfigured");
+        let (_, synthesis) = pinned_local();
+        let response = compose_activity(eight_memories_no_rows(), &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Blocked);
+        // Detect is the live Entities step, so the asset reports Detect's
+        // 0/8 — not Confirm's 0/0.
+        let entities = entities_asset(&response);
+        assert_eq!(entities.state, ActivityStepState::Blocked);
+        assert_eq!((entities.done, entities.total), (0, 8));
+    }
+
+    #[test]
+    fn blocked_counts_items_not_step_instances() {
+        let everyday = job_route("basic", None, "unconfigured");
+        let (_, synthesis) = pinned_local();
+        let response = compose_activity(eight_memories_no_rows(), &[], &everyday, &synthesis);
+        // Eight memories pending in both Summarize and Link is eight blocked
+        // items, not sixteen.
+        assert_eq!(memories_asset(&response).blocked, 8);
+    }
+
+    #[test]
+    fn idle_asset_rests_on_its_settled_step() {
+        let (everyday, synthesis) = pinned_local();
+        let counts = ActivityCounts {
+            memories_total: 8,
+            step_counts: [
+                "title_enrich",
+                "page_growth",
+                "entity_extract",
+                "entity_link",
+            ]
+            .into_iter()
+            .map(|step_name| StepCount {
+                step_name: step_name.to_string(),
+                status: "ok".to_string(),
+                count: 8,
+            })
+            .collect(),
+            entities_confirmed: 5,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::UpToDate);
+        // Every step idle: Entities rests on Confirm's 5/5, not Detect's 8/8.
+        let entities = entities_asset(&response);
+        assert_eq!(entities.state, ActivityStepState::Idle);
+        assert_eq!((entities.done, entities.total), (5, 5));
     }
 
     #[tokio::test]

--- a/crates/wenlan-server/src/activity_routes.rs
+++ b/crates/wenlan-server/src/activity_routes.rs
@@ -124,32 +124,16 @@ fn headline(steps: &[ActivityStep], resting: ActivityStepName) -> (u64, u64) {
         .unwrap_or((0, 0))
 }
 
-/// One step's share of its asset's blocked count: failed work, plus waiting
-/// work when this step's lane cannot serve it. Steps with no lane (Store,
-/// Confirm) contribute failed work only — their backlog is someone else's
-/// turn (the import request, the user), never a missing model.
-fn blocked_contribution(step: &ActivityStep, lane_available: bool) -> u64 {
-    let pending = step.total.saturating_sub(step.done + step.failed);
-    step.failed
-        + if step.job.is_some() && !lane_available {
-            pending
-        } else {
-            0
-        }
-}
-
-/// An asset's blocked count is the maximum across its steps, not the sum:
-/// the number is shown as a count of items ("12 pages blocked"), and one
-/// memory pending in two steps is still one item. A floor, stated honestly:
-/// distinct memories may be blocked in different steps, so the true item
-/// count is at least the max and at most the sum — the max is the claim we
-/// can prove.
-fn blocked_max(steps: &[ActivityStep], lane_available: bool) -> u64 {
-    steps
-        .iter()
-        .map(|step| blocked_contribution(step, lane_available))
-        .max()
-        .unwrap_or(0)
+/// An asset's blocked count is an exact distinct-item count from the reader:
+/// failed items when the lane can serve them (only failures are stuck),
+/// unfinished items when it cannot (waiting work is stuck too). A memory
+/// failed in one step and waiting in another counts once.
+fn asset_blocked(backlog: &wenlan_core::db::AssetBacklog, lane_available: bool) -> u64 {
+    if lane_available {
+        backlog.failed
+    } else {
+        backlog.unfinished
+    }
 }
 
 /// Map a `JobRoute.source` string onto its lane. Unknown sources fall to
@@ -235,29 +219,28 @@ pub(crate) fn compose_activity(
         ]),
         done: memories_done,
         total: memories_total,
-        blocked: blocked_max(&memory_steps, everyday_route.available),
+        blocked: asset_blocked(&counts.memories_backlog, everyday_route.available),
         steps: memory_steps,
     };
 
     // ── Entities ────────────────────────────────────────────────────
-    // Detect is `entity_extract` + `entity_link`: a memory is done only when
-    // both are done. The reader returns counts, not pairs, so `done` is the
-    // overlap lower bound (`min`) and `failed` the union upper bound (`max`);
-    // pending is the rest of the memory population. That total already covers
-    // every memory, so memories with no row for either step are pending here
-    // without a backlog term (adding one would double-count).
-    let extract = tally(&counts, &["entity_extract"]);
-    let entity_link = tally(&counts, &["entity_link"]);
-    let detect_done = extract.done.min(entity_link.done);
-    let detect_failed = extract.failed.max(entity_link.failed);
-    let detect_total = counts.memories_total.max(detect_done + detect_failed);
-    let detect_pending = detect_total.saturating_sub(detect_done + detect_failed);
+    // Detect's done/failed are exact distinct-memory counts from the reader:
+    // done has BOTH `entity_extract` and `entity_link` done, failed has
+    // EITHER failed without being done. Total is the memory population;
+    // pending is the remainder.
+    let detect_pending = counts
+        .memories_total
+        .saturating_sub(counts.detect.done + counts.detect.failed);
     let detect = ActivityStep {
         name: ActivityStepName::Detect,
-        state: step_state(detect_pending, detect_failed, everyday_route.available),
-        done: detect_done,
-        total: detect_total,
-        failed: detect_failed,
+        state: step_state(
+            detect_pending,
+            counts.detect.failed,
+            everyday_route.available,
+        ),
+        done: counts.detect.done,
+        total: counts.memories_total,
+        failed: counts.detect.failed,
         job: ActivityStepName::Detect.job(),
     };
     // Confirm is user-driven in the Wiki: no lane, always Idle.
@@ -276,38 +259,44 @@ pub(crate) fn compose_activity(
         state: rollup(&[entity_steps[0].state, entity_steps[1].state]),
         done: entities_done,
         total: entities_total,
-        // Detect's share is already a memory count (min/max over the memory
-        // population), so the max keeps it exact.
-        blocked: blocked_max(&entity_steps, everyday_route.available),
+        blocked: asset_blocked(&counts.entities_backlog, everyday_route.available),
         steps: entity_steps,
     };
 
     // ── Pages ───────────────────────────────────────────────────────
-    // Write (Distill) is served by the synthesis lane. Stale pages are the
-    // backlog; refresh-blocked ones are failed.
-    let write_total = counts.pages_active + counts.pages_stale;
-    let write_pending =
-        write_total.saturating_sub(counts.pages_active + counts.pages_refresh_blocked);
+    // Write (Distill) is served by the synthesis lane. The three page counts
+    // are NESTED — stale and refresh-blocked are subsets of the total — so
+    // current pages are derived by subtraction, never by addition.
+    // (Debug-asserted: the reader guarantees the nesting.)
+    debug_assert!(counts.pages_stale + counts.pages_refresh_blocked <= counts.pages_total);
+    let write_done = counts
+        .pages_total
+        .saturating_sub(counts.pages_stale + counts.pages_refresh_blocked);
     let write = ActivityStep {
         name: ActivityStepName::Write,
         state: step_state(
-            write_pending,
+            counts.pages_stale,
             counts.pages_refresh_blocked,
             synthesis_route.available,
         ),
-        done: counts.pages_active,
-        total: write_total,
+        done: write_done,
+        total: counts.pages_total,
         failed: counts.pages_refresh_blocked,
         job: ActivityStepName::Write.job(),
     };
     let page_steps = vec![write];
-    let (pages_done, pages_total) = headline(&page_steps, ActivityStepName::Write);
+    let (pages_done, pages_asset_total) = headline(&page_steps, ActivityStepName::Write);
     let pages = ActivityAssetStatus {
         kind: ActivityAssetKind::Pages,
         state: page_steps[0].state,
         done: pages_done,
-        total: pages_total,
-        blocked: blocked_max(&page_steps, synthesis_route.available),
+        total: pages_asset_total,
+        // One row per page: exact in both lane states.
+        blocked: if synthesis_route.available {
+            counts.pages_refresh_blocked
+        } else {
+            counts.pages_refresh_blocked + counts.pages_stale
+        },
         steps: page_steps,
     };
 
@@ -347,7 +336,7 @@ mod tests {
     use std::sync::Arc;
     use tokio::sync::RwLock;
     use tower::ServiceExt;
-    use wenlan_core::db::{StepBacklog, StepCount};
+    use wenlan_core::db::{AssetBacklog, StepBacklog, StepCount};
 
     fn job_route(source: &str, model: Option<&str>, mode: &str) -> JobRoute {
         JobRoute {
@@ -370,9 +359,18 @@ mod tests {
             memories_total: 0,
             step_counts: vec![],
             memories_without_step: vec![],
+            detect: wenlan_core::db::DetectTally { done: 0, failed: 0 },
+            memories_backlog: AssetBacklog {
+                failed: 0,
+                unfinished: 0,
+            },
+            entities_backlog: AssetBacklog {
+                failed: 0,
+                unfinished: 0,
+            },
             entities_detected: 0,
             entities_confirmed: 0,
-            pages_active: 0,
+            pages_total: 0,
             pages_stale: 0,
             pages_refresh_blocked: 0,
             last_step_updated_at: None,
@@ -427,12 +425,100 @@ mod tests {
             memories_total: 8,
             step_counts: vec![],
             memories_without_step: unstarted_backlog(),
+            detect: wenlan_core::db::DetectTally { done: 0, failed: 0 },
+            memories_backlog: AssetBacklog {
+                failed: 0,
+                unfinished: 8,
+            },
+            entities_backlog: AssetBacklog {
+                failed: 0,
+                unfinished: 8,
+            },
             ..empty_counts()
         }
     }
 
     fn pages_asset(response: &ActivityResponse) -> &ActivityAssetStatus {
         &response.assets[2]
+    }
+
+    /// A fresh install: no memories, no pages, and no model configured. The
+    /// spec's headline edge case — nothing is waiting, so nothing is blocked.
+    #[test]
+    fn empty_db_with_unconfigured_lanes_is_up_to_date() {
+        let everyday = job_route("basic", None, "unconfigured");
+        let synthesis = job_route("none", None, "unconfigured");
+        let response = compose_activity(empty_counts(), &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::UpToDate);
+        for asset in &response.assets {
+            assert_eq!(asset.state, ActivityStepState::Idle, "{:?}", asset.kind);
+            assert_eq!(asset.blocked, 0, "{:?}", asset.kind);
+            assert_eq!((asset.done, asset.total), (0, 0), "{:?}", asset.kind);
+        }
+    }
+
+    /// `available` is a conjunction: a pinned route with no model cannot run,
+    /// and a model on an unavailable pin cannot either. The other fixtures
+    /// always vary both together, so only this test pins the conjunction.
+    #[test]
+    fn available_requires_both_pinned_and_a_model() {
+        let pinned_without_model = job_route("on_device", None, "pinned");
+        let model_without_pin = job_route("on_device", Some("qwen3-4b"), "pinned_unavailable");
+        for broken in [pinned_without_model, model_without_pin] {
+            let counts = ActivityCounts {
+                memories_total: 8,
+                memories_without_step: unstarted_backlog(),
+                memories_backlog: AssetBacklog {
+                    failed: 0,
+                    unfinished: 8,
+                },
+                entities_backlog: AssetBacklog {
+                    failed: 0,
+                    unfinished: 8,
+                },
+                ..empty_counts()
+            };
+            let synthesis = job_route("on_device", Some("qwen3-4b"), "pinned");
+            let response = compose_activity(counts, &[], &broken, &synthesis);
+            assert!(!response.everyday.available, "{:?}", broken.mode);
+            // Work is waiting on a lane that cannot run it.
+            assert_eq!(response.state, ActivityState::Blocked, "{:?}", broken.mode);
+            assert_eq!(memories_asset(&response).blocked, 8, "{:?}", broken.mode);
+        }
+    }
+
+    /// The roll-up counts items, not step instances, and a memory stuck in
+    /// two different steps still counts once. Five memories failed in
+    /// Summarize and five DIFFERENT ones failed in Link is ten items, which
+    /// only the reader's distinct-memory tally can see: a max across steps
+    /// would say five and a sum would say ten only by accident.
+    #[test]
+    fn blocked_counts_distinct_memories_across_steps() {
+        let (everyday, synthesis) = pinned_local();
+        let counts = ActivityCounts {
+            memories_total: 10,
+            step_counts: vec![
+                StepCount {
+                    step_name: "title_enrich".to_string(),
+                    status: "failed".to_string(),
+                    count: 5,
+                },
+                StepCount {
+                    step_name: "page_growth".to_string(),
+                    status: "failed".to_string(),
+                    count: 5,
+                },
+            ],
+            memories_backlog: AssetBacklog {
+                failed: 10,
+                unfinished: 10,
+            },
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        let memories = memories_asset(&response);
+        assert_eq!(memories.state, ActivityStepState::Blocked);
+        assert_eq!(memories.blocked, 10);
     }
 
     #[test]
@@ -473,6 +559,10 @@ mod tests {
                 status: "pending".to_string(),
                 count: 10,
             }],
+            memories_backlog: AssetBacklog {
+                failed: 0,
+                unfinished: 10,
+            },
             ..empty_counts()
         };
         let response = compose_activity(counts, &[], &everyday, &synthesis);
@@ -494,6 +584,10 @@ mod tests {
                 status: "pending".to_string(),
                 count: 10,
             }],
+            memories_backlog: AssetBacklog {
+                failed: 0,
+                unfinished: 10,
+            },
             ..empty_counts()
         };
         let response = compose_activity(counts, &[], &everyday, &synthesis);
@@ -513,6 +607,10 @@ mod tests {
                 status: "failed".to_string(),
                 count: 2,
             }],
+            memories_backlog: AssetBacklog {
+                failed: 2,
+                unfinished: 10,
+            },
             ..empty_counts()
         };
         let response = compose_activity(counts, &[], &everyday, &synthesis);
@@ -523,11 +621,14 @@ mod tests {
     }
 
     #[test]
+    #[test]
     fn stale_pages_with_synthesis_lane_are_organizing() {
         let (everyday, _) = pinned_local();
         let synthesis = job_route("anthropic", Some("claude-sonnet-4-6"), "pinned");
+        // 12 live pages, of which 3 stale: stale is a subset of the total,
+        // not a second population.
         let counts = ActivityCounts {
-            pages_active: 12,
+            pages_total: 12,
             pages_stale: 3,
             ..empty_counts()
         };
@@ -535,8 +636,9 @@ mod tests {
         assert_eq!(response.state, ActivityState::Organizing);
         let pages = pages_asset(&response);
         assert_eq!(pages.state, ActivityStepState::Running);
-        assert_eq!(pages.done, 12);
-        assert_eq!(pages.total, 15);
+        assert_eq!(pages.done, 9);
+        assert_eq!(pages.total, 12);
+        assert_eq!(pages.blocked, 0);
     }
 
     #[test]
@@ -544,7 +646,7 @@ mod tests {
         let (everyday, _) = pinned_local();
         let synthesis = job_route("none", None, "unconfigured");
         let counts = ActivityCounts {
-            pages_active: 12,
+            pages_total: 12,
             pages_stale: 3,
             ..empty_counts()
         };
@@ -552,7 +654,29 @@ mod tests {
         assert_eq!(response.state, ActivityState::Blocked);
         let pages = pages_asset(&response);
         assert_eq!(pages.state, ActivityStepState::Blocked);
+        assert_eq!((pages.done, pages.total), (9, 12));
         assert_eq!(pages.blocked, 3);
+    }
+
+    #[test]
+    fn pages_total_does_not_double_count_stale() {
+        let (everyday, _) = pinned_local();
+        let synthesis = job_route("anthropic", Some("claude-sonnet-4-6"), "pinned");
+        // 10 live pages: 6 current, 3 waiting, 1 refresh-blocked.
+        let counts = ActivityCounts {
+            pages_total: 10,
+            pages_stale: 3,
+            pages_refresh_blocked: 1,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        let pages = pages_asset(&response);
+        // One refresh-blocked page is a failed step, so Write is Blocked even
+        // though the synthesis lane is available. The point of this test is
+        // the arithmetic: 10 pages, not 13, and 6 current, not 10.
+        assert_eq!(pages.state, ActivityStepState::Blocked);
+        assert_eq!((pages.done, pages.total), (6, 10));
+        assert_eq!(pages.blocked, 1);
     }
 
     #[test]
@@ -622,6 +746,9 @@ mod tests {
                 count: 8,
             })
             .collect(),
+            // Every step row is ok, so the exact tallies agree: all 8
+            // memories are finished in both lanes, nothing unfinished.
+            detect: wenlan_core::db::DetectTally { done: 8, failed: 0 },
             entities_confirmed: 5,
             ..empty_counts()
         };

--- a/crates/wenlan-server/src/activity_routes.rs
+++ b/crates/wenlan-server/src/activity_routes.rs
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `GET /api/activity` — one typed call describing all background organizing
+//! work, grouped by asset (Memories, Entities, Pages).
+//!
+//! Data-layer only: counts from existing readers plus the resolved job routes.
+//! Counts, enum labels and model ids only — never page or memory prose.
+
+use crate::config_routes::{resolve_job_routes, JobRoute};
+use crate::error::ServerError;
+use crate::import_routes::DEFAULT_ACTIVE_IMPORT_BATCH_LIMIT;
+use crate::route_registry::{get, TrackedRouter};
+use crate::state::SharedState;
+use axum::{extract::State, response::Json};
+use wenlan_core::config;
+use wenlan_core::db::ActivityCounts;
+use wenlan_types::activity::{
+    ActivityAssetKind, ActivityAssetStatus, ActivityJob, ActivityLane, ActivityResponse,
+    ActivityRoute, ActivityState, ActivityStep, ActivityStepName, ActivityStepState,
+};
+use wenlan_types::import::ImportBatchStatus;
+
+pub(crate) fn register(router: TrackedRouter<SharedState>) -> TrackedRouter<SharedState> {
+    router.route("/api/activity", get(handle_activity))
+}
+
+/// GET /api/activity — background-work summary for the Activity surface.
+pub async fn handle_activity(
+    State(state): State<SharedState>,
+) -> Result<Json<ActivityResponse>, ServerError> {
+    // Snapshot everything the handler needs out of the state lock in one
+    // short block, then drop the guard before any await.
+    let cfg = config::load_config();
+    let (db, everyday, synthesis) = {
+        let s = state.read().await;
+        let db = s.db.clone().ok_or(ServerError::DbNotInitialized)?;
+        let (everyday, synthesis) = resolve_job_routes(&cfg, &s);
+        (db, everyday, synthesis)
+    };
+    let counts = db.activity_counts().await?;
+    let batches = db
+        .active_import_batches(DEFAULT_ACTIVE_IMPORT_BATCH_LIMIT)
+        .await?;
+    Ok(Json(compose_activity(
+        counts, &batches, &everyday, &synthesis,
+    )))
+}
+
+/// Done/failed/pending split for one group of `enrichment_steps` rows.
+///
+/// Step status vocabulary (from `import_batch_status`): `"ok"` and
+/// `"skipped"` are done; `"failed"` and `"abandoned"` are failed; anything
+/// else is still in flight.
+#[derive(Debug, Default)]
+struct StepTally {
+    done: u64,
+    failed: u64,
+    pending: u64,
+}
+
+fn tally(counts: &ActivityCounts, step_names: &[&str]) -> StepTally {
+    let mut tally = StepTally::default();
+    for cell in &counts.step_counts {
+        if !step_names.contains(&cell.step_name.as_str()) {
+            continue;
+        }
+        match cell.status.as_str() {
+            "ok" | "skipped" => tally.done += cell.count,
+            "failed" | "abandoned" => tally.failed += cell.count,
+            _ => tally.pending += cell.count,
+        }
+    }
+    tally
+}
+
+/// Per-step liveness from its backlog and its lane: failed work blocks even
+/// when the lane is healthy; waiting work blocks only when no lane serves it.
+fn step_state(pending: u64, failed: u64, lane_available: bool) -> ActivityStepState {
+    if failed > 0 || (pending > 0 && !lane_available) {
+        ActivityStepState::Blocked
+    } else if pending > 0 {
+        ActivityStepState::Running
+    } else {
+        ActivityStepState::Idle
+    }
+}
+
+fn rollup(states: &[ActivityStepState]) -> ActivityStepState {
+    if states.contains(&ActivityStepState::Blocked) {
+        ActivityStepState::Blocked
+    } else if states.contains(&ActivityStepState::Running) {
+        ActivityStepState::Running
+    } else {
+        ActivityStepState::Idle
+    }
+}
+
+/// Map a `JobRoute.source` string onto its lane. Unknown sources fall to
+/// `None`: an unrecognized lane must read as "no model", never as healthy.
+fn lane_of(source: &str) -> ActivityLane {
+    match source {
+        "anthropic" => ActivityLane::Anthropic,
+        "external" => ActivityLane::External,
+        "on_device" => ActivityLane::OnDevice,
+        "basic" => ActivityLane::Basic,
+        "none" => ActivityLane::None,
+        _ => ActivityLane::None,
+    }
+}
+
+fn route_of(job: ActivityJob, route: &JobRoute) -> ActivityRoute {
+    ActivityRoute {
+        job,
+        lane: lane_of(&route.source),
+        model: route.model.clone(),
+        mode: route.mode.clone(),
+        available: route.mode == "pinned" && route.model.is_some(),
+    }
+}
+
+/// Assemble an `ActivityResponse` from raw counts. Pure: unit-testable without
+/// a DB.
+pub(crate) fn compose_activity(
+    counts: ActivityCounts,
+    batches: &[ImportBatchStatus],
+    everyday: &JobRoute,
+    synthesis: &JobRoute,
+) -> ActivityResponse {
+    let everyday_route = route_of(ActivityJob::Everyday, everyday);
+    let synthesis_route = route_of(ActivityJob::Synthesis, synthesis);
+
+    // ── Memories ────────────────────────────────────────────────────
+    let store = ActivityStep {
+        name: ActivityStepName::Store,
+        state: ActivityStepState::Idle,
+        done: counts.memories_total,
+        total: counts.memories_total,
+        failed: 0,
+        job: ActivityStepName::Store.job(),
+    };
+    // Summarize (Enrich) is `title_enrich`; memories with no step row at all
+    // are still waiting for it, so they count as pending here.
+    let summarize_tally = tally(&counts, &["title_enrich"]);
+    let summarize_pending = summarize_tally.pending + counts.memories_without_steps;
+    let summarize = ActivityStep {
+        name: ActivityStepName::Summarize,
+        state: step_state(
+            summarize_pending,
+            summarize_tally.failed,
+            everyday_route.available,
+        ),
+        done: summarize_tally.done,
+        total: summarize_tally.done + summarize_tally.failed + summarize_pending,
+        failed: summarize_tally.failed,
+        job: ActivityStepName::Summarize.job(),
+    };
+    // Link is `page_growth`.
+    let link_tally = tally(&counts, &["page_growth"]);
+    let link = ActivityStep {
+        name: ActivityStepName::Link,
+        state: step_state(
+            link_tally.pending,
+            link_tally.failed,
+            everyday_route.available,
+        ),
+        done: link_tally.done,
+        total: link_tally.done + link_tally.failed + link_tally.pending,
+        failed: link_tally.failed,
+        job: ActivityStepName::Link.job(),
+    };
+    let memories = ActivityAssetStatus {
+        kind: ActivityAssetKind::Memories,
+        state: rollup(&[store.state, summarize.state, link.state]),
+        done: summarize.done,
+        total: summarize.total,
+        blocked: summarize.failed
+            + link.failed
+            + if everyday_route.available {
+                0
+            } else {
+                summarize_pending + link_tally.pending
+            },
+        steps: vec![store, summarize, link],
+    };
+
+    // ── Entities ────────────────────────────────────────────────────
+    // Detect is `entity_extract` + `entity_link`: a memory is done only when
+    // both are done. The reader returns counts, not pairs, so `done` is the
+    // overlap lower bound (`min`) and `failed` the union upper bound (`max`);
+    // pending is the rest of the memory population.
+    let extract = tally(&counts, &["entity_extract"]);
+    let entity_link = tally(&counts, &["entity_link"]);
+    let detect_done = extract.done.min(entity_link.done);
+    let detect_failed = extract.failed.max(entity_link.failed);
+    let detect_total = counts.memories_total.max(detect_done + detect_failed);
+    let detect_pending = detect_total.saturating_sub(detect_done + detect_failed);
+    let detect = ActivityStep {
+        name: ActivityStepName::Detect,
+        state: step_state(detect_pending, detect_failed, everyday_route.available),
+        done: detect_done,
+        total: detect_total,
+        failed: detect_failed,
+        job: ActivityStepName::Detect.job(),
+    };
+    // Confirm is user-driven in the Wiki: no lane, always Idle.
+    let confirm = ActivityStep {
+        name: ActivityStepName::Confirm,
+        state: ActivityStepState::Idle,
+        done: counts.entities_confirmed,
+        total: counts.entities_detected + counts.entities_confirmed,
+        failed: 0,
+        job: ActivityStepName::Confirm.job(),
+    };
+    let entities = ActivityAssetStatus {
+        kind: ActivityAssetKind::Entities,
+        state: rollup(&[detect.state, confirm.state]),
+        done: confirm.done,
+        total: confirm.total,
+        blocked: detect.failed
+            + if everyday_route.available {
+                0
+            } else {
+                detect_pending
+            },
+        steps: vec![detect, confirm],
+    };
+
+    // ── Pages ───────────────────────────────────────────────────────
+    // Write (Distill) is served by the synthesis lane. Stale pages are the
+    // backlog; refresh-blocked ones are failed.
+    let write_total = counts.pages_active + counts.pages_stale;
+    let write_pending =
+        write_total.saturating_sub(counts.pages_active + counts.pages_refresh_blocked);
+    let write = ActivityStep {
+        name: ActivityStepName::Write,
+        state: step_state(
+            write_pending,
+            counts.pages_refresh_blocked,
+            synthesis_route.available,
+        ),
+        done: counts.pages_active,
+        total: write_total,
+        failed: counts.pages_refresh_blocked,
+        job: ActivityStepName::Write.job(),
+    };
+    let pages = ActivityAssetStatus {
+        kind: ActivityAssetKind::Pages,
+        state: write.state,
+        done: write.done,
+        total: write.total,
+        blocked: write.failed
+            + if synthesis_route.available {
+                0
+            } else {
+                write_pending
+            },
+        steps: vec![write],
+    };
+
+    // ── Overall ─────────────────────────────────────────────────────
+    let assets = vec![memories, entities, pages];
+    let state = if assets
+        .iter()
+        .any(|asset| asset.state == ActivityStepState::Blocked)
+    {
+        ActivityState::Blocked
+    } else if assets
+        .iter()
+        .any(|asset| asset.state == ActivityStepState::Running)
+        || batches.iter().any(|batch| !batch.complete)
+    {
+        ActivityState::Organizing
+    } else {
+        ActivityState::UpToDate
+    };
+
+    ActivityResponse {
+        state,
+        last_activity_at: counts
+            .last_step_updated_at
+            .max(batches.iter().map(|batch| batch.updated_at).max()),
+        assets,
+        everyday: everyday_route,
+        synthesis: synthesis_route,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+    use tower::ServiceExt;
+    use wenlan_core::db::StepCount;
+
+    fn job_route(source: &str, model: Option<&str>, mode: &str) -> JobRoute {
+        JobRoute {
+            source: source.to_string(),
+            model: model.map(str::to_string),
+            mode: mode.to_string(),
+            pin: None,
+        }
+    }
+
+    fn pinned_local() -> (JobRoute, JobRoute) {
+        (
+            job_route("on_device", Some("qwen3-4b"), "pinned"),
+            job_route("on_device", Some("qwen3-4b"), "pinned"),
+        )
+    }
+
+    fn empty_counts() -> ActivityCounts {
+        ActivityCounts {
+            memories_total: 0,
+            step_counts: vec![],
+            memories_without_steps: 0,
+            entities_detected: 0,
+            entities_confirmed: 0,
+            pages_active: 0,
+            pages_stale: 0,
+            pages_refresh_blocked: 0,
+            last_step_updated_at: None,
+        }
+    }
+
+    fn incomplete_batch() -> ImportBatchStatus {
+        ImportBatchStatus {
+            batch_id: "batch-1".to_string(),
+            source: "other".to_string(),
+            started_at: 1_700_000_000,
+            updated_at: 1_700_000_100,
+            chunks_received: 1,
+            memories_imported: 10,
+            memories_skipped: 0,
+            entities_detected: 0,
+            entities_established: 0,
+            pages_distilled: 0,
+            phases: vec![],
+            complete: false,
+            space: None,
+        }
+    }
+
+    fn memories_asset(response: &ActivityResponse) -> &ActivityAssetStatus {
+        &response.assets[0]
+    }
+
+    fn pages_asset(response: &ActivityResponse) -> &ActivityAssetStatus {
+        &response.assets[2]
+    }
+
+    #[test]
+    fn empty_db_with_pinned_lanes_is_up_to_date() {
+        let (everyday, synthesis) = pinned_local();
+        let response = compose_activity(empty_counts(), &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::UpToDate);
+        assert_eq!(response.last_activity_at, None);
+        assert_eq!(
+            response
+                .assets
+                .iter()
+                .map(|asset| asset.kind)
+                .collect::<Vec<_>>(),
+            vec![
+                ActivityAssetKind::Memories,
+                ActivityAssetKind::Entities,
+                ActivityAssetKind::Pages,
+            ]
+        );
+        for asset in &response.assets {
+            assert_eq!(asset.state, ActivityStepState::Idle);
+            assert_eq!(asset.done, 0);
+            assert_eq!(asset.total, 0);
+            assert_eq!(asset.blocked, 0);
+        }
+        assert!(response.everyday.available);
+        assert!(response.synthesis.available);
+    }
+
+    #[test]
+    fn pending_enrichment_with_lane_is_organizing() {
+        let (everyday, synthesis) = pinned_local();
+        let counts = ActivityCounts {
+            memories_total: 10,
+            step_counts: vec![StepCount {
+                step_name: "title_enrich".to_string(),
+                status: "pending".to_string(),
+                count: 10,
+            }],
+            memories_without_steps: 0,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Organizing);
+        let memories = memories_asset(&response);
+        assert_eq!(memories.state, ActivityStepState::Running);
+        assert_eq!(memories.total, 10);
+        assert_eq!(memories.blocked, 0);
+    }
+
+    #[test]
+    fn pending_enrichment_without_lane_is_blocked() {
+        let everyday = job_route("on_device", None, "pinned_unavailable");
+        let (_, synthesis) = pinned_local();
+        let counts = ActivityCounts {
+            memories_total: 10,
+            step_counts: vec![StepCount {
+                step_name: "title_enrich".to_string(),
+                status: "pending".to_string(),
+                count: 10,
+            }],
+            memories_without_steps: 0,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Blocked);
+        let memories = memories_asset(&response);
+        assert_eq!(memories.state, ActivityStepState::Blocked);
+        assert_eq!(memories.blocked, 10);
+    }
+
+    #[test]
+    fn failed_enrichment_with_lane_is_blocked() {
+        let (everyday, synthesis) = pinned_local();
+        let counts = ActivityCounts {
+            memories_total: 10,
+            step_counts: vec![StepCount {
+                step_name: "title_enrich".to_string(),
+                status: "failed".to_string(),
+                count: 2,
+            }],
+            memories_without_steps: 0,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Blocked);
+        let memories = memories_asset(&response);
+        assert_eq!(memories.state, ActivityStepState::Blocked);
+        assert_eq!(memories.blocked, 2);
+    }
+
+    #[test]
+    fn stale_pages_with_synthesis_lane_are_organizing() {
+        let (everyday, _) = pinned_local();
+        let synthesis = job_route("anthropic", Some("claude-sonnet-4-6"), "pinned");
+        let counts = ActivityCounts {
+            pages_active: 12,
+            pages_stale: 3,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Organizing);
+        let pages = pages_asset(&response);
+        assert_eq!(pages.state, ActivityStepState::Running);
+        assert_eq!(pages.done, 12);
+        assert_eq!(pages.total, 15);
+    }
+
+    #[test]
+    fn stale_pages_without_synthesis_lane_are_blocked() {
+        let (everyday, _) = pinned_local();
+        let synthesis = job_route("none", None, "unconfigured");
+        let counts = ActivityCounts {
+            pages_active: 12,
+            pages_stale: 3,
+            ..empty_counts()
+        };
+        let response = compose_activity(counts, &[], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Blocked);
+        let pages = pages_asset(&response);
+        assert_eq!(pages.state, ActivityStepState::Blocked);
+        assert_eq!(pages.blocked, 3);
+    }
+
+    #[test]
+    fn incomplete_batch_with_zero_counts_is_organizing() {
+        let (everyday, synthesis) = pinned_local();
+        let batch = incomplete_batch();
+        let response = compose_activity(empty_counts(), &[batch], &everyday, &synthesis);
+        assert_eq!(response.state, ActivityState::Organizing);
+        // The batch's write is newer than any step row: it wins the timestamp.
+        assert_eq!(response.last_activity_at, Some(1_700_000_100));
+    }
+
+    #[tokio::test]
+    async fn activity_without_db_returns_503() {
+        let state = Arc::new(RwLock::new(crate::state::ServerState::default()));
+        let app = crate::router::build_router(state);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/activity")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        // 503 = DbNotInitialized, the same mapping the debug pipeline route
+        // reports when no database is attached.
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/crates/wenlan-server/src/config_routes.rs
+++ b/crates/wenlan-server/src/config_routes.rs
@@ -292,7 +292,7 @@ pub async fn handle_get_setup_status(
 
 /// Resolved route for one job class: the source that serves it, the model, and
 /// how it was chosen.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct JobRoute {
     /// The RESOLVED source that serves this job.
     /// everyday: "anthropic" | "external" | "on_device" | "basic";
@@ -344,19 +344,18 @@ pub struct ResolvedRoutingResponse {
     pub pool: RoutingPool,
 }
 
-/// GET /api/config/routing — resolved per-job routing derived at request time
-/// from the live provider slots, using the SAME hard-pin resolvers the refinery
-/// runs so what the app displays cannot drift from what the daemon does. Never
-/// includes key material.
-pub async fn handle_get_resolved_routing(
-    State(state): State<SharedState>,
-) -> Result<Json<ResolvedRoutingResponse>, ServerError> {
-    let cfg = config::load_config();
-    let s = state.read().await;
-
+/// Resolve both job routes from config pins against the live provider slots.
+///
+/// Shared by `GET /api/config/routing` and `GET /api/activity` so the two
+/// routes cannot drift: both run the exact hard-pin resolvers background work
+/// runs. Missing pins authorize no inference; an unavailable pin remains
+/// pinned and never falls back across sources.
+pub(crate) fn resolve_job_routes(
+    cfg: &config::Config,
+    s: &crate::state::ServerState,
+) -> (JobRoute, JobRoute) {
     // Live resolution — the exact hard-pin resolvers background work runs, so
-    // display cannot drift from behavior. Missing pins authorize no inference;
-    // an unavailable pin remains pinned and never falls back across sources.
+    // display cannot drift from behavior.
     let everyday_pin = wenlan_core::refinery::EverydaySource::parse(cfg.everyday_source.as_deref());
     let everyday_route = wenlan_core::refinery::resolve_everyday(
         everyday_pin,
@@ -385,6 +384,20 @@ pub async fn handle_get_resolved_routing(
         mode: synth_route.mode.as_str().to_string(),
         pin: cfg.synthesis_source.clone(),
     };
+    (everyday, synthesis)
+}
+
+/// GET /api/config/routing — resolved per-job routing derived at request time
+/// from the live provider slots, using the SAME hard-pin resolvers the refinery
+/// runs so what the app displays cannot drift from what the daemon does. Never
+/// includes key material.
+pub async fn handle_get_resolved_routing(
+    State(state): State<SharedState>,
+) -> Result<Json<ResolvedRoutingResponse>, ServerError> {
+    let cfg = config::load_config();
+    let s = state.read().await;
+
+    let (everyday, synthesis) = resolve_job_routes(&cfg, &s);
 
     // Pool — the configuration view (what each lane WOULD use). Anthropic model
     // names come from the live slot when loaded, else the configured default,

--- a/crates/wenlan-server/src/import_routes.rs
+++ b/crates/wenlan-server/src/import_routes.rs
@@ -15,7 +15,7 @@ use wenlan_types::responses::ImportMemoriesResponse;
 use wenlan_types::WriteSpaceSource;
 
 /// Default cap for `GET /api/import/batches/active`.
-const DEFAULT_ACTIVE_IMPORT_BATCH_LIMIT: usize = 20;
+pub(crate) const DEFAULT_ACTIVE_IMPORT_BATCH_LIMIT: usize = 20;
 
 async fn request_import_priority(
     state: &Arc<RwLock<ServerState>>,

--- a/crates/wenlan-server/src/lib.rs
+++ b/crates/wenlan-server/src/lib.rs
@@ -4,6 +4,7 @@
 //! Only the modules needed by `tests/` are re-exported here. The binary
 //! entry-point (`main.rs`) continues to own the daemon lifecycle.
 
+pub mod activity_routes;
 pub mod activity_tag_routes;
 pub mod ambient_routes;
 pub mod brief_files;

--- a/crates/wenlan-server/src/route_registry.rs
+++ b/crates/wenlan-server/src/route_registry.rs
@@ -373,7 +373,7 @@ where
 
 #[rustfmt::skip]
 const NON_SENSITIVE_PATHS: &[&str] = &[
-    "/api/health", "/api/status", "/api/lint", "/api/repairs/plan", "/api/repairs/plan/entries", "/api/repairs/prepare", "/api/repairs/apply", "/api/repairs/verify", "/api/llm/test", "/api/shutdown", "/api/debug/pipeline", "/api/telemetry",
+    "/api/health", "/api/status", "/api/activity", "/api/lint", "/api/repairs/plan", "/api/repairs/plan/entries", "/api/repairs/prepare", "/api/repairs/apply", "/api/repairs/verify", "/api/llm/test", "/api/shutdown", "/api/debug/pipeline", "/api/telemetry",
     "/api/ambient/status", "/api/ambient/sweep",
     "/api/steep", "/api/distill", "/api/distill/{page_id}",
     "/api/ingest/text", "/api/ingest/webpage", "/api/ingest/memory", "/api/documents/{source}/{source_id}",

--- a/crates/wenlan-server/src/route_registry.rs
+++ b/crates/wenlan-server/src/route_registry.rs
@@ -373,7 +373,7 @@ where
 
 #[rustfmt::skip]
 const NON_SENSITIVE_PATHS: &[&str] = &[
-    "/api/health", "/api/status", "/api/activity", "/api/lint", "/api/repairs/plan", "/api/repairs/plan/entries", "/api/repairs/prepare", "/api/repairs/apply", "/api/repairs/verify", "/api/llm/test", "/api/shutdown", "/api/debug/pipeline", "/api/telemetry",
+    "/api/health", "/api/status", "/api/lint", "/api/repairs/plan", "/api/repairs/plan/entries", "/api/repairs/prepare", "/api/repairs/apply", "/api/repairs/verify", "/api/llm/test", "/api/shutdown", "/api/debug/pipeline", "/api/telemetry",
     "/api/ambient/status", "/api/ambient/sweep",
     "/api/steep", "/api/distill", "/api/distill/{page_id}",
     "/api/ingest/text", "/api/ingest/webpage", "/api/ingest/memory", "/api/documents/{source}/{source_id}",

--- a/crates/wenlan-server/src/route_registry/handler_manifest.txt
+++ b/crates/wenlan-server/src/route_registry/handler_manifest.txt
@@ -1,4 +1,5 @@
 # Exact route-to-handler bindings, captured from the production builders.
+main|get|/api/activity|wenlan_server::activity_routes::handle_activity
 main|get|/api/activities|wenlan_server::activity_tag_routes::handle_list_activities
 main|get|/api/agents|wenlan_server::profile_agents_routes::handle_list_agents
 main|get|/api/agents/{name}|wenlan_server::profile_agents_routes::handle_get_agent

--- a/crates/wenlan-server/src/router.rs
+++ b/crates/wenlan-server/src/router.rs
@@ -6,13 +6,13 @@ pub use crate::route_registry::AppRouter;
 use crate::route_registry::{get, TrackedRouter};
 use crate::state::SharedState;
 use crate::{
-    activity_tag_routes, ambient_routes, brief_routes, briefing_routes, community_routes,
-    config_routes, decisions_routes, entity_graph_routes, import_routes, indexed_files_routes,
-    ingest_routes, knowledge_routes, lint_routes, memory_detail_routes, memory_revision_routes,
-    memory_routes, onboarding_routes, outbox_routes, page_map_routes, page_routes,
-    pinned_memory_routes, profile_agents_routes, profile_narrative_routes, refinery_routes,
-    repair_routes, routes, security, snapshot_routes, source_routes, spaces_routes,
-    telemetry_routes, truth_guard, websocket,
+    activity_routes, activity_tag_routes, ambient_routes, brief_routes, briefing_routes,
+    community_routes, config_routes, decisions_routes, entity_graph_routes, import_routes,
+    indexed_files_routes, ingest_routes, knowledge_routes, lint_routes, memory_detail_routes,
+    memory_revision_routes, memory_routes, onboarding_routes, outbox_routes, page_map_routes,
+    page_routes, pinned_memory_routes, profile_agents_routes, profile_narrative_routes,
+    refinery_routes, repair_routes, routes, security, snapshot_routes, source_routes,
+    spaces_routes, telemetry_routes, truth_guard, websocket,
 };
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use wenlan_core::truth_manifest::Builder;
@@ -54,6 +54,7 @@ pub fn build_router_with_shutdown(state: SharedState, shutdown: ShutdownHandle) 
     let router = outbox_routes::register(router);
     let router = community_routes::register(router);
     let router = ingest_routes::register(router);
+    let router = activity_routes::register(router);
     let router = import_routes::register(router);
     let router = memory_routes::register_core(router);
     let router = entity_graph_routes::register_writes(router);

--- a/crates/wenlan-server/src/sensitive_read_routes/tests.rs
+++ b/crates/wenlan-server/src/sensitive_read_routes/tests.rs
@@ -87,6 +87,7 @@ fn canonical_matrix_freezes_exact_global_and_scoped_keys() {
         (Method::Get, "/api/memory/rejections"),
         (Method::Get, "/api/refinery/queue"),
         (Method::Get, "/api/capture-stats"),
+        (Method::Get, "/api/activity"),
         (Method::Get, "/api/decisions/domains"),
         (Method::Get, "/api/snapshots"),
     ];
@@ -155,8 +156,8 @@ fn canonical_matrix_freezes_exact_global_and_scoped_keys() {
         .map(|row| (row.method, row.path))
         .collect::<BTreeSet<_>>();
 
-    assert_eq!(rows.len(), 64);
-    assert_eq!(keys.len(), 64, "duplicate sensitive route key");
+    assert_eq!(rows.len(), 65);
+    assert_eq!(keys.len(), 65, "duplicate sensitive route key");
     assert_eq!(global, GLOBAL.iter().copied().collect());
     assert_eq!(scoped, SCOPED.iter().copied().collect());
     assert_eq!(

--- a/crates/wenlan-server/tests/space_scoping/case_runner.rs
+++ b/crates/wenlan-server/tests/space_scoping/case_runner.rs
@@ -366,12 +366,12 @@ pub fn assert_wave_4_knowledge_catalog_contract() {
     }
 
     let rows = wenlan_server::sensitive_read_routes::sensitive_read_routes().collect::<Vec<_>>();
-    assert_eq!(rows.len(), 64);
+    assert_eq!(rows.len(), 65);
     assert_eq!(
         rows.iter()
             .filter(|row| row.scope_binding == ScopeBinding::Global)
             .count(),
-        18
+        19
     );
     assert_eq!(
         rows.iter()
@@ -415,7 +415,7 @@ pub fn assert_global_executed_keys(executed: impl IntoIterator<Item = (Method, &
     let executed = executed.into_iter().collect::<Vec<_>>();
     let unique = executed.iter().copied().collect::<BTreeSet<_>>();
 
-    assert_eq!(expected.len(), 18, "Global route catalog count drifted");
+    assert_eq!(expected.len(), 19, "Global route catalog count drifted");
     assert_eq!(
         unique.len(),
         executed.len(),

--- a/crates/wenlan-server/tests/space_scoping/global_cases.rs
+++ b/crates/wenlan-server/tests/space_scoping/global_cases.rs
@@ -34,6 +34,7 @@ pub async fn global_routes_ignore_space_header() {
         ("/api/memory/rejections", "/api/memory/rejections"),
         ("/api/refinery/queue", "/api/refinery/queue"),
         ("/api/capture-stats", "/api/capture-stats"),
+        ("/api/activity", "/api/activity"),
         ("/api/decisions/domains", "/api/decisions/domains"),
         ("/api/snapshots", "/api/snapshots"),
     ];

--- a/crates/wenlan-types/src/activity.rs
+++ b/crates/wenlan-types/src/activity.rs
@@ -114,7 +114,10 @@ pub struct ActivityAssetStatus {
     pub state: ActivityStepState,
     pub done: u64,
     pub total: u64,
-    /// Items that cannot proceed: failed steps, or pending steps with no lane.
+    /// Exact count of items that cannot proceed: items with a failed step
+    /// when the asset's lane is available, plus items still waiting when it
+    /// is not. Each item counts once no matter how many of its steps are
+    /// stuck.
     pub blocked: u64,
     pub steps: Vec<ActivityStep>,
 }

--- a/crates/wenlan-types/src/activity.rs
+++ b/crates/wenlan-types/src/activity.rs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wire types for `GET /api/activity` — one call describing all background
+//! organizing work, grouped by asset (Memories, Entities, Pages).
+//!
+//! Counts, enum labels and model ids only: never page or memory prose, so the
+//! route is truth-manifest `NotApplicable` like `/api/config/routing`.
+
+use serde::{Deserialize, Serialize};
+
+/// Overall background-work state. Precedence: Blocked over Organizing over
+/// UpToDate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityState {
+    UpToDate,
+    Organizing,
+    Blocked,
+}
+
+/// The three asset groups the Activity surface reports on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityAssetKind {
+    Memories,
+    Entities,
+    Pages,
+}
+
+/// One background step inside an asset. `Store` and `Confirm` finish without
+/// a model lane (the import request stores; the user confirms).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityStepName {
+    Store,
+    Summarize,
+    Link,
+    Detect,
+    Confirm,
+    Write,
+}
+
+impl ActivityStepName {
+    /// The job whose resolved lane serves this step; `None` for the laneness
+    /// steps `Store` (done inside the import request) and `Confirm`
+    /// (user-driven in the Wiki).
+    pub fn job(self) -> Option<ActivityJob> {
+        match self {
+            ActivityStepName::Summarize | ActivityStepName::Link | ActivityStepName::Detect => {
+                Some(ActivityJob::Everyday)
+            }
+            ActivityStepName::Write => Some(ActivityJob::Synthesis),
+            ActivityStepName::Store | ActivityStepName::Confirm => None,
+        }
+    }
+}
+
+/// Per-step liveness. There is no queued/pending variant: anything not done
+/// and not failed is in flight while its lane is available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityStepState {
+    Idle,
+    Running,
+    Blocked,
+}
+
+/// The two background job classes, served by the resolved routing lanes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityJob {
+    Everyday,
+    Synthesis,
+}
+
+/// Resolved lane serving a job. Mirrors `JobRoute.source` strings verbatim.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityLane {
+    OnDevice,
+    External,
+    Anthropic,
+    Basic,
+    None,
+}
+
+/// One resolved job route: which lane serves the job and whether it can run.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActivityRoute {
+    pub job: ActivityJob,
+    pub lane: ActivityLane,
+    pub model: Option<String>,
+    /// "pinned" | "pinned_unavailable" | "unconfigured", verbatim from routing.
+    pub mode: String,
+    /// True only when `mode == "pinned"` and `model.is_some()`.
+    pub available: bool,
+}
+
+/// Progress of one background step.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActivityStep {
+    pub name: ActivityStepName,
+    pub state: ActivityStepState,
+    pub done: u64,
+    pub total: u64,
+    pub failed: u64,
+    /// The job whose lane serves this step; `None` for Store and Confirm.
+    pub job: Option<ActivityJob>,
+}
+
+/// Progress of one asset group.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActivityAssetStatus {
+    pub kind: ActivityAssetKind,
+    pub state: ActivityStepState,
+    pub done: u64,
+    pub total: u64,
+    /// Items that cannot proceed: failed steps, or pending steps with no lane.
+    pub blocked: u64,
+    pub steps: Vec<ActivityStep>,
+}
+
+/// The `GET /api/activity` response body.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActivityResponse {
+    pub state: ActivityState,
+    /// Unix seconds of the newest enrichment step write; None on an empty DB.
+    pub last_activity_at: Option<i64>,
+    /// Always three entries in order Memories, Entities, Pages.
+    pub assets: Vec<ActivityAssetStatus>,
+    pub everyday: ActivityRoute,
+    pub synthesis: ActivityRoute,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activity_wire_labels_are_snake_case() {
+        assert_eq!(
+            serde_json::to_value(ActivityState::UpToDate).unwrap(),
+            serde_json::Value::String("up_to_date".to_string())
+        );
+        assert_eq!(
+            serde_json::to_value(ActivityLane::OnDevice).unwrap(),
+            serde_json::Value::String("on_device".to_string())
+        );
+        for (state, label) in [
+            (ActivityState::UpToDate, "up_to_date"),
+            (ActivityState::Organizing, "organizing"),
+            (ActivityState::Blocked, "blocked"),
+        ] {
+            let json = serde_json::to_string(&state).unwrap();
+            assert_eq!(json, format!("\"{label}\""));
+        }
+    }
+
+    #[test]
+    fn activity_step_job_mapping() {
+        assert_eq!(
+            ActivityStepName::Summarize.job(),
+            Some(ActivityJob::Everyday)
+        );
+        assert_eq!(ActivityStepName::Link.job(), Some(ActivityJob::Everyday));
+        assert_eq!(ActivityStepName::Detect.job(), Some(ActivityJob::Everyday));
+        assert_eq!(ActivityStepName::Write.job(), Some(ActivityJob::Synthesis));
+        assert_eq!(ActivityStepName::Store.job(), None);
+        assert_eq!(ActivityStepName::Confirm.job(), None);
+    }
+
+    #[test]
+    fn activity_response_round_trips_with_mode_passthrough() {
+        let response = ActivityResponse {
+            state: ActivityState::Blocked,
+            last_activity_at: Some(1_700_000_000),
+            assets: vec![ActivityAssetStatus {
+                kind: ActivityAssetKind::Pages,
+                state: ActivityStepState::Blocked,
+                done: 12,
+                total: 15,
+                blocked: 3,
+                steps: vec![ActivityStep {
+                    name: ActivityStepName::Write,
+                    state: ActivityStepState::Blocked,
+                    done: 12,
+                    total: 15,
+                    failed: 0,
+                    job: Some(ActivityJob::Synthesis),
+                }],
+            }],
+            everyday: ActivityRoute {
+                job: ActivityJob::Everyday,
+                lane: ActivityLane::OnDevice,
+                model: Some("qwen3-4b".to_string()),
+                mode: "pinned".to_string(),
+                available: true,
+            },
+            synthesis: ActivityRoute {
+                job: ActivityJob::Synthesis,
+                lane: ActivityLane::Anthropic,
+                model: None,
+                // Opaque routing label: passed through verbatim, never parsed.
+                mode: "pinned_unavailable".to_string(),
+                available: false,
+            },
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"pinned_unavailable\""));
+        assert!(json.contains("\"on_device\""));
+        let back: ActivityResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, response);
+    }
+}

--- a/crates/wenlan-types/src/lib.rs
+++ b/crates/wenlan-types/src/lib.rs
@@ -5,6 +5,7 @@
 //! wenlan-core, wenlan-server, and the Tauri app. Dependencies are
 //! limited to serde and serde_json -- no heavy runtime deps.
 
+pub mod activity;
 pub mod brand;
 pub mod brief;
 pub mod briefing;

--- a/preview/mocks/live-invoke.ts
+++ b/preview/mocks/live-invoke.ts
@@ -894,6 +894,7 @@ export const HANDLERS: Record<string, (a: any) => Promise<unknown>> = {
   },
   update_memory_cmd: (a) => put(`/api/memory/${enc(a.sourceId)}/update`, { content: a.content }),
   get_pipeline_status: () => get("/api/debug/pipeline"),
+  get_activity: () => get("/api/activity"),
   list_onboarding_milestones: () =>
     get("/api/onboarding/milestones").then((r) => r.milestones ?? r),
 

--- a/preview/mocks/live-invoke.ts
+++ b/preview/mocks/live-invoke.ts
@@ -832,8 +832,10 @@ export const HANDLERS: Record<string, (a: any) => Promise<unknown>> = {
   // TagData shape: the UI reads both r.tags and r.document_tags — no unwrap.
   list_all_tags: () => get("/api/tags"),
   list_agents: () => get("/api/agents"),
-  list_agent_activity: (a) => get(`/api/activities${qs({ limit: a?.limit ?? 50 })}`),
-  list_activities: (a) => get(`/api/activities${qs({ limit: a?.limit ?? 50 })}`),
+  list_agent_activity: (a) =>
+    get(`/api/activities${qs({ limit: a?.limit ?? 50 })}`).then((r) => r.activities ?? r),
+  list_activities: (a) =>
+    get(`/api/activities${qs({ limit: a?.limit ?? 50 })}`).then((r) => r.activities ?? r),
   list_recent_retrievals: (a) => get(`/api/retrievals/recent${qs({ limit: a?.limit ?? 20 })}`),
   list_pending_revisions: (a) =>
     get(`/api/memory/pending-revisions${qs({ limit: a?.limit })}`).then((r) => r.revisions ?? r),

--- a/scripts/lib/smoke-common.sh
+++ b/scripts/lib/smoke-common.sh
@@ -260,16 +260,34 @@ smoke_assert_ownership() {
 
 # Isolation readback, from the LIVE daemon, both halves.
 smoke_assert_isolation() {
-    local reported logged_root logged_cmp want_cmp
+    local reported logged_root logged_cmp want_cmp log_candidate
     reported="$(curl -sf --max-time 5 "$HOST/api/knowledge/path")" ||
         fail "pages readback request FAILED — unmeasured, not a match"
     [ "$reported" = "{\"path\":\"$NATIVE_PAGES_DIR\"}" ] ||
         fail "pages readback mismatch: got [$reported] want [{\"path\":\"$NATIVE_PAGES_DIR\"}]"
+    # The startup line does not always reach stdout. On macOS the tracing
+    # subscriber installs a rotating FILE writer under the data root (see the
+    # `target_os = "macos"` branch of `crates/wenlan-server/src/main.rs`), so
+    # `daemon.log` — a plain stdout capture — holds only the
+    # `WENLAN_LISTENING_ON=` println and this assertion failed on every macOS
+    # run. Ask both places rather than branching on the platform, so the two
+    # cannot drift apart again; carrying the line in neither is still fatal.
+    #
     # One process, no pipe: `sed … | head -1` CAN SIGPIPE sed, and under
     # pipefail that is indistinguishable from a parse failure.
-    logged_root="$(sed -n '/Wenlan data root: /{s/.*Wenlan data root: //;s/\r$//;s/ (database [^)]*)$//;p;q;}' "$DATA_DIR/daemon.log")" ||
-        fail "extracting the logged data root FAILED — unmeasured, not a match"
-    [ -n "$logged_root" ] || fail "the daemon log has no 'Wenlan data root:' line at all"
+    # Choose the file BEFORE parsing, so this function keeps exactly ONE line
+    # that assigns logged_root:
+    # `bind_addr_tests::smoke_common_sed_strips_the_database_suffix_the_daemon_logs`
+    # lifts the sed program out of the first such line it finds, so a second one
+    # would silently feed that test the wrong text.
+    log_candidate="$DATA_DIR/daemon.log"
+    if ! grep -q 'Wenlan data root: ' "$log_candidate" 2>/dev/null; then
+        log_candidate="$DATA_DIR/logs/wenlan-server.log"
+    fi
+    logged_root="$(sed -n '/Wenlan data root: /{s/.*Wenlan data root: //;s/\r$//;s/ (database [^)]*)$//;p;q;}' "$log_candidate")" ||
+        fail "extracting the logged data root from [$log_candidate] FAILED — unmeasured, not a match"
+    [ -n "$logged_root" ] ||
+        fail "no daemon log carries a 'Wenlan data root:' line (looked in $DATA_DIR/daemon.log and $DATA_DIR/logs/wenlan-server.log)"
     if (( HOST_IS_WINDOWS == 1 )); then
         # Windows spells one directory many ways; compare the way the production
         # guard does, folding separator and case and nothing else.

--- a/src/lib/reviewCommandContract.test.ts
+++ b/src/lib/reviewCommandContract.test.ts
@@ -60,6 +60,7 @@ const OUTSIDE_THE_REVIEW_SURFACE: readonly string[] = [
   "download_on_device_model",
   "export_page_to_obsidian",
   "export_pages_to_obsidian",
+  "get_activity",
   "get_agent",
   "get_api_key",
   "get_avatar_data_url",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -566,6 +566,65 @@ export async function getPipelineStatus(): Promise<PipelineStatusResponse> {
   return invoke("get_pipeline_status");
 }
 
+// ── Activity status (daemon ≥ activity route; GET /api/activity) ───────────
+// Field names and enum string values mirror wenlan_types::activity exactly.
+
+export type ActivityState = "up_to_date" | "organizing" | "blocked";
+export type ActivityAssetKind = "memories" | "entities" | "pages";
+export type ActivityStepName =
+  | "store"
+  | "summarize"
+  | "link"
+  | "detect"
+  | "confirm"
+  | "write";
+export type ActivityStepState = "idle" | "running" | "blocked";
+export type ActivityJob = "everyday" | "synthesis";
+export type ActivityLane =
+  | "on_device"
+  | "external"
+  | "anthropic"
+  | "basic"
+  | "none";
+
+export interface ActivityRoute {
+  job: ActivityJob;
+  lane: ActivityLane;
+  model: string | null;
+  mode: string;
+  available: boolean;
+}
+
+export interface ActivityStep {
+  name: ActivityStepName;
+  state: ActivityStepState;
+  done: number;
+  total: number;
+  failed: number;
+  job: ActivityJob | null;
+}
+
+export interface ActivityAssetStatus {
+  kind: ActivityAssetKind;
+  state: ActivityStepState;
+  done: number;
+  total: number;
+  blocked: number;
+  steps: ActivityStep[];
+}
+
+export interface ActivityResponse {
+  state: ActivityState;
+  last_activity_at: number | null;
+  assets: ActivityAssetStatus[];
+  everyday: ActivityRoute;
+  synthesis: ActivityRoute;
+}
+
+export async function getActivity(): Promise<ActivityResponse> {
+  return invoke("get_activity");
+}
+
 // ── Tags ────────────────────────────────────────────────────────────────
 
 export interface TagData {


### PR DESCRIPTION
One daemon route that answers "what is Wenlan doing in the background right now", grouped by what the user recognises rather than by pipeline phase. This is PR 1 of 3 behind the activity indicator; it ships the data only, no UI.

The design contract is `2026-09-11-activity-indicator.md` in the private specs repo.

## What it returns

`GET /api/activity` returns three assets, Memories, Entities and Pages, each with its steps, plus the resolved model lane for each job and one overall state: `up_to_date`, `organizing` or `blocked`. Precedence is Blocked over Organizing over Up to date.

A step is Blocked when it has failed work, or when it has waiting work and no model lane can run it. That second case is why a fresh install needs care: no memories and no model configured must read Up to date, not Blocked, because nothing is actually waiting.

## Why the numbers took three passes

The first implementation passed its unit tests and was still wrong three times over, because the tests fed hand-made inputs that the real database cannot produce. Running it against a live scratch daemon and a read-only review found the rest.

- **Pages were double-counted.** The active, stale and refresh-blocked page counts are nested, not disjoint. Adding stale to active counted stale pages twice and reported blocked pages as written. Current pages are now derived by subtraction.
- **The backlog counted chunks, not memories.** The memories table holds one row per chunk, so a document split into six chunks reported "0 of 6" and six blocked for a single memory. Worst exactly where it is most visible, a large import.
- **Detect estimated and called it exact.** `min(extract, link)` is a ceiling on both-done, so progress was overstated, and `max` is a floor on union-failed, so trouble was understated. One grouped query now counts it exactly.
- **Blocked was a floor.** The max across steps could not see five memories failed in one step and five different ones failed in another. The reader now returns exact distinct-memory tallies.

Every count reaches a user as a sentence like "12 pages blocked", so an estimate does not belong on the wire.

## Route classification

The route reads memories, enrichment steps and pages, so it is registered in the serving-scope catalogue as a global aggregate read, next to `/api/capture-stats` and `/api/knowledge/count`. It carries counts and route names only, never a row, an id or any prose.

`resolve_job_routes` was extracted from the existing routing handler so this route and `/api/config/routing` cannot drift apart. The extraction is behaviour-preserving and both routes agree live.

## Verification

Checked against an isolated scratch daemon on its own port and data directory, never the development daemon.

- A six-chunk import reports 1 of 1, where the old code said 6.
- A fresh install with no model reads up to date.
- Routing agrees between this route and `/api/config/routing`.

Suites: `wenlan-server` lib 459 passed, `wenlan-core` lib 4252 passed, `wenlan-app` activity tests passed, formatting and TypeScript clean. A separate async-safety review confirmed no lock guard is held across an await.

## Follow-ups, not in this PR

PR 2 adds the status line, the by-asset popover and the Activity page section with a user-chosen layout. PR 3 migrates Diagnostics and removes `/api/debug/pipeline`.

One known limit: the reader holds the single connection mutex across its queries, and that mutex also serves the writer, so a frequent poll could stall enrichment writes on a large database. It is the same shape as the existing pipeline reader. The polling interval is decided in PR 2, so it is deliberately left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3mnLzAyZVszRSzJF6wwrz